### PR TITLE
Add myself as a maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16744,6 +16744,12 @@
     githubId = 7026881;
     name = "Jarosław Jedynak";
   };
+  msoos = {
+    email = "soos.mate@gmail.com";
+    github = "msoos";
+    githubId = 1334841;
+    name = "Mate Soos";
+  };
   mstarzyk = {
     email = "mstarzyk@gmail.com";
     github = "mstarzyk";


### PR DESCRIPTION
## Things done

I am adding myself as a maintainer. I am the author of several packages' source already in Nix: 

[cryptominisat](https://search.nixos.org/packages?channel=24.11&show=cryptominisat&from=0&size=50&sort=relevance&type=packages&query=cryptominisat)
[approxmc](https://search.nixos.org/packages?channel=24.11&show=approxmc&from=0&size=50&sort=relevance&type=packages&query=approxmc)

I would like to help maintain them, e.g. by updating them when I release a new version on GitHub. Currently, they are slightly behind. I would also like to add a new package, [Ganak](https://github.com/meelgroup/ganak/), which is also a state-of-the-art tool, in this case for exact propositional model counting. 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
