### PR TITLE
shibboleth-sp: fix build for Clang >=19

### DIFF
--- a/pkgs/by-name/sh/shibboleth-sp/package.nix
+++ b/pkgs/by-name/sh/shibboleth-sp/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchgit,
+  fetchpatch,
   autoreconfHook,
   boost,
   fcgi,
@@ -23,6 +24,26 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "1qb4dbz5gk10b9w1rf6f4vv7c2wb3a8bfzif6yiaq96ilqad7gdr";
   };
+
+  # Upgrade to Clang 19 (and thereby LLVM19) causes `std::char_traits` to now be present,
+  # making `char_traits` references ambiguous due to both `std` and `xmltooling` exporting this symbol,
+  # and the file in question uses both `using namespace std;` and `using namespace xmltooling;`
+  # The patches below result in `xmltooling` being removed.
+  # As `char_traits` is a compile time construct, no runtime repercussions can stem from this.
+  # See https://shibboleth.atlassian.net/browse/SSPCPP-998 for a related discussion.
+  patches = lib.optionals (stdenv.cc.isClang && lib.versionAtLeast stdenv.cc.version "19") [
+    (fetchpatch {
+      name = "char-traits-ambig-1";
+      url = "https://git.shibboleth.net/view/?p=cpp-sp.git;a=blobdiff_plain;f=shibsp/util/IPRange.cpp;h=532cf9e94c915667c091d127c696979f63939eb5;hp=d6f00bc36ea25997817a2308314bcdbea572936f;hb=49cd05fa6d9935a45069fa555db7a26ca77d23db;hpb=293ff2ab6454b0946b3b03719efa132bff461f1f";
+      hash = "sha256-ZF0jsZJoHaxaPPjVbT6Wlq+wjyPQLTnEKcUxONji/hE=";
+    })
+
+    (fetchpatch {
+      name = "char-traits-ambig-2";
+      url = "https://git.shibboleth.net/view/?p=cpp-sp.git;a=blobdiff_plain;f=shibsp/util/IPRange.cpp;h=da954870eb03c7cd054ecc5c52a6c1f011787760;hp=354010d5f5e533262cb385ea16756df53fe0c241;hb=793663a67aaa4e9a4aa9172728d924f8cec45cf6;hpb=a43814935030930c49b7a08f5515b861906525c7";
+      hash = "sha256-4iGwCGpGwAkriOwQmh5AgvHLX1o39NuQ2l4sAJbD2bc=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/403336
Depends on #407880 for the package to build successfully.

Conditionally patches out the headers that provide a conflicting `char_traits` symbol, which broke compilation, as the file contains two `using namespace`'s for namespaces that export this symbol.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
