### PR TITLE
python3Packages.openusd: 25.02a -> 25.05; opensubdiv: fix static target path

### DIFF
--- a/pkgs/by-name/op/opensubdiv/cmake-config.patch
+++ b/pkgs/by-name/op/opensubdiv/cmake-config.patch
@@ -1,0 +1,13 @@
+diff --git a/opensubdiv-config.cmake.in b/opensubdiv-config.cmake.in
+index 08a005aa..48fd2cdc 100644
+--- a/opensubdiv-config.cmake.in
++++ b/opensubdiv-config.cmake.in
+@@ -1,6 +1,6 @@
+ @PACKAGE_INIT@
+ 
+-set_and_check(OpenSubdiv_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
+-set_and_check(OpenSubdiv_LIB_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
++set(OpenSubdiv_INCLUDE_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
++set(OpenSubdiv_LIB_DIR "@CMAKE_INSTALL_FULL_LIBDIR@")
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/OpenSubdivTargets.cmake")

--- a/pkgs/by-name/op/opensubdiv/package.nix
+++ b/pkgs/by-name/op/opensubdiv/package.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals cudaSupport [
       cudaPackages.cuda_nvcc
     ];
+
   buildInputs =
     lib.optionals stdenv.hostPlatform.isUnix [
       libGLU
@@ -55,11 +56,17 @@ stdenv.mkDerivation (finalAttrs: {
       xorg.libXinerama
       xorg.libXi
     ]
-    ++ lib.optionals (openclSupport && stdenv.hostPlatform.isLinux) [ ocl-icd ]
-
+    ++ lib.optionals (openclSupport && stdenv.hostPlatform.isLinux) [
+      ocl-icd
+    ]
     ++ lib.optionals cudaSupport [
       cudaPackages.cuda_cudart
     ];
+
+  patches = [
+    # Prevent CMake from generating a redundant nested path like /nix/store/.../nix/store/...
+    ./cmake-config.patch
+  ];
 
   # It's important to set OSD_CUDA_NVCC_FLAGS,
   # because otherwise OSD might piggyback unwanted architectures:
@@ -105,8 +112,14 @@ stdenv.mkDerivation (finalAttrs: {
       ''
     else
       ''
-        moveToOutput "lib/*.a" $static
+        moveToOutput "lib/libosd*.a" $static
       '';
+
+  postFixup = ''
+    # Adjust static library path to reflect relocation to $static
+    sed -i -E "s|\\\$\{_IMPORT_PREFIX\}/lib/(libosd.*\.a)|$static/lib/\1|" \
+      $dev/lib/cmake/OpenSubdiv/OpenSubdivTargets-release.cmake
+  '';
 
   meta = {
     description = "Open-Source subdivision surface library";

--- a/pkgs/development/compilers/osl/default.nix
+++ b/pkgs/development/compilers/osl/default.nix
@@ -15,6 +15,7 @@
   bison,
   partio,
   pugixml,
+  robin-map,
   util-linux,
   python3,
 }:
@@ -24,13 +25,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "openshadinglanguage";
-  version = "1.13.11.0";
+  version = "1.14.5.1";
 
   src = fetchFromGitHub {
     owner = "AcademySoftwareFoundation";
     repo = "OpenShadingLanguage";
     rev = "v${version}";
-    hash = "sha256-E/LUTtT0ZU0SBuwtJPA0FznvOuc2a3aJn2/n3ru5l0s=";
+    hash = "sha256-dmGVCx4m2bkeKhAJbU1mrzEDAmnL++7GA5okb9wwk/Y=";
   };
 
   cmakeFlags = [
@@ -43,10 +44,12 @@ stdenv.mkDerivation rec {
     "-DLLVM_DIRECTORY=${llvm}"
     "-DLLVM_CONFIG=${llvm.dev}/bin/llvm-config"
     "-DLLVM_BC_GENERATOR=${clang}/bin/clang++"
-
-    # Set C++11 to C++14 required for LLVM10+
-    "-DCMAKE_CXX_STANDARD=14"
   ];
+
+  prePatch = ''
+    substituteInPlace src/cmake/modules/FindLLVM.cmake \
+      --replace-fail "NO_DEFAULT_PATH" ""
+  '';
 
   preConfigure = "patchShebangs src/liboslexec/serialize-bc.bash ";
 
@@ -67,6 +70,7 @@ stdenv.mkDerivation rec {
       partio
       pugixml
       python3.pkgs.pybind11
+      robin-map
       util-linux # needed just for hexdump
       zlib
     ]

--- a/pkgs/development/compilers/osl/default.nix
+++ b/pkgs/development/compilers/osl/default.nix
@@ -23,14 +23,14 @@
 let
   boost_static = boost.override { enableStatic = true; };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openshadinglanguage";
   version = "1.14.5.1";
 
   src = fetchFromGitHub {
     owner = "AcademySoftwareFoundation";
     repo = "OpenShadingLanguage";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-dmGVCx4m2bkeKhAJbU1mrzEDAmnL++7GA5okb9wwk/Y=";
   };
 
@@ -51,7 +51,9 @@ stdenv.mkDerivation rec {
       --replace-fail "NO_DEFAULT_PATH" ""
   '';
 
-  preConfigure = "patchShebangs src/liboslexec/serialize-bc.bash ";
+  preConfigure = ''
+    patchShebangs src/liboslexec/serialize-bc.bash
+  '';
 
   nativeBuildInputs = [
     bison
@@ -83,11 +85,11 @@ stdenv.mkDerivation rec {
       --replace '=''${exec_prefix}//' '=/'
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Advanced shading language for production GI renderers";
     homepage = "https://opensource.imageworks.com/osl.html";
-    maintainers = with maintainers; [ hodapp ];
-    license = licenses.bsd3;
-    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ hodapp ];
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/compilers/osl/default.nix
+++ b/pkgs/development/compilers/osl/default.nix
@@ -8,7 +8,7 @@
   libxml2,
   zlib,
   openexr,
-  openimageio_2,
+  openimageio,
   llvm,
   boost,
   flex,
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
       libclang
       llvm
       openexr
-      openimageio_2
+      openimageio
       partio
       pugixml
       python3.pkgs.pybind11

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -23,7 +23,7 @@
   ninja,
   numpy,
   opencolorio,
-  openimageio_2,
+  openimageio,
   opensubdiv,
   osl,
   ptex,
@@ -118,7 +118,7 @@ buildPythonPackage rec {
       imath
       materialx
       opencolorio
-      openimageio_2
+      openimageio
       opensubdiv
       ptex
       tbb

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -51,14 +51,14 @@ in
 
 buildPythonPackage rec {
   pname = "openusd";
-  version = "25.02a";
+  version = "25.05.01";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "PixarAnimationStudios";
     repo = "OpenUSD";
     tag = "v${version}";
-    hash = "sha256-QFwG6kOLM+R+QIAozk/Dbldj8LRt9kCJv0W/EGHkq6Q=";
+    hash = "sha256-gxikEC4MqTkhgYaRsCVYtS/VmXClSaCMdzpQ0LmiR7Q=";
   };
 
   stdenv = python.stdenv;
@@ -69,8 +69,8 @@ buildPythonPackage rec {
     (fetchpatch {
       name = "port-to-embree-4.patch";
       # https://github.com/PixarAnimationStudios/OpenUSD/pull/2266
-      url = "https://github.com/PixarAnimationStudios/OpenUSD/commit/a07a6b4d1da19bfc499db49641d74fb7c1a71e9b.patch?full_index=1";
-      hash = "sha256-Gww6Ll2nKwpcxMY9lnf5BZ3eqUWz1rik9P3mPKDOf+Y=";
+      url = "https://github.com/PixarAnimationStudios/OpenUSD/commit/9ea3bc1ab550ec46c426dab04292d9667ccd2518.patch?full_index=1";
+      hash = "sha256-QjA3kjUDsSleUr+S/bQLb+QK723SNFvnmRPT+ojjgq8=";
     })
   ];
 
@@ -100,6 +100,8 @@ buildPythonPackage rec {
       cmake
       ninja
       setuptools
+      opensubdiv.dev
+      opensubdiv.static
     ]
     ++ lib.optionals withDocs [
       git

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4098,9 +4098,9 @@ with pkgs;
   };
 
   osl = libsForQt5.callPackage ../development/compilers/osl {
-    libclang = llvmPackages_15.libclang;
-    clang = clang_15;
-    llvm = llvm_15;
+    libclang = llvmPackages_19.libclang;
+    clang = clang_19;
+    llvm = llvm_19;
   };
 
   ossec-agent = callPackage ../tools/security/ossec/agent.nix { };


### PR DESCRIPTION
Release: https://github.com/PixarAnimationStudios/OpenUSD/releases/tag/v25.05

Diff: https://github.com/PixarAnimationStudios/OpenUSD/compare/v25.02...v25.05

I have build it successful on `aarch64-darwin`, and I am try to run a `nixpkgs-review` but it may take a long time.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
