### PR TITLE
vtk: 9.2.6 -> 9.4.2

### DIFF
--- a/pkgs/by-name/el/elmerfem/package.nix
+++ b/pkgs/by-name/el/elmerfem/package.nix
@@ -14,19 +14,20 @@
   libsForQt5,
   tbb,
   vtkWithQt5,
+  llvmPackages,
 }:
 let
   opencascade-occt = opencascade-occt_7_6;
 in
 stdenv.mkDerivation rec {
   pname = "elmerfem";
-  version = "unstable-2023-09-18";
+  version = "unstable-2025-05-19";
 
   src = fetchFromGitHub {
     owner = "elmercsc";
     repo = "elmerfem";
-    rev = "0fcced06f91c93f44557efd6a5f10b2da5c7066c";
-    hash = "sha256-UuARDYW7D3a4dB6I86s2Ed5ecQxc+Y/es3YIeF2VyTc=";
+    rev = "6233dbe0f2ecc9fdda1b6ba88246f2023101f7d8";
+    hash = "sha256-cHGhKIcsAzEZ2c7m60eP2pBRDYJf9qafRNPAzcmyH3o=";
   };
 
   hardeningDisable = [ "format" ];
@@ -50,7 +51,7 @@ stdenv.mkDerivation rec {
     opencascade-occt
     tbb
     vtkWithQt5
-  ];
+  ] ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
   preConfigure = ''
     patchShebangs ./
