### PR TITLE
makeHardcodeGsettingsPatch: Fix `schemaExistsFunction` w/o stdbool.h

### DIFF
--- a/pkgs/build-support/make-hardcode-gsettings-patch/hardcode-gsettings.cocci
+++ b/pkgs/build-support/make-hardcode-gsettings-patch/hardcode-gsettings.cocci
@@ -162,4 +162,4 @@ expression SCHEMA_ID;
 identifier schema_exists_fn.fn;
 @@
 -fn(SCHEMA_ID)
-+true
++TRUE

--- a/pkgs/test/make-hardcode-gsettings-patch/fixtures/example-project-patched-with-exists-fn/main.c
+++ b/pkgs/test/make-hardcode-gsettings-patch/fixtures/example-project-patched-with-exists-fn/main.c
@@ -74,7 +74,7 @@ void schema_id_with_path() {
 }
 
 void exists_fn_guard() {
-  if (!true) {
+  if (!TRUE) {
     return;
   }
 
@@ -89,7 +89,7 @@ void exists_fn_guard() {
 }
 
 void exists_fn_nested() {
-  if (true) {
+  if (TRUE) {
     g_autoptr(GSettings) settings = NULL;
     {
       g_autoptr(GSettingsSchemaSource) schema_source;
@@ -102,7 +102,7 @@ void exists_fn_nested() {
 }
 
 void exists_fn_unknown() {
-  if (true) {
+  if (TRUE) {
     g_autoptr(GSettings) settings = NULL;
     {
       g_autoptr(GSettingsSchemaSource) schema_source;


### PR DESCRIPTION
If project uses C and does not include `stdbool.h`, it will not have available lowercase booleans. However, since this tool targets GLib programs, we can rely on uppercase constants defined by GLib.

Noticed in: https://github.com/NixOS/nixpkgs/pull/407740

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
