### PR TITLE
nixos/systemd: unconditional systemd-journald-audit.socket

### DIFF
--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -116,22 +116,19 @@ in
   };
 
   config = {
-    systemd.additionalUpstreamSystemUnits =
-      [
-        "systemd-journald.socket"
-        "systemd-journald@.socket"
-        "systemd-journald-varlink@.socket"
-        "systemd-journald.service"
-        "systemd-journald@.service"
-        "systemd-journal-flush.service"
-        "systemd-journal-catalog-update.service"
-        "systemd-journald-sync@.service"
-      ]
-      ++ (lib.optional (!config.boot.isContainer) "systemd-journald-audit.socket")
-      ++ [
-        "systemd-journald-dev-log.socket"
-        "syslog.socket"
-      ];
+    systemd.additionalUpstreamSystemUnits = [
+      "systemd-journald.socket"
+      "systemd-journald@.socket"
+      "systemd-journald-varlink@.socket"
+      "systemd-journald.service"
+      "systemd-journald@.service"
+      "systemd-journal-flush.service"
+      "systemd-journal-catalog-update.service"
+      "systemd-journald-sync@.service"
+      "systemd-journald-audit.socket"
+      "systemd-journald-dev-log.socket"
+      "syslog.socket"
+    ];
 
     systemd.sockets.systemd-journald-audit.wantedBy = [
       "systemd-journald.service"

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -12,11 +12,17 @@ import ./make-test-python.nix (
     };
     nodes.auditd = {
       security.auditd.enable = true;
+      security.audit.enable = true;
       environment.systemPackages = [ pkgs.audit ];
+      boot.kernel.sysctl."kernel.printk_ratelimit" = 0;
+      boot.kernelParams = [ "audit_backlog_limit=8192" ];
     };
     nodes.journaldAudit = {
       services.journald.audit = true;
+      security.audit.enable = true;
       environment.systemPackages = [ pkgs.audit ];
+      boot.kernel.sysctl."kernel.printk_ratelimit" = 0;
+      boot.kernelParams = [ "audit_backlog_limit=8192" ];
     };
 
     testScript = ''

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -24,6 +24,12 @@ import ./make-test-python.nix (
       boot.kernel.sysctl."kernel.printk_ratelimit" = 0;
       boot.kernelParams = [ "audit_backlog_limit=8192" ];
     };
+    nodes.containerCheck = {
+      containers.c1 = {
+        autoStart = true;
+        config = { };
+      };
+    };
 
     testScript = ''
       machine.wait_for_unit("multi-user.target")
@@ -56,6 +62,16 @@ import ./make-test-python.nix (
         # logs ideally should NOT end up in kmesg, but they do due to
         # https://github.com/systemd/systemd/issues/15324
         journaldAudit.succeed("journalctl _TRANSPORT=kernel --grep 'unit=systemd-journald'")
+
+
+      with subtest("container systemd-journald-audit not running"):
+        containerCheck.wait_for_unit("multi-user.target");
+        containerCheck.wait_until_succeeds("systemctl -M c1 is-active default.target");
+
+        # systemd-journald-audit.socket should exist but not run due to the upstream unit's `Condition*` settings
+        (status, output) = containerCheck.execute("systemctl -M c1 is-active systemd-journald-audit.socket")
+        containerCheck.log(output)
+        assert status == 3 and output == "inactive\n", f"systemd-journald-audit.socket should exist in a container but remain inactive, was {output}"
     '';
   }
 )


### PR DESCRIPTION
Containers did not have *systemd-journald-audit.socket* in *additionalUpstreamSystemUnits*, which meant that the unit was not provided. However the *wantedBy* was added without any additional check, therefore creating an empty unit with just the *WantedBy* on *boot.isContainer* machines. This caused `systemd-analyze verify` to fail:

```text
systemd-journald-audit.socket: Unit has no Listen setting (ListenStream=, ListenDatagram=, ListenFIFO=, ...). Refusing.
systemd-journald-audit.socket: Cannot add dependency job, ignoring: Unit systemd-journald-audit.socket has a bad unit file setting.
systemd-journald-audit.socket: Cannot add dependency job, ignoring: Unit systemd-journald-audit.socket has a bad unit file setting.
```

The upstream unit already contains the following, which should make it safe to include regardless:

```ini
[Unit]
ConditionSecurity=audit
ConditionCapability=CAP_AUDIT_READ
```

For reference, this popped up in the context of #[360426](https://redirect.github.com/NixOS/nixpkgs/issues/360426) as well as #[407696](https://redirect.github.com/NixOS/nixpkgs/pull/407696).

---

Above is the commit message verbatim (`redirect.github.com` links to avoid pinging issues multiple times when amending commits and all that).

Relevant pings:

- #407696
- @ElvishJerricco 
- @arianvp 
- @SuperSandro2000 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (only non-container)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