@@ -71,6 +72,7 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DCMAKE_OpenGL_GL_PREFERENCE=GLVND"
+    "-DUSE_MACOS_PACKAGE_MANAGER=False"
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/ex/exhibit/package.nix
+++ b/pkgs/by-name/ex/exhibit/package.nix
@@ -36,7 +36,7 @@ python3Packages.buildPythonApplication rec {
 
   dependencies = with python3Packages; [
     pygobject3
-    f3d_egl
+    f3d
   ];
 
   dontWrapGApps = true;

--- a/pkgs/by-name/f3/f3d/package.nix
+++ b/pkgs/by-name/f3/f3d/package.nix
@@ -9,10 +9,7 @@
   libXt,
   openusd,
   tbb,
-  # There is a f3d overridden with EGL enabled vtk in top-level/all-packages.nix
-  # compiling with EGL enabled vtk will result in f3d running in headless mode
-  # See https://github.com/NixOS/nixpkgs/pull/324022. This may change later.
-  vtk_9,
+  vtk,
   autoPatchelfHook,
   python3Packages,
   opencascade-occt,
@@ -61,7 +58,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [
-      vtk_9
+      vtk
       opencascade-occt
       assimp
       fontconfig

--- a/pkgs/by-name/f3/f3d/package.nix
+++ b/pkgs/by-name/f3/f3d/package.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation rec {
       "-DF3D_MODULE_EXTERNAL_RENDERING=ON"
       "-DF3D_PLUGIN_BUILD_ASSIMP=ON"
       "-DF3D_PLUGIN_BUILD_OCCT=ON"
+      "-DF3D_LINUX_INSTALL_DEFAULT_CONFIGURATION_FILE_IN_PREFIX=ON"
     ]
     ++ lib.optionals withManual [
       "-DF3D_LINUX_GENERATE_MAN=ON"
@@ -94,6 +95,11 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withUsd [
       "-DF3D_PLUGIN_BUILD_USD=ON"
     ];
+
+  # Install default configuration files, config and thumbnail.
+  postInstall = ''
+    cmake --install . --component configuration
+  '';
 
   meta = with lib; {
     description = "Fast and minimalist 3D viewer using VTK";

--- a/pkgs/by-name/he/headlessDisplayHook/headless-display-hook.sh
+++ b/pkgs/by-name/he/headlessDisplayHook/headless-display-hook.sh
@@ -1,0 +1,10 @@
+appendToVar prePhases setupHeadlessDisplay
+
+setupHeadlessDisplay() {
+  export FONTCONFIG_FILE=@fontconfig_file@
+  export XDG_RUNTIME_DIR=$(mktemp -d)
+  export XDG_CACHE_HOME=$(mktemp -d)
+  export LD_LIBRARY_PATH="@ld_library_path@:${LD_LIBRARY_PATH:-}"
+  Xvfb :99 -screen 0 800x600x24 >/dev/null 2>&1 &
+  export DISPLAY=:99
+}

--- a/pkgs/by-name/he/headlessDisplayHook/package.nix
+++ b/pkgs/by-name/he/headlessDisplayHook/package.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  stdenv,
+  makeSetupHook,
+  xvfb,
+  fontconfig,
+  mesa,
+}:
+if stdenv.hostPlatform.isLinux then
+  makeSetupHook {
+    name = "headlessDisplayHook";
+    propagatedBuildInputs = [
+      xvfb
+      mesa.llvmpipeHook
+    ];
+    substitutions = {
+      fontconfig_file = "${fontconfig.out}/etc/fonts/fonts.conf";
+      ld_library_path = lib.makeLibraryPath [ mesa ];
+    };
+  } ./headless-display-hook.sh
+else
+  null

--- a/pkgs/by-name/ot/otb/package.nix
+++ b/pkgs/by-name/ot/otb/package.nix
@@ -234,9 +234,13 @@ stdenv.mkDerivation (finalAttrs: {
     ./1-otb-swig-include-itk.diff
   ];
 
-  postPatch = (
-    "substituteInPlace Modules/Core/Wrappers/SWIG/src/python/CMakeLists.txt --replace-fail '''$''{ITK_INCLUDE_DIRS}' ${otb-itk}/include/ITK-${itkMajorMinorVersion}"
-  );
+  postPatch = ''
+    substituteInPlace Modules/Core/Wrappers/SWIG/src/python/CMakeLists.txt \
+      --replace-fail ''\'''${ITK_INCLUDE_DIRS}' "${otb-itk}/include/ITK-${itkMajorMinorVersion}"
+
+    # Macro VNL_CONFIG_LEGACY_METHODS is needed to define the legacy vcl_* function.
+    sed -i '/#include "vnl\/vnl_matrix.h"/a #define VNL_CONFIG_LEGACY_METHODS 1' Modules/Core/Mosaic/include/otbMosaicFunctors.h
+  '';
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/gdcm/add-missing-losslylosslessarray-in-TestTransferSyntax.patch
+++ b/pkgs/development/libraries/gdcm/add-missing-losslylosslessarray-in-TestTransferSyntax.patch
@@ -1,0 +1,14 @@
+diff --git a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestTransferSyntax.cxx b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestTransferSyntax.cxx
+index 7ad350d..6f962ce 100644
+--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestTransferSyntax.cxx
++++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestTransferSyntax.cxx
+@@ -43,6 +43,9 @@ static const int losslylosslessarray[][3] = {
+     { 1, 0, 1 }, //    MPEG2MainProfileHighLevel
+     { 1, 0, 1 }, //    MPEG4AVCH264HighProfileLevel4_1
+     { 1, 0, 1 }, //    MPEG4AVCH264BDcompatibleHighProfileLevel4_1
++    { 0, 1, 1 }, //    HTJ2KLossless
++    { 0, 1, 1 }, //    HTJ2KRPCLLossless
++    { 1, 0, 1 }, //    HTJ2K
+ };
+ 
+ static int TestTransferSyntaxAll()

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -14,6 +14,7 @@
   openjpeg,
   zlib,
   pkg-config,
+  ctestCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -97,11 +98,10 @@ stdenv.mkDerivation rec {
       "TestRescaler2"
     ];
 
-  checkPhase = ''
-    runHook preCheck
-    ctest --exclude-regex '^(${lib.concatStringsSep "|" disabledTests})$'
-    runHook postCheck
-  '';
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
   doCheck = true;
   # note that when the test data is available to the build via `fetchSubmodules = true`,
   # a number of additional but much slower tests are enabled

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -18,14 +18,16 @@
 
 stdenv.mkDerivation rec {
   pname = if enablePython then "python-gdcm" else "gdcm";
-  version = "3.0.24";
+  version = "3.0.25";
 
   src = fetchFromGitHub {
     owner = "malaterre";
     repo = "GDCM";
     tag = "v${version}";
-    hash = "sha256-Zlb6UCP4aFZOJJNhFQBBrwzst+f37gs1zaCBMTOUgZE=";
+    hash = "sha256-PYVVlSqeAZCWvnWPqqWGQIWatMfPYqnrXc7cqi8UseU=";
   };
+
+  patches = [ ./add-missing-losslylosslessarray-in-TestTransferSyntax.patch ];
 
   cmakeFlags =
     [

--- a/pkgs/development/libraries/vtk/9.x.nix
+++ b/pkgs/development/libraries/vtk/9.x.nix
@@ -1,5 +1,0 @@
-import ./generic.nix {
-  majorVersion = "9.2";
-  minorVersion = "6";
-  sourceSha256 = "sha256-BvyNScTlb0mMQPyzilY+2NTsMTWNAQHomI8LtNU53RI=";
-}

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -1,10 +1,4 @@
 {
-  majorVersion,
-  minorVersion,
-  sourceSha256,
-  patchesToFetch ? [ ],
-}:
-{
   stdenv,
   lib,
   fetchurl,
@@ -30,7 +24,7 @@
 let
   inherit (lib) optionalString optionals;
 
-  version = "${majorVersion}.${minorVersion}";
+  version = "9.2.6";
   pythonMajor = lib.substring 0 1 python.pythonVersion;
 
 in
@@ -39,8 +33,8 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchurl {
-    url = "https://www.vtk.org/files/release/${majorVersion}/VTK-${version}.tar.gz";
-    sha256 = sourceSha256;
+    url = "https://www.vtk.org/files/release/9.2/VTK-9.2.6.tar.gz";
+    sha256 = "sha256-BvyNScTlb0mMQPyzilY+2NTsMTWNAQHomI8LtNU53RI=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -1,142 +1,330 @@
 {
-  stdenv,
   lib,
+  newScope,
+  stdenv,
   fetchurl,
+  fetchpatch2,
   cmake,
-  libGLU,
-  libGL,
-  libX11,
-  xorgproto,
-  libXt,
+  mpi,
+  fmt,
+  verdict,
+  double-conversion,
+  python3Packages,
+
+  # headers used by vtk and downstream packages
+  boost,
+  cli11,
+  eigen,
+  exprtk,
+  utf8cpp,
+  nlohmann_json,
+
+  # common data libraries
+  lz4,
+  xz,
+  zlib,
+  pugixml,
+  expat,
+  jsoncpp,
+  libxml2,
+
+  # io modules
+  ffmpeg,
+  libjpeg,
   libpng,
   libtiff,
-  fetchpatch,
-  enableQt ? false,
-  qtx11extras,
-  qttools,
-  qtdeclarative,
-  qtEnv,
+  proj,
+  sqlite,
+  libogg,
+  libharu,
+  libtheora,
+  hdf5,
+  netcdf,
+  opencascade-occt,
+
+  # threading
+  tbb,
+
+  # rendering
+  freetype,
+  fontconfig,
+  libX11,
+  libXfixes,
+  libXrender,
+  libXcursor,
+  gl2ps,
+  libGL,
+  qt5,
+  qt6,
+
+  # check
+  ctestCheckHook,
+  headlessDisplayHook,
+  mpiCheckPhaseHook,
+
+  # custom options
+  withQt5 ? false,
+  withQt6 ? false,
+  mpiSupport ? false,
   enablePython ? false,
-  python ? throw "vtk: Python support requested, but no python interpreter was given.",
-  enableEgl ? false,
 }:
-
 let
-  inherit (lib) optionalString optionals;
+  vtkPackages = lib.makeScope newScope (self: {
+    inherit
+      mpi
+      mpiSupport
+      ;
 
-  version = "9.2.6";
-  pythonMajor = lib.substring 0 1 python.pythonVersion;
-
+    hdf5 = hdf5.override {
+      inherit mpi mpiSupport;
+      cppSupport = !mpiSupport;
+    };
+    netcdf = self.callPackage netcdf.override { };
+  });
 in
-stdenv.mkDerivation {
-  pname = "vtk" + optionalString enableEgl "-egl" + optionalString enableQt "-qvtk";
-  inherit version;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vtk";
+  version = "9.4.2";
 
-  src = fetchurl {
-    url = "https://www.vtk.org/files/release/9.2/VTK-9.2.6.tar.gz";
-    sha256 = "sha256-BvyNScTlb0mMQPyzilY+2NTsMTWNAQHomI8LtNU53RI=";
-  };
-
-  nativeBuildInputs = [ cmake ];
-
-  buildInputs =
+  srcs =
     [
-      libpng
-      libtiff
+      (fetchurl {
+        url = "https://www.vtk.org/files/release/${lib.versions.majorMinor finalAttrs.version}/VTK-${finalAttrs.version}.tar.gz";
+        hash = "sha256-NsmODalrsSow/lNwgJeqlJLntm1cOzZuHI3CUeKFagI=";
+      })
     ]
-    ++ optionals enableQt [
-      (qtEnv "qvtk-qt-env" [
-        qtx11extras
-        qttools
-        qtdeclarative
-      ])
-    ]
-    ++ optionals stdenv.hostPlatform.isLinux [
-      libGLU
-      xorgproto
-      libXt
-    ]
-    ++ optionals enablePython [
-      python
+    ++ lib.optionals finalAttrs.finalPackage.doCheck [
+      (fetchurl {
+        url = "https://www.vtk.org/files/release/${lib.versions.majorMinor finalAttrs.version}/VTKData-${finalAttrs.version}.tar.gz";
+        hash = "sha256-Hgqj32POOXXSnutmmF/DczMIJPkMKZG+UpUa0qgkGxE=";
+      })
     ];
-  propagatedBuildInputs = optionals stdenv.hostPlatform.isLinux [
-    libX11
-    libGL
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/vtk/-/raw/b4d07bd7ee5917e2c32f7f056cf78472bcf1cec2/netcdf-4.9.3.patch?full_index=1";
+      hash = "sha256-h1NVeLuwAj7eUG/WSvrpXN9PtpjFQ/lzXmJncwY0r7w=";
+    })
   ];
-  # see https://github.com/NixOS/nixpkgs/pull/178367#issuecomment-1238827254
 
-  patches = map fetchpatch patchesToFetch;
-
-  # GCC 13: error: 'int64_t' in namespace 'std' does not name a type
   postPatch =
     ''
-      sed '1i#include <cstdint>' \
-        -i ThirdParty/libproj/vtklibproj/src/proj_json_streaming_writer.hpp \
-        -i IO/Image/vtkSEPReader.h
+      substituteInPlace Filters/Sources/Testing/Cxx/TestHyperTreeGridSourceDistributed.cxx \
+        --replace-fail "<char, NbTrees>" "<signed char, NbTrees>"
     ''
-    + optionalString stdenv.hostPlatform.isDarwin ''
-      sed -i 's|COMMAND vtkHashSource|COMMAND "DYLD_LIBRARY_PATH=''${VTK_BINARY_DIR}/lib" ''${VTK_BINARY_DIR}/bin/vtkHashSource-${majorVersion}|' ./Parallel/Core/CMakeLists.txt
-      sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/' ./ThirdParty/libxml2/vtklibxml2/xmlschemas.c
-      sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/g' ./ThirdParty/libxml2/vtklibxml2/xpath.c
+    # While char_traits<uint8_t> is not officially supported by any C++
+    # standard, gcc and libcxx(<19) have extensions to support the type. The
+    # C++20 standard introduces support for char_traits<char8_t>.
+    # Starting with libcxx-19, the extensions to support char_traits<T> where
+    # T is not a type specified by a C++ standard has been dropped. See
+    # https://reviews.llvm.org/D138307 for details.
+    + lib.optionalString stdenv.cc.isClang ''
+      substituteInPlace IO/Geometry/vtkGLTFDocumentLoaderInternals.cxx \
+        --replace-fail "return value == extensionUsedByModel;" "return value == extensionUsedByModel.get<std::string>();" \
+        --replace-fail "return value == extensionRequiredByModel;" "return value == extensionRequiredByModel.get<std::string>();"
+
+      echo "vtk_module_set_properties(VTK::ParallelDIY CXX_STANDARD 20)" >> Parallel/DIY/CMakeLists.txt
+      echo "vtk_module_set_properties(VTK::FiltersExtraction CXX_STANDARD 20)" >> Filters/Extraction/CMakeLists.txt
     '';
+
+  nativeBuildInputs = [ cmake ] ++ lib.optional enablePython python3Packages.python;
+
+  buildInputs = [
+    ffmpeg
+    opencascade-occt
+  ];
+
+  # propagated by VTK-vtk-module-find-packages.cmake
+  propagatedBuildInputs =
+    [
+      fmt
+      boost
+      verdict
+      double-conversion
+
+      # headers used by vtk and downstream packages
+      cli11
+      eigen
+      exprtk
+      utf8cpp
+      nlohmann_json
+
+      # common data libraries
+      lz4
+      xz
+      zlib
+      pugixml
+      expat
+      jsoncpp
+      libxml2
+
+      # io modules
+      libjpeg
+      libpng
+      libtiff
+      proj
+      sqlite
+      libogg
+      libharu
+      libtheora
+      vtkPackages.hdf5
+      vtkPackages.netcdf
+
+      # rendering
+      freetype
+      fontconfig
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libX11
+      libXfixes
+      libXrender
+      libXcursor
+      gl2ps
+      libGL
+      tbb
+    ]
+    ++ lib.optionals mpiSupport [
+      mpi
+    ]
+    ++ lib.optionals withQt5 [
+      qt5.qttools
+      qt5.qtdeclarative
+    ]
+    ++ lib.optionals withQt6 [
+      qt6.qttools
+      qt6.qtdeclarative
+    ]
+    # create meta package providing dist-info for python3Pacakges.vtk that common cmake build does not do
+    ++ lib.optionals enablePython [
+      (python3Packages.mkPythonMetaPackage {
+        inherit (finalAttrs) pname version meta;
+        dependencies =
+          with python3Packages;
+          [
+            wslink
+            numpy
+            matplotlib
+          ]
+          ++ lib.optional mpiSupport (mpi4py.override { inherit mpi; });
+      })
+    ];
+
+  # wrapper script calls qmlplugindump, crashes due to lack of minimal platform plugin
+  # Could not find the Qt platform plugin "minimal" in ""
+  preConfigure = lib.optionalString withQt5 ''
+    export QT_PLUGIN_PATH=${lib.getBin qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}
+  '';
+
+  cmakeFlags =
+    [
+      (lib.cmakeBool "VTK_VERSIONED_INSTALL" false)
+      (lib.cmakeBool "VTK_USE_MPI" mpiSupport)
+      (lib.cmakeBool "VTK_USE_EXTERNAL" true)
+      (lib.cmakeBool "VTK_MODULE_USE_EXTERNAL_VTK_fast_float" false) # required version incompatible
+      (lib.cmakeBool "VTK_MODULE_USE_EXTERNAL_VTK_pegtl" false) # required version incompatible
+      (lib.cmakeBool "VTK_MODULE_USE_EXTERNAL_VTK_cgns" false) # missing in nixpkgs
+      (lib.cmakeBool "VTK_MODULE_USE_EXTERNAL_VTK_ioss" false) # missing in nixpkgs
+      (lib.cmakeBool "VTK_MODULE_USE_EXTERNAL_VTK_token" false) # missing in nixpkgs
+      (lib.cmakeBool "VTK_MODULE_USE_EXTERNAL_VTK_xdmf2" false) # missing in nixpkgs
+      (lib.cmakeBool "VTK_MODULE_USE_EXTERNAL_VTK_xdmf3" false) # missing in nixpkgs
+      (lib.cmakeBool "VTK_MODULE_USE_EXTERNAL_VTK_gl2ps" stdenv.hostPlatform.isLinux) # External gl2ps causes failure linking to macOS OpenGL.framework
+      (lib.cmakeFeature "VTK_MODULE_ENABLE_VTK_IOOCCT" "YES")
+      (lib.cmakeFeature "VTK_MODULE_ENABLE_VTK_IOFFMPEG" "YES")
+      (lib.cmakeFeature "VTK_MODULE_ENABLE_VTK_IOXdmf2" "YES")
+      (lib.cmakeFeature "VTK_MODULE_ENABLE_VTK_IOXdmf3" "YES")
+      (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
+      (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+      (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
+      # `VTK_SMP_IMPLEMENTATION_TYPE` can be used to select one of Sequential, OpenMP, TBB, and STDThread.
+      (lib.cmakeFeature "VTK_SMP_IMPLEMENTATION_TYPE" (
+        if stdenv.hostPlatform.isLinux then "TBB" else "STDThread"
+      ))
+    ]
+    ++ lib.optionals (withQt6 || withQt5) [
+      (lib.cmakeFeature "VTK_GROUP_ENABLE_Qt" "YES")
+      (lib.cmakeFeature "VTK_QT_VERSION" "Auto") # will search for Qt6 first
+    ]
+    ++ lib.optionals enablePython [
+      (lib.cmakeBool "VTK_WRAP_PYTHON" true)
+      (lib.cmakeBool "VTK_BUILD_PYI_FILES" true)
+      (lib.cmakeFeature "VTK_PYTHON_VERSION" "3")
+      (lib.cmakeFeature "VTK_MODULE_ENABLE_VTK_WebPython" "YES")
+    ]
+    ++ lib.optionals finalAttrs.finalPackage.doCheck [
+      (lib.cmakeFeature "VTK_BUILD_TESTING" "ON")
+    ];
+
+  preCheck =
+    lib.optionalString withQt5 ''
+      export QML2_IMPORT_PATH=${lib.getBin qt5.qtdeclarative}/${qt5.qtbase.qtQmlPrefix}
+    ''
+    + lib.optionalString withQt6 ''
+      export QML2_IMPORT_PATH=${lib.getBin qt6.qtdeclarative}/${qt6.qtbase.qtQmlPrefix}
+    ''
+    # libvtkglad.so will find and load libGL.so at runtime.
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf --add-rpath ${lib.getLib libGL}/lib lib/libvtkglad${stdenv.hostPlatform.extensions.sharedLibrary}
+    '';
+
+  __darwinAllowLocalNetworking = finalAttrs.finalPackage.doCheck && mpiSupport;
+
+  nativeCheckInputs = [
+    ctestCheckHook
+    headlessDisplayHook
+  ] ++ lib.optional mpiSupport mpiCheckPhaseHook;
+
+  # Test results may vary across platforms; we primarily support x86_64-linux
+  doCheck = stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isLinux;
+
+  disabledTests = [
+    # flaky tests
+    "VTK::GUISupportQtQuickCxx-TestQQuickVTKRenderItem"
+    "VTK::GUISupportQtQuickCxx-TestQQuickVTKRenderItemWidget"
+    "VTK::GUISupportQtQuickCxx-TestQQuickVTKRenderWindow"
+    "VTK::InteractionWidgetsPython-TestTensorWidget2"
+    "VTK::RenderingOpenGL2Cxx-TestGlyph3DMapperPickability"
+    # caught SIGSEGV/SIGTERM in mpiexec
+    "VTK::FiltersParallelCxx-MPI-DistributedData"
+    "VTK::FiltersParallelCxx-MPI-DistributedDataRenderPass"
+    # caught SIGSEGV in _XFlush(libX11.so)
+    "VTK::RenderingCoreCxx-TestCompositePolyDataMapperToggleScalarVisibilities"
+    "VTK::CommonDataModelCxx-quadraticIntersection"
+  ];
+
+  # byte-compile python modules since the CMake build does not do it
+  postInstall = lib.optionalString enablePython ''
+    python -m compileall -s $out $out/${python3Packages.python.sitePackages}
+  '';
 
   dontWrapQtApps = true;
 
-  # Shared libraries don't work, because of rpath troubles with the current
-  # nixpkgs cmake approach. It wants to call a binary at build time, just
-  # built and requiring one of the shared objects.
-  # At least, we use -fPIC for other packages to be able to use this in shared
-  # objects.
-  cmakeFlags =
-    [
-      "-DCMAKE_C_FLAGS=-fPIC"
-      "-DCMAKE_CXX_FLAGS=-fPIC"
-      "-DVTK_MODULE_USE_EXTERNAL_vtkpng=ON"
-      "-DVTK_MODULE_USE_EXTERNAL_vtktiff=1"
-      "-DVTK_MODULE_ENABLE_VTK_RenderingExternal=YES"
-    ]
-    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-      "-DOPENGL_INCLUDE_DIR=${lib.getInclude libGL}/include"
-      (lib.cmakeBool "VTK_OPENGL_HAS_EGL" enableEgl)
-    ]
-    ++ [
-      "-DCMAKE_INSTALL_LIBDIR=lib"
-      "-DCMAKE_INSTALL_INCLUDEDIR=include"
-      "-DCMAKE_INSTALL_BINDIR=bin"
-      "-DVTK_VERSIONED_INSTALL=OFF"
-    ]
-    ++ optionals enableQt [
-      "-DVTK_GROUP_ENABLE_Qt:STRING=YES"
-    ]
-    ++ optionals enablePython [
-      "-DVTK_WRAP_PYTHON:BOOL=ON"
-      "-DVTK_PYTHON_VERSION:STRING=${pythonMajor}"
-    ];
+  postFixup =
+    # Remove thirdparty find module that have been provided in nixpkgs
+    ''
+      rm -rf $out/lib/cmake/vtk/patches
+      rm $out/lib/cmake/vtk/Find{double-conversion,EXPAT,Freetype,utf8cpp,LibXml2,FontConfig}.cmake
+    ''
+    # add rpath again as the rpath will be stripped in fixupPhase.
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf --add-rpath ${lib.getLib libGL}/lib $out/lib/libvtkglad${stdenv.hostPlatform.extensions.sharedLibrary}
+    '';
 
-  env = {
-    # Lots of warnings in vendored code…
-    NIX_CFLAGS_COMPILE =
-      if stdenv.cc.isClang then
-        "-Wno-error=incompatible-function-pointer-types"
-      else
-        "-Wno-error=incompatible-pointer-types";
+  passthru = {
+    inherit
+      enablePython
+      mpiSupport
+      vtkPackages
+      ;
   };
 
-  postInstall = optionalString enablePython ''
-    substitute \
-      ${./vtk.egg-info} \
-      $out/${python.sitePackages}/vtk-${version}.egg-info \
-      --subst-var-by VTK_VER "${version}"
-  '';
-
-  meta = with lib; {
+  meta = {
     description = "Open source libraries for 3D computer graphics, image processing and visualization";
     homepage = "https://www.vtk.org/";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
       tfmoraes
+      qbisi
     ];
-    platforms = platforms.unix;
-    badPlatforms = optionals enableEgl platforms.darwin;
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/libraries/vtk/vtk.egg-info
+++ b/pkgs/development/libraries/vtk/vtk.egg-info
@@ -1,5 +1,0 @@
-Metadata-Version: 2.1
-Name: vtk
-Version: @VTK_VER@
-Summary: VTK is an open-source toolkit for 3D computer graphics, image processing, and visualization
-Platform: UNKNOWN

--- a/pkgs/development/python-modules/mayavi/default.nix
+++ b/pkgs/development/python-modules/mayavi/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   envisage,
   fetchPypi,
-  numpy_1,
+  numpy,
   packaging,
   pyface,
   pygments,
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "mayavi";
-  version = "4.8.2";
+  version = "4.8.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-sQ/pFF8hxI5JAvDnRrNgOzy2lNEUVlFaRoIPIaCnQik=";
+    hash = "sha256-72nMvfWPIPGzlJMNXjoW3aSxo5rcvHb3mr0mSD0prPU=";
   };
 
   nativeBuildInputs = [ wrapQtAppsHook ];
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     apptools
     envisage
-    numpy_1
+    numpy
     packaging
     pyface
     pygments
@@ -52,6 +52,9 @@ buildPythonPackage rec {
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
+
+  # stripping the ico file on macos cause segfault
+  stripExclude = [ "*.ico" ];
 
   meta = with lib; {
     description = "3D visualization of scientific data in Python";

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -74,6 +74,15 @@ buildPythonPackage rec {
     })
   ];
 
+  # Target OpenGL/X11 is required when MATERIALX_SUPPORT is enabled.
+  postPatch = ''
+    sed -i '/find_dependency(MaterialX)/a\
+    find_dependency(OpenGL)\
+    \
+    find_dependency(X11)
+    ' pxr/pxrConfig.cmake.in
+  '';
+
   env.OSL_LOCATION = "${osl}";
 
   cmakeFlags = [
@@ -124,11 +133,6 @@ buildPythonPackage rec {
       ptex
       tbb
     ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      libGL
-      libX11
-      libXt
-    ]
     ++ lib.optionals withOsl [ osl ]
     ++ lib.optionals withUsdView [ qt6.qtbase ]
     ++ lib.optionals (withUsdView && stdenv.hostPlatform.isLinux) [ qt6.qtwayland ];
@@ -141,6 +145,11 @@ buildPythonPackage rec {
       opensubdiv
       pyopengl
       distutils
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libGL
+      libX11
+      libXt
     ]
     ++ lib.optionals (withTools || withUsdView) [
       pyside-tools-uic

--- a/pkgs/development/python-modules/pyvista/default.nix
+++ b/pkgs/development/python-modules/pyvista/default.nix
@@ -43,7 +43,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "pyvista" ];
 
   meta = with lib; {
-    broken = pythonAtLeast "3.13"; # segfault
     description = "Easier Pythonic interface to VTK";
     homepage = "https://pyvista.org";
     changelog = "https://github.com/pyvista/pyvista/releases/tag/${src.tag}";

--- a/pkgs/development/python-modules/wslink/default.nix
+++ b/pkgs/development/python-modules/wslink/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  msgpack,
+}:
+
+buildPythonPackage rec {
+  pname = "wslink";
+  version = "2.3.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kitware";
+    repo = "wslink";
+    tag = "v${version}";
+    hash = "sha256-m820SiPu3fTAWGI74wtXm6b8oNn4W1wsthQZXAsg1VM=";
+  };
+
+  # add missing version string in dist-info
+  postPatch = ''
+    sed -i "/name *= */a\    version='${version}'," python/setup.py
+  '';
+
+  preConfigure = ''
+    cd python
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    msgpack
+  ];
+
+  pythonImportsCheck = [ "wslink" ];
+
+  # doCheck need interacting with the http server
+  doCheck = false;
+
+  meta = {
+    description = "Python/JavaScript library for communicating over WebSocket";
+    homepage = "https://github.com/Kitware/wslink";
+    changelog = "https://github.com/Kitware/wslink/releases/tag/${src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2001,6 +2001,7 @@ mapAliases {
   vocal = throw "'vocal' has been archived upstream. Consider using 'gnome-podcasts' or 'kasts' instead."; # Added 2025-04-12
   void = throw "'void' has been removed due to lack of upstream maintenance"; # Added 2025-01-25
   volnoti = throw "'volnoti' has been removed due to lack of maintenance upstream."; # Added 2024-12-04
+  vtk_9_egl = lib.warnOnInstantiate "vtk_9 is built with EGL enabled now, use vtk_9 instead" vtk_9; # Added 2025-05-22
   vuze = throw "'vuze' was removed because it is unmaintained upstream and insecure (CVE-2018-13417). BiglyBT is a maintained fork."; # Added 2024-11-22
   vwm = throw "'vwm' was removed as it is broken and not maintained upstream"; # Added 2025-05-17
   inherit (libsForQt5.mauiPackages) vvave; # added 2022-05-17

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -633,7 +633,7 @@ mapAliases {
   eww-wayland = lib.warnOnInstantiate "eww now can build for X11 and wayland simultaneously, so `eww-wayland` is deprecated, use the normal `eww` package instead." eww;
 
   ### F ###
-
+  f3d_egl = throw "f3d is now by default built with EGL enabled VTK, use f3d instead"; # added 2025-05-20
   factor-lang-scope = throw "'factor-lang-scope' has been renamed to 'factorPackages'"; # added 2024-11-28
   fahcontrol = throw "fahcontrol has been removed because the download is no longer available"; # added 2024-09-24
   fahviewer = throw "fahviewer has been removed because the download is no longer available"; # added 2024-09-24

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9740,7 +9740,7 @@ with pkgs;
     wine = wineWowPackages.staging;
   };
 
-  vtk_9 = libsForQt5.callPackage ../development/libraries/vtk/9.x.nix {
+  vtk_9 = libsForQt5.callPackage ../development/libraries/vtk {
     stdenv = if stdenv.cc.isClang then llvmPackages_17.stdenv else stdenv;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9740,17 +9740,17 @@ with pkgs;
     wine = wineWowPackages.staging;
   };
 
-  vtk_9 = libsForQt5.callPackage ../development/libraries/vtk {
-    stdenv = if stdenv.cc.isClang then llvmPackages_17.stdenv else stdenv;
-  };
+  vtk_9 = libsForQt5.callPackage ../development/libraries/vtk { };
 
-  vtk_9_withQt5 = vtk_9.override { enableQt = true; };
+  vtk_9_withQt5 = vtk_9.override { withQt5 = true; };
+
+  vtk_9_withQt6 = vtk_9.override { withQt6 = true; };
 
   vtk = vtk_9;
 
-  vtk_9_egl = vtk_9.override { enableEgl = true; };
-
   vtkWithQt5 = vtk_9_withQt5;
+
+  vtkWithQt6 = vtk_9_withQt6;
 
   vulkan-caps-viewer = libsForQt5.callPackage ../tools/graphics/vulkan-caps-viewer { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2170,8 +2170,6 @@ with pkgs;
     # If buildGoModule is overridden, provide a matching version of the go attribute
   };
 
-  f3d_egl = f3d.override { vtk_9 = vtk_9_egl; };
-
   fast-cli = nodePackages.fast-cli;
 
   fdroidcl = pkgs.callPackage ../development/mobile/fdroidcl { };

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -234,6 +234,7 @@ mapAliases ({
   ev3dev2 = python-ev3dev2; # added 2023-06-19
   evernote = throw "evernote is intended for use with Python 2.X";
   eyeD3 = eyed3; # added 2024-01-03
+  f3d_egl = throw "f3d is now by default built with EGL enabled VTK, use f3d instead"; # added 2025-05-20
   Fabric = fabric; # addedd 2023-02-19
   face_recognition = face-recognition; # added 2022-10-15
   face_recognition_models = face-recognition-models; # added 2022-10-15

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19146,6 +19146,8 @@ self: super: with self; {
 
   wsgitools = callPackage ../development/python-modules/wsgitools { };
 
+  wslink = callPackage ../development/python-modules/wslink { };
+
   wsme = callPackage ../development/python-modules/wsme { };
 
   wsproto = callPackage ../development/python-modules/wsproto { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18824,8 +18824,8 @@ self: super: with self; {
   vtjp = callPackage ../development/python-modules/vtjp { };
 
   vtk = toPythonModule (
-    pkgs.vtk_9.override {
-      inherit python;
+    pkgs.vtk.override {
+      python3Packages = self;
       enablePython = true;
     }
   );

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8623,12 +8623,10 @@ self: super: with self; {
 
   mayavi = pkgs.libsForQt5.callPackage ../development/python-modules/mayavi {
     inherit buildPythonPackage pythonOlder pythonAtLeast;
-    # when next release contains numpy2 support unpin
-    # https://github.com/enthought/mayavi/pull/1315
     inherit (self)
       pyface
       pygments
-      numpy_1
+      numpy
       packaging
       vtk
       traitsui

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4731,13 +4731,6 @@ self: super: with self; {
     }
   );
 
-  f3d_egl = toPythonModule (
-    pkgs.f3d_egl.override {
-      withPythonBinding = true;
-      python3Packages = self;
-    }
-  );
-
   f5-icontrol-rest = callPackage ../development/python-modules/f5-icontrol-rest { };
 
   f5-sdk = callPackage ../development/python-modules/f5-sdk { };


### PR DESCRIPTION
The vtk packages has been outdated for a while since upgrading the vtk packages may broke lots of package depends on it.
Also, the current vtk package recipe is not tested, we are not sure if updating vtk source to 9.4.2 also works fine at runtime.

This pr add vtk 9.4.2 that has been tested/fixed on x86-64-linux platform, it works fine with downstream pyvsita on both x86-64-linux and aarch64-darwin platform.

The check depends on the newly created hooks headlessDIsplayHook that can be reused by downstream pyvista* packages in nativeCheckInputs.

# added 2025-05-19
the vtk-config.cmake requires nearly all its buildInputs as propagatedBuildInputs, for downstream package maintainers that use vtk as buildInputs, please check your buildInputs, some maybe required by the vtk-config.cmake and they are now propagated by vtk, so you should remove thouse deplicated buildInputs. e.g.
```
expat
libjpeg
utf8cpp
...
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
