### PR TITLE
xalanc: fix Clang 19 and GCC 15 compat

### DIFF
--- a/pkgs/by-name/xa/xalanc/0001-clang19-gcc15-compat.patch
+++ b/pkgs/by-name/xa/xalanc/0001-clang19-gcc15-compat.patch
@@ -1,0 +1,48 @@
+diff --git a/src/xalanc/XMLSupport/XalanOtherEncodingWriter.hpp b/src/xalanc/XMLSupport/XalanOtherEncodingWriter.hpp
+index 8741cea49..075b1ad4f 100644
+--- a/src/xalanc/XMLSupport/XalanOtherEncodingWriter.hpp
++++ b/src/xalanc/XMLSupport/XalanOtherEncodingWriter.hpp
+@@ -301,43 +301,6 @@ public:
+         return write(chars, start, length, m_charRefFunctor);
+     }
+ 
+-    void
+-    writeSafe(
+-            const XalanDOMChar*     theChars,
+-            size_type               theLength)
+-    {
+-        for(size_type i = 0; i < theLength; ++i)
+-        {
+-            const XalanDOMChar  ch = theChars[i];
+-
+-            if (isUTF16HighSurrogate(ch) == true)
+-            {
+-                if (i + 1 >= theLength)
+-                {
+-                    throwInvalidUTF16SurrogateException(ch, 0,  getMemoryManager());
+-                }
+-                else 
+-                {
+-                    XalanUnicodeChar    value = decodeUTF16SurrogatePair(ch, theChars[i+1],  getMemoryManager());
+-
+-                    if (this->m_isPresentable(value))
+-                    {
+-                        write(value);
+-                    }
+-                    else
+-                    {
+-                        this->writeNumberedEntityReference(value);
+-                    }
+-
+-                    ++i;
+-                }
+-            }
+-            else
+-            {
+-                write(static_cast<XalanUnicodeChar>(ch));
+-            }
+-        }
+-    }
+ 
+     void
+     write(const XalanDOMChar*     theChars)

--- a/pkgs/by-name/xa/xalanc/package.nix
+++ b/pkgs/by-name/xa/xalanc/package.nix
@@ -18,6 +18,16 @@ stdenv.mkDerivation {
     sha256 = "sha256:0q1204qk97i9h14vxxq7phcfpyiin0i1zzk74ixvg4wqy87b62s8";
   };
 
+  patches = [
+    # See https://github.com/llvm/llvm-project/issues/96859
+    # xalan-c contains a templated code path that tries to access non-existent methods,
+    # but before Clang 19 and GCC 15 this was no error as the template was never instantiated.
+    # Note that the suggested fix of adding "-fdelayed-template-parsing"
+    # to CXX_FLAGS would be sufficient for Clang 19, but as it would break again
+    # once we upgrade to GCC 15, we remove the dead code entirely.
+    ./0001-clang19-gcc15-compat.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     xercesc


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZHF: #403336

See https://github.com/llvm/llvm-project/issues/96859
xalan-c contains a templated code path that tries to access non-existent methods, but before Clang 19 and GCC 15 this was no error as the template was never instantiated.
Note that the suggested fix of adding `-fdelayed-template-parsing` to `CXX_FLAGS` would be sufficient for Clang 19, but as it would break again once we upgrade to GCC 15, we remove the dead code entirely.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
