### PR TITLE
postgresql.withPackages.pg_config: fix paths

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/omnigres.nix
+++ b/pkgs/servers/sql/postgresql/ext/omnigres.nix
@@ -48,8 +48,6 @@ postgresqlBuildExtension (finalAttrs: {
   cmakeFlags = [
     "-DOPENSSL_CONFIGURED=1"
     "-DPG_CONFIG=${pgWithExtensions.pg_config}/bin/pg_config"
-    "-DPostgreSQL_EXTENSION_DIR=${pgWithExtensions}/share/postgresql/extension/"
-    "-DPostgreSQL_PACKAGE_LIBRARY_DIR=${pgWithExtensions}/lib/"
     "-DPostgreSQL_TARGET_EXTENSION_DIR=${builtins.placeholder "out"}/share/postgresql/extension/"
     "-DPostgreSQL_TARGET_PACKAGE_LIBRARY_DIR=${builtins.placeholder "out"}/lib/"
   ];

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -610,66 +610,78 @@ let
     f:
     let
       installedExtensions = f postgresql.pkgs;
-    in
-    buildEnv {
-      name = "${postgresql.pname}-and-plugins-${postgresql.version}";
-      paths = installedExtensions ++ [
-        postgresql
-        postgresql.man # in case user installs this into environment
-      ];
+      finalPackage = buildEnv {
+        name = "${postgresql.pname}-and-plugins-${postgresql.version}";
+        paths = installedExtensions ++ [
+          # consider keeping in-sync with `postBuild` below
+          postgresql
+          postgresql.man # in case user installs this into environment
+        ];
 
-      pathsToLink = [
-        "/"
-        "/bin"
-      ];
+        pathsToLink = [
+          "/"
+          "/bin"
+          "/share/postgresql/extension"
+          # Unbreaks Omnigres' build system
+          "/share/postgresql/timezonesets"
+          "/share/postgresql/tsearch_data"
+        ];
 
-      nativeBuildInputs = [ makeBinaryWrapper ];
-      postBuild =
-        let
-          args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
-        in
-        ''
-          wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
-        '';
+        nativeBuildInputs = [ makeBinaryWrapper ];
+        postBuild =
+          let
+            args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
+          in
+          ''
+            wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
 
-      passthru = {
-        inherit installedExtensions;
-        inherit (postgresql)
-          pg_config
-          pkgs
-          psqlSchema
-          version
-          ;
+            mkdir -p "$out/nix-support"
+            substitute "${lib.getDev postgresql}/nix-support/pg_config.env" "$out/nix-support/pg_config.env" \
+              --replace-fail "${postgresql}" "$out" \
+              --replace-fail "${postgresql.man}" "$out"
+          '';
 
-        withJIT = postgresqlWithPackages {
-          inherit
-            buildEnv
-            lib
-            makeBinaryWrapper
-            postgresql
+        passthru = {
+          inherit installedExtensions;
+          inherit (postgresql)
+            pkgs
+            psqlSchema
+            version
             ;
-        } (_: installedExtensions ++ [ postgresql.jit ]);
-        withoutJIT = postgresqlWithPackages {
-          inherit
-            buildEnv
-            lib
-            makeBinaryWrapper
-            postgresql
-            ;
-        } (_: lib.remove postgresql.jit installedExtensions);
 
-        withPackages =
-          f':
-          postgresqlWithPackages {
+          pg_config = postgresql.pg_config.override { inherit finalPackage; };
+
+          withJIT = postgresqlWithPackages {
             inherit
               buildEnv
               lib
               makeBinaryWrapper
               postgresql
               ;
-          } (ps: installedExtensions ++ f' ps);
+          } (_: installedExtensions ++ [ postgresql.jit ]);
+          withoutJIT = postgresqlWithPackages {
+            inherit
+              buildEnv
+              lib
+              makeBinaryWrapper
+              postgresql
+              ;
+          } (_: lib.remove postgresql.jit installedExtensions);
+
+          withPackages =
+            f':
+            postgresqlWithPackages {
+              inherit
+                buildEnv
+                lib
+                makeBinaryWrapper
+                postgresql
+                ;
+            } (ps: installedExtensions ++ f' ps);
+        };
       };
-    };
+    in
+    finalPackage;
 
 in
 # passed by <major>.nix

--- a/pkgs/servers/sql/postgresql/pg_config.env.mk
+++ b/pkgs/servers/sql/postgresql/pg_config.env.mk
@@ -9,5 +9,6 @@ pg_config.env: $(top_builddir)/src/port/pg_config_paths.h | $(top_builddir)/src/
 	echo "LDFLAGS_EX=\"$(LDFLAGS_EX)\"" >>$@
 	echo "LDFLAGS_SL=\"$(LDFLAGS_SL)\"" >>$@
 	echo "LIBS=\"$(LIBS)\"" >>$@
+	echo "PGXS=\"$(dev)/lib/pgxs/src/makefiles/pgxs.mk\"" >>$@
 	cat $(top_builddir)/src/port/pg_config_paths.h $(top_builddir)/src/include/pg_config.h \
 	  | sed -nE 's/^#define ([^ ]+) ("?)(.*)\2$$/\1="\3"/p' >>$@

--- a/pkgs/servers/sql/postgresql/pg_config.sh
+++ b/pkgs/servers/sql/postgresql/pg_config.sh
@@ -70,7 +70,7 @@ for opt; do
         --mandir)               show+=("$MANDIR") ;;
         --sharedir)             show+=("$PGSHAREDIR") ;;
         --sysconfdir)           show+=("$SYSCONFDIR") ;;
-        --pgxs)                 show+=("@postgresql-dev@/lib/pgxs/src/makefiles/pgxs.mk") ;;
+        --pgxs)                 show+=("$PGXS") ;;
         --configure)            show+=("$CONFIGURE_ARGS") ;;
         --cc)                   show+=("$CC") ;;
         --cppflags)             show+=("$CPPFLAGS") ;;
