### PR TITLE
pgadmin4: fix build for sandbox=relaxed builds on darwin

### DIFF
--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -13,21 +13,30 @@
   libtool,
   libpng,
   nasm,
+  cmake,
   pkg-config,
   stdenv,
+  srcOnly,
   server-mode ? true,
 }:
 
 let
   pname = "pgadmin";
   version = "9.3";
-  yarnHash = "sha256-75FwwQ67j0aTHGvD4YwAaR8CWV4u4KsuMghidbkgVsw=";
+  yarnHash = "sha256-T6RKWuAAoJgbzJKef4ioOoUDtoGM9s9BFqxFdy5EtyQ=";
 
   src = fetchFromGitHub {
     owner = "pgadmin-org";
     repo = "pgadmin4";
     rev = "REL-${lib.versions.major version}_${lib.versions.minor version}";
     hash = "sha256-4uupF1dw6OE/briAI5PWiQ7h6RPx1sUqf8PB8cJsNSU=";
+  };
+
+  mozjpeg-bin = fetchFromGitHub {
+    owner = "imagemin";
+    repo = "mozjpeg-bin";
+    rev = "c0587fbc00b21ed8cad8bae499a0827baeaf7ffa";
+    hash = "sha256-D/pXQBlIIyk7KAgxJ1gKqxYxtlfBbLzUSmYZbH659cA=";
   };
 
   # keep the scope, as it is used throughout the derivation and tests
