### PR TITLE
msi-ec-kmods: 0-unstable-2024-11-04 -> 0-unstable-2025-05-17

### DIFF
--- a/pkgs/os-specific/linux/msi-ec/default.nix
+++ b/pkgs/os-specific/linux/msi-ec/default.nix
@@ -9,18 +9,21 @@
 }:
 stdenv.mkDerivation {
   pname = "msi-ec-kmods";
-  version = "0-unstable-2024-11-04";
+  version = "0-unstable-2025-05-17";
 
   src = fetchFromGitHub {
     owner = "BeardOverflow";
     repo = "msi-ec";
-    rev = "be6f7156cd15f6ecf9d48dfcc30cbd1f693916b8";
-    hash = "sha256-gImiP4OaBt80n+qgVnbhd0aS/zW+05o3DzGCw0jq+0g=";
+    rev = "796be9047b13c311ac4cdec33913775f4057f600";
+    hash = "sha256-npJbnWFBVb8TK9ynVD/kXWq2iqO0ACKF4UYsu5mQuok=";
   };
 
   dontMakeSourcesWritable = false;
 
-  patches = [ ./patches/makefile.patch ];
+  patches = [
+    ./patches/makefile.patch
+    ./patches/kernel-string-choices.patch
+  ];
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/msi-ec/patches/kernel-string-choices.patch
+++ b/pkgs/os-specific/linux/msi-ec/patches/kernel-string-choices.patch
@@ -1,0 +1,37 @@
+--- a/msi-ec.c
++++ b/msi-ec.c
+@@ -38,7 +38,12 @@
+ #include <linux/slab.h>
+ #include <linux/version.h>
+ #include <linux/rtc.h>
+-#include <linux/string_choices.h>
++
++#include <linux/version.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,6,0)
++#include <linux/string_choices.h>
++#endif
++
+
+ static DEFINE_MUTEX(ec_set_by_mask_mutex);
+ static DEFINE_MUTEX(ec_unset_by_mask_mutex);
+@@ -1141,6 +1146,20 @@ static struct msi_ec_conf CONF52 __initdata = {
+ 	},
+ };
+
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0)
++/* Define our own string choice helpers for older kernels */
++static inline const char *str_on_off(bool v)
++{
++    return v ? "on" : "off";
++}
++
++static inline const char *str_yes_no(bool v)
++{
++    return v ? "yes" : "no";
++}
++#endif
++
++
+ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
+ 	&CONF0,
+ 	&CONF1,


### PR DESCRIPTION
Resolves #408040

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
