### PR TITLE
wikiman: 2.13.2 -> 2.14.1

### DIFF
--- a/pkgs/by-name/wi/wikiman/fix-paths.patch
+++ b/pkgs/by-name/wi/wikiman/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/wikiman.sh b/wikiman.sh
-index 89a436e..adc6510 100755
+index 994c0b7..49bfc4b 100755
 --- a/wikiman.sh
 +++ b/wikiman.sh
-@@ -46,38 +46,7 @@ if printenv WIKIMAN_TUI_PREVIEW >/dev/null; then
+@@ -50,38 +50,7 @@ if printenv WIKIMAN_TUI_PREVIEW >/dev/null; then
  fi
  
  init() {
@@ -22,23 +22,23 @@ index 89a436e..adc6510 100755
 -		*)
 -			case "$(dirname "$(command -v wikiman)")" in
 -				"$HOME/bin"|"$HOME/.local/bin")
--					echo 'warning: unsupported installation path, using fallback for user install' 1>&2;
+-					>&2 echo 'warning: unsupported installation path, using fallback for user install' ;
 -					conf_sys_usr="$HOME/.local/share";
 -					conf_sys_etc="${XDG_CONFIG_HOME:-"$HOME/.config"}/wikiman";;
 -				'/bin'|'/sbin'|'/usr/bin'|'/usr/sbin')
--					echo 'warning: unsupported installation path, using fallback for Linux' 1>&2;
+-					>&2 echo 'warning: unsupported installation path, using fallback for Linux' ;
 -					conf_sys_usr='/usr';
 -					conf_sys_etc='/etc';;
 -				'/usr/local/bin'|'/usr/local/sbin')
--					echo 'warning: unsupported installation path, using fallback for BSD' 1>&2;
+-					>&2 echo 'warning: unsupported installation path, using fallback for BSD' ;
 -					conf_sys_usr='/usr/local';
 -					conf_sys_etc='/usr/local/etc';;
 -				*)
--					echo 'error: unsupported installation path - failed to establish fallback' 1>&2;
+-					>&2 echo 'error: unsupported installation path - failed to establish fallback' ;
 -					exit 5;;
 -			esac;;
 -	esac
-+	conf_sys_etc="/etc/xdg/wikiman/wikiman.conf"
++	conf_sys_etc="/etc"
  
  	export conf_sys_usr
  	export conf_sys_etc

--- a/pkgs/by-name/wi/wikiman/package.nix
+++ b/pkgs/by-name/wi/wikiman/package.nix
@@ -15,13 +15,13 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "wikiman";
-  version = "2.13.2";
+  version = "2.14.1";
 
   src = fetchFromGitHub {
     owner = "filiparag";
     repo = "wikiman";
     tag = finalAttrs.version;
-    hash = "sha256-gk/9PVIRw9OQrdCSS+LcniXDYNcHUQUxZ2XGQCwpHaI=";
+    hash = "sha256-EvYMUHKFJhSFyoW85EEzI7q5OMGGe9c+A2JlkAoxt3o=";
   };
 
   patches = [ ./fix-paths.patch ];


### PR DESCRIPTION
Diff: https://github.com/filiparag/wikiman/compare/2.13.2...2.14.1
Changelog: https://github.com/filiparag/wikiman/releases/tag/2.14.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
