### PR TITLE
nixos/telepathy: Remove GNOME remnants

### DIFF
--- a/nixos/modules/services/desktops/telepathy.nix
+++ b/nixos/modules/services/desktops/telepathy.nix
@@ -8,7 +8,7 @@
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    maintainers = [ ];
   };
 
   ###### interface
@@ -37,11 +37,6 @@
     environment.systemPackages = [ pkgs.telepathy-mission-control ];
 
     services.dbus.packages = [ pkgs.telepathy-mission-control ];
-
-    # Enable runtime optional telepathy in gnome-shell
-    services.xserver.desktopManager.gnome.sessionPath = with pkgs; [
-      telepathy-glib
-    ];
   };
 
 }


### PR DESCRIPTION
GNOME Shell 46 dropped the telepathy support so we no longer need to add the typelib to session path.
https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/c5ec3e45e4562246ba65ac2ca19eadfdfee627ca

Looking at Debian code search, no packages other than Polari should need the typelib from path anyway, and Polari already gets it from a wrapper:
https://codesearch.debian.net/search?q=TelepathyGLib+-package%3Atelepathy-glib+-package%3Asugar+-path%3Avala&literal=0

Also unmaintain as it is no longer used by GNOME.

The daemon components are needed by lomiri and polari:
https://codesearch.debian.net/search?q=org.freedesktop.Telepathy.MissionControl5%7Corg.freedesktop.Telepathy.AccountManager%7C%5Cbmc-tool%5Cb%7Cmc-wait-for-name&literal=0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested, as applicable:
  - [x] `nixosTests.gnome` (no rebuild)
  - [x] `nixosTests.gnome-extensions` (no rebuild)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
