### PR TITLE
OCaml: bump ppxlib, ppx_deriving and ppx_deriving_yojson

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -12,7 +12,9 @@
   ounit2,
   ocaml-migrate-parsetree,
   version ?
-    if lib.versionAtLeast ppxlib.version "0.32" then
+    if lib.versionAtLeast ppxlib.version "0.36" then
+      "6.1.0"
+    else if lib.versionAtLeast ppxlib.version "0.32" then
       "6.0.3"
     else if lib.versionAtLeast ppxlib.version "0.20" then
       "5.2.1"
@@ -25,6 +27,7 @@
 let
   hash =
     {
+      "6.1.0" = "sha256-dHpWiOpjD3elCw6QJUrG+KZr3Ul0suhzdjQUJ4B9S1Y=";
       "6.0.3" = "sha256-N0qpezLF4BwJqXgQpIv6IYwhO1tknkRSEBRVrBnJSm0=";
       "5.2.1" = "sha256:11h75dsbv3rs03pl67hdd3lbim7wjzh257ij9c75fcknbfr5ysz9";
       "5.1" = "sha256:1i64fd7qrfzbam5hfbl01r0sx4iihsahcwqj13smmrjlnwi3nkxh";

--- a/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_yojson/default.nix
@@ -13,7 +13,13 @@
 
 let
   param =
-    if lib.versionAtLeast ppxlib.version "0.30" then
+    if lib.versionAtLeast ppxlib.version "0.36" then
+      {
+        version = "3.10.0";
+        sha256 = "sha256-Dy9egNpZdxsTPLo2mbpiFTMh5cYUXXOlOZLlQJuAK+E=";
+        checkInputs = [ ounit2 ];
+      }
+    else if lib.versionAtLeast ppxlib.version "0.30" then
       {
         version = "3.9.0";
         sha256 = "sha256-0d6YcBkeFoHXffCYjLIIvruw8B9ZB6NbUijhTv9uyN8=";

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -6,7 +6,7 @@
   version ?
     if lib.versionAtLeast ocaml.version "4.07" then
       if lib.versionAtLeast ocaml.version "4.08" then
-        if lib.versionAtLeast ocaml.version "4.11" then "0.33.0" else "0.24.0"
+        if lib.versionAtLeast ocaml.version "4.11" then "0.36.0" else "0.24.0"
       else
         "0.15.0"
     else
@@ -75,14 +75,21 @@ let
       "0.30.0" = {
         sha256 = "sha256-3UpjvenSm0mBDgTXZTk3yTLxd6lByg4ZgratU6xEIRA=";
         min_version = "4.07";
+        max_version = "5.2";
       };
       "0.32.1" = {
         sha256 = "sha256-nbrYvLHItPPfP1i8pgpe0j2GUx8No0tBlshr1YXAnX8=";
         min_version = "4.07";
+        max_version = "5.3";
       };
       "0.33.0" = {
         sha256 = "sha256-/6RO9VHyO3XiHb1pijAxBDE4Gq8UC5/kuBwucKLSxjo=";
         min_version = "4.07";
+        max_version = "5.3";
+      };
+      "0.36.0" = {
+        sha256 = "sha256-WrobzhTFMQhhQTARDIQ9AEv5O9LPOgd4/XCGuFOQpDQ=";
+        min_version = "4.08";
       };
     }
     ."${version}";


### PR DESCRIPTION
- https://github.com/ocaml-ppx/ppxlib/releases/tag/0.36.0
- https://github.com/ocaml-ppx/ppx_deriving/releases/tag/v6.1.0
- https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/tag/v3.10.0

Tested with `ocaml-ng.ocamlPackages_`... `4_13`, `4_14`, `5_0`, `5_1`, `5_2`, and `5_3`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
