### PR TITLE
python3Packages.langchain-community: 0.3.22 -> 0.3.24

### DIFF
--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -23,6 +23,8 @@
 
   # tests
   blockbuster,
+  duckdb,
+  duckdb-engine,
   httpx,
   langchain-tests,
   lark,
@@ -38,14 +40,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-community";
-  version = "0.3.22";
+  version = "0.3.24";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
-    repo = "langchain";
-    tag = "langchain-community==${version}";
-    hash = "sha256-fotu3vUCWnAVyjFjsIUjk1If81yQ3/YLj26PksmnvGE=";
+    repo = "langchain-community";
+    tag = "libs/community/v${version}";
+    hash = "sha256-4Rcczuz7tCb10HPvO15n48DBKjVBLXNPdRfD4lRKNGk=";
   };
 
   sourceRoot = "${src.name}/libs/community";
@@ -62,6 +64,10 @@ buildPythonPackage rec {
     "tenacity"
   ];
 
+  pythonRemoveDeps = [
+    "bs4"
+  ];
+
   dependencies = [
     aiohttp
     dataclasses-json
@@ -76,10 +82,13 @@ buildPythonPackage rec {
     sqlalchemy
     tenacity
   ];
+
   pythonImportsCheck = [ "langchain_community" ];
 
   nativeCheckInputs = [
     blockbuster
+    duckdb
+    duckdb-engine
     httpx
     langchain-tests
     lark
@@ -93,29 +102,18 @@ buildPythonPackage rec {
     toml
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  pytestFlagsArray = [
+    "tests/unit_tests"
+  ];
 
   __darwinAllowLocalNetworking = true;
 
   disabledTests = [
-    # Test require network access
-    "test_ovhcloud_embed_documents"
-    "test_yandex"
-    "test_table_info"
-    "test_sql_database_run"
-    # pydantic.errors.PydanticUserError: `SQLDatabaseToolkit` is not fully defined; you should define `BaseCache`, then call `SQLDatabaseToolkit.model_rebuild()`.
-    "test_create_sql_agent"
-    # pydantic.errors.PydanticUserError: `NatBotChain` is not fully defined; you should define `BaseCache`, then call `NatBotChain.model_rebuild()`.
-    "test_proper_inputs"
-    # pydantic.errors.PydanticUserError: `NatBotChain` is not fully defined; you should define `BaseCache`, then call `NatBotChain.model_rebuild()`.
-    "test_variable_key_naming"
-    # Tests against magic values in dict
-    "test_serializable_mapping"
+    # requires bs4, aka BeautifulSoup
+    "test_importable_all"
   ];
 
   disabledTestPaths = [
-    # ValueError: Received unsupported arguments {'strict': None}
-    "tests/unit_tests/chat_models/test_cloudflare_workersai.py"
     # depends on Pydantic v1 notations, will not load
     "tests/unit_tests/document_loaders/test_gitbook.py"
   ];
@@ -123,14 +121,14 @@ buildPythonPackage rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "langchain-community==([0-9.]+)"
+      "libs/community/v([0-9.]+)"
     ];
   };
 
   meta = {
-    changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-community==${version}";
     description = "Community contributed LangChain integrations";
-    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/community";
+    homepage = "https://github.com/langchain-ai/langchain-community";
+    changelog = "https://github.com/langchain-ai/langchain-community/releases/tag/libs%2Fcommunity%2fv${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       natsukium


### PR DESCRIPTION
* langchain-community switched to a new repository:
  * Switched to using new repo
  * Fixed `updateScript` regex
  * Fixed homepage link
  * Bumped version (original version wasn't available in this repo)
* Audited the tests
  * Commented out `disabledTests`/`disabledTestPaths` and discovered what was still failing
  * Added test dependencies as needed
  * Disabled the `bs4` dependency (beautiful soup) and a single test.
  * Disabled remaining breaking test.

changelog: https://github.com/langchain-ai/langchain-community/releases/tag/libs%2Fcommunity%2Fv0.3.24

diff: n/a

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