@@ -108,7 +108,7 @@ LOCALEDIR = $LOCALEDIR
 MANDIR = $MANDIR
 SHAREDIR = $PGSHAREDIR
 SYSCONFDIR = $SYSCONFDIR
-PGXS = @postgresql-dev@/lib/pgxs/src/makefiles/pgxs.mk
+PGXS = $PGXS
 CONFIGURE = $CONFIGURE_ARGS
 CC = $CC
 CPPFLAGS = $CPPFLAGS


### PR DESCRIPTION
Previously, `pg_config` would report the paths of the underlying `postgresql` derivation and not the paths of the `buildEnv` that `postgresql.withPackages` creates.

That's a problem when users of `pg_config` use it to find PostgreSQL's `sharedir`, in which they'd like to find the extensions added via `withPackages`. Those are only linked into the created `buildEnv`, but not available in the `postgresql` derivation.

By providing our own `nix-support/pg_config.env` file, we can swap out those paths. We also do the same for the -man output, because this output is linked into `buildEnv` as well. Other paths, which are not available in the `buildEnv` environment, will still link to the original `postgresql` derivation. Win-win!

This came up in #404027, where it's currently required to pass the following `cmakeFlags`:
```nix
    "-DPG_CONFIG=${pgWithExtensions.pg_config}/bin/pg_config"
    "-DPostgreSQL_EXTENSION_DIR=${lib.getDev pgWithExtensions}/share/postgresql/extension/"
    "-DPostgreSQL_PACKAGE_LIBRARY_DIR=${lib.getDev pgWithExtensions}/lib/"
```

Even though `pg_config` is made available, the two paths still need to be specified explicitly, because they point to the wrong location.

Note: This is a fix, that should allow omnigres to only require the first line about pg_config. However, it currently still breaks the otherwise succeeding build in that PR with, what I suspect, an upstream bug in their cmake files. I still think we should do this, because it's the correct thing to do.

(review with whitespace disabled, most of that is just indentation)

## Things done

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
