### PR TITLE
gnomeExtensions.applications-menu: fix GMenu import

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -6,6 +6,7 @@
   easyeffects,
   gjs,
   glib,
+  gnome-menus,
   nautilus,
   gobject-introspection,
   hddtemp,
@@ -47,6 +48,17 @@ in
 # the upstream repository's sources.
 super:
 lib.trivial.pipe super [
+  (patchExtension "apps-menu@gnome-shell-extensions.gcampax.github.com" (old: {
+    patches = [
+      (replaceVars
+        ./extensionOverridesPatches/apps-menu_at_gnome-shell-extensions.gcampax.github.com.patch
+        {
+          gmenu_path = "${gnome-menus}/lib/girepository-1.0";
+        }
+      )
+    ];
+  }))
+
   (patchExtension "caffeine@patapon.info" (old: {
     meta.maintainers = with lib.maintainers; [ eperuffo ];
   }))

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/apps-menu_at_gnome-shell-extensions.gcampax.github.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/apps-menu_at_gnome-shell-extensions.gcampax.github.com.patch
@@ -1,0 +1,17 @@
+diff --git a/extension.js b/extension.js
+index c608441..2b25335 100644
+--- a/extension.js
++++ b/extension.js
+@@ -9,7 +9,11 @@ import Atk from 'gi://Atk';
+ import Clutter from 'gi://Clutter';
+ import Gio from 'gi://Gio';
+ import GLib from 'gi://GLib';
+-import GMenu from 'gi://GMenu';
++
++import GIRepository from 'gi://GIRepository';
++GIRepository.Repository.prepend_search_path('@gmenu_path@');
++const {default: GMenu} = await import('gi://GMenu');
++
+ import GObject from 'gi://GObject';
+ import Gtk from 'gi://Gtk';
+ import Meta from 'gi://Meta';


### PR DESCRIPTION
ZHF: #403336

Fixes [nixos.tests.gnome-extensions.x86_64-linux](https://hydra.nixos.org/build/297119729), which was failing with the following message `Error: Requiring GMenu, version none: Typelib file for namespace 'GMenu' (any version) not found`.

As such, I replaced the import of `gi://GMenu` with code that correctly locates the dependency.

I followed the approach taken in [pkgs/desktops/gnome/extensions/arcmenu/fix_gmenu.patch](https://github.com/NixOS/nixpkgs/blob/593fa724e2a84fe3ec13e781b99ac1dd60946dae/pkgs/desktops/gnome/extensions/arcmenu/fix_gmenu.patch) and [pkgs/by-name/gn/gnome-shell-extensions/fix_gmenu.patch](https://github.com/NixOS/nixpkgs/blob/593fa724e2a84fe3ec13e781b99ac1dd60946dae/pkgs/by-name/gn/gnome-shell-extensions/fix_gmenu.patch).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
