### PR TITLE
karlyriceditor: init at 3.3

### DIFF
--- a/pkgs/by-name/ka/karlyriceditor/package.nix
+++ b/pkgs/by-name/ka/karlyriceditor/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  qt6,
+  ffmpeg_4,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "karlyriceditor";
+  version = "3.3";
+
+  src = fetchFromGitHub {
+    owner = "gyunaev";
+    repo = "karlyriceditor";
+    rev = finalAttrs.version;
+    hash = "sha256-i4uZtHxnreow7a5ZX6WCXMUSwgkUJS/1oDCJOgfFjHw=";
+  };
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+    qt6.qmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    ffmpeg_4
+    qt6.qtmultimedia
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bin/karlyriceditor $out/bin/karlyriceditor
+    install -Dm644 packages/karlyriceditor.desktop $out/share/applications/karlyriceditor.desktop
+    install -Dm644 packages/karlyriceditor.png $out/share/pixmaps/karlyriceditor.png
+
+    substituteInPlace $out/share/applications/karlyriceditor.desktop \
+      --replace-fail 'Icon=/usr/share/pixmaps/karlyriceditor.png' 'Icon=karlyriceditor'
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Edit and synchronize lyrics with karaoke songs in various formats";
+    homepage = "https://github.com/gyunaev/karlyriceditor";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      DPDmancul
+    ];
+    mainProgram = "karlyricseditor";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adding a new package: [Karaoke Lyric Editor](https://github.com/gyunaev/karlyriceditor).

This  program lets you edit and synchronize lyrics with karaoke songs in various formats. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
