### PR TITLE
nix-generate-from-cpan: escape description quotes

### DIFF
--- a/maintainers/scripts/nix-generate-from-cpan.pl
+++ b/maintainers/scripts/nix-generate-from-cpan.pl
@@ -422,6 +422,7 @@ if ( defined $description ) {
     $description =~ s/\.$//;          # remove period at the end
     $description =~ s/\s*$//;
     $description =~ s/^\s*//;
+    $description =~ s/"/\\\"/g;       # escape quotes
     $description =~ s/\n+/ /;         # Replace new lines by space.
     INFO("description: $description");
 }


### PR DESCRIPTION
This handles escaping on Perl CPAN modules that contain quotes in the description (or abstract as it's referred to in CPAN). Hopefully, sensible contributors will spot this and fix the outputted Nix code, but I spotted it while looking into Nix-ising a CPAN module.

There are 2,439 releases on CPAN that have double quotes in their abstracts as of today. Here are a random selection of modules that have quotes in their abstracts:

* [Module::Setup](https://metacpan.org/pod/Module::Setup)
* [XML::Invisible](https://metacpan.org/pod/XML::Invisible)
* [Mojolicious::Plugin::ReCAPTCHAv2](https://metacpan.org/pod/Mojolicious::Plugin::ReCAPTCHAv2)
* [Tk::JBrowseEntry](https://metacpan.org/pod/Tk::JBrowseEntry)
* [Game::Battleship](https://metacpan.org/pod/Game::Battleship)

<details>
<summary>curl command that finds *all* such examples...</summary>
Meta-CPAN has an ElasticSearch API. You can query it like this to get all releases where the abstract contains a double quote symbol.

```
$ curl -XPOST https://fastapi.metacpan.org/v1/release/_search -d '
{"query": {"wildcard": { "abstract": "*\\"*" } },
 "size": 100, "fields": [ "name", "abstract" ] }'
```
</details>

I haven't done all the relevant testing as it is not a package change but a little one line change to a Perl script (also I'm a newbie and still clambering up Nix's rather steep learning curve).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
