### PR TITLE
mvnd: fix build with graalvm-ce 24

### DIFF
--- a/pkgs/by-name/mv/mvnd/package.nix
+++ b/pkgs/by-name/mv/mvnd/package.nix
@@ -19,6 +19,7 @@ let
     x86_64-darwin = "darwin-amd64";
     x86_64-linux = "linux-amd64";
   };
+  inherit (platformMap.${stdenv.system}) os arch;
 in
 
 maven.buildMavenPackage rec {
@@ -30,10 +31,11 @@ maven.buildMavenPackage rec {
     rev = version;
     sha256 = "sha256-c1jD7m4cOdPWQEoaUMcNap2zvvX7H9VaWQv8JSgAnRU=";
   };
+  patches = [ ./patches/0001-update-groovy-for-compatibility-with-Java-24.patch ];
 
   # need graalvm at build-time for the `native-image` tool
   mvnJdk = graalvmPackages.graalvm-ce;
-  mvnHash = "sha256-Bx0XSnpHNxNX07uVPc18py9qbnG5b3b7J4vs44ty034=";
+  mvnHash = "sha256-/Ful6v3hfm+0aa0vBQhqMK6VE+93L3o7pwZ6wmeXzQY=";
 
   nativeBuildInputs = [
     graalvmPackages.graalvm-ce
@@ -101,7 +103,7 @@ maven.buildMavenPackage rec {
     description = "The Apache Maven Daemon";
     homepage = "https://maven.apache.org/";
     license = lib.licenses.asl20;
-    platforms = lib.platforms.unix;
+    platforms = builtins.attrNames platformMap;
     maintainers = with lib.maintainers; [ nathanregner ];
     mainProgram = "mvnd";
   };

--- a/pkgs/by-name/mv/mvnd/patches/0001-update-groovy-for-compatibility-with-Java-24.patch
+++ b/pkgs/by-name/mv/mvnd/patches/0001-update-groovy-for-compatibility-with-Java-24.patch
@@ -1,0 +1,34 @@
+From 4d92b26f6cfc7c5f164caf11c1d5325815058624 Mon Sep 17 00:00:00 2001
+From: Nathan Regner <nathanregner@gmail.com>
+Date: Fri, 16 May 2025 23:28:13 -0600
+Subject: [PATCH] build: update groovy for compatibility with Java 24
+
+---
+ pom.xml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pom.xml b/pom.xml
+index c1cec38b..7534ffd5 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -80,7 +80,7 @@
+     <!-- cannot upgrade graalvm to 23.0.0 which requires JDK >= 20 -->
+     <graalvm.version>24.0.2</graalvm.version>
+     <graalvm.plugin.version>0.10.2</graalvm.plugin.version>
+-    <groovy.version>4.0.22</groovy.version>
++    <groovy.version>4.0.24</groovy.version>
+     <jakarta.inject.version>1.0</jakarta.inject.version>
+     <jline.version>3.26.3</jline.version>
+     <maven.version>3.9.9</maven.version>
+@@ -91,7 +91,7 @@
+ 
+     <!-- plugin versions a..z -->
+     <buildnumber-maven-plugin.version>3.2.0</buildnumber-maven-plugin.version>
+-    <groovy-maven-plugin.version>3.0.2</groovy-maven-plugin.version>
++    <groovy-maven-plugin.version>4.2.0</groovy-maven-plugin.version>
+     <mrm.version>1.6.0</mrm.version>
+     <junit-platform-launcher.version>1.10.3</junit-platform-launcher.version>
+     <takari-provisio.version>1.0.25</takari-provisio.version>
+-- 
+2.49.0
+


### PR DESCRIPTION
ZHF: #403336

Needs backport to 25.05

Fixes build error caused by the latest `graalvm-ce` upgrade:

> [ERROR] Failed to execute goal org.codehaus.gmavenplus:gmavenplus-plugin:3.0.2:execute (set-platform-properties) on project mvnd: Error occurred while calling a method on a Groovy class from classpath.: InvocationTargetException: BUG! exception in phase 'semantic analysis' in source unit 'Script1.groovy' Unsupported class file major version 68 -> [Help 1]

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
