### PR TITLE
python313Packages.supervisor: fix build with python 3.13

### DIFF
--- a/pkgs/development/python-modules/supervisor/default.nix
+++ b/pkgs/development/python-modules/supervisor/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   mock,
   pytestCheckHook,
   pythonOlder,
@@ -20,6 +21,16 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-NHYbrhojxYGSKBpRFfsH+/IsmwEzwIFmvv/HD+0+vBI=";
   };
+
+  patches = [
+    # adapted from 49b74cafb6e72e0e620e321711c1b81a0823be12
+    ./fix-python313-unittest.patch
+    # Fix SubprocessTests.test_getProcessStateDescription on python 3.13
+    (fetchpatch {
+      url = "https://github.com/Supervisor/supervisor/commit/27efcd59b454e4f3a81e5e1b02ab0d8d0ff2f45f.patch";
+      hash = "sha256-9KNcdRJwnZJA00dDy/mAS7RJuBei60YzVhWkeQgmJ8c=";
+    })
+  ];
 
   propagatedBuildInputs = [ setuptools ];
 

--- a/pkgs/development/python-modules/supervisor/fix-python313-unittest.patch
+++ b/pkgs/development/python-modules/supervisor/fix-python313-unittest.patch
@@ -1,0 +1,337 @@
+From e18f91d4ddbc30920c828e782ce40fbe844fcab9 Mon Sep 17 00:00:00 2001
+From: Mike Naberezny <mike@naberezny.com>
+Date: Sun, 25 Dec 2022 10:58:24 -0800
+Subject: [PATCH] Remove unused test_suite() that now causes unittest and
+ pytest warnings
+
+supervisor/tests/test_confecho.py::test_suite
+  /home/runner/work/supervisor/supervisor/supervisor/tests/test_confecho.py:18: DeprecationWarning: unittest.findTestCases() is deprecated and will be removed in Python 3.13. Please use unittest.TestLoader.loadTestsFromModule() instead.
+    return unittest.findTestCases(sys.modules[__name__])
+
+supervisor/tests/test_confecho.py::test_suite
+  /home/runner/work/supervisor/supervisor/.tox/py311/lib/python3.11/site-packages/_pytest/python.py:199: PytestReturnNotNoneWarning: Expected None, but supervisor/tests/test_confecho.py::test_suite returned <unittest.suite.TestSuite tests=[<unittest.suite.TestSuite tests=[<supervisor.tests.test_confecho.TopLevelFunctionTests testMethod=test_main_writes_data_out_that_looks_like_a_config_file>]>]>, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
+---
+ supervisor/tests/test_childutils.py     |  7 -------
+ supervisor/tests/test_confecho.py       |  7 -------
+ supervisor/tests/test_dispatchers.py    |  6 ------
+ supervisor/tests/test_end_to_end.py     |  6 ------
+ supervisor/tests/test_events.py         |  7 -------
+ supervisor/tests/test_http.py           |  6 ------
+ supervisor/tests/test_loggers.py        |  6 ------
+ supervisor/tests/test_options.py        |  7 -------
+ supervisor/tests/test_poller.py         |  7 -------
+ supervisor/tests/test_rpcinterfaces.py  |  8 --------
+ supervisor/tests/test_socket_manager.py | 20 --------------------
+ supervisor/tests/test_states.py         |  7 -------
+ supervisor/tests/test_supervisorctl.py  |  7 -------
+ supervisor/tests/test_supervisord.py    |  7 -------
+ supervisor/tests/test_templating.py     |  9 ---------
+ supervisor/tests/test_web.py            |  6 ------
+ supervisor/tests/test_xmlrpc.py         |  1 -
+ 17 files changed, 124 deletions(-)
+
+diff --git a/supervisor/tests/test_childutils.py b/supervisor/tests/test_childutils.py
+index f2b39d8..94193fc 100644
+--- a/supervisor/tests/test_childutils.py
++++ b/supervisor/tests/test_childutils.py
+@@ -132,10 +132,3 @@ class TestEventListenerProtocol(unittest.TestCase):
+         listener.send(msg, stdout)
+         expected = '%s%s\n%s' % (begin, len(msg), msg)
+         self.assertEqual(stdout.getvalue(), expected)
+-
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_confecho.py b/supervisor/tests/test_confecho.py
+index 6ae5108..f35f845 100644
+--- a/supervisor/tests/test_confecho.py
++++ b/supervisor/tests/test_confecho.py
+@@ -12,10 +12,3 @@ class TopLevelFunctionTests(unittest.TestCase):
+ 
+         output = sio.getvalue()
+         self.assertTrue("[supervisord]" in output)
+-
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_dispatchers.py b/supervisor/tests/test_dispatchers.py
+index 87692e2..ee6e44a 100644
+--- a/supervisor/tests/test_dispatchers.py
++++ b/supervisor/tests/test_dispatchers.py
+@@ -1227,9 +1227,3 @@ class stripEscapeTests(unittest.TestCase):
+     def test_noansi(self):
+         noansi = b'Hello world... this is longer than a token!'
+         self.assertEqual(self._callFUT(noansi), noansi)
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_end_to_end.py b/supervisor/tests/test_end_to_end.py
+index dd5c977..763da48 100644
+--- a/supervisor/tests/test_end_to_end.py
++++ b/supervisor/tests/test_end_to_end.py
+@@ -419,9 +419,3 @@ class EndToEndTests(BaseTestCase):
+         finally:
+             transport.close()
+         self.assertEqual(ident, "from_command_line")
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_events.py b/supervisor/tests/test_events.py
+index bd33a0c..a432da8 100644
+--- a/supervisor/tests/test_events.py
++++ b/supervisor/tests/test_events.py
+@@ -508,10 +508,3 @@ class TestUtilityFunctions(unittest.TestCase):
+             self.assertTrue(events.EventTypes.FOO is FooEvent)
+         finally:
+             del events.EventTypes.FOO
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+-
+diff --git a/supervisor/tests/test_http.py b/supervisor/tests/test_http.py
+index 1198597..f4c4496 100644
+--- a/supervisor/tests/test_http.py
++++ b/supervisor/tests/test_http.py
+@@ -684,9 +684,3 @@ class DummyProducer:
+             return self.data.pop(0)
+         else:
+             return b''
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_loggers.py b/supervisor/tests/test_loggers.py
+index 0742c17..a9ae297 100644
+--- a/supervisor/tests/test_loggers.py
++++ b/supervisor/tests/test_loggers.py
+@@ -599,9 +599,3 @@ class DummyHandler:
+         self.records.append(record)
+     def close(self):
+         self.closed = True
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_options.py b/supervisor/tests/test_options.py
+index f43537a..18e7399 100644
+--- a/supervisor/tests/test_options.py
++++ b/supervisor/tests/test_options.py
+@@ -3804,10 +3804,3 @@ class UtilFunctionsTests(unittest.TestCase):
+         self.assertEqual(s('process'), ('process', 'process'))
+         self.assertEqual(s('group:'), ('group', None))
+         self.assertEqual(s('group:*'), ('group', None))
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+-
+diff --git a/supervisor/tests/test_poller.py b/supervisor/tests/test_poller.py
+index 1b12a8e..fb5bf81 100644
+--- a/supervisor/tests/test_poller.py
++++ b/supervisor/tests/test_poller.py
+@@ -437,10 +437,3 @@ class FakeKEvent(object):
+     def __init__(self, ident, filter):
+         self.ident = ident
+         self.filter = filter
+-
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_rpcinterfaces.py b/supervisor/tests/test_rpcinterfaces.py
+index 0827adf..ec88a90 100644
+--- a/supervisor/tests/test_rpcinterfaces.py
++++ b/supervisor/tests/test_rpcinterfaces.py
+@@ -2392,14 +2392,6 @@ class Test_make_main_rpcinterface(unittest.TestCase):
+             )
+ 
+ 
+-
+ class DummyRPCInterface:
+     def hello(self):
+         return 'Hello!'
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+-
+diff --git a/supervisor/tests/test_socket_manager.py b/supervisor/tests/test_socket_manager.py
+index 626d786..8eaafaa 100644
+--- a/supervisor/tests/test_socket_manager.py
++++ b/supervisor/tests/test_socket_manager.py
+@@ -51,7 +51,6 @@ class ProxyTest(unittest.TestCase):
+         proxy = self._makeOne(Subject(), on_delete=self.setOnDeleteCalled)
+         self.assertEqual(5, proxy.getValue())
+         proxy = None
+-        gc_collect()
+         self.assertTrue(self.on_deleteCalled)
+ 
+ class ReferenceCounterTest(unittest.TestCase):
+@@ -94,9 +93,6 @@ class ReferenceCounterTest(unittest.TestCase):
+ 
+ class SocketManagerTest(unittest.TestCase):
+ 
+-    def tearDown(self):
+-        gc_collect()
+-
+     def _getTargetClass(self):
+         from supervisor.socket_manager import SocketManager
+         return SocketManager
+@@ -160,12 +156,10 @@ class SocketManagerTest(unittest.TestCase):
+         self.assertTrue(sock_manager.is_prepared())
+         self.assertFalse(sock_manager.socket.close_called)
+         sock = None
+-        gc_collect()
+         # Socket not actually closed yet b/c ref ct is 1
+         self.assertTrue(sock_manager.is_prepared())
+         self.assertFalse(sock_manager.socket.close_called)
+         sock2 = None
+-        gc_collect()
+         # Socket closed
+         self.assertFalse(sock_manager.is_prepared())
+         self.assertTrue(sock_manager.socket.close_called)
+@@ -178,7 +172,6 @@ class SocketManagerTest(unittest.TestCase):
+         self.assertNotEqual(sock_id, sock3_id)
+         # Drop ref ct to zero
+         del sock3
+-        gc_collect()
+         # Now assert that socket is closed
+         self.assertFalse(sock_manager.is_prepared())
+         self.assertTrue(sock_manager.socket.close_called)
+@@ -193,7 +186,6 @@ class SocketManagerTest(unittest.TestCase):
+         self.assertEqual('Creating socket %s' % repr(conf), logger.data[0])
+         # socket close
+         del sock
+-        gc_collect()
+         self.assertEqual(len(logger.data), 2)
+         self.assertEqual('Closing socket %s' % repr(conf), logger.data[1])
+ 
+@@ -242,15 +234,3 @@ class SocketManagerTest(unittest.TestCase):
+             self.fail()
+         except Exception as e:
+             self.assertEqual(e.args[0], 'Socket has not been prepared')
+-
+-def gc_collect():
+-    if __pypy__ is not None:
+-        gc.collect()
+-        gc.collect()
+-        gc.collect()
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_states.py b/supervisor/tests/test_states.py
+index ba8e58f..41fed7b 100644
+--- a/supervisor/tests/test_states.py
++++ b/supervisor/tests/test_states.py
+@@ -50,10 +50,3 @@ class TopLevelEventListenerStateTests(unittest.TestCase):
+     def test_getEventListenerStateDescription_returns_None_when_not_found(self):
+         self.assertEqual(states.getEventListenerStateDescription(3.14159),
+             None)
+-    
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_supervisorctl.py b/supervisor/tests/test_supervisorctl.py
+index 3c0e097..af2149b 100644
+--- a/supervisor/tests/test_supervisorctl.py
++++ b/supervisor/tests/test_supervisorctl.py
+@@ -2067,10 +2067,3 @@ class DummyPlugin:
+ 
+     def do_help(self, arg):
+         self.helped = True
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+-
+diff --git a/supervisor/tests/test_supervisord.py b/supervisor/tests/test_supervisord.py
+index 3d7b4ff..4099bba 100644
+--- a/supervisor/tests/test_supervisord.py
++++ b/supervisor/tests/test_supervisord.py
+@@ -834,10 +834,3 @@ class SupervisordTests(unittest.TestCase):
+         self.assertEqual(supervisord.ticks[3600], 3600)
+         self.assertEqual(len(L), 6)
+         self.assertEqual(L[-1].__class__, events.Tick3600Event)
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+-
+diff --git a/supervisor/tests/test_templating.py b/supervisor/tests/test_templating.py
+index 29311a7..8970c4f 100644
+--- a/supervisor/tests/test_templating.py
++++ b/supervisor/tests/test_templating.py
+@@ -1785,12 +1785,3 @@ def normalize_xml(s):
+     s = re.sub(r"(?s)\s+<", "<", s)
+     s = re.sub(r"(?s)>\s+", ">", s)
+     return s
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-def main():
+-    unittest.main(defaultTest='test_suite')
+-
+-if __name__ == '__main__':
+-    main()
+diff --git a/supervisor/tests/test_web.py b/supervisor/tests/test_web.py
+index 8bae3ed..f31972d 100644
+--- a/supervisor/tests/test_web.py
++++ b/supervisor/tests/test_web.py
+@@ -177,9 +177,3 @@ class StatusViewTests(unittest.TestCase):
+ 
+ class DummyContext:
+     pass
+-
+-def test_suite():
+-    return unittest.findTestCases(sys.modules[__name__])
+-
+-if __name__ == '__main__':
+-    unittest.main(defaultTest='test_suite')
+diff --git a/supervisor/tests/test_xmlrpc.py b/supervisor/tests/test_xmlrpc.py
+index 3d49ce0..8cee058 100644
+--- a/supervisor/tests/test_xmlrpc.py
++++ b/supervisor/tests/test_xmlrpc.py
+@@ -917,4 +917,3 @@ class DummyConnection:
+ 
+     def close(self):
+         self.closed = True
+-
+-- 
+2.49.0
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ZHF: #403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
