### PR TITLE
dts-lsp: init at 0.1.5-unstable-2025-03-24

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8144,6 +8144,12 @@
     githubId = 40620903;
     name = "figsoda";
   };
+  filippo-biondi = {
+    email = "biondifilippo00@gmail.com";
+    github = "filippo-biondi";
+    githubId = 83963482;
+    name = "Filippo Biondi";
+  };
   fionera = {
     email = "nix@fionera.de";
     github = "fionera";

--- a/pkgs/by-name/dt/dts-lsp/package.nix
+++ b/pkgs/by-name/dt/dts-lsp/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage ({
+  pname = "dts-lsp";
+  version = "0.1.5-unstable-2025-03-24";
+
+  src = fetchFromGitHub {
+    owner = "igor-prusov";
+    repo = "dts-lsp";
+    rev = "e43331e09a4a2e6a8f770194cce2f4bb58507f1a";
+    hash = "sha256-qoUzkV+RpT+unROz8IZHDwrRDePU1JXfbRusfi9b+ys=";
+  };
+
+  cargoHash = "sha256-NWmdGmM0cdvhscPxjYlIJKgf9towHh+BfY8cuGbS3MA=";
+
+  meta = {
+    description = "LSP for DTS files built on top of tree-sitter-devicetree grammar";
+    homepage = "https://github.com/igor-prusov/dts-lsp";
+    license = lib.licenses.mit;
+    mainProgram = "dts-lsp";
+    maintainers = with lib.maintainers; [ filippo-biondi ];
+    platforms = with lib.platforms; darwin ++ linux;
+  };
+})

--- a/pkgs/by-name/dt/dts-lsp/package.nix
+++ b/pkgs/by-name/dt/dts-lsp/package.nix
@@ -4,7 +4,7 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage ({
+rustPlatform.buildRustPackage {
   pname = "dts-lsp";
   version = "0.1.5-unstable-2025-03-24";
 
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage ({
     maintainers = with lib.maintainers; [ filippo-biondi ];
     platforms = with lib.platforms; darwin ++ linux;
   };
-})
+}


### PR DESCRIPTION
[https://github.com/igor-prusov/dts-lsp](https://github.com/igor-prusov/dts-lsp)
dts-lsp is an LSP server for Device Tree Source files offering go-to-definition, find references and rename support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
