### PR TITLE
emacs: bump elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "a68-mode";
       ename = "a68-mode";
-      version = "1.0.0.20250322.101009";
+      version = "1.2.0.20250516.72801";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/a68-mode-1.0.0.20250322.101009.tar";
-        sha256 = "0wisz07vd5ciqd81hncxs7pcipmg0ip3lbisnrjx9k21gy4zaj62";
+        url = "https://elpa.gnu.org/devel/a68-mode-1.2.0.20250516.72801.tar";
+        sha256 = "09nxmij8db3ddhl9hyz0khw2crpfxgrhp2rci1v4w4g3y6k6pjxk";
       };
       packageRequires = [ ];
       meta = {
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.0.9.0.20250401.125949";
+      version = "14.0.9.0.20250515.195355";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.0.9.0.20250401.125949.tar";
-        sha256 = "1nbf08jz1i5n9iwijswhv8x0kknv9wlkpfnj58rxgjqgb6pnxw9z";
+        url = "https://elpa.gnu.org/devel/auctex-14.0.9.0.20250515.195355.tar";
+        sha256 = "0n39wh9cw1pfjmyjcahxrgsa3b1p0swwkh31wn5wc2c2rfjkl8xk";
       };
       packageRequires = [ ];
       meta = {
@@ -548,10 +548,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.1.1.0.20250211.151603";
+      version = "0.2.0.20250516.15306";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.1.1.0.20250211.151603.tar";
-        sha256 = "1qirlk0wjrhxxy0k01mr2cx3dzp16ns3047j2a3mpfhq83413w43";
+        url = "https://elpa.gnu.org/devel/auth-source-xoauth2-plugin-0.2.0.20250516.15306.tar";
+        sha256 = "0i205h7fc4gkaa7hn1516bqzffv64bani2v1080kn7cbnrf9kq1b";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -633,10 +633,10 @@
     elpaBuild {
       pname = "autocrypt";
       ename = "autocrypt";
-      version = "0.4.2.0.20240410.70023";
+      version = "0.4.2.0.20250415.115030";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/autocrypt-0.4.2.0.20240410.70023.tar";
-        sha256 = "13g6422lcv8bjwcfrkxmw7fi5by1liz2ni6zxf10pr3qcpv6046n";
+        url = "https://elpa.gnu.org/devel/autocrypt-0.4.2.0.20250415.115030.tar";
+        sha256 = "1lf52r37ik8y8chc047k6mya560q4ybbbq82brdm088rabl81khx";
       };
       packageRequires = [ ];
       meta = {
@@ -740,10 +740,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.3.0.0.20250124.74505";
+      version = "1.3.0.0.20250410.82528";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/beframe-1.3.0.0.20250124.74505.tar";
-        sha256 = "0g99znfyx4zbqacmq5xmkhxzw9rr6l3nmwci6srvdijncvqbmzas";
+        url = "https://elpa.gnu.org/devel/beframe-1.3.0.0.20250410.82528.tar";
+        sha256 = "1rdq1yrszn22np2maibn54qrq1d5231a34l9xrczi13fv0b6sah2";
       };
       packageRequires = [ ];
       meta = {
@@ -971,10 +971,10 @@
     elpaBuild {
       pname = "buffer-env";
       ename = "buffer-env";
-      version = "0.6.0.20240323.72724";
+      version = "0.6.0.20250516.122320";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/buffer-env-0.6.0.20240323.72724.tar";
-        sha256 = "061cbq2pb5wg3jap3l9lbm1axb700aqar9s8vx2zys0hl65klw51";
+        url = "https://elpa.gnu.org/devel/buffer-env-0.6.0.20250516.122320.tar";
+        sha256 = "0m1kb8h2mjjd5hznp86yxjdic0zngq89x67vd7srvikxxbj312d9";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1014,10 +1014,10 @@
     elpaBuild {
       pname = "bufferlo";
       ename = "bufferlo";
-      version = "0.8.0.20240920.145100";
+      version = "1.1.0.20250503.201002";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bufferlo-0.8.0.20240920.145100.tar";
-        sha256 = "1ai7y5nxjglzbxwq4ln8mlmxw8irh0m005izcrx9qby8i3zs4fwz";
+        url = "https://elpa.gnu.org/devel/bufferlo-1.1.0.20250503.201002.tar";
+        sha256 = "05bpgfyizzc6364c7jv8l2d8z78ighmswxn2hxgzwsvbyhnfmxpr";
       };
       packageRequires = [ ];
       meta = {
@@ -1105,10 +1105,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.0.0.20250315.85532";
+      version = "2.0.0.20250512.155407";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-2.0.0.20250315.85532.tar";
-        sha256 = "0jvn4schd8d2dks0wmprl9q4ads7yal60a9yblhpbgpsvn7jn5cf";
+        url = "https://elpa.gnu.org/devel/cape-2.0.0.20250512.155407.tar";
+        sha256 = "13j8wcdj4azmi7gfaqs08wm0b6razj10i8wkh3qa8bqadjyqmhfw";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1318,10 +1318,10 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.2.3.0.20250330.183449";
+      version = "1.2.3.0.20250508.204004";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.3.0.20250330.183449.tar";
-        sha256 = "1xj4020g8k2h18syd6vns09glhhziq0x5q86siq47zqyw8v9046k";
+        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.3.0.20250508.204004.tar";
+        sha256 = "1zrdxxc115h4zk2a1lhl45is7cjvxq333m1f1lmrmnyahzgg3a46";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1386,10 +1386,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20250228.25856";
+      version = "1.0.2.0.20250426.131956";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20250228.25856.tar";
-        sha256 = "0bjl3i1vxqxinj396f22072z7xpzd9j7cd0mp55v8sa9kb1riiq3";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20250426.131956.tar";
+        sha256 = "1lkrhb0xc9d2ylb85k49h62w9k3dnm4j2i6438xc2jkjrjids575";
       };
       packageRequires = [ ];
       meta = {
@@ -1546,10 +1546,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.2.0.20250402.65908";
+      version = "2.3.0.20250512.141021";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-2.2.0.20250402.65908.tar";
-        sha256 = "001v9pf0aknbni1jmrm7wk8fkc8f01qz0mvi665sxngfzncviz03";
+        url = "https://elpa.gnu.org/devel/consult-2.3.0.20250512.141021.tar";
+        sha256 = "1k3xhqqrz72zfy92376h8livr938z2kqarkljdri44vh8yqm7j0i";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1569,10 +1569,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.2.4.0.20250325.81913";
+      version = "0.3.1.0.20250501.44152";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-denote-0.2.4.0.20250325.81913.tar";
-        sha256 = "1cw4yxh76xg68my7d6nsi9hdy7iflw11rnyk7hq7yrgfhr4ynfsw";
+        url = "https://elpa.gnu.org/devel/consult-denote-0.3.1.0.20250501.44152.tar";
+        sha256 = "1kxk38yi1m9z4j422skn43xyynazwd2n0d9sq78yn7cbnpf050wn";
       };
       packageRequires = [
         consult
@@ -1659,10 +1659,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.0.0.20250328.143011";
+      version = "2.1.0.20250516.184150";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-2.0.0.20250328.143011.tar";
-        sha256 = "0s43c3sr5d33q980nn0rci4g7x737nrm4p7bclgi35dwn0svgpcw";
+        url = "https://elpa.gnu.org/devel/corfu-2.1.0.20250516.184150.tar";
+        sha256 = "1fnhsn6mvz2cp6cwphrjgr0lizkkfpirp3bxg2vxnj869asyayva";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1940,10 +1940,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.23.0.0.20250330.183823";
+      version = "0.24.1.0.20250509.163537";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.23.0.0.20250330.183823.tar";
-        sha256 = "0p4511jm8hi9bb832g8f1w1v4dy5maabfi9mgkr3plzpyk5xrvia";
+        url = "https://elpa.gnu.org/devel/dape-0.24.1.0.20250509.163537.tar";
+        sha256 = "0r0kjrzqw0dlj0vw7lgsc2mg2sr0js1aambkwc3qvf57jp875jwb";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -2027,10 +2027,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.44.0.20250311.94450";
+      version = "0.44.0.20250505.144705";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/debbugs-0.44.0.20250311.94450.tar";
-        sha256 = "0w1mhj8byz2msn02h0kb95z3y9f4dimb5by03lhr3llpy3ar26hg";
+        url = "https://elpa.gnu.org/devel/debbugs-0.44.0.20250505.144705.tar";
+        sha256 = "104nk2svlyp7gsr4fpa7q25yi89j29m3c6ydb0zdspbrggw2zfka";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2074,10 +2074,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "3.1.0.0.20250331.81427";
+      version = "4.0.0.0.20250508.42428";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-3.1.0.0.20250331.81427.tar";
-        sha256 = "0hh116prs73s7ykv9vsqmi7s4snavg7yadhp0rgc4djk0anw58s5";
+        url = "https://elpa.gnu.org/devel/denote-4.0.0.0.20250508.42428.tar";
+        sha256 = "1zi78mfncjpaldvaq4g99ls65vs9qi1rphcwmzhqwnv9ckgdnqv1";
       };
       packageRequires = [ ];
       meta = {
@@ -2096,10 +2096,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.0.0.1.0.20250402.42932";
+      version = "0.1.1.0.20250422.45242";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-journal-0.0.0.1.0.20250402.42932.tar";
-        sha256 = "1bdh2pj9vp8nfvmps5m4rxvnddmrl9f7m7r9pqspi62rr35a1zx7";
+        url = "https://elpa.gnu.org/devel/denote-journal-0.1.1.0.20250422.45242.tar";
+        sha256 = "1hyhahdyxnx6q2lxy8pngj0isscb0wv1946w5bp1qkq6ygjp3chv";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2118,10 +2118,10 @@
     elpaBuild {
       pname = "denote-markdown";
       ename = "denote-markdown";
-      version = "0.0.0.1.0.20250322.71429";
+      version = "0.1.1.0.20250419.74350";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-markdown-0.0.0.1.0.20250322.71429.tar";
-        sha256 = "1b87h16s0ic1b8r4hj1vddqd62amsh1bs1ps2kxbydxjq3hs5ijn";
+        url = "https://elpa.gnu.org/devel/denote-markdown-0.1.1.0.20250419.74350.tar";
+        sha256 = "0q3fc8zyaspd6z0zan40rsjfpgvja72bp0qm93pyr69q6iijshh8";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2162,10 +2162,10 @@
     elpaBuild {
       pname = "denote-org";
       ename = "denote-org";
-      version = "0.0.0.1.0.20250322.71330";
+      version = "0.1.1.0.20250508.64419";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-org-0.0.0.1.0.20250322.71330.tar";
-        sha256 = "05ywsfg7mxq6kh8p742mz8j7d9jhzjbp1kl59a6zrp08yn0gl6f7";
+        url = "https://elpa.gnu.org/devel/denote-org-0.1.1.0.20250508.64419.tar";
+        sha256 = "1xnvpdpn55vcws1v5dhkvragiyq1kn40xmylxpxi1xv9rv61z6ml";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2184,10 +2184,10 @@
     elpaBuild {
       pname = "denote-search";
       ename = "denote-search";
-      version = "1.0.3.0.20250330.114925";
+      version = "1.0.3.0.20250501.205109";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-search-1.0.3.0.20250330.114925.tar";
-        sha256 = "1dfvvjh2rhj2wk614rcvnps67v6z71ipnvqzygbvysq8f0cdkcza";
+        url = "https://elpa.gnu.org/devel/denote-search-1.0.3.0.20250501.205109.tar";
+        sha256 = "0xpb39936fxldbv9d8i0122yvcapjvxkghv6d3ybxgm4wc8svbrn";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2206,10 +2206,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.0.0.1.0.20250401.84519";
+      version = "0.1.1.0.20250501.102153";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-sequence-0.0.0.1.0.20250401.84519.tar";
-        sha256 = "1cvwp507mljp4d7c9z8nbf2yhz531wdp8rshbmc01pd3qkxw6hhz";
+        url = "https://elpa.gnu.org/devel/denote-sequence-0.1.1.0.20250501.102153.tar";
+        sha256 = "08aqb3ps1czag73jm6avk4xq3wbxx02gyl0bml8vnxdc0l22skjy";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2228,10 +2228,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.0.0.1.0.20250322.71039";
+      version = "0.1.1.0.20250419.74326";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-silo-0.0.0.1.0.20250322.71039.tar";
-        sha256 = "05cgwfa0yvpillj4zqsqmhi92kg84xs3fmqd94vbdxg7byf6dfka";
+        url = "https://elpa.gnu.org/devel/denote-silo-0.1.1.0.20250419.74326.tar";
+        sha256 = "1ysbm6mbnr4g4h3yhay1b7d98y1dh11dq5pv2ix2c3ld2952h7sy";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2318,10 +2318,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "0.5.0.20250322.120827";
+      version = "0.5.0.20250512.155532";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dicom-0.5.0.20250322.120827.tar";
-        sha256 = "09qrvvadvdrab7p70w8b0mj40vvx3prkbqrfprnk95r5absvdzyb";
+        url = "https://elpa.gnu.org/devel/dicom-0.5.0.20250512.155532.tar";
+        sha256 = "1kbdc8m40z449p1r39ix10fvwq7gzqpg5q3i4xs4fyg6v2769z8d";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2368,10 +2368,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20250327.31410";
+      version = "1.10.0.0.20250507.203711";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20250327.31410.tar";
-        sha256 = "0j594as6idkzyiqns2n41qh909zb490cfkdh025i2jymcv5k24lr";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20250507.203711.tar";
+        sha256 = "1gv7yn2hynf09sw5r5axg6b0vb79id4jv6n07cmr2wknf0q3di4a";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2495,10 +2495,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.4.0.0.20250318.50115";
+      version = "0.5.2.0.20250427.44935";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dired-preview-0.4.0.0.20250318.50115.tar";
-        sha256 = "0xkh3izw0m2bghahw684yhp4pplqgsja0h7k67prfp1rhg0nkp5n";
+        url = "https://elpa.gnu.org/devel/dired-preview-0.5.2.0.20250427.44935.tar";
+        sha256 = "0zc7kd1apyq0bwxi3qjihxayjb5j6ga9rhmzc3lmm29ysxfz90n5";
       };
       packageRequires = [ ];
       meta = {
@@ -2580,10 +2580,10 @@
     elpaBuild {
       pname = "do-at-point";
       ename = "do-at-point";
-      version = "0.1.2.0.20250131.91127";
+      version = "0.1.2.0.20250501.125137";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/do-at-point-0.1.2.0.20250131.91127.tar";
-        sha256 = "0bjw91hrv4d5vqrgkx9bas3nwgqyfpbar7b5d07m3agw436yafqf";
+        url = "https://elpa.gnu.org/devel/do-at-point-0.1.2.0.20250501.125137.tar";
+        sha256 = "1sszwgf740yklj2cm47rzc5ia8ygn8vzfagpadcsv38mpcxpdzz0";
       };
       packageRequires = [ ];
       meta = {
@@ -2609,6 +2609,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/doc-toc.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  doc-view-follow = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "doc-view-follow";
+      ename = "doc-view-follow";
+      version = "0.3.2.0.20250427.143824";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/doc-view-follow-0.3.2.0.20250427.143824.tar";
+        sha256 = "04jk93rkv682w6zcfr283gpwgi5fiq5w3xdpv49zkwddx783crfa";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/doc-view-follow.html";
         license = lib.licenses.free;
       };
     }
@@ -2806,7 +2827,7 @@
       version = "2.3.0.20241006.95158";
       src = fetchurl {
         url = "https://elpa.gnu.org/devel/ediprolog-2.3.0.20241006.95158.tar";
-        sha256 = "0jbbxyx2xcfqg8jgs63dri1d5cc3x6b3scys8khf6acd4f9grnxd";
+        sha256 = "1xwha4xn7hpb57vvlrhcm5z0r59wz82vrcdx13kp46zvmll0zcrd";
       };
       packageRequires = [ ];
       meta = {
@@ -2845,10 +2866,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.9.0.0.20250220.64933";
+      version = "1.10.0.0.20250429.104336";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-1.9.0.0.20250220.64933.tar";
-        sha256 = "0iq4lc8r1y255r3vphay9fjcphgv176hdp4a4gbwj2xrldsqwwvi";
+        url = "https://elpa.gnu.org/devel/ef-themes-1.10.0.0.20250429.104336.tar";
+        sha256 = "0a4fpc9i4sjfx4cnngbdddffs6qg03c15fz2znix56b4hp7jl4sv";
       };
       packageRequires = [ ];
       meta = {
@@ -2873,10 +2894,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.18.0.20250329.174949";
+      version = "1.18.0.20250513.114504";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20250329.174949.tar";
-        sha256 = "1kb90wkqxb9cnqfm4v6139n6wzalzk0war7skd1pm9yxgwfk23lj";
+        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20250513.114504.tar";
+        sha256 = "0jgma92l0smvm8np78sx924dlvbli1j3pgjrpps8m7av7xjab5v1";
       };
       packageRequires = [
         eldoc
@@ -2902,10 +2923,10 @@
     elpaBuild {
       pname = "el-job";
       ename = "el-job";
-      version = "2.4.3.0.20250327.30600";
+      version = "2.4.7.0.20250516.190810";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/el-job-2.4.3.0.20250327.30600.tar";
-        sha256 = "12mpsky46qrm9aj67sp1df05rl7p0hn9ikd718hk6gbipyd2jcra";
+        url = "https://elpa.gnu.org/devel/el-job-2.4.7.0.20250516.190810.tar";
+        sha256 = "14l3xa5xii7xg6006gyap5jcd3z5ramik0q9sd14gaqx7i9s8081";
       };
       packageRequires = [ ];
       meta = {
@@ -3021,10 +3042,10 @@
     elpaBuild {
       pname = "elisp-benchmarks";
       ename = "elisp-benchmarks";
-      version = "1.16.0.20250215.101900";
+      version = "1.16.0.20250424.171436";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/elisp-benchmarks-1.16.0.20250215.101900.tar";
-        sha256 = "1qcr6sss94hy5c79b8n78950y1ybdc8rwxd6sj1q7xb9m9rgwls1";
+        url = "https://elpa.gnu.org/devel/elisp-benchmarks-1.16.0.20250424.171436.tar";
+        sha256 = "06ryqghnn904c7qjxdi5qy6fi4b6c73i6mlqh4sal6f7p2624k4i";
       };
       packageRequires = [ ];
       meta = {
@@ -3094,10 +3115,10 @@
     elpaBuild {
       pname = "embark";
       ename = "embark";
-      version = "1.1.0.20250131.230144";
+      version = "1.1.0.20250423.105002";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-1.1.0.20250131.230144.tar";
-        sha256 = "0ky3cm9dn8hwms3nmzfkm339v859wc6qgchkqn4i7p2206bp4cqj";
+        url = "https://elpa.gnu.org/devel/embark-1.1.0.20250423.105002.tar";
+        sha256 = "1i01q1imn32sbii0kwz51i41a9f5mql564lmhbifwh4hsgrras2g";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3118,10 +3139,10 @@
     elpaBuild {
       pname = "embark-consult";
       ename = "embark-consult";
-      version = "1.1.0.20250131.230144";
+      version = "1.1.0.20250423.105002";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20250131.230144.tar";
-        sha256 = "1ggk135338cbxkhvzc4g9wyyvz2sxxqyx5yqwzsffx9yprp618ng";
+        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20250423.105002.tar";
+        sha256 = "1qkg36d67fwhijrhkfjs7397rcmjs7cga7l9dj0n9d1634f7q3h4";
       };
       packageRequires = [
         compat
@@ -3150,10 +3171,10 @@
     elpaBuild {
       pname = "ement";
       ename = "ement";
-      version = "0.17pre0.20241122.210222";
+      version = "0.17pre0.20250511.153249";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ement-0.17pre0.20241122.210222.tar";
-        sha256 = "1gn5hjlggcs7p31mkr8vg398jgzsnhjv04g1hpx4b03j31rxwhxl";
+        url = "https://elpa.gnu.org/devel/ement-0.17pre0.20250511.153249.tar";
+        sha256 = "0vkkk79z2q73niffjkjbywiqr3ykdvb9ssq3095kxjnrc7k6vzvz";
       };
       packageRequires = [
         map
@@ -3182,10 +3203,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "22.0.20250326.124336";
+      version = "22.0.20250405.101736";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emms-22.0.20250326.124336.tar";
-        sha256 = "0d0n1lmhvqdbkdw4in1625a1wzh0phzj19nhlq3zdmqkzk6fqv4g";
+        url = "https://elpa.gnu.org/devel/emms-22.0.20250405.101736.tar";
+        sha256 = "0vz92gq1hw9p4s24w0vc1finq9bx6is7vsi1izi9b5bghd837rb8";
       };
       packageRequires = [
         cl-lib
@@ -3271,10 +3292,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.1snapshot0.20250312.13833";
+      version = "5.6.1snapshot0.20250416.173013";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250312.13833.tar";
-        sha256 = "03352zza9zmv5paha806yj4pbv0p9pmbnr2b574a7xlw6qn5kzn0";
+        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250416.173013.tar";
+        sha256 = "0ii5wh8cg8v0ip57x059hx408bg09d80wz6sm4p5p17nj7klnpm0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3318,10 +3339,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "25.1.0.0.20250110.143746";
+      version = "25.1.0.0.20250508.73511";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20250110.143746.tar";
-        sha256 = "0mppliby454pm7x0w7mrxk5741gcgzmim6sq36rdq8yh3q0abk77";
+        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20250508.73511.tar";
+        sha256 = "126ld8y7qk9z72vrd85mzqc25mbyyc6k0wl0iilbhcl268szy7xi";
       };
       packageRequires = [ ];
       meta = {
@@ -3438,10 +3459,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.33.0.20250319.185706";
+      version = "0.33.0.20250426.232314";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.33.0.20250319.185706.tar";
-        sha256 = "0svn8wix5rk6wj3xbj20csidm61xb35bnmskc043ybyzriyzwrx4";
+        url = "https://elpa.gnu.org/devel/exwm-0.33.0.20250426.232314.tar";
+        sha256 = "090kdzcayczn0jv3bkcg2kp08f9w2acjdrq9ly87li41rpsbh2gk";
       };
       packageRequires = [
         compat
@@ -3506,10 +3527,10 @@
     elpaBuild {
       pname = "filechooser";
       ename = "filechooser";
-      version = "0.2.1.0.20240707.120050";
+      version = "0.2.2.0.20250411.154303";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/filechooser-0.2.1.0.20240707.120050.tar";
-        sha256 = "0ri460zys97h9q4bqg43vlfdpjrizvv412y3f4hj4cazsvwlr9k1";
+        url = "https://elpa.gnu.org/devel/filechooser-0.2.2.0.20250411.154303.tar";
+        sha256 = "0xgvwjxsckmdijmrsb4c6ln515an07x84az3x5vd4mjll85mcm86";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3593,10 +3614,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.3.7.0.20250327.181545";
+      version = "1.4.1.0.20250508.221328";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.3.7.0.20250327.181545.tar";
-        sha256 = "14q04ih94qb8ff2mnl9lbmgza3rdny1cy81nl0p3akk47sn2vwk1";
+        url = "https://elpa.gnu.org/devel/flymake-1.4.1.0.20250508.221328.tar";
+        sha256 = "0sc45x3fwxmdbq4pz23kjibk38zwv1zxx8ihfg368syinik883gw";
       };
       packageRequires = [
         eldoc
@@ -3681,10 +3702,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "3.0.0.0.20250220.111012";
+      version = "3.0.1.0.20250415.152114";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/fontaine-3.0.0.0.20250220.111012.tar";
-        sha256 = "122a5hapm0jk43gd7sn1qsv9nz9b55rhff9irnqmv78f0wxxy3sy";
+        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20250415.152114.tar";
+        sha256 = "1cnx5ch9s18lmwslrzi1652xv964zpigcijwf7jpmvxj0cfi0g9b";
       };
       packageRequires = [ ];
       meta = {
@@ -4151,10 +4172,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.12.6.0.20250304.171535";
+      version = "0.12.6.0.20250304.172206";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.12.6.0.20250304.171535.tar";
-        sha256 = "0maqbx42xg1zbijdbs354iqxclzkfi0pdy5zjyi1n9pwxgxmc7vd";
+        url = "https://elpa.gnu.org/devel/greader-0.12.6.0.20250304.172206.tar";
+        sha256 = "1cpvh9pn855q8gjz43alpipbchfbbgg0ds6qbnn7k9s0n38iyzr3";
       };
       packageRequires = [
         compat
@@ -4196,10 +4217,10 @@
     elpaBuild {
       pname = "gtags-mode";
       ename = "gtags-mode";
-      version = "1.8.2.0.20241113.2312";
+      version = "1.8.5.0.20250511.220137";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/gtags-mode-1.8.2.0.20241113.2312.tar";
-        sha256 = "0mxw27kn5f85rprk13171k56q2dq2gfmvgyhfxrbz3zj7ijvrfg1";
+        url = "https://elpa.gnu.org/devel/gtags-mode-1.8.5.0.20250511.220137.tar";
+        sha256 = "185c583y06lm97hd1nlhsx96byz34m0fg2xlz99vwxzm75ch3s5h";
       };
       packageRequires = [ ];
       meta = {
@@ -4413,10 +4434,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20250331.73512";
+      version = "9.0.2pre0.20250509.132519";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250331.73512.tar";
-        sha256 = "1y9xqfznlh827x3arram5yq6wj2r32pjcrd8pdlnzk4yq8zjmx37";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250509.132519.tar";
+        sha256 = "0jmjaa6bj93qw7i62spc4kk117bbc3g3nvdq0lkcwd9900ir1xhb";
       };
       packageRequires = [ ];
       meta = {
@@ -4477,10 +4498,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.8.2.0.20250306.142956";
+      version = "0.8.4.0.20250508.135540";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/indent-bars-0.8.2.0.20250306.142956.tar";
-        sha256 = "1j2a8jixv1k52dmh57id1l4b70rz79hl3gaydmk6pzpdri38msd5";
+        url = "https://elpa.gnu.org/devel/indent-bars-0.8.4.0.20250508.135540.tar";
+        sha256 = "0167f1q8snk98j7akns3mg07pxm1221i9vxplc4x55z7qlryvi7c";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4583,10 +4604,10 @@
     elpaBuild {
       pname = "ivy";
       ename = "ivy";
-      version = "0.15.1.0.20250329.144259";
+      version = "0.15.1.0.20250417.121946";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-0.15.1.0.20250329.144259.tar";
-        sha256 = "0zq2g603sqnvjmyib4q69nia4dvci6p2bmpvnsghwb6kbfm99wlv";
+        url = "https://elpa.gnu.org/devel/ivy-0.15.1.0.20250417.121946.tar";
+        sha256 = "13xrixysvh3g358fi91lx2b4ra8npyhl573klfzvwr0w1pkpzc8g";
       };
       packageRequires = [ ];
       meta = {
@@ -4790,10 +4811,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.0.0.20250402.103750";
+      version = "2.1.0.20250512.155547";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-2.0.0.20250402.103750.tar";
-        sha256 = "18jpcfm1q4ksnynzavv35im0a6c81h8s8aj9ly7xxcq78yydy55h";
+        url = "https://elpa.gnu.org/devel/jinx-2.1.0.20250512.155547.tar";
+        sha256 = "13yi3cv4111px48fzr8rnx70bhcb7b3gy64vcddvpcr2gvwlrzvz";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4983,10 +5004,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.4.3.0.20250211.173738";
+      version = "0.4.3.0.20250422.135008";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/kubed-0.4.3.0.20250211.173738.tar";
-        sha256 = "0fwlhq9l4bcfscyfch83vkxnp14dv24qalrhxrjffh06h3lw96zm";
+        url = "https://elpa.gnu.org/devel/kubed-0.4.3.0.20250422.135008.tar";
+        sha256 = "1mcx3zah4yifrissa5065gsbkaj90m11rbhz70pk8yl60hyn9d0a";
       };
       packageRequires = [ ];
       meta = {
@@ -5217,10 +5238,10 @@
     elpaBuild {
       pname = "literate-scratch";
       ename = "literate-scratch";
-      version = "1.0.0.20240621.41043";
+      version = "2.2.0.20250425.54453";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/literate-scratch-1.0.0.20240621.41043.tar";
-        sha256 = "0k1vgb1pmrdhq0mlvrpgdsamqfbhvrjwm2jgixla82j7814zzckq";
+        url = "https://elpa.gnu.org/devel/literate-scratch-2.2.0.20250425.54453.tar";
+        sha256 = "0wv9fmkv37j4gss36rd81wyp37cssmxvxpf98xf4yscj84vv742m";
       };
       packageRequires = [ ];
       meta = {
@@ -5231,6 +5252,7 @@
   ) { };
   llm = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -5241,12 +5263,13 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.24.2.0.20250331.211307";
+      version = "0.25.0.0.20250510.105336";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.24.2.0.20250331.211307.tar";
-        sha256 = "1n95x8430kasbcrv12j6wv0g12lk4xvbz1cav37y1lig09ak87pz";
+        url = "https://elpa.gnu.org/devel/llm-0.25.0.0.20250510.105336.tar";
+        sha256 = "0mnc820if3jcj909bmsjgcvdg10d7ijzqa4fgc0bw2s92hrzp37n";
       };
       packageRequires = [
+        compat
         plz
         plz-event-source
         plz-media-type
@@ -5480,10 +5503,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.0.0.20250317.163219";
+      version = "2.0.0.20250512.155419";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-2.0.0.20250317.163219.tar";
-        sha256 = "0swxq6v8g0pphfmm883hx09cvkhs6gg60049phy60xcmxf1sdq9w";
+        url = "https://elpa.gnu.org/devel/marginalia-2.0.0.20250512.155419.tar";
+        sha256 = "042nay3vr19ldbgqz1hzmacf53gz66dgpazr53xffq6pjxpih5p1";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5555,6 +5578,28 @@
       };
     }
   ) { };
+  mathsheet = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      peg,
+    }:
+    elpaBuild {
+      pname = "mathsheet";
+      ename = "mathsheet";
+      version = "1.1.0.20250513.62537";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/mathsheet-1.1.0.20250513.62537.tar";
+        sha256 = "05fghv85j1fddb8y3frdz61xa2x5srm1fv6d1k030arwqqzq7224";
+      };
+      packageRequires = [ peg ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/mathsheet.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   matlab-mode = callPackage (
     {
       elpaBuild,
@@ -5564,10 +5609,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "6.3.0.20250401.100138";
+      version = "6.3.0.20250512.120312";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/matlab-mode-6.3.0.20250401.100138.tar";
-        sha256 = "1bfx0n5s24kzppl3m914ax8y2yx56hn8kyj8zxb836crr0ad5yad";
+        url = "https://elpa.gnu.org/devel/matlab-mode-6.3.0.20250512.120312.tar";
+        sha256 = "07lsjj3ch66xl680isn9mrmbiz28n7r85gwgrzqva9gyxilfh1wm";
       };
       packageRequires = [ ];
       meta = {
@@ -5757,10 +5802,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.4.4.0.20250402.134355";
+      version = "0.5.4.0.20250510.3940";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/minuet-0.4.4.0.20250402.134355.tar";
-        sha256 = "0lpm8mvg5xxja60cdpdcfgvb93mb0rgiagbvc529av4l5mk3i9gy";
+        url = "https://elpa.gnu.org/devel/minuet-0.5.4.0.20250510.3940.tar";
+        sha256 = "0akavbg2bl1amwr55ch1m3apkjdwdgiqar1kjnld28rfa027gxj6";
       };
       packageRequires = [
         dash
@@ -5803,10 +5848,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.6.0.0.20250327.84301";
+      version = "4.7.0.0.20250428.45622";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-4.6.0.0.20250327.84301.tar";
-        sha256 = "0cgrifxm8iy4dnjx48m1csl3g3vai3xsz3b06n1nfkgdffiiimn4";
+        url = "https://elpa.gnu.org/devel/modus-themes-4.7.0.0.20250428.45622.tar";
+        sha256 = "0dyicvmcnf99isdrjg8wazxm1hmqdy81s72glnc86pl6xaiikxf9";
       };
       packageRequires = [ ];
       meta = {
@@ -5824,10 +5869,10 @@
     elpaBuild {
       pname = "mpdired";
       ename = "mpdired";
-      version = "3.0.20250314.151545";
+      version = "4pre0.20250502.114712";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mpdired-3.0.20250314.151545.tar";
-        sha256 = "0mkmmjikckc7x95nrn2ak590hwgriayxn4ci8bswyjgcrad50pyq";
+        url = "https://elpa.gnu.org/devel/mpdired-4pre0.20250502.114712.tar";
+        sha256 = "1s831xln9vlxcchmxmis8ky751r3xwi5nlnnchdn7sjngkqjkl30";
       };
       packageRequires = [ ];
       meta = {
@@ -6234,10 +6279,10 @@
     elpaBuild {
       pname = "ob-asymptote";
       ename = "ob-asymptote";
-      version = "1.0.1.0.20241018.115612";
+      version = "1.0.2.0.20250511.114502";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ob-asymptote-1.0.1.0.20241018.115612.tar";
-        sha256 = "0hr0rfj344yshrplcavncphrl16a1n7gx1r906dma53x7nmkhcf7";
+        url = "https://elpa.gnu.org/devel/ob-asymptote-1.0.2.0.20250511.114502.tar";
+        sha256 = "0hkfqgym36lmlbqq4a5aj031hz14isfsnjn6qhkgxg06pc1wlzcl";
       };
       packageRequires = [ ];
       meta = {
@@ -6384,10 +6429,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20250401.155443";
+      version = "9.8pre0.20250512.165453";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250401.155443.tar";
-        sha256 = "1d03254n53x5icvmpzd3mgw7l9xcgcx44mky4gx7prc30pm97gf2";
+        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250512.165453.tar";
+        sha256 = "1hdy7zxl1d9hpv02j99r0w0kqrwpw567w6sycx3d1xdz8r93z8c5";
       };
       packageRequires = [ ];
       meta = {
@@ -6406,10 +6451,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.1.0.20250309.165914";
+      version = "1.1.0.20250513.100113";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250309.165914.tar";
-        sha256 = "1nx4b15g7zai76587phi3dy19adywmhmaan2jg62vl11mij2z08b";
+        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250513.100113.tar";
+        sha256 = "03rbhicxw9glwrdhsw364kyjxdzbs4h63h927n5scbn71gkwr3bc";
       };
       packageRequires = [ org ];
       meta = {
@@ -6503,10 +6548,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.7.0.20250402.171258";
+      version = "1.7.0.20250512.155443";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.7.0.20250402.171258.tar";
-        sha256 = "1axg6l5gxrmbwgp8v3l7rzlwsf0ys4p6pdabwaqp4fyipdhh5mz4";
+        url = "https://elpa.gnu.org/devel/org-modern-1.7.0.20250512.155443.tar";
+        sha256 = "0pnnwsfamfmg3cm832736kaxjlj9bg62f00bjcdrxkkad0c0gbf6";
       };
       packageRequires = [
         compat
@@ -6683,10 +6728,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.6.0.20250301.161304";
+      version = "1.7.0.20250512.155425";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-1.6.0.20250301.161304.tar";
-        sha256 = "14d10amng3xij0wnj29iz480rsv6z8hkn6ynnh13lfc9kaf5bhh0";
+        url = "https://elpa.gnu.org/devel/osm-1.7.0.20250512.155425.tar";
+        sha256 = "0x0dxx1zy90lf0bfwhw9va4az6f9z1rlp3j75zd3a1vrh18dh2f4";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6768,10 +6813,10 @@
     elpaBuild {
       pname = "package-x";
       ename = "package-x";
-      version = "1.0.0.20250212.211602";
+      version = "1.0.0.20250516.155254";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/package-x-1.0.0.20250212.211602.tar";
-        sha256 = "0plkkpdf9apjhr60n4j7idbg5brmx3hndfg2lq8d00si6gr5c73b";
+        url = "https://elpa.gnu.org/devel/package-x-1.0.0.20250516.155254.tar";
+        sha256 = "1lr9g496sm8h6ph8x7w8c2ayhnlh7w30hhl6xwwfdsh0sqp2hy50";
       };
       packageRequires = [ ];
       meta = {
@@ -6811,10 +6856,10 @@
     elpaBuild {
       pname = "parser-generator";
       ename = "parser-generator";
-      version = "0.2.4.0.20241220.142732";
+      version = "0.2.5.0.20250505.82351";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/parser-generator-0.2.4.0.20241220.142732.tar";
-        sha256 = "0q46ywjv4ymjal0jfmrm4i1ck6nkcil06xgzhncqp6j8fbn4mvj5";
+        url = "https://elpa.gnu.org/devel/parser-generator-0.2.5.0.20250505.82351.tar";
+        sha256 = "1gdaaas4p6xgmp67fwz0l43fyk0akj6q1vbv8gfgmzyaz9glwkaw";
       };
       packageRequires = [ ];
       meta = {
@@ -6939,10 +6984,10 @@
     elpaBuild {
       pname = "phps-mode";
       ename = "phps-mode";
-      version = "0.4.50.0.20250303.193108";
+      version = "0.4.51.0.20250428.55352";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/phps-mode-0.4.50.0.20250303.193108.tar";
-        sha256 = "1a7251cn5jiq6322ffs7bzz3bqyfdap2skwb0s1kwxn0zhq1hjcz";
+        url = "https://elpa.gnu.org/devel/phps-mode-0.4.51.0.20250428.55352.tar";
+        sha256 = "1r0faz9ijidagzcbphz7w2qwbxbdyznxk9ffx2rmrhjbizknrcm9";
       };
       packageRequires = [ ];
       meta = {
@@ -6960,10 +7005,10 @@
     elpaBuild {
       pname = "pinentry";
       ename = "pinentry";
-      version = "0.1.0.20241123.141";
+      version = "0.1.0.20250408.22039";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pinentry-0.1.0.20241123.141.tar";
-        sha256 = "14ssm8hrkx70iaww77yrhsbp7k6962bp4k2w7mgj4mj4wkfyrw89";
+        url = "https://elpa.gnu.org/devel/pinentry-0.1.0.20250408.22039.tar";
+        sha256 = "10372ijcmwz48k03lbfw5s4lh2kmizhzfpd7in61zl12f2qv9rw7";
       };
       packageRequires = [ ];
       meta = {
@@ -7003,10 +7048,10 @@
     elpaBuild {
       pname = "plz-event-source";
       ename = "plz-event-source";
-      version = "0.1.3pre0.20250228.134816";
+      version = "0.1.4pre0.20250413.93107";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.3pre0.20250228.134816.tar";
-        sha256 = "08dasdzl53rnb29jl023vmcqs0xall1ra2dfpzqsjjzc1a1lz08y";
+        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.4pre0.20250413.93107.tar";
+        sha256 = "1g4bvdbdg5c0ch62l8314rv44b2wyymkbydyi0fkdjjb3a9ns4b0";
       };
       packageRequires = [ plz-media-type ];
       meta = {
@@ -7025,10 +7070,10 @@
     elpaBuild {
       pname = "plz-media-type";
       ename = "plz-media-type";
-      version = "0.2.4pre0.20250228.133501";
+      version = "0.2.5pre0.20250412.100044";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.4pre0.20250228.133501.tar";
-        sha256 = "1m38fzbcmvqh8nwxsb2wic549af8wicpqxsd18d5631z04910ryb";
+        url = "https://elpa.gnu.org/devel/plz-media-type-0.2.5pre0.20250412.100044.tar";
+        sha256 = "1w35bdxgsv1wvqwn64miyzplbb6gqry25wnl6l7dyd2n71h2hmxl";
       };
       packageRequires = [ plz ];
       meta = {
@@ -7131,10 +7176,10 @@
     elpaBuild {
       pname = "polymode";
       ename = "polymode";
-      version = "0.2.2.0.20241204.120252";
+      version = "0.2.2.0.20250511.135208";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20241204.120252.tar";
-        sha256 = "1ipdg4byc58gc4jncak5p6w7iyw0y173y4aky2fz88h1ccag2s2g";
+        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20250511.135208.tar";
+        sha256 = "1l5x9y6m8la0rlz56s1iqlqfr9v5gq0wfykiv8gir8sk0xgnz315";
       };
       packageRequires = [ ];
       meta = {
@@ -7281,10 +7326,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1.0.20250401.193603";
+      version = "0.11.1.0.20250428.24648";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250401.193603.tar";
-        sha256 = "0s7ih568lf1440h1zmgdx9f5wc5njpwk2ylkqvny9k0nwm8pp73m";
+        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250428.24648.tar";
+        sha256 = "142jsslwxg2s590szngpzm2srw1n7qdvl3gzbqrnngy91wpv7n9a";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7417,10 +7462,10 @@
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.30.0.20250329.174949";
+      version = "0.30.0.20250505.74536";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.30.0.20250329.174949.tar";
-        sha256 = "0ri9h0qc2kdlcg5nw9x7yhpqiiblhhzjj5zm1gb8fixx3css3x2m";
+        url = "https://elpa.gnu.org/devel/python-0.30.0.20250505.74536.tar";
+        sha256 = "0xcwr1vrcqafc5q9lzi0g3hb7xhv2cqc163mfsbhi7y2a80gylwi";
       };
       packageRequires = [
         compat
@@ -8215,10 +8260,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "0.2.1.0.20250303.51849";
+      version = "0.3.0.0.20250426.112415";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/show-font-0.2.1.0.20250303.51849.tar";
-        sha256 = "1nbgvb5id2jfjpics0fxmkc6mj343ry1ww6n8l1glk8nchskqx78";
+        url = "https://elpa.gnu.org/devel/show-font-0.3.0.0.20250426.112415.tar";
+        sha256 = "0ygk5qq98rmbyjnh58c5rpdszrpwvpn9vr55s6lpp94lwl1yhkwq";
       };
       packageRequires = [ ];
       meta = {
@@ -8385,10 +8430,10 @@
     elpaBuild {
       pname = "sml-mode";
       ename = "sml-mode";
-      version = "6.12.0.20230411.5343";
+      version = "6.12.0.20250404.173928";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/sml-mode-6.12.0.20230411.5343.tar";
-        sha256 = "1a7n0lvrjq4xnn0cr6qwgh7l54m95mf2nxwv1rplair4r8si8y0d";
+        url = "https://elpa.gnu.org/devel/sml-mode-6.12.0.20250404.173928.tar";
+        sha256 = "05cdfdsnphxxww1mb05fzf18gray50s7k96m4nfpqcwlyzmbi947";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -8492,10 +8537,10 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.6.0.0.20250106.104943";
+      version = "0.6.1.0.20250429.100228";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/spacious-padding-0.6.0.0.20250106.104943.tar";
-        sha256 = "0z27zcpfsxbkqhdajh42r201yzr2143cgszm3slxa4qalmzpmjsx";
+        url = "https://elpa.gnu.org/devel/spacious-padding-0.6.1.0.20250429.100228.tar";
+        sha256 = "189fqdm0j1mqpjwsl9jp3nqfr6ngn0y49nvraljakc9q6yxs46a3";
       };
       packageRequires = [ ];
       meta = {
@@ -9061,10 +9106,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.4.0.20250316.101606";
+      version = "1.4.0.20250512.155414";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.4.0.20250316.101606.tar";
-        sha256 = "179kwky5k79ci5yl0spj28c32f9jl3ka0q9b0702spgmv8slf5h4";
+        url = "https://elpa.gnu.org/devel/tempel-1.4.0.20250512.155414.tar";
+        sha256 = "173jl07yiv0kbb3gdci98dy08acaylmm564i4rgsrl4nyv32ad67";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9210,10 +9255,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.0.0.0.20241111.101250";
+      version = "1.1.0.0.20250426.50246";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tmr-1.0.0.0.20241111.101250.tar";
-        sha256 = "19g5xz0vfxjrfghdl8h4566v6sdr8cf4svm5yx98jijdr5np2a6s";
+        url = "https://elpa.gnu.org/devel/tmr-1.1.0.0.20250426.50246.tar";
+        sha256 = "01ya6w9fhrj6jmhnkhaxck1a7z9vq1zgm5fq4vv8hs3xbmidzpsv";
       };
       packageRequires = [ ];
       meta = {
@@ -9299,10 +9344,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.2.2.0.20250227.73653";
+      version = "2.7.2.3.1.0.20250408.65900";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.7.2.2.0.20250227.73653.tar";
-        sha256 = "19iaj5dzxqjw413j4fawgsi3fia73d28c3v2iy5la9xaxrqxwig5";
+        url = "https://elpa.gnu.org/devel/tramp-2.7.2.3.1.0.20250408.65900.tar";
+        sha256 = "0fl70dainnhz78bx611x4295ic751d4ranz9zh89xdygaj6hvzz8";
       };
       packageRequires = [ ];
       meta = {
@@ -9385,10 +9430,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.8.7.0.20250401.165541";
+      version = "0.8.8.0.20250511.180821";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.8.7.0.20250401.165541.tar";
-        sha256 = "05kkd8iq2jrx6jxr3kk8cx3ccgq4j9wr5rwm22iynnx1m7abhb5w";
+        url = "https://elpa.gnu.org/devel/transient-0.8.8.0.20250511.180821.tar";
+        sha256 = "1lh8d85qfc7yxc6gj33j930bikq3f7j7n87ajmjsd3y3bjayrcw9";
       };
       packageRequires = [
         compat
@@ -9479,10 +9524,10 @@
     elpaBuild {
       pname = "triples";
       ename = "triples";
-      version = "0.5.0.0.20250126.191724";
+      version = "0.6.0.0.20250510.230302";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/triples-0.5.0.0.20250126.191724.tar";
-        sha256 = "1wc1y1cl0dbyz76ni3xj1sp87i0cv0ixj2cj4sb8pp7i2k4xcqdl";
+        url = "https://elpa.gnu.org/devel/triples-0.6.0.0.20250510.230302.tar";
+        sha256 = "0xgx32rwxw4cf1c178mfasvpw7ng85mrakqyvzmmmbysj16dkcw8";
       };
       packageRequires = [ seq ];
       meta = {
@@ -9697,10 +9742,10 @@
     elpaBuild {
       pname = "use-package";
       ename = "use-package";
-      version = "2.4.6.0.20250330.141700";
+      version = "2.4.6.0.20250427.74855";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20250330.141700.tar";
-        sha256 = "099884d87xppwcgrg2lk25kmz8dab57qq55i3f1nx4cd36vnrfyb";
+        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20250427.74855.tar";
+        sha256 = "19x0hi00ychc2j18g323rkq7lghfc8p0g9kq3chwhqb46vmqr993";
       };
       packageRequires = [ bind-key ];
       meta = {
@@ -9830,10 +9875,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.1.0.20250323.115851";
+      version = "0.2.0.20250430.120738";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-jj-0.1.0.20250323.115851.tar";
-        sha256 = "15qjv10assm3zn2ny6kz9x0xfl88cmha1sxcj39qc6zaixzfvi2c";
+        url = "https://elpa.gnu.org/devel/vc-jj-0.2.0.20250430.120738.tar";
+        sha256 = "0gmqilpaaalg5sgdd7hcwgwz64k29v0a22zg14492bn7906zr1fs";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9937,10 +9982,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.0.0.20250401.162832";
+      version = "2.1.0.20250516.184229";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-2.0.0.20250401.162832.tar";
-        sha256 = "0aczd29i9g2rlvsmnrl5h9vhglp54bggjh97a3pb04mqmp0i0w9p";
+        url = "https://elpa.gnu.org/devel/vertico-2.1.0.20250516.184229.tar";
+        sha256 = "07dmj8p760c13grz45fc1wvpy7li2xvqg6scy7jx3jc9j5gdqdk9";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10068,10 +10113,10 @@
     elpaBuild {
       pname = "vundo";
       ename = "vundo";
-      version = "2.4.0.0.20250314.193537";
+      version = "2.4.0.0.20250417.151603";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vundo-2.4.0.0.20250314.193537.tar";
-        sha256 = "0pzcaryrj62b460vklxsikbg4n50hkfnkyqlxypzk2j2gavn0cyg";
+        url = "https://elpa.gnu.org/devel/vundo-2.4.0.0.20250417.151603.tar";
+        sha256 = "0rcplghs9pxjpkr658phkp3dfyzxrmjavqwz66i2jzc9lnpfq6rl";
       };
       packageRequires = [ ];
       meta = {
@@ -10413,10 +10458,10 @@
     elpaBuild {
       pname = "xeft";
       ename = "xeft";
-      version = "3.3.0.20230913.220528";
+      version = "3.6.0.20250501.222827";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xeft-3.3.0.20230913.220528.tar";
-        sha256 = "1zpm678nmnfs7vwirjil35nfwjkhr83f6pmn43lcdzrcz6y7nxn1";
+        url = "https://elpa.gnu.org/devel/xeft-3.6.0.20250501.222827.tar";
+        sha256 = "157384q5asxxibjz3g537cl0pa39z6scji53c3wnj8w3w1zm6jbm";
       };
       packageRequires = [ ];
       meta = {
@@ -10435,10 +10480,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.20.0.20250101.94850";
+      version = "0.20.0.20250426.232241";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xelb-0.20.0.20250101.94850.tar";
-        sha256 = "03lma8c203j736kl2pg1vmjd4iw52qg67qlb0617pr6dd7p7jr8j";
+        url = "https://elpa.gnu.org/devel/xelb-0.20.0.20250426.232241.tar";
+        sha256 = "19w0k5kn7g2254l2hvrs9m368s3rkbxkl9ymdlcilcnzs8z91c66";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10503,10 +10548,10 @@
     elpaBuild {
       pname = "xref";
       ename = "xref";
-      version = "1.7.0.0.20250321.211107";
+      version = "1.7.0.0.20250515.124004";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20250321.211107.tar";
-        sha256 = "059wmg5ch8smgs3ir2flhjj2dibqpr1875724lni1vk2dr3g6kmq";
+        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20250515.124004.tar";
+        sha256 = "1h93z4dlk7vd2wif93zsypr55mdfnd2yyy6n69wz3d410jf51jf7";
       };
       packageRequires = [ ];
       meta = {
@@ -10567,10 +10612,10 @@
     elpaBuild {
       pname = "yasnippet";
       ename = "yasnippet";
-      version = "0.14.1.0.20250112.175154";
+      version = "0.14.2.0.20250403.152613";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/yasnippet-0.14.1.0.20250112.175154.tar";
-        sha256 = "0f6fx935lv1rar7blqprwrcz0vilpgh4k564y801pnlcxh5ssnnh";
+        url = "https://elpa.gnu.org/devel/yasnippet-0.14.2.0.20250403.152613.tar";
+        sha256 = "0lsd7j5g3fk0gbk5qjr3vrwffyy56pf6hzgkqcsjz7jps0s8jw2v";
       };
       packageRequires = [ cl-lib ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "a68-mode";
       ename = "a68-mode";
-      version = "1.0";
+      version = "1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/a68-mode-1.0.tar";
-        sha256 = "1fhmsix14wmysbp3w0zaywlf3m5wqmgydw2377zsgbaz7k3s3y8x";
+        url = "https://elpa.gnu.org/packages/a68-mode-1.2.tar";
+        sha256 = "1x40j0w6kzjxxrj7qdvll1psackq526cfrihfmacmq97c9g8xwm6";
       };
       packageRequires = [ ];
       meta = {
@@ -527,10 +527,10 @@
     elpaBuild {
       pname = "auth-source-xoauth2-plugin";
       ename = "auth-source-xoauth2-plugin";
-      version = "0.1.1";
+      version = "0.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.1.1.tar";
-        sha256 = "0wag5iq3bgk3sazlc4a0g67l4517kv4khidkiwrrgv1b1nq0kcrl";
+        url = "https://elpa.gnu.org/packages/auth-source-xoauth2-plugin-0.2.tar";
+        sha256 = "18mmjcyqja46fkggghm45ln6gp1jjb68q4q4q93l3s2vx3hlk60y";
       };
       packageRequires = [ oauth2 ];
       meta = {
@@ -993,10 +993,10 @@
     elpaBuild {
       pname = "bufferlo";
       ename = "bufferlo";
-      version = "0.8";
+      version = "1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/bufferlo-0.8.tar";
-        sha256 = "0ypd611xmjsir24nv8gr19pq7f1n0gbgq9yzvfy3m6k97gpw2jzq";
+        url = "https://elpa.gnu.org/packages/bufferlo-1.1.tar";
+        sha256 = "0g72k2y5nfqa6j3y0c4z0x3crn8ynlkgvwysxhgh9vypq7cqldj0";
       };
       packageRequires = [ ];
       meta = {
@@ -1526,10 +1526,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.2";
+      version = "2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-2.2.tar";
-        sha256 = "082n0a27jpdz4z8g46m0c35s6xhca5s042wbzvrvh9hhd3mz64b7";
+        url = "https://elpa.gnu.org/packages/consult-2.3.tar";
+        sha256 = "0rmb5j0kv36lqy135rknfabbzaa7cpfqsgzkicsyzbq3rh3nmf1p";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1549,10 +1549,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.2.4";
+      version = "0.3.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-denote-0.2.4.tar";
-        sha256 = "1a5gxrm8qw638hdplvlizwmyvm84ispm5w751vd7ngmcsiaabvmp";
+        url = "https://elpa.gnu.org/packages/consult-denote-0.3.1.tar";
+        sha256 = "1rvn90wv6r48129w4s8wcc2gp9wa92zxwc0a4yc70xc5xxm85xi4";
       };
       packageRequires = [
         consult
@@ -1639,10 +1639,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.0";
+      version = "2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/corfu-2.0.tar";
-        sha256 = "0qih9km4l7i6isaskap9knqhqnjc85qlr2wrrik5cc8yl6yrc36g";
+        url = "https://elpa.gnu.org/packages/corfu-2.1.tar";
+        sha256 = "07ffi16b2ay1rcc8bdryg1h901pjbhfaq1qqsm463iis490rzm81";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1899,10 +1899,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.23.0";
+      version = "0.24.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dape-0.23.0.tar";
-        sha256 = "0y6snj9cwn1f754bn2smyf8ggjihws7a0rxb3b5s8dsvdkgz5hzy";
+        url = "https://elpa.gnu.org/packages/dape-0.24.1.tar";
+        sha256 = "01w2sr9cbs1d9zh15gajyac7xcqbz40f5xfwv0c7jmsqkn7rv7aq";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -2033,10 +2033,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "3.1.0";
+      version = "4.0.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-3.1.0.tar";
-        sha256 = "03l9ya2n0nrj72dpnflxv19k8agzl3lab7hq0aqb7vzxafjfip74";
+        url = "https://elpa.gnu.org/packages/denote-4.0.0.tar";
+        sha256 = "13a1aynmrj1vzq9xljs2h96pywqhr7iblyag51asxjynkzj2z27g";
       };
       packageRequires = [ ];
       meta = {
@@ -2055,10 +2055,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.0.0.1";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-journal-0.0.0.1.tar";
-        sha256 = "07xb58jqkh0nwzc8l8k1cvqdlkm7iyb3ajjndkz6kvg7vhxiaaqi";
+        url = "https://elpa.gnu.org/packages/denote-journal-0.1.1.tar";
+        sha256 = "0922hjzah7nz49z3q3qyq06n77yqxd7mxiw7fmawavjh920dv3fq";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2077,10 +2077,10 @@
     elpaBuild {
       pname = "denote-markdown";
       ename = "denote-markdown";
-      version = "0.0.0.1";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-markdown-0.0.0.1.tar";
-        sha256 = "1sn3h6jjclqwda5hch8c23s485w9sra2m3lqz9qcsjdcmb85cxk1";
+        url = "https://elpa.gnu.org/packages/denote-markdown-0.1.1.tar";
+        sha256 = "0ic8kqfw56xsm9s0rlq7cgnh0dzjsbbcx7kdk55dggpvxv67jj62";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2121,10 +2121,10 @@
     elpaBuild {
       pname = "denote-org";
       ename = "denote-org";
-      version = "0.0.0.1";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-org-0.0.0.1.tar";
-        sha256 = "0mipl5b728qwxwskc28jrvxjf1n5x25gggsrfx8qmdz5z4p0dglr";
+        url = "https://elpa.gnu.org/packages/denote-org-0.1.1.tar";
+        sha256 = "0nwyyzx96d5k6dw4jb8bvni9fjr1plip57mdsyabrha19p6n282d";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2165,10 +2165,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.0.0.1";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-sequence-0.0.0.1.tar";
-        sha256 = "0z947wk5n2ign2d36b1ahdldr99ir7cmvdhmq4i5dv2kwj36ga1n";
+        url = "https://elpa.gnu.org/packages/denote-sequence-0.1.1.tar";
+        sha256 = "06s2k555in897rpr2iabzv29dr79lm6fkpjp3yssidr9irxymf0h";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2187,10 +2187,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.0.0.1";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-silo-0.0.0.1.tar";
-        sha256 = "011l6nd7wqjy2zwg0pifi1zqr1diay4i170binl78wv4bxd5z0ln";
+        url = "https://elpa.gnu.org/packages/denote-silo-0.1.1.tar";
+        sha256 = "1jxr52npjiwisambwav6rasndjdxhll8x278q8cr7giq71am7c8b";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2449,10 +2449,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.4.0";
+      version = "0.5.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dired-preview-0.4.0.tar";
-        sha256 = "1ns0vgg0rmx823rcd4c18xxg6kjj22lklv74bhxf7cj6h50r4z7l";
+        url = "https://elpa.gnu.org/packages/dired-preview-0.5.2.tar";
+        sha256 = "1zipwb9ydyx6cscpf8p7vf2fl03rd7diivdvq9h73pbz754m0bq9";
       };
       packageRequires = [ ];
       meta = {
@@ -2563,6 +2563,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/doc-toc.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  doc-view-follow = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "doc-view-follow";
+      ename = "doc-view-follow";
+      version = "0.3.2";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/doc-view-follow-0.3.2.tar";
+        sha256 = "1lwzcmxsqcbwf42s8yisw3wraka3yphhwf51pznlvdwhwax4h4ph";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/doc-view-follow.html";
         license = lib.licenses.free;
       };
     }
@@ -2799,10 +2820,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.9.0";
+      version = "1.10.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ef-themes-1.9.0.tar";
-        sha256 = "03gi3gwrng9arffypmlnd96404yxac78k59q5yb1y1f8fahy199k";
+        url = "https://elpa.gnu.org/packages/ef-themes-1.10.0.tar";
+        sha256 = "1mpaw1icvalq1ydxby9zfbjdgkk9wvld31xjrbr684ps5ix8f1f2";
       };
       packageRequires = [ ];
       meta = {
@@ -2860,10 +2881,10 @@
     elpaBuild {
       pname = "el-job";
       ename = "el-job";
-      version = "2.4.3";
+      version = "2.4.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/el-job-2.4.3.tar";
-        sha256 = "1iqbs2f71a0mmrmfr2l6dwr6l5h1399z14jv8zfl5zh8h75sm9pm";
+        url = "https://elpa.gnu.org/packages/el-job-2.4.7.tar";
+        sha256 = "0gh4vwq986jhfld0cibxmy5zcngzq4mxw4j4rpsv8nhwg0wpr84j";
       };
       packageRequires = [ ];
       meta = {
@@ -3463,10 +3484,10 @@
     elpaBuild {
       pname = "filechooser";
       ename = "filechooser";
-      version = "0.2.1";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/filechooser-0.2.1.tar";
-        sha256 = "1q9yxq4c6lp1fllcd60mcj4bs0ia03i649jilknkcp7jmjihq07i";
+        url = "https://elpa.gnu.org/packages/filechooser-0.2.2.tar";
+        sha256 = "1y1f6nihay2xbnywki39kp01x20pmg41jl2r0qhw7s31q4qaxyrv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3549,10 +3570,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.3.7";
+      version = "1.4.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/flymake-1.3.7.tar";
-        sha256 = "15ikzdqyh77cgx94jaigfrrzfvwvpca8s2120gi82i9aaiypr7jl";
+        url = "https://elpa.gnu.org/packages/flymake-1.4.1.tar";
+        sha256 = "0l20gxzlvpl0d3wvvsam3mda5hdlag4anplx3fd4xksbvfhndzlk";
       };
       packageRequires = [
         eldoc
@@ -3637,10 +3658,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "3.0.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/fontaine-3.0.0.tar";
-        sha256 = "1v2gwry755m3gj6gxrxgcbvw39sdgrmazpw09nkayrvx9ar5fszw";
+        url = "https://elpa.gnu.org/packages/fontaine-3.0.1.tar";
+        sha256 = "0bgfg6pkw724id1d3igiw4g0204wnjwsbnabfy2rq6nrf99z1qwr";
       };
       packageRequires = [ ];
       meta = {
@@ -4152,10 +4173,10 @@
     elpaBuild {
       pname = "gtags-mode";
       ename = "gtags-mode";
-      version = "1.8.2";
+      version = "1.8.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/gtags-mode-1.8.2.tar";
-        sha256 = "1lmaaqlklsifjzagi3miplr17vmzqjzglbkxccffj50mi6y5w4cs";
+        url = "https://elpa.gnu.org/packages/gtags-mode-1.8.5.tar";
+        sha256 = "0pia7ivd11hw9ngdghvcbrapndkpq5ra0jx566f7vgrdxxl73ynm";
       };
       packageRequires = [ ];
       meta = {
@@ -4437,10 +4458,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.8.2";
+      version = "0.8.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/indent-bars-0.8.2.tar";
-        sha256 = "1bhdrykkklsscgiz3p29x8kdkw0kbc4mlpnhxghvphx159clhgym";
+        url = "https://elpa.gnu.org/packages/indent-bars-0.8.4.tar";
+        sha256 = "0k674rzl32zzqgkix6924987rb09bs7f3blakqybvzi59cpz9afz";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4750,10 +4771,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.0";
+      version = "2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jinx-2.0.tar";
-        sha256 = "1haix1q4rfz18m4bblp4k4gqjd9jbwg9j9zl411b8s2ga268pdkk";
+        url = "https://elpa.gnu.org/packages/jinx-2.1.tar";
+        sha256 = "1v4a00bgs6qcpim861kky1i2w0qfn2hza9vj0inn7lh1sic82rkm";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5177,10 +5198,10 @@
     elpaBuild {
       pname = "literate-scratch";
       ename = "literate-scratch";
-      version = "1.0";
+      version = "2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/literate-scratch-1.0.tar";
-        sha256 = "1rby70wfj6g0p4hc6xqzwgqj2g8780qm5mnjn95bl2wrvdi0ds6n";
+        url = "https://elpa.gnu.org/packages/literate-scratch-2.2.tar";
+        sha256 = "01n27aps7dkydqda89xblmhc82g8y6dkmbhxgfav13vw2ns2r7sc";
       };
       packageRequires = [ ];
       meta = {
@@ -5201,10 +5222,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.24.2";
+      version = "0.25.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.24.2.tar";
-        sha256 = "16d3758k1xc1w8am9yjzmgri2ijw4gpyaxqvsc1db08ravzqnc21";
+        url = "https://elpa.gnu.org/packages/llm-0.25.0.tar";
+        sha256 = "0ykzx0g6w3b9hlxyx41rkbj2n5pjkpf3y0jqiwl012j7zxg1ay6w";
       };
       packageRequires = [
         plz
@@ -5715,10 +5736,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.4.4";
+      version = "0.5.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/minuet-0.4.4.tar";
-        sha256 = "0ci47awqky1c28zk3azd4id9wcpd3n9nj5jw5s8ji613kqc1nqs2";
+        url = "https://elpa.gnu.org/packages/minuet-0.5.4.tar";
+        sha256 = "01mw4sqb7rp9zpxjm590a9qvxiyawwhjyq3k568gv30pj3a9lrxp";
       };
       packageRequires = [
         dash
@@ -5761,10 +5782,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.6.0";
+      version = "4.7.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/modus-themes-4.6.0.tar";
-        sha256 = "19hg2gqpa19rnlj0pn7v8sd52q5mkinf39l7rb0a6xqbkfzqvsnd";
+        url = "https://elpa.gnu.org/packages/modus-themes-4.7.0.tar";
+        sha256 = "1p0lfcc897dxf9f3ylnym1ird4j90sgy2i34yvmbr22ii2pc47sw";
       };
       packageRequires = [ ];
       meta = {
@@ -6189,10 +6210,10 @@
     elpaBuild {
       pname = "ob-asymptote";
       ename = "ob-asymptote";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ob-asymptote-1.0.1.tar";
-        sha256 = "0f1vpq691pna1p1lgqw2nzmdw25sjsmpcvgm2lj7n14kg7dizxal";
+        url = "https://elpa.gnu.org/packages/ob-asymptote-1.0.2.tar";
+        sha256 = "0b9glzj3aq39rksb0bg4qvsnqknwjk7lbixapw9695hfr2l4hv02";
       };
       packageRequires = [ ];
       meta = {
@@ -6339,10 +6360,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.7.27";
+      version = "9.7.30";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.7.27.tar";
-        sha256 = "0y2x94qxi6wa7mrcdppyynylv9j5sszik25bmjwsfriiwqwk5gp6";
+        url = "https://elpa.gnu.org/packages/org-9.7.30.tar";
+        sha256 = "1886c5aw050iwqh7k3grp73ghdr70y20nfbpxgcwbzwkhkz2w9xy";
       };
       packageRequires = [ ];
       meta = {
@@ -6634,10 +6655,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.6";
+      version = "1.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/osm-1.6.tar";
-        sha256 = "09fybkkcjn0c55w0accxgv2581kf3s2nhcn3wvny2zfpysijpw13";
+        url = "https://elpa.gnu.org/packages/osm-1.7.tar";
+        sha256 = "1iqg0cjqq2fzrimzgxqa7jsvhzajycl4nq1c7fsr3pd5yjp8d4z8";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6762,10 +6783,10 @@
     elpaBuild {
       pname = "parser-generator";
       ename = "parser-generator";
-      version = "0.2.4";
+      version = "0.2.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/parser-generator-0.2.4.tar";
-        sha256 = "01b5bwh484fpicv0g2z64694pjkhrcqz9f8jpq6hk41kzhvr23m1";
+        url = "https://elpa.gnu.org/packages/parser-generator-0.2.5.tar";
+        sha256 = "1bfvhqwv3qapqvl35v6ac1nsl1p9fwzja02vdqif3sdyr30ps340";
       };
       packageRequires = [ ];
       meta = {
@@ -6889,10 +6910,10 @@
     elpaBuild {
       pname = "phps-mode";
       ename = "phps-mode";
-      version = "0.4.50";
+      version = "0.4.51";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/phps-mode-0.4.50.tar";
-        sha256 = "1dyxqkyik6cxmqnwmxlxd1v42jcnkh0hl1qqm65nhvmf3ksq59kh";
+        url = "https://elpa.gnu.org/packages/phps-mode-0.4.51.tar";
+        sha256 = "1qiy16gh24sh274sasshxb230r2r2bx1b7awr9php854840p7pvx";
       };
       packageRequires = [ ];
       meta = {
@@ -6953,10 +6974,10 @@
     elpaBuild {
       pname = "plz-event-source";
       ename = "plz-event-source";
-      version = "0.1.2";
+      version = "0.1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/plz-event-source-0.1.2.tar";
-        sha256 = "1gq0w6pkg58066gwc58y3j0w2hbfzmy1r62j02jfiqjb5am1gfjk";
+        url = "https://elpa.gnu.org/packages/plz-event-source-0.1.3.tar";
+        sha256 = "1ayi272pvbblynrxhh51adq34jdjp6j2wfzwry7ysq0fz8vxs7nj";
       };
       packageRequires = [ plz-media-type ];
       meta = {
@@ -6975,10 +6996,10 @@
     elpaBuild {
       pname = "plz-media-type";
       ename = "plz-media-type";
-      version = "0.2.3";
+      version = "0.2.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/plz-media-type-0.2.3.tar";
-        sha256 = "1qb0zag7isnl9hx71jma5yk6rinfdbscmlgwg2489067vshf9x7b";
+        url = "https://elpa.gnu.org/packages/plz-media-type-0.2.4.tar";
+        sha256 = "1gsq86zb3bsasryafhgxbln2sy1w722iz61pd6fi4j6xszb5pb32";
       };
       packageRequires = [ plz ];
       meta = {
@@ -8101,10 +8122,10 @@
     elpaBuild {
       pname = "show-font";
       ename = "show-font";
-      version = "0.2.1";
+      version = "0.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/show-font-0.2.1.tar";
-        sha256 = "1nbmzbf6gqzllv025xdbrqpq1j7prmv8vh86h9abaikjradiysmx";
+        url = "https://elpa.gnu.org/packages/show-font-0.3.0.tar";
+        sha256 = "1xrpzrb1i3593fawqy6bgfjn0fixgpnkq0kad14fk8qibh9iwb0x";
       };
       packageRequires = [ ];
       meta = {
@@ -8378,10 +8399,10 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.6.0";
+      version = "0.6.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/spacious-padding-0.6.0.tar";
-        sha256 = "0czx4w6vm56blvc26gymmijvcqhvmrlakqwlks1prckgnkgsvcpx";
+        url = "https://elpa.gnu.org/packages/spacious-padding-0.6.1.tar";
+        sha256 = "0g5f8hagv494773mdzaajmccjzzqgd2ixv2rmwwhjgwck910zwqg";
       };
       packageRequires = [ ];
       meta = {
@@ -9043,7 +9064,6 @@
   ) { };
   tmr = callPackage (
     {
-      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -9051,12 +9071,12 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tmr-1.0.0.tar";
-        sha256 = "02dj5kh8ayhfy1w9vy77s7izz4495n4jkcbw6xscc8wyfml0j15f";
+        url = "https://elpa.gnu.org/packages/tmr-1.1.0.tar";
+        sha256 = "1bvysr05007qgzy2z6rxhhxpaq4b648icfmnj6qf8ydn8b5ih5kw";
       };
-      packageRequires = [ compat ];
+      packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/tmr.html";
         license = lib.licenses.free;
@@ -9140,10 +9160,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.2.2";
+      version = "2.7.2.3.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.7.2.2.tar";
-        sha256 = "0nq441hdr9akpdklplnf4hcza4jgj4vq2718mvf2iznbqqs4b33k";
+        url = "https://elpa.gnu.org/packages/tramp-2.7.2.3.1.tar";
+        sha256 = "171jmgb9sdj1iqq6a77kxin15yik952vvavhpvdr0wxhdq095mgg";
       };
       packageRequires = [ ];
       meta = {
@@ -9226,10 +9246,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.8.7";
+      version = "0.8.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.8.7.tar";
-        sha256 = "0j4n8zqnc2l2p6hy3k9b7zahzqxwk8d239whnn0yjp91z11i945c";
+        url = "https://elpa.gnu.org/packages/transient-0.8.8.tar";
+        sha256 = "0rirggilwk42ha9lykfca6ma4l1pn0wwkvdh2njviaksidy7jasi";
       };
       packageRequires = [
         compat
@@ -9320,10 +9340,10 @@
     elpaBuild {
       pname = "triples";
       ename = "triples";
-      version = "0.5.0";
+      version = "0.6.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/triples-0.5.0.tar";
-        sha256 = "0s2p5zkgp1xavib3yrjwkbyqy6clgafz7ywy65kharapx0cjl4nm";
+        url = "https://elpa.gnu.org/packages/triples-0.6.0.tar";
+        sha256 = "12qf91ldgkwgkwj3a5g68qy4sbmrqmxq4qcgcnygj570ipjv49q8";
       };
       packageRequires = [ seq ];
       meta = {
@@ -9666,6 +9686,28 @@
       };
     }
   ) { };
+  vc-jj = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "vc-jj";
+      ename = "vc-jj";
+      version = "0.2";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/vc-jj-0.2.tar";
+        sha256 = "19yhv1jgix49pvclf42xx23fh2zbr32q51664a99dncn8jhy7bdy";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/vc-jj.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   vcard = callPackage (
     {
       elpaBuild,
@@ -9761,10 +9803,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.0";
+      version = "2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-2.0.tar";
-        sha256 = "1x34vsrr812wlawb5wy5aq81467xsjxjz0zsjsxq121d4pzam4z3";
+        url = "https://elpa.gnu.org/packages/vertico-2.1.tar";
+        sha256 = "03xkl8df90gs26cy00qbk0w23192bkaj32fgaf1w3ajq7mdvfd6p";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10236,10 +10278,10 @@
     elpaBuild {
       pname = "xeft";
       ename = "xeft";
-      version = "3.3";
+      version = "3.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/xeft-3.3.tar";
-        sha256 = "00zkhqajkkf979ccbnz076dpav2v52q44li2m4m4c6p3z0c3y255";
+        url = "https://elpa.gnu.org/packages/xeft-3.6.tar";
+        sha256 = "0vdnl0rp9bkl5gyyacqczbl41vl8hrvah51jbfx4szf4qldmfhsm";
       };
       packageRequires = [ ];
       meta = {
@@ -10390,10 +10432,10 @@
     elpaBuild {
       pname = "yasnippet";
       ename = "yasnippet";
-      version = "0.14.1";
+      version = "0.14.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/yasnippet-0.14.1.tar";
-        sha256 = "0xsq0i9xv9hib5a52rv5vywq1v6gr44gjsyfmqxwffmw1a25x25g";
+        url = "https://elpa.gnu.org/packages/yasnippet-0.14.2.tar";
+        sha256 = "0cq31r58vxh660bws26yhpnjz89yr5f2ldjw1q5a1gp3hbzd2130";
       };
       packageRequires = [ cl-lib ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -48,18 +48,20 @@
       elpaBuild,
       fetchurl,
       lib,
+      markdown-mode,
       transient,
     }:
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.1.0.20250401.165709";
+      version = "1.3.0.20250515.132734";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.1.0.20250401.165709.tar";
-        sha256 = "1jk832psy61ss04dr7h0563np2v6j57qxbf78b5kpzfsc0x1m946";
+        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.3.0.20250515.132734.tar";
+        sha256 = "010sxd4k7xqkpf2jyyffrkxkgn1cq6wq0mkmmh56xpj3mrrxchyp";
       };
       packageRequires = [
         compat
+        markdown-mode
         transient
       ];
       meta = {
@@ -119,10 +121,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.3.1.0.20250320.130448";
+      version = "2.4.2.0.20250515.142850";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.3.1.0.20250320.130448.tar";
-        sha256 = "16djnp8mknq8rdk4sa4szsmbbg879677dx736pqg621gdy0p2p8m";
+        url = "https://elpa.nongnu.org/nongnu-devel/annotate-2.4.2.0.20250515.142850.tar";
+        sha256 = "0g30jcpb44vdb43msn93w8j4f2zk0zm7n3l2ghndvm31qc3qr1k8";
       };
       packageRequires = [ ];
       meta = {
@@ -182,10 +184,10 @@
     elpaBuild {
       pname = "apache-mode";
       ename = "apache-mode";
-      version = "2.2.0.0.20240327.1751";
+      version = "2.2.0.0.20250422.172352";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/apache-mode-2.2.0.0.20240327.1751.tar";
-        sha256 = "0yr3m1340327skxln7z2acns6kingaid4wryi9lyfv05fwhfgl5a";
+        url = "https://elpa.nongnu.org/nongnu-devel/apache-mode-2.2.0.0.20250422.172352.tar";
+        sha256 = "1gqjb98d1wihfryacdyjivsxidydilb6glgivf39l8ca2xk44dbg";
       };
       packageRequires = [ ];
       meta = {
@@ -268,10 +270,10 @@
     elpaBuild {
       pname = "autothemer";
       ename = "autothemer";
-      version = "0.2.18.0.20230907.60046";
+      version = "0.2.18.0.20250421.72550";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/autothemer-0.2.18.0.20230907.60046.tar";
-        sha256 = "0qay7d5z0p91kzpbp140daqyiclsksql6cnp0bn1602n4f3dn4ii";
+        url = "https://elpa.nongnu.org/nongnu-devel/autothemer-0.2.18.0.20250421.72550.tar";
+        sha256 = "0y6k0ysy4z7am8zapp1gynr3rjm9vwggi8syc1a19niaqvzm80c4";
       };
       packageRequires = [ dash ];
       meta = {
@@ -310,10 +312,10 @@
     elpaBuild {
       pname = "bash-completion";
       ename = "bash-completion";
-      version = "3.2.1snapshot0.20250101.145820";
+      version = "3.2.1snapshot0.20250425.222123";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20250101.145820.tar";
-        sha256 = "11a2fijxi102mnm63vbxgrrw2rr9nf5rhlfal3766m8rv2drwhd7";
+        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20250425.222123.tar";
+        sha256 = "0a9z0r6sj5jyyqhmai5cfkc147aprqzy6kmbix2n3kwnn95vbqkq";
       };
       packageRequires = [ ];
       meta = {
@@ -436,10 +438,10 @@
     elpaBuild {
       pname = "blueprint-ts-mode";
       ename = "blueprint-ts-mode";
-      version = "0.0.3.0.20231031.183012";
+      version = "0.0.3.0.20250510.181219";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/blueprint-ts-mode-0.0.3.0.20231031.183012.tar";
-        sha256 = "1pa2a2r54pn7lmkgmwrc2lxvnabjbjlqs8rgkmqrfgnq1gkrm6rh";
+        url = "https://elpa.nongnu.org/nongnu-devel/blueprint-ts-mode-0.0.3.0.20250510.181219.tar";
+        sha256 = "0vz3ds7pm31gkckhhqy69k051x3gl7d1i143q1jb6k1xqvgiz6h4";
       };
       packageRequires = [ ];
       meta = {
@@ -570,10 +572,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.18.0snapshot0.20250401.193622";
+      version = "1.18.0.0.20250512.132717";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.18.0snapshot0.20250401.193622.tar";
-        sha256 = "08grbaz79nlylmjkza6qw6rh1kzqp0v7ydx6867wfi5xg15xvik2";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.18.0.0.20250512.132717.tar";
+        sha256 = "0xg81szscjzi8acq96frknpsqqpqwy4lrjs0xjd96smfdz22l47c";
       };
       packageRequires = [
         clojure-mode
@@ -599,10 +601,10 @@
     elpaBuild {
       pname = "clojure-mode";
       ename = "clojure-mode";
-      version = "5.20.0snapshot0.20241211.152233";
+      version = "5.20.0snapshot0.20250406.154328";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.20.0snapshot0.20241211.152233.tar";
-        sha256 = "0m6bafwl3687ccl815q70bw4q8k3w12vkfl24g5x9rn6dn44ppxx";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.20.0snapshot0.20250406.154328.tar";
+        sha256 = "16m89nva2wrin5pbn3iskv43clc9vmvvzc3m2ldyy2vl08lkzbbd";
       };
       packageRequires = [ ];
       meta = {
@@ -620,10 +622,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.2.4snapshot0.20250326.192250";
+      version = "0.4.0.0.20250516.71256";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.2.4snapshot0.20250326.192250.tar";
-        sha256 = "1s32fz618kiglhspdy51p8pa7rmyr0djg4f5kpii3xvcn7lhfa77";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.4.0.0.20250516.71256.tar";
+        sha256 = "1r8r0ym20qc791svcz560m2ir0p4siid7q98y7mn23yfw9kakz81";
       };
       packageRequires = [ ];
       meta = {
@@ -664,10 +666,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.0.0.20250101.91433";
+      version = "1.0.0.20250512.155519";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250101.91433.tar";
-        sha256 = "05ms0zhswsdlvvrz71md4nsqisshar284xn7idw7z01ddd05rjmb";
+        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250512.155519.tar";
+        sha256 = "09zzr69iais44669bm52ciw3jh55zi98z3kc0nr1v2h656z5yaq4";
       };
       packageRequires = [
         consult
@@ -714,10 +716,10 @@
     elpaBuild {
       pname = "crux";
       ename = "crux";
-      version = "0.6.0snapshot0.20250212.201746";
+      version = "0.6.0snapshot0.20250421.93605";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/crux-0.6.0snapshot0.20250212.201746.tar";
-        sha256 = "1apz9kfs416l9r47wkbw1a6wpysxn1fvyywpkfwfb4r7j9dlmsdm";
+        url = "https://elpa.nongnu.org/nongnu-devel/crux-0.6.0snapshot0.20250421.93605.tar";
+        sha256 = "1kzscg15rb237q0y9brl9xbb5z5ygfq6malzhr3axlx2r20xgdi4";
       };
       packageRequires = [ ];
       meta = {
@@ -736,10 +738,10 @@
     elpaBuild {
       pname = "csv2ledger";
       ename = "csv2ledger";
-      version = "1.5.4.0.20250204.233740";
+      version = "1.5.4.0.20250417.171625";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/csv2ledger-1.5.4.0.20250204.233740.tar";
-        sha256 = "1rx1k7fzlnlxn8crjm21qnq57g5p31zlk6z6zf883sakc2jwal7f";
+        url = "https://elpa.nongnu.org/nongnu-devel/csv2ledger-1.5.4.0.20250417.171625.tar";
+        sha256 = "1m72znfi5hd9pwavc99g8amxwc0jdyly7gsww2aq0fw4q971kiaf";
       };
       packageRequires = [ csv-mode ];
       meta = {
@@ -779,10 +781,10 @@
     elpaBuild {
       pname = "cycle-at-point";
       ename = "cycle-at-point";
-      version = "0.2.0.20240422.30057";
+      version = "0.2.0.20250421.105916";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20240422.30057.tar";
-        sha256 = "18nlbg8jwdgvi56qgbvqs0z8yfj9nkw30da45d7anjaln6a8089j";
+        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20250421.105916.tar";
+        sha256 = "1k8wx7lvdv6194l1367a3z15qbgx8ypipqwrk99wbq1hjiwqs07q";
       };
       packageRequires = [ recomplete ];
       meta = {
@@ -821,10 +823,10 @@
     elpaBuild {
       pname = "dart-mode";
       ename = "dart-mode";
-      version = "1.0.7.0.20250224.120240";
+      version = "1.0.7.0.20250422.170214";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20250224.120240.tar";
-        sha256 = "0jc4snbk62fi2ksnca8cp7m3jc7xr0yaap9p9hjjv72h1hnnl1rl";
+        url = "https://elpa.nongnu.org/nongnu-devel/dart-mode-1.0.7.0.20250422.170214.tar";
+        sha256 = "1q0znwlbg9adgp2nis1mzyxn281ddh3jyjwqan7mr116qxjsrxcv";
       };
       packageRequires = [ ];
       meta = {
@@ -928,10 +930,10 @@
     elpaBuild {
       pname = "diff-ansi";
       ename = "diff-ansi";
-      version = "0.2.0.20250224.222628";
+      version = "0.2.0.20250408.234444";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20250224.222628.tar";
-        sha256 = "03qqmcn0lni4sb0vz25sjspq64f1b2a0nkvy7bfyifsjn8an1kqs";
+        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20250408.234444.tar";
+        sha256 = "1wkja7733l5kwj4j2jlfa9c9607059asyvap6xdihqqd1ic1l3w5";
       };
       packageRequires = [ ];
       meta = {
@@ -950,10 +952,10 @@
     elpaBuild {
       pname = "dirvish";
       ename = "dirvish";
-      version = "2.2.7.0.20250402.153806";
+      version = "2.3.0.0.20250504.80741";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dirvish-2.2.7.0.20250402.153806.tar";
-        sha256 = "0zqyvcqmvxjrbnj8s47phmmx3fxdgj6613i27w8mjjd8p3l6ggn7";
+        url = "https://elpa.nongnu.org/nongnu-devel/dirvish-2.3.0.0.20250504.80741.tar";
+        sha256 = "0h8ap8bnqy2czvgkc71l49ms3kwk8lciz0ydzi2yy5xgh5pvs71k";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1013,10 +1015,10 @@
     elpaBuild {
       pname = "dracula-theme";
       ename = "dracula-theme";
-      version = "1.8.2.0.20250325.124646";
+      version = "1.8.2.0.20250407.120528";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.2.0.20250325.124646.tar";
-        sha256 = "13jry36wqjqdljk0lq2zm6gcs2hr33aj30l69jkhk6y4yiicjm9j";
+        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.2.0.20250407.120528.tar";
+        sha256 = "04xy1glqxzildh9rbl529mlsvabx5bzwdd8gd12cki5lgx320fn5";
       };
       packageRequires = [ ];
       meta = {
@@ -1120,10 +1122,10 @@
     elpaBuild {
       pname = "editorconfig";
       ename = "editorconfig";
-      version = "0.11.0.0.20250219.152840";
+      version = "0.11.0.0.20250426.231051";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20250219.152840.tar";
-        sha256 = "1dhb67w0hjh59hbkscw7xs4l5sizdip0xif2s11yx1nxzk86aw8w";
+        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20250426.231051.tar";
+        sha256 = "18l7z7qzwyb93pmlmwvp3lbka0i23afs95ql5j5wa9y0nggyxhnp";
       };
       packageRequires = [ ];
       meta = {
@@ -1225,10 +1227,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.0.0.20250401.150013";
+      version = "4.3.0.0.20250509.141847";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.0.0.20250401.150013.tar";
-        sha256 = "1bx0mg3i45m6qa3a7iar0kjmapqf5xqpxvfskqrvxgc5ac3kvxs1";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.0.0.20250509.141847.tar";
+        sha256 = "140mzggvkfjgfx52q4zahbbskcqcbv6vxpw7k9ky9hawr30gbq0a";
       };
       packageRequires = [ ];
       meta = {
@@ -1721,10 +1723,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "35.0snapshot0.20250226.154115";
+      version = "35.0.0.20250424.133949";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0snapshot0.20250226.154115.tar";
-        sha256 = "1sxlipzvh0sr057zydh1pqdnx6ginh0yrfycbv1ps3bwvpc7g8a5";
+        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0.0.20250424.133949.tar";
+        sha256 = "1k54zvcrl3wms2bsza44h56kxbwjqpaym4p70a6dxxw3ac60jlfq";
       };
       packageRequires = [ ];
       meta = {
@@ -1858,10 +1860,10 @@
     elpaBuild {
       pname = "free-keys";
       ename = "free-keys";
-      version = "1.0.0.20211116.150106";
+      version = "1.0.0.20250512.152751";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/free-keys-1.0.0.20211116.150106.tar";
-        sha256 = "08z5w5xxaz577lnwfmvrbh7485rbra7rl6b77m54vjxi24m75jhv";
+        url = "https://elpa.nongnu.org/nongnu-devel/free-keys-1.0.0.20250512.152751.tar";
+        sha256 = "0nf29341jhwbpiqqzfi66yn9gw8m7y8cnd6afb0bixci1hnhaz1n";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2177,10 +2179,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.4.0.20240805.132007";
+      version = "1.4.4.0.20250509.145352";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.4.0.20240805.132007.tar";
-        sha256 = "0gbgjdk6gi1898nbxj2wbiifbmld42v4s2zsckgqv4r5pxdwc6ai";
+        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.4.0.20250509.145352.tar";
+        sha256 = "11ylk079n4zhly3pp3a5b1d7h454dxhwf859r7rvj6njxkc1vwa8";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2375,10 +2377,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.8.0.20250402.114541";
+      version = "0.9.8.0.20250515.225537";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.8.0.20250402.114541.tar";
-        sha256 = "0nc9dxhva2wrdsan84vxjhc9pavzrnsjs4zm916rg46bmm8z01j1";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.8.0.20250515.225537.tar";
+        sha256 = "0wcy7qq8d1pnpjf6fqwcff8r4gbl08azlayyxabqsakgr3498p5d";
       };
       packageRequires = [
         compat
@@ -2549,10 +2551,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1.0.20250315.43516";
+      version = "1.1.4.0.20250516.134138";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.0.20250315.43516.tar";
-        sha256 = "1a6jdmx8h9w9naqhj80v1vq7ms1a9sr58zqnq634xnj35jygzlib";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.1.4.0.20250516.134138.tar";
+        sha256 = "15d4bc5i7p7r9psqdaljyvhxvzlwigzy8sb4iv0wxhbv7wwgwv37";
       };
       packageRequires = [ ];
       meta = {
@@ -2572,10 +2574,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.2.0.20250401.65011";
+      version = "4.0.3.0.20250515.54814";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.2.0.20250401.65011.tar";
-        sha256 = "09fs2fd7vdywg2z7gwy7z6vbi7ya65nz4sscd34v41pqhzqnc9bw";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.3.0.20250515.54814.tar";
+        sha256 = "0q6scri31v9pjbjkf8sf969aqal228yx66hsahb77gcpvfx0ribg";
       };
       packageRequires = [
         helm-core
@@ -2597,10 +2599,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.2.0.20250401.65011";
+      version = "4.0.3.0.20250515.54814";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.2.0.20250401.65011.tar";
-        sha256 = "0zlv04s1l487hszx0zs08awn5lcx1ngkiw6pkmndgxy1dhwqc4j9";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.3.0.20250515.54814.tar";
+        sha256 = "0f66yi42zqccv8i7mlqclvy6c3a5xqc58j54lc4qqr826wmmizbf";
       };
       packageRequires = [ async ];
       meta = {
@@ -2730,10 +2732,10 @@
     elpaBuild {
       pname = "hyperdrive";
       ename = "hyperdrive";
-      version = "0.6pre0.20250330.212748";
+      version = "0.6pre0.20250406.152517";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.6pre0.20250330.212748.tar";
-        sha256 = "01lz4aak0ccqfffp61d8gfwpscbhdy9132bwbxpsrfiasxvkbfl8";
+        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.6pre0.20250406.152517.tar";
+        sha256 = "190cj2hflahfg592w6g9h24m5pa62dn7jc38lrf5qabgpbrk5ksb";
       };
       packageRequires = [
         compat
@@ -2808,10 +2810,10 @@
     elpaBuild {
       pname = "idris-mode";
       ename = "idris-mode";
-      version = "1.1.0.0.20240704.133442";
+      version = "1.1.0.0.20250424.90824";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20240704.133442.tar";
-        sha256 = "0rbgv5gkm6q3a6l8yqmgn3mn6ic9jr1w80vrl4gvkfpklwys9y5f";
+        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20250424.90824.tar";
+        sha256 = "0zs0z9p7c1xbsy0fw0q03x9z42d5ac37k4f2aljir0c62r5mckxl";
       };
       packageRequires = [
         cl-lib
@@ -3006,10 +3008,10 @@
     elpaBuild {
       pname = "julia-mode";
       ename = "julia-mode";
-      version = "1.0.2.0.20241213.162017";
+      version = "1.0.2.0.20250428.81943";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.0.2.0.20241213.162017.tar";
-        sha256 = "09l2awhz4362g03qnpsy4813afjabm2dqh8g3ma354k7ql8rr95h";
+        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.0.2.0.20250428.81943.tar";
+        sha256 = "05sx6pwwrvxwrpd1fskhqnr8yvzav7yafk7im5iscxic061xggpv";
       };
       packageRequires = [ ];
       meta = {
@@ -3028,10 +3030,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.2.0.20250301.164536";
+      version = "1.4.3.0.20250509.122154";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.2.0.20250301.164536.tar";
-        sha256 = "1zipc2baxzx5ima0r34q9d8v9bfw3a41hv2423gbx8036ndq3h2g";
+        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.3.0.20250509.122154.tar";
+        sha256 = "07gxsn77m6h6831mk4y8v10yxqzbamvcn9yysfy4hh0iywzqnx4b";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3071,10 +3073,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "0.6.2.0.20250314.200910";
+      version = "0.6.2.0.20250509.122131";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/llama-0.6.2.0.20250314.200910.tar";
-        sha256 = "0x39lvrjdqdyfdy5v88s9mpsgvdjvk1q3v2556sjdrw1q571d5wf";
+        url = "https://elpa.nongnu.org/nongnu-devel/llama-0.6.2.0.20250509.122131.tar";
+        sha256 = "0clbp1f4s98yzd7cw4yn4rmg06d6vfj5ik3kx92i57n58za73cdp";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3306,10 +3308,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.8alpha0.20250402.45223";
+      version = "2.8alpha0.20250501.55146";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20250402.45223.tar";
-        sha256 = "1j8axf1p9ijx4kgyr8qnhhy2rs9y52kammqq8zpqp25zh0a8ydjr";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20250501.55146.tar";
+        sha256 = "14fij3h882brdixrw516hhcim9rmkjp2wbxf75rcmgnfvhfq4vx7";
       };
       packageRequires = [ ];
       meta = {
@@ -3404,10 +3406,10 @@
     elpaBuild {
       pname = "meow";
       ename = "meow";
-      version = "1.5.0.0.20250317.230021";
+      version = "1.5.0.0.20250404.143236";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20250317.230021.tar";
-        sha256 = "1m7nf329y7jq4543mganpwl5sy6ci854ln468qbb3ik3lf8c8bq0";
+        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20250404.143236.tar";
+        sha256 = "098ca9ypmm5q2wviarqbcabz971ngf53lv8k1idnsvw8n34a0h83";
       };
       packageRequires = [ ];
       meta = {
@@ -3642,10 +3644,10 @@
     elpaBuild {
       pname = "org-auto-tangle";
       ename = "org-auto-tangle";
-      version = "0.6.0.0.20230201.195019";
+      version = "0.6.0.0.20250429.50000";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-auto-tangle-0.6.0.0.20230201.195019.tar";
-        sha256 = "1895wp7fajpz4mddp4qr136h30rp3ashn3zdb6zdrb2qfa275rri";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-auto-tangle-0.6.0.0.20250429.50000.tar";
+        sha256 = "0sbvkj1b8ibjq95ahhbw9qp488da3s3v5m4dfp6l8p4hdlz0xi4h";
       };
       packageRequires = [ async ];
       meta = {
@@ -3714,10 +3716,10 @@
     elpaBuild {
       pname = "org-journal";
       ename = "org-journal";
-      version = "2.2.0.0.20250306.142904";
+      version = "2.2.0.0.20250425.93636";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-journal-2.2.0.0.20250306.142904.tar";
-        sha256 = "1bknrir6g0zw24plizf5gdaa76navb5p913l83zba64m67mi0bwg";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-journal-2.2.0.0.20250425.93636.tar";
+        sha256 = "0si4zircvmqkh1rk46gs102w0a6kaqx1jc5pr5zk90bgah54jy8f";
       };
       packageRequires = [ org ];
       meta = {
@@ -3850,10 +3852,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.2.0.20250401.181022";
+      version = "2.0.2.0.20250509.121824";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.2.0.20250401.181022.tar";
-        sha256 = "1imiy9h0yrr995x5swy7mlrzn7zmgscr11a1g4b53dxcinywndcj";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.2.0.20250509.121824.tar";
+        sha256 = "0spqa4zm3k4dnnkns9p9fbji2qryrzlf272a64lhc2l4p5kl5s5d";
       };
       packageRequires = [
         compat
@@ -3897,10 +3899,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.25.0.20250324.192216";
+      version = "0.26.0.20250418.142545";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.25.0.20250324.192216.tar";
-        sha256 = "0m1a5bs4kiplxqva0fmsznpxbq3jhpprgji3dpf0jq226cjm45d9";
+        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20250418.142545.tar";
+        sha256 = "0qpsyimq3i6p8s03ax2grnzn474ngmx2lcvsvf5db6fryhw9qxj3";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -4097,10 +4099,10 @@
     elpaBuild {
       pname = "php-mode";
       ename = "php-mode";
-      version = "1.26.1.0.20250331.173641";
+      version = "1.26.1.0.20250422.172013";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250331.173641.tar";
-        sha256 = "16glbb3rinpqpqb3vd9j9h3ldgsjc18ics324rfajx3kilwp00gv";
+        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250422.172013.tar";
+        sha256 = "1d2ahw3vd7r9ylwb5cm5rjdd70cvfp7zy82rkx1ix2ddamfmbqya";
       };
       packageRequires = [ ];
       meta = {
@@ -4139,10 +4141,10 @@
     elpaBuild {
       pname = "popup";
       ename = "popup";
-      version = "0.5.9.0.20250224.15605";
+      version = "0.5.9.0.20250422.161227";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20250224.15605.tar";
-        sha256 = "11l0k9lrh7jhjshag9mclq5qa8vmll98vqf08837svlgpf0nwc4z";
+        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20250422.161227.tar";
+        sha256 = "0rj578i7l0hcmb3apch5ld05habq1iw3f3fazlax0n6r85g6phmy";
       };
       packageRequires = [ ];
       meta = {
@@ -4181,10 +4183,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.6snapshot0.20250402.90650";
+      version = "4.6snapshot0.20250516.91308";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20250402.90650.tar";
-        sha256 = "0ay9r63scg3zray4cx0vp7qrl74sfz9vl7kj2bw31jf891sal4s1";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20250516.91308.tar";
+        sha256 = "0fkl0zm8wm6snp0baab0hbabzsli7jw8pq13kzvng2mj8djsm8l2";
       };
       packageRequires = [ ];
       meta = {
@@ -4217,6 +4219,7 @@
   ) { };
   racket-mode = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -4224,12 +4227,12 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250324.74422";
+      version = "1.0.20250514.102731";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250324.74422.tar";
-        sha256 = "0pwn822nyzbysq1h2gvyrwcxbrg7dbsn7rxv02sg7bl4nsmqzjjk";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250514.102731.tar";
+        sha256 = "1da7v2w83kn7q07nb3pili3hsiymxa9h2l7nhf7y8sskq8j1sscc";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/racket-mode.html";
         license = lib.licenses.free;
@@ -4434,10 +4437,10 @@
     elpaBuild {
       pname = "rust-mode";
       ename = "rust-mode";
-      version = "1.0.6.0.20250225.10231";
+      version = "1.0.6.0.20250423.1515";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20250225.10231.tar";
-        sha256 = "1j25kqpwrg898zgs21vad5zzh6i54g48lxgzc2rb8wmifd2zd792";
+        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20250423.1515.tar";
+        sha256 = "1vkbg2gg9i1lyz4g7zkqjrixh7867x8py7ay7pcq76srwn01hja3";
       };
       packageRequires = [ ];
       meta = {
@@ -4609,10 +4612,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.31snapshot0.20250330.174001";
+      version = "2.31snapshot0.20250417.201511";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250330.174001.tar";
-        sha256 = "03hmilx1w1jf4gcz2bmlidpfd99znhpjrs540qgy6grrrnhqny3s";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250417.201511.tar";
+        sha256 = "0pbm04m0wzr63vs45xs624xgkjskpcvprwgizqmh84bvqg6g4zvh";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4630,10 +4633,10 @@
     elpaBuild {
       pname = "sly";
       ename = "sly";
-      version = "1.0.43.0.20250203.154027";
+      version = "1.0.43.0.20250501.191827";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sly-1.0.43.0.20250203.154027.tar";
-        sha256 = "1w1h6zh5r1b2q1m01jbw92x5mdnq7g97g282899crqzfbirj4xds";
+        url = "https://elpa.nongnu.org/nongnu-devel/sly-1.0.43.0.20250501.191827.tar";
+        sha256 = "026z57k7bg8brvgi8pngdxrb0djski7ryj9mlrzbjwr1r5z5c1z4";
       };
       packageRequires = [ ];
       meta = {
@@ -4652,10 +4655,10 @@
     elpaBuild {
       pname = "smartparens";
       ename = "smartparens";
-      version = "1.11.0.0.20241220.125445";
+      version = "1.11.0.0.20250511.235418";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/smartparens-1.11.0.0.20241220.125445.tar";
-        sha256 = "0ww5m3cj78abbpfrshbszgs21mnd6pfcpwrbnqz81a4qk37q3nny";
+        url = "https://elpa.nongnu.org/nongnu-devel/smartparens-1.11.0.0.20250511.235418.tar";
+        sha256 = "0ah3jlc4s90xziccf0s2kvbl4cildhf2li572pryps7zh1bn319f";
       };
       packageRequires = [ dash ];
       meta = {
@@ -4821,10 +4824,10 @@
     elpaBuild {
       pname = "sweeprolog";
       ename = "sweeprolog";
-      version = "0.27.6.0.20241107.191437";
+      version = "0.27.6.0.20250430.125630";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sweeprolog-0.27.6.0.20241107.191437.tar";
-        sha256 = "0y543svzd7sqqb2izlflvmv0mdyfwwzjgli107ra89w5jl6jxawh";
+        url = "https://elpa.nongnu.org/nongnu-devel/sweeprolog-0.27.6.0.20250430.125630.tar";
+        sha256 = "172vzsbiy1xy08isxwn10cqzwh0vbcivj390qhnyzcmw1ncd22hx";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4843,10 +4846,10 @@
     elpaBuild {
       pname = "swift-mode";
       ename = "swift-mode";
-      version = "9.2.0.0.20250111.53952";
+      version = "9.3.0.0.20250412.62413";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-9.2.0.0.20250111.53952.tar";
-        sha256 = "0xv6ia7nsk1bq9ybmqlckl8qy3p0cjnxfb2zkd7lr2sal476gnlx";
+        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-9.3.0.0.20250412.62413.tar";
+        sha256 = "0mgjswp1ldqcwicgxa3rr6nv8g2yi6pgqlxi9m2pvzihy9x70b53";
       };
       packageRequires = [ seq ];
       meta = {
@@ -5105,10 +5108,10 @@
     elpaBuild {
       pname = "treesit-fold";
       ename = "treesit-fold";
-      version = "0.2.1.0.20250305.214142";
+      version = "0.2.1.0.20250422.155540";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250305.214142.tar";
-        sha256 = "1h3ymlcimrvgm62k2w05xf53fk8n80n3pxz9f4lm6nwpjn8ns8ll";
+        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250422.155540.tar";
+        sha256 = "02svdk7sas6xy2acqsm2d0qmafxp16qhb2p8n2mchg6aa3yldk9b";
       };
       packageRequires = [ ];
       meta = {
@@ -5190,10 +5193,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.11.0.0.20250318.13735";
+      version = "0.12.0.0.20250424.101629";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.11.0.0.20250318.13735.tar";
-        sha256 = "1b710ynajshrdjqga5hdkkcsxq4avckh9qzjajg72jxdwpv02f6h";
+        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.0.0.20250424.101629.tar";
+        sha256 = "1yjiw5l6ni7rvp2ggfhf6jgiqpgb466sq6wwcsm0rqnmvs6y2jdz";
       };
       packageRequires = [ ];
       meta = {
@@ -5316,10 +5319,10 @@
     elpaBuild {
       pname = "visual-fill-column";
       ename = "visual-fill-column";
-      version = "2.6.3.0.20250323.152945";
+      version = "2.6.3.0.20250505.230743";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.6.3.0.20250323.152945.tar";
-        sha256 = "0rcn0wxdylcb0ci0cjipbjc5hrrvigrj5in2qh3fpj742pqda6mm";
+        url = "https://elpa.nongnu.org/nongnu-devel/visual-fill-column-2.6.3.0.20250505.230743.tar";
+        sha256 = "1cl39911k73cz5qbllyy82jw7hhbd6dly3s4p0kfnmav461b3qcp";
       };
       packageRequires = [ ];
       meta = {
@@ -5339,10 +5342,10 @@
     elpaBuild {
       pname = "vm";
       ename = "vm";
-      version = "8.3.0snapshot0.20250208.60553";
+      version = "8.3.0snapshot0.20250504.193215";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20250208.60553.tar";
-        sha256 = "0d2m9q8zwpd2i0zvcmkasp59ihsymmqyg8c0a1wp72akffxh3if1";
+        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20250504.193215.tar";
+        sha256 = "0r64xnwzhx3h3yw6jac9x357rpbh2scg1zdzbg4aihj4r8d1x6lx";
       };
       packageRequires = [
         cl-lib
@@ -5474,10 +5477,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.3.0.20241201.141907";
+      version = "3.4.3.0.20250509.145538";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.3.0.20241201.141907.tar";
-        sha256 = "1srqg86809lb1b0dj421gb6n522cx19snhvhvxb4nxkk98afiywp";
+        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.3.0.20250509.145538.tar";
+        sha256 = "1chrmrlxx61q1n2kqghka8vq2mj7rnk2slx8rfp7nkcsja4b6nz7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5584,10 +5587,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.11.20250325184849.0.20250325.185005";
+      version = "26.12.20250503115607.0.20250503.115753";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-26.11.20250325184849.0.20250325.185005.tar";
-        sha256 = "1ihvslx530i6q1iwz58wailwjqk1qmq07s2c8kpnynrpbi53jr3h";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-26.12.20250503115607.0.20250503.115753.tar";
+        sha256 = "1vn45rxy14ij4w7iswcwlkgvgjnjbgana2v2a34k71xn392gsf32";
       };
       packageRequires = [ ];
       meta = {
@@ -5670,10 +5673,10 @@
     elpaBuild {
       pname = "yasnippet-snippets";
       ename = "yasnippet-snippets";
-      version = "1.0.0.20250225.95035";
+      version = "1.0.0.20250507.200229";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20250225.95035.tar";
-        sha256 = "1cmf2vg50lhbkcq5wrzgcc8h5idwdywg42dnizv3dbsvv4h5kcpl";
+        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20250507.200229.tar";
+        sha256 = "0nq70rc7kgm8ldgja0gyza99xljpcg4qqhfwn1qa7y1rvbvbbgk0";
       };
       packageRequires = [ yasnippet ];
       meta = {
@@ -5713,10 +5716,10 @@
     elpaBuild {
       pname = "zig-mode";
       ename = "zig-mode";
-      version = "0.0.8.0.20250305.223352";
+      version = "0.0.8.0.20250426.144319";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250305.223352.tar";
-        sha256 = "1hdmvsnfvqb0ngx3kzv7855c9bmn30bk2zc4nizh98abdh1gk02g";
+        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250426.144319.tar";
+        sha256 = "1aaaarlbn15qmhmq7kxyh7c931h3x2cmxs7cf4c5j7n7qbzjna4w";
       };
       packageRequires = [ reformatter ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -48,18 +48,20 @@
       elpaBuild,
       fetchurl,
       lib,
+      markdown-mode,
       transient,
     }:
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.1";
+      version = "1.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.1.tar";
-        sha256 = "1g1p5prz9b2giy01hja04zqf90s53yckjxfwkrznpqvpar25l1nz";
+        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.3.tar";
+        sha256 = "03s08h5xp57l228gn9lay4a7h19zk6wyn777r2icsn1a1ii63l82";
       };
       packageRequires = [
         compat
+        markdown-mode
         transient
       ];
       meta = {
@@ -119,10 +121,10 @@
     elpaBuild {
       pname = "annotate";
       ename = "annotate";
-      version = "2.3.1";
+      version = "2.4.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/annotate-2.3.1.tar";
-        sha256 = "1s5v3zxr7fvwm0xz176vl3y50rl7mvn748jgn19b8x7zn4zsnf42";
+        url = "https://elpa.nongnu.org/nongnu/annotate-2.4.2.tar";
+        sha256 = "12510awgjx14kcz88a66walybvxqf7whbb0gckxj1dxsn0r1spfa";
       };
       packageRequires = [ ];
       meta = {
@@ -570,10 +572,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.17.1";
+      version = "1.18.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cider-1.17.1.tar";
-        sha256 = "0h708n6yz4v50843rp5wan9g35zd4f91nia5lryzmdqskah1yrcg";
+        url = "https://elpa.nongnu.org/nongnu/cider-1.18.0.tar";
+        sha256 = "15k2klm84x0jsglbc398fg9y83xkw6dbcn1jkg0zpw886j32dhxr";
       };
       packageRequires = [
         clojure-mode
@@ -620,10 +622,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.2.3";
+      version = "0.4.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/clojure-ts-mode-0.2.3.tar";
-        sha256 = "1gk48s87cryr3xvrjw9l0mv3yb1w6h4xg8zn2wnz5qnrw8cdb1wv";
+        url = "https://elpa.nongnu.org/nongnu/clojure-ts-mode-0.4.0.tar";
+        sha256 = "177qqqr823mfbj0czm3y30c7bb2jb0cv2kd4799m8d283r77wkgg";
       };
       packageRequires = [ ];
       meta = {
@@ -965,6 +967,7 @@
   ) { };
   dirvish = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -972,12 +975,12 @@
     elpaBuild {
       pname = "dirvish";
       ename = "dirvish";
-      version = "2.2.7";
+      version = "2.3.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/dirvish-2.2.7.tar";
-        sha256 = "1739ghnd6rig5rc0538l9xhm02ag79b33d26mhhrii60q42zkpqg";
+        url = "https://elpa.nongnu.org/nongnu/dirvish-2.3.0.tar";
+        sha256 = "0am64p4h08isz8al70zz3dchx43szgnl5qa6i81s3mf3bmw8vpn6";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/dirvish.html";
         license = lib.licenses.free;
@@ -1738,10 +1741,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "34.1";
+      version = "35.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/flycheck-34.1.tar";
-        sha256 = "1jj1c4gq39ik8fihsz13wp4c26fm2m6kyr7ir22ql0d007zm3173";
+        url = "https://elpa.nongnu.org/nongnu/flycheck-35.0.tar";
+        sha256 = "1nrsnp5d2jfrg6k9qf55v9mlygkc3ln44j31qmirsp5ad5xrflhm";
       };
       packageRequires = [ ];
       meta = {
@@ -2564,10 +2567,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/haskell-ts-mode-1.tar";
-        sha256 = "16x2dr64f6s8837pl7dn7my3xpfc0x11p556r1ds5hwg0c82ikh4";
+        url = "https://elpa.nongnu.org/nongnu/haskell-ts-mode-1.1.4.tar";
+        sha256 = "1430hddrj9lkfxapxa5d13q800awqxhg84r87abmry9skn35jfs7";
       };
       packageRequires = [ ];
       meta = {
@@ -2587,10 +2590,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.2";
+      version = "4.0.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-4.0.2.tar";
-        sha256 = "1gp0gfd5xr2nxis6ss41v5izh5cbgj9j2z2swkfjg0dqngfzl3xs";
+        url = "https://elpa.nongnu.org/nongnu/helm-4.0.3.tar";
+        sha256 = "0hha3fkdxm6k74a73259la62dis1xp475a8f9a2r1ivs6qblv6b9";
       };
       packageRequires = [
         helm-core
@@ -2612,10 +2615,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.2";
+      version = "4.0.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.2.tar";
-        sha256 = "1mgc89k12lwivj453q3frcwzwag10wngy13jz6jxdl7135gsmywd";
+        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.3.tar";
+        sha256 = "16c9fv3xh1rr1fcayvbf09c5jd0xvajlg19b2kfc2z40sryy95ip";
       };
       packageRequires = [ async ];
       meta = {
@@ -3043,10 +3046,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.2";
+      version = "1.4.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.2.tar";
-        sha256 = "0lmqqpqib7gz12m9ckappf3rw8n8x0nridmsf4c48vbn2jh607hy";
+        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.3.tar";
+        sha256 = "1d0n8jshjblrb7c5finjpnkdil96zbcy0696sqx4si9kak6j4k5i";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3919,10 +3922,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.25";
+      version = "0.26";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/package-lint-0.25.tar";
-        sha256 = "0nagz2ynqg0vlh8sz1ss0g78j1qi3ni1x74gzbnk3i67wwkrld8k";
+        url = "https://elpa.nongnu.org/nongnu/package-lint-0.26.tar";
+        sha256 = "0sgqq19zvnlvf64ash2cig3n2avjrsjn107wfvm222sk2bm0ld1j";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -4239,6 +4242,7 @@
   ) { };
   racket-mode = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -4246,12 +4250,12 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250324.74422";
+      version = "1.0.20250514.102731";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250324.74422.tar";
-        sha256 = "0iwcm689jhqv4wzj7awfljmczmn2hzsjaj2yc2zkf9yzlzzbrkxf";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250514.102731.tar";
+        sha256 = "0d5q08q3bm2ws0g0cys1xzjvznrqxhwxikjrkdri9js8y14z50l3";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/racket-mode.html";
         license = lib.licenses.free;
@@ -4860,10 +4864,10 @@
     elpaBuild {
       pname = "swift-mode";
       ename = "swift-mode";
-      version = "9.2.0";
+      version = "9.3.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/swift-mode-9.2.0.tar";
-        sha256 = "1mnkwy7cglwrfln8hknbxyzg4z6zb6cmycl19acxslbgrviwh9j3";
+        url = "https://elpa.nongnu.org/nongnu/swift-mode-9.3.0.tar";
+        sha256 = "04pp8hpqxibzcfyzrls1r18r6v3hyga4f39vxcdzn75lan4qgpqd";
       };
       packageRequires = [ seq ];
       meta = {
@@ -5229,10 +5233,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.11.0";
+      version = "0.12.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/typst-ts-mode-0.11.0.tar";
-        sha256 = "0waf2m5cypfpcbb5g39xf9z5ik84wx83178d8s4npspw1zfhmbh3";
+        url = "https://elpa.nongnu.org/nongnu/typst-ts-mode-0.12.0.tar";
+        sha256 = "1wks4jqh1bh4gr0m507dqa0a0mka21v10agqpsy7ws4k2sjsyp9h";
       };
       packageRequires = [ ];
       meta = {
@@ -5597,10 +5601,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.11.20250325184849";
+      version = "26.12.20250503115607";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-26.11.20250325184849.tar";
-        sha256 = "0j5a89pq304bzyg8qb6y8yysw5z6p4436fyy7lk61kbavc5srqvs";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-26.12.20250503115607.tar";
+        sha256 = "1mh6rssi7g6dfl2glpivfixpdfk0kdlsbilszazmhzc6bh34blj5";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -518,37 +518,6 @@
   }
  },
  {
-  "ename": "ac-emacs-eclim",
-  "commit": "1e9d3075587fbd9ca188535fd945a7dc451c6d7e",
-  "sha256": "0bkh7x6zj5drdvm9ji4vwqdxv7limd9a1idy8lsg0lcca3rjq3s5",
-  "fetcher": "github",
-  "repo": "emacs-eclim/emacs-eclim",
-  "unstable": {
-   "version": [
-    20180911,
-    1121
-   ],
-   "deps": [
-    "auto-complete",
-    "eclim"
-   ],
-   "commit": "edff7e0e30c87036710d88fb0b7a4644750858e8",
-   "sha256": "0ywifqdhv7cibgl42m7i15widna9i1dk5kl5rglyql7hy05nk9gj"
-  },
-  "stable": {
-   "version": [
-    0,
-    4
-   ],
-   "deps": [
-    "auto-complete",
-    "eclim"
-   ],
-   "commit": "8203fbf8544e65324a948a67718f7a16ba2d52e6",
-   "sha256": "10bbbxhvlwm526g1wib1f87grnayirlg8jbsvmpzxr9nmdjgikz3"
-  }
- },
- {
   "ename": "ac-emmet",
   "commit": "39861b4f0a458c8ccf02f7a3443c54b0e74daa11",
   "sha256": "09ycjllfpdgqaf5iis5bkkhal1vxvl3qkxrn2759p67s97c49f3x",
@@ -1833,11 +1802,11 @@
   "repo": "thierryvolpiatto/addressbook-bookmark",
   "unstable": {
    "version": [
-    20240422,
-    1801
+    20250412,
+    1903
    ],
-   "commit": "a990a6d45a11c0e0dee57410d103fe20a4b00a6e",
-   "sha256": "1cjxpx15xgf68n9gb8j2w036nbb41g4k50ib31frgc7drlb89aw3"
+   "commit": "21f19e0f4c1b7d0932e4655db8df200e73cc2f6e",
+   "sha256": "1wfc26fyf7gvyzrgbqj4vrbq573q09n6hz239gbw6v7kfia0zkah"
   },
   "stable": {
    "version": [
@@ -2254,30 +2223,32 @@
   "repo": "tninja/aider.el",
   "unstable": {
    "version": [
-    20250402,
-    316
+    20250514,
+    1549
    ],
    "deps": [
     "magit",
     "markdown-mode",
+    "s",
     "transient"
    ],
-   "commit": "cc353a84b8c2f5c440077ce1d5109292115844da",
-   "sha256": "04ymmlw0m3a8za59j5k8yz7gsrx3421rf23j129cb72p81vf00pc"
+   "commit": "0b57024e1bb49e2329d8803e63454a6392499c31",
+   "sha256": "0wa9ivdbi8gc1cdhy9f8m8vrdc5d3n066gjvx0y5ysk4y175jc21"
   },
   "stable": {
    "version": [
     0,
-    6,
+    9,
     0
    ],
    "deps": [
     "magit",
     "markdown-mode",
+    "s",
     "transient"
    ],
-   "commit": "bf02bfeaf4453a984758b9b28c0f7a261bc3aafa",
-   "sha256": "0s0b9z7m9jji1khkagnnpgvzw12dy15ylyrh0bkcrlhyyapqplzy"
+   "commit": "a86111360cc9d1fd69c7082923feac67ce8743cd",
+   "sha256": "0r2axp6nx1wrc84z6mby4ixabwcq52n5q4lwfwllzgig85flx56x"
   }
  },
  {
@@ -2288,27 +2259,29 @@
   "repo": "MatthewZMD/aidermacs",
   "unstable": {
    "version": [
-    20250401,
-    2057
+    20250515,
+    1727
    ],
    "deps": [
     "compat",
+    "markdown-mode",
     "transient"
    ],
-   "commit": "38aa5bfa5c5a66664abb5bb9cd7f191d1ac3d915",
-   "sha256": "15l28149akn1xxcqbqzymyw2r84sr3dafdxil8x7m7cx3260p7ni"
+   "commit": "e829b9e2964a41aa1b1754c44dd46031fb2d5d0d",
+   "sha256": "1842wh65b69zabm3vgqwbq9jacz9wnh6klmskk92dayxd6aqdb32"
   },
   "stable": {
    "version": [
     1,
-    2
+    3
    ],
    "deps": [
     "compat",
+    "markdown-mode",
     "transient"
    ],
-   "commit": "38aa5bfa5c5a66664abb5bb9cd7f191d1ac3d915",
-   "sha256": "15l28149akn1xxcqbqzymyw2r84sr3dafdxil8x7m7cx3260p7ni"
+   "commit": "9eef7a26e50669b5fea16ede7bbf9a11848dba4d",
+   "sha256": "15p10im3rv0yv33ygq4kzxrqakdq240mazxhj5sms6m361kgr83z"
   }
  },
  {
@@ -2366,14 +2339,14 @@
   "repo": "AnthonyDiGirolamo/airline-themes",
   "unstable": {
    "version": [
-    20240530,
-    1704
+    20250502,
+    1915
    ],
    "deps": [
     "powerline"
    ],
-   "commit": "baaa4f1f0acd339b1efc1058654ea7d9e6e44ead",
-   "sha256": "0biyna1agxknsg2farj2bi0pnqqxkvdnicmnazl77kcxknhs0r9s"
+   "commit": "827a2dae106ecf1fb14793c43f13c4a6cd045c9a",
+   "sha256": "1cw5fa2l43jdhwaw68khjsmmhw87vh35c53y20j00v4085x3ssd8"
   },
   "stable": {
    "version": [
@@ -2916,11 +2889,11 @@
   "repo": "cryon/almost-mono-themes",
   "unstable": {
    "version": [
-    20220422,
-    1714
+    20250515,
+    743
    ],
-   "commit": "0641bf565c113caef8d5c2a93f38cff32ebb62b7",
-   "sha256": "17r605k8zb30l1sl8zy5w753mvzdppqr9lbkidancasvp1p47rs7"
+   "commit": "5d70b6860aed9a2ef312bff4ff4101b12561e3de",
+   "sha256": "1h507l0nwi5w9zms3zhxiwhjfxdlcg5ffx5f9pvzf8d3l1cm49v4"
   }
  },
  {
@@ -3167,8 +3140,8 @@
   "repo": "pythonic-emacs/anaconda-mode",
   "unstable": {
    "version": [
-    20250310,
-    1512
+    20250430,
+    227
    ],
    "deps": [
     "dash",
@@ -3176,8 +3149,8 @@
     "pythonic",
     "s"
    ],
-   "commit": "28b3e0088ac7113390aa006bf277c8aa14e561a2",
-   "sha256": "068rf93nwymajj6l43rbfd0aslyjqp3bswsqkbf0yip87f9vc24h"
+   "commit": "ee1562c6b443be9208910c700e229824b2f1af7a",
+   "sha256": "11aqcqv00q8rbj872mr6ggz14wllhmya1llb2rgizqwayrdrrx01"
   },
   "stable": {
    "version": [
@@ -3372,11 +3345,11 @@
   "repo": "lujun9972/anki-connect.el",
   "unstable": {
    "version": [
-    20250327,
-    621
+    20250414,
+    1301
    ],
-   "commit": "9cf0c546358690f66c4e4498c8f81011dd56b95e",
-   "sha256": "072fp2ikicydl51rprwlfdkxdr75nsq1nlwjzvqm4q1vgigprhk3"
+   "commit": "e32e611d54a3819f88c5ff58009df70c9ae01934",
+   "sha256": "0hhvjrl2djkq4i16bmgyf8qj0r9bn4i956f3wg74fd8p5as18i2h"
   }
  },
  {
@@ -3502,11 +3475,11 @@
   "repo": "bastibe/annotate.el",
   "unstable": {
    "version": [
-    20250320,
-    1304
+    20250515,
+    1428
    ],
-   "commit": "7b1c5aa531d30d60c5c1b5317e374b3eeaf123c3",
-   "sha256": "1qkp7qyr780xzi03572kidcsi0bj17jwgk1w9alayddpi98vbn27"
+   "commit": "dc6e884265c9de5b0e486b9f6bd9509a14b85c94",
+   "sha256": "07jbi3ripkmbsx51w57qiwi9pi2bd1a05rd627vg99avv9j00mj5"
   },
   "stable": {
    "version": [
@@ -3882,20 +3855,20 @@
   "repo": "dieter-wilhelm/apdl-mode",
   "unstable": {
    "version": [
-    20211023,
-    1831
+    20250508,
+    908
    ],
-   "commit": "ba756eaa1d229c9bf6936fb8d2d4126ad073d488",
-   "sha256": "0vy6sf351i7q21bifi2s8rshkbq504dlwxx1cw1hc4xhpab24ivs"
+   "commit": "4883ab085811b85cc75c44b5af478ab8f7e98386",
+   "sha256": "18z0kicrl8hkgihy5w8pm7q5m0hik39p8z7x0p158paf7428hkqr"
   },
   "stable": {
    "version": [
     20,
-    5,
+    6,
     0
    ],
-   "commit": "ee5f546f6659b9ca3c6895a1959087531b4a016a",
-   "sha256": "1qpqji2qx4srxk22684gh3sjj8sa87kd5fbr1xh8dscn19h5yvx9"
+   "commit": "9950b3092933adde85d613410432971071e33263",
+   "sha256": "0d5flyrcd1286rkfkdw5cqkbmvz2jhwp34i4drrhlx7lfczbn8ak"
   }
  },
  {
@@ -3921,19 +3894,20 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20250331,
-    2246
+    20250514,
+    109
    ],
-   "commit": "2b491144fe157867ce1cc4538a9562edff57c891",
-   "sha256": "0r48qdi7lmxgvd6zr9s73f58fqcf91gxkg57v6dsrqh1868ngx00"
+   "commit": "82cbb665bc6a62de59e00aa76dcef29ef3a6c3a2",
+   "sha256": "06zbl4syvk05qh57mlzwyw9avyag26yirw99b9l3z0fxcmyn8l39"
   },
   "stable": {
    "version": [
     4,
-    4
+    4,
+    1
    ],
-   "commit": "d8ccc0ba0f127c11df39e79313a17bcb740359c0",
-   "sha256": "1dqx5wjmaxxl3xdj0kh2q157d4x9ygfwn4fschcw9vwm5jrcph51"
+   "commit": "82cbb665bc6a62de59e00aa76dcef29ef3a6c3a2",
+   "sha256": "06zbl4syvk05qh57mlzwyw9avyag26yirw99b9l3z0fxcmyn8l39"
   }
  },
  {
@@ -4208,11 +4182,11 @@
   "repo": "motform/arduino-cli-mode",
   "unstable": {
    "version": [
-    20250303,
-    1649
+    20250412,
+    2204
    ],
-   "commit": "4286110c98abb4f9d8397207735736dcf05475d7",
-   "sha256": "05vgrsms110qb027bkfx8hkc4cx2rhfrqii44w252spk8zjkcfnm"
+   "commit": "15c3e0a7fa766cbb05c7fc4cb3696c18353e1817",
+   "sha256": "1wvzim8anrxd34ynvp6v7qi0gq27wcp09xywcwfrkbc37f7lmjv2"
   }
  },
  {
@@ -5158,20 +5132,20 @@
   "repo": "vaartis/auth-source-kwallet",
   "unstable": {
    "version": [
-    20210605,
-    1032
+    20250419,
+    1330
    ],
-   "commit": "57335d80876a526adb63a5ab57b83f55e8d79953",
-   "sha256": "0cz36ar7hkp6l2kqgmh348gimlnabz4fd2rc3lv2rmvafn6h669p"
+   "commit": "1e1bff2403966c3a0683ee65fb28cb8d8ff2c389",
+   "sha256": "0dv7s3s9hjq1k2lxgabblmplgvqm0fy49y94j2flljcygdnds74r"
   },
   "stable": {
    "version": [
     0,
     0,
-    1
+    2
    ],
-   "commit": "1309cfcd00264a2bb8e0d1b435d4d03e3e02f314",
-   "sha256": "182wks10k0z1h24lkqx2rrs78f33rzarcq4s0r69cc6w67vj0fra"
+   "commit": "1e1bff2403966c3a0683ee65fb28cb8d8ff2c389",
+   "sha256": "0dv7s3s9hjq1k2lxgabblmplgvqm0fy49y94j2flljcygdnds74r"
   }
  },
  {
@@ -5239,20 +5213,20 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20250301,
-    1627
+    20250414,
+    1548
    ],
-   "commit": "5304e2f8a69ed9610b2392b846471f43b28b773b",
-   "sha256": "1mclnf6ichsjdnjd1b6bg4vqhhjpy6y3458khnxvr1fpn67h6iny"
+   "commit": "f92ad088e0b280178b8b19b3dcbecb382c014563",
+   "sha256": "02xi4fx310v9967h9nz4pjpj0ccd4k4vm9kkx8vwhnjjp7i7lyvi"
   },
   "stable": {
    "version": [
     2,
     0,
-    5
+    6
    ],
-   "commit": "5304e2f8a69ed9610b2392b846471f43b28b773b",
-   "sha256": "1mclnf6ichsjdnjd1b6bg4vqhhjpy6y3458khnxvr1fpn67h6iny"
+   "commit": "f92ad088e0b280178b8b19b3dcbecb382c014563",
+   "sha256": "02xi4fx310v9967h9nz4pjpj0ccd4k4vm9kkx8vwhnjjp7i7lyvi"
   }
  },
  {
@@ -6205,14 +6179,14 @@
   "repo": "nameiwillforget/avy-act",
   "unstable": {
    "version": [
-    20250201,
-    1311
+    20250420,
+    1805
    ],
    "deps": [
     "avy"
    ],
-   "commit": "eb3be5667b5d1ae024910faf997a12456bca6aa8",
-   "sha256": "1np3dhv3sik04p7k3qbbnmhz5hx919whxiqdj2i6shiqfmidcygy"
+   "commit": "b50b6ee3435ed63eea1a6ffff39ecd121ae4d091",
+   "sha256": "06xqmkv3nah7cw4kzfgz79w1xwqnlh881c517xlibsx9s58zcn2k"
   }
  },
  {
@@ -6389,6 +6363,30 @@
    ],
    "commit": "12e8e0b49878099bda5d3e4915cc3c738c87b95c",
    "sha256": "03vw6y4bjfip4ryr265hkkwm66rl3m7gwird7hgrqzilmb9sahia"
+  }
+ },
+ {
+  "ename": "aws-athena-babel",
+  "commit": "98f54d427d1fbb6fe96b9639a795ab673f85ddfd",
+  "sha256": "0xz6kjwdl210vrmh4brb0xrngpw8ij1grkk8fcw6gffnl4m22piq",
+  "fetcher": "github",
+  "repo": "will-abb/aws-athena-babel",
+  "unstable": {
+   "version": [
+    20250420,
+    1632
+   ],
+   "commit": "fce1b2d49e0862782405168f37a2dc392f6f8928",
+   "sha256": "1kkqgybal4b61m5cyilwzq7dndfcpcl5qa2gqwrrb1xi9p2lcyrv"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    2
+   ],
+   "commit": "fce1b2d49e0862782405168f37a2dc392f6f8928",
+   "sha256": "1kkqgybal4b61m5cyilwzq7dndfcpcl5qa2gqwrrb1xi9p2lcyrv"
   }
  },
  {
@@ -6610,15 +6608,15 @@
   "repo": "tarsius/backline",
   "unstable": {
    "version": [
-    20240805,
-    1306
+    20250515,
+    1829
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "9c791fb9a4a2e4a09443ec8b0da8f1f10890c0c6",
-   "sha256": "1gpfg0bvp0333aw9nfaa61nyd01linn9fhishfsyri167k3avihr"
+   "commit": "2c77490c76bbbc7b8954eaaf1f226567f5e40631",
+   "sha256": "0vwb99y4nnfrbh0zdwz45m1jlc7g8nbjrxdhcifywlpj7rvrvw8p"
   },
   "stable": {
    "version": [
@@ -6769,6 +6767,36 @@
   }
  },
  {
+  "ename": "bank-buddy",
+  "commit": "05deb525362ef480dd3866124d24ef99a455cae0",
+  "sha256": "1cs0nq7p5l01c3ljg2swl2q9r9mj9airjg9hz218bwmdvsa5drmp",
+  "fetcher": "github",
+  "repo": "captainflasmr/bank-buddy",
+  "unstable": {
+   "version": [
+    20250509,
+    734
+   ],
+   "deps": [
+    "async"
+   ],
+   "commit": "b30c04b375e71a01430d85146630a514870d4e9b",
+   "sha256": "1aizbkvs99swig8zr3xinrvfh3ijiaf4ddpw84dn535vxl4v3hj9"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "async"
+   ],
+   "commit": "0002826a3f47b908fb6fd2a867193e04cb465273",
+   "sha256": "060zd4cm8pg67p0sn2nynlcck3ag9r1myibclzb6a6g9p0c1hld2"
+  }
+ },
+ {
   "ename": "banner-comment",
   "commit": "4bb69f15cb6be38a86abf4d15450a29c9a819068",
   "sha256": "0i5nkfdwfr9mcir2ijdhw563azmr5p7hyl6rfy1r04fzs8j7w2pc",
@@ -6845,11 +6873,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20250330,
-    125
+    20250420,
+    126
    ],
-   "commit": "73bfd1adebd712f93bab06b5bee471822d8bb2f5",
-   "sha256": "0lfqkbvbd0j1l25q38w55g7qqdrvf970fmzfihspd8aaykf6fycm"
+   "commit": "71e1ccc7bbc7a12b20b230944d91128f380e82db",
+   "sha256": "180q3jb1l2gyl2vpygf3vjr87zljmncxkb18gbshbxsbyrzb3cph"
   },
   "stable": {
    "version": [
@@ -6891,11 +6919,11 @@
   "repo": "szermatt/emacs-bash-completion",
   "unstable": {
    "version": [
-    20250101,
-    1458
+    20250425,
+    1830
    ],
-   "commit": "a4c8fbc90221b01d5376ad068d3640350d9130a8",
-   "sha256": "1wxxi3ylmc1k4dbd7lbcr33496lnz7zwxf7l4zfhgci1nfywk3ii"
+   "commit": "a96525afd9077c06d781c59e78bfc6620e41be8f",
+   "sha256": "11amjvs5k9jh5sld42sbay2yri32nlygxq3xnnz06hmwdsvqir6x"
   },
   "stable": {
    "version": [
@@ -7727,14 +7755,14 @@
   "repo": "cpitclaudel/biblio.el",
   "unstable": {
    "version": [
-    20250102,
-    1345
+    20250409,
+    2132
    ],
    "deps": [
     "biblio-core"
    ],
-   "commit": "b700f0f2929829b2ca971511c5ebe61c67027e9f",
-   "sha256": "1wmibsdyfpxi80fyacs6qllcffwdgg1vf7i22a3nr60vciac56f9"
+   "commit": "0314982c0ca03d0f8e0ddbe9fc20588c35021098",
+   "sha256": "1m637bnafbmifx2mr7xbijyv5v0dqnx6id6v58gwkyjran2lg4h7"
   },
   "stable": {
    "version": [
@@ -9015,6 +9043,21 @@
   }
  },
  {
+  "ename": "bookmarks-menu",
+  "commit": "a3a57de54191b8f222ccab913d66403d5a72cb2d",
+  "sha256": "06f6vfqzyzrqiyd99hjwfv15l7mr2gvpvc55n9sw808432j2ql5v",
+  "fetcher": "github",
+  "repo": "ajrosen/bookmarks-menu",
+  "unstable": {
+   "version": [
+    20250508,
+    2114
+   ],
+   "commit": "e279bd3c27773e72b23eb698e9b1eed3f7d764c9",
+   "sha256": "1yqa4gi6bpdrl96b0ddbmsvlg3s54is8vc1fc39sjpqnv7ngli20"
+  }
+ },
+ {
   "ename": "bool-flip",
   "commit": "f56377a7c3f4b75206ad9ba570c35dbf752079e9",
   "sha256": "1xfspqxshx7m8gh6g1snkaahka9f71fnq7hx81nik4s9s8pmxj9c",
@@ -9079,28 +9122,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20250401,
-    1806
+    20250428,
+    1247
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "dad9508836fc04edec8634e17998708bf48febc6",
-   "sha256": "162jx8y2gac4day1h2cm28gmm7hrxzs73f4ma4izl8pgq3v87rsj"
+   "commit": "a9a7ad9746a2b759d183e39166739f15da34604b",
+   "sha256": "12xd36ai6d177m750pn7aflwf3b1n9h0m3gyf0m0fasg2mr6944b"
   },
   "stable": {
    "version": [
     4,
     1,
-    4
+    5
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "dad9508836fc04edec8634e17998708bf48febc6",
-   "sha256": "162jx8y2gac4day1h2cm28gmm7hrxzs73f4ma4izl8pgq3v87rsj"
+   "commit": "a9a7ad9746a2b759d183e39166739f15da34604b",
+   "sha256": "12xd36ai6d177m750pn7aflwf3b1n9h0m3gyf0m0fasg2mr6944b"
   }
  },
  {
@@ -9239,15 +9282,15 @@
   "repo": "museoa/bqn-mode",
   "unstable": {
    "version": [
-    20241012,
-    1136
+    20250410,
+    38
    ],
    "deps": [
     "compat",
     "eros"
    ],
-   "commit": "c7b71c85e69c8b1bcec2bdd718d7a91929af28d7",
-   "sha256": "1kzbmmxwm4v05614pqy16fdlh8xs2dnvzk0d90sjq5nfkjr6z472"
+   "commit": "81eca6e1a6735e738cac3117810db5c9a4762452",
+   "sha256": "0zl6s0c0nd8m55f83yamgnl8kg1a9jrzl0wrmixrixzn7zmdj6qk"
   }
  },
  {
@@ -9516,11 +9559,11 @@
   "repo": "agzam/browser-hist.el",
   "unstable": {
    "version": [
-    20240607,
-    406
+    20250501,
+    1450
    ],
-   "commit": "0372c6d984ca194d9454b14eba6eadec480ec3ff",
-   "sha256": "0s19gglc9jwapy7a9mf4i97a7r5q9lpm2ivvn0zjhqxcmzj3295j"
+   "commit": "1cd80081feaab99fef9e8eadd55d68b3cef90144",
+   "sha256": "12jarw5sca6r171lzba727xbii6xjlv432j8frgkph4r0k0946id"
   }
  },
  {
@@ -9662,14 +9705,14 @@
   "repo": "astoff/buffer-env",
   "unstable": {
    "version": [
-    20240323,
-    727
+    20250516,
+    1223
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3814bdf3585ffffea3014b1d01549894ec1aa897",
-   "sha256": "1rqr8y3kclds087y09r2l4mrk6x8mm7p84fg2wf2kdvbqmdv7sf0"
+   "commit": "fc5cab4db55f0b95c4b97fbe3104e394da34b91a",
+   "sha256": "0a30li0s06qviz44cdnbw1mh0kxlap9zzwa2cfdd79xj8aj5r3z4"
   }
  },
  {
@@ -9776,16 +9819,16 @@
   "repo": "countvajhula/buffer-ring",
   "unstable": {
    "version": [
-    20220120,
-    124
+    20250507,
+    1635
    ],
    "deps": [
     "dynaring",
     "ht",
     "s"
    ],
-   "commit": "177d67238c4d126a0270585e21c0f03ae750ca2a",
-   "sha256": "1li3fq5797hcd2wy5w2vp6hmgf779mrm0pw2nj4a19snwl9ak02j"
+   "commit": "7359c523d2ae222137602907d37852d102394c5a",
+   "sha256": "0vvyrbmw5pr1my5m93pm2wh1vg5li0zvcvhddn1km3kywhk5p98p"
   },
   "stable": {
    "version": [
@@ -9947,6 +9990,30 @@
    ],
    "commit": "ee4bf49cc69573f690e2e9f36f03c20b322c1730",
    "sha256": "0qqajbr3pfpxjjw7bimyqxj7gvmd09313ai581ld4ik9n48izhv1"
+  }
+ },
+ {
+  "ename": "bufferfile",
+  "commit": "ba54690f2638301f2f0c5eef81e3208126914490",
+  "sha256": "1jph71didkdclsf6qiq0vz3bb1yjrvzvx2r7k8iy5kfldv36i6xw",
+  "fetcher": "github",
+  "repo": "jamescherti/bufferfile.el",
+  "unstable": {
+   "version": [
+    20250413,
+    1959
+   ],
+   "commit": "39689ccff11fc592b6c83d8b05dcffc02a269df6",
+   "sha256": "0v00dbr6npnrb57n95sax9ii9qs82qfz88p22qam1hwaiaqw8lgg"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    5
+   ],
+   "commit": "39689ccff11fc592b6c83d8b05dcffc02a269df6",
+   "sha256": "0v00dbr6npnrb57n95sax9ii9qs82qfz88p22qam1hwaiaqw8lgg"
   }
  },
  {
@@ -10881,8 +10948,8 @@
   "repo": "chenyanming/calibredb.el",
   "unstable": {
    "version": [
-    20250330,
-    331
+    20250509,
+    1401
    ],
    "deps": [
     "dash",
@@ -10892,8 +10959,8 @@
     "s",
     "transient"
    ],
-   "commit": "64c211a461177e675b01be2eeb28526e50a8df6f",
-   "sha256": "0d5gsnpwqijig04lx7k3433p4gsbl0aqxp0bzbsrxqc5wvd7rc3p"
+   "commit": "689ea5157e62947c149aee32fdee0ae8cad13b44",
+   "sha256": "180y11p69pvyfy2nvn52cics4knw50gza5njjyzidwb76xpqyc8z"
   },
   "stable": {
    "version": [
@@ -10956,20 +11023,20 @@
   "repo": "kickingvegas/calle24",
   "unstable": {
    "version": [
-    20250315,
-    1812
+    20250507,
+    304
    ],
-   "commit": "2b5bb21c791083c4f509fd57274c601e5dfd6614",
-   "sha256": "1iy4jsh54kx0jjdbs9srfc18dnixliq6xsracyv3p447gjwzxqrn"
+   "commit": "7a80bfe2c58c3374f29011fd6f824f1011bc5a6a",
+   "sha256": "1p67pd6scf5v82c69rx5nq2kabhnc0c2pzkkqphk9zcwn3d1qyl2"
   },
   "stable": {
    "version": [
     1,
     0,
-    8
+    9
    ],
-   "commit": "2b5bb21c791083c4f509fd57274c601e5dfd6614",
-   "sha256": "1iy4jsh54kx0jjdbs9srfc18dnixliq6xsracyv3p447gjwzxqrn"
+   "commit": "7a80bfe2c58c3374f29011fd6f824f1011bc5a6a",
+   "sha256": "1p67pd6scf5v82c69rx5nq2kabhnc0c2pzkkqphk9zcwn3d1qyl2"
   }
  },
  {
@@ -11083,14 +11150,14 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20250315,
-    855
+    20250509,
+    2032
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f72ebcaeff4252ca0d7a9ac4636d8db0fdf54c55",
-   "sha256": "01wwn54q6izgkrbp0n0lmi3a0vgj3bp9kpy8ldbkq72kf0fj187v"
+   "commit": "4b5be758515cf06cf22de2d1b5de459491f7197b",
+   "sha256": "106b179y26y93zd897dx3clglqnvw2xz2f3k3siv9nb4ggcjsvhj"
   },
   "stable": {
    "version": [
@@ -11411,26 +11478,26 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20250314,
-    2245
+    20250509,
+    1838
    ],
    "deps": [
     "transient"
    ],
-   "commit": "9c476ea12cdff376f508b1199373257d7e9b8715",
-   "sha256": "1jqk5jzj6ykijaa39rpyg85s1czwa4q2qdfv077vnv57wfknzvfy"
+   "commit": "f478f82a9cf11402688186181ca8e96a60476261",
+   "sha256": "0ndl3fzdy3352f3vddl26qwqjh5lk492knk0qqd2v1xs40bcwa4f"
   },
   "stable": {
    "version": [
     2,
     4,
-    1
+    2
    ],
    "deps": [
     "transient"
    ],
-   "commit": "9c476ea12cdff376f508b1199373257d7e9b8715",
-   "sha256": "1jqk5jzj6ykijaa39rpyg85s1czwa4q2qdfv077vnv57wfknzvfy"
+   "commit": "f478f82a9cf11402688186181ca8e96a60476261",
+   "sha256": "0ndl3fzdy3352f3vddl26qwqjh5lk492knk0qqd2v1xs40bcwa4f"
   }
  },
  {
@@ -12052,16 +12119,16 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20250330,
-    805
+    20250504,
+    804
    ],
    "deps": [
     "f",
     "s",
     "yaml-mode"
    ],
-   "commit": "3e3992f739132676db7f38a1ff5860989a80ca03",
-   "sha256": "011bra8xzf7f5kn0vj7nga8cpkksf70p73wqbzsnzy4m6nwqxn16"
+   "commit": "cea4db0ea7ffeef14cf667ecf0d5fddd1d0340b2",
+   "sha256": "02wjkaggvcv6sxcvaizn7pndbc4ybsmq33kb742r9v9pyjap5g2z"
   },
   "stable": {
    "version": [
@@ -12151,20 +12218,20 @@
   "repo": "GrammarSoft/cg3",
   "unstable": {
    "version": [
-    20250315,
-    1016
+    20250430,
+    1005
    ],
-   "commit": "9cbd0db112347de6f60e52475d435ca1d97626cd",
-   "sha256": "1lah7587npz5jqaavfwybjhrrif4kibk0vhzc9ibqgjczcm2ljs9"
+   "commit": "8ab7e26352c615326d74feeec71f531fc7a8855d",
+   "sha256": "04c85kjhhlixgb96dvqk9bpa3x0px2rzv1jymbg7c1ywianxpcyq"
   },
   "stable": {
    "version": [
     1,
     5,
-    0
+    1
    ],
-   "commit": "51c6f82d7cc686aec96587abd2eabe1b5c1ed9e1",
-   "sha256": "07jh0nirsij9v311nmff5yzcs2hq9izri7abrrml5k0kk115nnpp"
+   "commit": "0b40c412971037a945d833e2fc9a75954d40f8bc",
+   "sha256": "1ziyrmcwy1vx765i21j859m0j41dbpsq9pr1ka2nxqib3618yxs7"
   }
  },
  {
@@ -12325,26 +12392,26 @@
   "repo": "xenodium/chatgpt-shell",
   "unstable": {
    "version": [
-    20250402,
-    1634
+    20250513,
+    904
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "0604df6676b13243692421dcc0b14c52a06a7a9a",
-   "sha256": "16r6v6f23wc7ng6q82rib0v9r1qq6zm5craaldn492zwn8hxdjji"
+   "commit": "80c75e0775f171d537ea4fd3d44ce9cdcf6b28a7",
+   "sha256": "0ir6xvw2l6y1z38dcwbyhpp73k2z7dfgg089a2gpqpf2w5jl1bmn"
   },
   "stable": {
    "version": [
     2,
-    16,
-    4
+    19,
+    1
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "b1bf3b331bcedc9487cc3b3656bb49a58812e0ac",
-   "sha256": "1lz1270hm24ghj0xgl0jsqyaqpw4wmrfvp37c11gin7ysf45g85b"
+   "commit": "3c8d95d9a550d2fb278bdf32e8446fed1974af03",
+   "sha256": "1fdav9jj06nav696xlqq4shmqshchsxyankmbllz6hlsjyxgfwvm"
   }
  },
  {
@@ -12355,15 +12422,15 @@
   "repo": "kimim/chatu",
   "unstable": {
    "version": [
-    20250403,
-    45
+    20250425,
+    645
    ],
    "deps": [
     "org",
     "plantuml-mode"
    ],
-   "commit": "d5d06c4efcc54156e6c8be3db488434508ce370f",
-   "sha256": "1540w06ga85a7vdrycqh9minpj78j66c7ia1h3qqkmprcjmzsdji"
+   "commit": "5324662e8dc3b16cdd7e596c98832f427962c223",
+   "sha256": "040y0kkz4a094ka29lb988209ihxmrhki8jnbsbcyldmnxhp9l18"
   }
  },
  {
@@ -12701,11 +12768,11 @@
   "repo": "gabrielelana/chip8.el",
   "unstable": {
    "version": [
-    20240210,
-    1459
+    20250405,
+    1408
    ],
-   "commit": "69a764f5c1119508dd109a0ba64080f04b5fb702",
-   "sha256": "1rzn804yl59h75323cvav4fgqax9nj5anv9y3189xpcyhzn1d3ld"
+   "commit": "e2d0131dc45e65151f9655833807fbe838267dbd",
+   "sha256": "0wxqyf4hs344300ady75y49s09kcrv0fa2cfyggbw0cb0v2pciq4"
   }
  },
  {
@@ -12763,26 +12830,26 @@
   "repo": "breatheoutbreathein/chordpro-mode.el",
   "unstable": {
    "version": [
-    20250331,
-    725
+    20250410,
+    707
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8221373d5784efcba50a32eb93a16016ff2f93fe",
-   "sha256": "1mbsw62k35kiaaipi8my1ci33pvipyjgdb4m3cwdvaqb0vkp61dg"
+   "commit": "9c559886e343fa37ba1524221eb3356adab1b6c7",
+   "sha256": "1pynhqrrvbkad0bp1n84pak60qzsrknjysvl8rpnm7mqinwgxlj7"
   },
   "stable": {
    "version": [
     2,
-    4,
+    6,
     0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d1517c29b702fc9c7c508aaac715ede20d948691",
-   "sha256": "190xzmkyz9fblsd2idh7888lwrp671sawwvxj97p7h4rpvimbpcn"
+   "commit": "c4167676831c790240610cfb4b5bbef93b5ddd49",
+   "sha256": "0x0a1990fip335ajd6zs90wq6lzb89gxaxr28nniyifrix8q8cxb"
   }
  },
  {
@@ -13010,8 +13077,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20250401,
-    1936
+    20250505,
+    1711
    ],
    "deps": [
     "clojure-mode",
@@ -13022,14 +13089,14 @@
     "spinner",
     "transient"
    ],
-   "commit": "de548e3084f6f6b5802dd7f939fd9ddf36e62038",
-   "sha256": "06c15xj4ls3axnl2rmpbgdbm83l6nc2mbz73g531cd0n1fs0bn2x"
+   "commit": "42e3cbac961a1d5f3b6cc1f8de3ce912ad73a6ee",
+   "sha256": "1yr19khh7ackr5zlkj4bff9rij53d00n24djkg7cymx355ss4322"
   },
   "stable": {
    "version": [
     1,
-    17,
-    1
+    18,
+    0
    ],
    "deps": [
     "clojure-mode",
@@ -13040,8 +13107,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "d2f34b60e5c5e569d4b7f4f79b36893f5c4dfa20",
-   "sha256": "02lilk85a7h9wxxvxr6k69p12wslbl9xp3jkcbdn11078fwhif6j"
+   "commit": "6d2d09318423f373bdbd546e97dc3e32b21c10e4",
+   "sha256": "0rcrc5cy0ph56wrpn4mz7wmanndfff032il1di64i3d9y746c0da"
   }
  },
  {
@@ -13244,25 +13311,25 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20250110,
-    2210
+    20250421,
+    1753
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "892f176c052d010eb66a104497e426b8ea883dc2",
-   "sha256": "1gz4l74jyx1bz2l9kxgf4dnv3lyngixic2vw3mxc278s9g2jai9f"
+   "commit": "9d9f63fd7cf8812797eb0ef77d7969e7387a9eb9",
+   "sha256": "12vq5p3bmqp4gh4s40s8sbz8hs2zczkcl4zfnn7ybr5sc36g1zax"
   },
   "stable": {
    "version": [
     2,
-    13
+    14
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "6f33a481af6bce68f55b9e25d5c14c1ed46fa9d9",
-   "sha256": "026dvi4v1dghfv3f2g15h8xz69an3l352kn5krcr6cb4s510b5qm"
+   "commit": "9d9f63fd7cf8812797eb0ef77d7969e7387a9eb9",
+   "sha256": "12vq5p3bmqp4gh4s40s8sbz8hs2zczkcl4zfnn7ybr5sc36g1zax"
   }
  },
  {
@@ -13312,6 +13379,21 @@
    ],
    "commit": "1432b0ad0f32b03fec564c0815951d5e096c2f6a",
    "sha256": "14c5m2cwmcap22371crz4c7204n2p1kb3mf1miznmq7vflm5a01p"
+  }
+ },
+ {
+  "ename": "circom-mode",
+  "commit": "f385fb5154d52bc79ba1150d669ebcbd1bb2b3b8",
+  "sha256": "07kln0zbw9l2fmy83inq8kwwhcr67vijd9mki0ci3ys9via8wlb2",
+  "fetcher": "github",
+  "repo": "taquangtrung/emacs-circom-mode",
+  "unstable": {
+   "version": [
+    20250406,
+    1817
+   ],
+   "commit": "6473decb0d89b756fcfc643ea302d476b9147186",
+   "sha256": "1jwivwy7qlrfakcxmjb9f2ddbic0rn720apxnkd96djmcv27bkl7"
   }
  },
  {
@@ -13422,16 +13504,30 @@
   "repo": "krisbalintona/citar-org-node",
   "unstable": {
    "version": [
-    20250402,
-    2014
+    20250422,
+    839
    ],
    "deps": [
     "citar",
     "ht",
     "org-node"
    ],
-   "commit": "a5df0165af6c0a8b417664b1c194c7ba93ff3025",
-   "sha256": "1d2yws0xs4kjafa1544dp3vii9ikmqxrrca53455jxldb024xf4z"
+   "commit": "ba832ea2c5a774d4dc5bcb66f321a030c6380600",
+   "sha256": "00k4h1qxcpwyglajxvycqafsibck9314bm7a12zq7pm4pa4ikjbz"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    5
+   ],
+   "deps": [
+    "citar",
+    "ht",
+    "org-node"
+   ],
+   "commit": "26979a7226e0149167c48e24dc43f72b8d12f798",
+   "sha256": "11hzn7gyh6vdcpbvy5l3v9b3ja5n4kr8xxd8nq43xvdggp6gj6v4"
   }
  },
  {
@@ -13442,15 +13538,15 @@
   "repo": "emacs-citar/citar-org-roam",
   "unstable": {
    "version": [
-    20241203,
-    2325
+    20250424,
+    1511
    ],
    "deps": [
     "citar",
     "org-roam"
    ],
-   "commit": "ff38add0aa40ba2014a6ee28a293fc1b9180cefa",
-   "sha256": "1zc8hy06dndkgl70z4cw45wifsb4ascq0f566ph6kck4qki73wik"
+   "commit": "9750cfbbf330ab3d5b15066b65bd0a0fe7c296fb",
+   "sha256": "0plza72rw2mz0cxg4dj5r8fcg4hslhahrshwpgj0wsb1b776xcm2"
   },
   "stable": {
    "version": [
@@ -13556,11 +13652,11 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20241028,
-    1548
+    20250411,
+    1406
    ],
-   "commit": "9220f430b5588f7e2d9ca82797eb37d1d7752620",
-   "sha256": "14698vwnsm1q3s3waz2mq5f36amgxyns2ygsg32dnxlssi3yai04"
+   "commit": "3e3c6e539c41c880f9d10ef7424cd0d2adcf3151",
+   "sha256": "0p2iifiadxpa2q75zk45gqj8bwa3wx9gcs82p5b303lrzid9mrga"
   },
   "stable": {
    "version": [
@@ -13687,11 +13783,11 @@
   "repo": "arteen1000/clang-format-lite",
   "unstable": {
    "version": [
-    20240708,
-    223
+    20250509,
+    246
    ],
-   "commit": "4e60389129601ac81f8c698c1a6985ad72224b3e",
-   "sha256": "1hiviarym9ahf3hi0zqf2ja5y14cyvm56z922m11kyapbmwqprka"
+   "commit": "46681aada7f93170a7e073332a43f8b19ee7b4c5",
+   "sha256": "0acgncalbdd74abd25max11l1q6vdcxsnr7g49gnq7v55qv0spqw"
   }
  },
  {
@@ -13978,14 +14074,14 @@
   "repo": "Fuco1/clippy.el",
   "unstable": {
    "version": [
-    20230822,
-    1348
+    20250511,
+    2020
    ],
    "deps": [
     "pos-tip"
    ],
-   "commit": "1e764902b3e9dbb11d5f02bc36c3b7ff4275f528",
-   "sha256": "1bc3a58xxvp9mjna47pcfnzk9h8akjwjn6jjlm2nsllmznzwa3pg"
+   "commit": "006e0bbe3f695c0e0ebdc0de5095255608eb9e6c",
+   "sha256": "16kdvf7xh401i3g3z3zlsvv8gbzn2d61pbws1ik1qzanglpq3glz"
   }
  },
  {
@@ -14056,8 +14152,8 @@
   "repo": "clojure-emacs/clj-refactor.el",
   "unstable": {
    "version": [
-    20240310,
-    2054
+    20250514,
+    1903
    ],
    "deps": [
     "cider",
@@ -14070,8 +14166,8 @@
     "seq",
     "yasnippet"
    ],
-   "commit": "dc1bbc8cdaa723bdbb6669ea7d280625c370755d",
-   "sha256": "0mha1wqn5hd9g8y0fp35qkhlnxlrwli62x7mbifman279h16gaml"
+   "commit": "362cb46bf808dc42d2aaf022afe93048439680c4",
+   "sha256": "09s9jav8xsgxqj5lkdl9nkbb0bbgz96qjpp7az197wckxsqrs26x"
   },
   "stable": {
    "version": [
@@ -14502,20 +14598,20 @@
   "repo": "clojure-emacs/clojure-ts-mode",
   "unstable": {
    "version": [
-    20250326,
-    1922
+    20250515,
+    732
    ],
-   "commit": "4cf4bd11428595b62002f5a587a53deaf21123b2",
-   "sha256": "19vm1j61smkmflk9awimdwb6kzd4j9n3pms9xl649kj7n156lq4x"
+   "commit": "c2269ea10a9129113a98eb58fc8abd8888a07e94",
+   "sha256": "0xd2gdny14x43d553bxn63nmscgkcqhy30196fzyn7m7imfv6hkx"
   },
   "stable": {
    "version": [
     0,
-    2,
-    3
+    4,
+    0
    ],
-   "commit": "9662b6caa86b67b51aa883b35e21645233ca6f68",
-   "sha256": "01gmv0cm0rirf91qwbbmy78ygmxrcn4swaack8bc2gdaybh2msnf"
+   "commit": "c2269ea10a9129113a98eb58fc8abd8888a07e94",
+   "sha256": "0xd2gdny14x43d553bxn63nmscgkcqhy30196fzyn7m7imfv6hkx"
   }
  },
  {
@@ -14765,10 +14861,10 @@
    "version": [
     4,
     0,
-    0
+    2
    ],
-   "commit": "f76a123f98111896ad9277f680b59b7d53071d4f",
-   "sha256": "0h0n7n6gmnsmv4prj7s4n7ipv0saxsr3264nlygfjj5dqd0gz9la"
+   "commit": "a12ed97b5c32a1e8f160ed557e7c97913ecf6ba5",
+   "sha256": "1c76ws079qd9yb5l9i645sz8prl04fxapdrm3d9yrdh1152b0hcv"
   }
  },
  {
@@ -15422,10 +15518,10 @@
   "stable": {
    "version": [
     1,
-    17
+    18
    ],
-   "commit": "81d8990085960824f700520d08027e6aca58feaa",
-   "sha256": "1x3aq6hadp158vh8mf9hmj5rikq0qz7a1frv7vbl39xr3wcnjj23"
+   "commit": "f3a993da26b3b6f778f5943e095e8b2816a6475c",
+   "sha256": "0r8q6ld2zma1bqq5pv61gpy99a4vx6bwx4v820ijzbymmi62vv3z"
   }
  },
  {
@@ -15901,11 +15997,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20250228,
-    258
+    20250426,
+    1319
    ],
-   "commit": "8d599ebc8a9aca27c0a6157aeb31c5b7f05ed0a3",
-   "sha256": "0k1k1rzqi6gc2iirlcg8nw1alv1hs8qf72a1wqcifmkx1ajb7d8i"
+   "commit": "41f07c7d401c1374a76f3004a3448d3d36bdf347",
+   "sha256": "16x0ssni2fxahdv292v3zqik12y3zvpqjkdbzsdgpb6z2p0j9ja0"
   },
   "stable": {
    "version": [
@@ -16291,39 +16387,6 @@
   }
  },
  {
-  "ename": "company-emacs-eclim",
-  "commit": "1e9d3075587fbd9ca188535fd945a7dc451c6d7e",
-  "sha256": "1l56hcy0y3cr38z1pjf0ilsdqdzvj3zwd40markm6si2xhdr8xig",
-  "fetcher": "github",
-  "repo": "emacs-eclim/emacs-eclim",
-  "unstable": {
-   "version": [
-    20180911,
-    1121
-   ],
-   "deps": [
-    "cl-lib",
-    "company",
-    "eclim"
-   ],
-   "commit": "edff7e0e30c87036710d88fb0b7a4644750858e8",
-   "sha256": "0ywifqdhv7cibgl42m7i15widna9i1dk5kl5rglyql7hy05nk9gj"
-  },
-  "stable": {
-   "version": [
-    0,
-    4
-   ],
-   "deps": [
-    "cl-lib",
-    "company",
-    "eclim"
-   ],
-   "commit": "8203fbf8544e65324a948a67718f7a16ba2d52e6",
-   "sha256": "10bbbxhvlwm526g1wib1f87grnayirlg8jbsvmpzxr9nmdjgikz3"
-  }
- },
- {
   "ename": "company-emoji",
   "commit": "57d010adb43ea1a6adc89bff9741dab6830f199b",
   "sha256": "0lyp65z19h9ccihrnav6k8iq04rhhy4jd96yk09i43i7fp8nfrwm",
@@ -16486,21 +16549,21 @@
   "repo": "jcs-elpa/company-fuzzy",
   "unstable": {
    "version": [
-    20250207,
-    140
+    20250424,
+    1433
    ],
    "deps": [
     "company",
     "ht",
     "s"
    ],
-   "commit": "cc144309cecb9d0b913f182a7c9a85ea1089db31",
-   "sha256": "0dg6l12dg5frh6lg6jmis5rzjj7ibfhs7ar1vjyhs3z8vmz49w05"
+   "commit": "536067f67281c5cc375bcc0ba1ce6e6a375e84a0",
+   "sha256": "0vs1spqy5zqhpi7s775cn1j9gqg73g4rh0x3bamv3b1k7qmjj1fa"
   },
   "stable": {
    "version": [
-    1,
-    4,
+    2,
+    0,
     0
    ],
    "deps": [
@@ -16508,8 +16571,8 @@
     "ht",
     "s"
    ],
-   "commit": "3aeb0bdcc15e969964b73e695aca8e0df60e3a1a",
-   "sha256": "1yfl1c92i0xn6imgvvj6h5zpadqp96akm69cmccxs7khfall5lmj"
+   "commit": "a359f5556ee1c989f6c111e35ab6be81c609f52c",
+   "sha256": "00gar55lmncf8r1jqxx2c3ddrmq9xqk8hdj40rpj9gb9hrdhcszg"
   }
  },
  {
@@ -17967,8 +18030,8 @@
   "repo": "mkcms/compiler-explorer.el",
   "unstable": {
    "version": [
-    20250224,
-    1232
+    20250417,
+    2126
    ],
    "deps": [
     "eldoc",
@@ -17976,8 +18039,8 @@
     "plz",
     "seq"
    ],
-   "commit": "228f562f0a7aa5edbb56ed8da6b6844fd013436e",
-   "sha256": "0wvd08mz4y0wj1b0gmw7093d8krmx5w520q4x52yn5cn4vr6bbwm"
+   "commit": "171cbde72993956e46cc478ecc98825997450140",
+   "sha256": "15w171fhh0khvsr02z2c110w818hmrzjpmpn1lazw7s0nq8a8mf5"
   },
   "stable": {
    "version": [
@@ -18157,6 +18220,42 @@
   }
  },
  {
+  "ename": "conda-project",
+  "commit": "3b5b46f6ecdf05a72be3144c3c28295cf80b466a",
+  "sha256": "0k3c4z3s5dvwy6l5vi59b4ca187hgpqd5rfqgjs7gc47zns011xd",
+  "fetcher": "github",
+  "repo": "gilbertwong96/conda-project.el",
+  "unstable": {
+   "version": [
+    20250415,
+    1442
+   ],
+   "deps": [
+    "pythonic",
+    "s",
+    "transient",
+    "yaml"
+   ],
+   "commit": "21becf078e21cc98a5890dff9049928c4712c235",
+   "sha256": "1qga2l1dx9dp4jhrminhkmk5n9qhwp1c0n5vg7h4s7c42r32piy0"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "pythonic",
+    "s",
+    "transient",
+    "yaml"
+   ],
+   "commit": "21becf078e21cc98a5890dff9049928c4712c235",
+   "sha256": "1qga2l1dx9dp4jhrminhkmk5n9qhwp1c0n5vg7h4s7c42r32piy0"
+  }
+ },
+ {
   "ename": "config-general-mode",
   "commit": "35763febad20f29320d459394f810668db6c3353",
   "sha256": "1pqivnyb1yljzs3fd554s0971wr9y6g1dx3lgym9gi5jhpyza38z",
@@ -18315,25 +18414,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20250402,
-    659
+    20250512,
+    1410
    ],
    "deps": [
     "compat"
    ],
-   "commit": "30a42ac8f3d42f653eda234ee538c1960704f4f2",
-   "sha256": "03kmdpgghbpwss8kkm0w9cprg0cws00ksamv912vryabs8c095zx"
+   "commit": "eae64815fbfa74327dcda9de3cb1b9a725d59b2d",
+   "sha256": "16cx1qzwylaar3lxi7f6507pv5vz4skjk40ghw0h6njgra13af4j"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "30a42ac8f3d42f653eda234ee538c1960704f4f2",
-   "sha256": "03kmdpgghbpwss8kkm0w9cprg0cws00ksamv912vryabs8c095zx"
+   "commit": "48d09c200c683ffb09ad5863d5496e230b9fe3f9",
+   "sha256": "01aiq5325xpxd0j88kjapryp44c1brifcks2s655w1fyhippmr9w"
   }
  },
  {
@@ -18617,29 +18716,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250328,
-    2026
+    20250415,
+    214
    ],
    "deps": [
     "consult",
     "markdown-mode",
     "ox-gfm"
    ],
-   "commit": "063b95ff92308d8fcdcd013c53394c1f9f1d7da0",
-   "sha256": "1nssjni5xnd9xvdarpf9p3pcf1s70wv57xvlk0lld78cb5hxamc4"
+   "commit": "3a352593aa1da234c8fb9df335bb1ec6f509fc23",
+   "sha256": "188ac5vl3mspp8dp78hfizpjj3v4cmqd0i5sjxvavgby244rxmi8"
   },
   "stable": {
    "version": [
     2,
-    3
+    5
    ],
    "deps": [
     "consult",
     "markdown-mode",
     "ox-gfm"
    ],
-   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
-   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
+   "commit": "3a352593aa1da234c8fb9df335bb1ec6f509fc23",
+   "sha256": "188ac5vl3mspp8dp78hfizpjj3v4cmqd0i5sjxvavgby244rxmi8"
   }
  },
  {
@@ -18650,29 +18749,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250328,
-    2015
+    20250415,
+    214
    ],
    "deps": [
     "consult",
     "consult-gh",
     "embark-consult"
    ],
-   "commit": "6ed4601dc5ce7d63f6340a6540b2ba7919d14718",
-   "sha256": "1v799kf5hl9bz9gyw136c6ksksznjiqr3xxc0dq6zy11wxci6z4z"
+   "commit": "3a352593aa1da234c8fb9df335bb1ec6f509fc23",
+   "sha256": "188ac5vl3mspp8dp78hfizpjj3v4cmqd0i5sjxvavgby244rxmi8"
   },
   "stable": {
    "version": [
     2,
-    3
+    5
    ],
    "deps": [
     "consult",
     "consult-gh",
     "embark-consult"
    ],
-   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
-   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
+   "commit": "3a352593aa1da234c8fb9df335bb1ec6f509fc23",
+   "sha256": "188ac5vl3mspp8dp78hfizpjj3v4cmqd0i5sjxvavgby244rxmi8"
   }
  },
  {
@@ -18683,29 +18782,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250328,
-    2015
+    20250415,
+    214
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "6ed4601dc5ce7d63f6340a6540b2ba7919d14718",
-   "sha256": "1v799kf5hl9bz9gyw136c6ksksznjiqr3xxc0dq6zy11wxci6z4z"
+   "commit": "3a352593aa1da234c8fb9df335bb1ec6f509fc23",
+   "sha256": "188ac5vl3mspp8dp78hfizpjj3v4cmqd0i5sjxvavgby244rxmi8"
   },
   "stable": {
    "version": [
     2,
-    3
+    5
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
-   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
+   "commit": "3a352593aa1da234c8fb9df335bb1ec6f509fc23",
+   "sha256": "188ac5vl3mspp8dp78hfizpjj3v4cmqd0i5sjxvavgby244rxmi8"
   }
  },
  {
@@ -18716,29 +18815,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250328,
-    2015
+    20250415,
+    214
    ],
    "deps": [
     "consult",
     "consult-gh",
     "pr-review"
    ],
-   "commit": "6ed4601dc5ce7d63f6340a6540b2ba7919d14718",
-   "sha256": "1v799kf5hl9bz9gyw136c6ksksznjiqr3xxc0dq6zy11wxci6z4z"
+   "commit": "3a352593aa1da234c8fb9df335bb1ec6f509fc23",
+   "sha256": "188ac5vl3mspp8dp78hfizpjj3v4cmqd0i5sjxvavgby244rxmi8"
   },
   "stable": {
    "version": [
     2,
-    3
+    5
    ],
    "deps": [
     "consult",
     "consult-gh",
     "pr-review"
    ],
-   "commit": "a1c307ddd9d022a142030e3e868df05ee30656fa",
-   "sha256": "1f7i1h5024d2i5nlcf7q9zzyxdwccakjin89zvb2yp32r8m4m7qq"
+   "commit": "3a352593aa1da234c8fb9df335bb1ec6f509fc23",
+   "sha256": "188ac5vl3mspp8dp78hfizpjj3v4cmqd0i5sjxvavgby244rxmi8"
   }
  },
  {
@@ -18797,28 +18896,26 @@
   "repo": "Nyoho/consult-hatena-bookmark",
   "unstable": {
    "version": [
-    20221125,
-    109
+    20250421,
+    1501
    ],
    "deps": [
-    "async-await",
     "consult"
    ],
-   "commit": "b85484b11705ebd896878d3ac7fdb12bc8c9637a",
-   "sha256": "1xvi28wvagcabk1q6ckw4f97knm59rl86jd3pndz2ljv842rzbix"
+   "commit": "8f2e48688455711df89533a7fe5af1d9cd02c137",
+   "sha256": "1gyiaid4076ix9jkgl1k6495scgl3vp5474r7dm4gd80hr05hs5v"
   },
   "stable": {
    "version": [
     0,
-    3,
+    4,
     1
    ],
    "deps": [
-    "async-await",
     "consult"
    ],
-   "commit": "b85484b11705ebd896878d3ac7fdb12bc8c9637a",
-   "sha256": "1xvi28wvagcabk1q6ckw4f97knm59rl86jd3pndz2ljv842rzbix"
+   "commit": "8f2e48688455711df89533a7fe5af1d9cd02c137",
+   "sha256": "1gyiaid4076ix9jkgl1k6495scgl3vp5474r7dm4gd80hr05hs5v"
   }
  },
  {
@@ -18829,14 +18926,14 @@
   "repo": "rcj/consult-ls-git",
   "unstable": {
    "version": [
-    20241023,
-    1113
+    20250419,
+    1320
    ],
    "deps": [
     "consult"
    ],
-   "commit": "beb253374e2cee10b8682fb8b377ca1f2caa4e27",
-   "sha256": "1znlvjplgmkp0zl94xf8z9jlkr9f4r39kv2nfd47ajnqccczkr85"
+   "commit": "85882e4b7af9ad40160d985e42b36b0fd6400ead",
+   "sha256": "06byp4d8pyvlvhi6i761zwf2rq2xwmvkjddq2xaycg8f27xlqfjv"
   }
  },
  {
@@ -19079,15 +19176,15 @@
   "repo": "eki3z/consult-todo",
   "unstable": {
    "version": [
-    20250201,
-    1342
+    20250417,
+    1903
    ],
    "deps": [
     "consult",
     "hl-todo"
    ],
-   "commit": "b50df0da6243d7a91016e1b8c9a208fb167695be",
-   "sha256": "1cj25n54dglj8frfb23w576yfn7rcv149xf2anjyv7w45mfgspnn"
+   "commit": "f9ba063a6714cb95ddbd886786ada93771f3c140",
+   "sha256": "13lfm1kg3llda0w4mwbaai6vrsaymq3yn4kagpvkh9i0iy22a5ii"
   },
   "stable": {
    "version": [
@@ -19141,15 +19238,15 @@
   "repo": "mohkale/consult-yasnippet",
   "unstable": {
    "version": [
-    20240314,
-    1838
+    20250411,
+    1922
    ],
    "deps": [
     "consult",
     "yasnippet"
    ],
-   "commit": "834d39acfe8a7d2c304afbe4d649b9372118c756",
-   "sha256": "0vjsqjhgzxvdhhcis5gx8xc56mjl3drpy1qn1265f6474j7y4frv"
+   "commit": "a3482dfbdcbe487ba5ff934a1bb6047066ff2194",
+   "sha256": "0cyzyxmdrk7dcpsw51pv1vz1f6px5yjmbmsa6r74vmshfdmljm3j"
   }
  },
  {
@@ -19288,21 +19385,21 @@
   "repo": "copilot-emacs/copilot.el",
   "unstable": {
    "version": [
-    20250402,
-    2229
+    20250506,
+    2016
    ],
    "deps": [
     "editorconfig",
     "f",
     "jsonrpc"
    ],
-   "commit": "8f4a04e1c764bea291840387a82d03e55b0a04cf",
-   "sha256": "0m1q9cxd4vbmi8nikvnchbindr0lq3d65l1iv0pzn9nlpizwc6qb"
+   "commit": "fe3f51b636dea1c9ac55a0d5dc5d7df02dcbaa48",
+   "sha256": "0066zm38fpivz99fd0mam7yiw60pj3ihycgh20znmn7ir0a0ismd"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
@@ -19310,8 +19407,8 @@
     "f",
     "jsonrpc"
    ],
-   "commit": "5fa27b5194ad84ffb21c51eeb10ef0e9559a1c56",
-   "sha256": "01i0vgrgf27zam7c94wgq23xys3yy86fkvbxx4frr3yc5sz0hfml"
+   "commit": "11b0739da1f74285dd661914c0ef92e24f9c4aa7",
+   "sha256": "1pf5j3xhhcrv4dj2cgp7627s67wsw4hm308szqyr4f58snlkx044"
   }
  },
  {
@@ -19322,8 +19419,8 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20250331,
-    737
+    20250515,
+    514
    ],
    "deps": [
     "aio",
@@ -19334,8 +19431,8 @@
     "shell-maker",
     "transient"
    ],
-   "commit": "c2b9d40e5909a8d4468ab57ea72a85518106658e",
-   "sha256": "117zhzq458h2h5s3v9ihl1kzav61273gcxy7ln2n1g47w165gfjd"
+   "commit": "e9c8a480d8a518a1a069afff1f1bc51ff2b0a2fc",
+   "sha256": "1zs9ypz4b8idfhkrm7laj5fw3hgfxg3ckbl9g40jyckiiajf7w98"
   },
   "stable": {
    "version": [
@@ -19506,25 +19603,25 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20250328,
-    1430
+    20250516,
+    1841
    ],
    "deps": [
     "compat"
    ],
-   "commit": "061d926d0f0eb2633416deeddc403a1a67b062ae",
-   "sha256": "15vmhbwpjgvc9ly8icrjf74jhbplhigfyfa762s45ipnrq6gyixq"
+   "commit": "10e24c8bdbdd4e6d3145878f3ce4357c3753b0a1",
+   "sha256": "0rqvnmv566ncppm4k2m5pi03llcvrxqs0piax1yp672cp4g77fpk"
   },
   "stable": {
    "version": [
     2,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "061d926d0f0eb2633416deeddc403a1a67b062ae",
-   "sha256": "15vmhbwpjgvc9ly8icrjf74jhbplhigfyfa762s45ipnrq6gyixq"
+   "commit": "6db826974963f8fb5d8b9832e7c09da2fea3296a",
+   "sha256": "0l6hyj8nywvqrjzy0mnp0g5al9qrcvgrbj3xxx33474s719gk405"
   }
  },
  {
@@ -20571,10 +20668,10 @@
  },
  {
   "ename": "crc",
-  "commit": "75219d010bfe386715b48cccc8c311d69b388873",
-  "sha256": "067ms2sy3ls1b9067gap5ks322l1akzz7yi4krw69fydanzqgw6b",
+  "commit": "a0cc4d5be5e123c984b752a37a639cb1fad7602b",
+  "sha256": "0sifp42fpds3zf4hwgq7lx9g97qbq9szb6lds0f4fs8vz1nfwwk9",
   "fetcher": "codeberg",
-  "repo": "Jaft/Emacs-CRC",
+  "repo": "tomenzgg/Emacs-CRC",
   "unstable": {
    "version": [
     20250303,
@@ -20828,11 +20925,11 @@
   "repo": "bbatsov/crux",
   "unstable": {
    "version": [
-    20250212,
-    2017
+    20250421,
+    936
    ],
-   "commit": "c83c54d3d746e83861bcb22b0309c66a2d4db17f",
-   "sha256": "0g8ph4brjsczfzmg0inzm4b1fwvbx0hgakczwnzxmkg1ssd1gigm"
+   "commit": "e42f5558199576628e827a6e3db29eae56f4126a",
+   "sha256": "03gjf43lf4pbr3n0i8di8j2sgcy22i9h4g8pzymgwq2s7mcbdn54"
   },
   "stable": {
    "version": [
@@ -21323,6 +21420,36 @@
   }
  },
  {
+  "ename": "cuckoo-search",
+  "commit": "2a0b297fe5131c0b670467fc07c8d63465016681",
+  "sha256": "0v5301fgq8spihjjjjm9qpbrmh5la3iv71wb9v11hfwa7zrjfhqm",
+  "fetcher": "github",
+  "repo": "rtrppl/cuckoo-search",
+  "unstable": {
+   "version": [
+    20250512,
+    821
+   ],
+   "deps": [
+    "elfeed"
+   ],
+   "commit": "b4688f81942255579b5e5fd2c879b9af1627dd45",
+   "sha256": "016nmm03g8a1fg99byhcj5zp70jjg8v7cyp7rv6mfqw7b5n276qh"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    5
+   ],
+   "deps": [
+    "elfeed"
+   ],
+   "commit": "b4688f81942255579b5e5fd2c879b9af1627dd45",
+   "sha256": "016nmm03g8a1fg99byhcj5zp70jjg8v7cyp7rv6mfqw7b5n276qh"
+  }
+ },
+ {
   "ename": "cucumber-goto-step",
   "commit": "d78d7abccfd9bcebf6888032639923327ad25309",
   "sha256": "1ydsd455dvaw6a180b6570bfgg0kxn01sn6cb57smqj835am6gx8",
@@ -21664,14 +21791,14 @@
   "repo": "ideasman42/emacs-cycle-at-point",
   "unstable": {
    "version": [
-    20240422,
-    300
+    20250421,
+    1059
    ],
    "deps": [
     "recomplete"
    ],
-   "commit": "317dd682924f1ddcb61cbcd0008072abe3c5264b",
-   "sha256": "1m29a15ilhf33as76pmpm28qnymsj28syv5qgjqrih9ncd5khwjr"
+   "commit": "30cfa6ac1ebf6594e4947b11c9ac95148dcb6f96",
+   "sha256": "11qnzj27jpirajsh8dx62403daji36b68jvssx7rljipprci2cbs"
   }
  },
  {
@@ -21870,15 +21997,15 @@
   "repo": "cbowdon/daemons.el",
   "unstable": {
    "version": [
-    20241223,
-    1448
+    20250514,
+    1107
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "e1c0f5bb940b8149e0db414cc77c1ce504f5e3eb",
-   "sha256": "1s91r6zl5c4cbfp6ybz3r8i5kw200nqc92dsidf9wmbzz435m1ds"
+   "commit": "7b08ce315c0be901d88c1099483f9607c653712e",
+   "sha256": "1p6vwmqwkl8y5323bb5b3k5mw1r8x9lcc9qzi8wcwq903cndq7ji"
   },
   "stable": {
    "version": [
@@ -22058,8 +22185,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20250228,
-    2153
+    20250406,
+    2127
    ],
    "deps": [
     "bui",
@@ -22072,8 +22199,8 @@
     "posframe",
     "s"
    ],
-   "commit": "56e92dd86b526c191275cf7813208baad14e0c5d",
-   "sha256": "1qmkxymzyg4rzv9by5z4s3bxpgg2h0szk4632nbm8khq09pkjcjx"
+   "commit": "68357594a615cb3af833346e869f10b2de260406",
+   "sha256": "0hq29ia2x62lhd1zz7gnicr10ck1m9cymgc4ii9n35zl6aai382f"
   },
   "stable": {
    "version": [
@@ -22433,11 +22560,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20250227,
-    121
+    20250509,
+    2153
    ],
-   "commit": "9616e5b5e793c3d8228a8fccf7b9ef7ace365005",
-   "sha256": "0pwjya3s83krx61rfdbqkc0jlsiv9g1fgk3d1wz7ll23rlqgnsi0"
+   "commit": "300f87567df7b177bb5a2f2b757983e80c596547",
+   "sha256": "0kl2pmcfiiflgfhxq7mh5psc4aqrfgaydm4icr0c7s3xpvpvk5nm"
   },
   "stable": {
    "version": [
@@ -22804,6 +22931,21 @@
   }
  },
  {
+  "ename": "ddp",
+  "commit": "edf8854cef5979b3a8e39ba84359422365f90ded",
+  "sha256": "0fnjf031dhkdbxzdlhqhm4jhhrl65ywvinbzy8rdqs7zsjzqxwx6",
+  "fetcher": "github",
+  "repo": "eki3z/ddp.el",
+  "unstable": {
+   "version": [
+    20250421,
+    353
+   ],
+   "commit": "ee02e658f3bf8f26115e2dd61c713137e01227a9",
+   "sha256": "0xypbghjs5slgv28b5n296x02573gpi3a1rx0i1vf0g063lyzqp6"
+  }
+ },
+ {
   "ename": "ddskk",
   "commit": "f9103b6c58996e75c0e5c23fc0fb12afd65424c0",
   "sha256": "1nf0f1aya2m3yzkks3kk79y2w5bg1a4y7hjspjpzcggh5p31hlz7",
@@ -22906,11 +23048,11 @@
   "url": "https://salsa.debian.org/emacsen-team/debian-el.git",
   "unstable": {
    "version": [
-    20250108,
-    2119
+    20250411,
+    2043
    ],
-   "commit": "3f7c2b582eb65b47bea081f3c74ae70833c5af7e",
-   "sha256": "020d9w7nw7fzdpmhijlgp0j4jg9ydll08fkx7n7kllsl01vzvvyi"
+   "commit": "ce6df85ee3c4220aedbaecdb6d623fb7b0707b21",
+   "sha256": "1sk82ad5c75kzbg0ym0z7qix7vlld7vxxk4jf4yijnwf5jnj75gj"
   },
   "stable": {
    "version": [
@@ -23452,15 +23594,15 @@
   "repo": "swflint/denote-agenda",
   "unstable": {
    "version": [
-    20250402,
-    1838
+    20250407,
+    2324
    ],
    "deps": [
     "denote",
     "seq"
    ],
-   "commit": "085f4a747498da487e532a23f7c0c452818e63dc",
-   "sha256": "0n8bs0aij6dkp19nmcaz0zip8p9y6ip90m7i8l0z9x553gc6p8vl"
+   "commit": "2643a4ebeb7185a2becc287ccfc6de1265c561be",
+   "sha256": "1y8d8kr5mlv8a9wpdydz4xb6s977xq16alh0y5mf9h87qg996p8x"
   }
  },
  {
@@ -23541,14 +23683,14 @@
   "repo": "swflint/denote-project-notes",
   "unstable": {
    "version": [
-    20250328,
-    1347
+    20250421,
+    1646
    ],
    "deps": [
     "denote"
    ],
-   "commit": "f1f12a9bc288e0a1c1ed451c905f8e2792d97509",
-   "sha256": "1kz15jlwzf0qln5w552w8cvk5jzblqim34qylcmk3nkyrbcs2nc2"
+   "commit": "4dfa153659e68296fc4150b8ffd1e89e76406869",
+   "sha256": "1mnnm7qprbgdz17k44kllnrlnylsya0rba845p9q8835n4al562x"
   }
  },
  {
@@ -23559,14 +23701,14 @@
   "repo": "swflint/denote-regexp",
   "unstable": {
    "version": [
-    20250324,
-    146
+    20250415,
+    2202
    ],
    "deps": [
     "denote"
    ],
-   "commit": "f61b8b895552364d4ce4903beb42d4afb4f4d98c",
-   "sha256": "0ambw2iamkyc2kb8lahzy3jn9bmxfvyxqqzpdr4vrirvsbgz6ls7"
+   "commit": "08d62cb5bb2d271eb4e0915b56a9601179f88627",
+   "sha256": "1xgg2z91iz070iz2095rma5crcwa033wpa0lvmayiar65ycpbvq6"
   }
  },
  {
@@ -23586,6 +23728,24 @@
    ],
    "commit": "00c7084652fa32f9f4ab504facaaed623f299684",
    "sha256": "0cd9207b9gwbxgv1vvlfk9yv9fy51697fwpr6j0s9v2px3jv9ahj"
+  }
+ },
+ {
+  "ename": "departure-times-norway",
+  "commit": "6fab35ad7b09bdaab751ac1b24f8a51749a17c66",
+  "sha256": "1cy1b0vrlw3546aiz71dd26hb7dsvs1aaxjmkb7kyy8aqx31wm1l",
+  "fetcher": "github",
+  "repo": "hsolg/emacs-departure-times-norway",
+  "unstable": {
+   "version": [
+    20250427,
+    852
+   ],
+   "deps": [
+    "persist"
+   ],
+   "commit": "11448dfe9f03c1e839d398a4d406984139bb0c40",
+   "sha256": "0nps5asnzajv1aayxrz1hr5aqlc9ljnzmilqbrcqvwl4ky96wl5r"
   }
  },
  {
@@ -24064,11 +24224,11 @@
   "repo": "ideasman42/emacs-diff-ansi",
   "unstable": {
    "version": [
-    20250224,
-    2226
+    20250408,
+    2344
    ],
-   "commit": "c2a402967b4043e104a431ab72c55477805ad2cb",
-   "sha256": "1sh9lwnwngdlhzg4zv728f3qmi5l7a6mnjf62ml4k8rlx0lcvww7"
+   "commit": "4cf357a4499a47c82e31fa1bd34485ae2c9eb353",
+   "sha256": "1nwvm14ag9a37qq9yqvlwiqhz8ly4waj9109pmqgja9sx3bx71kw"
   }
  },
  {
@@ -24094,14 +24254,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20250327,
-    314
+    20250507,
+    2037
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7da881a957b8c15ddcc754dd73543c95b128d716",
-   "sha256": "0ban6vi5hmxxh1aammq4n25vjw1cn994b1ac8m5k3sjdsmcz1bbf"
+   "commit": "c2852b0e4b9d8b3b499b5df72d1fc549838a646e",
+   "sha256": "0irx9r5qs04n8m4fprbbdy3azmcjc72hf1qzffai5vi41rk4d2sh"
   },
   "stable": {
    "version": [
@@ -24217,16 +24377,16 @@
   "repo": "pkryger/difftastic.el",
   "unstable": {
    "version": [
-    20250219,
-    1602
+    20250516,
+    1623
    ],
    "deps": [
     "compat",
     "magit",
     "transient"
    ],
-   "commit": "ddc460e2c7da8b0c8308163edbd8a0a6428c891e",
-   "sha256": "0xczmm39g62275dnlf6jjc5icfwi1gssszabm2j8x1z2k5gf6qkn"
+   "commit": "77166b5b7230684e1764d0799d0a96ea79fb06cb",
+   "sha256": "0nvxc8mxi6al5a79z16x3d9fvb14pi9xwxp19kwakwjcy7h0xmah"
   }
  },
  {
@@ -24260,11 +24420,11 @@
   "repo": "retroj/digistar-mode",
   "unstable": {
    "version": [
-    20250114,
-    2244
+    20250429,
+    1455
    ],
-   "commit": "40a12b714d7efd9c396415795ae1fe0a2b12dc71",
-   "sha256": "1qbkhyvr99yy7ccnlnngg04w3z0il7aqzvqwjhw3vny6xh6jy11b"
+   "commit": "54b38bd570cd52348065b61360d1194a779a5af6",
+   "sha256": "0y5939bql53mgdjyxjgfkbzj8k9g01rjqs2fbz5wg7rc1rzh15vr"
   },
   "stable": {
    "version": [
@@ -24393,14 +24553,14 @@
   "repo": "tarsius/dim-autoload",
   "unstable": {
    "version": [
-    20240805,
-    1309
+    20250509,
+    1453
    ],
    "deps": [
     "compat"
    ],
-   "commit": "dbe0f038c0a7fcc7e0f021947a42db5b0e8f143d",
-   "sha256": "1mj1h0j6sdb5c7ylcks51xn69003l0j12kifwz7cmwrhv55g54az"
+   "commit": "f2d5e3f5b272d958423a9eec1fd094b4764c7395",
+   "sha256": "1gn7zz1c45ijkqay2mw2dwpjqgiyz3alxz20m4kr20h8m0qi9br0"
   },
   "stable": {
    "version": [
@@ -24838,11 +24998,11 @@
   "repo": "jixiuf/dired-filetype-face",
   "unstable": {
    "version": [
-    20180907,
-    1339
+    20250412,
+    1344
    ],
-   "commit": "7ade7f7e8c2d7518c65f3f0343a10c272da0f47e",
-   "sha256": "0s8mqz331iw2bk4xdvj9zljklqj8dxv0yaw100lddg37qmdf7lgl"
+   "commit": "41288f9f35a7ef830b9e78fe252b367aee078c96",
+   "sha256": "05x7383s727vz60jpz8maqkjhdhf8gg4137sw2s33gs13zp2qy2m"
   }
  },
  {
@@ -25111,15 +25271,15 @@
   "repo": "Fuco1/dired-hacks",
   "unstable": {
    "version": [
-    20240629,
-    1953
+    20250511,
+    2303
    ],
    "deps": [
     "dash",
     "dired-hacks-utils"
    ],
-   "commit": "e9e408e8571aee5574ca0a431ef15cac5a3585d4",
-   "sha256": "0lq73f49qd4ld55f3842vdhy8j6yxz2j37qhzy608pcnbraq0408"
+   "commit": "bb5d1c3c8b0bb6025335dabb4b3639d60acc6a12",
+   "sha256": "0jvq84gsg3ma2gh3810l2ywzqnxk2vsckxahn4kj0x96dhb0pnjm"
   }
  },
  {
@@ -25733,23 +25893,26 @@
   "repo": "alexluigit/dirvish",
   "unstable": {
    "version": [
-    20250403,
-    459
+    20250504,
+    807
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7011a0fbff90c09285cf86905a0ca009d43708f9",
-   "sha256": "0m7k5v14fjmrgkfvdc2z8xfs2b7cw85b53ba04gmjgzywp3yirrm"
+   "commit": "d877433f957a363ad78b228e13a8e5215f2d6593",
+   "sha256": "0d9c7i3x4vfl7k4vi29zyrz1d2cx7kfdnir8slqdjbapyacrl4s0"
   },
   "stable": {
    "version": [
     2,
-    2,
-    7
+    3,
+    0
    ],
-   "commit": "a8e3a4ddcfe07dce284acb6276515bb813a57e14",
-   "sha256": "13y066sj6ax8czlfp6vy2da310q988vij933wvw31frihwd2v200"
+   "deps": [
+    "compat"
+   ],
+   "commit": "cd235f87ecd67c9195e3e857b4ea313f258c8457",
+   "sha256": "1x79j3xlvhrvigh38vqhfrzqvdnpzaivbxsjzfi0pnx00y8czs5q"
   }
  },
  {
@@ -26125,14 +26288,14 @@
   "repo": "unhammer/dix",
   "unstable": {
    "version": [
-    20241128,
-    1111
+    20250430,
+    915
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "9770a2edd1fd0f872cc4ca72fa8f4b1007cb3da8",
-   "sha256": "050xh28jhk6gqm4psqkgjh3wqh5jrggrp9ky380f05x8v1ijgvhq"
+   "commit": "c833800623eaeab74b4d578a2d0219882320c0d2",
+   "sha256": "1xm9fni1sszd4l19aw2sa0hz4rzzpjci0jnl3wr6c5bq0lzg4k6z"
   },
   "stable": {
    "version": [
@@ -26503,8 +26666,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20250313,
-    2007
+    20250411,
+    709
    ],
    "deps": [
     "aio",
@@ -26513,8 +26676,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "36cc66f2a975d2a1864545d0bd57dd4b6db3e6a5",
-   "sha256": "0cpka14s620qy69njx9cw44h85f4kfmllg6mvykcxb1r6idza8yv"
+   "commit": "75a5716e26cbab2147df68dd885c28950c89f854",
+   "sha256": "0fvq6rlqjq7q0b91342m203f3r5903yx5fg8krckba2m6lcl2krb"
   },
   "stable": {
    "version": [
@@ -26904,16 +27067,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20250401,
-    1348
+    20250423,
+    1614
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "05fec1d4866b1dd5c7c264bc4671dbfd4b96c556",
-   "sha256": "0f8ixbbrxbxa7wkqz2crnv3dyv28a189ybjzhfjmka50gl9k9frz"
+   "commit": "297b57585fe3b3de9e694512170c44c6e104808f",
+   "sha256": "0psh1k6fnjv9gazcdrqz6yzhcs1iaj45bh74hcz0dakn270c7n6m"
   },
   "stable": {
    "version": [
@@ -27184,14 +27347,14 @@
   "url": "https://salsa.debian.org/emacsen-team/dpkg-dev-el.git",
   "unstable": {
    "version": [
-    20250401,
-    2244
+    20250408,
+    635
    ],
    "deps": [
     "debian-el"
    ],
-   "commit": "1f75d3a714c60762cf56f319c3affe8c4ea2ee04",
-   "sha256": "0m45aic46jc9r63xw1j77sfj1ciq2hpbbai4ibxxlr4whw4n9rrg"
+   "commit": "14a47e96b4f0e20ab9008bac6dc554d07335cbd6",
+   "sha256": "1gm7f1lh6rrqp21p3pzarqdpw0j1bpi39rl1aaydr163k4akh0yy"
   },
   "stable": {
    "version": [
@@ -27237,11 +27400,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20250325,
-    1246
+    20250407,
+    1205
    ],
-   "commit": "ab09e8532c70bf73caed55ab9ce52ba3fb14583e",
-   "sha256": "1d1bph92vnpw9f10vphznhfdmy5fwvl54n6k5j6ip9m1cziwc7gn"
+   "commit": "8b3a005db9e8b7ac57e683bc6631cdc7643e8150",
+   "sha256": "1f0z53ad89cqs9nskinvqnz3286gvjr4ldifcyc5qyb7r58pivz6"
   },
   "stable": {
    "version": [
@@ -27554,19 +27717,19 @@
   "repo": "jscheid/dtrt-indent",
   "unstable": {
    "version": [
-    20250130,
-    1702
+    20250409,
+    1325
    ],
-   "commit": "22498ca24ac93c051d233abef630aece1ac45dd1",
-   "sha256": "1j3sqfs791cmxa3mysrl4r4wxg96dqkkcikqs363qfvi3688k4z9"
+   "commit": "015b26d6d6af9465c1dc48ef721db119ecd78437",
+   "sha256": "0lf0q4v5rg9bkw0zxbs9ijblwrgxmc8dqnkags1as1yqp6q1lkb7"
   },
   "stable": {
    "version": [
     1,
-    23
+    24
    ],
-   "commit": "4a5c08c9e0d79d56cfe2e39ccb57b10ddb40f9b5",
-   "sha256": "0qhnjq3dkdsqgpi9vjn4m0lyzx3jg2z5j0nb895x7nh7c1vhikbi"
+   "commit": "015b26d6d6af9465c1dc48ef721db119ecd78437",
+   "sha256": "0lf0q4v5rg9bkw0zxbs9ijblwrgxmc8dqnkags1as1yqp6q1lkb7"
   }
  },
  {
@@ -27636,16 +27799,16 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20250310,
-    2014
+    20250516,
+    1032
    ],
    "deps": [
     "dash",
     "popup",
     "s"
    ],
-   "commit": "737267a6139a988369cb95ecd365b2db95e05db0",
-   "sha256": "1mr06xiqqrknalg7a1xp1kgc4m9pm23sanhq1s3pzsqr6zz1p0zi"
+   "commit": "42f97dea503367bf45c53a69de959177b06b0f59",
+   "sha256": "1gjl34q1qmdajl5lvsyhjzxciq1gyafspvm5zg5g0haqb2hdnr99"
   },
   "stable": {
    "version": [
@@ -27713,11 +27876,11 @@
   "stable": {
    "version": [
     3,
-    17,
+    18,
     2
    ],
-   "commit": "fedec664a6ba500f94ba4558112f52d5719bed4d",
-   "sha256": "08ayi5z171qwny40a2kjm4qmxa7zc39fj7cnjll4s5ji4zy3ps31"
+   "commit": "7b971c877d1403da3d536cc180cdd384c7b26341",
+   "sha256": "0i8ihn3wwkkkcd39g5zwk832rgrgwcbn58smdr8nigshf16p6rqh"
   }
  },
  {
@@ -28384,20 +28547,20 @@
   "repo": "emacs-eask/eask",
   "unstable": {
    "version": [
-    20250403,
-    257
+    20250514,
+    232
    ],
-   "commit": "7faf67d059a8271c4b9e2eb23f8e1dc807a974e7",
-   "sha256": "1s7cq89rz26vkrgy9js3195gb1a57fcaz82c8f0c6f339cqwn8f1"
+   "commit": "db438a5e09a8a026cc66af09ca409d14ef322633",
+   "sha256": "0lx1ilc6rvfm4bv1dbvmhg93vxps7wx4qph16230fiqdh8j9bkrw"
   },
   "stable": {
    "version": [
     0,
-    10,
-    3
+    11,
+    4
    ],
-   "commit": "25f7f00ad4d73aacca027d6e1ba6070b8b2019b0",
-   "sha256": "1i6pck66l45x0p04kayjrsvi0516z730wb68cpshyfrbc409narx"
+   "commit": "c9942846da64f4f2806eb071239cf6de60e3fd4b",
+   "sha256": "0g1kzfxy0qn27j3xfcjrggf7vvxic8hxvddfa49165l3w54ibc8b"
   }
  },
  {
@@ -28435,8 +28598,8 @@
   "repo": "emacs-eask/easky",
   "unstable": {
    "version": [
-    20250101,
-    836
+    20250404,
+    17
    ],
    "deps": [
     "ansi",
@@ -28445,8 +28608,8 @@
     "lv",
     "marquee-header"
    ],
-   "commit": "fbb64633a690ee1afe8aef873b7be3471e766788",
-   "sha256": "17xdwfq42mvklikfmpf6q6bsa8rli977rgd56z1z1zjif6p5x5jl"
+   "commit": "070c734bdc5fafdf0de060f9584b1a037681eac2",
+   "sha256": "0zcw1575kkabifxcyvw88dh5snp1b265f0s8fmhpvrbb350l24v5"
   },
   "stable": {
    "version": [
@@ -28650,11 +28813,11 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20250318,
-    2203
+    20250426,
+    1725
    ],
-   "commit": "4ca5cf06d3ad3ad8c9f7b9d1dcdd885f8da712af",
-   "sha256": "1abgb21skyc8z5ib719nm1br09x3zyck15h7i79aab26vnxmazrv"
+   "commit": "2d478bf264b8f4e8bae9222e67fc69553bee7cc7",
+   "sha256": "0d5cipvgrxn07plim9af4lp59bfaliim4m63fjgad8ib6hxlfqrf"
   },
   "stable": {
    "version": [
@@ -28739,28 +28902,27 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20250325,
-    2311
+    20250508,
+    1426
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "7a11f676401434623bf3a6e24b1e0b07d78ce0d6",
-   "sha256": "1pzhdk082kh8j2imw1wmkf8zr345ifs49w9cx1d339rjc0myvkcb"
+   "commit": "95c9b970f0b3e20dcf650726c4928cae6461c776",
+   "sha256": "0g9cwd9jv9p0m9a488f34fw8vlxhyasdjbcv36hfiyzzls93r2rp"
   },
   "stable": {
    "version": [
     2,
-    49,
-    1
+    50
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "afe85e3d048ec602ededc24d241b4d8bd459ea99",
-   "sha256": "0b2ybyjnw8ig7vjw4x7c1dsvj7d56b7a8nmli7nbsp5ncz6w7jpp"
+   "commit": "95c9b970f0b3e20dcf650726c4928cae6461c776",
+   "sha256": "0g9cwd9jv9p0m9a488f34fw8vlxhyasdjbcv36hfiyzzls93r2rp"
   }
  },
  {
@@ -28857,45 +29019,6 @@
    ],
    "commit": "80f5a8bbd8ac848d4a69796c9568b4a55958e974",
    "sha256": "1mpq8ha42lffzzwy0ib8vbb2dp9fgqnh112wfa1a6b3vh21wnxm8"
-  }
- },
- {
-  "ename": "eclim",
-  "commit": "1e9d3075587fbd9ca188535fd945a7dc451c6d7e",
-  "sha256": "1n60ci6kjmzy2khr3gs7s8gf21j1f9zjaj5a1yy2dyygsarbxw7b",
-  "fetcher": "github",
-  "repo": "emacs-eclim/emacs-eclim",
-  "unstable": {
-   "version": [
-    20181108,
-    1134
-   ],
-   "deps": [
-    "cl-lib",
-    "dash",
-    "json",
-    "popup",
-    "s",
-    "yasnippet"
-   ],
-   "commit": "23f5b294f833ce58516d7b9ae08a7792d70022a1",
-   "sha256": "17q972354nkkynfjmwih4vp7s5dzdvr3nf7ni3ci095lzb0zzf4g"
-  },
-  "stable": {
-   "version": [
-    0,
-    4
-   ],
-   "deps": [
-    "cl-lib",
-    "dash",
-    "json",
-    "popup",
-    "s",
-    "yasnippet"
-   ],
-   "commit": "8203fbf8544e65324a948a67718f7a16ba2d52e6",
-   "sha256": "10bbbxhvlwm526g1wib1f87grnayirlg8jbsvmpzxr9nmdjgikz3"
   }
  },
  {
@@ -29273,11 +29396,11 @@
   "repo": "stsquad/emacs_chrome",
   "unstable": {
    "version": [
-    20220908,
-    1014
+    20250417,
+    1401
    ],
-   "commit": "3ce09c6eb2919d56ef052b1584bba6abb12f7e99",
-   "sha256": "1yvcwpi5khrzs647nwg0hh8r537xvxjq6ylwq1ss4hd5yg58brsk"
+   "commit": "e45b213a22bc93ca52962203784e7b5d25a53245",
+   "sha256": "0cshj27g2zgdi4jm8fqcc0qjfyfgxidrsls32p0ch626wzwdp4wh"
   },
   "stable": {
    "version": [
@@ -29729,16 +29852,16 @@
   "repo": "fsharp/emacs-fsharp-mode",
   "unstable": {
    "version": [
-    20240514,
-    1923
+    20250403,
+    1925
    ],
    "deps": [
     "eglot",
     "fsharp-mode",
     "jsonrpc"
    ],
-   "commit": "677d78c4d6cb574086408082dedbcaef04a85359",
-   "sha256": "0by1ln0raa89dj2jng6kak69b7nzr3ic090wrg4gg6mqky5qbm5n"
+   "commit": "8d08f057889bcd19812d17d955865428626d8c47",
+   "sha256": "153zg59gk76zr0cff60zv3a9v529dmj6m9zlkl7fr2l1rvpxvzrv"
   },
   "stable": {
    "version": [
@@ -30084,28 +30207,28 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20250313,
-    436
+    20250516,
+    1438
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "eb79cc31ec6ee93ef1db97868b6e2d7593321441",
-   "sha256": "0mp97z5bnz5wnk7pgd432k828wypwiwlv7fwkr21wwrr0181jpr9"
+   "commit": "d3b7766e524de4b354d8f5dc961b796ac5a282c7",
+   "sha256": "0byyc6gq99n5kj7q973q8w0xr7qsyz9d9nm5h0sfndjnhf37xnim"
   },
   "stable": {
    "version": [
     0,
-    6,
-    4
+    7,
+    1
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "942457bb75574f17058cba1da25e46aeee3fde4b",
-   "sha256": "0cmridxl0ngvh93lbndpbvzp4wbi5wd3hm30hhh4wp8qw280xygj"
+   "commit": "3000fa56aa97fffa42b203037e2db6f4fe56bb7d",
+   "sha256": "19n3ffjydnkj9qrhvyhljih446inah1fggxw5q6168pxzpz6p8yk"
   }
  },
  {
@@ -30271,20 +30394,20 @@
   "repo": "meedstrom/el-job",
   "unstable": {
    "version": [
-    20250327,
-    306
+    20250516,
+    1908
    ],
-   "commit": "b80bc0380edca448b1e856441659d8eb4d97a3f7",
-   "sha256": "09zipgg52zh7kfamnslbrrghs2sndkwj0kcmbb8mxwmx5k5zi62d"
+   "commit": "9258e707ad154170a8beae3f84b25161f42aa200",
+   "sha256": "0gspy2yvi7pyzvw73p49s42a3w104xlrwwvwykw93rf277kq4i6d"
   },
   "stable": {
    "version": [
     2,
     4,
-    3
+    7
    ],
-   "commit": "b80bc0380edca448b1e856441659d8eb4d97a3f7",
-   "sha256": "09zipgg52zh7kfamnslbrrghs2sndkwj0kcmbb8mxwmx5k5zi62d"
+   "commit": "9258e707ad154170a8beae3f84b25161f42aa200",
+   "sha256": "0gspy2yvi7pyzvw73p49s42a3w104xlrwwvwykw93rf277kq4i6d"
   }
  },
  {
@@ -30342,15 +30465,15 @@
   "repo": "zetagon/el-secretario",
   "unstable": {
    "version": [
-    20220426,
-    1905
+    20250407,
+    1946
    ],
    "deps": [
     "hercules",
     "org-ql"
    ],
-   "commit": "575396ca689065188ad0f90c379d9bcf7ff6fc0b",
-   "sha256": "07kdwl4wr777ncidlv1v3jllfhimbkkhhimz9zgskmbfgrxw5sxn"
+   "commit": "0c728c3bdd1d19356c192ba333a945d732bd16b8",
+   "sha256": "075dvn7mr0wxbbghkz3lhw777wfgp4ppzkjcp46dwcpqmdgy2h4i"
   }
  },
  {
@@ -30361,15 +30484,15 @@
   "repo": "zetagon/el-secretario",
   "unstable": {
    "version": [
-    20211214,
-    1851
+    20250407,
+    1946
    ],
    "deps": [
     "el-secretario",
     "elfeed"
    ],
-   "commit": "2a5290ad57d9800d4b56896a768e37631bef06b0",
-   "sha256": "15b2jz0ddvikpfg8m85l1m84ddmj1l9pvai0frw61p6mg5rnwxaj"
+   "commit": "0c728c3bdd1d19356c192ba333a945d732bd16b8",
+   "sha256": "075dvn7mr0wxbbghkz3lhw777wfgp4ppzkjcp46dwcpqmdgy2h4i"
   }
  },
  {
@@ -30380,15 +30503,15 @@
   "repo": "zetagon/el-secretario",
   "unstable": {
    "version": [
-    20220422,
-    2006
+    20250407,
+    1946
    ],
    "deps": [
     "el-secretario",
     "org-ql"
    ],
-   "commit": "78a811f02c7104a39b908f9e4c8436abde4b9620",
-   "sha256": "0hj7ly33jahpvhlwq1cwc262ymsqf70jf1vq9zaqmsz9wn04nryi"
+   "commit": "0c728c3bdd1d19356c192ba333a945d732bd16b8",
+   "sha256": "075dvn7mr0wxbbghkz3lhw777wfgp4ppzkjcp46dwcpqmdgy2h4i"
   }
  },
  {
@@ -30399,15 +30522,15 @@
   "repo": "zetagon/el-secretario",
   "unstable": {
    "version": [
-    20220428,
-    1058
+    20250407,
+    1946
    ],
    "deps": [
     "el-secretario",
     "notmuch"
    ],
-   "commit": "c4e21ac5a9be2b2ea6cf7c153a6fae48c78a61b9",
-   "sha256": "0jnr75fzhi2m1b65z72q2m970nk52rkvzwkkv27rzbprd43hxnzd"
+   "commit": "0c728c3bdd1d19356c192ba333a945d732bd16b8",
+   "sha256": "075dvn7mr0wxbbghkz3lhw777wfgp4ppzkjcp46dwcpqmdgy2h4i"
   }
  },
  {
@@ -30418,16 +30541,16 @@
   "repo": "zetagon/el-secretario",
   "unstable": {
    "version": [
-    20220411,
-    1419
+    20250407,
+    1946
    ],
    "deps": [
     "dash",
     "el-secretario",
     "org-ql"
    ],
-   "commit": "fe6fc69d298368ae24a6aac27a325ee03ad9e64c",
-   "sha256": "0qwlgjzssaapl6pyxv5zj5z0qqp6pgff9kma7qncq4pyd8w3vqxs"
+   "commit": "0c728c3bdd1d19356c192ba333a945d732bd16b8",
+   "sha256": "075dvn7mr0wxbbghkz3lhw777wfgp4ppzkjcp46dwcpqmdgy2h4i"
   }
  },
  {
@@ -30713,11 +30836,11 @@
   "repo": "casouri/eldoc-box",
   "unstable": {
    "version": [
-    20250120,
-    502
+    20250510,
+    1854
    ],
-   "commit": "ebc0e2c13791f5a22cf81be050b32f0ebf726855",
-   "sha256": "0l8xrl7p50ixdfg100my71y88m5pvn1arhhfy3dw1b26w1wxh8p0"
+   "commit": "fb1ae42c37c5f3bb80b441b2fdfada914891a714",
+   "sha256": "0id77zab8q7pll9akdb0l1akvpl25zc61qyz3lx9wvavg59aby3w"
   },
   "stable": {
    "version": [
@@ -30936,20 +31059,20 @@
   "repo": "swflint/electric-ospl-mode",
   "unstable": {
    "version": [
-    20240428,
-    1829
+    20250502,
+    1439
    ],
-   "commit": "deab4493530ab4bb2112c18d8ca6ccc652e24a63",
-   "sha256": "1l8d2yjg7rq67vwd0mq8lnfbvwvdp707nm856m9ns3j7jbhpzf9a"
+   "commit": "a17f7312ef48eba1586c7d0637336eb19aee057e",
+   "sha256": "04mp6pqxr5p01z4wqkj8wy07ys3p1n5fm9h3yzplknvr3n2djvxl"
   },
   "stable": {
    "version": [
     3,
-    2,
-    0
+    3,
+    1
    ],
-   "commit": "deab4493530ab4bb2112c18d8ca6ccc652e24a63",
-   "sha256": "1l8d2yjg7rq67vwd0mq8lnfbvwvdp707nm856m9ns3j7jbhpzf9a"
+   "commit": "a17f7312ef48eba1586c7d0637336eb19aee057e",
+   "sha256": "04mp6pqxr5p01z4wqkj8wy07ys3p1n5fm9h3yzplknvr3n2djvxl"
   }
  },
  {
@@ -30984,10 +31107,10 @@
  },
  {
   "ename": "elein",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "01y5yrmm3biyrfgnl3qjfpn1xvjk2nabwjr8cls53ds697qpz5x2",
-  "fetcher": "github",
-  "repo": "remvee/elein",
+  "commit": "0ddcfbc20264759a22712130c8ccf0825d3d198b",
+  "sha256": "0nh3kvm3vdbpc48cbs1dlfb9yaxyg25nwr62w2diynqlpgl797d0",
+  "fetcher": "codeberg",
+  "repo": "rwv/elein",
   "unstable": {
    "version": [
     20120120,
@@ -31491,11 +31614,11 @@
   "repo": "ideasman42/emacs-elisp-autofmt",
   "unstable": {
    "version": [
-    20250224,
-    2229
+    20250421,
+    1112
    ],
-   "commit": "5d6d843d2a94aa462c32456e2ec751ce5ca3cab0",
-   "sha256": "16062wbkxfg39q2c5v2j64vymx9sxvhzkpmrlajgrgas6jxyacc6"
+   "commit": "30c9895f9cb64ac83a53b9f3e78a27f5abca322a",
+   "sha256": "192m68jwjplqxjnja4mc32fgrdixrxnr3y4xl64s8v4nwjd1rvs2"
   }
  },
  {
@@ -32036,14 +32159,11 @@
   "repo": "lujun9972/elog",
   "unstable": {
    "version": [
-    20221207,
-    643
+    20250413,
+    100
    ],
-   "deps": [
-    "eieio"
-   ],
-   "commit": "e171d0ff0a21011124204d77111e5992b50b7007",
-   "sha256": "0ikaf8cak6m9rm78hnfd4bh3hx6vrm1307dggxxsz3862kcwj5aw"
+   "commit": "c65288fd32eb187d3e63d4a7799a69e57da0eab4",
+   "sha256": "1sv0j59hr9f9qdrxwfzfc7jsbxc9fcbx3amwsq6vv3ckrvhf3hq7"
   }
  },
  {
@@ -32229,8 +32349,8 @@
   "repo": "jorgenschaefer/elpy",
   "unstable": {
    "version": [
-    20241227,
-    2255
+    20250404,
+    2349
    ],
    "deps": [
     "company",
@@ -32239,8 +32359,8 @@
     "s",
     "yasnippet"
    ],
-   "commit": "bcfd5e8c25e5efbcb26cfcf389f1bf01c2e2f44f",
-   "sha256": "00vvwa7h371fnq687mvccnlv38mjwzlr6h6yrzg0s8bl8vjg85q3"
+   "commit": "0b381f55969438ab2ccc2d1a1614045fcf7c9545",
+   "sha256": "0398zwzq5c33fi8icyy2x50q7rs819i5xkpmhbfm1s34m6prv46a"
   },
   "stable": {
    "version": [
@@ -32606,14 +32726,14 @@
   "repo": "lanceberge/elysium",
   "unstable": {
    "version": [
-    20250216,
-    2328
+    20250406,
+    1638
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "21276b513f009f291594ba072f5e5fbf9c14d2d8",
-   "sha256": "0marbjrg3nfdzgpqv1n0151b00kdbvcp2v67b9fwdqhwxm9hmi1b"
+   "commit": "049ad3091baf3ce578791187c5e5e4f932c26044",
+   "sha256": "0x1lk24xrd0jq14h4bcmp25x2brfi5rmdxigz0wj5ipf2b57vv2y"
   },
   "stable": {
    "version": [
@@ -32810,14 +32930,14 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20250127,
-    1315
+    20250423,
+    1650
    ],
    "deps": [
     "compat"
    ],
-   "commit": "755cb49b59801ff420193cc0e3b1a7aa12bf22e3",
-   "sha256": "0n8khkgk3mnm48b9426radzmrgda0k6zcc0c0ws8yl2gpnkblkxn"
+   "commit": "923d0ec52e2e3e0ae44e497c31c7888e87d08a8f",
+   "sha256": "133fwgaddsm72r7mgk85zbjwii6fs9ld9vsdvyly50mb7zn6bl00"
   },
   "stable": {
    "version": [
@@ -33063,16 +33183,16 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20250326,
-    1641
+    20250405,
+    1417
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "338462506d7de508f7f74a01d15753f9113cd3cb",
-   "sha256": "0s89r9fr79kv864zydqgkv2fdwxa0n84w5b40v87rj5hlya0kx6v"
+   "commit": "abb4f614dae6b7e90ee1f275d8a5e40721c39d54",
+   "sha256": "0xbqgv01say2hidrls6rwy2d902ks28z41h1hkpj73f8s4h0d520"
   },
   "stable": {
    "version": [
@@ -33213,16 +33333,16 @@
   "repo": "sarg/emms-spotify",
   "unstable": {
    "version": [
-    20250405,
-    915
+    20250411,
+    619
    ],
    "deps": [
     "compat",
     "emms",
     "s"
    ],
-   "commit": "dec0d34736da7ff538117033b3758edde3b8e546",
-   "sha256": "1fhffnspnlw75523y5xma5i3wsyjd3h10p0z2h207cdlz1d1bwvv"
+   "commit": "ca80431b00738e6130b924c64dc1f2cddadcc0b8",
+   "sha256": "0vv739axlp3hfvmh10ap0n70i4qd6jls9fb5ppczdxjcr5h9bgd7"
   },
   "stable": {
    "version": [
@@ -33474,15 +33594,15 @@
   "repo": "isamert/empv.el",
   "unstable": {
    "version": [
-    20250331,
-    731
+    20250406,
+    2037
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "71515a73d223ab7442581aa0984f8c1512a31f03",
-   "sha256": "0v7whd6hcz7hp3x22l2gm990d5abcazb0l32zmjzgcdk7pcd22zb"
+   "commit": "f14d4ac96e24368ad4688efc4a71da39804892f0",
+   "sha256": "06ahark9jin8cfk7d6d82xyhy0pp1yrd03c4lawhyppn1aswkb5z"
   },
   "stable": {
    "version": [
@@ -33983,8 +34103,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20250302,
-    4
+    20250509,
+    1442
    ],
    "deps": [
     "closql",
@@ -33992,14 +34112,14 @@
     "emacsql",
     "llama"
    ],
-   "commit": "553550bf285af0f168ce8b58483d70ceb3dee73f",
-   "sha256": "1a6zw1z318ip4vnqfgv99b2knbm3qq6ji7spqq9g5w3lls40aqvx"
+   "commit": "327709a01a6eded82016a24c478456b8be31da09",
+   "sha256": "0rxpcjkgmmishalhvg3lfc3lcq704kssq8w9g5c1v5ppppp36fnk"
   },
   "stable": {
    "version": [
     4,
     0,
-    5
+    6
    ],
    "deps": [
     "closql",
@@ -34007,8 +34127,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "553550bf285af0f168ce8b58483d70ceb3dee73f",
-   "sha256": "1a6zw1z318ip4vnqfgv99b2knbm3qq6ji7spqq9g5w3lls40aqvx"
+   "commit": "e66f246ec2df5d62665c0bdcf3f8f5534225b934",
+   "sha256": "0sl45frbvkfiblbbpa3xlv58bql8p8bms80p7yi2fp4ggipq8k19"
   }
  },
  {
@@ -34703,20 +34823,20 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20250115,
-    1500
+    20250416,
+    708
    ],
-   "commit": "dd160c846e656634a34f4cc4b4aed46cbe5d6744",
-   "sha256": "17dyf73iaqlifccyjxjvm3yafq4rwkifd7widnpswgdqwhd49fka"
+   "commit": "a87183f1eb847119b6ecc83054bf13c26b8ccfaa",
+   "sha256": "1zq43jaw99vdzlj48dbm72aiyimq5gbxvs0amaqn2dal0nry1q5d"
   },
   "stable": {
    "version": [
     27,
     3,
-    1
+    4
    ],
-   "commit": "76266a91989378ce53159eee4bd16773e248f5f3",
-   "sha256": "077k6aq141ypr7qx0irycc0z9jkvrv0jrvmn9zc00kmnqk0m3ran"
+   "commit": "c388a2d1b3f9918652276d4798692dd4d8ef97fc",
+   "sha256": "0aadwh3mqn0y2h8wsg18p2hvyb76dh5s0klca4824z9rp7bqv625"
   }
  },
  {
@@ -35294,14 +35414,14 @@
   "repo": "mallt/eshell-fixed-prompt-mode",
   "unstable": {
    "version": [
-    20220104,
-    1535
+    20250414,
+    914
    ],
    "deps": [
     "s"
    ],
-   "commit": "302c241b42764bd6b4ed6d3c6ea360b5a2292fbc",
-   "sha256": "10igzz5vhjkq4m7mc45ngfi3ahimcn2c0zcqqazk3jgysy1hjgp2"
+   "commit": "f495a7bdf0f5da87e9eb3021862aa8e2ec578948",
+   "sha256": "1vxaw2mq80i39lid8c2la14bs6pk3jg87nmfh3gnmjc3sh3ka6cy"
   }
  },
  {
@@ -35459,14 +35579,14 @@
   "repo": "4DA/eshell-toggle",
   "unstable": {
    "version": [
-    20240417,
-    1536
+    20250513,
+    1742
    ],
    "deps": [
     "dash"
    ],
-   "commit": "222e05870c0b3f4a4d96f9bdb7065c53eb43a917",
-   "sha256": "13j2jgpiqa0y24hv4dw26m6dmfy0apyjbizxrgm63qy4b24lj1i3"
+   "commit": "04e501e02c475bd9067eebcf8807c951f2316194",
+   "sha256": "0l26njh99asr9vd40iy5vp03jlzdhm7qzs2jwg2q00qwws3r6zbs"
   }
  },
  {
@@ -35742,11 +35862,11 @@
   "repo": "walseb/espy",
   "unstable": {
    "version": [
-    20200317,
-    2333
+    20250417,
+    1352
    ],
-   "commit": "2c01be937a5e5bde62921684a0b27300705fb4e0",
-   "sha256": "1nnnr184y29g1svxqxlqyg5irzrf1xmay4p78jfv8v07sisl90kp"
+   "commit": "f58049ed86798b6cb7f462e0a71bf3ecb1f0f9e5",
+   "sha256": "04q3s7pj55m4h0vdh5kss5yy17gxxsg01pcr0makvhg4yf9gk1h7"
   }
  },
  {
@@ -35794,11 +35914,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20250110,
-    1437
+    20250508,
+    735
    ],
-   "commit": "0eb240bcb6d0e933615f6cfaa9761b629ddbabdd",
-   "sha256": "089kvjjrzas0zsv6wjhmcir62mkbscjpzvqifq0cp58m7wmrbxs2"
+   "commit": "cf5c97bc68432c6d40b85803a5ce32b4f456fab2",
+   "sha256": "1z440ay4l5k81s8l14ywmnyv6ds02w49fwgnx121c7varijxwm8z"
   },
   "stable": {
    "version": [
@@ -35939,16 +36059,16 @@
   "repo": "GioBo/ess-view",
   "unstable": {
    "version": [
-    20181001,
-    1730
+    20250409,
+    2120
    ],
    "deps": [
     "ess",
     "f",
     "s"
    ],
-   "commit": "d4e5a340b7bcc58c434867b97923094bd0680283",
-   "sha256": "1yzki5f2k7gmj4m0871h4h46zalv2x71rbpa6glkfx7bm9kyc193"
+   "commit": "82df032e6e367e7f587e6131925c0a349c685f93",
+   "sha256": "1irhlh31qjmyp8jb7z7k63bm81baxy1rm9r93d7jlfqw0wh1djc3"
   }
  },
  {
@@ -35959,15 +36079,16 @@
   "repo": "ShuguangSun/ess-view-data",
   "unstable": {
    "version": [
-    20240127,
-    1701
+    20250516,
+    121
    ],
    "deps": [
     "csv-mode",
-    "ess"
+    "ess",
+    "transient"
    ],
-   "commit": "c077741bc3386a469635ca7438db4cf58b7541b9",
-   "sha256": "0gbim8hkflj5cxg84wnv32zfwacri3v26azmcfzh6w3mkflfp1bq"
+   "commit": "5ec1c7206f1431c7b24f0990497ecc7e0fb33939",
+   "sha256": "1nbwk312rqx1nlqk1cy7nirj8dsjpbwy0rqzybgly5s1rgldfnl5"
   },
   "stable": {
    "version": [
@@ -36040,28 +36161,26 @@
   "repo": "tali713/esxml",
   "unstable": {
    "version": [
-    20230308,
-    2254
+    20250421,
+    1632
    ],
    "deps": [
-    "cl-lib",
-    "kv"
+    "cl-lib"
    ],
-   "commit": "225693096a587492d76bf696d1f0c25c61f7d531",
-   "sha256": "1cciflr51smahv1x0hr2kwl24ivv54arnqn32s16l77dwy5dvy60"
+   "commit": "affada143fed7e2da08f2b3d927a027f26ad4a8f",
+   "sha256": "1yqwx53yzn2izhdzchm3cp8qcln2j0n015xlyg3c020q08sai1ha"
   },
   "stable": {
    "version": [
     0,
     3,
-    7
+    8
    ],
    "deps": [
-    "cl-lib",
-    "kv"
+    "cl-lib"
    ],
-   "commit": "9f96449f6059cb75491dc812ddeb1b6200ec6740",
-   "sha256": "1xzxmgsg0j72sf1vjh9gjswz3c29js0kqhm7r3jrqrh3a5agdnml"
+   "commit": "affada143fed7e2da08f2b3d927a027f26ad4a8f",
+   "sha256": "1yqwx53yzn2izhdzchm3cp8qcln2j0n015xlyg3c020q08sai1ha"
   }
  },
  {
@@ -36452,11 +36571,11 @@
   "repo": "mekeor/evenok",
   "unstable": {
    "version": [
-    20250320,
-    1137
+    20250506,
+    1255
    ],
-   "commit": "5fc6494c4efba2bb0615e3e5c813f5425be21ec7",
-   "sha256": "0izmcw69wipz1pr2kqs78r9xf71rni90pid9vf0z8c09jw9zjzf7"
+   "commit": "f3c875139ae57fcb52f2d7ab2d4238c2af8e204c",
+   "sha256": "0r5j958zvqzsrmgj71rvwkmx69f8p360f5c26qlx0l0ng5ff12ng"
   },
   "stable": {
    "version": [
@@ -36701,15 +36820,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20250331,
-    1556
+    20250426,
+    1557
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "3ac7bb303e86c5753aad70571f36aa81e2a72869",
-   "sha256": "1zssfad7698nyk88n1zy871kikygngkdxpwnb54jlxzn53nlmd3g"
+   "commit": "fca81ddb2ca1ac3838aa7e8969b2313712807a45",
+   "sha256": "0grp87nb9pxx47rzclhngqn9gvgbn39yfk0szz6a4xh0pf56f100"
   },
   "stable": {
    "version": [
@@ -37249,14 +37368,14 @@
   "repo": "redguardtoo/evil-mark-replace",
   "unstable": {
    "version": [
-    20240303,
-    1416
+    20250422,
+    242
    ],
    "deps": [
     "evil"
    ],
-   "commit": "217d5b507aa11dd0b334d5c3e1f74ac1fc2f66a4",
-   "sha256": "17mn7jybnlzhb82h6jkxdhcr76p1p5dk1v7dpb74r3ccd75sqn2b"
+   "commit": "90ee84748582be05fa8f9a02872321a08b455282",
+   "sha256": "1w2f2df48hvabb750p3c9lsb2clpif4bv11z67wl9vafci53lahh"
   },
   "stable": {
    "version": [
@@ -37874,15 +37993,15 @@
   "repo": "hlissner/evil-snipe",
   "unstable": {
    "version": [
-    20230821,
-    1602
+    20250505,
+    508
    ],
    "deps": [
     "cl-lib",
     "evil"
    ],
-   "commit": "c2108d3932fcd2f75ac3e48250d6badd668f5b4f",
-   "sha256": "1h7vh24fvbbrq6vl2dfamfm20rxx9dx1rjfs639psksy57nj58j1"
+   "commit": "16317d7e54313490a0fe8642ed9a1a72498e7ad2",
+   "sha256": "0rg677wdybgjqz8kfr8v7xrcqw53qm1kxcsdsqqq8z0wklb0s29d"
   },
   "stable": {
    "version": [
@@ -39514,11 +39633,11 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20250206,
-    1617
+    20250416,
+    1410
    ],
-   "commit": "b2e7072cd3bcfa47a55a1d45579373c988c1f8a4",
-   "sha256": "1i2qncwsd2i3zba673sa0vaqxq2mswflqwldjxxca7720yf1k6ng"
+   "commit": "7936ff70dfcdd919e525b275533612f5f267b4a4",
+   "sha256": "04zxwlfpf4jljhdaii3v0b6svqwbjwdzk7n3krkpda9dh381lrlk"
   },
   "stable": {
    "version": [
@@ -39972,10 +40091,10 @@
  },
  {
   "ename": "feature-mode",
-  "commit": "0a70991695f9ff305f12cfa45e0a597f4a782ba3",
-  "sha256": "0ryinmpqb3c91qcna6gbijcmqv3skxdc947dlr5s1w623z9nxgqg",
+  "commit": "cd38594a46df624a19c8a0100f2ff037d9c4639e",
+  "sha256": "0gk6b0l5af5gsh2w3qp8dwxvg6vxai92gy64zlwqyz2nynagarwg",
   "fetcher": "github",
-  "repo": "michaelklishin/cucumber.el",
+  "repo": "freesteph/cucumber.el",
   "unstable": {
    "version": [
     20250401,
@@ -40002,14 +40121,14 @@
   "repo": "martianh/fedi.el",
   "unstable": {
    "version": [
-    20250316,
-    1151
+    20250408,
+    738
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "460ec9874b8344fb215bc44041ffb3beb1fd20f8",
-   "sha256": "0wabr50jgwpfln8i128226qyrzq4x4qqls268qwis61ikznwc42f"
+   "commit": "e53f4d61cab19a4037f8594daaa247db4ca6c116",
+   "sha256": "02z5nhv1hr9713b2blfymrb8hckss5ghhr07mjz572a8xdy3rqq8"
   },
   "stable": {
    "version": [
@@ -40099,11 +40218,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20250401,
-    732
+    20250419,
+    1823
    ],
-   "commit": "8e5dc2088de6a4d02cd6e4d2bf598112737bdfa8",
-   "sha256": "0p1papj7pj7ib1f4c5bv7hwsa63srhfzzjlnwsp91yml4mjgl4ji"
+   "commit": "df8e83d6e2bb1e447dc1b426348883f3dc87cd35",
+   "sha256": "0jxiiv1v8sl5hj357z9h2lhs6ymygsq135n1ckdpj87wj7nssf28"
   },
   "stable": {
    "version": [
@@ -40483,20 +40602,20 @@
   "repo": "redguardtoo/find-file-in-project",
   "unstable": {
    "version": [
-    20250116,
-    128
+    20250501,
+    50
    ],
-   "commit": "3ae5d067a8613f2b9a51c3de8a851bdc85323542",
-   "sha256": "1aqlzx1aibhkmvqasb7vbawj277rbyrk93v6svqs0m3v6n3g996i"
+   "commit": "f56292e7aba1d012fa51d65ee625e73dcc16dbe9",
+   "sha256": "07yzr2kxw58w9ab7dn3npalc0ljwx8wa3bs64n1n0ldnxpd7d6pl"
   },
   "stable": {
    "version": [
     6,
     2,
-    2
+    3
    ],
-   "commit": "3ae5d067a8613f2b9a51c3de8a851bdc85323542",
-   "sha256": "1aqlzx1aibhkmvqasb7vbawj277rbyrk93v6svqs0m3v6n3g996i"
+   "commit": "f56292e7aba1d012fa51d65ee625e73dcc16dbe9",
+   "sha256": "07yzr2kxw58w9ab7dn3npalc0ljwx8wa3bs64n1n0ldnxpd7d6pl"
   }
  },
  {
@@ -41201,27 +41320,28 @@
   "repo": "plandes/flex-compile",
   "unstable": {
    "version": [
-    20241018,
-    2140
+    20250411,
+    2337
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "713c07b6be627fc05417d477ec6d1526ab1797fe",
-   "sha256": "01afnw8hw6k4h2xs23k41aaf3v4aqw4pzias7sy9s82bczx70ya6"
+   "commit": "00c23361b73f3b3c1656a205ec31943d40867cff",
+   "sha256": "12g69mcjrvippgvyhjk2z9zc4377sri1kj1v4h6y2fgggkd6gmg7"
   },
   "stable": {
    "version": [
     1,
-    5
+    6,
+    0
    ],
    "deps": [
     "buffer-manage",
     "dash"
    ],
-   "commit": "713c07b6be627fc05417d477ec6d1526ab1797fe",
-   "sha256": "01afnw8hw6k4h2xs23k41aaf3v4aqw4pzias7sy9s82bczx70ya6"
+   "commit": "00c23361b73f3b3c1656a205ec31943d40867cff",
+   "sha256": "12g69mcjrvippgvyhjk2z9zc4377sri1kj1v4h6y2fgggkd6gmg7"
   }
  },
  {
@@ -41563,19 +41683,19 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20250226,
-    1541
+    20250423,
+    1305
    ],
-   "commit": "b9db1379dcc3e59238dc1fdd7db368c66e8734ba",
-   "sha256": "1ny1lqmh55bwfgsrgr5rg13gbgqp5rdw5sx72hz1nx2vfcwcklvl"
+   "commit": "2842e237f6abe6602ac3b3bb1ce45bc130e0a1ec",
+   "sha256": "0j6vqnq4xxbv61k8da3n7rndpvxm3sf7050k5xrc4nyynwxh5522"
   },
   "stable": {
    "version": [
-    34,
-    1
+    35,
+    0
    ],
-   "commit": "5a9ff918f91e230ae08a6bdce7ec1f107864a5e2",
-   "sha256": "1rhsrbbg3y50qc4drbdgwa1z0hw7w84blgr0xl6zi9mqnjnak495"
+   "commit": "6e43c07e83406cdd3f75952ee988d61d7573ec11",
+   "sha256": "1jj9w1j1qgpj3cdihwkgaj7nd714a0sgsydh413j9rsv6a3d4cgg"
   }
  },
  {
@@ -41730,15 +41850,15 @@
   "repo": "shuxiao9058/flycheck-buf-lint",
   "unstable": {
    "version": [
-    20240612,
-    1219
+    20250408,
+    1011
    ],
    "deps": [
     "flycheck",
     "s"
    ],
-   "commit": "6cf7e7a01bfe150f9be45e83f9fc2d0c8b9d8de3",
-   "sha256": "1lf69gmbh0q9drjxb1h1wz426hxjr4mkzl8grz6ggl56rxwxj2f4"
+   "commit": "0cf5eec5cf647e3156bc13be67927fa37c167902",
+   "sha256": "13v81s5n1g9g0k3jgrg73kh5jip3vcksjd7r53kzvw1jzixnx43a"
   }
  },
  {
@@ -42584,14 +42704,14 @@
   "repo": "weijiangan/flycheck-golangci-lint",
   "unstable": {
    "version": [
-    20250211,
-    1910
+    20250407,
+    559
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "424ba1b3a13f5548c440b7a25822932ad4b51cd6",
-   "sha256": "1a58anq6vzhwl0z45rrm1y28fl8qh2yhmi6zd8kc9jmsavp4019w"
+   "commit": "14bf143ea7ae190544326576a156de9c915a4751",
+   "sha256": "1d61prv2zkss604k51751l26mmrp6rs9li9c62bmddmvdp0jrx7x"
   }
  },
  {
@@ -43156,14 +43276,14 @@
   "repo": "emacs-languagetool/flycheck-languagetool",
   "unstable": {
    "version": [
-    20250101,
-    852
+    20250407,
+    21
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "24910498ea5c9588813cc2c602de935aebb06505",
-   "sha256": "1m0xnq3rynzq6y6zgq6czc8jyz09gn37a13c0fyqxqd0x6x8xikw"
+   "commit": "e44bd8bf7ec481bf8911435544becc4bef74e9e8",
+   "sha256": "0ig23x32ihzgcw0h7xx2a66ic31ayxdriq8knf87fwqywms7xgs8"
   },
   "stable": {
    "version": [
@@ -43533,15 +43653,15 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20250331,
-    1920
+    20250408,
+    1205
    ],
    "deps": [
     "flycheck",
     "phpstan"
    ],
-   "commit": "e1aa8b269c0e3281c323bc1fad509edabb668441",
-   "sha256": "1nqsf9bh8pd3pjmpmsiqazy8639h8938jm37qqcmdn13n69n0pxm"
+   "commit": "a91ef35cee18141d48f30148018555152cd1e6d1",
+   "sha256": "10kjszbcafyqs4dv3mpyrchy0zb51l2fnxhnbazcbwr731lm4cnm"
   },
   "stable": {
    "version": [
@@ -44402,20 +44522,20 @@
   "repo": "jamescherti/flymake-ansible-lint.el",
   "unstable": {
    "version": [
-    20250313,
-    1901
+    20250502,
+    19
    ],
-   "commit": "eb5ee90e7dbfbaca4da393fc086a5242fd0b0f79",
-   "sha256": "0lf6hmmk3dcwwsvbjc9g75pr7ljlj0dyag4azy9658jcdrkhmw34"
+   "commit": "64cd28ad98aa6c0474dca7100f34098b38d25185",
+   "sha256": "1h16525z7r6wscn6lc1pwiz7yl3n5l6vkxzwsj4z6dwfdjcwbrad"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    3
    ],
-   "commit": "eb5ee90e7dbfbaca4da393fc086a5242fd0b0f79",
-   "sha256": "0lf6hmmk3dcwwsvbjc9g75pr7ljlj0dyag4azy9658jcdrkhmw34"
+   "commit": "df15c34ee9c7926fb34278630c92c377e9edc6e0",
+   "sha256": "1w3dvcc32xbi1cla2wbfhpr638gky978c2ms8vi9x8dy669x11rf"
   }
  },
  {
@@ -44441,26 +44561,26 @@
   "repo": "jamescherti/flymake-bashate.el",
   "unstable": {
    "version": [
-    20250313,
-    1933
+    20250416,
+    1624
    ],
    "deps": [
     "flymake-quickdef"
    ],
-   "commit": "7b0ad8cf05abeabba54ffe74b0ef25770b5ff9eb",
-   "sha256": "04fz0qcclh3ink58w5b2sa8mcnl7180gb28ch9cp2ld9vlpvy8j6"
+   "commit": "c599d3c15c6f174a54c1f3d0081311758e682089",
+   "sha256": "1xwngb8i39siw2wb0m4pvgwnd1ax5rl5xq9ny3s40bcxs262grm7"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    4
    ],
    "deps": [
     "flymake-quickdef"
    ],
-   "commit": "5d15a0b5263f7fc885a2d7469466c9df58884f67",
-   "sha256": "114jnrlw73z4gy652yid6q9v9cd7nax0d0k04bv3h7v1h0bs100v"
+   "commit": "c599d3c15c6f174a54c1f3d0081311758e682089",
+   "sha256": "1xwngb8i39siw2wb0m4pvgwnd1ax5rl5xq9ny3s40bcxs262grm7"
   }
  },
  {
@@ -45674,14 +45794,14 @@
   "repo": "erickgnavar/flymake-ruff",
   "unstable": {
    "version": [
-    20250217,
-    2352
+    20250428,
+    1558
    ],
    "deps": [
     "project"
    ],
-   "commit": "7921f331defb1c6e071b4b56d9c61c4c8a7de572",
-   "sha256": "13fy1pyi2kxjh8f499njpqsj0mf1khh3lzdxsyk9vw34c22263s5"
+   "commit": "304c23393c5a959884df7595b9392957df1fd74c",
+   "sha256": "04sk7x2ykxxx68jd5fgq1lzc0knlnl1lwn2g0mlfb38vjh1wga62"
   }
  },
  {
@@ -46625,8 +46745,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20250401,
-    1803
+    20250516,
+    1009
    ],
    "deps": [
     "closql",
@@ -46641,8 +46761,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "9db4d386a1ce32b574e413771996d41d9b2407e8",
-   "sha256": "02ks8zc3nqqqqfq2picf0pxsw7wygb5hv9abnva1cv44x091w6zw"
+   "commit": "8e4dd7ed05212abb3f5318d1f2de5ef880d0d848",
+   "sha256": "1c5659s0crj0qcp1ibprbapnib0rrmgf37vjjr6fkbz5npw7mgjq"
   },
   "stable": {
    "version": [
@@ -46675,15 +46795,15 @@
   "repo": "rogs/forge-llm",
   "unstable": {
    "version": [
-    20250331,
-    1948
+    20250403,
+    1333
    ],
    "deps": [
     "forge",
     "llm"
    ],
-   "commit": "e0d7c3f532de7cb8d26969786f1ab54e90200142",
-   "sha256": "0zbljik2gn2pf1dwrj217gl414smbi6phhk9qbmzbr6ihvhkssca"
+   "commit": "62c925deffcddd30256d6827040fb9faf13119d3",
+   "sha256": "003m9c05d29m17yzpyms4vf2kw9rjh393hkipjcyvxpdigxzb3nm"
   }
  },
  {
@@ -46694,11 +46814,11 @@
   "url": "https://depp.brause.cc/form-feed.git",
   "unstable": {
    "version": [
-    20210508,
-    1627
+    20250426,
+    2028
    ],
-   "commit": "ac1f0ef30a11979f5dfe12d8c05a666739e486ff",
-   "sha256": "1rrsnc6qwbqk091v1xinfn48fc0gbi3l5fy9hyafgl4zdx5ia2bg"
+   "commit": "6258fe6390a7bf264a6f02813502bf83a645d872",
+   "sha256": "1ycxmmzx88a2rg0r4ykx1mj3z1hgyn420ncm97lswgqxmisc97pb"
   },
   "stable": {
    "version": [
@@ -47164,14 +47284,14 @@
   "repo": "Fuco1/free-keys",
   "unstable": {
    "version": [
-    20211116,
-    1501
+    20250512,
+    1527
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7348ce68192871b8a69b687ec124d9f816d493ca",
-   "sha256": "0f99vykxvvcsdqs03ig5kyd3vdrclk8mcryn7b310ysg840ksrw8"
+   "commit": "bed8e9c356c889cd98dd7a4a63c69d6c4960cf82",
+   "sha256": "02f32h6nsfgd6ck54x3rh1zbb1j7cbgbny1d5a464b3ihdwsbywg"
   },
   "stable": {
    "version": [
@@ -47223,6 +47343,38 @@
    ],
    "commit": "6891d3b7a85da13e6d5982ac6b9588473941ec98",
    "sha256": "0bwd3hw5qdijmvbfm69iyhijjx12yqvsa8n08cawxfa26cs6hi1g"
+  }
+ },
+ {
+  "ename": "fretboard",
+  "commit": "4144db1e5d57b94cb5b6023a78a65fbbfb7a109f",
+  "sha256": "1ibx1n76yln7xakv26idv7j2b0p4qg7m1c9p3ci6sm1j0lhawjsq",
+  "fetcher": "github",
+  "repo": "skyefreeman/fretboard.el",
+  "unstable": {
+   "version": [
+    20250420,
+    326
+   ],
+   "deps": [
+    "dash",
+    "s"
+   ],
+   "commit": "064aeb7553c9bef86cf3de8d3c124809f1b3b381",
+   "sha256": "1w3a4acbg1202n9qdjx2f17gsn1fy4yjwlq7ndys0znsq81xw0rp"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    3
+   ],
+   "deps": [
+    "dash",
+    "s"
+   ],
+   "commit": "064aeb7553c9bef86cf3de8d3c124809f1b3b381",
+   "sha256": "1w3a4acbg1202n9qdjx2f17gsn1fy4yjwlq7ndys0znsq81xw0rp"
   }
  },
  {
@@ -47510,11 +47662,11 @@
   "repo": "fsharp/emacs-fsharp-mode",
   "unstable": {
    "version": [
-    20230622,
-    1854
+    20250403,
+    1922
    ],
-   "commit": "b4d31c3da018cfbb3d1f9e6fd416d8777f0835bd",
-   "sha256": "1rhyc7yhpi4bjzq5f6bm3v4ab16prl6fvp9kjif6lq6ihh8xb520"
+   "commit": "d92a973e59e18d9510adaf9ddc7f0c866f2633a1",
+   "sha256": "0s2xxzmqxg9a6bql9yg0rpc0s79vvmbg5aibc93jkd0sf79dnz47"
   },
   "stable": {
    "version": [
@@ -47523,6 +47675,21 @@
    ],
    "commit": "15964df7c65a3b46d704c85873619fec073eabc6",
    "sha256": "1irw05118p835djcvzb2y67avcpryvs6i1p4mp5snygk4n8nl2gc"
+  }
+ },
+ {
+  "ename": "fsrs",
+  "commit": "a5ea6ecf15fd62aa9ee4c55afe1433a4e67b2c4f",
+  "sha256": "1g9k9z18b0773fs44lr0spgbn8wd6sxfjwlpxhv28lggaajzwdlg",
+  "fetcher": "github",
+  "repo": "open-spaced-repetition/lisp-fsrs",
+  "unstable": {
+   "version": [
+    20250330,
+    1613
+   ],
+   "commit": "f6a31365d6e298749daea1bb91270fbc7d11cb53",
+   "sha256": "10fy6dscpin12hm8qsmh1h7ajf0i8a7cyhl8s2d5s3y0y7r7iplg"
   }
  },
  {
@@ -47874,14 +48041,14 @@
   "repo": "tarsius/fwb-cmds",
   "unstable": {
    "version": [
-    20240805,
-    1318
+    20250509,
+    1453
    ],
    "deps": [
     "compat"
    ],
-   "commit": "973a0033c406ce644ce0fb87de70c2f4046ab1b7",
-   "sha256": "0dwrmm4hir83xbnhxqjyalb17zk40y62m32i90q7svp32ydw3abg"
+   "commit": "4001ed8f655a62d7a3974b18aed3471564d3837f",
+   "sha256": "07qy8p8kv8g7nn92c71qxdjm4kbww396ixiwbjprms39j2ggncp9"
   },
   "stable": {
    "version": [
@@ -48136,11 +48303,11 @@
   "repo": "godotengine/emacs-gdscript-mode",
   "unstable": {
    "version": [
-    20241207,
-    610
+    20250420,
+    1418
    ],
-   "commit": "c3d99889843db92fc6e4c51226c222779eadd7d6",
-   "sha256": "1bh7icz4k70x62z50lnjgnrxxh0mhlgrj421wm4sqiphk30vmck4"
+   "commit": "1938aa7e2d1aac1d111b1c3d55e3cf932ae63cc4",
+   "sha256": "1b7qa01ivj9n3k4hn1qvgr7h0hdc7v3hfjdxr88am1gp6p10amf0"
   },
   "stable": {
    "version": [
@@ -49100,8 +49267,8 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20250401,
-    1509
+    20250509,
+    1440
    ],
    "deps": [
     "compat",
@@ -49109,14 +49276,14 @@
     "llama",
     "treepy"
    ],
-   "commit": "1fbce5379e21565f497c0f59bbe5349773c4be62",
-   "sha256": "00xc8957j700zfjcazbp2mcwk6gj8jyrw017864sw47j50p83wy7"
+   "commit": "6bb612e7b7eada22569d84cc529f4ca36e08032d",
+   "sha256": "1ivv031hsqd7jwlpx8frq9sj1z2nl8vvka569wbfj7l4w85ai12b"
   },
   "stable": {
    "version": [
     4,
     3,
-    0
+    1
    ],
    "deps": [
     "compat",
@@ -49124,8 +49291,8 @@
     "llama",
     "treepy"
    ],
-   "commit": "1fbce5379e21565f497c0f59bbe5349773c4be62",
-   "sha256": "00xc8957j700zfjcazbp2mcwk6gj8jyrw017864sw47j50p83wy7"
+   "commit": "214a14627f463449e8ad01d1beb172917120e816",
+   "sha256": "1a2kyiw63fpp2xbmzmc9hp9r73fq3iwvidvcjjhgs0y0hq7x5sqx"
   }
  },
  {
@@ -49826,14 +49993,14 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20240805,
-    1320
+    20250509,
+    1453
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f99010bbeb8b6d8a0819fac0195a2ef0159d08f0",
-   "sha256": "0nvkpy3bv9816hvgm91fv9l8lla4xras4i05579bs7bc8fck1mr3"
+   "commit": "2b2d02e935ee6aa649afa99e9ebc77054a9974b9",
+   "sha256": "07s6yz7na4aj5vy3h49m639pf2b3jdypyvyn0spdwqm2dalwl1bi"
   },
   "stable": {
    "version": [
@@ -50319,6 +50486,24 @@
   }
  },
  {
+  "ename": "github-topics",
+  "commit": "9ba499e716a05e2995f14f466e5271a52e8620ae",
+  "sha256": "1fh0hz15kmgnphiws4hndzcan0yacgjpk570zk3hbivbf2wilw21",
+  "fetcher": "github",
+  "repo": "agzam/github-topics",
+  "unstable": {
+   "version": [
+    20250416,
+    2102
+   ],
+   "deps": [
+    "ts"
+   ],
+   "commit": "296cb525c5387e5242b89950d2d84d258ff82fd2",
+   "sha256": "1l5n5wgcnws0iz5ym4znbssin67dzgz3iwq3cp04jf1nssay863h"
+  }
+ },
+ {
   "ename": "gitignore-snippets",
   "commit": "b1d03ee45e45fc6ec30936a5f4bd8b756728da31",
   "sha256": "0mj0rrcd65py4w0ahy6l3yx6pmki2lqjhmi8hlxbjv0zzks71wy3",
@@ -50692,11 +50877,11 @@
   "repo": "gleam-lang/gleam-mode",
   "unstable": {
    "version": [
-    20250223,
-    1619
+    20250412,
+    1910
    ],
-   "commit": "75b5b1a2eede31969a94322f117b0c82036ff40b",
-   "sha256": "1225g79kajzicbgswlvygf03ap6kq3l6wc2mpand2qb564vbhld4"
+   "commit": "8e981614536f0e36fb14721a9fae8bf72c287a40",
+   "sha256": "0xspx3hpiw21pqcqpp82ngxzsdbc209cbp7yjl5i1j5rwj6d09r7"
   }
  },
  {
@@ -50740,11 +50925,11 @@
   "repo": "jimhourihan/glsl-mode",
   "unstable": {
    "version": [
-    20241021,
-    919
+    20250324,
+    1304
    ],
-   "commit": "c5f2c2e7edf8a647eda74abe2cdf73fa6f62ebd2",
-   "sha256": "1ilx7zgkbnsxlq3np6yli7d6r09hww455kl9lsydpr448mqqifkm"
+   "commit": "86e6bb6cf28d1053366039683a4498401bab9c47",
+   "sha256": "03ajf9q2ijgfmmqvk7kmmxba6bsyrb2q49li93fmdj5dwdyjkgqv"
   }
  },
  {
@@ -52054,11 +52239,11 @@
   "repo": "jixiuf/golden-ratio-scroll-screen",
   "unstable": {
    "version": [
-    20221102,
-    240
+    20250412,
+    358
    ],
-   "commit": "ed82ac7e9129c7be5983b44def0b9239b54d4dcf",
-   "sha256": "12w5xdpnmpqyf3phl4y822w3sz84x2a0xv2jqkhzz0paywn1abb6"
+   "commit": "60eb00ed7e51c0875a38cff25c9a87fe79296484",
+   "sha256": "1j83dz6wclxqviy4cmg2l78jjl9sqk2syj01azpdrys0bfvaqv9k"
   }
  },
  {
@@ -52214,11 +52399,11 @@
   "repo": "Malabarba/emacs-google-this",
   "unstable": {
    "version": [
-    20170810,
-    1215
+    20250407,
+    1500
    ],
-   "commit": "8a2e3ca5da6a8c89bfe99a21486c6c7db125dc84",
-   "sha256": "1dbra309w8awmi0g0pp7r2dm9nwrj2j9lpl7md8wa89rnzazwahl"
+   "commit": "abdcb565503844e2146de42ab5ba898e90a2bb09",
+   "sha256": "0lk83rgbsqnsdw4l0wsvqqfpqqyzsd7l1j8dqcng0aiqk5zmixv7"
   },
   "stable": {
    "version": [
@@ -52511,8 +52696,8 @@
   "repo": "vmware/govmomi",
   "unstable": {
    "version": [
-    20250325,
-    2024
+    20250503,
+    250
    ],
    "deps": [
     "dash",
@@ -52520,13 +52705,13 @@
     "magit-popup",
     "s"
    ],
-   "commit": "f6bae07d1df377a2898bcec6bbe4970ca0240755",
-   "sha256": "1v4yzw4g37k4hdf42pydw4r4x7jrvwzypczsgc680ykdy97s4aq8"
+   "commit": "95320a7de48d30233d7125b01727fb50c1cbc310",
+   "sha256": "14yrw8ddrpv3c2wq3h3c85brfaxdzzjdjfnp6d74pa7w5c7wwp77"
   },
   "stable": {
    "version": [
     0,
-    49,
+    50,
     0
    ],
    "deps": [
@@ -52535,8 +52720,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "bd808e86d9a22201072ed0aac198372b8abd95b4",
-   "sha256": "1w2b3kcjligpp4k5fvl8jyrx7n6ddv8ck99hhh09j31gnikd5nvl"
+   "commit": "6ed9b22e62347bc66a9d2d1c8d220700f3da4e98",
+   "sha256": "025lfaafwbxxiyx5lmvf5995kyc6zf3s7z4fs69q5xwvvxgv1lg1"
   }
  },
  {
@@ -52619,11 +52804,11 @@
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20250301,
-    2043
+    20250517,
+    149
    ],
-   "commit": "32e234f5243e25fd13ddfad6c8a533072b7a20b8",
-   "sha256": "1v321yq9bsxazlvmvvd33g8h33na2fdc5fjrjp4qwq0pb1w1i3z4"
+   "commit": "be8cce1b79c250b661c074f976e02e0c826be151",
+   "sha256": "05gi42qwy55ac27f94978i3jgb7pfvfp75j26v6b5gci9rpb7k4j"
   }
  },
  {
@@ -52690,15 +52875,15 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20250402,
-    1845
+    20250516,
+    555
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "4b505e72e9ad0cdbf800457996a4b85c6cb68519",
-   "sha256": "1kfckl05n98smp68mkn2lw7yr3gb39p10w7w2h7p2c62n5h5cnvc"
+   "commit": "fcdbe074140bf7b9c027a3478902edafe8ec76f8",
+   "sha256": "0079lg68d81j76cm7jr710gdj3b9vrn08ws9cgv6anldvlqqvqkj"
   },
   "stable": {
    "version": [
@@ -52763,6 +52948,25 @@
   }
  },
  {
+  "ename": "gptel-magit",
+  "commit": "ff0bfddad842451900e66c345838d7738091f66c",
+  "sha256": "17q19y38ckgzkl98c8dr087gj88bqzzs89dxyzjgvl5nfvviz1xz",
+  "fetcher": "github",
+  "repo": "ragnard/gptel-magit",
+  "unstable": {
+   "version": [
+    20250504,
+    1238
+   ],
+   "deps": [
+    "gptel",
+    "magit"
+   ],
+   "commit": "7f586943040bbb6885adafaf3e61fb5137c64558",
+   "sha256": "18q32k48syasil6sj829wlk97qhk6pqy9kxqsml1wj5yd94p3ay0"
+  }
+ },
+ {
   "ename": "gpx",
   "commit": "4c77f84fd928654cee560b238c35240d1b984366",
   "sha256": "196zdi3f1mi8dr2sigv66hlrxz9n2klgipl7izb9fqkvxv9g3xi2",
@@ -52770,11 +52974,11 @@
   "repo": "mkcms/gpx-mode",
   "unstable": {
    "version": [
-    20240609,
-    2200
+    20250417,
+    2141
    ],
-   "commit": "88aa5fed1b0987d90f442eb002ab0f2e4731e223",
-   "sha256": "1gc52avqkwq9l119ckah0qvwml6cc3w02gvl772ncj821ci90d7r"
+   "commit": "c66bae867160fcf0d18799baedb7087466dcbf0d",
+   "sha256": "02mqisgdny26y2dybw6izjqvvsfrxscffp427cf0k6m96q9w28xl"
   },
   "stable": {
    "version": [
@@ -53234,14 +53438,14 @@
   "unstable": {
    "version": [
     20250304,
-    1715
+    1722
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "7d47cf845e0f6116b0748f05c903db6d0b94e495",
-   "sha256": "19j8fbxyylq5h8w9q6w3vwkqncdm8ljhbwfnw3r92hxmbq9w02si"
+   "commit": "e78251009a55efec7ef8f4012e3b4ea87768d882",
+   "sha256": "04i3jl08l32b5pcmjpddjna18qksr8njdnv6y8q2919j6j7aq041"
   }
  },
  {
@@ -53390,20 +53594,20 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20250307,
-    1011
+    20250426,
+    602
    ],
-   "commit": "e90e3b47d8fcbb7625106e1ea840519a58c2c39c",
-   "sha256": "04ybyxv2ps7bydb89shhfwhdayhr0kbyzwjxf3a6chmymdvny4wh"
+   "commit": "96a927dce69d7607b981d7754cf8b415ebf9d6a8",
+   "sha256": "17srcnhb1hb2ck0gkjni5adxz3hnjwwh3ajmmbp35h9kjl0b2fh8"
   },
   "stable": {
    "version": [
     2,
-    4,
+    5,
     0
    ],
-   "commit": "ffce7f78ebe48645b93fa162038ac7f678ffd618",
-   "sha256": "1lndn60xgamxfmca623frqfqv6dvzrmqzw5x805px58838nfdrhd"
+   "commit": "31c03ec19b4fbef95be00a586171e0c26a330966",
+   "sha256": "1mrpmzcxgc9hkv55d6kv79f8y6ldqrf5b48f0a4fy30qlgby2wyz"
   }
  },
  {
@@ -53848,24 +54052,24 @@
  },
  {
   "ename": "guix",
-  "commit": "f01c0af156ac4f89ebb706c93085f46f1740f212",
-  "sha256": "17gd0farvxs38l0a8v20cc1d6h1ri7nmdjl7i1mnwfb410rijvhy",
-  "fetcher": "git",
-  "url": "https://git.savannah.gnu.org/git/guix/emacs-guix.git",
+  "commit": "26b8eeb90e3f190ebd668b650abf5c8bc81dfc7f",
+  "sha256": "0lagxg0bi7m9vqrf8clh7brxgcann1zfrg6pn8mqfxwrw1j99azh",
+  "fetcher": "codeberg",
+  "repo": "guix/emacs-guix",
   "unstable": {
    "version": [
-    20250309,
-    2106
+    20250513,
+    652
    ],
    "deps": [
     "bui",
     "dash",
     "edit-indirect",
     "geiser",
-    "magit-popup"
+    "transient"
    ],
-   "commit": "287fc4fbea0c90efca01af8fd0d64748903253cf",
-   "sha256": "09dxbl2r8f2l6axqpmfh620mnbs37j9wnaz89pq8hhh7fmfz8xff"
+   "commit": "cabfa2f3b5a98cdee0fd7c1f334b235b2e54af30",
+   "sha256": "0cp0m5v7fi95lrl6v5pbavp628zi05cv0511ixwcdm4h9fcazd09"
   }
  },
  {
@@ -54762,20 +54966,20 @@
   "repo": "ErikPrantare/hatty.el",
   "unstable": {
    "version": [
-    20250227,
-    2326
+    20250414,
+    2155
    ],
-   "commit": "dd95986529fa90e47eaadeedd671986c5ab15aa7",
-   "sha256": "0gs6gbgaxr1p7j4gqnzx5lq3krnn6nxlmgwfp5d5i8fdkg1c1ka7"
+   "commit": "20e6a92abd997c655e263cd32d7b5b0550dea409",
+   "sha256": "1hjs0zx810xkaigqwxjpfrx4b7z0kxdl9ll19i9g3nkg1s9arbxr"
   },
   "stable": {
    "version": [
     1,
-    1,
+    3,
     0
    ],
-   "commit": "25fcffa9fcc96ef44fbfa7583873deda6a1dda81",
-   "sha256": "12klhmsqpvbb3arbq8wc1nbhgq218ickvjy9p8j7w3pymiyvkgv0"
+   "commit": "20e6a92abd997c655e263cd32d7b5b0550dea409",
+   "sha256": "1hjs0zx810xkaigqwxjpfrx4b7z0kxdl9ll19i9g3nkg1s9arbxr"
   }
  },
  {
@@ -54948,11 +55152,11 @@
   "repo": "wkirschbaum/heex-ts-mode",
   "unstable": {
    "version": [
-    20240113,
-    1104
+    20250511,
+    643
    ],
-   "commit": "90142df2929956536dc1eaae3bb5ca04dc4232ab",
-   "sha256": "0yi3z59sc2ah2173ffpw2l033pmwg5km3id53mpry36pgki02ajn"
+   "commit": "7496adcad0339978ef462b92160b6d40c3595841",
+   "sha256": "1aam3h468ci8cpf1hpzlk02wgm3dj5m8rlf6hiy68sl2m6ad08pr"
   }
  },
  {
@@ -54978,28 +55182,28 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250401,
-    626
+    20250515,
+    548
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "87cc8dc495d7213212c98dc80dddcb0c2834c605",
-   "sha256": "0jnlprs36hq4w9q6fsy1kmfz21nam28fwdnall5jxw0mp333c9z8"
+   "commit": "387b8c8c5ae83150151672979d432e9cd790b79a",
+   "sha256": "0s6sx1akr7pbbj8h944xwbbrb418ybns45ik5v8xdcpi4ak7qz5m"
   },
   "stable": {
    "version": [
     4,
     0,
-    2
+    3
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "af3a6a3d842c350b469a735b31ee00bd22fedcc9",
-   "sha256": "0l9p6yiv8w9s0rpa4fyrp9gw1dgwpyr9fmkhs53bhc6v9x7br8ix"
+   "commit": "e03edf775af41053c8a4de98f370689d4525077b",
+   "sha256": "1amm4n5v2v5z2ln1qzhf0n2rj4v89flhk9dip3kbngdwy2a8q2h4"
   }
  },
  {
@@ -55868,26 +56072,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250401,
-    650
+    20250514,
+    1025
    ],
    "deps": [
     "async"
    ],
-   "commit": "f948dc4464d3a02eebd5b75d75a8cd811c18b271",
-   "sha256": "1dsxgxdz2r2ynmivf537c0sfs21alm39vhml5bq582g2wklmb2l9"
+   "commit": "e03edf775af41053c8a4de98f370689d4525077b",
+   "sha256": "1amm4n5v2v5z2ln1qzhf0n2rj4v89flhk9dip3kbngdwy2a8q2h4"
   },
   "stable": {
    "version": [
     4,
     0,
-    2
+    3
    ],
    "deps": [
     "async"
    ],
-   "commit": "af3a6a3d842c350b469a735b31ee00bd22fedcc9",
-   "sha256": "0l9p6yiv8w9s0rpa4fyrp9gw1dgwpyr9fmkhs53bhc6v9x7br8ix"
+   "commit": "e03edf775af41053c8a4de98f370689d4525077b",
+   "sha256": "1amm4n5v2v5z2ln1qzhf0n2rj4v89flhk9dip3kbngdwy2a8q2h4"
   }
  },
  {
@@ -56167,16 +56371,16 @@
   "repo": "emacs-helm/helm-emms",
   "unstable": {
    "version": [
-    20220314,
-    1633
+    20250405,
+    1018
    ],
    "deps": [
     "cl-lib",
     "emms",
     "helm"
    ],
-   "commit": "aefa44ab77808626c4951be2df49a2eab7820805",
-   "sha256": "07ric1lghxdccq30jr3nfzkqa0mpx61kp4mjyi0zsxqcwfyz7zx3"
+   "commit": "2e8b53a46b32f956efacfda2dbf3f1b0db867472",
+   "sha256": "0gv4pb6s4jimlddc047vl1pi7r3h56s7ldz3z8c4klf2j30096l9"
   },
   "stable": {
    "version": [
@@ -57404,14 +57608,14 @@
   "repo": "emacs-helm/helm-ls-git",
   "unstable": {
    "version": [
-    20250227,
-    1652
+    20250418,
+    356
    ],
    "deps": [
     "helm"
    ],
-   "commit": "640cc6ccd8720462ac949d75de9bc99883830d92",
-   "sha256": "19wxmnq7l42kwqdrfvb861z5llm50rz3dbxlckqlmz1cggdzicv3"
+   "commit": "754c0c27a11a416a1589ea67be7cd57ce5017d02",
+   "sha256": "0mx9mwgldmky4alyk0rc0908cih2ndpd4lxqrfj7m291dyxik458"
   },
   "stable": {
    "version": [
@@ -57806,14 +58010,14 @@
   "repo": "emacs-helm/helm-org",
   "unstable": {
    "version": [
-    20250227,
-    1650
+    20250405,
+    1720
    ],
    "deps": [
     "helm"
    ],
-   "commit": "22d60952f8017e154c53b03087619eb269e12339",
-   "sha256": "1wb8666gkx24lwhc2p6zfgf8brsg5dkj1ivq8mf5jqxyqzlflj46"
+   "commit": "4744ca7f8b35e17bafce9cb0093deb87a232699d",
+   "sha256": "1vn9jn8pkrcgi9ayzw0w69a69jygfs6cjxcrd8jcykh907bnq9sp"
   },
   "stable": {
    "version": [
@@ -59674,8 +59878,8 @@
   "repo": "Wilfred/helpful",
   "unstable": {
    "version": [
-    20250227,
-    1527
+    20250408,
+    334
    ],
    "deps": [
     "dash",
@@ -59683,8 +59887,8 @@
     "f",
     "s"
    ],
-   "commit": "3794389ef685b6a59b3a487d0492c3add3c42c2f",
-   "sha256": "0343h1zrr2cfnfzcqazsrv6c9cs7c8q7cq5pzj9hjka5yw5n8v7r"
+   "commit": "03756fa6ad4dcca5e0920622b1ee3f70abfc4e39",
+   "sha256": "1q4q0x7n1v4jzap3xzjn5ir4skkyz02iw3jvkw0jhjc0w9mm3icq"
   },
   "stable": {
    "version": [
@@ -60385,11 +60589,11 @@
   "repo": "fgeller/highlight-thing.el",
   "unstable": {
    "version": [
-    20230217,
-    728
+    20250416,
+    1107
    ],
-   "commit": "ad788d7a7ee9eb287a8cca3adb21510b89270dca",
-   "sha256": "1p829ydpc1qhqabwi0xaa9yy4rqz9wbkphq7kdly6qiz59jasdq1"
+   "commit": "fd0309e72727e5332be3397e15edb035b426dd0b",
+   "sha256": "1xq18k8mzkp4ggxy2zl5mmc0h5c0y98hi2id78siaw0brwldvp04"
   }
  },
  {
@@ -60794,11 +60998,11 @@
   "repo": "ideasman42/emacs-hl-prog-extra",
   "unstable": {
    "version": [
-    20240829,
-    101
+    20250427,
+    111
    ],
-   "commit": "5e98b3fed32d7d126087129e3efe60dd8e501a83",
-   "sha256": "1q2iykx85p2lw5jd1yamr6nb1mz494kbp197nidn2z6bv7h0kavj"
+   "commit": "83624cd4a4bb39d9c62173a9d5edc802d022e3e9",
+   "sha256": "0s646klgnnvq3mmn8l7kaxid9s800j2q7jzrb4sp4vcp2q8hc1yq"
   }
  },
  {
@@ -61233,14 +61437,14 @@
   "repo": "kaorahi/howm",
   "unstable": {
    "version": [
-    20250323,
-    1119
+    20250512,
+    1135
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "53bbfe3b9e4677ac58dd838399da93e2b03db356",
-   "sha256": "1r309zqy7555mrdx51cdhsa8vbyvk71jhx19wqhzmg88ka0fizvc"
+   "commit": "ad8385817e478f97eeb65d8e13081fede7d6f8a5",
+   "sha256": "176q6vania09nw1ajz08q9lsciygy3n5ni0l7dkarkrrdx80bsf1"
   },
   "stable": {
    "version": [
@@ -61860,11 +62064,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20250331,
-    735
+    20250509,
+    1325
    ],
-   "commit": "f3ea2cb33889e87165ea63406eabb1615a2c1724",
-   "sha256": "0hchpjfi3s0rmar9rvxav1fqrr7a5793klxnn36bnqmlj77w0q7g"
+   "commit": "f2220314dd02c8766c436e0dc365957a75f62c7a",
+   "sha256": "1y169fa35gp7wij5lwkxbm4mvpvjx666gjr77f06hkkypx6i1ifw"
   },
   "stable": {
    "version": [
@@ -62896,11 +63100,11 @@
   "repo": "creichert/ido-vertical-mode.el",
   "unstable": {
    "version": [
-    20210205,
-    436
+    20250424,
+    1552
    ],
-   "commit": "b1659e967da0687abceca733b389ace24004fa66",
-   "sha256": "0wihhkbcfsfy3drqhg443vlz931c0nvpr9rdmp8l8m33ca1bbx5i"
+   "commit": "35c521789bb009a7f4b0df30b68d595fdbe056a9",
+   "sha256": "1hy8gh9j4q4rfflr84nl8cs3r09f6giyyxw8a9898kh82pg0p78l"
   },
   "stable": {
    "version": [
@@ -62972,15 +63176,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20240704,
-    1334
+    20250424,
+    908
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "09de86a8f056c61de72c678386039894779a9375",
-   "sha256": "1kdsrbh32dr3j0icnplpd4wjyp0n6d0kp7gfgbz1xcvh21gn8rdb"
+   "commit": "ccf32ed0b509f2173672297f6659b4459446064f",
+   "sha256": "0m3mpksyw9w3kfzq8yw8i1x9fyh2jcrj6dss6995nzb00zhqhzfa"
   },
   "stable": {
    "version": [
@@ -63258,14 +63462,14 @@
   "repo": "tarsius/imake",
   "unstable": {
    "version": [
-    20241001,
-    1019
+    20250509,
+    1454
    ],
    "deps": [
     "compat"
    ],
-   "commit": "21951b7081e4b36641bf87793b064e06670943d1",
-   "sha256": "11dykwg2dll66n5yivhmcy7pv5hr2ai05z6phml7lw941qh7nhhb"
+   "commit": "2cd1b2451fdd91da6f2d9450c202729cc1ef7cf1",
+   "sha256": "0b0xncspir2yqmg5dnnnndicgghfv1rr3smcfn390p1iqs3c0gcd"
   },
   "stable": {
    "version": [
@@ -63684,11 +63888,11 @@
   "repo": "flashcode/impostman",
   "unstable": {
    "version": [
-    20240524,
-    847
+    20250412,
+    1521
    ],
-   "commit": "c0d7b5b0950fd8113f55a02b3ee7e0fc9c431bea",
-   "sha256": "0iydxmv5kawizfi0ibzlz38ycnacgskj6l1mrx47a2hxd5laz71i"
+   "commit": "c1e764b16d32930d157e5bf2d2e6ac4dc3a23b8c",
+   "sha256": "0b0jg4kscd8n9kccqckv9zl14ymd4w4aa6krvb3bh446y7j3i1hl"
   },
   "stable": {
    "version": [
@@ -63844,40 +64048,6 @@
    ],
    "commit": "c731f05fa3950e2e8580ec61b88abbc705639830",
    "sha256": "0jri2vxd5a4sx93xq6kjcc5zx9yrhv789x3lyq6r2p2422diw2jr"
-  }
- },
- {
-  "ename": "indexed",
-  "commit": "4ca1824396b1b4b0069ef5bdb8dc026331a9d9da",
-  "sha256": "0f11fr50922ghmrh773025nhs9a6g9rch5laqbl4ypp1jj2ahzzn",
-  "fetcher": "github",
-  "repo": "meedstrom/indexed",
-  "unstable": {
-   "version": [
-    20250327,
-    1025
-   ],
-   "deps": [
-    "el-job",
-    "emacsql",
-    "llama"
-   ],
-   "commit": "1a0a8e2776cdc861ffbe9b49f99d5aac70c7d89a",
-   "sha256": "1p1vpv2jjym107fc0xj3iiqqnxijd7n57kx3z9z7w1pahg346w4l"
-  },
-  "stable": {
-   "version": [
-    0,
-    6,
-    3
-   ],
-   "deps": [
-    "el-job",
-    "emacsql",
-    "llama"
-   ],
-   "commit": "1a0a8e2776cdc861ffbe9b49f99d5aac70c7d89a",
-   "sha256": "1p1vpv2jjym107fc0xj3iiqqnxijd7n57kx3z9z7w1pahg346w4l"
   }
  },
  {
@@ -64260,6 +64430,30 @@
   }
  },
  {
+  "ename": "inform-mode",
+  "commit": "6ffe1cd9f7000e37c4ccca56447c00aaca0124e0",
+  "sha256": "04dxn3jc4mkz9wlf8av4vz8aw9m01fz7mlr4193m7jsf0wswg7kz",
+  "fetcher": "github",
+  "repo": "rrthomas/inform-mode",
+  "unstable": {
+   "version": [
+    20250422,
+    1949
+   ],
+   "commit": "71ae49c060b0cef8deee9fe6361d42ed64980e48",
+   "sha256": "1dhjpjgd50nihjmxfzapa1278g496cqmkv6xr68g0c42c1vn05kz"
+  },
+  "stable": {
+   "version": [
+    2,
+    0,
+    0
+   ],
+   "commit": "f24b44dfd623d47a3a83b43bd969dad33435cd09",
+   "sha256": "1sh2v50x4abf6ni7r8mgss2lxi9q6syj2m7bzciv0f50z8q75jq5"
+  }
+ },
+ {
   "ename": "inform7",
   "commit": "5d62f9e9e513103dbebc84bfcb0d18dcf7563211",
   "sha256": "1h8bba0npnsjcyvmd40lbm54ib1rsa5c5df6lc7m53zg2h9fzcbd",
@@ -64344,11 +64538,11 @@
   "repo": "jamescherti/inhibit-mouse.el",
   "unstable": {
    "version": [
-    20250314,
-    1100
+    20250504,
+    336
    ],
-   "commit": "7bac3116a0546f3d40e0eee625b6f01be44095bc",
-   "sha256": "1v15kb5zdz0jw7y8l8f924zy98diiarkmrsdj7qfxb8p9x3z1r1q"
+   "commit": "53c8f3edcc8779bb0f4cafb75fd627becaf2856a",
+   "sha256": "12kh731vbdn4yp20c3zb8nx8bklh0b4amdnlybb3ww3sjax41h4f"
   },
   "stable": {
    "version": [
@@ -64934,11 +65128,11 @@
   "repo": "srdja/iodine-theme",
   "unstable": {
    "version": [
-    20151031,
-    1639
+    20250418,
+    2328
    ],
-   "commit": "02fb780e1d8d8a6b9c709bfac399abe1665c6999",
-   "sha256": "14zfxa8fc7h4rkz1hyplwf4q2lga3l5dd7a2xq5kk0kvf2fs4mk3"
+   "commit": "f8f8a446c82e61100519a5ab3f979953b008ce41",
+   "sha256": "16izpmxxpch06h5imqia9kckjvrsc3ybkkb7b7bpd9dx1a08gp6p"
   }
  },
  {
@@ -65359,10 +65553,10 @@
  },
  {
   "ename": "iso-639",
-  "commit": "75219d010bfe386715b48cccc8c311d69b388873",
-  "sha256": "1kg4229aw00651p86mfxd7hmdq29vg5srb633xa50caz6zn169y2",
+  "commit": "228c1a49c6538075e52a0ad673eed6d32b026437",
+  "sha256": "1whvxvzj2klggvm4iw6436mr162r1jh7ifrnsv56k7bqfmjqndrl",
   "fetcher": "codeberg",
-  "repo": "Jaft/emacs-iso-639",
+  "repo": "tomenzgg/emacs-iso-639",
   "unstable": {
    "version": [
     20250303,
@@ -65496,14 +65690,14 @@
   "repo": "thierryvolpiatto/iterator",
   "unstable": {
    "version": [
-    20210109,
-    1859
+    20250504,
+    1720
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b514d4d1d0167e5973afbc93a34070d1aa967d82",
-   "sha256": "1xl64lz45z4s90ja96wy86qyr0xahk96v5rdvbamnfgw32kkxyh5"
+   "commit": "9cbe0d1153ce03d11c75f1d2b010091092b476ea",
+   "sha256": "10znb4hrv979zc65wk6d6zz5g6pdbgfxbp5k6zsfcagbmmm660cj"
   }
  },
  {
@@ -65551,11 +65745,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20250329,
-    1401
+    20250417,
+    1209
    ],
-   "commit": "e33b028ed4b1258a211c87fd5fe801bed25de429",
-   "sha256": "1yv40k0swdywk0zwxs2s95s4y1pa9k2m3s25fx7gv9pnmf7yw8p1"
+   "commit": "2529a23f9f510a94efa6c088bd14217aa764dafb",
+   "sha256": "1y53dg76vrc45z4qljn0cd5ycd4c9q1dwvhhii3j560hp88wkabi"
   },
   "stable": {
    "version": [
@@ -67302,25 +67496,25 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20250401,
-    1540
+    20250510,
+    1639
    ],
    "deps": [
     "compat"
    ],
-   "commit": "42e6d7f1f3b12dc95f203753926d252c98f8bbc8",
-   "sha256": "1davdw9ws371dlxkrch2xyjqcx072p0ckriqz5iaa9zzvjkb9wlj"
+   "commit": "1c9be6c3293a5f34c205042c326ac3617ccab7fe",
+   "sha256": "1abdgjh1mfrcq6h4vh7r7bba1p0l62xibzghgv4qmhc039y7kydr"
   },
   "stable": {
    "version": [
     2,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9c778357ffaac972c86f4acd39d70c547abcaf46",
-   "sha256": "1xmhfrxbyw9yqxa845m90rikm6zg3fdhsb74i3qg6pgm5fiwpj1f"
+   "commit": "84fc35aedddfbf24de144245fe9d1c8a61852f7a",
+   "sha256": "1kfxx9657zn4sy463gxwsqqh4bcdxxaf3x7jkgasl4v18mrvid1i"
   }
  },
  {
@@ -67331,8 +67525,8 @@
   "repo": "unmonoqueteclea/jira.el",
   "unstable": {
    "version": [
-    20250329,
-    1650
+    20250419,
+    1812
    ],
    "deps": [
     "magit-section",
@@ -67340,14 +67534,14 @@
     "tablist",
     "transient"
    ],
-   "commit": "239b55c83850df97f59c10d1711911015986e424",
-   "sha256": "0zg7qx05i92xpsa43y9gsxbn08gmzng88dvkva7y70zvrzx58zz2"
+   "commit": "961ef56406980958f345a9265970b7100b0e92a4",
+   "sha256": "0nhjs1mmv63gpvmy08bm76vd1n6hy5m2r9ncjiv0xdl0x5vmpna3"
   },
   "stable": {
    "version": [
     0,
-    7,
-    0
+    9,
+    1
    ],
    "deps": [
     "magit-section",
@@ -67355,8 +67549,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "239b55c83850df97f59c10d1711911015986e424",
-   "sha256": "0zg7qx05i92xpsa43y9gsxbn08gmzng88dvkva7y70zvrzx58zz2"
+   "commit": "961ef56406980958f345a9265970b7100b0e92a4",
+   "sha256": "0nhjs1mmv63gpvmy08bm76vd1n6hy5m2r9ncjiv0xdl0x5vmpna3"
   }
  },
  {
@@ -67452,6 +67646,21 @@
    ],
    "commit": "caf256543cfe5404333f5cf914a478d14b2ec102",
    "sha256": "1iiinybr3alh0afmyhb2mz7c1r3c360bxy7x6ha2jhjk8ncz946c"
+  }
+ },
+ {
+  "ename": "jjdescription",
+  "commit": "5d500f520c2345ff83b75d3e124ca2d2b8fd166f",
+  "sha256": "1rs95l6s3lkyi8qzgzz4h2arxr2s7vajrk0dzj8jzjz0xvsv7frf",
+  "fetcher": "github",
+  "repo": "necaris/jjdescription.el",
+  "unstable": {
+   "version": [
+    20250423,
+    2333
+   ],
+   "commit": "ef3c337cb82e58b3a9a9b0394e84c883a35ab795",
+   "sha256": "0r8wr1ddjwiramj48mxmx12h6w78igl48xnskgvavjxc458laxa7"
   }
  },
  {
@@ -68141,13 +68350,13 @@
   "unstable": {
    "version": [
     20240608,
-    725
+    737
    ],
    "deps": [
     "json-mode"
    ],
-   "commit": "c4a9566142de6b0812cf4dfe0b0bf49b3e35f038",
-   "sha256": "0hhwhlfxrm6qnb99awy3hxm5zdjsz40jifxyp6qjsny5cg418zf9"
+   "commit": "7b346b0f0db62d65f382ce48a9b2ecd9e180b0d7",
+   "sha256": "1rppp5yi3v3jf90di9jsil18fl00l4qlgandzb3bdrv0j9z2lfqc"
   },
   "stable": {
    "version": [
@@ -68296,11 +68505,11 @@
   "repo": "iwahbe/jsonian",
   "unstable": {
    "version": [
-    20231229,
-    1444
+    20250507,
+    1231
    ],
-   "commit": "f200035b847d6dd10bd7987f4540cff9edd3b881",
-   "sha256": "0zr49wnvr7r8d5a4przxsfg9gjqkpijnngq9kzjhakhqdmqbwf8q"
+   "commit": "513219ebb3ccdefc915715e4bf2dd6e718fabccd",
+   "sha256": "0liyv5lgx8lp7gkkljr7crich03w6w07i0jx1qifpxpq4rxmwpi0"
   },
   "stable": {
    "version": [
@@ -68355,6 +68564,30 @@
    ],
    "commit": "54a89b0aaba7a68782008c5e1ab00d5ec757316a",
    "sha256": "14nxfa91yg2243v4d5kvynp2645x3811ispmhmpgil3x9qbl9jg9"
+  }
+ },
+ {
+  "ename": "jsonp",
+  "commit": "38c7893aaf22cd4ca6abf739b076bc5a57cff25e",
+  "sha256": "1n9f2rizkslyjzxcjravkrb9mpbjzx8anb5sdhnga3rshsqipk27",
+  "fetcher": "github",
+  "repo": "joshbax189/jsonp-el",
+  "unstable": {
+   "version": [
+    20250513,
+    23
+   ],
+   "commit": "91c6ef2f998c4a70d3ebe30bf72d99f9c70ff6c7",
+   "sha256": "0jwa4gdy601z7pckbhjhkh61qrxvdmc5jl5sx8r57h84bs5i12aw"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    2
+   ],
+   "commit": "91c6ef2f998c4a70d3ebe30bf72d99f9c70ff6c7",
+   "sha256": "0jwa4gdy601z7pckbhjhkh61qrxvdmc5jl5sx8r57h84bs5i12aw"
   }
  },
  {
@@ -68420,11 +68653,11 @@
   "repo": "llemaitre19/jtsx",
   "unstable": {
    "version": [
-    20250316,
-    2
+    20250414,
+    2100
    ],
-   "commit": "02d6a4a969829b8fd8dab69cfe4be3377b1776a4",
-   "sha256": "1z7zfvj7fvzi3qyrcka4j6ljipkw3m4sfviynicsfxhvq7c0bd1p"
+   "commit": "f715f9b97d504492378a31004c40db3b661b15e1",
+   "sha256": "19w1ndnc1rivcl0z3frrykrjbq5683cg62mhsp7xjac5hglcd5km"
   },
   "stable": {
    "version": [
@@ -68462,11 +68695,11 @@
   "repo": "JuliaEditorSupport/julia-emacs",
   "unstable": {
    "version": [
-    20241213,
-    1620
+    20250407,
+    841
    ],
-   "commit": "0f4d74f9049df28e2f522733141bfc5b7a0f69a3",
-   "sha256": "0vyr48afhlm207hidmahp1rsnjdfxdf2li8bisswjd6l3hhd8wxv"
+   "commit": "7fc071eb2c383d44be6d61ea6cef73b0cc8ef9b7",
+   "sha256": "1dfls9ggn192xblfyjrbxi007hg4yd25s2cl8zh0v40akpqclhqc"
   },
   "stable": {
    "version": [
@@ -68601,25 +68834,25 @@
   "repo": "shg/julia-vterm.el",
   "unstable": {
    "version": [
-    20240514,
-    724
+    20250502,
+    1103
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "2298cd42d354f069adbb7bb06b3b15222e5f54a2",
-   "sha256": "0r0anwzar8rwiwzwg637nshj59mssiipbilcc6kvxr73ffviy127"
+   "commit": "310fa8fc32e86d4e588985b0dd46e2162e42560f",
+   "sha256": "0anr5jycj9553wq3s9w3kkbj8ww33b2mv2b842x6c1mf57sz1ax0"
   },
   "stable": {
    "version": [
     0,
-    25
+    27
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "5e94f761be563db1f537ce37508ffa2cc33fc567",
-   "sha256": "01hvb5b884rv7q3mng8l71iwikzinvbwns41na30l0rqpzljcqs7"
+   "commit": "310fa8fc32e86d4e588985b0dd46e2162e42560f",
+   "sha256": "0anr5jycj9553wq3s9w3kkbj8ww33b2mv2b842x6c1mf57sz1ax0"
   }
  },
  {
@@ -68784,6 +69017,21 @@
   }
  },
  {
+  "ename": "jupyter-ascending",
+  "commit": "a8a92e318a404f62df8f732fe3415e2a22b512e0",
+  "sha256": "0w52lvb6b5a1gclld4hjj2anvxy6xr08cm19dfvrzvr2hqss5nfa",
+  "fetcher": "github",
+  "repo": "Duncan-Britt/jupyter-ascending",
+  "unstable": {
+   "version": [
+    20250427,
+    2101
+   ],
+   "commit": "dda5bb675ca5f1e0d23e9fcb430f49adcafd2d2e",
+   "sha256": "0mj3c2a9q6ccv01x128kww4caxlqfxpnyygkxdgvcxaprc1kv12y"
+  }
+ },
+ {
   "ename": "just-mode",
   "commit": "4ae56fd7c24a37769aeaba2de086a126d6ff23d3",
   "sha256": "0sm5l2jb0k17661738jfx6hz06j6kdadwsc86ck750mpw0pb391r",
@@ -68919,14 +69167,14 @@
   "repo": "TxGVNN/emacs-k8s-mode",
   "unstable": {
    "version": [
-    20230305,
-    1039
+    20250408,
+    844
    ],
    "deps": [
     "yaml-mode"
    ],
-   "commit": "83266cecd6a39cdf57d124270646047860bfb7ab",
-   "sha256": "0vnq41dg20nwixcdabjz88pnhdis8c1rpc7g7sxmkzk8gfgcilmv"
+   "commit": "39a189d1e030aa108e90a82fd40f0042b1e69b21",
+   "sha256": "0jhll0v7c905jmqkss0kjnbhzlp4f6k9a7sq614gia7c728j5fxp"
   },
   "stable": {
    "version": [
@@ -69214,11 +69462,11 @@
   "url": "https://hg.sr.ht/~arnebab/kanban.el",
   "unstable": {
    "version": [
-    20230210,
-    1505
+    20250501,
+    957
    ],
-   "commit": "d70fa7acab2bfcbb7d3da43c1343073f7eff4998",
-   "sha256": "0ic1gllj8ffvypn911w9rcw8jjahsqnzp3mk8shim06nw8qjs6af"
+   "commit": "6bfdc94e4cee0f946fc032a2471898b945e25aea",
+   "sha256": "1b29mvfvpml7nn9bl0gw200vgz0bh27x11r3yswi7hy0cxbd0adf"
   }
  },
  {
@@ -69681,26 +69929,26 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20250301,
-    1645
+    20250505,
+    2146
    ],
    "deps": [
     "compat"
    ],
-   "commit": "df329db48c22a3905d540c4240ac65c7b45f51dd",
-   "sha256": "130jfvy3pr3syqk6xaz910nignja32bzfnx342rr927jwa1vprfm"
+   "commit": "965ceb09db7af1d20c2848e7dfdc9d83a2b7dada",
+   "sha256": "18xvyki6jlq6m2l14rsy32bmhj4n5qyr3314xj2jmb7xmvs05l2v"
   },
   "stable": {
    "version": [
     1,
     4,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "df329db48c22a3905d540c4240ac65c7b45f51dd",
-   "sha256": "130jfvy3pr3syqk6xaz910nignja32bzfnx342rr927jwa1vprfm"
+   "commit": "83216f97b3dd99dbb1d4dbc781e863f205b6d5d9",
+   "sha256": "0s6mrz52si6kdd25l0nmv1lbjpkv7qsz049rmmnrsww9kz8jvrdi"
   }
  },
  {
@@ -69784,14 +70032,14 @@
   "repo": "tarsius/keymap-utils",
   "unstable": {
    "version": [
-    20240805,
-    1326
+    20250511,
+    1413
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a1ea60ce0adfbb4b47cdd7f29943e5ee362b71ce",
-   "sha256": "1va7dsh0c2xf234lfkkmw63c9p0m9h8aiikrlf361nllrzz77497"
+   "commit": "0fa24784cbdd48912a95fd88db602a41fdfd3cfd",
+   "sha256": "0rxfpkgvspcx6kjnz8zfa7xklnn2xknbbmxkfd2jmzvvhif9ldxv"
   },
   "stable": {
    "version": [
@@ -70030,28 +70278,28 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20250329,
-    1300
+    20250423,
+    1331
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "713ba06a8d8d11eea02b57d412bfa73884b06883",
-   "sha256": "1n9crapzmcpr6m3znrmii0gm6z1cay9qpdd7b8s2c2n9y69c6fwy"
+   "commit": "964a784acff6905f3eb7cbf76dff557228513aee",
+   "sha256": "1pn2srzmy5j5fpmj944lf8kszba1s4pdsbybcwlz84grjz45hi78"
   },
   "stable": {
    "version": [
     1,
-    38,
+    41,
     0
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "713ba06a8d8d11eea02b57d412bfa73884b06883",
-   "sha256": "1n9crapzmcpr6m3znrmii0gm6z1cay9qpdd7b8s2c2n9y69c6fwy"
+   "commit": "964a784acff6905f3eb7cbf76dff557228513aee",
+   "sha256": "1pn2srzmy5j5fpmj944lf8kszba1s4pdsbybcwlz84grjz45hi78"
   }
  },
  {
@@ -70327,25 +70575,25 @@
  },
  {
   "ename": "klere-theme",
-  "commit": "75219d010bfe386715b48cccc8c311d69b388873",
-  "sha256": "1kxhdaw2mn4vkdxyx0zdhzy0p7axwg0ayi125pmfbv18y1ypdh6q",
+  "commit": "6d04c0f70e95329bc897a3a0cf548b58abbcc870",
+  "sha256": "185rfh3md6psz94nrcvyxa2r82v1szfd35bbfr1qppcnmabg1bhk",
   "fetcher": "codeberg",
-  "repo": "Jaft/emacs-klere-theme",
+  "repo": "tomenzgg/emacs-klere-theme",
   "unstable": {
    "version": [
-    20250225,
-    2027
+    20250517,
+    452
    ],
-   "commit": "4a8e28002b3cd6acd67886aab01d59b21b659dda",
-   "sha256": "0hq4dnm7aaq39b8kcps3frv4l1xb6qr61cjs0nrfj54sdwnrz2xx"
+   "commit": "377cc33617184e23acde6707beaf8938915fe093",
+   "sha256": "15rgq1a6k64ws0fh864awnw22qzpb58z5s2gj2cp1svw4yakr84w"
   }
  },
  {
   "ename": "klondike",
-  "commit": "75219d010bfe386715b48cccc8c311d69b388873",
-  "sha256": "0g0x1p6mn57fknj1knk2gn325lkchz93jyycfybbg025s1wi0zw0",
+  "commit": "464dbf70ffc13c99adf6ee7d03215042c80f64dc",
+  "sha256": "1scbcjcjzz673cbnhjx2hlixqj6f8cijg0rnhi49zc013vg416dd",
   "fetcher": "codeberg",
-  "repo": "Jaft/Emacs-Klondike",
+  "repo": "tomenzgg/Emacs-Klondike",
   "unstable": {
    "version": [
     20250301,
@@ -70372,11 +70620,11 @@
   "repo": "vifon/kmacro-x.el",
   "unstable": {
    "version": [
-    20240721,
-    1103
+    20250514,
+    1246
    ],
-   "commit": "3f58f5421b98b436122dba2514cf559a7359904d",
-   "sha256": "0l3qrxgb8d67vwny7gpjjwnz367pbrj1qhy29cj9bbl9bbnlnkp8"
+   "commit": "6250d4d6e49b8708ac640e3d9b5ab4c072993067",
+   "sha256": "19nk9j8jfgmrxywbc3433sr81mb533n9zkdp3r0qjpplwf2ax48i"
   }
  },
  {
@@ -70686,8 +70934,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20250110,
-    1811
+    20250507,
+    1654
    ],
    "deps": [
     "dash",
@@ -70695,8 +70943,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "d587d6a09faa4add084847643821ec1aa60882d5",
-   "sha256": "19s4jc0ml22di47c7fz51bk24b56mzwrfgkba0k3qcpjhjrnv51f"
+   "commit": "61ec610b817c9ef59b2f25a242b71dee3f2e068a",
+   "sha256": "0h0k9zz6dvdbg2h96zkjn3gl6k9fk7fddjac81vbs7g8gyj5pfjd"
   },
   "stable": {
    "version": [
@@ -71097,16 +71345,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20250326,
-    1855
+    20250418,
+    1238
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "52f444984e3fd435f9fc598182e73c67290d2a6b",
-   "sha256": "1643ji8xz9spc7iv7r6iiqywbmnpqp8z8x6fahlgcqwc7ik7h61s"
+   "commit": "4f22b700f61665e3d87e7a86774b61d26f0b6efb",
+   "sha256": "1nk9mvf0y3ya49jlmgpc6zkhn8qxvnh9nwnv61jm8klhvnfc7hlj"
   },
   "stable": {
    "version": [
@@ -72108,16 +72356,16 @@
   "repo": "kaiwk/leetcode.el",
   "unstable": {
    "version": [
-    20250314,
-    1045
+    20250417,
+    1453
    ],
    "deps": [
     "aio",
     "log4e",
     "s"
    ],
-   "commit": "f61ad97ccf9199de82b9e7d0551c1b14c9337409",
-   "sha256": "163z96ks5hib4dqzy7ms8b6inm0sydqjwsn5v67c5c705nhjihjk"
+   "commit": "7f1d6804ed3b9de98d2737e1eab275cd9cbcdb16",
+   "sha256": "0id54jbcva1nnxb84sbg9pfs182fljrm127yw6qz83kmskgw9gas"
   },
   "stable": {
    "version": [
@@ -72350,20 +72598,20 @@
   "repo": "fniessen/emacs-leuven-theme",
   "unstable": {
    "version": [
-    20250301,
-    1634
+    20250422,
+    932
    ],
-   "commit": "43c9836cd3a3b96a56b200a340eb5c92e0766efa",
-   "sha256": "1qwn8565bpdqs1w1k248i2xg3lr6al5v8bzmj90d8ysqpalhr235"
+   "commit": "d84b1d8b435a517b7daf70d341784245fde1e8c0",
+   "sha256": "1y52vgfwy7qqyz1cnm82l9i0nr6658j3cnmwnnrzsj052272lyw6"
   },
   "stable": {
    "version": [
     2,
     5,
-    301
+    422
    ],
-   "commit": "43c9836cd3a3b96a56b200a340eb5c92e0766efa",
-   "sha256": "1qwn8565bpdqs1w1k248i2xg3lr6al5v8bzmj90d8ysqpalhr235"
+   "commit": "d84b1d8b435a517b7daf70d341784245fde1e8c0",
+   "sha256": "1y52vgfwy7qqyz1cnm82l9i0nr6658j3cnmwnnrzsj052272lyw6"
   }
  },
  {
@@ -73567,11 +73815,20 @@
   "repo": "countvajhula/lithium",
   "unstable": {
    "version": [
-    20250403,
-    156
+    20250430,
+    2353
    ],
-   "commit": "a99437f46b5b823082e2fe4570911dd6cb06ef23",
-   "sha256": "1070xp3dwl0ns2wp4bd98yw4qv9f0n7q48i7q0n2y890505jarvw"
+   "commit": "0be5e40a508ed053b0da13ec655b3aa498434cc1",
+   "sha256": "1fppbhynky3vqw4pg7f229w4grv15s0my3qd4nxxinb53p0x979n"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "commit": "8d97cec32fe724750ef5dd85626e49dcf436deaf",
+   "sha256": "0a2ns44n9daapnzcm0hdlx2445l864hysln46s99jxxxw7ar5nvv"
   }
  },
  {
@@ -73752,14 +74009,14 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20250314,
-    2009
+    20250509,
+    1221
    ],
    "deps": [
     "compat"
    ],
-   "commit": "48e5bc4919a4a29665362832d59ade8e248b0c3e",
-   "sha256": "0agn4n744fzf1f5i22448p1r7njd0kyxzs763gvml588r2ql2ja5"
+   "commit": "7de288e79329bfb3e2b4a2f9b574cf834bd371dd",
+   "sha256": "1cmm0yiv0aq0jq54m5amwb1g9gagfajhblb1m8871gpcfw4f5am0"
   },
   "stable": {
    "version": [
@@ -74314,11 +74571,11 @@
   "repo": "petermao/look-mode",
   "unstable": {
    "version": [
-    20220626,
-    641
+    20250511,
+    602
    ],
-   "commit": "726c5b9098926278603a83e978b488371c0e9143",
-   "sha256": "00c9v9jp7bgqr0bi0j6fhl6j2fj2xfk7lxrczxbcsvpx1896il93"
+   "commit": "6d82a013ede5f9ef5493801c3071bad5f6b283bb",
+   "sha256": "1hbhvj2z41sdb03srm9q88pl5f7dzvgif9y5p7sw45gpz1bmnhmf"
   }
  },
  {
@@ -74984,14 +75241,14 @@
  },
  {
   "ename": "lsp-mode",
-  "commit": "525ea5927f1c66dc56b49aab40667be15a7ea063",
-  "sha256": "0vjk60avwydap3zacygmrxsapbkfxb26k89km38633sg3788xqx9",
+  "commit": "6eb7943a6bc2593130db5f1faef404044714a894",
+  "sha256": "1sa63rx8x87dndav6galln5p46qh4di7bc60v91wa8qccfn2334y",
   "fetcher": "github",
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20250331,
-    802
+    20250516,
+    1008
    ],
    "deps": [
     "dash",
@@ -75002,8 +75259,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "7c0df125c19536646634dca9e27ecb3705db7521",
-   "sha256": "018w5356xaaw0q7r073gsgh3cy6i1chawc3qq82k3xlpylzflfly"
+   "commit": "8a266b83ea0fb880ef697771893c41f8745a04de",
+   "sha256": "15acxx01qk1bijg6j8j3nnjlmxmdxhkjfdlvvgdwc9jflvpnj894"
   },
   "stable": {
    "version": [
@@ -75205,28 +75462,28 @@
   "repo": "rgherdt/emacs-lsp-scheme",
   "unstable": {
    "version": [
-    20230606,
-    1722
+    20250425,
+    1731
    ],
    "deps": [
     "f",
     "lsp-mode"
    ],
-   "commit": "99251252005650d6f39cead8b2b9698c83251f01",
-   "sha256": "1b96ziqf3lx429w7qcbh30n85bzq17yknx04qmvvs9a1zbvicw9n"
+   "commit": "e50f92618ad34c6d6752cffe12b116f8f9705712",
+   "sha256": "1vi9wvh2ap0bbalckqa7x0xz9bmr481v1whs5l0bwgw411h7wpaj"
   },
   "stable": {
    "version": [
     0,
     1,
-    1
+    2
    ],
    "deps": [
     "f",
     "lsp-mode"
    ],
-   "commit": "c18afd39c841201c811583ff449a495d835b4773",
-   "sha256": "1h46bqpmnig64yhamniyi8wia256jm0diqqql0wxwi1pw25dcwa6"
+   "commit": "1821cf7ecc089251e08f03cf4ab11b60e9b58dda",
+   "sha256": "1j34pa2q3viyf03m6a44p2v4k2qyq7l1xh65xvcvgfiwvgni9d64"
   }
  },
  {
@@ -75319,15 +75576,15 @@
   "repo": "merrickluo/lsp-tailwindcss",
   "unstable": {
    "version": [
-    20241018,
-    200
+    20250425,
+    326
    ],
    "deps": [
     "f",
     "lsp-mode"
    ],
-   "commit": "ca5e611d2a38fea8802a365bcdd6fdc73e3d79af",
-   "sha256": "0632nrmdfcwgzl1cqf83rwsxrk3fckg7y8h3fhcaa3j47zd32q53"
+   "commit": "294121ada4feb4f4ad4d1a8b2dc69de89d518d31",
+   "sha256": "18p7kg2sx4vmasapgsq45650yckji7xhvnl9bw571359y31y9hq7"
   },
   "stable": {
    "version": [
@@ -75949,15 +76206,15 @@
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20250402,
-    1954
+    20250429,
+    1530
    ],
    "deps": [
     "compat",
     "yasnippet"
    ],
-   "commit": "38cbfd51fa9276ee4aff51c0996efb0872855ac9",
-   "sha256": "025d3216irm0yghkmqzwnp5kdnmrw1pwxzb4bphk3dlnwz9wq9dy"
+   "commit": "17f1a1a7d3145cebd958fa8bfe786957728a5e18",
+   "sha256": "1sap5ix4bia1fgkdigk478cjhpdsy5pxmxnmj07sp5m0mhaaiik0"
   },
   "stable": {
    "version": [
@@ -75980,8 +76237,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250401,
-    1753
+    20250516,
+    742
    ],
    "deps": [
     "compat",
@@ -75991,14 +76248,14 @@
     "transient",
     "with-editor"
    ],
-   "commit": "bf58615a033b8c827bf630962531c67539789215",
-   "sha256": "0k15p39r5jikin86r5wsf5z9jsaica01f4s4sbwczikjjpfpq9r8"
+   "commit": "cfe4faaaf6791e6f0aa64108b16b9b0074251fb8",
+   "sha256": "1wqriq06lkii3sbwjl5y4c12sjf0krfkl82ws0c78nv54p5y4j92"
   },
   "stable": {
    "version": [
     4,
     3,
-    2
+    5
    ],
    "deps": [
     "compat",
@@ -76008,8 +76265,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "bf58615a033b8c827bf630962531c67539789215",
-   "sha256": "0k15p39r5jikin86r5wsf5z9jsaica01f4s4sbwczikjjpfpq9r8"
+   "commit": "04ee83d93fabbfbe202e9e7dc781b0dcd4d5b502",
+   "sha256": "0g0ji4m39z8mcq1krj8v3kdhb2a8v2w0m00dqq3z925ibq0lv01r"
   }
  },
  {
@@ -76301,16 +76558,16 @@
   "repo": "douo/magit-gptcommit",
   "unstable": {
    "version": [
-    20250327,
-    139
+    20250421,
+    1917
    ],
    "deps": [
     "dash",
     "llm",
     "magit"
    ],
-   "commit": "bd8b2ba558d0a6c44209488404755889d02c1b80",
-   "sha256": "1i82gqdcv30av538cxz927jc7kj5r0c1fq7xbx2iz7gyks93r9sv"
+   "commit": "97dfcf33777731ba8d8ad0522c2deb0554a143fe",
+   "sha256": "1nwxkmgg5a5ni365rp23bg6r80j36bjlz0544lhw4k99ydxm0clm"
   }
  },
  {
@@ -76568,30 +76825,30 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250401,
-    1753
+    20250514,
+    1738
    ],
    "deps": [
     "compat",
     "llama",
     "seq"
    ],
-   "commit": "bf58615a033b8c827bf630962531c67539789215",
-   "sha256": "0k15p39r5jikin86r5wsf5z9jsaica01f4s4sbwczikjjpfpq9r8"
+   "commit": "04ee83d93fabbfbe202e9e7dc781b0dcd4d5b502",
+   "sha256": "0g0ji4m39z8mcq1krj8v3kdhb2a8v2w0m00dqq3z925ibq0lv01r"
   },
   "stable": {
    "version": [
     4,
     3,
-    2
+    5
    ],
    "deps": [
     "compat",
     "llama",
     "seq"
    ],
-   "commit": "bf58615a033b8c827bf630962531c67539789215",
-   "sha256": "0k15p39r5jikin86r5wsf5z9jsaica01f4s4sbwczikjjpfpq9r8"
+   "commit": "04ee83d93fabbfbe202e9e7dc781b0dcd4d5b502",
+   "sha256": "0g0ji4m39z8mcq1krj8v3kdhb2a8v2w0m00dqq3z925ibq0lv01r"
   }
  },
  {
@@ -77491,11 +77748,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20250402,
-    452
+    20250501,
+    551
    ],
-   "commit": "9d2850ed58719778d3e76411242d112e54998fd3",
-   "sha256": "1m7g12h94bv4m9fbcxa8q4kf81npniqka2mym6cgcbp8s896a783"
+   "commit": "90ad4af79a8bb65a3a5cdd6314be44abd9517cfc",
+   "sha256": "19c1jza1xkj3dhf23jw7if2qmr26db7qq6xp5d8q5gyc4v2pm11w"
   },
   "stable": {
    "version": [
@@ -78010,11 +78267,11 @@
   "repo": "mathworks/Emacs-MATLAB-Mode",
   "unstable": {
    "version": [
-    20250401,
-    1401
+    20250512,
+    1603
    ],
-   "commit": "8686c85cf376f90549d3aaf8478ed381f22282aa",
-   "sha256": "02zfp0j562rcydkfb3l49jlrjnqmc4wknyax6nwmy5xzd0hb65pr"
+   "commit": "3bbd36c45f7057b99131352d6d534fdb091b38e9",
+   "sha256": "12mci2micy2ac4i6czpnkklxx8nfs1mwh5xdfxbaw1ga7wqd784q"
   },
   "stable": {
    "version": [
@@ -78318,11 +78575,11 @@
   "repo": "jumper047/media-progress",
   "unstable": {
    "version": [
-    20230805,
-    2231
+    20250511,
+    1045
    ],
-   "commit": "951742e9e741a71bf527a23bf56deeedb12af7bd",
-   "sha256": "0f6h1w8nz9038pmlgmabv28qpq3n80fs812a4gz6773gknd50cjz"
+   "commit": "7055f5830690c9b1330816f899ee05791f35b406",
+   "sha256": "1i27pm1gg3096pammxdvfl21czs7m2pnn4z32gvq46jfm8d3qx67"
   }
  },
  {
@@ -78351,15 +78608,15 @@
   "repo": "jumper047/media-progress",
   "unstable": {
    "version": [
-    20230520,
-    1547
+    20250511,
+    1045
    ],
    "deps": [
     "dirvish",
     "media-progress"
    ],
-   "commit": "ec777d2d200ecb85795a225b482808f048c30a1c",
-   "sha256": "0i3yafqny2n8cha62xxmgg9nssv2qb0njjf218bzp9300c7qkfap"
+   "commit": "7055f5830690c9b1330816f899ee05791f35b406",
+   "sha256": "1i27pm1gg3096pammxdvfl21czs7m2pnn4z32gvq46jfm8d3qx67"
   }
  },
  {
@@ -78604,11 +78861,11 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20250317,
-    2300
+    20250404,
+    1432
    ],
-   "commit": "a7edff29d01195580c8ef723c2ab374b19552a5e",
-   "sha256": "0ijhf4if1a14ascprk9pa7wf4y97dx4vx0wg5iy1ppcxi96sx0d5"
+   "commit": "e5817f3b5ef82cbcf8a729af205191dc6b142282",
+   "sha256": "15nic2v054256696r4phfrfgbpa9vyjf2z2shdvx6zp10nkc936x"
   },
   "stable": {
    "version": [
@@ -78628,14 +78885,14 @@
   "repo": "skissue/meow-tree-sitter",
   "unstable": {
    "version": [
-    20250314,
-    1730
+    20250513,
+    1948
    ],
    "deps": [
     "meow"
    ],
-   "commit": "3d578e0296a430f6f9d8a058ae7b3e3202422f5f",
-   "sha256": "0ccvvckrwz9z1phh3jrfl7d9pq07mmzczg23m3yb9i925zmgazr2"
+   "commit": "b05d54a5e19f8ba0258b0bbf0ffcd4bc7bad112c",
+   "sha256": "05v3gi29rnl47fnq1l3yrarsdyrfir5bx42rh2kj93f180jjp3z2"
   },
   "stable": {
    "version": [
@@ -78791,26 +79048,26 @@
   "repo": "KeyWeeUsr/mermaid-docker-mode",
   "unstable": {
    "version": [
-    20250313,
-    652
+    20250424,
+    1730
    ],
    "deps": [
     "mermaid-mode"
    ],
-   "commit": "d40e4a4c031f363b58ef1cef9eefc097d4c4d85a",
-   "sha256": "0aj9pk0wjx9swza884frk7jgqlm0ggxm9w7yj8z7wmpi55jcfzr8"
+   "commit": "ce5f941cdb1bb360872bd5f80574a50d23f85531",
+   "sha256": "1jl0b22i1p8lqmw087pwpfgr49k2xd3g6037apn4k1p0ii22zv76"
   },
   "stable": {
    "version": [
     2,
-    1,
+    2,
     0
    ],
    "deps": [
     "mermaid-mode"
    ],
-   "commit": "d40e4a4c031f363b58ef1cef9eefc097d4c4d85a",
-   "sha256": "0aj9pk0wjx9swza884frk7jgqlm0ggxm9w7yj8z7wmpi55jcfzr8"
+   "commit": "ce5f941cdb1bb360872bd5f80574a50d23f85531",
+   "sha256": "1jl0b22i1p8lqmw087pwpfgr49k2xd3g6037apn4k1p0ii22zv76"
   }
  },
  {
@@ -79222,14 +79479,14 @@
   "repo": "yoshinari-nomura/mhc",
   "unstable": {
    "version": [
-    20240419,
-    10
+    20250423,
+    342
    ],
    "deps": [
     "calfw"
    ],
-   "commit": "b527a88748651d06222ad24f7417941088515275",
-   "sha256": "00wgf4jia9cxjpykzndsgn1jbnm6yqc7l3svfk2hj5j2ga1fax7g"
+   "commit": "2b22bc6c2041170df40e96b718d4b99a8330e3e3",
+   "sha256": "1pfv0nx4qisbsfd7pl8fd1rgjfi0p7cin6vjrx5k4fsj9ah29pcm"
   },
   "stable": {
    "version": [
@@ -79252,20 +79509,20 @@
   "repo": "daut/miasma-theme.el",
   "unstable": {
    "version": [
-    20250312,
-    2221
+    20250513,
+    2310
    ],
-   "commit": "6604a9cd76183394447e9b2cec2265d7e62aa26b",
-   "sha256": "1limia5jnq9fxhvnhws1b5iw3ssdqajnyvrlzvbx3axvbgix1c2c"
+   "commit": "7eda5d6889716811e7d5fd51edaff9ed7b09ce15",
+   "sha256": "0ncy7z5gdpvq6l8b81am6czysygfyvqm2lpswgv1536xcs6iilkd"
   },
   "stable": {
    "version": [
     1,
     6,
-    0
+    1
    ],
-   "commit": "232e4ea1d8182c53b7ed803e1df3ad687dd22a92",
-   "sha256": "07fci5vli5d8m607v0v6q535gnmcf4aqyw7020pzq0d7ij4vwacj"
+   "commit": "7eda5d6889716811e7d5fd51edaff9ed7b09ce15",
+   "sha256": "0ncy7z5gdpvq6l8b81am6czysygfyvqm2lpswgv1536xcs6iilkd"
   }
  },
  {
@@ -79493,15 +79750,14 @@
   "repo": "eki3z/mini-echo.el",
   "unstable": {
    "version": [
-    20250216,
-    1955
+    20250517,
+    401
    ],
    "deps": [
-    "hide-mode-line",
-    "llama"
+    "hide-mode-line"
    ],
-   "commit": "a604f1c6630452e99a18a61586cc984822550985",
-   "sha256": "0nrqwyqr38gd0200my1qf8bjnwwi8dk6d2pf3dqnc2w0xgs936ms"
+   "commit": "94a7747cba5e57169647f2013a95a6868b755fc7",
+   "sha256": "1lwn18pw0369viyw87fqssxyv2m3ribqyqzlw0g9dw101hmna3s7"
   },
   "stable": {
    "version": [
@@ -79724,26 +79980,26 @@
   "repo": "tarsius/minions",
   "unstable": {
    "version": [
-    20250101,
-    1417
+    20250428,
+    1253
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7ccb5e23a54c10f64880d1f55676f86681ff2f07",
-   "sha256": "1rinshdxln1wvzf7by8gq9wiqgcqy406k5jl1f86jd17b3wv5bxx"
+   "commit": "8d5acf28bb332ad75410e1d280d41f5d602c63c9",
+   "sha256": "1zln984w4bvflxvm922fs052qlri514p68cgxz4rrm56j8cddiqw"
   },
   "stable": {
    "version": [
     1,
-    0,
-    3
+    1,
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7ccb5e23a54c10f64880d1f55676f86681ff2f07",
-   "sha256": "1rinshdxln1wvzf7by8gq9wiqgcqy406k5jl1f86jd17b3wv5bxx"
+   "commit": "8d5acf28bb332ad75410e1d280d41f5d602c63c9",
+   "sha256": "1zln984w4bvflxvm922fs052qlri514p68cgxz4rrm56j8cddiqw"
   }
  },
  {
@@ -79868,28 +80124,28 @@
   "repo": "milanglacier/minuet-ai.el",
   "unstable": {
    "version": [
-    20250401,
-    1535
+    20250510,
+    439
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "78175bf60b4536ef1d64a0c7405fb575d4ef8f66",
-   "sha256": "1dcc1fdbpkzcd39sxz2dglah2zy6953w8plkaw6cx239g5dmhll9"
+   "commit": "9ad630acdce77a86eb8e4457f09c1cf547bcb186",
+   "sha256": "1sv7br0ixzq18m54jrg1gsgqpj373lgia64j56hy2z721q7hgqwj"
   },
   "stable": {
    "version": [
     0,
     5,
-    0
+    4
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "bb1bff593496713ea7be99ea25060087905378dd",
-   "sha256": "1fb9azpxpayx99045ih85hrp377kyndhd4js8zmnkj24xbmin4iw"
+   "commit": "8e4075713885f7ec7253936e3e74c7860ce7f77f",
+   "sha256": "0r8316spbcmv9nsqhmw5df3cwghbra4ncck0dzihjn9agss7zj27"
   }
  },
  {
@@ -79971,19 +80227,19 @@
   "repo": "szermatt/mistty",
   "unstable": {
    "version": [
-    20250401,
-    1512
+    20250509,
+    1801
    ],
-   "commit": "37124e957ebc442b7a91de681f913007956aaa7b",
-   "sha256": "01db57s23jl9pqg4vwfbr8d0v51ifpcibym4isxaqqnw9rr6h4gm"
+   "commit": "248ad94b6285ddf092f9e4156221ac4acc1ff712",
+   "sha256": "1c2rl9bqql0fh4rcjazzk06lx8kg5gqil7awjhvzq9h1dqnvx21d"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
-   "commit": "012007eefee8b5dd454c0d4671902e454b0de199",
-   "sha256": "1garqzcx14mwakbrp5p2vqynlbh819w8gjnf24x4xhv5aa5xy81j"
+   "commit": "e12c6af9894d6dbfd127047663275c763cab4e89",
+   "sha256": "1dlb4k7sbjjgyhikbcw0qf9js328vhs964lmhciyh8ahcfb7i9l6"
   }
  },
  {
@@ -80155,9 +80411,9 @@
  },
  {
   "ename": "mo-git-blame",
-  "commit": "a784f931849ca836557390999b179ef9f6e775f3",
-  "sha256": "14ngwwgzrnnysq1k1k681b5i06ad8r3phhgpvn5alp2fj3il03l3",
-  "fetcher": "gitlab",
+  "commit": "2463fcab700b48d3af3afdca26acfbc0451c7be6",
+  "sha256": "02fyv4dnrkbsflivk30s2zay2asy12zdhr5x2jn7icfyjw8wvn0y",
+  "fetcher": "codeberg",
   "repo": "mbunkus/mo-git-blame",
   "unstable": {
    "version": [
@@ -80426,14 +80682,14 @@
   "repo": "tarsius/mode-line-debug",
   "unstable": {
    "version": [
-    20240805,
-    1423
+    20250509,
+    1454
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a88406d1a999107610a765550c3bc4d64850f8a0",
-   "sha256": "07mbq8psd5mzsqigdvjk5hdc8kbppfghg976p5nqq4xfy3p6n0v9"
+   "commit": "d7bf6862b97e53d47c4b1841c70d3c776f21e50e",
+   "sha256": "0jq315crrmni0hvprlrm58k8mcz3i05wi1mvw71yz2a0kf3hnh5x"
   },
   "stable": {
    "version": [
@@ -80624,20 +80880,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20250327,
-    843
+    20250428,
+    456
    ],
-   "commit": "55609222f9817f7f76f5832d87e95ac11bba9a86",
-   "sha256": "14w3g3yhlib0piq9k0lclrbdj9dns9mxsgkg9qz5kxmy21phr3wa"
+   "commit": "847311bf740a043deff3124492d5c53141e5701c",
+   "sha256": "0qsy1hf11hzh9abnz4sgnkf5p8am9fyf3mxsy2hfmg20lhdk4wam"
   },
   "stable": {
    "version": [
     4,
-    6,
+    7,
     0
    ],
-   "commit": "895e10936adac93aa8187c9cc91092dbca898677",
-   "sha256": "05vzbjhas9a4zapjk2d57a6ljabf2q24d9c1zxncyff8kyimzkq2"
+   "commit": "d5a0eeb4f0fc5f865862465c6d17482d166b3b3d",
+   "sha256": "06snn66nb9qs8d8gs1dl2jhmgdris9y6pslpm0lsnq58w3ha71vl"
   }
  },
  {
@@ -80986,14 +81242,14 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20250101,
-    1418
+    20250505,
+    1556
    ],
    "deps": [
     "compat"
    ],
-   "commit": "26dd59b300c149a0e2e332023115b280b42ead12",
-   "sha256": "1byphhdp41cn2qs91la6fvgzrwgbyx4yaajknvwz8qxzgl2c4aq2"
+   "commit": "bc7d4c2e89fb9e568ad58f5f34d4bb6fc76b8c75",
+   "sha256": "0baj5pgc9jisw4isz8x9dljggd0dajpws3n93gy250k1rkxk2fni"
   },
   "stable": {
    "version": [
@@ -81977,11 +82233,11 @@
   "repo": "mkcms/mu4e-overview",
   "unstable": {
    "version": [
-    20241201,
-    1012
+    20250406,
+    1225
    ],
-   "commit": "25a1c0c5fbac240e5faa1518b511609b709e3c53",
-   "sha256": "0q2xc3dpg70j3xk9f6c7wpiznvmscdfggzxkf8c4xxg4jfvbdcxh"
+   "commit": "527c3d3a4618c6ba7e6dec679ec2eff8854775d2",
+   "sha256": "1fxxbfn8hgx07rr9rrfr8bmhay576shc1s14smnjakrg51a69sl9"
   },
   "stable": {
    "version": [
@@ -83376,11 +83632,11 @@
   "repo": "nickav/naysayer-theme.el",
   "unstable": {
    "version": [
-    20240220,
-    2159
+    20250406,
+    2017
    ],
-   "commit": "5e0bfaffb5162f3f35690ef3397a5ab63006042f",
-   "sha256": "1vzl06dgsczmnjl84sc2wzl5icn55c99czfij8mw589vqhzx5fjs"
+   "commit": "00fe031e38f1111614f088505776b09a5453f4ff",
+   "sha256": "0w910rkmd22yj2qf6jibqp2ax6vmnnhnh7srscwd6w7172d7671y"
   }
  },
  {
@@ -83545,11 +83801,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20250324,
-    147
+    20250506,
+    1721
    ],
-   "commit": "14f7278dd7eb5eca762a6ff32467c72c661c0aae",
-   "sha256": "1r5wj13k6khlmkn5wy2q2n674bc551rpxn04x46j0brzgmd85k7g"
+   "commit": "1cb883d928ec046358d2b65db0bb898a1dfffd0a",
+   "sha256": "0r3gv9z04asqjsnasjm2avk9gllqkng6ns14l0svrqxac4c2pp70"
   },
   "stable": {
    "version": [
@@ -83569,15 +83825,15 @@
   "repo": "rainstormstudio/nerd-icons-completion",
   "unstable": {
    "version": [
-    20241221,
-    1846
+    20250509,
+    1949
    ],
    "deps": [
     "compat",
     "nerd-icons"
    ],
-   "commit": "8e5b995eb2439850ab21ba6062d9e6942c82ab9c",
-   "sha256": "0nbyrzz5sscycbr1h65ggzrm1m9agfwig2mjg7jljzw8dk1bmmd2"
+   "commit": "e15e21a263bad06424982c11e8d68ffe1372a4e7",
+   "sha256": "08ianr8dwxal6dw674ngnaiw6k5kwvsfldmzxhj0fwsqg7ah90l3"
   }
  },
  {
@@ -83618,14 +83874,14 @@
   "repo": "rainstormstudio/nerd-icons-dired",
   "unstable": {
    "version": [
-    20241013,
-    212
+    20250506,
+    1729
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "c0b0cda2b92f831d0f764a7e8c0c6728d6a27774",
-   "sha256": "1iwqzh32j6fsx0nl4y337iqkx6prbdv6j83490riraklzywv126a"
+   "commit": "69b5d3176b7bb08ac1f477cf7c5a491b9b0b5b54",
+   "sha256": "1q6zyx2m4h9fnirphrw933w9hrz7s5gk0sqgazgyg57szd99bzc2"
   }
  },
  {
@@ -84991,11 +85247,11 @@
   "repo": "ashton314/nordic-night",
   "unstable": {
    "version": [
-    20250206,
-    2258
+    20250508,
+    2029
    ],
-   "commit": "7d37878b7e216dc28e4e00f2ecaad413c8712536",
-   "sha256": "1r2083fcxcf9mrvzxvfsm2j5cyidslvbspgj70lxf23wip5w5d7r"
+   "commit": "6b274e5d2e6136a5108f0278806e52270c2b12e2",
+   "sha256": "1g3svq8clyq4kp6kngh4sj42k48sn99iiy3w570lrnsklykyhkns"
   },
   "stable": {
    "version": [
@@ -86001,6 +86257,24 @@
   }
  },
  {
+  "ename": "ob-bigquery",
+  "commit": "a4eb76fa0ca7755430450c4987c4f8b5d980d957",
+  "sha256": "12b8m4arrwlfa2bcxkzs3d3da25szshlcmk9494dfvqsaqzwbadh",
+  "fetcher": "github",
+  "repo": "lhernanz/ob-bigquery",
+  "unstable": {
+   "version": [
+    20250425,
+    651
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "64d1c6f7fb7f04a8d23a38e648d2558513e98cf6",
+   "sha256": "019q3rwg69ssy4yzcshygkmiwfyj63rm3461lyhck6rxhklksf43"
+  }
+ },
+ {
   "ename": "ob-bitfield",
   "commit": "4032df23d0f2fdab9655a386bf5645d30acf5f53",
   "sha256": "0aiq97h595h03fv6hz276vx1aaacl6gk4yn60ncizkas3vs8sj6h",
@@ -86676,27 +86950,27 @@
   "repo": "shg/ob-julia-vterm.el",
   "unstable": {
    "version": [
-    20240514,
-    328
+    20250501,
+    1404
    ],
    "deps": [
     "julia-vterm",
     "queue"
    ],
-   "commit": "e1aae4f54cd06f33c63a16d88df4856947f46201",
-   "sha256": "04hknkcqkfn5bfbxx9mx1naczjxnk1aalhyqvra6m7p1n832mvqm"
+   "commit": "bb2eea8a98046c5f63501bca7b4c2df2b3bff087",
+   "sha256": "18vlmrdargdgxfhz79ybb2hjbjdd8zy3hr43r8cnjsxff23rm609"
   },
   "stable": {
    "version": [
     0,
-    5
+    7
    ],
    "deps": [
     "julia-vterm",
     "queue"
    ],
-   "commit": "e1aae4f54cd06f33c63a16d88df4856947f46201",
-   "sha256": "04hknkcqkfn5bfbxx9mx1naczjxnk1aalhyqvra6m7p1n832mvqm"
+   "commit": "bb2eea8a98046c5f63501bca7b4c2df2b3bff087",
+   "sha256": "18vlmrdargdgxfhz79ybb2hjbjdd8zy3hr43r8cnjsxff23rm609"
   }
  },
  {
@@ -87528,20 +87802,21 @@
   },
   "stable": {
    "version": [
-    1,
-    4,
-    4
+    2,
+    0,
+    0
    ],
    "deps": [
     "dash",
     "elgrep",
     "f",
+    "ht",
     "markdown-mode",
     "s",
     "yaml"
    ],
-   "commit": "3814b08fb43d633c4a31b17deef1c2b71e5b5420",
-   "sha256": "0hkwiha8xrw3iila3wny287lwbmwqmraar8xfp53xvhpg8fxkl7c"
+   "commit": "0b31775d5da1dfd3d1ffcf9fa05908a3ba26ed15",
+   "sha256": "0djxlkhqm1zrrq2xqjlcc1vygd4a6h4jcivn7iq8ryg2iga15i9z"
   }
  },
  {
@@ -87567,20 +87842,20 @@
   "repo": "tarides/ocaml-eglot",
   "unstable": {
    "version": [
-    20250401,
-    1605
+    20250428,
+    129
    ],
-   "commit": "049449a28bf8b5be87854df344963865303998ce",
-   "sha256": "0pabbw8kx8f436pmvarlbcky8vfqp2s9hl50bvi363b4sh84vqxg"
+   "commit": "90efa3dc9fdef671e142f641a7f9d9556c0215f9",
+   "sha256": "0hk38rc7qf7v4ga155br5v3d6p5ki974fdqn63f293h880iknsz4"
   },
   "stable": {
    "version": [
     1,
-    1,
+    2,
     0
    ],
-   "commit": "08b35089c4f3cd1bab18a314b2baa733a0e09e42",
-   "sha256": "0r2y4mfh27lysc77vv3xpaqn25h69j1m7wpa8h37n8dq0pq41746"
+   "commit": "7ce2c083987d14cdefec5c05c5361e2a01607865",
+   "sha256": "0jlfvcgix7awlv31xwbmacz3a3rzz4lnk5vky1gj9yqw9pp5llr7"
   }
  },
  {
@@ -87645,11 +87920,11 @@
   "repo": "dgtized/occur-context-resize.el",
   "unstable": {
    "version": [
-    20210121,
-    50
+    20250510,
+    1447
    ],
-   "commit": "9d62a5b5c39ab7921dfc12dd0ab139b38dd16582",
-   "sha256": "1s2j0205sp40nz1ljwa2nf2zm5mlkvsp95xfrra6rzbdrvbsfxyi"
+   "commit": "7a3f039b54274d353ec2f24067666da9edaaa185",
+   "sha256": "14dw9kvsw1h1prsag9hdcg8ph070k7kk8k76p8r7mxw6qzprigr6"
   }
  },
  {
@@ -88021,11 +88296,11 @@
   "repo": "captainflasmr/ollama-buddy",
   "unstable": {
    "version": [
-    20250401,
-    1942
+    20250515,
+    1327
    ],
-   "commit": "8fa0875eb996e961d1f645f5a875a24ecec727bd",
-   "sha256": "1ycafmfvchq94l0zl53rgwr9rn50vzmw79nh6fx22nsw4mjnnrnp"
+   "commit": "88f72aa80c59eef3fd85629408e31e252db3e657",
+   "sha256": "1jmdkc1y3i55lkg8jqafx73p50gdzqhlz2vgcllacycbh3vhkfd4"
   },
   "stable": {
    "version": [
@@ -88318,24 +88593,6 @@
   }
  },
  {
-  "ename": "on-screen",
-  "commit": "628f43fdfdb41174800fb8171e71134c27730f6f",
-  "sha256": "104jisc2bckzrajxlvj1cfx1drnjj7jhqjblvm89ry32xdnjxmqb",
-  "fetcher": "github",
-  "repo": "michael-heerdegen/on-screen.el",
-  "unstable": {
-   "version": [
-    20160302,
-    950
-   ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "206468aa4de299ad26c2db12b757f5ad7290912f",
-   "sha256": "1rrby3mbh24qd43nsb3ymcrjxh1cz6iasf1gv0a8fmivmb4f7dyz"
-  }
- },
- {
   "ename": "one",
   "commit": "be5e0550ba1eb789cad64ba18528c832128fe47c",
   "sha256": "17plv1b2zwamjdwmazii5sxcfx6svhk9j9frr20yzg6hb9vg94wp",
@@ -88504,11 +88761,11 @@
   "repo": "salmanebah/opencl-mode",
   "unstable": {
    "version": [
-    20240712,
-    1835
+    20250512,
+    1753
    ],
-   "commit": "204d5d9e0f5cb2cbe810f2933230eb08fe2c7695",
-   "sha256": "1x3h187r7waibrx5llsk6irb5afhqsrddb1f9hm3f9saks6n1ldv"
+   "commit": "0d305f9618ff56eb7e5e35c5bae980bcf957e972",
+   "sha256": "1pkn0cfv26jljnfsm8k28gjrc0cq48kgq91d4kr2kzrjwbpnc8j7"
   },
   "stable": {
    "version": [
@@ -88912,14 +89169,14 @@
   "repo": "rksm/org-ai",
   "unstable": {
    "version": [
-    20250131,
-    2236
+    20250418,
+    2323
    ],
    "deps": [
     "websocket"
    ],
-   "commit": "5a906fd4ecc4ff4d8ad561da14346a9d8b1d17db",
-   "sha256": "0agxq903w35ci144jr378ynaxl20hri3a42xl3m8h08a50x5s87j"
+   "commit": "cc4a4eb778e4689573ebd2d472b8164f4477e8b8",
+   "sha256": "00pwgpw2yaxi9rwcs36iv569db506phiw9fby912fh1nav44nh89"
   },
   "stable": {
    "version": [
@@ -88998,21 +89255,21 @@
   "repo": "eyeinsky/org-anki",
   "unstable": {
    "version": [
-    20240630,
-    1401
+    20250509,
+    1552
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "8b255bba68ee19c4e8a2704c1197ad963d0eb128",
-   "sha256": "19y513k1m6na6gvby10icdcl7bkik2694aq55liybp4iz33sw8ys"
+   "commit": "02832230e514f5d8e001ce8986ae11fca8f7dad0",
+   "sha256": "0l6vlsf2jhr7l020n8yc9qf0yb7kb9dahf4abcr7dw9kynh8mrwf"
   },
   "stable": {
    "version": [
     3,
-    3,
+    5,
     2
    ],
    "deps": [
@@ -89020,8 +89277,8 @@
     "promise",
     "request"
    ],
-   "commit": "8b255bba68ee19c4e8a2704c1197ad963d0eb128",
-   "sha256": "19y513k1m6na6gvby10icdcl7bkik2694aq55liybp4iz33sw8ys"
+   "commit": "02832230e514f5d8e001ce8986ae11fca8f7dad0",
+   "sha256": "0l6vlsf2jhr7l020n8yc9qf0yb7kb9dahf4abcr7dw9kynh8mrwf"
   }
  },
  {
@@ -89215,14 +89472,14 @@
   "repo": "zondo/org-autoexport",
   "unstable": {
    "version": [
-    20250302,
-    1553
+    20250502,
+    1854
    ],
    "deps": [
     "org"
    ],
-   "commit": "0cd22707014f3ee14da6fa823b3991e2ebddf0dc",
-   "sha256": "14lmx124ng1jgvgvni0ciik1xgsa9riy2y6nywica7ijxmvyqh6r"
+   "commit": "90b8646ad1c8d658fcb142b34a3cdecc1f48b469",
+   "sha256": "1ny8sxd00pwlby88b9wq0jrswjdh0gig8mixlb7sxlyr8mkvd6rc"
   },
   "stable": {
    "version": [
@@ -89376,14 +89633,14 @@
   "url": "https://repo.or.cz/org-bookmarks.git",
   "unstable": {
    "version": [
-    20250113,
-    647
+    20250428,
+    532
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "7c9387862b3035f4c722706fbe94a59e18d06a96",
-   "sha256": "1gvmvd5vakvlc6a116ajgzryar5pvzw7v8chzx5801vamg964fz9"
+   "commit": "ceb22cb1c316462b91e1606b9d89dd9656b1181d",
+   "sha256": "0kd4c9g2y239xf101awaqg55k9cfag4qm3qi4gf0v6bx2si4alrr"
   },
   "stable": {
    "version": [
@@ -89872,14 +90129,14 @@
   "url": "https://repo.or.cz/org-contacts.git",
   "unstable": {
    "version": [
-    20250309,
-    1659
+    20250513,
+    1001
    ],
    "deps": [
     "org"
    ],
-   "commit": "b06a59736800865b8a7e8d6d45774169cb31528a",
-   "sha256": "0kpk62606is9wwigwd8bwna24zz95nbcz3r052x5fg7rq7v5wq0h"
+   "commit": "3d9ef1d5a9df30c7135d7a4085a450bc2a1a2cf2",
+   "sha256": "0h32cwbam0z24igj8n2mv0r88zbf1lhbb1m86p4ff87rq4inxhr9"
   }
  },
  {
@@ -90406,11 +90663,11 @@
   "repo": "lorniu/org-expose-emphasis-markers",
   "unstable": {
    "version": [
-    20250320,
-    848
+    20250512,
+    511
    ],
-   "commit": "79479b72a683faaad01e73ca4ee16deabd11d533",
-   "sha256": "0w65dmm7icyx98vv964frg1zm68y7yz1y85a2vfbksy0y2nic40d"
+   "commit": "ca6b5a1057be8ecf73888345af732ad9dfd0f83c",
+   "sha256": "0n4s0g5p02ky0hj2m9ps5mzygg87ljkzabrgbih2dmbp0jv1b55w"
   }
  },
  {
@@ -90649,6 +90906,30 @@
    ],
    "commit": "d500f3a1b269b26097dd2f4cd414c3cb7c68ca23",
    "sha256": "0ms7bi4hb13z8srz0a8zfx258846y227dvs884jbxycrgnxzxsi0"
+  }
+ },
+ {
+  "ename": "org-hide-drawers",
+  "commit": "f33928816a1a869f34da59762974fb66d9894b96",
+  "sha256": "0aildz0hchs782nc5slh5zw6q4cahyadgp15c9zacgj275qrchv6",
+  "fetcher": "github",
+  "repo": "krisbalintona/org-hide-drawers",
+  "unstable": {
+   "version": [
+    20250428,
+    1637
+   ],
+   "commit": "e6311f1d72027ec701d3a0f88fc0c72ed114e8d0",
+   "sha256": "1c2vqjm33wmkdw2jp0jfn50lii2shim79r53lbskxjhm80zsa544"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "ce5d12bdfa8629c8d69b689ffa103f7c6207f249",
+   "sha256": "101gd1f8nf0gm597kvsg92j4205pd3x6p3gja5z5dmvycvl6rasw"
   }
  },
  {
@@ -90895,20 +91176,20 @@
   "repo": "trevdev/org-invoice-table",
   "unstable": {
    "version": [
-    20250330,
-    2308
+    20250409,
+    402
    ],
-   "commit": "6bbd8178d8170c4716ef09dae1f8bbf0d181497c",
-   "sha256": "0zg3j2iy5b839751jzpw2z85q2qrj7n33gzxy1qqgpbkh1blhlyb"
+   "commit": "3fe481f54050bb98493a0e3a1eb2a0693cda36d6",
+   "sha256": "0srhfw3rcq7k9vrl9wf20a75hzcarcq3ni9nnkrchym66fj76psb"
   },
   "stable": {
    "version": [
     1,
-    0,
-    1
+    1,
+    2
    ],
-   "commit": "fea8084575e82abb024cd7c8cbcc14c7317c962f",
-   "sha256": "0c2vf99d5hz9hs3q4wjg1cayy69m4xgc2fpihhqck3yk1vrs33gl"
+   "commit": "3fe481f54050bb98493a0e3a1eb2a0693cda36d6",
+   "sha256": "0srhfw3rcq7k9vrl9wf20a75hzcarcq3ni9nnkrchym66fj76psb"
   }
  },
  {
@@ -90989,16 +91270,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20250110,
-    2220
+    20250424,
+    41
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "5d8b291d66fca2bf8bbdaab673400570d1bbc295",
-   "sha256": "1h722cxfp7s712hfp08wakkqxxzjqqwfxivg7hgvlkjxgs092m5b"
+   "commit": "dfdc26ab8bfb54f4419d3eb52a17be5361d74b87",
+   "sha256": "1k2h7f2i9r73rxl4lnd0i9x3z63l54fg9dnav68f15f9pqmnh209"
   },
   "stable": {
    "version": [
@@ -91023,14 +91304,14 @@
   "repo": "bastibe/org-journal",
   "unstable": {
    "version": [
-    20250306,
-    1429
+    20250425,
+    936
    ],
    "deps": [
     "org"
    ],
-   "commit": "cf721732332d707de5d5af71e6d9a87599cc84a2",
-   "sha256": "1clw4dyqh3dqv2d8ky5r1sjk35jx546wrzq8dg6v76aicq3nka7p"
+   "commit": "e581bf5530054a40f933fdcc41e65aa0eedbd7da",
+   "sha256": "1gnwb3p4lfn01hp5amwjgbdm57hgksn2nicb26yawjn39isj9018"
   },
   "stable": {
    "version": [
@@ -91196,15 +91477,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20250331,
-    814
+    20250429,
+    353
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "f1047d50c2a13a5a7fd010fc1e6a90e7bbc9f72d",
-   "sha256": "0hqmlzn4c1xlj3c3dwi37hn9ncfqc6h5vah11jsf6l58p3fplrj6"
+   "commit": "36a6a376689ce532723229d2a1064c80bb912e15",
+   "sha256": "1jzlli2pq92a1npjn2c5rzq2fnlqj5ikcvw5gqv8xcyf6rh3a04w"
   },
   "stable": {
    "version": [
@@ -91358,6 +91639,38 @@
   }
  },
  {
+  "ename": "org-mem",
+  "commit": "e1b5f0b97b74adccc94abb1b36ffea1f6e81a0b6",
+  "sha256": "08bzvc0ddk8d8s9csrchdlii2qr8xv5bdk6d3xd0f9mpkh5kbvrf",
+  "fetcher": "github",
+  "repo": "meedstrom/org-mem",
+  "unstable": {
+   "version": [
+    20250516,
+    1743
+   ],
+   "deps": [
+    "el-job",
+    "llama"
+   ],
+   "commit": "aa03c1872d49fe285b6fd87c8fbedac8045c72a2",
+   "sha256": "1sxvgrw6q8nkpzwhl9vhbjcpwl9p3ks79r9b8v79n7slbqb2lcnf"
+  },
+  "stable": {
+   "version": [
+    0,
+    9,
+    2
+   ],
+   "deps": [
+    "el-job",
+    "llama"
+   ],
+   "commit": "aa03c1872d49fe285b6fd87c8fbedac8045c72a2",
+   "sha256": "1sxvgrw6q8nkpzwhl9vhbjcpwl9p3ks79r9b8v79n7slbqb2lcnf"
+  }
+ },
+ {
   "ename": "org-mime",
   "commit": "521678fa13884dae69c2b4b7a2af718b2eea4b28",
   "sha256": "14154pajl2bbawdd8iqfwgc67pcjp2lxl6f92c62nwq12wkcnny6",
@@ -91408,30 +91721,30 @@
   "repo": "ndwarshuis/org-ml",
   "unstable": {
    "version": [
-    20230410,
-    30
+    20250514,
+    2314
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "f57336a9126a168ad32ccce017c072474555395a",
-   "sha256": "16j03fdikha5hwg8ifj0shsn4prbgf7dsggy3ksidpl63w3g05h4"
+   "commit": "e348f446746bd1699eae05a82dccd4276c6cc9a8",
+   "sha256": "002ha6lzl7bnv9bnvfmqa6kxamlqy6q9vsi4h0r6kk7b6bhixgnp"
   },
   "stable": {
    "version": [
-    5,
-    8,
-    8
+    6,
+    0,
+    2
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "7a7b1e918e8440f3f6ddb37db9bd1471d0dad37d",
-   "sha256": "16j03fdikha5hwg8ifj0shsn4prbgf7dsggy3ksidpl63w3g05h4"
+   "commit": "27ec4c118621ceccf832dd993d17d1ef29a1cb8a",
+   "sha256": "002ha6lzl7bnv9bnvfmqa6kxamlqy6q9vsi4h0r6kk7b6bhixgnp"
   }
  },
  {
@@ -91460,15 +91773,15 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20250326,
-    1539
+    20250427,
+    1402
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "0e0756f319c637abf424cef96ee35617a7d8c320",
-   "sha256": "1vp6bkkh4bdc3fighhqfv00whaaj580qraay16fg5kgci4rkkh10"
+   "commit": "032201b5916297f20e254e78993676d8bb41066d",
+   "sha256": "1zvhwszkhnd9ki118nlwnp4samcn1kmrqk48k0z9qzg0wl49flac"
   },
   "stable": {
    "version": [
@@ -91695,30 +92008,30 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20250326,
-    1504
+    20250516,
+    1658
    ],
    "deps": [
-    "el-job",
     "llama",
-    "magit-section"
+    "magit-section",
+    "org-mem"
    ],
-   "commit": "a6d42efe84f1e3c881c0aeca7521b9f5cba3c3f1",
-   "sha256": "03600cxy8dr2sd49d07v61izxpvdxgfyiangjzkbma4qdpbkmjgh"
+   "commit": "219b0f93d7442df865cc4cf5cb64c21c78e106c7",
+   "sha256": "0z0qapg98wcd3jd9jqphr7550k0l9mpm5vjxyxv03p4jj8gxn43m"
   },
   "stable": {
    "version": [
-    2,
-    4,
-    1
+    3,
+    0,
+    4
    ],
    "deps": [
-    "el-job",
     "llama",
-    "magit-section"
+    "magit-section",
+    "org-mem"
    ],
-   "commit": "cdd28c693986879e6460535ee8a34d4eeeeef35d",
-   "sha256": "0yvc61ydz8c8wms5pwb14v67da7w4l3xvd5w4x83qf81d9f44w9v"
+   "commit": "5c68e57e39eba38a8a278bf843facb08ba8f2f59",
+   "sha256": "0yjipjad14f5wf9mjggb0gkl449cw15vqhqvcdcv6i1k7mb4p544"
   }
  },
  {
@@ -91729,32 +92042,30 @@
   "repo": "meedstrom/org-node-fakeroam",
   "unstable": {
    "version": [
-    20250316,
-    1005
+    20250515,
+    1314
    ],
    "deps": [
-    "compat",
-    "emacsql",
+    "org-mem",
     "org-node",
     "org-roam"
    ],
-   "commit": "fda864320606e1e860b5bd9a6b2b08aec9abc8de",
-   "sha256": "0kf9a3fzczjwc2m1gi1kvmka49rw3682867i1f0xzb63hhdln5pg"
+   "commit": "61617d6075923c6191fbac0f107e3abb14395e61",
+   "sha256": "00pfp1v0rp03xgp9yi5g0hfm38hf7jp0948r48y054nr89iksikw"
   },
   "stable": {
    "version": [
-    2,
+    3,
     0,
-    0
+    1
    ],
    "deps": [
-    "compat",
-    "emacsql",
+    "org-mem",
     "org-node",
     "org-roam"
    ],
-   "commit": "6e0c5afed0f99eebcda6d824c2ef7ec258ad3546",
-   "sha256": "1gy88r44625vis6md88sh38z8i8viav42sg52x9p48374lhrchdx"
+   "commit": "61617d6075923c6191fbac0f107e3abb14395e61",
+   "sha256": "00pfp1v0rp03xgp9yi5g0hfm38hf7jp0948r48y054nr89iksikw"
   }
  },
  {
@@ -92276,8 +92587,8 @@
   "repo": "alphapapa/org-ql",
   "unstable": {
    "version": [
-    20241107,
-    345
+    20250421,
+    133
    ],
    "deps": [
     "compat",
@@ -92292,8 +92603,8 @@
     "transient",
     "ts"
    ],
-   "commit": "a5650e2be831ae130af8d9f5419bcb141e36b1d4",
-   "sha256": "1008hjqrlcc5pm6zw65p42ivf6gljj3mivvkinv8byyqkanrhklb"
+   "commit": "4b8330a683c43bb4a2c64ccce8cd5a90c8b174ca",
+   "sha256": "1a1ynnlqrg8wki4925kpjis6f368adv3q9kgmc0xv6yjkk2xpdih"
   },
   "stable": {
    "version": [
@@ -92682,28 +92993,28 @@
   "repo": "akirak/org-reverse-datetree",
   "unstable": {
    "version": [
-    20250401,
-    1407
+    20250513,
+    848
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "4ba47f2cd3a08a032858795fa37416212662b585",
-   "sha256": "0y95im68xgxbfnpslkhmh743fw7dik1dnki1jncw8q6nsx2jkvvy"
+   "commit": "8466a3566292cf17e70e6ab4e7fb9e1b48831586",
+   "sha256": "0hivhanj3jz32qp64mppi0wx0zavvvchh5g2g9pjbza90l6alxhy"
   },
   "stable": {
    "version": [
     0,
     4,
-    3
+    4
    ],
    "deps": [
     "dash",
     "org"
    ],
-   "commit": "4ba47f2cd3a08a032858795fa37416212662b585",
-   "sha256": "0y95im68xgxbfnpslkhmh743fw7dik1dnki1jncw8q6nsx2jkvvy"
+   "commit": "8466a3566292cf17e70e6ab4e7fb9e1b48831586",
+   "sha256": "0hivhanj3jz32qp64mppi0wx0zavvvchh5g2g9pjbza90l6alxhy"
   }
  },
  {
@@ -92714,11 +93025,11 @@
   "repo": "brabalan/org-review",
   "unstable": {
    "version": [
-    20241115,
-    701
+    20250416,
+    802
    ],
-   "commit": "2d9c04776a58b94cfff790ed80a471a9e5b4873b",
-   "sha256": "19q8hw4cr01mfvh5bw4p3zjdc3sjfp0bsjw39l5m77jnkg35gjfn"
+   "commit": "1f24fa504d58d619bb81a2c16058f685d85c2151",
+   "sha256": "1va21vgfaxwz19qg378vbq1dnb09l9klc2x31mc0r07p14dqhfy1"
   }
  },
  {
@@ -92822,8 +93133,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20241231,
-    1802
+    20250509,
+    2337
    ],
    "deps": [
     "dash",
@@ -92833,8 +93144,8 @@
     "s",
     "transient"
    ],
-   "commit": "2b7cf0110c5c13b26c3e1b35c9854263089ba13e",
-   "sha256": "0gwd4cyhwmnwkzc6ps5pikdf1ak17y1k006sl1b0sc2lwxyr4p4v"
+   "commit": "27059ae662a75bc0b2c9d2e8f6dcbbd6179d4a45",
+   "sha256": "1dz33vzhf9lb6pkkm5blsjlgfqy6zii3rgybcwl8gv01sw0wzn07"
   },
   "stable": {
    "version": [
@@ -92860,8 +93171,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20240721,
-    306
+    20250424,
+    2227
    ],
    "deps": [
     "org-ql",
@@ -92870,8 +93181,8 @@
     "s",
     "transient"
    ],
-   "commit": "f5c367fea8693491215ac61b211e98aef8dfaeec",
-   "sha256": "09pj272x1w3fys84xld8v7gpya5syh70irxd98sf0x2bpsrsqfry"
+   "commit": "72634dadc224786284c7d733f67900f2a514eab2",
+   "sha256": "00v3rwpbwpyn5vjpga2kaxvj044gvhjpz8bzdlf5cif5sjpvy3zx"
   },
   "stable": {
    "version": [
@@ -93124,14 +93435,11 @@
   "repo": "jcfk/org-sliced-images",
   "unstable": {
    "version": [
-    20240624,
-    428
+    20250408,
+    2114
    ],
-   "deps": [
-    "org"
-   ],
-   "commit": "b98b88a55eff07e998e7789e0bf7307dd71db050",
-   "sha256": "0iq03zp3bm1ph5ryhx6zpjm830sliqj6bb7i0h2v0nfn07l0cby2"
+   "commit": "cbe25ca63bb4c3979396834f279308cf87923f71",
+   "sha256": "1gmn5gmr74y5gfggmcngkqp2klg7f0fff68ajwi9f351z5iw4fiw"
   }
  },
  {
@@ -93354,8 +93662,8 @@
   "repo": "alphapapa/org-super-agenda",
   "unstable": {
    "version": [
-    20240916,
-    1753
+    20250421,
+    130
    ],
    "deps": [
     "compat",
@@ -93365,8 +93673,8 @@
     "s",
     "ts"
    ],
-   "commit": "d0954b8e7780a4efe49ab32fc11941db21c22bfd",
-   "sha256": "0f1s10sh217lj2z8z79x5z7i2dp4753a1j4db2r3dpwkp5pj15ai"
+   "commit": "fb20ad9c8a9705aa05d40751682beae2d094e0fe",
+   "sha256": "04xv8pymlzzgpllg7wbx6fl45ljrzl67qyi80y19a9qpgjlcwbh0"
   },
   "stable": {
    "version": [
@@ -93543,14 +93851,14 @@
   "url": "https://repo.or.cz/org-tag-beautify.git",
   "unstable": {
    "version": [
-    20250115,
-    504
+    20250410,
+    1242
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "bf02185770b56122d3b3d0c685f55676b7453c7f",
-   "sha256": "05x35dzcwzdhfpb644scw3s8hr241zagf4x8fmfgvpq2mcz928mj"
+   "commit": "9df9782fc6d68e7271cf164212d0ad37bf6d85f9",
+   "sha256": "1kcxw9mzlx2pw2p6i6ib4ll6dg6h2h9bdd888ahmxdhkdjah78v3"
   }
  },
  {
@@ -94849,11 +95157,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20250328,
-    1730
+    20250505,
+    729
    ],
-   "commit": "20060ab4d7a73beffe141145ee319d6a6b86d891",
-   "sha256": "0cph5p8b24s4pg0284q69ffk25jl3bkxyf9mw61qdrnk0wcpcigr"
+   "commit": "04f9b0f895fe2e29d5cb404b348b62ab02032333",
+   "sha256": "1ghdj1phw4pmi7nbbnkzqz5ni26i7ffda5x3pvzp6gj6ia0vy5py"
   }
  },
  {
@@ -94879,11 +95187,11 @@
   "repo": "tbanel/orgtblfit",
   "unstable": {
    "version": [
-    20250210,
-    1535
+    20250403,
+    2031
    ],
-   "commit": "aa4c132d8186e10ddb3c2a336be72123c284eb2c",
-   "sha256": "09yyp8a7p068kjg2vg27fzv130bkabq6ln32h511wcbfk84ix6fi"
+   "commit": "5d9a7efd23fdee4c6c79a74770cafba931c16c67",
+   "sha256": "1cxi469ggl7nmg1v0d55akka6lqsr5s12sm4a0ydyi6r5vbc9nwq"
   }
  },
  {
@@ -94894,11 +95202,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20250218,
-    903
+    20250505,
+    740
    ],
-   "commit": "c0ddfc7f0550918cbb22d5f5cf102caf57275826",
-   "sha256": "0mqzk2nyp8r731ssicypxs435mvngnv9rmjj3nrkzjynlm4ilsp3"
+   "commit": "332c7717045e06f6888a9cc1cd20729b6c8d9bf7",
+   "sha256": "02k6xfmq923vkry4bwdxbj8r64gaxcdlny666fmixalvdavy3nmp"
   }
  },
  {
@@ -95057,25 +95365,25 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20250301,
-    1613
+    20250404,
+    1131
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7af69f09465219d65ec75ffd4bb44a47d7f56dc9",
-   "sha256": "0i6n3hf4g286fkry7k25032cm0jg2njcrnws2kh39mml31vp8a4z"
+   "commit": "72112b358c41d2147122b217d11f272a22f285e4",
+   "sha256": "0fw0hgi2542ivc05dbq07ybr8c2mf8ja0z3f07lnslvn7vn5xp9i"
   },
   "stable": {
    "version": [
     1,
-    6
+    7
    ],
    "deps": [
     "compat"
    ],
-   "commit": "308e67cc25c2c2725a32f48fed6e67c87dcc3eed",
-   "sha256": "078dd89jyz51755adrxm90ka0kvmgmm5h2w2c9f0986g3jmb9daq"
+   "commit": "72112b358c41d2147122b217d11f272a22f285e4",
+   "sha256": "0fw0hgi2542ivc05dbq07ybr8c2mf8ja0z3f07lnslvn7vn5xp9i"
   }
  },
  {
@@ -95330,26 +95638,26 @@
   "repo": "abougouffa/one-tab-per-project",
   "unstable": {
    "version": [
-    20241212,
-    2306
+    20250514,
+    2103
    ],
    "deps": [
     "compat"
    ],
-   "commit": "82c49c5c8551d2c0dd33f6b56549e1890d621651",
-   "sha256": "0dj8mfgzlmvybkg7z4cvaa75v0hq8sbv3fkd2wxs8mhz2hhvmxl2"
+   "commit": "96ae7c156cd9a78a577942db5d1b12ecdecf519b",
+   "sha256": "0n64zgxiqshq9b82x9yzdzi1v1mdi65sgpf1w821hwx1knwi84l0"
   },
   "stable": {
    "version": [
     3,
-    1,
-    2
+    2,
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "82c49c5c8551d2c0dd33f6b56549e1890d621651",
-   "sha256": "0dj8mfgzlmvybkg7z4cvaa75v0hq8sbv3fkd2wxs8mhz2hhvmxl2"
+   "commit": "96ae7c156cd9a78a577942db5d1b12ecdecf519b",
+   "sha256": "0n64zgxiqshq9b82x9yzdzi1v1mdi65sgpf1w821hwx1knwi84l0"
   }
  },
  {
@@ -95419,26 +95727,26 @@
   "repo": "tarsius/outline-minor-faces",
   "unstable": {
    "version": [
-    20250101,
-    1421
+    20250514,
+    1243
    ],
    "deps": [
     "compat"
    ],
-   "commit": "66199fcbd64181f5d74e44ed03bd7bb4502fa547",
-   "sha256": "1zr0ix28vis4y88h8w6lf4lsp0x24qi5v2y3xsk6vi2am08w613g"
+   "commit": "a1ef3834f9f643cf1f65c5424691514169f8bf31",
+   "sha256": "09s7a4jab5w7p9k5hirv6w2r9nqh365r5g2qa5569jjlq12r8bh3"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "66199fcbd64181f5d74e44ed03bd7bb4502fa547",
-   "sha256": "1zr0ix28vis4y88h8w6lf4lsp0x24qi5v2y3xsk6vi2am08w613g"
+   "commit": "f9be85200c8bba29b0a9df354b4795f186840dfa",
+   "sha256": "0cbwx9aw37lkzmmxag7y0x7gv25lxrv2w37dycbimh3rj1mh3a3b"
   }
  },
  {
@@ -95769,19 +96077,19 @@
   "repo": "fjesser/ox-beamer-lecture",
   "unstable": {
    "version": [
-    20250306,
-    4
+    20250407,
+    219
    ],
-   "commit": "647e7ef74c559ca189b46f1e79e9fcf8146a2af3",
-   "sha256": "0v450b65mixl73sp3iwyv5lkik65575wpynbhy4y9wxcgkyvz98p"
+   "commit": "77546eaf9ac8f94b6079720f1d93c33dbbcc4108",
+   "sha256": "1yhmarx2af98ff43h8lrc9r6p85c6xk4k9l26bv2wkcwpvqgkh54"
   },
   "stable": {
    "version": [
     1,
     0
    ],
-   "commit": "647e7ef74c559ca189b46f1e79e9fcf8146a2af3",
-   "sha256": "0v450b65mixl73sp3iwyv5lkik65575wpynbhy4y9wxcgkyvz98p"
+   "commit": "77546eaf9ac8f94b6079720f1d93c33dbbcc4108",
+   "sha256": "1yhmarx2af98ff43h8lrc9r6p85c6xk4k9l26bv2wkcwpvqgkh54"
   }
  },
  {
@@ -96227,16 +96535,16 @@
   "repo": "emacsorphanage/ox-pandoc",
   "unstable": {
    "version": [
-    20240710,
-    1424
+    20250424,
+    908
    ],
    "deps": [
     "dash",
     "ht",
     "org"
    ],
-   "commit": "34e6ea97b586e20529d07158a73af3cf33cdd1d5",
-   "sha256": "0s4d639vfvqb6spnr3b0isrspbl876h22977pkb943ygd93bzx4p"
+   "commit": "5766c70b6db5a553829ccdcf52fcf3c6244e443d",
+   "sha256": "1di51izd09x4z5ph3sqrlfllvmbcj77q421wndbs3q8z0w5a74q2"
   },
   "stable": {
    "version": [
@@ -96392,14 +96700,14 @@
   "repo": "msnoigrs/ox-rst",
   "unstable": {
    "version": [
-    20250402,
-    923
+    20250428,
+    534
    ],
    "deps": [
     "org"
    ],
-   "commit": "a196a3e5284cb9d16a49ae6c23fb08eaaad1ea7b",
-   "sha256": "078qj8l4p8h9981klr7cbgmv3mv5f4pi3myz4a3gwjcfnz8qwy29"
+   "commit": "b73eff187eebac24b457688bfd27f09eff434860",
+   "sha256": "0d2i94zhskbdrvhwj38j611dzyiby34l43cnb92zaas6li82cqid"
   }
  },
  {
@@ -96798,6 +97106,21 @@
   }
  },
  {
+  "ename": "pache-dark-theme",
+  "commit": "79ce96ad8a2028fc6aff3c77fd5e0a1cfdfbeb3e",
+  "sha256": "0hkljp23qsq6174mb0jbj9d2zrqmfcwc5j49wmmfh62bj85gs5sn",
+  "fetcher": "github",
+  "repo": "0xhenrique/pache-dark-theme",
+  "unstable": {
+   "version": [
+    20250330,
+    1714
+   ],
+   "commit": "fd6ead16c9f33bebd2cd6fea70c5350d0dd2a6bc",
+   "sha256": "08bylpwzn7bbzslhzh0qkcgxi0yh31j3rbm6sbdca6pd49cwnfjx"
+  }
+ },
+ {
   "ename": "pack",
   "commit": "96f55c1f15ca24134da378a1ea31f7bb31c84ea9",
   "sha256": "0lwdhfrpqwpqqg3yhcyj11jv2mm8k9k54qdxlhdi8sxj1fdxmanw",
@@ -96901,25 +97224,25 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20250324,
-    1912
+    20250418,
+    1425
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "d6554e3bd4b8399be6fcc22e887fe3f9865c995a",
-   "sha256": "0m666f94h9kzhgpsnviyk7kyf4klk85i4mm3h22kbhdnh1hrqfw6"
+   "commit": "2dc48e5fb9c37390d9290d4f5ab371c39b7a3829",
+   "sha256": "10d75s3jk16rgd6ghdzcbpl7jak9ch42pgczj2wf4xs3g0z390yz"
   },
   "stable": {
    "version": [
     0,
-    25
+    26
    ],
    "deps": [
     "let-alist"
    ],
-   "commit": "6170c1e5b79f9b9f606ab17ab4d9ffb9bce3ebde",
-   "sha256": "1fvi79pwlvvdakcmvf6jv9ba400lqfjsdcshg2q4rnj5v1a797pn"
+   "commit": "26b27201f1276a71257d328513152494e3edfc5d",
+   "sha256": "0x1ikwfz1zr8bl8a67kgcbyzrqxnn6bslbz6pdfaczmshy7ry757"
   }
  },
  {
@@ -96930,25 +97253,25 @@
   "repo": "purcell/package-lint",
   "unstable": {
    "version": [
-    20250307,
-    912
+    20250418,
+    1424
    ],
    "deps": [
     "package-lint"
    ],
-   "commit": "6170c1e5b79f9b9f606ab17ab4d9ffb9bce3ebde",
-   "sha256": "1fvi79pwlvvdakcmvf6jv9ba400lqfjsdcshg2q4rnj5v1a797pn"
+   "commit": "26b27201f1276a71257d328513152494e3edfc5d",
+   "sha256": "0x1ikwfz1zr8bl8a67kgcbyzrqxnn6bslbz6pdfaczmshy7ry757"
   },
   "stable": {
    "version": [
     0,
-    25
+    26
    ],
    "deps": [
     "package-lint"
    ],
-   "commit": "6170c1e5b79f9b9f606ab17ab4d9ffb9bce3ebde",
-   "sha256": "1fvi79pwlvvdakcmvf6jv9ba400lqfjsdcshg2q4rnj5v1a797pn"
+   "commit": "26b27201f1276a71257d328513152494e3edfc5d",
+   "sha256": "0x1ikwfz1zr8bl8a67kgcbyzrqxnn6bslbz6pdfaczmshy7ry757"
   }
  },
  {
@@ -98745,11 +99068,11 @@
   "repo": "mpwang/perfect-margin",
   "unstable": {
    "version": [
-    20241012,
-    1900
+    20250421,
+    2011
    ],
-   "commit": "2d70e1cab1365fcedfb16cfff38d9fd0da77514a",
-   "sha256": "19vagkirvmm7xgi02dwwjsvdasadwgls0969vjqh9gygq390ig5m"
+   "commit": "43d2b02c5ae23f7165cc42be7656174a8f9298ba",
+   "sha256": "1fcnsjnlp89svbnlqwy8d82r74mqkr8cbir4lh9h1gxvallfjxxs"
   }
  },
  {
@@ -98779,11 +99102,11 @@
   "url": "https://hg.sr.ht/~pranshu/perl-ts-mode",
   "unstable": {
    "version": [
-    20250128,
-    1327
+    20250425,
+    953
    ],
-   "commit": "c343d3573e3165f151b93fc7517b22d72bbd5d6d",
-   "sha256": "0s4cy4i1a3a3sa0vc0vndvv5vrfgabrfci96qiil6dawq7lrmjxa"
+   "commit": "aa34c2a15aec61febb05afb74926b38f6a77f60e",
+   "sha256": "0h70wasdzjysk4cj5z5055430jllm6fpb3xshvxldydx2n9kldjm"
   }
  },
  {
@@ -98822,6 +99145,30 @@
    ],
    "commit": "99e22bd6dd7b768c617596da952a5b8e53d16ecb",
    "sha256": "1lg1myxb5pqf9m19kza2iwbcdcdghkrcb7fbgk7jghn2ag0naasf"
+  }
+ },
+ {
+  "ename": "persist-text-scale",
+  "commit": "ed542f20a5bb1628e91e74f5f453cad8474e9a78",
+  "sha256": "0plr37c9c896iqyw5qixxp7mx7pnc9cdlmqms1pyzq8c2l4hh9cd",
+  "fetcher": "github",
+  "repo": "jamescherti/persist-text-scale.el",
+  "unstable": {
+   "version": [
+    20250429,
+    1936
+   ],
+   "commit": "4a23ae098186d3f193eca86b172050ecdd6db017",
+   "sha256": "17w7ha59y5mhlimhxrvwqr52lap7kfpfx42iiyx75b9d4m7spbmj"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    2
+   ],
+   "commit": "84127d1a54ed55e40038b1f12828f4ad26146dfc",
+   "sha256": "0gc3v6j9ggh4av29r41zyndn5jzdjab8240jcs4d1x7ifnyiz7w5"
   }
  },
  {
@@ -99202,25 +99549,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20250329,
-    1244
+    20250503,
+    834
    ],
    "deps": [
     "peg"
    ],
-   "commit": "b5978eab882e65b23b7fdf1c3cf7adc834e9e8bf",
-   "sha256": "03m4rqplfdny94akpgpznzr320sdhkhfx16jsdvxgmlsfajm1cvc"
+   "commit": "4f2d0cf8e7a0d3b1ffbfe84989f38eabea5589b4",
+   "sha256": "0q7s0f1clqr57pifs0wz7kcws0i1gb824c0glrdpmjagax87w28v"
   },
   "stable": {
    "version": [
     0,
-    51
+    54
    ],
    "deps": [
     "peg"
    ],
-   "commit": "b5978eab882e65b23b7fdf1c3cf7adc834e9e8bf",
-   "sha256": "03m4rqplfdny94akpgpznzr320sdhkhfx16jsdvxgmlsfajm1cvc"
+   "commit": "4f2d0cf8e7a0d3b1ffbfe84989f38eabea5589b4",
+   "sha256": "0q7s0f1clqr57pifs0wz7kcws0i1gb824c0glrdpmjagax87w28v"
   }
  },
  {
@@ -99659,8 +100006,8 @@
   "repo": "emacs-php/phpactor.el",
   "unstable": {
    "version": [
-    20250331,
-    1310
+    20250510,
+    1951
    ],
    "deps": [
     "async",
@@ -99668,8 +100015,8 @@
     "f",
     "php-runtime"
    ],
-   "commit": "e22e9820992aae9220a81ee4f04faece0265215d",
-   "sha256": "0b46kag95b1hk6vw2fdwiv0nqwdsz2yy10xxack7iv7isp73h2ja"
+   "commit": "037187f9e204d3ed17017e7fb54236c005725fb7",
+   "sha256": "0vz9ckpkbqcf30aca7swizc1nx2jaghmyr4b1s64cncwr8z4jg5h"
   },
   "stable": {
    "version": [
@@ -99693,16 +100040,16 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20250331,
-    1920
+    20250407,
+    1727
    ],
    "deps": [
     "compat",
     "php-mode",
     "php-runtime"
    ],
-   "commit": "e1aa8b269c0e3281c323bc1fad509edabb668441",
-   "sha256": "1nqsf9bh8pd3pjmpmsiqazy8639h8938jm37qqcmdn13n69n0pxm"
+   "commit": "e224a90db19ded92d2a440f0654ce3a3ca65a4d9",
+   "sha256": "0g5vy761s4k0h7wn2k871697nnhp89ragch2hrb8ffc442465yrd"
   },
   "stable": {
    "version": [
@@ -100045,6 +100392,21 @@
    ],
    "commit": "f7892d373e30df0b2e8d2191e4ddb2064a92dd3c",
    "sha256": "1zxmc2l41h28rl058lrfr8c26hjzqmp37ii8r29mpsm03hsw30fh"
+  }
+ },
+ {
+  "ename": "pink-bliss-uwu-theme",
+  "commit": "2cebcc2fca87b870b6283e218362f92bcc85282e",
+  "sha256": "02kfwsm060kx2am7ffqb2jihxwhhgix709n0kbpyfnsyk7vyj365",
+  "fetcher": "github",
+  "repo": "themkat/pink-bliss-uwu",
+  "unstable": {
+   "version": [
+    20250517,
+    645
+   ],
+   "commit": "9c5c39f4509315c69a58f5cffde351dc70613f6a",
+   "sha256": "0i1krkzwh5l2zba6hpg0l8n3bh9qfmspmhs1b4rfd4c61da56mwi"
   }
  },
  {
@@ -100494,26 +100856,26 @@
   "repo": "skuro/plantuml-mode",
   "unstable": {
    "version": [
-    20191102,
-    2056
+    20250514,
+    1906
    ],
    "deps": [
     "dash"
    ],
-   "commit": "ea45a13707abd2a70df183f1aec6447197fc9ccc",
-   "sha256": "0rbmn2964w9kms6ql25dzpnyygj693123xs7gxasylgw5jall9wx"
+   "commit": "5e6b505c0695f75666a571b9e6fe1d52fa3ec34d",
+   "sha256": "1gxblp31ihvi51n5ywa68kknzas421zdj8rbl24wz7p0rba6w24y"
   },
   "stable": {
    "version": [
     1,
-    4,
-    1
+    5,
+    0
    ],
    "deps": [
     "dash"
    ],
-   "commit": "5889166b6cfe94a37532ea27fc8de13be2ebfd02",
-   "sha256": "0yp41d2dmf3sx7qnl5x0zdjcr9y71b2wwc9m0q31v22xqn938ipc"
+   "commit": "5e6b505c0695f75666a571b9e6fe1d52fa3ec34d",
+   "sha256": "1gxblp31ihvi51n5ywa68kknzas421zdj8rbl24wz7p0rba6w24y"
   }
  },
  {
@@ -101175,16 +101537,17 @@
   "repo": "polymode/poly-R",
   "unstable": {
    "version": [
-    20230416,
-    1454
+    20250502,
+    1525
    ],
    "deps": [
+    "ess",
     "poly-markdown",
     "poly-noweb",
     "polymode"
    ],
-   "commit": "8024e852cfca642dea2045a41b2033baa2f1f9a5",
-   "sha256": "1r4cbvvg1fjyq18ap1mj7gpvgllpc6hf6g7nf697vgwmahlb7jgf"
+   "commit": "fee0b6e99943fa49ca5ba8ae1a97cbed5ed51946",
+   "sha256": "18g462p5yh7fakb1w4mxl5m8kf5ny2xah67dic2qc9ffc6rc7pm2"
   },
   "stable": {
    "version": [
@@ -101209,8 +101572,8 @@
   "repo": "mavit/poly-ansible",
   "unstable": {
    "version": [
-    20240803,
-    1612
+    20250501,
+    1455
    ],
    "deps": [
     "ansible",
@@ -101220,14 +101583,14 @@
     "systemd",
     "yaml-mode"
    ],
-   "commit": "6fcfbb7163f7a74db9da0d54a5ecaec2ac93b315",
-   "sha256": "17c0c2gsxw892hq1acxsvl3i1cgpwfkk76hszcr9ydw566478972"
+   "commit": "fc31708bff007a40314c1cfd5a5b9659f39b024a",
+   "sha256": "1n313pmaifldqsdlvzvwv51fyr06fymhfilzl5z3l15wax7nqfxs"
   },
   "stable": {
    "version": [
     0,
     5,
-    1
+    2
    ],
    "deps": [
     "ansible",
@@ -101237,8 +101600,8 @@
     "systemd",
     "yaml-mode"
    ],
-   "commit": "6fcfbb7163f7a74db9da0d54a5ecaec2ac93b315",
-   "sha256": "17c0c2gsxw892hq1acxsvl3i1cgpwfkk76hszcr9ydw566478972"
+   "commit": "fc31708bff007a40314c1cfd5a5b9659f39b024a",
+   "sha256": "1n313pmaifldqsdlvzvwv51fyr06fymhfilzl5z3l15wax7nqfxs"
   }
  },
  {
@@ -102185,11 +102548,11 @@
   "repo": "jschaf/powershell.el",
   "unstable": {
    "version": [
-    20240825,
-    1440
+    20250417,
+    2013
    ],
-   "commit": "38727f1cdaf0c937a62b68ee52ec7196b8149f93",
-   "sha256": "19nprnwp6cly90dqa98d9h6kgbgg6idpqsjgckrvk1bn2wkx6axv"
+   "commit": "9efa1b4d0a3cc5c0caae166c144a0f76b1d0e5f4",
+   "sha256": "0lgvri5frma2pz8aqn9v50dzajdn198jjh7lzs1s8xvmz9q74zg2"
   }
  },
  {
@@ -102303,8 +102666,8 @@
   "repo": "blahgeek/emacs-pr-review",
   "unstable": {
    "version": [
-    20250328,
-    132
+    20250413,
+    919
    ],
    "deps": [
     "ghub",
@@ -102312,13 +102675,13 @@
     "magit-section",
     "markdown-mode"
    ],
-   "commit": "6b3895c7919762b87a57e4373920ff3592e4a696",
-   "sha256": "0xlqkfy71ncn6kpwq5243a396j2mz092z4vg21bhr0zq0g91ak54"
+   "commit": "7c2ce9deafe5158b4b0fe7c1e70104d64727c15e",
+   "sha256": "0ryf2jk54iqg7q494qdghg2pkhw8ky3s53dpj55871x6p2m1387r"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
@@ -102327,8 +102690,8 @@
     "magit-section",
     "markdown-mode"
    ],
-   "commit": "9fa4ef4d1922cbd6dd37b631ea05aed0ef358178",
-   "sha256": "1cm92263jqvq2lg378xqi8ikbqw98lxjpsl29sja2xg2wf6p7gml"
+   "commit": "7c2ce9deafe5158b4b0fe7c1e70104d64727c15e",
+   "sha256": "0ryf2jk54iqg7q494qdghg2pkhw8ky3s53dpj55871x6p2m1387r"
   }
  },
  {
@@ -103786,11 +104149,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20250402,
-    804
+    20250516,
+    913
    ],
-   "commit": "a78543cba785a7b0b0d1a8d4fe343305c6264d15",
-   "sha256": "159bhxj7xw66600l3rgpkfd792qvx45f5ijpmhrgl0299b99m4aw"
+   "commit": "f5d929ec447f3ad9cddba454e7c2dc6ca43cd732",
+   "sha256": "0qvvsagl5dicmfzmb7x73lfczbkqibd9zxsm0wps85ky93p8l0m2"
   },
   "stable": {
    "version": [
@@ -103898,11 +104261,11 @@
   },
   "stable": {
    "version": [
-    30,
-    2
+    31,
+    0
    ],
-   "commit": "43e1626812c1b543e56a7bec59dc09eb18248bd2",
-   "sha256": "002l7bi6jbxv7bvs56s5dw3qj7i1sp110w64a1zlvhisym010i4j"
+   "commit": "3d4adad5c4c4e6a6f9f038769b8c90716065b0e4",
+   "sha256": "1z2k6q0f1sifm1bm4zc8m7a5sbaizrmdwvnf49d8pi3xb4f96nk3"
   }
  },
  {
@@ -104414,20 +104777,20 @@
   "url": "https://depp.brause.cc/punpun-themes.git",
   "unstable": {
    "version": [
-    20240929,
-    2238
+    20250421,
+    1819
    ],
-   "commit": "a0b26442293e7afc6fd2ba9be199fc7b4f5138e3",
-   "sha256": "1bhv92kr5dmqh1v631s9lc2y0i731vmws1ysyrwrjr2alxpnlivz"
+   "commit": "735cedca649e0576ffba3771a039744c4a70528d",
+   "sha256": "160ivqmmaxyi4cy694cdgdirlviqyz7fkr84gcf761q5k2jrabwa"
   },
   "stable": {
    "version": [
     0,
     0,
-    2
+    3
    ],
-   "commit": "6a7e04de1ad9f7ba9074b7206bffc9241c33349c",
-   "sha256": "0661rhlh3nbbrjdg118y9nk7kmshb5p0jzgfpnqvqmf7j6p6rpg7"
+   "commit": "a0b26442293e7afc6fd2ba9be199fc7b4f5138e3",
+   "sha256": "1bhv92kr5dmqh1v631s9lc2y0i731vmws1ysyrwrjr2alxpnlivz"
   }
  },
  {
@@ -104467,11 +104830,11 @@
   "repo": "smoeding/puppet-ts-mode",
   "unstable": {
    "version": [
-    20250226,
-    723
+    20250503,
+    1625
    ],
-   "commit": "459e831ac40e7375864f4d6ae8571421f4e8533b",
-   "sha256": "0i3z6d255ibpchy3ml3q3wdycw757d28hzqfzgxkr1fyh1bczwfa"
+   "commit": "8a4a9609bf8a4615c562ab837ade587bb75fef2f",
+   "sha256": "0lz7qjmifip26bcpjn0vg1nr3rdzn54sn1dakzh0dmqa0rwrbfgz"
   }
  },
  {
@@ -104482,11 +104845,11 @@
   "repo": "purescript-emacs/purescript-mode",
   "unstable": {
    "version": [
-    20250307,
-    416
+    20250513,
+    1922
    ],
-   "commit": "a3d6ca4ba5b6ead6f19cf635258f2560c25a6e1f",
-   "sha256": "1sghd6mi1nm0yyl5wg5gbv3hnyd3gfrsrfkfwh1ks8j31xqqnwyc"
+   "commit": "023cdf2a81c2f98ec77b4fe4b9c5b501d02ab4e9",
+   "sha256": "1zkmh44vfsw8h60qskqkgw2b6qdl1qjyrn3dggwsas5f33nzfkg4"
   }
  },
  {
@@ -104607,11 +104970,11 @@
   "repo": "ideasman42/emacs-py-autopep8",
   "unstable": {
    "version": [
-    20250224,
-    2305
+    20250421,
+    1116
    ],
-   "commit": "45e46abc8dcf271505de6a75929b704fca663a91",
-   "sha256": "01zbpjyi7kpxafl9jnhxp0y8xi16a99cjkvrqc3ah3rpxdmww352"
+   "commit": "69fa9a47c15801172503987237c6043bc92761f5",
+   "sha256": "0n5d7lfgzg7rfj4kxcfp904h66yh73024bhvcwl0k6r6jc8sbvkh"
   },
   "stable": {
    "version": [
@@ -105497,11 +105860,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20250325,
-    1815
+    20250514,
+    727
    ],
-   "commit": "c33cf01d8d0c7cb5b0cca983158323bf12536837",
-   "sha256": "04wksvhr3a4ikwcjq9803hzwjvzp8q4v3wm06ly2p02r1vygvicv"
+   "commit": "413e7b99bb1495aa00df6c84b21558ab81d36cdb",
+   "sha256": "1d8wfvr8766jfbhmzy6fhqdf6yn5qwddijf61jmd9wp1i891bx08"
   },
   "stable": {
    "version": [
@@ -105725,11 +106088,11 @@
   "repo": "psaris/q-mode",
   "unstable": {
    "version": [
-    20250119,
-    1527
+    20250415,
+    154
    ],
-   "commit": "a4a8718605c418c3de0bc48be305dec765151f29",
-   "sha256": "1kf6afhfm1asqy7hps4wxyda1ssw8h4s3h58m6z05j7yhrgamfq9"
+   "commit": "7f41e1c62640c1badcb67daaead24dc291cd16ab",
+   "sha256": "0y7qf3h16xca9dj36d95p0bl6q4nf4ycygzx97jbx98hnlzvdcy2"
   }
  },
  {
@@ -106097,14 +106460,14 @@
   "repo": "emacsorphanage/quickrun",
   "unstable": {
    "version": [
-    20250214,
-    813
+    20250503,
+    2058
    ],
    "deps": [
     "ht"
    ],
-   "commit": "7345432cea36d4a6cdfcf5371f76af640cc6d192",
-   "sha256": "0jjqxcf6x5si095z1aj26hyqjcnrm5m6cy13m361k5gq9cqkb63q"
+   "commit": "bae8efb8c5bc428e4df731b5c214aae478c707da",
+   "sha256": "1ci1flsa8c5ydmkrxnync1zkf6d26ld08h9n71ffzpxhkdxgph8v"
   },
   "stable": {
    "version": [
@@ -106280,11 +106643,14 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20250324,
-    1144
+    20250514,
+    1427
    ],
-   "commit": "6b9a51828a5d08ac9ee4d96a21f6cff95f0e6a17",
-   "sha256": "1p8sr96bga4nhfm5md8m1p5x0dp444z63m7xrrbg337wsyqq49h7"
+   "deps": [
+    "compat"
+   ],
+   "commit": "1ec8ac5341ba9f9b70de02a8397fa02297594c16",
+   "sha256": "19syc0xagsgl44j7lw00k6ma6y4s09ck4x9hynha6hwd1xdrr3np"
   }
  },
  {
@@ -107020,20 +107386,20 @@
   "repo": "xenodium/ready-player",
   "unstable": {
    "version": [
-    20250211,
-    710
+    20250410,
+    816
    ],
-   "commit": "7a37e6fe82d74d525d1e0280f68d357a22c1a312",
-   "sha256": "0c9lgk40p19ji5hcrgz957i70ap3z35jbpaw5paf9ba72x3rn3mk"
+   "commit": "ea0633f7b8cb4478073b3082e01c3a46b2e888b1",
+   "sha256": "1qhdmb1rlj7r3nzhv8ajl90yibgmfjb1x9rjyljgqyfmizrp87lv"
   },
   "stable": {
    "version": [
     0,
-    30,
-    1
+    31,
+    2
    ],
-   "commit": "3bb454a834e7d0f91bf27c957fc52ce15a17b739",
-   "sha256": "0vmx2bycyvd0a4bmd9whav14kry5dm8kh7fq1khy81y33cbzgnn0"
+   "commit": "ea0633f7b8cb4478073b3082e01c3a46b2e888b1",
+   "sha256": "1qhdmb1rlj7r3nzhv8ajl90yibgmfjb1x9rjyljgqyfmizrp87lv"
   }
  },
  {
@@ -108199,11 +108565,11 @@
   "repo": "Reagankm/renpy-mode",
   "unstable": {
    "version": [
-    20200607,
-    135
+    20250509,
+    825
    ],
-   "commit": "f2f95a72a8c842f229f80999132e8ea8ee73f6fc",
-   "sha256": "1jka61j6zrc0yzjcplnyg1kp1d45ikwnkmayjg41v9w0pfrzzim3"
+   "commit": "fd97f97c12ab7e3fae9590b7f39362d6084d6fc8",
+   "sha256": "0kclg1mm4i4lrpc0sd0jdfwsvcy8kh5a6ljgflxz65aj3ln05qi0"
   }
  },
  {
@@ -108214,11 +108580,11 @@
   "repo": "ideasman42/emacs-repeat-fu",
   "unstable": {
    "version": [
-    20250331,
-    818
+    20250428,
+    2323
    ],
-   "commit": "409f954adf295a3beb3d2e481c773ebef8bf8f9f",
-   "sha256": "0247gi4ds0fzhalmvdq5f8j68jrrfsdkg1x143njmj89lvysmzbf"
+   "commit": "c7707c98730bb3ffaf84aeed341fae3cf35c314b",
+   "sha256": "0qfbf8rg9lpdmr4xfy5nmq4130zbjbkaqhk780zp5jin8p71jb5s"
   }
  },
  {
@@ -108742,14 +109108,14 @@
   "repo": "swflint/retraction-viewer",
   "unstable": {
    "version": [
-    20240509,
-    1440
+    20250510,
+    1847
    ],
    "deps": [
     "plz"
    ],
-   "commit": "e8ab96e5a95a93849b912e2684b9776c685ac4bd",
-   "sha256": "10kyj2jjykbzi2afyqg57w1pkf310155zjb3hzl6nm6h844gnhji"
+   "commit": "21fc8844a744b28153dff055cec6c6a3859b1529",
+   "sha256": "0fqsxzj45451sjzb2fhkangb891gzj2ccfbq0gxkr420av422fgv"
   },
   "stable": {
    "version": [
@@ -109770,11 +110136,11 @@
   "repo": "marcowahl/rope-read-mode",
   "unstable": {
    "version": [
-    20211228,
-    1126
+    20250428,
+    1236
    ],
-   "commit": "6aad44e006a2999980c138f608d28c8ecab92b35",
-   "sha256": "1hgkndd5y7hihzyb19pixdx3pnsxspaknq0kvxj8sq1d8iqk0300"
+   "commit": "7cd80d6c8e4a7e24a5147c06f083d745aef91b55",
+   "sha256": "1f55x5cwc87jqhxpg7bwgr8mwv544awqf1sn6fnc7qzma8bm02pn"
   },
   "stable": {
    "version": [
@@ -110624,11 +110990,11 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20241112,
-    438
+    20250423,
+    15
    ],
-   "commit": "542f1755d8929ca83564322d7030d558f3392fe1",
-   "sha256": "1a6p50hkw2qlgh2v1yivhbifp8l7ffsqs4712sd971scb00yv2r4"
+   "commit": "25d91cff281909e9b7cb84e31211c4e7b0480f94",
+   "sha256": "1dhacxmhjgwjyplaqivhv0v9wsk4dclbj2d9slwzib6s4dcgki87"
   },
   "stable": {
    "version": [
@@ -110671,8 +111037,8 @@
   "repo": "emacs-rustic/rustic",
   "unstable": {
    "version": [
-    20250310,
-    1415
+    20250514,
+    156
    ],
    "deps": [
     "dash",
@@ -110685,8 +111051,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "22a5ef8bfd5a34ced945c2722938eb29632371d4",
-   "sha256": "1lpa887lf1jvyzwpdpa2j8qdzymh60qbdfqgk11xyh0rkh057bjw"
+   "commit": "194f15c91ace0c3e95a81d315d2a481480d80a3e",
+   "sha256": "0i0fclbip38wbnnrapbaj0mq991hnjhs6j3wwddc8vmzwgrn29ml"
   },
   "stable": {
    "version": [
@@ -111333,11 +111699,11 @@
   "repo": "KaranAhlawat/scala-ts-mode",
   "unstable": {
    "version": [
-    20241027,
-    701
+    20250418,
+    813
    ],
-   "commit": "039af6d4e353726245e60756667f0b7378840f6c",
-   "sha256": "0b4f9zax2rgg3zrlsg40mgiz7f5z9dq52adg7xrgwrc1k65mlxlf"
+   "commit": "c7671e10419261ef70b1820d3b970ad39f6fcfe2",
+   "sha256": "15skmacj0mv5dmxhwjmk2xgqd2bfamc0fy10arkxwd39g3lgrdwy"
   }
  },
  {
@@ -111793,11 +112159,11 @@
   "repo": "precompute/sculpture-themes",
   "unstable": {
    "version": [
-    20250303,
-    1824
+    20250416,
+    1506
    ],
-   "commit": "59e8962f34a33a73be7bfd2d69ae53c14bba6b33",
-   "sha256": "0a3xq8mjaa4qam0vw4cfp1l7hyqzvrm4bf2a3andaww1yv2fm1sl"
+   "commit": "33a0309acba6e78f9fe5f5befa12904dd1390630",
+   "sha256": "15p9gqy425bg4gf2bxrb91gzl5n60ps553qj6jq5h9vibdfixvgw"
   },
   "stable": {
    "version": [
@@ -111853,15 +112219,15 @@
   "repo": "sdm-lang/emacs-sdml-mode",
   "unstable": {
    "version": [
-    20241104,
-    1705
+    20250424,
+    2016
    ],
    "deps": [
     "tree-sitter",
     "tree-sitter-indent"
    ],
-   "commit": "ec867931868b0bced385f9b7517a8b48cd146ac4",
-   "sha256": "0mzbllnpr6kqm7f3yr3yq6wr42k8kps7qrzw7023fb9kh3q1xg6g"
+   "commit": "36c77e0d5af0165104cf8b7fdb489ae405993d64",
+   "sha256": "116anp92chdm6nn8fynrl2jnvkisq76c6h0257hq6ixg9l1k1xmh"
   },
   "stable": {
    "version": [
@@ -112137,14 +112503,14 @@
   "repo": "captainflasmr/selected-window-accent-mode",
   "unstable": {
    "version": [
-    20250304,
-    1623
+    20250423,
+    700
    ],
    "deps": [
     "transient"
    ],
-   "commit": "e51f58ebbe51d17a16912c0c16e402db68013a69",
-   "sha256": "1rzqz27v45i44h2hpbx2hc26r71gvczcl12z04rai5vw5zzlzfz2"
+   "commit": "44e43b9706bf0cc09f54f36859b060df53ae5278",
+   "sha256": "07s5flk5501nwrr77q4d7k7dcwwb5mvapwfphv8ikkhba5yk0d7j"
   },
   "stable": {
    "version": [
@@ -112489,15 +112855,15 @@
   "repo": "twlz0ne/separedit.el",
   "unstable": {
    "version": [
-    20241012,
-    125
+    20250506,
+    833
    ],
    "deps": [
     "dash",
     "edit-indirect"
    ],
-   "commit": "0001d2b4fcc6e5f40ebc82dd3c80ac7ce4031234",
-   "sha256": "14cs3vjfs077w5v1vnhddi8a7xag2x8b9vam8pdlcn48737bk7mw"
+   "commit": "5cb46a65fc6e12b753dce8f581fbfa144d011a80",
+   "sha256": "1cgvj1ii6hfq3z6lq8cb7xiximyaglzwbwyf3aws0hw504q9kf8w"
   },
   "stable": {
    "version": [
@@ -113027,14 +113393,14 @@
   "repo": "sebasmonia/sharper",
   "unstable": {
    "version": [
-    20230129,
-    1827
+    20250403,
+    1243
    ],
    "deps": [
     "transient"
    ],
-   "commit": "496e90e337cb09329d85a6d171c0953a85e918fe",
-   "sha256": "1a8x6mywxkhcc34lv0s5gq48vnhnq0cir0841zbkdjp1fviyx7j6"
+   "commit": "5049795848609e6508e4c9718a9f97ee481bf36c",
+   "sha256": "10w8hnny8grnxhkx1cgsgq74p9cp2ni73n0w233inmids46661ha"
   }
  },
  {
@@ -113114,11 +113480,11 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20250320,
-    908
+    20250515,
+    1649
    ],
-   "commit": "db0c2726922657e0891e224ca4a5523be01e55c1",
-   "sha256": "1p9ksnfpvbshiy92br3lyh7q0aamzx0pv5cp05ga6iikjhjp062d"
+   "commit": "9920a316bf59639c5a1a24d40e230100c78cf2ed",
+   "sha256": "0p6g61yc0nmmc713szwgackx1mnlrzl256infm73dhjcni6qn8bj"
   },
   "stable": {
    "version": [
@@ -113405,11 +113771,11 @@
   "repo": "ideasman42/emacs-shift-number",
   "unstable": {
    "version": [
-    20250314,
-    234
+    20250421,
+    1057
    ],
-   "commit": "b25fc4fc02a0755c1f5bd6483a65c970fbd30190",
-   "sha256": "1pf979dsrsrjs1q657flpycqfqfz7r8km7rbvsy8r0fxawjjjgai"
+   "commit": "0538161aa693676d6ab662302250995fac3ebdf1",
+   "sha256": "0wvpiaxg78lxvfazhp4mh6v2dsg87nrkwwy08rym7z5yqfxs9bra"
   },
   "stable": {
    "version": [
@@ -113624,14 +113990,14 @@
   "repo": "xuchunyang/shr-tag-pre-highlight.el",
   "unstable": {
    "version": [
-    20240515,
-    1420
+    20250501,
+    1509
    ],
    "deps": [
     "language-detection"
    ],
-   "commit": "af8ae8d558d1e26d276130c100e02746278ce037",
-   "sha256": "1ncmgziclhj3694kzq6qwsrafzcpn6a5r6fwbcjnjk6z9dahisq8"
+   "commit": "02a93d48f030d71eba460bd09d091baedcad6626",
+   "sha256": "0c6j0wyinagi28hkq0yxw2l9imxvpx0cd5a8h879w39nax9fd0cz"
   },
   "stable": {
    "version": [
@@ -113931,14 +114297,14 @@
   "repo": "emacs-sideline/sideline",
   "unstable": {
    "version": [
-    20250311,
-    2149
+    20250517,
+    508
    ],
    "deps": [
     "ht"
    ],
-   "commit": "ed0d5ca69104aea2e3de0d9ab62f8709fa07b8e1",
-   "sha256": "1z39crhdpsn96qxqi66yls3cpgn378nphjcy4sqnxka20dnz4d9p"
+   "commit": "6c0562c5abfa9eb16320cec755ffe09ebc26c0cc",
+   "sha256": "1hr5978i7g9px8jy5rmhl7avcxw4agrqrnwwnccak08l945n72fj"
   },
   "stable": {
    "version": [
@@ -114060,14 +114426,14 @@
   "repo": "emacs-sideline/sideline-flymake",
   "unstable": {
    "version": [
-    20250330,
-    2040
+    20250514,
+    2147
    ],
    "deps": [
     "sideline"
    ],
-   "commit": "cece68ca230e8a539b91ef5cb89934a938ea3970",
-   "sha256": "0i8w5bwqr1b6ry9fhrsj2ycf4fby0ik4bjbwk2vfv672bdml1rir"
+   "commit": "46f6cdd69bfa6825cf06f71f9417de8364280353",
+   "sha256": "1hvc0psjmwgf2lavjjzpgjzmnqbmdj5nb3jqlwak72zzrir146j8"
   },
   "stable": {
    "version": [
@@ -114357,9 +114723,9 @@
  },
  {
   "ename": "simple-rtm",
-  "commit": "1ae754064cd1f062bbdd6ecf9af03fa0c2798cf6",
-  "sha256": "09m5akqrdn22lxr50z3x2zyldh1m62b8sbwkq6pb428bhanvhky2",
-  "fetcher": "gitlab",
+  "commit": "8b4469d549ad280654f3cfd1aa2837dc07b066b7",
+  "sha256": "1cmcfc0jnvgyq3gb1086brn33zdlb2hm9kv5w5v3gg786wwsrzp4",
+  "fetcher": "codeberg",
   "repo": "mbunkus/simple-rtm",
   "unstable": {
    "version": [
@@ -114397,11 +114763,11 @@
   "repo": "rolandwalker/simpleclip",
   "unstable": {
    "version": [
-    20220518,
-    1251
+    20250505,
+    1710
    ],
-   "commit": "023f239275115169c3a3637ad95fae4a036c005e",
-   "sha256": "1mvjlcmldcx3vd6xkk3nriy8lghp6nqa6l13a6kax5n8dc0hi4qi"
+   "commit": "105b7adce212fdc9bbcbe7801531669a658c735b",
+   "sha256": "1d3gfhmmr7ca812cn9z426b0ki0gfsxx16gcykrnjvqkk6fa14dy"
   },
   "stable": {
    "version": [
@@ -114559,11 +114925,11 @@
   "repo": "laishulu/emacs-smart-input-source",
   "unstable": {
    "version": [
-    20250328,
-    142
+    20250426,
+    1916
    ],
-   "commit": "f7881a9af563b99db9f8efa47af738d0748f83d8",
-   "sha256": "1p7zismv1gm3r5kv7jan9wf7afza2lz4xrk30xk84pyk6xaq8kcj"
+   "commit": "a438a90209289fd12156285c06ce98e13e2f5834",
+   "sha256": "1mwc510kf2s91cm11w0qvk9k2r6l0sv5v0cxax18ji6hgdzq3lwk"
   }
  },
  {
@@ -114842,8 +115208,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20250327,
-    1218
+    20250429,
+    13
    ],
    "deps": [
     "alert",
@@ -114855,8 +115221,8 @@
     "ts",
     "websocket"
    ],
-   "commit": "ac4d42928fd2250f0558b8a2bd7664142ab8fba8",
-   "sha256": "1pzqcdv2fjcxwgim0dmaglyxi5rax62q63q30b8283r9sz3x3xnk"
+   "commit": "1cd67882054ca2dd22b312577fc4ea5b6af2edf0",
+   "sha256": "0s555sk2shz5rw5l2rq6rbql6dvv2nlp7h5j9h9w2287xm2n2d1d"
   }
  },
  {
@@ -114914,14 +115280,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20250330,
-    1740
+    20250417,
+    2015
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "36878496d6f9d06cd3e4dfa3f51ab57acc5fe95f",
-   "sha256": "0ilqdgnhim5jlampgfnjim2njkxhv8yxkrlgdgy151f5dkxxwbpg"
+   "commit": "47c8249d56d6b10d3b680e9ebb18126541afb2af",
+   "sha256": "0a89k8710alf9a5jrf6p2rp2j6f5wc6rhjbsi119vphyrjpbh6p9"
   },
   "stable": {
    "version": [
@@ -115181,11 +115547,11 @@
   "repo": "joaotavora/sly",
   "unstable": {
    "version": [
-    20250203,
-    2040
+    20250501,
+    1918
    ],
-   "commit": "c48defcf58596e035d473f3a125fdd1485593146",
-   "sha256": "0nzbsby7nliq6lfm3pqbqjrd3z51k71dck9alq3kr9mvirp2vw8q"
+   "commit": "ce17a568efd3673e9d6f41438acc4023379c198e",
+   "sha256": "17yydln76w4h3c2vwhp980x8r1wrswdj7hvcsf45440q59255ids"
   },
   "stable": {
    "version": [
@@ -115723,14 +116089,14 @@
   "repo": "Fuco1/smartparens",
   "unstable": {
    "version": [
-    20241220,
-    1254
+    20250511,
+    2354
    ],
    "deps": [
     "dash"
    ],
-   "commit": "b0d935c11813bcd40f8d35bae8800e0741334c29",
-   "sha256": "1j3x0bwvgymgaxi6clasr00gwsh7vwbhysfabqxynb044m1kccq6"
+   "commit": "603325ab3d1186fb10da5c2a7ec1afb88018d792",
+   "sha256": "1d242visiid2fcshja4vw6ri94bla3wssc1hz993g3zdjzzcz78f"
   },
   "stable": {
    "version": [
@@ -117331,14 +117697,14 @@
   "repo": "ljos/sparql-mode",
   "unstable": {
    "version": [
-    20230104,
-    1113
+    20250508,
+    1044
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1f6196094ec6626722c6e03a13f6844c68f62703",
-   "sha256": "031n56bsicrw99ls49rwg4padgbh5adb97lb9gxg852x57hilivr"
+   "commit": "be606dc08d808e7d996e531d2878ce5a27ad37f4",
+   "sha256": "0i0agz819qqnrypbzb8fyxr9py3b9npg7mmii2bigksci5az2869"
   },
   "stable": {
    "version": [
@@ -117580,15 +117946,15 @@
   "repo": "Fuco1/sphinx-mode",
   "unstable": {
    "version": [
-    20220417,
-    1552
+    20250511,
+    2023
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "77ca51adf9ee877f3a8f43e744f59e650772f121",
-   "sha256": "0imv3baiy0cq4aj220l8rx4d1drsmiak7vrhbshsg9987026b8ig"
+   "commit": "038a9195b00636d38aa2fc3cf6cbff5cf84e0561",
+   "sha256": "0s51lz4v2rwck1q35dkymrzm11iz10srkq7pvzgrpmxyahmqhd97"
   },
   "stable": {
    "version": [
@@ -118171,11 +118537,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20250326,
-    2022
+    20250510,
+    121
    ],
-   "commit": "97da6f7c5b8f5fc35a647434d7af87aba01c1b23",
-   "sha256": "0s6kczjwnh2jhlrkyfzy8wc739qpgz6dij0z2bly1xs80r8aclwm"
+   "commit": "f1f8451476fa0cee6b8d06c7a540af5ed469b6b4",
+   "sha256": "1fcl7hr4q0zwfxfnjsm9rslia0431hkqk8rnwxhbs57h4r6w3jh9"
   },
   "stable": {
    "version": [
@@ -118645,11 +119011,11 @@
   "repo": "stacked-git/stgit",
   "unstable": {
    "version": [
-    20250222,
-    2041
+    20250412,
+    2135
    ],
-   "commit": "a9fd1cb3baf5ea3f7d0edb6c319a16507aa9a64c",
-   "sha256": "1876366a0vmn90sfwhzx1l7lwyhc2527yvz2lsbzj228wgi5zck2"
+   "commit": "92abf02d077bcbec00ba39d9b9bf30c089a3b586",
+   "sha256": "0hnla60x0jhmrwpg5qc0gdxgry73hjzp5cpdhqyv7r6ipn3jd8yx"
   },
   "stable": {
    "version": [
@@ -119026,11 +119392,11 @@
   "repo": "jamescherti/stripspace.el",
   "unstable": {
    "version": [
-    20250330,
-    2329
+    20250513,
+    1731
    ],
-   "commit": "70eac3a2f99feedcc3fcd03ceb3b2c51b82fb1bf",
-   "sha256": "1b1v3jkvrgk0fcdwgv1gd4fzdksrzmp69ly58ahj7df6frm4am6n"
+   "commit": "ad553e53dad42c89b8bf7225d1c60f94cba930d5",
+   "sha256": "0c59cyj2n40sbafn2qv1hfwj3y6hzdbs2whm888jrn692zbxxxvk"
   },
   "stable": {
    "version": [
@@ -119405,21 +119771,21 @@
   "repo": "kiyoka/Sumibi",
   "unstable": {
    "version": [
-    20231019,
-    1246
+    20250516,
+    1007
    ],
    "deps": [
     "deferred",
     "popup",
     "unicode-escape"
    ],
-   "commit": "d6bbc65b71f0c59a471fffe13797d1ab6cac80f8",
-   "sha256": "1fpjm1r1k4idgn6k34v5x4mprh4maa842s19p9b29mnfkslz75kn"
+   "commit": "0db077ee319340b2ba9f9fdedb503047d84c3a6e",
+   "sha256": "1aimhfhhn9x0hy2rcfj6vaq0icbqv7smfr5bd7wrgzkdb07n821i"
   },
   "stable": {
    "version": [
     2,
-    0,
+    3,
     0
    ],
    "deps": [
@@ -119427,8 +119793,8 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "d6bbc65b71f0c59a471fffe13797d1ab6cac80f8",
-   "sha256": "1fpjm1r1k4idgn6k34v5x4mprh4maa842s19p9b29mnfkslz75kn"
+   "commit": "0db077ee319340b2ba9f9fdedb503047d84c3a6e",
+   "sha256": "1aimhfhhn9x0hy2rcfj6vaq0icbqv7smfr5bd7wrgzkdb07n821i"
   }
  },
  {
@@ -119698,8 +120064,8 @@
   "repo": "isamert/swagg.el",
   "unstable": {
    "version": [
-    20240326,
-    737
+    20250413,
+    1409
    ],
    "deps": [
     "compat",
@@ -119708,8 +120074,8 @@
     "s",
     "yaml"
    ],
-   "commit": "27d5e7d06c2296cd356ac4a5b97ec84f2dabbb53",
-   "sha256": "0c7j62rd9yd9ckk28gxbh0lffamm479v1zcl7rsdircfnkixkks3"
+   "commit": "841159b8db75fd600c929e7d09c87526d94d0756",
+   "sha256": "1azw1jhnjq0sm7pfyvv74ks7ysz9h32mv6c7wspafczxcp6qwiz7"
   },
   "stable": {
    "version": [
@@ -119936,26 +120302,26 @@
   "repo": "swift-emacs/swift-mode",
   "unstable": {
    "version": [
-    20250111,
-    539
+    20250412,
+    624
    ],
    "deps": [
     "seq"
    ],
-   "commit": "2c0b2b72dc908652914b62a1e64b1d30144839ce",
-   "sha256": "06zhz1rhh2lwj12dmx4qsixwfavg3mxkp65isnxmg2bvvx4q96mi"
+   "commit": "e30b9d46e031fd25e794f00f23b6427f44f7d221",
+   "sha256": "0m4w29fhpzraixqlz36z9b0nl5g5mrvq1iasv56gcjsi0g2m1irp"
   },
   "stable": {
    "version": [
     9,
-    2,
+    3,
     0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "ab189d6e89ac4c0f776d691a41ddeaf9730260d1",
-   "sha256": "176p83c5gjm645qdvw0zcgs5l2yr68l6nyy03rs30b170yah14h6"
+   "commit": "e30b9d46e031fd25e794f00f23b6427f44f7d221",
+   "sha256": "0m4w29fhpzraixqlz36z9b0nl5g5mrvq1iasv56gcjsi0g2m1irp"
   }
  },
  {
@@ -121236,11 +121602,11 @@
   "repo": "trevdev/tangonov-theme",
   "unstable": {
    "version": [
-    20250325,
-    1357
+    20250416,
+    340
    ],
-   "commit": "eda1e6cd9bb6faeace30385648f44d2cac9c7309",
-   "sha256": "0fphhphajj2cn7l0wiyqcd2x1fh9s1jjv1g3z96dzbpkfh0zn6ra"
+   "commit": "cb62069f84c5a475b466e2cc1c252f655c673259",
+   "sha256": "1zg40smhsjnsrap4mq3vxfq8wncm1lvn2iprby2jdibrmsl66jpg"
   },
   "stable": {
    "version": [
@@ -121673,14 +122039,14 @@
   "repo": "Crandel/tempel-collection",
   "unstable": {
    "version": [
-    20241229,
-    1149
+    20250410,
+    1607
    ],
    "deps": [
     "tempel"
    ],
-   "commit": "b2fd7929bd767db9d31b2782168f91dcdc75af5b",
-   "sha256": "0m52k8fx88ry9ay6xs5xaq6j56rx2lykb1jgxmia26xyf4h5ykd9"
+   "commit": "5cb6bc6b5856c70806ff6b2f952814ff702137c6",
+   "sha256": "0h295rh21v2li8l5ldajh3nb2fvphnr5lw7s0mmhvwzxg7wk8gnl"
   }
  },
  {
@@ -122115,6 +122481,21 @@
    ],
    "commit": "f824d634aef3600cb7a8e2ddf9e8444c6607c160",
    "sha256": "150xvmr5vsydg0197m1k62mwy2810mzh1iwqj9yl9fg47fbzbg0i"
+  }
+ },
+ {
+  "ename": "termint",
+  "commit": "f427e7fc6e81e4b9d776448a42ab2483c34b893d",
+  "sha256": "0320hfg3smvjvx9yaca2s725q7y7f27lnxnawh4rm9kp9kb2abar",
+  "fetcher": "github",
+  "repo": "milanglacier/termint.el",
+  "unstable": {
+   "version": [
+    20250428,
+    1400
+   ],
+   "commit": "156af0ecd08b7ae26a516a7d20721659621b78dc",
+   "sha256": "07sqc5c4nq5mp5rhpmp8rymjyazg3m427zdjbgkrckg4snh3jkxq"
   }
  },
  {
@@ -122874,21 +123255,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20250330,
-    1638
+    20250512,
+    1242
    ],
-   "commit": "eeb175ae401943d897d20d66fbc2f17d3aff23ae",
-   "sha256": "0y9x0633gy6bq3lxyp0kl5phyzwvyyvmfzqzqc49avl8aib1qazn"
+   "commit": "fb526469d6a6cd85fed2fea4a274479eeee1062a",
+   "sha256": "0n79yh3yh837d5lnj3f98ldg1rzvncqi07z3y7m15kl7361dz86k"
   },
   "stable": {
    "version": [
     2025,
-    3,
-    31,
+    5,
+    12,
     0
    ],
-   "commit": "eeb175ae401943d897d20d66fbc2f17d3aff23ae",
-   "sha256": "0y9x0633gy6bq3lxyp0kl5phyzwvyyvmfzqzqc49avl8aib1qazn"
+   "commit": "fb526469d6a6cd85fed2fea4a274479eeee1062a",
+   "sha256": "0n79yh3yh837d5lnj3f98ldg1rzvncqi07z3y7m15kl7361dz86k"
   }
  },
  {
@@ -123278,11 +123659,11 @@
   "repo": "aimebertrand/timu-caribbean-theme",
   "unstable": {
    "version": [
-    20250320,
-    125
+    20250411,
+    23
    ],
-   "commit": "5b0b96b5aa2407c9a071fe7eb96c09e9327d702f",
-   "sha256": "0fi7ddnd9rswhsc89w0hc501105gi2w7wz3fa2vml1swqpmym4zg"
+   "commit": "ae8fbab1c3fbb14ca797b0207c45d723d7d25b22",
+   "sha256": "0grg522v4d4affk3s4zh4nzh1d7qmhaw9x1sdi3waki9i3zsn7wn"
   },
   "stable": {
    "version": [
@@ -123324,19 +123705,19 @@
   "repo": "aimebertrand/timu-macos-theme",
   "unstable": {
    "version": [
-    20250320,
-    125
+    20250409,
+    41
    ],
-   "commit": "437a52fa460dbcbc51c82006c9d9db88a8916a71",
-   "sha256": "1b385w8wwrikz4mpp3lv6vpwsb9z9hy55pk0957gl4b2b2whpdnh"
+   "commit": "48bf3f4f011efaa0392bd93d7e4d0acd0c159bcb",
+   "sha256": "196rcv3zjpsb5vpwd4rv4dlds9xbx02jrl3hjinqqjx6xs43bpkd"
   },
   "stable": {
    "version": [
     1,
-    6
+    7
    ],
-   "commit": "f5810cd705ae7e8c82894847fbbce9eb9556b53f",
-   "sha256": "0m1j8a6pb77l9v03myw6a6lv8vxl2539nmccgz4shjpn63lmw885"
+   "commit": "699df447695f82b576e9ce9ccb633319b6d5bfc3",
+   "sha256": "196rcv3zjpsb5vpwd4rv4dlds9xbx02jrl3hjinqqjx6xs43bpkd"
   }
  },
  {
@@ -123347,19 +123728,19 @@
   "repo": "aimebertrand/timu-rouge-theme",
   "unstable": {
    "version": [
-    20250320,
-    124
+    20250411,
+    36
    ],
-   "commit": "20aa8cee01e52fcd22549585cf4a918437893243",
-   "sha256": "0qgvhk04nbmx55i1pjpgr1ypdgmrbcy441bd010macpnrq4pkwqi"
+   "commit": "a9f396ee77c18c1df79b52389e203850446fce56",
+   "sha256": "13xjmklzsa8ls81r6j2r2lf0dpx40jsklz2ljdsh8igv85vz9kp8"
   },
   "stable": {
    "version": [
-    1,
-    9
+    2,
+    0
    ],
-   "commit": "87117f15ea5fcfacbbad23ea6f345d18c2ff0009",
-   "sha256": "1w67jy0vqmdqq1k2jj60nya8jiwy4kadzyyq534ic9iy9gb4rjan"
+   "commit": "a9f396ee77c18c1df79b52389e203850446fce56",
+   "sha256": "13xjmklzsa8ls81r6j2r2lf0dpx40jsklz2ljdsh8igv85vz9kp8"
   }
  },
  {
@@ -123370,19 +123751,19 @@
   "repo": "aimebertrand/timu-spacegrey-theme",
   "unstable": {
    "version": [
-    20250320,
-    124
+    20250410,
+    2248
    ],
-   "commit": "41b599c60a82ca31b1fbb67ad23203c1dfbefb65",
-   "sha256": "1h6026y1ir94m4kslpxhyqf13lr8ipqj62dff0wg0cg27p3s28y6"
+   "commit": "a90616ae0b110920c8be134cb7ffacee75552ac7",
+   "sha256": "1zh40hgw93lssk3f3k8h3jc0jglgsvm19h9a2151y0sv40fpi6as"
   },
   "stable": {
    "version": [
-    2,
-    9
+    3,
+    0
    ],
-   "commit": "0505a7c0d306632972f29e584e83e0cd58eba2ce",
-   "sha256": "0k4jpfc9m6834gng6w4zab8jh0d4i3dh5yvn89mlznsb9r9d6148"
+   "commit": "a90616ae0b110920c8be134cb7ffacee75552ac7",
+   "sha256": "1zh40hgw93lssk3f3k8h3jc0jglgsvm19h9a2151y0sv40fpi6as"
   }
  },
  {
@@ -123853,6 +124234,30 @@
   }
  },
  {
+  "ename": "tomlparse",
+  "commit": "efe3889c591ea409b56945fadce409e4e87e03ef",
+  "sha256": "1lk99kyah1hj9b7j8dwaik0892pi44mnpx995nxcp3s2f6fsswap",
+  "fetcher": "github",
+  "repo": "johannes-mueller/tomlparse.el",
+  "unstable": {
+   "version": [
+    20250512,
+    1937
+   ],
+   "commit": "637acb0a1e410b4db9ebe91598fb782c8e6c5ee9",
+   "sha256": "15l6z2xhd7p168plcr0bh16vjq1fz92blgam7zjs90301mq32kay"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "637acb0a1e410b4db9ebe91598fb782c8e6c5ee9",
+   "sha256": "15l6z2xhd7p168plcr0bh16vjq1fz92blgam7zjs90301mq32kay"
+  }
+ },
+ {
   "ename": "tommyh-theme",
   "commit": "da9b40184e1559c33edd5e6dac6447013710cb79",
   "sha256": "0nb9r407h08yxxdihxqx0c645bcz6qywbh2l654s3zfzdsqi1aj4",
@@ -123875,11 +124280,11 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20250331,
-    1758
+    20250408,
+    1812
    ],
-   "commit": "c7fb285218c685972f48a43a82247eddd3da8102",
-   "sha256": "0g9r17rj571sh7jmdjl8g66y3lhc3ssjfrhaf81piscnxbq0myfa"
+   "commit": "f5e18450e1d1f10dcc5a607f0e3fe82339755992",
+   "sha256": "0sanaq38q5kdpkbaq738izlgqq5rqnf9y4imz0b36vcgfay3qykb"
   },
   "stable": {
    "version": [
@@ -124033,6 +124438,21 @@
    ],
    "commit": "58a9fb0ffca63e3dfb3b27c7d91b4630e422903b",
    "sha256": "0ajbqrkg3v0yn8mj7dsv12w9zzcwjkabd776fabxamhcj6zbvza3"
+  }
+ },
+ {
+  "ename": "total-recall",
+  "commit": "3467337b09004515a0c0bf7ab7ba9d0de0a79bcf",
+  "sha256": "0s853fccyk23b8wp74kdq2b0i34v93mbrhznrl6rpalza8syjwhp",
+  "fetcher": "github",
+  "repo": "phf-1/total-recall",
+  "unstable": {
+   "version": [
+    20250511,
+    614
+   ],
+   "commit": "e37874a7b78d172ad8c777cb11b16b2c134015c4",
+   "sha256": "0a6pa09s083mcy89lx28drbr22cjbjlj2pn0ziida6y3c28izf4h"
   }
  },
  {
@@ -124270,19 +124690,19 @@
   "repo": "emacs-circe/circe",
   "unstable": {
    "version": [
-    20240225,
-    1112
+    20250421,
+    1753
    ],
-   "commit": "6f33a481af6bce68f55b9e25d5c14c1ed46fa9d9",
-   "sha256": "026dvi4v1dghfv3f2g15h8xz69an3l352kn5krcr6cb4s510b5qm"
+   "commit": "9d9f63fd7cf8812797eb0ef77d7969e7387a9eb9",
+   "sha256": "12vq5p3bmqp4gh4s40s8sbz8hs2zczkcl4zfnn7ybr5sc36g1zax"
   },
   "stable": {
    "version": [
     2,
-    13
+    14
    ],
-   "commit": "6f33a481af6bce68f55b9e25d5c14c1ed46fa9d9",
-   "sha256": "026dvi4v1dghfv3f2g15h8xz69an3l352kn5krcr6cb4s510b5qm"
+   "commit": "9d9f63fd7cf8812797eb0ef77d7969e7387a9eb9",
+   "sha256": "12vq5p3bmqp4gh4s40s8sbz8hs2zczkcl4zfnn7ybr5sc36g1zax"
   }
  },
  {
@@ -124420,28 +124840,28 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20250401,
-    1655
+    20250516,
+    1031
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "afc88b24e4faa5c7e246303648e70b4507652f32",
-   "sha256": "1p3l2j1jrs39j1arzhczwi1ndcqmj5wvbq0y88brk3srzkwj69dr"
+   "commit": "41b6e06cf56c029465fae72dc4c6e16cfd304e47",
+   "sha256": "0kcpmldszriwlkrlspphnd06bhgmwj205pyzap624wa32g7hkn31"
   },
   "stable": {
    "version": [
     0,
     8,
-    7
+    8
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "afc88b24e4faa5c7e246303648e70b4507652f32",
-   "sha256": "1p3l2j1jrs39j1arzhczwi1ndcqmj5wvbq0y88brk3srzkwj69dr"
+   "commit": "25b994a565ce8035330b0a3071ee430c0282349e",
+   "sha256": "0m780p5g2jgnbkk3yqs6sbr27gpz0pc2xm13k9cpglclssircg86"
   }
  },
  {
@@ -124717,15 +125137,15 @@
   "repo": "tarsius/tray",
   "unstable": {
    "version": [
-    20240831,
-    2205
+    20250509,
+    1455
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "68d6fa2f2cd7d40c82af6c78b7647a585755c1d1",
-   "sha256": "1cp9fs2ijnjvf2f409i4wabzk062wl3hv9mc6ipkjgrka1rnvp93"
+   "commit": "e5a3a52d0bc821aca7aaf01e4d6f7adc052d0c32",
+   "sha256": "159r0ln2zfdsdpnh6cmhjlcfi2i6l15cq6dwmlciqm09dq9w0pyq"
   },
   "stable": {
    "version": [
@@ -124896,26 +125316,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20250206,
-    19
+    20250511,
+    737
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "2ff446b4b813543b7a90015808d38f362f039b10",
-   "sha256": "0dnm1iph0ysa797npc9flinyh7vc55lqgv7k5k2gsn3bibm85blc"
+   "commit": "becd29c756a3272bc91d09de642df99a0fca6cee",
+   "sha256": "1zfzqmrims95zb8idw138m6zra6bqqc8mj8rxs2k25phbw20biy8"
   },
   "stable": {
    "version": [
     0,
     12,
-    267
+    277
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "ddc021402295b9c5591a173e3447f8c25a2bd0a0",
-   "sha256": "1jq55zzh8jmmp5sa3fl603r823pp5vck3a65mgbbf96j9y5jrny3"
+   "commit": "becd29c756a3272bc91d09de642df99a0fca6cee",
+   "sha256": "1zfzqmrims95zb8idw138m6zra6bqqc8mj8rxs2k25phbw20biy8"
   }
  },
  {
@@ -124926,14 +125346,14 @@
   "repo": "purplg/treebundel",
   "unstable": {
    "version": [
-    20240531,
-    2321
+    20250515,
+    2241
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b0a5d1bf924d8cadde5bae50b8d9ac131279b828",
-   "sha256": "0smcnpmchm6kgxbdirfw6y17ad4innppab4xzpvvnixhnqbnr655"
+   "commit": "5c98d9aac3b3859bdfb490436dd8225aaa6f5ae9",
+   "sha256": "1d510k2cydlslb8ws8zhdmca3vvmnawwgaa2dp5ljq04r71aals9"
   },
   "stable": {
    "version": [
@@ -124992,8 +125412,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20250322,
-    1303
+    20250423,
+    2024
    ],
    "deps": [
     "ace-window",
@@ -125005,8 +125425,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "96a808f06760ec8c595d27eb5c991ea905c948f6",
-   "sha256": "0wqrv7nvz6jjq9kw104wz6jj1pawdkz7fxpgi6785grn08r3m4m9"
+   "commit": "820b09db106a48db76d95e3a266d1e67ae1b6bdb",
+   "sha256": "1gmp3dvji3ank0qh0fhygla2iy9pc2pg07d342wzs1mysgcdj2l8"
   },
   "stable": {
    "version": [
@@ -127050,14 +127470,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20250331,
-    1141
+    20250515,
+    652
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "d7b1e74010c732c721d96d4d1adf964d31aded2f",
-   "sha256": "0qb0xbpgbjqk4mmail99r9lxbvmqcbgi5s35bzg8baxqh0dlrqzf"
+   "commit": "1d95cda103cdb3eaba18c39598472b88d1792663",
+   "sha256": "1ab28yhqwp0w635swxl9n6n6bmknkzw49q8nddasyyaydmjslwgv"
   }
  },
  {
@@ -127550,11 +127970,11 @@
   "repo": "ursalang/ursa-ts-mode",
   "unstable": {
    "version": [
-    20240927,
-    1611
+    20250407,
+    1303
    ],
-   "commit": "9d2b4059511979fb9d09b3287b8fc64b510adbd1",
-   "sha256": "115f1caaxgqfngpmpbpkx5hcjpyj3n3h5wvvk4ypaffc2m4k1b7y"
+   "commit": "25dd8c309ad9433a5bb57b47b947447c420efb77",
+   "sha256": "02nkfaz8wwb3fywvig21br7m4rd6xk7gz04izv6vya9fsybphd2a"
   },
   "stable": {
    "version": [
@@ -127766,11 +128186,11 @@
   "repo": "ideasman42/emacs-utimeclock",
   "unstable": {
    "version": [
-    20240421,
-    702
+    20250421,
+    1055
    ],
-   "commit": "c4df85ac38b270628c4dacd9f6fb1da197f5aedd",
-   "sha256": "0fjws4y6njbcbz36kv5d85fn71026vw7ywd5vv1b4s39qzlyjqzi"
+   "commit": "179f50ea3c46ab99d7c8635ef1f8753e485ce689",
+   "sha256": "0alfr11mldchiwns7s471m7xcpabi5vq7n55pmcyg8r7i5d0qg1k"
   }
  },
  {
@@ -127867,11 +128287,11 @@
   "repo": "kborling/uwu-theme",
   "unstable": {
    "version": [
-    20250308,
-    155
+    20250416,
+    117
    ],
-   "commit": "c68f7698ebae174fd72ef7ef88b4b42829e1ee73",
-   "sha256": "0p0hgp9k92x6fc7sfg8drpzjqrlfz811vfr7grqri9a2zgbrqsbn"
+   "commit": "13baeac7649762d8d0220d954c177c5aeb1d3b1b",
+   "sha256": "0xvdax4w28rpzyb9gy7ixpdyzikfiqax8b5n04dc3xdvjrmiyyyq"
   }
  },
  {
@@ -128799,25 +129219,25 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20250318,
-    1630
+    20250516,
+    1842
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c3b788b6bea10e3493ebc05a96bbde294824cff6",
-   "sha256": "0z35pl6rn5a7f8aq7vp4vv7862miah8c0yza6843rgyri4qff6ra"
+   "commit": "54829f61034c9408cf620dac1e6af304f38d79ed",
+   "sha256": "1qh2hcddkv3cbc0wbynyk8jny43mkr2gwl7vl8dch3276w43iqri"
   },
   "stable": {
    "version": [
     2,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "026a81a9c893b1d73cdbcb12436a0fad3ebdeb5f",
-   "sha256": "0qgw0mhfrjylhyznjmjf7wqs5p3xvdv0lq19pql54plbnr6fspqk"
+   "commit": "3e1e55319fb377a59954ebce4acf772dbb5c9b10",
+   "sha256": "1cyqk67lxc7c8mzzbj9mxb10afq3ahbgpsyjdzz0hjf03qi8pbzd"
   }
  },
  {
@@ -129538,6 +129958,21 @@
   }
  },
  {
+  "ename": "votd",
+  "commit": "97bc76fa5779c6be203d9f8f492969ec576771f8",
+  "sha256": "16yil98znnvryrfihpkyjj02xwwhzm5aj6ykiq7mbp5hdg18b7lz",
+  "fetcher": "github",
+  "repo": "kristjoc/votd",
+  "unstable": {
+   "version": [
+    20250424,
+    1603
+   ],
+   "commit": "2a8e2348714f4aaf3edec20d47bbec12e6603141",
+   "sha256": "1g0ln9gh22zhc2j13bnw5j12gyahf7myz696nmqn0z7r87ji83hd"
+  }
+ },
+ {
   "ename": "vs-dark-theme",
   "commit": "094a9cbc18882daa4f2efd3d72bb0a34e6bd9f63",
   "sha256": "1rz2flacnh6h40k559l0r1vwcnx89w4j9ipp1ysnh8rzji3wl07k",
@@ -129545,11 +129980,11 @@
   "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20250211,
-    133
+    20250408,
+    452
    ],
-   "commit": "8fac750fc562f89c94bfa76ea2032f90a0cb4237",
-   "sha256": "01qi23f723574jklayig8ngvaf4gc8s24f2zy6wci3177dzgr0vq"
+   "commit": "12ba997de72db95effae672d9615e7dcba56dd9f",
+   "sha256": "1rzdvj0br5rjqs1kmvhx6wrp7jpp6nxwh82r4jk3p2qjhqkxlhxs"
   },
   "stable": {
    "version": [
@@ -129568,11 +130003,11 @@
   "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20250211,
-    133
+    20250408,
+    453
    ],
-   "commit": "3690bb3eea3863bc81e6864b3f34546d9660b86e",
-   "sha256": "120rar8gpm878jbjngz7w7g2gjap1v31amxg3v00464qkqvqhdyd"
+   "commit": "a561237f191048e505b72899b4a6c340a8e5e7f1",
+   "sha256": "0jqan8wg7fbch26ic1r328sjzd3l7w0lqcc9hf77m1qhqfpc64ja"
   },
   "stable": {
    "version": [
@@ -129777,6 +130212,25 @@
   }
  },
  {
+  "ename": "vue3-mode",
+  "commit": "56a4bae74ba5f3bd079884cddac745f92768dc00",
+  "sha256": "0ihwnkx7zb8sf97ayppvylp2hy2m44w6rzvjdznvhy8srj4p6z28",
+  "fetcher": "github",
+  "repo": "vsalvino/vue3-mode",
+  "unstable": {
+   "version": [
+    20250331,
+    1625
+   ],
+   "deps": [
+    "polymode",
+    "vue-html-mode"
+   ],
+   "commit": "a1ad84c0cc5ea100dd11aeae9b52669918830730",
+   "sha256": "109hg79556jfsgb3i23drmsgrfs34ky1jacxwq8mzc18ci2ddv00"
+  }
+ },
+ {
   "ename": "vuiet",
   "commit": "4f63056cf2f637fcb3426851501eeff5e6f40bb3",
   "sha256": "0hf99rgzhi66in3lr0pl3g8g56l00zcvz1qgclfsbw1yb9ig626y",
@@ -129937,11 +130391,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20250226,
-    28
+    20250503,
+    2349
    ],
-   "commit": "dbae2cc7020be1622eb116e6b5b2d79311c1bfd5",
-   "sha256": "08aglcga9lnzzjcn2vsmdw7cfvmkrnywww00fzi66px32d56xfhb"
+   "commit": "fc0f30f96a69bae4d4c92f42bceafb8ccf2a72ec",
+   "sha256": "0imb71q2kv41l8l5kqv16anm2hir447aj5ys1irzq2ygk5h7b01g"
   }
  },
  {
@@ -130029,11 +130483,11 @@
   "repo": "darkstego/wakib-keys",
   "unstable": {
    "version": [
-    20240609,
-    1601
+    20250405,
+    1416
    ],
-   "commit": "85a96e0476d620add31e6e73481dbcf57cabc13e",
-   "sha256": "0fr70jmrcnyyl16h0k6kj3gcd50422ggqps688wa7x51dk6f9cvr"
+   "commit": "07258b0293c9f31ba11bd89298b9f90eb232a94c",
+   "sha256": "0b3a800165rx58dvvsmlvz3gkxdgnimkxzdpxxzc1msac7dccl7b"
   },
   "stable": {
    "version": [
@@ -130127,6 +130581,27 @@
   }
  },
  {
+  "ename": "wallabag",
+  "commit": "68fed6e91a9466bed7153e529ec81a5b7c778f16",
+  "sha256": "0ppndh6f4z08mnj4zzqbwabz6hqirisn7yz0grmlfcp61iingjh5",
+  "fetcher": "github",
+  "repo": "chenyanming/wallabag.el",
+  "unstable": {
+   "version": [
+    20250421,
+    1046
+   ],
+   "deps": [
+    "emacsql",
+    "gptel",
+    "request",
+    "s"
+   ],
+   "commit": "5f4da856ef31bea112c6d0491ee22339c1acd725",
+   "sha256": "19h09yklgm05nkv37325whmj7a3zippvhhzq1p5kqmp9dns7q00g"
+  }
+ },
+ {
   "ename": "wallpaper",
   "commit": "764c5b8438197d6f24113e7b3a696b8327a8d6d9",
   "sha256": "18wpj5qzac0msp9mi8511kpw6157k7dj9zvzh1y6rhd7a5nd0clg",
@@ -130211,16 +130686,16 @@
   "repo": "emacsmirror/wanderlust",
   "unstable": {
    "version": [
-    20250330,
-    1813
+    20250422,
+    1943
    ],
    "deps": [
     "apel",
     "flim",
     "semi"
    ],
-   "commit": "840bb4b137a2e35cb30f4b78437b11b852ef6389",
-   "sha256": "1g8kx22i2j9pl4xz5frf5gf6ccklwpna63jfnsxqkmvq4m2qpa88"
+   "commit": "7113fd9a8bf0aa1e9e489e8110e3b0313645e522",
+   "sha256": "0kh06cf5f6ld8nd869dsv9b58sajb179kwjg30n8vspqymnx51l5"
   }
  },
  {
@@ -130435,6 +130910,24 @@
    ],
    "commit": "b59680c1ab908b32513954034ba894dfb8564dd8",
    "sha256": "0qx92jqzsimjk92pql2h8pzhq66mqijwqgjqwp7rmq5b6k0nvx1z"
+  }
+ },
+ {
+  "ename": "weather-scout",
+  "commit": "dd2f50bb59565270066e25950c044d245d86e2f2",
+  "sha256": "13r2iv85p823kidllbz24x0lhnhraw46x26178qgqz0b9cqpmcqq",
+  "fetcher": "github",
+  "repo": "hsolg/emacs-weather-scout",
+  "unstable": {
+   "version": [
+    20250427,
+    2030
+   ],
+   "deps": [
+    "persist"
+   ],
+   "commit": "11c749204d6720a3265fe0a32dcf81777fd18455",
+   "sha256": "05agfay28bvc30nc0pwh3jvia2fmq6psv2aa5abivppqya396rrs"
   }
  },
  {
@@ -131807,11 +132300,11 @@
   "repo": "dgtized/winnow.el",
   "unstable": {
    "version": [
-    20210105,
-    1919
+    20250502,
+    1745
    ],
-   "commit": "c3beff15688481162d14ae8600f59a366bb4c829",
-   "sha256": "1clrfdhjx4570bww84iqkh5xqm2rv8ayvz1cqcq6lw1z735nd0rm"
+   "commit": "858e74314c06c060596d6e6119471deef759be4d",
+   "sha256": "1klplaqi6q3a4dxjmw19h6g2a92qp6wjj18l49is9rsks3s6rv3j"
   }
  },
  {
@@ -131946,14 +132439,14 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20241201,
-    1419
+    20250509,
+    1455
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ca902ae02972bdd6919a902be2593d8cb6bd991b",
-   "sha256": "0h21qs60qihv4p72x5wbmc0xly4g74wc25qj8m9slfbc4am9mwys"
+   "commit": "cc86ac08bdea5bbe2503ac1df3506b5e81330e16",
+   "sha256": "04sn4xk643q42xr8x6i5d36vh25rrvalsw6gdm1wq2cd4xwd4h7b"
   },
   "stable": {
    "version": [
@@ -132982,11 +133475,11 @@
   "repo": "captainflasmr/xkb-mode",
   "unstable": {
    "version": [
-    20240506,
-    904
+    20250421,
+    840
    ],
-   "commit": "b1de5233dc12749a97ad6a63d86b921bf1e33d3b",
-   "sha256": "0lhmr10k8vszfmq6s0x2vilxf15chci0lhf3990jwnl0y8x08i33"
+   "commit": "0e317a08dd665bfa8d1bbfbe23c7ca3ae0975519",
+   "sha256": "0l2jnqzn219dc7s4arbinhnpv4a4853xzwsvlfhkjkjq9p86vqnw"
   },
   "stable": {
    "version": [
@@ -133741,26 +134234,26 @@
   "repo": "zkry/yaml-pro",
   "unstable": {
    "version": [
-    20241223,
-    1723
+    20250418,
+    447
    ],
    "deps": [
     "yaml"
    ],
-   "commit": "f7706ea170de98d29b7cdd5a4f189bd038b1e27b",
-   "sha256": "0gx6sxr68bbmqv6rbs9gd4kfgw0avg2fqgbwq14n35yfgr18xc7l"
+   "commit": "dd3e14adc0f1bc9483ac32fccedceeefeb3533d9",
+   "sha256": "0pj5rnj77ia3g9bx2yhhwg971ma880j30gakdg8fx21396wx2h4v"
   },
   "stable": {
    "version": [
     1,
     3,
-    1
+    2
    ],
    "deps": [
     "yaml"
    ],
-   "commit": "f7706ea170de98d29b7cdd5a4f189bd038b1e27b",
-   "sha256": "0gx6sxr68bbmqv6rbs9gd4kfgw0avg2fqgbwq14n35yfgr18xc7l"
+   "commit": "dd3e14adc0f1bc9483ac32fccedceeefeb3533d9",
+   "sha256": "0pj5rnj77ia3g9bx2yhhwg971ma880j30gakdg8fx21396wx2h4v"
   }
  },
  {
@@ -133960,14 +134453,14 @@
   "repo": "joaotavora/yasnippet",
   "unstable": {
    "version": [
-    20250112,
-    1504
+    20250403,
+    1926
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "03b1b11547eab76851574eadd18e2ad186b2a080",
-   "sha256": "14rmv13110x9ljj1kf3qji1dl7rgag88chrqkvh21w0q0cil4miz"
+   "commit": "2384fe1655c60e803521ba59a34c0a7e48a25d06",
+   "sha256": "118iv62izrdrwvhndhfq5ywgdrv2gsl53623sqw69w1gln17v31h"
   },
   "stable": {
    "version": [
@@ -134008,14 +134501,14 @@
   "repo": "AndreaCrotti/yasnippet-snippets",
   "unstable": {
    "version": [
-    20250225,
-    950
+    20250507,
+    2002
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "46945ccf63122190dc564af4ec26f828eaa29b43",
-   "sha256": "0ab7b033lvvh6ijzg9y27wbhzwcqyp0829jzn5fqy63m7a4lwihy"
+   "commit": "48e968d555afe8bf64829da364d5c8915980cc32",
+   "sha256": "04w2lk4y7x47b6rc4a2z3rypxy5n2sln6p8hr0wh4msfq11iy4wx"
   },
   "stable": {
    "version": [
@@ -134830,14 +135323,14 @@
   "repo": "Vidianos-Giannitsis/zetteldesk.el",
   "unstable": {
    "version": [
-    20230517,
-    2020
+    20250405,
+    1601
    ],
    "deps": [
     "org-roam"
    ],
-   "commit": "73f691989c094ec196bb614318ae51b60209a8de",
-   "sha256": "1p0609v6510miaa7x10va0sa1ggnd9r6i48hrw2i98sv2lnpxpva"
+   "commit": "0196835c5d6df65d46a4f642b716e6901ad0f4c1",
+   "sha256": "16s3mllq6l0h04a467k4rb0pp3i17dbmrcy9xhrs2mxxsczpbw1z"
   },
   "stable": {
    "version": [
@@ -134860,14 +135353,14 @@
   "repo": "Vidianos-Giannitsis/zetteldesk.el",
   "unstable": {
    "version": [
-    20230517,
-    2020
+    20250405,
+    1601
    ],
    "deps": [
     "zetteldesk"
    ],
-   "commit": "73f691989c094ec196bb614318ae51b60209a8de",
-   "sha256": "1p0609v6510miaa7x10va0sa1ggnd9r6i48hrw2i98sv2lnpxpva"
+   "commit": "0196835c5d6df65d46a4f642b716e6901ad0f4c1",
+   "sha256": "16s3mllq6l0h04a467k4rb0pp3i17dbmrcy9xhrs2mxxsczpbw1z"
   },
   "stable": {
    "version": [
@@ -134890,16 +135383,16 @@
   "repo": "Vidianos-Giannitsis/zetteldesk.el",
   "unstable": {
    "version": [
-    20230517,
-    2020
+    20250405,
+    1601
    ],
    "deps": [
     "hydra",
     "major-mode-hydra",
     "zetteldesk"
    ],
-   "commit": "73f691989c094ec196bb614318ae51b60209a8de",
-   "sha256": "1p0609v6510miaa7x10va0sa1ggnd9r6i48hrw2i98sv2lnpxpva"
+   "commit": "0196835c5d6df65d46a4f642b716e6901ad0f4c1",
+   "sha256": "16s3mllq6l0h04a467k4rb0pp3i17dbmrcy9xhrs2mxxsczpbw1z"
   },
   "stable": {
    "version": [
@@ -134924,15 +135417,15 @@
   "repo": "Vidianos-Giannitsis/zetteldesk.el",
   "unstable": {
    "version": [
-    20230517,
-    2020
+    20250405,
+    1601
    ],
    "deps": [
     "bibtex-completion",
     "zetteldesk"
    ],
-   "commit": "73f691989c094ec196bb614318ae51b60209a8de",
-   "sha256": "1p0609v6510miaa7x10va0sa1ggnd9r6i48hrw2i98sv2lnpxpva"
+   "commit": "0196835c5d6df65d46a4f642b716e6901ad0f4c1",
+   "sha256": "16s3mllq6l0h04a467k4rb0pp3i17dbmrcy9xhrs2mxxsczpbw1z"
   },
   "stable": {
    "version": [
@@ -134956,15 +135449,15 @@
   "repo": "Vidianos-Giannitsis/zetteldesk.el",
   "unstable": {
    "version": [
-    20230517,
-    2020
+    20250405,
+    1601
    ],
    "deps": [
     "org-remark",
     "zetteldesk"
    ],
-   "commit": "73f691989c094ec196bb614318ae51b60209a8de",
-   "sha256": "1p0609v6510miaa7x10va0sa1ggnd9r6i48hrw2i98sv2lnpxpva"
+   "commit": "0196835c5d6df65d46a4f642b716e6901ad0f4c1",
+   "sha256": "16s3mllq6l0h04a467k4rb0pp3i17dbmrcy9xhrs2mxxsczpbw1z"
   },
   "stable": {
    "version": [
@@ -135083,8 +135576,8 @@
   "repo": "WillForan/zim-wiki-mode",
   "unstable": {
    "version": [
-    20241020,
-    2315
+    20250425,
+    2345
    ],
    "deps": [
     "dokuwiki-mode",
@@ -135093,8 +135586,8 @@
     "link-hint",
     "pretty-hydra"
    ],
-   "commit": "8afce06846b9b8c62e7eeb2ac874ee4f68f31616",
-   "sha256": "09qijra2pfy2lrjlx7pkpqd5z1ba3ck4i6nwbyfb7cq2q0irclpx"
+   "commit": "a6ddbdfe41ddb1f445d3480801f1db0f000c31a2",
+   "sha256": "18z3h7vc1wzqlx3byp00jwhp03shs852zi8s0rp2kmrjs61svq3x"
   }
  },
  {
@@ -135123,11 +135616,11 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20241205,
-    926
+    20250405,
+    2035
    ],
-   "commit": "2bd80f73485927a081d06a754d7f299b1350c5e7",
-   "sha256": "14kszbnd0yj5y2q0ba71a0r969b6nwz8sij84h2g3aqdlnnj7f6m"
+   "commit": "38703add4740e54862e406b44e38269b7d65671d",
+   "sha256": "01yp2a7nd0v82f37b6c1kiaxfpvscg1s0kgswa5wkz5a1x7q02c9"
   },
   "stable": {
    "version": [
@@ -135177,14 +135670,14 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20241006,
-    1334
+    20250405,
+    2034
    ],
    "deps": [
     "zk"
    ],
-   "commit": "297ebd0df13c957f4ba9700cafc5466dafacc5cb",
-   "sha256": "0r6frhdpakzjrh6qhcr913jcf95ncbs0rsfdgkrka5d5gkrdds41"
+   "commit": "181e2ed7206fd168e8eca315a63e90871bb7562f",
+   "sha256": "03q344pjycp6nz9sraby5r0iscpv6y8pqps6ym60z920scadyyap"
   },
   "stable": {
    "version": [
@@ -135206,15 +135699,15 @@
   "repo": "localauthor/zk-luhmann",
   "unstable": {
    "version": [
-    20240926,
-    1827
+    20250406,
+    844
    ],
    "deps": [
     "zk",
     "zk-index"
    ],
-   "commit": "fef5cace6ac12a86ba9a8d4abc80e87699966f8c",
-   "sha256": "011mg8wpgw6wzmrqbyfvxsqlm0jw91p2jpr5nw64zpb5dvaq5bxy"
+   "commit": "1fe0d9053b603037898530ae8aa6361c4e409e46",
+   "sha256": "1gphp973a4msciy0xcfpkw8nmdvn23d5chg7qjqq7a93rpyx3qir"
   }
  },
  {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- emacs-overlay commit: 59c04dd982a4af9dbf5180da5fcb10b0333bfa7f
- [hydra](https://hydra.nix-community.org/eval/434928?filter=x86_64-linux.unstable.packages.)
- new failed toplevel builds:
  - [X] [emacs-stgit-20250412.2135](https://hydra.nix-community.org/build/5459852): reported to [upstream](https://github.com/stacked-git/stgit/issues/560)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
