### PR TITLE
workflows/periodic-merge: set custom name for haskell-updates merge

### DIFF
--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -35,10 +35,12 @@ jobs:
             into: staging-next-25.05
           - from: staging-next-25.05
             into: staging-25.05
-          - from: master staging
+          - name: merge-base(master,staging) → haskell-updates
+            from: master staging
             into: haskell-updates
     uses: ./.github/workflows/periodic-merge.yml
     with:
       from: ${{ matrix.pairs.from }}
       into: ${{ matrix.pairs.into }}
+    name: ${{ matrix.pairs.name || format('{0} → {1}', matrix.pairs.from, matrix.pairs.into) }}
     secrets: inherit

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -35,4 +35,5 @@ jobs:
     with:
       from: ${{ matrix.pairs.from }}
       into: ${{ matrix.pairs.into }}
+    name: ${{ format('{0} → {1}', matrix.pairs.from, matrix.pairs.into) }}
     secrets: inherit

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   merge:
     runs-on: ubuntu-24.04-arm
-    name: ${{ inputs.from }} → ${{ inputs.into }}
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered
       # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs


### PR DESCRIPTION
The simple name can lead to [confusion](https://github.com/NixOS/nixpkgs/pull/404362#issuecomment-2886837675). Adding an explicit override to make it more clear.

While this is less confusing, the problem with the longer title is this:

![2025-05-17T15:08:12,859185149+02:00](https://github.com/user-attachments/assets/44640a3b-b751-429b-8b51-be5f399f4c08)

We can't even see the `haskell-updates` part.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
