### PR TITLE
insulator2: clean up dependencies and fix structure of $out

### DIFF
--- a/pkgs/by-name/in/insulator2/package.nix
+++ b/pkgs/by-name/in/insulator2/package.nix
@@ -1,26 +1,26 @@
 {
   lib,
-  cmake,
-  dbus,
+  stdenv,
+
   fetchFromGitHub,
   fetchYarnDeps,
-  openssl,
-  pkg-config,
-  freetype,
-  libsoup_2_4,
-  gtk3,
-  webkitgtk_4_0,
-  perl,
-  cyrus_sasl,
-  stdenv,
-  yarnConfigHook,
-  nodejs-slim,
-  cargo-tauri_1,
+
   cargo,
-  rustPlatform,
-  rustc,
+  cargo-tauri_1,
+  cmake,
   jq,
   moreutils,
+  nodejs-slim,
+  pkg-config,
+  rustc,
+  rustPlatform,
+  yarnConfigHook,
+
+  cyrus_sasl,
+  freetype,
+  libsoup_2_4,
+  openssl,
+  webkitgtk_4_0,
 }:
 
 stdenv.mkDerivation rec {
@@ -60,35 +60,32 @@ stdenv.mkDerivation rec {
   cargoRoot = "backend/";
   buildAndTestSubdir = cargoRoot;
 
+  strictDeps = true;
+
   dontUseCmakeConfigure = true;
 
-  preInstall = ''
-    mkdir -p "$out"
-  '';
-
   nativeBuildInputs = [
-    cmake
-    pkg-config
-    perl
-    rustPlatform.cargoSetupHook
     cargo
-    rustc
     cargo-tauri_1.hook
-    yarnConfigHook
-    nodejs-slim
-    cyrus_sasl
+    cmake
     jq
     moreutils # for sponge
+    nodejs-slim
+    pkg-config
+    rustc
+    rustPlatform.cargoSetupHook
+    yarnConfigHook
   ];
 
   buildInputs = [
-    dbus
-    openssl.out
+    cyrus_sasl
     freetype
     libsoup_2_4
-    gtk3
+    openssl
     webkitgtk_4_0
   ];
+
+  env.OPENSSL_NO_VENDOR = 1;
 
   meta = with lib; {
     description = "Client UI to inspect Kafka topics, consume, produce and much more";


### PR DESCRIPTION
The `preInstall` phase creating `$out` early made the tauri hook install the files in an incorrect way.
Related: https://github.com/NixOS/nixpkgs/pull/407796
I removed `preInstall` and it is fine now.

Other than that, I cleaned up the dependencies:
- `openssl` was actually being built from source, so I had to set `OPENSSL_NO_VENDOR = 1`.
- `cyrus_sasl` was incorrectly placed into `nativeBuildInputs` instead of `buildInputs`
- `dbus` was not necessary
- I sorted the deps alphabetically

Also, I set `strictDeps = true` so that the `cyrus_sasl` mistake doesn't happen again.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
