### PR TITLE
glibc: use secure_getenv for loading locale archive

### DIFF
--- a/pkgs/development/libraries/glibc/nix-locale-archive.patch
+++ b/pkgs/development/libraries/glibc/nix-locale-archive.patch
@@ -1,8 +1,8 @@
 diff --git a/locale/loadarchive.c b/locale/loadarchive.c
-index 512769eaec..171dbb4ad9 100644
+index 452e3eb6e3..e2016a8aab 100644
 --- a/locale/loadarchive.c
 +++ b/locale/loadarchive.c
-@@ -123,6 +123,23 @@ calculate_head_size (const struct locarhead *h)
+@@ -123,6 +123,25 @@ calculate_head_size (const struct locarhead *h)
    return MAX (namehash_end, MAX (string_end, locrectab_end));
  }
  
@@ -10,12 +10,14 @@ index 512769eaec..171dbb4ad9 100644
 +open_locale_archive (void)
 +{
 +  int fd = -1;
-+  char *versioned_path = getenv ("LOCALE_ARCHIVE_2_27");
-+  char *path = getenv ("LOCALE_ARCHIVE");
++  char *versioned_path = secure_getenv ("LOCALE_ARCHIVE_2_27");
++  char *path = secure_getenv ("LOCALE_ARCHIVE");
 +  if (versioned_path)
 +    fd = __open_nocancel (versioned_path, O_RDONLY|O_LARGEFILE|O_CLOEXEC);
 +  if (path && fd < 0)
 +    fd = __open_nocancel (path, O_RDONLY|O_LARGEFILE|O_CLOEXEC);
++  if (fd < 0)
++    fd = __open_nocancel("/run/current-system/sw/lib/locale/locale-archive", O_RDONLY|O_LARGEFILE|O_CLOEXEC);
 +  if (fd < 0)
 +    fd = __open_nocancel ("/usr/lib/locale/locale-archive", O_RDONLY|O_LARGEFILE|O_CLOEXEC);
 +  if (fd < 0)
@@ -26,7 +28,7 @@ index 512769eaec..171dbb4ad9 100644
  
  /* Find the locale *NAMEP in the locale archive, and return the
     internalized data structure for its CATEGORY data.  If this locale has
-@@ -202,7 +219,7 @@ _nl_load_locale_from_archive (int category, const char **namep)
+@@ -202,7 +221,7 @@ _nl_load_locale_from_archive (int category, const char **namep)
        archmapped = &headmap;
  
        /* The archive has never been opened.  */
@@ -35,7 +37,7 @@ index 512769eaec..171dbb4ad9 100644
        if (fd < 0)
  	/* Cannot open the archive, for whatever reason.  */
  	return NULL;
-@@ -397,8 +414,7 @@ _nl_load_locale_from_archive (int category, const char **namep)
+@@ -397,8 +416,7 @@ _nl_load_locale_from_archive (int category, const char **namep)
  	  if (fd == -1)
  	    {
  	      struct __stat64_t64 st;
@@ -46,10 +48,10 @@ index 512769eaec..171dbb4ad9 100644
  		/* Cannot open the archive, for whatever reason.  */
  		return NULL;
 diff --git a/locale/programs/locale.c b/locale/programs/locale.c
-index ca0a95be99..e484783402 100644
+index c7ee1874e8..af20fbac3e 100644
 --- a/locale/programs/locale.c
 +++ b/locale/programs/locale.c
-@@ -633,6 +633,24 @@ nameentcmp (const void *a, const void *b)
+@@ -632,6 +632,26 @@ nameentcmp (const void *a, const void *b)
  }
  
  
@@ -57,12 +59,14 @@ index ca0a95be99..e484783402 100644
 +open_locale_archive (void)
 +{
 +  int fd = -1;
-+  char *versioned_path = getenv ("LOCALE_ARCHIVE_2_27");
-+  char *path = getenv ("LOCALE_ARCHIVE");
++  char *versioned_path = secure_getenv ("LOCALE_ARCHIVE_2_27");
++  char *path = secure_getenv ("LOCALE_ARCHIVE");
 +  if (versioned_path)
 +    fd = open64 (versioned_path, O_RDONLY);
 +  if (path && fd < 0)
 +    fd = open64 (path, O_RDONLY);
++  if (fd < 0)
++    fd = open64 ("/run/current-system/sw/lib/locale/locale-archive", O_RDONLY|O_LARGEFILE|O_CLOEXEC);
 +  if (fd < 0)
 +    fd = open64 ("/usr/lib/locale/locale-archive", O_RDONLY);
 +  if (fd < 0)
@@ -74,7 +78,7 @@ index ca0a95be99..e484783402 100644
  static int
  write_archive_locales (void **all_datap, char *linebuf)
  {
-@@ -645,7 +663,7 @@ write_archive_locales (void **all_datap, char *linebuf)
+@@ -644,7 +664,7 @@ write_archive_locales (void **all_datap, char *linebuf)
    int fd, ret = 0;
    uint32_t cnt;
  
@@ -84,10 +88,10 @@ index ca0a95be99..e484783402 100644
      return 0;
  
 diff --git a/locale/programs/locarchive.c b/locale/programs/locarchive.c
-index f38e835c52..779a3199fc 100644
+index 8d79a1b6d1..93118c52e3 100644
 --- a/locale/programs/locarchive.c
 +++ b/locale/programs/locarchive.c
-@@ -117,6 +117,22 @@ prepare_address_space (int fd, size_t total, size_t *reserved, int *xflags,
+@@ -116,6 +116,22 @@ prepare_address_space (int fd, size_t total, size_t *reserved, int *xflags,
  }
  
  
@@ -95,8 +99,8 @@ index f38e835c52..779a3199fc 100644
 +open_locale_archive (const char * archivefname, int flags)
 +{
 +  int fd = -1;
-+  char *versioned_path = getenv ("LOCALE_ARCHIVE_2_27");
-+  char *path = getenv ("LOCALE_ARCHIVE");
++  char *versioned_path = secure_getenv ("LOCALE_ARCHIVE_2_27");
++  char *path = secure_getenv ("LOCALE_ARCHIVE");
 +  if (versioned_path)
 +    fd = open64 (versioned_path, flags);
 +  if (path && fd < 0)
@@ -110,7 +114,7 @@ index f38e835c52..779a3199fc 100644
  static void
  create_archive (const char *archivefname, struct locarhandle *ah)
  {
-@@ -578,7 +594,7 @@ open_archive (struct locarhandle *ah, bool readonly)
+@@ -577,7 +593,7 @@ open_archive (struct locarhandle *ah, bool readonly)
    while (1)
      {
        /* Open the archive.  We must have exclusive write access.  */


### PR DESCRIPTION
To quote `getenv(3)`:

> The  GNU-specific  secure_getenv()  function  is just like
> getenv() except that it returns NULL in cases where "secure
> execution" is required.

One of these cases is running in setuid mode. In this case, one could make `sudo` load an arbitrary file as locale archive by modifying the LOCALE_ARCHIVE env variable accordingly.

After consultation with the security team we came to the conclusion that this is not exploitable by itself since it'd need another issue that can be triggered by a maliciously crafted locale archive. Since this is a valid issue nonetheless[1], I decided to fix it, but go through the normal PR & staging lifecycle.

This patch also adds another fallback to
`/run/current-system/sw/lib/locale/locale-archive`: otherwise `sudo` would fail to load any locale archive since that would be in LOCALE_ARCHIVE/LOCALE_ARCHIVE_2_27 and thus setuid programs would regress on translated output.

Thank you to Elliot Cameron for reporting this.

[1] glibc's internal environment filtering also prevents setuid
    processes to use certain locale settings from the environment
    such as LOCPATH.

---

cc @mweinelt @risicle @de11n 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
