### PR TITLE
nixos/efingerd: init

### DIFF
--- a/nixos/modules/services/networking/efingerd.nix
+++ b/nixos/modules/services/networking/efingerd.nix
@@ -1,0 +1,78 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.efingerd;
+in
+{
+  options.services.efingerd = {
+    enable = mkEnableOption "efingerd finger daemon via xinetd";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.efingerd;
+      defaultText = "pkgs.efingerd";
+      description = "The efingerd package to use.";
+    };
+
+    user = mkOption {
+      type = types.str;
+      description = "User to run efingerd as (required).";
+    };
+
+    connectionTimeout = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 25;
+      description = "Time in seconds to keep connection. If null, default behavior is used.";
+    };
+
+    noLookupAddresses = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Do not lookup addresses, use IP numbers instead.";
+    };
+
+    useIdentService = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Use ident service to query the name of the fingerer.";
+    };
+
+    hideFullNames = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Do not display users' full names.";
+    };
+
+    ignoreUserFiles = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Ignore user-specific .efingerd file.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.xinetd = {
+      enable = true;
+      services = singleton {
+        name = "finger";
+        user = cfg.user;
+        server = "${cfg.package}/sbin/efingerd";
+        serverArgs = concatStringsSep " " (
+          (optional (cfg.connectionTimeout != null) "-t ${toString cfg.connectionTimeout}")
+          ++ (optional cfg.noLookupAddresses "-n")
+          ++ (optional cfg.useIdentService "-i")
+          ++ (optional cfg.hideFullNames "-f")
+          ++ (optional cfg.ignoreUserFiles "-u")
+        );
+      };
+    };
+  };
+}

--- a/pkgs/by-name/ef/efingerd/package.nix
+++ b/pkgs/by-name/ef/efingerd/package.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  lib,
+  fetchzip,
+  libident,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "efingerd";
+  version = "1.6.5";
+  src = fetchzip {
+    url = "https://kassiopeia.juls.savba.sk/~garabik/software/${pname}/${pname}_${version}.tar.gz";
+    curlOpts = "-k";
+    hash = "sha256-mtv6dZOHYF8EyM75R57ywS8bdkY14I1Hs1C7aP67yas=";
+  };
+  nativeBuildInputs = [
+    libident
+    versionCheckHook
+  ];
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '/usr/lib/libident.a' '${libident}/lib/libident.a'
+
+    substituteInPlace Makefile \
+      --replace 'CFLAGS = -O2 -Wall -Wsurprising' 'CFLAGS = -O2 -Wall -Wsurprising -fcommon'
+  '';
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/sbin
+
+    install -Dm755 efingerd $out/sbin/efingerd
+
+    runHook postInstall
+  '';
+  doInstallCheck = true;
+  # The binary is silly and still prints 1.6.4
+  preVersionCheck = ''
+    export version=1.6.4
+  '';
+  meta = with lib; {
+    homepage = "https://kassiopeia.juls.savba.sk/~garabik/software/efingerd.html";
+    description = "finger daemon that gives you complete control over what to send";
+    mainProgram = "efingerd";
+    maintainers = with maintainers; [
+      ezrizhu
+    ];
+    license = with licenses; [ gpl2 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/li/libident/package.nix
+++ b/pkgs/by-name/li/libident/package.nix
@@ -1,0 +1,33 @@
+{
+  stdenv,
+  lib,
+  fetchzip,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libident";
+  version = "0.22";
+  src = fetchzip {
+    url = "https://ftp.lysator.liu.se/pub/ident/libs/${pname}-${version}.tar.gz";
+    hash = "sha256-kMh5Ch8r6k76wFLwhfICaFySIjdKG2751rZLmQ0pkoE=";
+  };
+  buildFlags = [ "linux" ];
+  makeFlags = [
+    "INSTROOT=${placeholder "out"}"
+    "LIBDIR=${placeholder "out"}/lib"
+    "INCDIR=${placeholder "out"}/include"
+    "MANDIR=${placeholder "out"}/man"
+  ];
+  preInstall = ''
+    mkdir -p $out/lib $out/include $out/man
+  '';
+  meta = with lib; {
+    homepage = "https://www.lysator.liu.se/~pen/pidentd/";
+    description = "simple RFC1413 client library";
+    maintainers = with maintainers; [
+      ezrizhu
+    ];
+    license = with licenses; [ publicDomain ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[efingerd](https://kassiopeia.juls.savba.sk/~garabik/software/efingerd.html) is another finger daemon, giving you complete control over what are you going to display about your computer. It's similar to bsd-fingerd, however efingerd allows the user complete control over what to send via .efingerd executable in their home directory. efingerd also has the ability to use the [ident protocol](https://en.wikipedia.org/wiki/Ident_protocol) to allow the user to configure a different responses per the querier's username and host. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
