### PR TITLE
replace-workspace-values.py: Update cargo.toml on only lints replace

### DIFF
--- a/pkgs/build-support/rust/replace-workspace-values.py
+++ b/pkgs/build-support/rust/replace-workspace-values.py
@@ -123,6 +123,7 @@ def main() -> None:
         and crate_manifest["lints"]["workspace"] is True
     ):
         crate_manifest["lints"] = workspace_manifest["lints"]
+        changed = True
 
     if not changed:
         return

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate_lints.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate_lints.toml
@@ -1,0 +1,15 @@
+[package]
+name = "im_using_workspaces"
+version = { workspace = true }
+publish = false
+keywords = [
+    "workspace",
+    "other_thing",
+    "third_thing",
+]
+
+[lints]
+workspace = true
+
+[dependencies]
+bar = "1.0.0"

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/default.nix
@@ -4,4 +4,8 @@ runCommand "git-dependency-workspace-inheritance-test" { } ''
   cp --no-preserve=mode ${./crate.toml} "$out"
   ${replaceWorkspaceValues} "$out" ${./workspace.toml}
   diff -u "$out" ${./want.toml}
+
+  cp --no-preserve=mode ${./crate_lints.toml} "$out"
+  ${replaceWorkspaceValues} "$out" ${./workspace.toml}
+  diff -u "$out" ${./want_lints.toml}
 ''

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want_lints.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want_lints.toml
@@ -1,0 +1,15 @@
+[package]
+name = "im_using_workspaces"
+version = "1.0.0"
+publish = false
+keywords = [
+    "workspace",
+    "other_thing",
+    "third_thing",
+]
+
+[lints]
+dbg_macro = "warn"
+
+[dependencies]
+bar = "1.0.0"

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/workspace.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/workspace.toml
@@ -3,3 +3,6 @@ version = "1.0.0"
 
 [workspace.dependencies]
 foo = { version = "1.0.0", features = ["meow"] }
+
+[workspace.lints]
+dbg_macro = "warn"


### PR DESCRIPTION
`replace-workspace-values.py` was missing a `changed = True` when it updated the lints section causing it to not write back the cargo.toml file when it _only_ changed the lints.

Example project that showed this issue is https://github.com/PyO3/pyo3/blob/main/pyo3-ffi/Cargo.toml#L49 when running this script locally against this crate with the original version it did not update the cargo.toml causing downstream build failures when using this in a vendored cargo build.

## Things done

Tested against `pyo3-ffi` locally via manually applying the script against it to show that it produced a valid Cargo.toml. `nixpkgs-review` seems like it wants to build a lot of packages so I will need to get to that in a few days when I have a more powerful machine at hand.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
