### PR TITLE
tyx: init at 0.1.10

### DIFF
--- a/pkgs/by-name/ty/tyx/0001-fix-duplicate-typst-macros.patch
+++ b/pkgs/by-name/ty/tyx/0001-fix-duplicate-typst-macros.patch
@@ -1,0 +1,22 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index d0bd77f..43d3cfb 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -6186,17 +6186,6 @@ dependencies = [
+  "syn 2.0.101",
+ ]
+ 
+-[[package]]
+-name = "typst-macros"
+-version = "0.13.1"
+-source = "git+https://github.com/Myriad-Dreamin/typst.git?tag=tinymist%2Fv0.13.10#946ea31fb554bcf62e3215f64ddda87d70b026af"
+-dependencies = [
+- "heck 0.5.0",
+- "proc-macro2",
+- "quote",
+- "syn 2.0.101",
+-]
+-
+ [[package]]
+ name = "typst-pdf"
+ version = "0.13.1"

--- a/pkgs/by-name/ty/tyx/package.nix
+++ b/pkgs/by-name/ty/tyx/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  fetchNpmDeps,
+
+  # nativeBuildInputs
+  cargo-tauri,
+  bun,
+  pkg-config,
+  wrapGAppsHook4,
+
+  # buildInputs
+  gtk3,
+  gobject-introspection,
+  webkitgtk_4_1,
+}:
+
+let
+  pin = lib.importJSON ./pin.json;
+
+  src = fetchFromGitHub {
+    owner = "tyx-editor";
+    repo = "TyX";
+    tag = "v${pin.version}";
+    hash = pin.srcHash;
+  };
+
+  node_modules = stdenv.mkDerivation {
+    pname = "tyx-node_modules";
+    inherit src;
+    version = pin.version;
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+    nativeBuildInputs = [ bun ];
+    dontConfigure = true;
+    buildPhase = ''
+      bun install --no-progress --frozen-lockfile
+    '';
+    installPhase = ''
+      mkdir -p $out/node_modules
+
+      cp -R ./node_modules $out
+    '';
+    outputHash = pin."${stdenv.system}";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tyx";
+  inherit (pin) version;
+  inherit src;
+
+  cargoPatches = [
+    ./0001-fix-duplicate-typst-macros.patch
+  ];
+
+  fetchCargoVendor = true;
+  inherit (pin) cargoHash;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    ln -s ${node_modules}/node_modules $out
+    cp -R ./* $out
+
+    # bun is referenced naked in the package.json generated script
+    makeBinaryWrapper ${lib.getExe bun} $out/bin/tyx \
+      --prefix PATH : ${lib.makeBinPath [ bun ]} \
+      --add-flags "run --prefer-offline --no-install --cwd $out ./src/app.ts"
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+
+    bun
+
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gobject-introspection
+    gtk3
+    webkitgtk_4_1 # javascriptcoregtk
+  ];
+
+  meta = {
+    description = "A LyX-like experience rewritten for Typst and the modern era";
+    homepage = "https://github.com/tyx-editor/TyX";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "tyx";
+  };
+})

--- a/pkgs/by-name/ty/tyx/pin.json
+++ b/pkgs/by-name/ty/tyx/pin.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.1.12",
+  "srcHash": "sha256-B6/MJ8+K3bd41/2fz4smaEFmJoPVeoryvFOTGEGR4c4=",
+  "cargoHash": "sha256-tnQSANMa1Q1d/7PWfKmJ9VIT4o1AWcq1l+UdotoOVtI=",
+  "x86_64-linux": "sha256-JYtaGY3SBnuB80p6aj0UTRs6jXvRc9By62cXZR974bg=",
+  "x86_64-darwin": "",
+  "aarch64-darwin": "",
+  "aarch64-linux": ""
+}


### PR DESCRIPTION
## Things done

Add [Tyx](https://github.com/tyx-editor/TyX), a LyX-like experience rewritten for Typst.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
