### PR TITLE
nixos/systemd: no systemd-journald-audit on containers

### DIFF
--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -133,10 +133,12 @@ in
         "syslog.socket"
       ];
 
-    systemd.sockets.systemd-journald-audit.wantedBy = [
-      "systemd-journald.service"
-      "sockets.target"
-    ];
+    systemd.sockets.systemd-journald-audit = lib.mkIf (!config.boot.isContainer) {
+      wantedBy = [
+        "systemd-journald.service"
+        "sockets.target"
+      ];
+    };
 
     environment.etc = {
       "systemd/journald.conf".text = ''


### PR DESCRIPTION
Containers do not have *systemd-journald-audit.socket* added to *additionalUpstreamSystemUnits*, something which is gated behind a condition based on *boot.isContainer*. However the *wantedBy* was added without any additional check, therefore creating an empty unit with just the *WantedBy*. This caused `systemd-analyze verify` to fail:

```text
systemd-journald-audit.socket: Unit has no Listen setting (ListenStream=, ListenDatagram=, ListenFIFO=, ...). Refusing.
systemd-journald-audit.socket: Cannot add dependency job, ignoring: Unit systemd-journald-audit.socket has a bad unit file setting.
systemd-journald-audit.socket: Cannot add dependency job, ignoring: Unit systemd-journald-audit.socket has a bad unit file setting.
```

For reference, this popped up in the context of #360426.

---

Above is the commit message verbatim, here's some extra info.

<details><summary>reproducer</summary>

```bash
cat $(nix build --impure --print-build-logs --print-out-paths -v --show-trace .#nixosConfigurations.test.config.system.build.toplevel)/etc/systemd/system/systemd-journald-audit.socket
```

```nix
# flake.nix
{
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";

  outputs =
    { nixpkgs, ... }:
    {
      nixosConfigurations.test = nixpkgs.lib.nixosSystem
      {
        system = builtins.currentSystem;
        modules =
        [
          "${nixpkgs}/nixos/modules/virtualisation/lxc-container.nix"
          ({ lib, pkgs, ... }:
          {
            # improve build caching for the PoC
            documentation.nixos.enable = lib.mkForce false;
          })
        ];
      };
    };
}
```

Before the patch:

```ini
[Unit]

[Socket]




[Install]
WantedBy=systemd-journald.service sockets.target
```

After the patch:

```text
cat: /nix/store/2yyipz2ydyw092k0h73qflwxzr00kriy-nixos-system-nixos-lxc-25.11.20250517.e84e9d3/etc/systemd/system/systemd-journald-audit.socket: No such file or directory
```

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
