### PR TITLE
trgui-ng: init at 1.4.0-unstable-2025-05-18

### DIFF
--- a/pkgs/by-name/tr/trgui-ng-web/package.nix
+++ b/pkgs/by-name/tr/trgui-ng-web/package.nix
@@ -1,0 +1,1 @@
+{ trgui-ng }: trgui-ng.passthru.frontend

--- a/pkgs/by-name/tr/trgui-ng/package.nix
+++ b/pkgs/by-name/tr/trgui-ng/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  alsa-lib,
+  cargo-tauri,
+  dbip-country-lite,
+  glib,
+  libayatana-appindicator,
+  nodejs,
+  npmHooks,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  webkitgtk_4_1,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "TrguiNG";
+  version = "1.4.0-unstable-2025-05-18";
+
+  src = fetchFromGitHub {
+    owner = "openscopeproject";
+    repo = "TrguiNG";
+    rev = "d2cd93ecc724f196d93c701fa27afa4288d2a37c";
+    hash = "sha256-Y3ZSpXmG+wi7x7qanKpRp917alssqF78L27Yt9K9Khs=";
+  };
+
+  cargoHash = "sha256-TflzT1BNAciMcxcejrlmIOIjXc1tpm/zX0kjk+dpGiM=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-npm-deps-${finalAttrs.version}";
+    inherit (finalAttrs) src;
+    hash = "sha256-sHZHAlV3zVeCmVTlIr0NeS1zxRCKfRMv1w9bW0tOg3g=";
+  };
+
+  postPatch =
+    ''
+      cp ${dbip-country-lite}/share/dbip/dbip-country-lite.mmdb src-tauri/dbip.mmdb
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
+        --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+    '';
+
+  env.TRGUING_VERSION = finalAttrs.version;
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      openssl
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      alsa-lib
+      glib
+      libayatana-appindicator
+      webkitgtk_4_1
+    ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+
+  meta = {
+    description = "Remote GUI for Transmission torrent daemon";
+    homepage = "https://github.com/openscopeproject/TrguiNG";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ ambroisie ];
+    mainProgram = "TrguiNG";
+  };
+})

--- a/pkgs/by-name/tr/trgui-ng/package.nix
+++ b/pkgs/by-name/tr/trgui-ng/package.nix
@@ -8,6 +8,7 @@
   dbip-country-lite,
   glib,
   libayatana-appindicator,
+  nix-update-script,
   openssl,
   pkg-config,
   rustPlatform,
@@ -93,6 +94,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildAndTestSubdir = "src-tauri";
 
   passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "-s"
+        "frontend"
+      ];
+    };
     inherit frontend;
   };
 

--- a/pkgs/by-name/tr/trgui-ng/package.nix
+++ b/pkgs/by-name/tr/trgui-ng/package.nix
@@ -2,22 +2,18 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchNpmDeps,
   alsa-lib,
+  buildNpmPackage,
   cargo-tauri,
   dbip-country-lite,
   glib,
   libayatana-appindicator,
-  nodejs,
-  npmHooks,
   openssl,
   pkg-config,
   rustPlatform,
   webkitgtk_4_1,
 }:
-
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "TrguiNG";
+let
   version = "1.4.0-unstable-2025-05-18";
 
   src = fetchFromGitHub {
@@ -27,29 +23,58 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-Y3ZSpXmG+wi7x7qanKpRp917alssqF78L27Yt9K9Khs=";
   };
 
-  cargoHash = "sha256-TflzT1BNAciMcxcejrlmIOIjXc1tpm/zX0kjk+dpGiM=";
-
-  npmDeps = fetchNpmDeps {
-    name = "${finalAttrs.pname}-npm-deps-${finalAttrs.version}";
-    inherit (finalAttrs) src;
-    hash = "sha256-sHZHAlV3zVeCmVTlIr0NeS1zxRCKfRMv1w9bW0tOg3g=";
+  meta = {
+    description = "Remote GUI for Transmission torrent daemon";
+    homepage = "https://github.com/openscopeproject/TrguiNG";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ ambroisie ];
   };
+
+  frontend = buildNpmPackage (finalAttrs: {
+    pname = "TrguiNG-frontend";
+    inherit version src;
+    npmDepsHash = "sha256-sHZHAlV3zVeCmVTlIr0NeS1zxRCKfRMv1w9bW0tOg3g=";
+
+    npmBuildScript = "webpack-prod";
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r dist/ $out
+
+      runHook postInstall
+    '';
+
+    env.TRGUING_VERSION = finalAttrs.version;
+
+    meta = meta // {
+      description = "Web UI for Transmission torrent daemon";
+    };
+  });
+in
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "TrguiNG";
+  inherit version src;
+
+  cargoHash = "sha256-TflzT1BNAciMcxcejrlmIOIjXc1tpm/zX0kjk+dpGiM=";
 
   postPatch =
     ''
       cp ${dbip-country-lite}/share/dbip/dbip-country-lite.mmdb src-tauri/dbip.mmdb
+
+      # Copy pre-built frontend and remove `beforeBuildCommand` to build it
+      cp -r ${finalAttrs.passthru.frontend} dist/
+      substituteInPlace src-tauri/tauri.conf.json \
+        --replace-fail '"npm run webpack-prod"' '""'
     ''
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
         --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
     '';
 
-  env.TRGUING_VERSION = finalAttrs.version;
-
   nativeBuildInputs = [
     cargo-tauri.hook
-    nodejs
-    npmHooks.npmConfigHook
     pkg-config
   ];
 
@@ -67,11 +92,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoRoot = "src-tauri";
   buildAndTestSubdir = "src-tauri";
 
-  meta = {
-    description = "Remote GUI for Transmission torrent daemon";
-    homepage = "https://github.com/openscopeproject/TrguiNG";
-    license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [ ambroisie ];
+  passthru = {
+    inherit frontend;
+  };
+
+  meta = meta // {
     mainProgram = "TrguiNG";
   };
 })


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
