### PR TITLE
epiphany: Various Pantheon fixes

### DIFF
--- a/pkgs/by-name/ep/epiphany/package.nix
+++ b/pkgs/by-name/ep/epiphany/package.nix
@@ -5,6 +5,7 @@
   ninja,
   gettext,
   fetchurl,
+  fetchpatch,
   pkg-config,
   gtk4,
   glib,
@@ -43,6 +44,22 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://gnome/sources/epiphany/${lib.versions.major finalAttrs.version}/epiphany-${finalAttrs.version}.tar.xz";
     hash = "sha256-2ilT5+K3O/dHPAozl5EE15NieVKV6qCio46hiFN9rxM=";
   };
+
+  patches = [
+    # shell: Fix startup crash on Pantheon
+    # https://gitlab.gnome.org/GNOME/epiphany/-/merge_requests/1818
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/epiphany/-/commit/da4437beb7f1fbc9c2fa3d4629b8c826d484835e.patch";
+      hash = "sha256-meufd5gnhLcK0dgIXEMDnid9e1R2M1D3jZ9Yoh6YobM=";
+    })
+
+    # action-bar-end: Fix startup crash on Pantheon
+    # https://gitlab.gnome.org/GNOME/epiphany/-/merge_requests/1819
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/epiphany/-/commit/d69866854b315123c8832fae58c6de008da20ea0.patch";
+      hash = "sha256-GnZQC4rtBYRr+x9mF8pCFDcDOjEJj+27ECdXBNL42kQ=";
+    })
+  ];
 
   nativeBuildInputs = [
     desktop-file-utils

--- a/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
@@ -12,13 +12,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "elementary-gtk-theme";
-  version = "8.2.0";
+  version = "8.2.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "stylesheet";
     rev = version;
-    sha256 = "sha256-l7E5o7JNqfJZzKpyvsjIVd2i9fwLh4Qn8oJ/S5RlFQ8=";
+    sha256 = "sha256-ymgSe4LKtbJVwmZJOwer1Geb/VgYltp+tSNHkWtaMlg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
~~Both MRs are not merged upstream yet.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

