### PR TITLE
qrencode: fix build failure

### DIFF
--- a/pkgs/by-name/qr/qrencode/package.nix
+++ b/pkgs/by-name/qr/qrencode/package.nix
@@ -1,11 +1,12 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   pkg-config,
   SDL2,
   libpng,
   libiconv,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: rec {
@@ -19,12 +20,17 @@ stdenv.mkDerivation (finalAttrs: rec {
     "dev"
   ];
 
-  src = fetchurl {
-    url = "https://fukuchi.org/works/qrencode/qrencode-${version}.tar.gz";
-    sha256 = "sha256-2kSO1PUqumvLDNSMrA3VG4aSvMxM0SdDFAL8pvgXHo4=";
+  src = fetchFromGitHub {
+    owner = "fukuchi";
+    repo = "libqrencode";
+    rev = "v${version}";
+    hash = "sha256-nbrmg9SqCqMrLE7WCfNEzMV/eS9UVCKCrjBrGMzAsLk";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
 
   buildInputs = [
     libiconv

--- a/pkgs/by-name/qr/qrencode/package.nix
+++ b/pkgs/by-name/qr/qrencode/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   pkg-config,
-  SDL2,
   libpng,
   libiconv,
   autoreconfHook,
@@ -36,8 +35,6 @@ stdenv.mkDerivation (finalAttrs: rec {
     libiconv
     libpng
   ];
-
-  nativeCheckInputs = [ SDL2 ];
 
   doCheck = false;
 


### PR DESCRIPTION
Resolves #407834 

The source tar is no more available at
https://fukuchi.org/works/qrencode/qrencode-4.1.1.tar.gz

E.g.

    $ curl -I 'https://fukuchi.org/works/qrencode/qrencode-4.1.1.tar.gz'
    HTTP/1.1 404 Not Found
    Date: Sat, 17 May 2025 07:13:20 GMT
    Server: Apache/2.4.62 (Debian)
    Strict-Transport-Security: max-age=31536000
    Content-Type: text/html; charset=iso-8859-

However, we can download it from the official repository on GitHub as mentioned
in the project's home page[1].

To make the package build, we use `autoreconfHook` to mimick the repo's
`autogen.sh` because the GitHub repo does not contain the configure script as
mentioned in the project's README[2]:

> If there is no "configure" script in the source code directory, run
> "autogen.sh" at first to generate it - this is mandatory if you downloaded
> the source from GitHub.

**Additionally**, nix fails with an infinite recursion error When running the tests with
SDL2 in `nativeCheckInputs`.

Removing the dependency fixes the error and the tests still run successfully.

~**NOTE**: I don't know to run the tests as defined in the `passthru.tests` attribute. Instead, it modified the package temporarily by setting `doCheck = true` and `configureFlags = [ "--with-tests" ]` directly in the derivation and observed that the build passed with the tests running successfuly after removing the SDL2 dependency.~

Running
```
nix build -L -I nixpkgs=./ '.#qrencode.passthru.tests'
```
on my local checkout works


[1] https://web.archive.org/web/20250413215821/https://fukuchi.org/en/works/qrencode/
[2] https://github.com/fukuchi/libqrencode/blob/50b3e5725cafccfde038c0833cdaa5b1c28491e2/README.md#compile--install


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
