### PR TITLE
darwin: remove `nix search` warning spam

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  mkStub = callPackage ../apple-sdk/mk-stub.nix { } "11.0";
+  mkStub = callPackage ../apple-sdk/mk-stub.nix { } "darwin.apple_sdk_11_0" "11.0";
 in
 lib.genAttrs [
   "CLTools_Executables"
@@ -249,17 +249,24 @@ lib.genAttrs [
     "simd"
   ] mkStub;
 
-  inherit (pkgs)
-    callPackage
-    stdenv
-    llvmPackages_12
-    llvmPackages_13
-    llvmPackages_14
-    llvmPackages_15
-    llvmPackages_16
-    rustPlatform
-    xcodebuild
-    ;
-
   version = "11.0";
 }
+//
+  lib.genAttrs
+    [
+      "callPackage"
+      "stdenv"
+      "llvmPackages_12"
+      "llvmPackages_13"
+      "llvmPackages_14"
+      "llvmPackages_15"
+      "llvmPackages_16"
+      "rustPlatform"
+      "xcodebuild"
+    ]
+    (
+      name:
+      lib.warn
+        "darwin.apple_sdk_11_0.${name}: deprecated and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions"
+        pkgs.${name}
+    )

--- a/pkgs/os-specific/darwin/apple-sdk-12.3/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-12.3/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  mkStub = callPackage ../apple-sdk/mk-stub.nix { } "12.3";
+  mkStub = callPackage ../apple-sdk/mk-stub.nix { } "darwin.apple_sdk_12_3" "12.3";
 in
 lib.genAttrs [
   "CLTools_Executables"

--- a/pkgs/os-specific/darwin/apple-sdk/mk-stub.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/mk-stub.nix
@@ -1,14 +1,18 @@
-{ stdenvNoCC }:
+{ lib, stdenvNoCC }:
 
-version: pname:
-stdenvNoCC.mkDerivation {
-  inherit pname version;
+prefix: version: pname:
+lib.warnOnInstantiate
+  "${prefix}.${pname}: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions."
+  (
+    stdenvNoCC.mkDerivation {
+      inherit pname version;
 
-  buildCommand = ''
-    mkdir -p "$out"
-    echo "Individual frameworks have been deprecated. See the stdenv documentation for how to use `apple-sdk`" \
-        > "$out/README"
-  '';
+      buildCommand = ''
+        mkdir -p "$out"
+        echo "Individual frameworks have been deprecated. See the stdenv documentation for how to use `apple-sdk`" \
+            > "$out/README"
+      '';
 
-  passthru.isDarwinCompatStub = true;
-}
+      passthru.isDarwinCompatStub = true;
+    }
+  )

--- a/pkgs/top-level/darwin-aliases.nix
+++ b/pkgs/top-level/darwin-aliases.nix
@@ -127,11 +127,11 @@ stubs
   ### L ###
 
   libauto = throw "'darwin.libauto' has been removed, as it was broken and unmaintained"; # added 2024-05-10
-  libresolvHeaders = lib.warn "darwin.libresolvHeaders: use `lib.getInclude darwin.libresolv`; this will be removed in 25.11" (
+  libresolvHeaders = lib.warnOnInstantiate "darwin.libresolvHeaders: use `lib.getInclude darwin.libresolv`; this will be removed in 25.11" (
     lib.getDev self.libresolv
   ); # added 2025-04-20
   libtapi = pkgs.libtapi; # 2024-08-16
-  libutilHeaders = lib.warn "darwin.libutilHeaders: use `lib.getInclude darwin.libutil`; this will be removed in 25.11" (
+  libutilHeaders = lib.warnOnInstantiate "darwin.libutilHeaders: use `lib.getInclude darwin.libutil`; this will be removed in 25.11" (
     lib.getDev self.libutil
   ); # added 2025-04-20
 
@@ -154,7 +154,8 @@ stubs
   ### S ###
 
   stdenvNoCF =
-    lib.warn "darwin.stdenvNoCF: use `stdenv` or `stdenvNoCC`; this will be removed in 25.11"
+    lib.warnOnInstantiate
+      "darwin.stdenvNoCF: use `stdenv` or `stdenvNoCC`; this will be removed in 25.11"
       (
         pkgs.stdenv.override {
           extraBuildInputs = [ ];

--- a/pkgs/top-level/darwin-aliases.nix
+++ b/pkgs/top-level/darwin-aliases.nix
@@ -49,18 +49,9 @@ let
 
   mkStub = pkgs.callPackage ../os-specific/darwin/apple-sdk/mk-stub.nix { };
 
-  warnStub =
-    prefix:
-    lib.warn "${prefix} these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions";
+  apple_sdk_11_0 = pkgs.callPackage ../os-specific/darwin/apple-sdk-11.0 { };
 
-  apple_sdk_11_0 = warnStub "darwin.apple_sdk_11_0.*:" (
-    pkgs.callPackage ../os-specific/darwin/apple-sdk-11.0 { }
-  );
-
-  apple_sdk_12_3 =
-    warnStub
-      "darwin.apple_sdk_12_3.*: add `apple-sdk_12` to build inputs instead to use the macOS 12 SDK."
-      (pkgs.callPackage ../os-specific/darwin/apple-sdk-12.3 { });
+  apple_sdk_12_3 = pkgs.callPackage ../os-specific/darwin/apple-sdk-12.3 { };
 
   apple_sdk = apple_sdk_11_0;
 
@@ -102,7 +93,7 @@ let
       "objc4"
       "ppp"
       "xnu"
-    ] (name: warnStub "darwin.${name}:" (mkStub "11.0" name));
+    ] (mkStub "darwin" "11.0");
 in
 
 stubs


### PR DESCRIPTION
Related to #407398.

This is a hacky mess but it does help: now `nix search` emits no Darwin-related warnings.

We still get warnings from specific usage of things like:

```
nix-repl> legacyPackages.aarch64-darwin.darwin.apple_sdk_11_0.callPackage
trace: evaluation warning: apple_sdk_11_0.callPackage: deprecated and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions
«lambda callPackageWith @ /nix/store/igkhqxk885qcxvzxqziqp9gjpszp9isd-source/lib/customisation.nix:240:15»
nix-repl> legacyPackages.aarch64-darwin.darwin.apple_sdk_12_3.objc4
trace: evaluation warning: apple_sdk_12_3.objc4: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions. Add `apple-sdk_12` to build inputs instead to use the macOS 12 SDK.
«derivation /nix/store/ibsxq4b9jzf23388g83sasrnjjlp7mh7-objc4-12.3.drv»
```

though the wording is a little different in places and the references to `darwin` are sometimes missing.

@emilazy I would extremely greatly appreciate some reassurance that I didn't break anything here (and that the warnings do actually get emitted if they're relevant).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
