### PR TITLE
x16: adopt, fix build on GCC 14, modernize

### DIFF
--- a/pkgs/by-name/x1/x16/package.nix
+++ b/pkgs/by-name/x1/x16/package.nix
@@ -6,6 +6,7 @@
   SDL2,
   callPackage,
   zlib,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -15,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "X16Community";
     repo = "x16-emulator";
-    rev = "r${finalAttrs.version}";
+    tag = "r${finalAttrs.version}";
     hash = "sha256-E4TosRoORCWLotOIXROP9oqwqo1IRSa6X13GnmuxE9A=";
   };
 
@@ -58,14 +59,16 @@ stdenv.mkDerivation (finalAttrs: {
     run = (callPackage ./run.nix { }) {
       inherit (finalAttrs.finalPackage) emulator rom;
     };
+
+    updateScript = nix-update-script { };
   };
 
   meta = {
     homepage = "https://cx16forum.com/";
     description = "Official emulator of CommanderX16 8-bit computer";
-    changelog = "https://github.com/X16Community/x16-emulator/blob/r${finalAttrs.version}/RELEASES.md";
+    changelog = "https://github.com/X16Community/x16-emulator/blob/${finalAttrs.src.rev}/RELEASES.md";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ pluiedev ];
     mainProgram = "x16emu";
     inherit (SDL2.meta) platforms;
     broken = stdenv.hostPlatform.isAarch64; # ofborg fails to compile it

--- a/pkgs/by-name/x1/x16/package.nix
+++ b/pkgs/by-name/x1/x16/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   SDL2,
   callPackage,
   zlib,
@@ -17,6 +18,15 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "r${finalAttrs.version}";
     hash = "sha256-E4TosRoORCWLotOIXROP9oqwqo1IRSa6X13GnmuxE9A=";
   };
+
+  # Fix build on GCC 14
+  # TODO: Remove for next release as it should already be included in upstream
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/X16Community/x16-emulator/commit/3da83c93d46a99635cf73a6f9fdcf1bd4a4ae04f.patch";
+      hash = "sha256-DZItqq7B1lXZ6VFsQUdQKn0wt1HaX4ymq2pI2DamY3w=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/by-name/x1/x16/rom.nix
+++ b/pkgs/by-name/x1/x16/rom.nix
@@ -5,6 +5,7 @@
   cc65,
   lzsa,
   python3,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs findsymbols scripts/
     substituteInPlace Makefile \
-    --replace-fail '/bin/echo' 'echo'
+      --replace-fail '/bin/echo' 'echo'
   '';
 
   dontConfigure = true;
@@ -47,13 +48,14 @@ stdenv.mkDerivation (finalAttrs: {
     # upstream project recommends emulator and rom to be synchronized; passing
     # through the version is useful to ensure this
     inherit (finalAttrs) version;
+    updateScript = nix-update-script { };
   };
 
   meta = {
     homepage = "https://github.com/X16Community/x16-rom";
     description = "ROM file for CommanderX16 8-bit computer";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ pluiedev ];
     inherit (cc65.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };

--- a/pkgs/by-name/x1/x16/run.nix
+++ b/pkgs/by-name/x1/x16/run.nix
@@ -1,7 +1,7 @@
 {
   runtimeShell,
   symlinkJoin,
-  writeTextFile,
+  writeShellScriptBin,
 }:
 
 { emulator, rom }:
@@ -9,18 +9,10 @@
 assert emulator.version == rom.version;
 
 let
-  runScript = writeTextFile {
-    name = "run-x16";
-    text = ''
-      #!${runtimeShell}
-
-      defaultRom="${rom}/share/x16-rom/rom.bin"
-
-      exec "${emulator}/bin/x16emu" -rom $defaultRom "$@"
-    '';
-    executable = true;
-    destination = "/bin/run-x16";
-  };
+  runScript = writeShellScriptBin "run-x16" ''
+    defaultRom="${rom}/share/x16-rom/rom.bin"
+    exec "${emulator}/bin/x16emu" -rom $defaultRom "$@"
+  '';
 in
 symlinkJoin {
   pname = "run-x16";


### PR DESCRIPTION
ZHF #403336
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
