### PR TITLE
geteduroam: init at 0.10

### DIFF
--- a/pkgs/by-name/ge/geteduroam/package.nix
+++ b/pkgs/by-name/ge/geteduroam/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  symlinkJoin,
+  versionCheckHook,
+  makeWrapper,
+  wrapGAppsHook4,
+  cairo,
+  gdk-pixbuf,
+  glib,
+  graphene,
+  gtk4,
+  libadwaita,
+  pango,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "geteduroam";
+  version = "0.10";
+
+  src = fetchFromGitHub {
+    owner = "geteduroam";
+    repo = "linux-app";
+    tag = finalAttrs.version;
+    hash = "sha256-Mtzt6i8vJ5M8T0vrAOxXhawlhCmCMEnDQz0Jo6uV88A=";
+  };
+
+  vendorHash = "sha256-b06wnqT88J7etNTFJ6nE9Uo0gOQOGvvs0vPNnJr6r4Q=";
+
+  subPackages = [
+    "cmd/geteduroam-gui"
+    "cmd/geteduroam-notifcheck"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/geteduroam-gui \
+      --set-default PUREGOTK_LIB_FOLDER ${finalAttrs.passthru.libraryPath}/lib \
+      ''${gappsWrapperArgs[@]}
+
+    # copy notifcheck service
+    mkdir -p $out/lib/systemd/system/
+    cp -v systemd/user/geteduroam/* $out/lib/systemd/system/
+    substituteInPlace $out/lib/systemd/system/geteduroam-notifs.service \
+      --replace-fail \
+        "ExecStart=/usr/bin/geteduroam-notifcheck" \
+        "ExecStart=$out/bin/geteduroam-notifcheck"
+
+    # copy icons and desktop entries
+    cp -r cmd/geteduroam-gui/resources/share $out/
+  '';
+
+  nativeBuildInputs = [
+    wrapGAppsHook4
+    makeWrapper
+  ];
+
+  dontWrapGApps = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/geteduroam-gui";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru = {
+    libraryPath = symlinkJoin {
+      name = "eduroam-gui-puregotk-lib";
+      # based on https://github.com/jwijenbergh/puregotk/blob/bc1a52f44fd4c491947f7af85296c66173da17ba/internal/core/core.go#L41
+      paths = [
+        cairo
+        gdk-pixbuf
+        glib.out
+        graphene
+        gtk4
+        libadwaita
+        pango.out
+      ];
+    };
+  };
+
+  meta = {
+    description = "GUI client to configure eduroam";
+    homepage = "https://eduroam.app";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ pbsds ];
+    platforms = lib.platforms.linux;
+    changelog = "https://github.com/geteduroam/linux-app/releases/tag/${finalAttrs.version}";
+    mainProgram = "geteduroam-gui";
+  };
+})


### PR DESCRIPTION
I initially planned to call the package `geteduroam-gui` due to the pre-existing `geteduroam-cli`, but then i discovered the [AUR package](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=geteduroam), using the simpler name.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
