### PR TITLE
hyprlandPlugins.hyprslidr: init at 0-unstable-2025-05-16

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -33,6 +33,7 @@ let
     } # Added 2025-05-09
     { hyprspace = import ./hyprspace.nix; }
     { hyprsplit = import ./hyprsplit.nix; }
+    { hyprslidr = import ./hyprslidr.nix; }
     (import ./hyprland-plugins.nix)
   ];
 in

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprslidr-fix.patch
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprslidr-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Slider.cpp b/src/Slider.cpp
+index 78fb8a1..2567403 100644
+--- a/src/Slider.cpp
++++ b/src/Slider.cpp
+@@ -48,6 +48,11 @@ void WinStack::focusWindow(PHLWINDOW w) {
+     }
+ }
+ 
++bool WinStack::toggleFullscreenActiveWindow() {
++    g_pCompositor->setWindowFullscreenInternal(stack[act_idx], FSMODE_FULLSCREEN);
++    return stack[act_idx]->isFullscreen();
++}
++
+ bool WinStack::isFullscreenActiveWindow() {
+     return stack[act_idx]->isFullscreen();
+ }

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprslidr.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprslidr.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitLab,
+  hyprland,
+  mkHyprlandPlugin,
+  nix-update-script,
+}:
+mkHyprlandPlugin hyprland {
+  pluginName = "hyprslidr";
+  version = "0-unstable-2025-05-16";
+
+  src = fetchFromGitLab {
+    owner = "magus";
+    repo = "hyprslidr";
+    rev = "d0e0ba745df8e1ce17f58a4cac0072db7d85ab77";
+    hash = "sha256-TTxBjRYyI/JsmrFCAz0UNrpKbLxGm6SQvPj8LrDSKvI=";
+  };
+
+  # allows it to load in 0.49.1
+  patches = [ ./hyprslidr-fix.patch ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    mv ./hyprslidr.so $out/lib/libhyprslidr.so
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "A Hyprland plugin for a sliding window layout. Inspired by PaperWM.";
+    homepage = "https://gitlab.com/magus/hyprslidr";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ youwen5 ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

I haven't actually tested the functionality yet but it builds so it probably works. CC @quantum9innovation.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
