### PR TITLE
ci/eval: allow configuration of the system to eval attrpaths on

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -36,6 +36,9 @@ let
   supportedSystems = builtins.fromJSON (builtins.readFile ../supportedSystems.json);
 
   attrpathsSuperset =
+    {
+      evalSystem,
+    }:
     runCommand "attrpaths-superset.json"
       {
         src = nixpkgs;
@@ -55,6 +58,7 @@ let
             -I "$src" \
             --option restrict-eval true \
             --option allow-import-from-derivation false \
+            --option eval-system "${evalSystem}" \
             --arg enableWarnings false > $out/paths.json
       '';
 
@@ -65,7 +69,7 @@ let
       # because `--argstr system` would only be passed to the ci/default.nix file!
       evalSystem,
       # The path to the `paths.json` file from `attrpathsSuperset`
-      attrpathFile ? "${attrpathsSuperset}/paths.json",
+      attrpathFile ? "${attrpathsSuperset { inherit evalSystem; }}/paths.json",
       # The number of attributes per chunk, see ./README.md for more info.
       chunkSize,
       checkMeta ? true,


### PR DESCRIPTION
When we recently changed our workflows to use ARM runners in #405943, we introduced a small regression: Because the `attrpaths` part of the eval workflow always collects attrpaths for the **current system**, we switched from collecting x86_64-linux attrpaths to collecting aarch64-linux ones. This means that any attrpath that is available on x86_64-linux, but not on aarch64-linux, is not evaluated anymore in CI.

The previous behavior of collecting attrpaths for x86_64-linux only and then evaluating them on all supported systems is what hydra does. But instead of reverting to that, this change improves the situation and always collects attrpaths for the system that is going to be evaluated. This is only possible, because we did #406266. With the new behavior, we will eval attrpaths that are only available on non-x86_64-linux systems, too - so a clear improvement.

This is a change by @winterqt that comes out of #406825:

> Right now, there are some paths that don't even get exposed to certain systems (notably Darwin, but some outliers exist for Linux such as the Darwin-specific Hackage overlay) for one reason or another, usually because of assertions like `stdenv.isLinux`. To catch these scenarios, this change implements a way to specify the system to evaluate attrpaths on, and makes it default to the system that we're evaluating outpaths for.

I'm just opening this as a separate PR to fix the regression sooner than later - and to get a better idea of which rebuilds are caused by this change and which rebuilds are caused by other changes in #406825.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