@@ -51,6 +60,14 @@ pythonPackages.buildPythonApplication rec {
   inherit pname version src;
 
   offlineCache = yarn-berry_3.fetchYarnBerryDeps {
+    # mozjpeg fails to build on darwin due to a hardocded path
+    # this has been fixed upstream on master but no new version
+    # has been released. We therefore point yarn to upstream
+    # see https://github.com/imagemin/mozjpeg-bin/issues/64
+    # and https://github.com/imagemin/mozjpeg-bin/issues/81
+    patches = [
+      ./mozjpeg.patch
+    ];
     src = src + "/web";
     hash = yarnHash;
   };
@@ -68,6 +85,11 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   postPatch = ''
+    # the patch needs to be executed inside the /web subfolder
+    # therefore it is included here and not in `patches`
+    cd web
+    patch -u yarn.lock ${./mozjpeg.patch}
+    cd ..
     # patching Makefile, so it doesn't try to build sphinx documentation here
     # (will do so later)
     substituteInPlace Makefile \
@@ -89,6 +111,8 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   dontYarnBerryInstallDeps = true;
+  env.YARN_ENABLE_SCRIPTS = "0";
+  dontUseCmakeConfigure = true;
 
   preBuild = ''
     # Adapted from pkg/pip/build.sh
@@ -116,6 +140,25 @@ pythonPackages.buildPythonApplication rec {
     (
     export LD=$CC # https://github.com/imagemin/optipng-bin/issues/108
     yarnBerryConfigHook
+    )
+    # mozjpeg vendored source isn't included in the checkout for yarn. If we copy it before the
+    # yarnConfigHook it will just get overwritten. So we first run the configHook without build,
+    # then copy the vendored source and then build the dependencies
+    # This has the disadvantage of repeating some of the yarnConfigHooks logic here
+    mkdir -p node_modules/mozjpeg/vendor/source
+    cp ${mozjpeg-bin}/vendor/source/mozjpeg.tar.gz node_modules/mozjpeg/vendor/source/
+    (
+    # https://github.com/mozilla/mozjpeg/issues/438
+    substituteInPlace node_modules/mozjpeg/lib/install.js --replace-fail "cmake -DCMAKE" "cmake -DENABLE_STATIC=FALSE -DCMAKE"
+    substituteInPlace node_modules/mozjpeg/lib/install.js --replace-fail "cp cjpeg-static" "cp cjpeg"
+    export LD=$CC
+    export HOME=$(mktemp -d)
+    export YARN_ENABLE_SCRIPTS=1
+    YARN_IGNORE_PATH=1 ${yarn-berry_3.yarn-berry-offline}/bin/yarn config set enableTelemetry false
+    YARN_IGNORE_PATH=1 ${yarn-berry_3.yarn-berry-offline}/bin/yarn config set enableGlobalCache false
+    export npm_config_nodedir="${srcOnly nodejs}"
+    export npm_config_node_gyp="${nodejs}/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js"
+    YARN_IGNORE_PATH=1 ${yarn-berry_3.yarn-berry-offline}/bin/yarn install --inline-builds
     )
     yarn webpacker
     cp -r * ../pip-build/pgadmin4
@@ -147,6 +190,7 @@ pythonPackages.buildPythonApplication rec {
     nodejs
 
     # for building mozjpeg2
+    cmake
     autoconf
     automake
     libtool

--- a/pkgs/tools/admin/pgadmin/mozjpeg.patch
+++ b/pkgs/tools/admin/pgadmin/mozjpeg.patch
@@ -1,0 +1,45 @@
+diff --git a/yarn.lock b/yarn.lock
+index fa189ef..54066a6 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -7299,6 +7299,23 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"execa@npm:^7.1.1":
++  version: 7.1.1
++  resolution: "execa@npm:7.1.1"
++  dependencies:
++    cross-spawn: ^7.0.3
++    get-stream: ^6.0.1
++    human-signals: ^3.0.1
++    is-stream: ^3.0.0
++    merge-stream: ^2.0.0
++    npm-run-path: ^5.1.0
++    onetime: ^6.0.0
++    signal-exit: ^3.0.7
++    strip-final-newline: ^3.0.0
++  checksum: 21fa46fc69314ace4068cf820142bdde5b643a5d89831c2c9349479c1555bff137a291b8e749e7efca36535e4e0a8c772c11008ca2e84d2cbd6ca141a3c8f937
++  languageName: node
++  linkType: hard
++
+ "executable@npm:^4.1.0":
+   version: 4.1.1
+   resolution: "executable@npm:4.1.1"
+@@ -11027,13 +11044,14 @@ __metadata:
+ 
+ "mozjpeg@npm:^8.0.0":
+   version: 8.0.0
+-  resolution: "mozjpeg@npm:8.0.0"
++  resolution: "mozjpeg@https://github.com/imagemin/mozjpeg-bin.git#commit=c0587fbc00b21ed8cad8bae499a0827baeaf7ffa"
+   dependencies:
+     bin-build: ^3.0.0
+     bin-wrapper: ^4.0.0
++    execa: ^7.1.1
+   bin:
+     mozjpeg: cli.js
+-  checksum: cba27c2efbc21a48434da1c6c8d6886988432430f958315fc59ef9b52bc2d6ee597e19f1cf6aae0fd611d5b2a113561fe2e85ec30a1ccd55c007340c638eb557
++  checksum: cba27c2efbc21a48434da1c6c8d6886988432430f958315fc59ef9b52bc2d6ee597e19f1cf6aae0fd611d5b2a113561fe2e85ec30a1ccd55c007340c638eb556
+   languageName: node
+   linkType: hard
+ 


### PR DESCRIPTION
fixes: clang: error: no such file or directory: '/usr/local/lib/libpng16.a' on sandboxed darwin boxes

1. mozjpeg hasn't been updated since 2021. The newest commit from 2023 fixes the build on darwin but no new release was put forward (see imagemin/mozjpeg-bin#64 and imagemin/mozjpeg-bin#81)
2. This prompts to manually patching the yarn.lock file
3. Which also needs to split the yarnConfigHook logic and duplicate it in parts in the derivation

The benefit is to be able to build pgadmin on aarch64-darwin without network.

See discussion [here](https://github.com/NixOS/nixpkgs/pull/407518)

@dotlambda 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
