### PR TITLE
nixos/filebrowser: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -12,6 +12,8 @@
 
 - [gtklock](https://github.com/jovanlanik/gtklock), a GTK-based lockscreen for Wayland. Available as [programs.gtklock](#opt-programs.gtklock.enable).
 
+- [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files. Available as [services.filebrowser](#opt-services.filebrowser.enable).
+
 - [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).
 
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1535,6 +1535,7 @@
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ethercalc.nix
   ./services/web-apps/fider.nix
+  ./services/web-apps/filebrowser.nix
   ./services/web-apps/filesender.nix
   ./services/web-apps/firefly-iii-data-importer.nix
   ./services/web-apps/firefly-iii.nix

--- a/nixos/modules/services/web-apps/filebrowser.nix
+++ b/nixos/modules/services/web-apps/filebrowser.nix
@@ -1,0 +1,137 @@
+{
+  config,
+  pkgs,
+  lib,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.filebrowser;
+  inherit (lib) types;
+  format = pkgs.formats.json { };
+in
+{
+  options = {
+    services.filebrowser = {
+      enable = lib.mkEnableOption "FileBrowser";
+
+      package = lib.mkPackageOption pkgs "filebrowser" { };
+
+      openFirewall = lib.mkEnableOption "opening firewall ports for FileBrowser";
+
+      settings = lib.mkOption {
+        default = { };
+        description = ''
+          Settings for FileBrowser.
+          Refer to <https://filebrowser.org/cli/filebrowser#options> for all supported values.
+        '';
+        type = types.submodule {
+          freeformType = format.type;
+
+          options = {
+            address = lib.mkOption {
+              default = "localhost";
+              description = ''
+                The address to listen on.
+              '';
+              type = types.str;
+            };
+
+            port = lib.mkOption {
+              default = 8080;
+              description = ''
+                The port to listen on.
+              '';
+              type = types.port;
+            };
+
+            root = lib.mkOption {
+              default = "/var/lib/filebrowser/data";
+              description = ''
+                The directory where FileBrowser stores files.
+              '';
+              type = types.path;
+            };
+
+            database = lib.mkOption {
+              default = "/var/lib/filebrowser/database.db";
+              description = ''
+                The path to FileBrowser's Bolt database.
+              '';
+              type = types.path;
+            };
+
+            cache-dir = lib.mkOption {
+              default = "/var/cache/filebrowser";
+              description = ''
+                The directory where FileBrowser stores its cache.
+              '';
+              type = types.path;
+              readOnly = true;
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd = {
+      services.filebrowser = {
+        after = [ "network.target" ];
+        description = "FileBrowser";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart =
+            let
+              args = [
+                (lib.getExe cfg.package)
+                "--config"
+                (format.generate "config.json" cfg.settings)
+              ];
+            in
+            utils.escapeSystemdExecArgs args;
+
+          StateDirectory = "filebrowser";
+          CacheDirectory = "filebrowser";
+          WorkingDirectory = cfg.settings.root;
+
+          DynamicUser = true;
+
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          MemoryDenyWriteExecute = true;
+          LockPersonality = true;
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          DevicePolicy = "closed";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+        };
+      };
+
+      tmpfiles.settings.filebrowser =
+        lib.genAttrs
+          [
+            cfg.settings.root
+            (builtins.dirOf cfg.settings.database)
+          ]
+          (_: {
+            d.mode = "0700";
+          });
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.settings.port ];
+  };
+
+  meta.maintainers = [
+    lib.maintainers.lukaswrz
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -466,6 +466,7 @@ in
   ferretdb = handleTest ./ferretdb.nix { };
   fider = runTest ./fider.nix;
   filesender = runTest ./filesender.nix;
+  filebrowser = runTest ./filebrowser.nix;
   filesystems-overlayfs = runTest ./filesystems-overlayfs.nix;
   firefly-iii = runTest ./firefly-iii.nix;
   firefly-iii-data-importer = runTest ./firefly-iii-data-importer.nix;

--- a/nixos/tests/filebrowser.nix
+++ b/nixos/tests/filebrowser.nix
@@ -1,0 +1,27 @@
+{
+  name = "filebrowser";
+
+  nodes.machine = {
+    services.filebrowser = {
+      enable = true;
+      settings = {
+        address = "localhost";
+        port = 8080;
+        database = "/var/lib/filebrowser/filebrowser.db";
+      };
+    };
+  };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("filebrowser.service")
+    machine.wait_for_open_port(8080)
+
+    machine.succeed("curl --fail http://localhost:8080/")
+
+    machine.succeed("stat /var/lib/filebrowser/filebrowser.db")
+
+    machine.shutdown()
+  '';
+}

--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -6,6 +6,8 @@
 
   nodejs_22,
   pnpm_9,
+
+  nixosTests,
 }:
 
 let
@@ -70,6 +72,9 @@ buildGo123Module {
 
   passthru = {
     inherit frontend;
+    tests = {
+      inherit (nixosTests) filebrowser;
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
This is a NixOS module for [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files.

Prior art:
* Closes #289750 (closed)
* Closes #306615 (inactive)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
