### PR TITLE
mopidy: exclude pipewire on darwin; mopidy-tidal: 0.3.2 -> 0.3.9

### DIFF
--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -24,30 +24,32 @@ pythonPackages.buildPythonApplication rec {
 
   nativeBuildInputs = [ wrapGAppsNoGuiHook ];
 
-  buildInputs = with gst_all_1; [
-    glib-networking
-    gst-plugins-bad
-    gst-plugins-base
-    gst-plugins-good
-    gst-plugins-ugly
-    # Required patches for the Spotify plugin (https://github.com/mopidy/mopidy-spotify/releases/tag/v5.0.0a3)
-    (gst-plugins-rs.overrideAttrs (
-      newAttrs: oldAttrs: {
-        cargoDeps = oldAttrs.cargoDeps.overrideAttrs (oldAttrs': {
-          vendorStaging = oldAttrs'.vendorStaging.overrideAttrs {
-            inherit (newAttrs) patches;
-            outputHash = "sha256-urRYH5N1laBq1/SUEmwFKAtsHAC+KWYfYp+fmb7Ey7s=";
-          };
-        });
+  buildInputs =
+    with gst_all_1;
+    [
+      glib-networking
+      gst-plugins-bad
+      gst-plugins-base
+      gst-plugins-good
+      gst-plugins-ugly
+      # Required patches for the Spotify plugin (https://github.com/mopidy/mopidy-spotify/releases/tag/v5.0.0a3)
+      (gst-plugins-rs.overrideAttrs (
+        newAttrs: oldAttrs: {
+          cargoDeps = oldAttrs.cargoDeps.overrideAttrs (oldAttrs': {
+            vendorStaging = oldAttrs'.vendorStaging.overrideAttrs {
+              inherit (newAttrs) patches;
+              outputHash = "sha256-urRYH5N1laBq1/SUEmwFKAtsHAC+KWYfYp+fmb7Ey7s=";
+            };
+          });
 
-        # https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/1801/
-        patches = oldAttrs.patches or [ ] ++ [
-          ./spotify-access-token-auth.patch
-        ];
-      }
-    ))
-    pipewire
-  ];
+          # https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/1801/
+          patches = oldAttrs.patches or [ ] ++ [
+            ./spotify-access-token-auth.patch
+          ];
+        }
+      ))
+    ]
+    ++ lib.optional (!stdenv.hostPlatform.isDarwin) pipewire;
 
   propagatedBuildInputs =
     [ gobject-introspection ]

--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -75,12 +75,12 @@ pythonPackages.buildPythonApplication rec {
     inherit (nixosTests) mopidy;
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.mopidy.com/";
     description = "Extensible music server that plays music from local disk, Spotify, SoundCloud, and more";
     mainProgram = "mopidy";
-    license = licenses.asl20;
-    maintainers = [ maintainers.fpletz ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.fpletz ];
     hydraPlatforms = [ ];
   };
 }

--- a/pkgs/applications/audio/mopidy/tidal.nix
+++ b/pkgs/applications/audio/mopidy/tidal.nix
@@ -31,10 +31,11 @@ python3Packages.buildPythonApplication rec {
 
   pytestFlagsArray = [ "tests/" ];
 
-  meta = with lib; {
+  meta = {
     description = "Mopidy extension for playing music from Tidal";
     homepage = "https://github.com/tehkillerbee/mopidy-tidal";
-    license = licenses.mit;
+    changelog = "https://github.com/tehkillerbee/mopidy-tidal/releases/tag/v${version}";
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/applications/audio/mopidy/tidal.nix
+++ b/pkgs/applications/audio/mopidy/tidal.nix
@@ -1,20 +1,25 @@
 {
   lib,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
   mopidy,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "Mopidy-Tidal";
-  version = "0.3.2";
+  version = "0.3.9";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-ekqhzKyU2WqTOeRR1ZSZA9yW3UXsLBsC2Bk6FZrQgmc=";
+  src = fetchFromGitHub {
+    owner = "tehkillerbee";
+    repo = "mopidy-tidal";
+    rev = "v${version}";
+    hash = "sha256-RFhuxsb6nQPYxkaeAEABQdCwjbmnOw5pnmYnx6gNCcg=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ python3Packages.poetry-core ];
+
+  dependencies = [
     mopidy
     python3Packages.tidalapi
   ];


### PR DESCRIPTION
Resolves #407759

Tests for mopidy-tidal were failing on darwin, so I have bumped the package (which seems to have fixed them) and moved to fetchFromGithub. I think the maintainer has changed - https://github.com/tehkillerbee/mopidy-tidal?tab=readme-ov-file#contributions, as I don't the the 0.3.2 tag in the new github repo.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
