### PR TITLE
nixosTests.curl-impersonate: skip failing test

### DIFF
--- a/nixos/tests/curl-impersonate.nix
+++ b/nixos/tests/curl-impersonate.nix
@@ -19,6 +19,9 @@
       We do that by creating a trusted CA and issuing a cert that includes
       all of the test domains as subject-alternative names and then spoofs the
       hostnames in /etc/hosts.
+    - We started skipping the test_http2_headers test due to log format differences
+      between the nghttpd2 version in nixpkgs and the outdated one curl-impersonate
+      uses upstream for its tests.
 */
 
 import ./make-test-python.nix (
@@ -125,7 +128,7 @@ import ./make-test-python.nix (
 
         # Run tests
         cd tests
-        pytest . --install-dir ../usr --capture-interface eth1
+        pytest . --install-dir ../usr --capture-interface eth1 --exitfirst -k 'not test_http2_headers'
       '';
   in
   {


### PR DESCRIPTION
We use a NixOS VM test to execute the upstream tests of curl-impersonate because they require networking which cannot be mocked easily in the sandbox.

Of those upstream tests, test_http2_headers spawns nghttpd2, makes request against it and then tries to parse the logs it emits. The last step, the parsing of the logs, it extremely fragile and version dependent. The version of nghttp2 that we carry in nixpkgs is newer than the one curl-impersonate expects and happens to emit a different log format.

So to fix the remaining test suite of curl-impersonate, we simply skip test_http2_headers.

ZHF: #403336 

PS @GGG-KILLER please make sure to actually run this VM test when reviewing `curl-impersonate` bumps. This has been failing since early October, which aligns with the bump in #344607. See https://hydra.nixos.org/build/274345196. `nixpkgs-review` will not run those VM tests for you, unfortunately.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
