### PR TITLE
pixivfe: init at 3.0.1

### DIFF
--- a/pkgs/by-name/pi/pixivfe/package.nix
+++ b/pkgs/by-name/pi/pixivfe/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitea,
+  buildGoModule,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pixivfe";
+  version = "3.0.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "PixivFE";
+    repo = "PixivFE";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jqS/pkoPgg9QHD4m7NIN8XFRkWMLr1xkAUCn82FOr18=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      echo "$(git show -s --format=%cd --date=format:"%Y.%m.%d")-$(git rev-parse --short HEAD)" > $out/COMMIT
+      rm -rf .git
+    '';
+  };
+
+  vendorHash = "sha256-CckbPZCpGyIgkHgf7XqWeYj7d9ujnNWPVyeYS3QRd3c=";
+
+  subPackages = [ "." ];
+
+  preBuild = ''
+    ldflags+=" -X codeberg.org/pixivfe/pixivfe/config.revision=$(cat COMMIT)"
+  '';
+
+  # Tests are supposed to be run with an instance running
+  doCheck = false;
+
+  meta = {
+    description = "Open source alternative frontend for Pixiv";
+    homepage = "https://codeberg.org/PixivFE/PixivFE";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ vnpower ];
+    platforms = with lib.platforms; unix;
+    mainProgram = "pixivfe";
+  };
+})


### PR DESCRIPTION
Adds [PixivFE](https://codeberg.org/PixivFE/PixivFE), an open source alternative frontend for Pixiv.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
