### PR TITLE
ps-remote-play: init at 8.0.0

### DIFF
--- a/pkgs/by-name/ps/ps-remote-play/package.nix
+++ b/pkgs/by-name/ps/ps-remote-play/package.nix
@@ -1,4 +1,14 @@
-{ stdenvNoCC, fetchurl, _7zz, cpio, xar, xcbuild, versionCheckHook, writeShellScript, lib }:
+{
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+  cpio,
+  xar,
+  xcbuild,
+  versionCheckHook,
+  writeShellScript,
+  lib,
+}:
 
 stdenvNoCC.mkDerivation {
   pname = "ps-remote-play";
@@ -19,13 +29,13 @@ stdenvNoCC.mkDerivation {
     cd $TMPDIR
     cat RemotePlay.pkg/Payload | gunzip -dc | cpio -i
     runHook postUnpack
-    '';
+  '';
   installPhase = ''
     runHook preInstall
     mkdir -p $out/Applications
     mv RemotePlay.app $out/Applications
     runHook postInstall
-    '';
+  '';
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = writeShellScript "version-check" ''
     ${xcbuild}/bin/PlistBuddy -c "Print :CFBundleShortVersionString" "$1"

--- a/pkgs/by-name/ps/ps-remote-play/package.nix
+++ b/pkgs/by-name/ps/ps-remote-play/package.nix
@@ -1,0 +1,44 @@
+{ stdenvNoCC, fetchurl, _7zz, cpio, xar, xcbuild, versionCheckHook, writeShellScript, lib }:
+
+stdenvNoCC.mkDerivation {
+  pname = "ps-remote-play";
+  version = "8.0.0";
+  src = fetchurl {
+    url = "https://remoteplay.dl.playstation.net/remoteplay/module/mac/RemotePlayInstaller.pkg";
+    sha256 = "sha256-+iyK9RcaFLqVlRZaHMGxxlMpxkGgCuP+zzW12xOjms4=";
+  };
+  buildInputs = [
+    _7zz
+    cpio
+    xar
+  ];
+  sourceRoot = ".";
+  unpackPhase = ''
+    runHook preUnpack
+    7zz x $src -o$TMPDIR
+    cd $TMPDIR
+    cat RemotePlay.pkg/Payload | gunzip -dc | cpio -i
+    runHook postUnpack
+    '';
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    mv RemotePlay.app $out/Applications
+    runHook postInstall
+    '';
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = writeShellScript "version-check" ''
+    ${xcbuild}/bin/PlistBuddy -c "Print :CFBundleShortVersionString" "$1"
+  '';
+  versionCheckProgramArg = [
+    "${placeholder "out"}/Applications/RemotePlay.app/Contents/Info.plist"
+  ];
+  doInstallCheck = true;
+  meta = with lib; {
+    homepage = "https://remoteplay.dl.playstation.net/remoteplay/lang/gb/";
+    maintainers = [ maintainers.ohheyrj ];
+    description = "PS Remote Play is a free app that lets you stream and play your PS5 or PS4 games on compatible devices like smartphones, tablets, PCs, and Macs, allowing you to game remotely over Wi-Fi or mobile data.";
+    license = licenses.unfree;
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/by-name/ps/ps-remote-play/package.nix
+++ b/pkgs/by-name/ps/ps-remote-play/package.nix
@@ -14,8 +14,8 @@ stdenvNoCC.mkDerivation {
   pname = "ps-remote-play";
   version = "8.0.0";
   src = fetchurl {
-    url = "https://remoteplay.dl.playstation.net/remoteplay/module/mac/RemotePlayInstaller.pkg";
-    sha256 = "sha256-+iyK9RcaFLqVlRZaHMGxxlMpxkGgCuP+zzW12xOjms4=";
+    url = "https://web.archive.org/web/20250519143727/https://remoteplay.dl.playstation.net/remoteplay/module/mac/RemotePlayInstaller.pkg";
+    hash = "sha256-+iyK9RcaFLqVlRZaHMGxxlMpxkGgCuP+zzW12xOjms4=";
   };
   buildInputs = [
     _7zz
@@ -44,11 +44,12 @@ stdenvNoCC.mkDerivation {
     "${placeholder "out"}/Applications/RemotePlay.app/Contents/Info.plist"
   ];
   doInstallCheck = true;
-  meta = with lib; {
+  meta = {
     homepage = "https://remoteplay.dl.playstation.net/remoteplay/lang/gb/";
-    maintainers = [ maintainers.ohheyrj ];
+    maintainers = with lib.maintainers; [ ohheyrj ];
     description = "PS Remote Play is a free app that lets you stream and play your PS5 or PS4 games on compatible devices like smartphones, tablets, PCs, and Macs, allowing you to game remotely over Wi-Fi or mobile data.";
-    license = licenses.unfree;
-    platforms = platforms.darwin;
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
 }


### PR DESCRIPTION
Added PS Remote Play application at version 8.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
