### PR TITLE
watchexec: 2.3.1 -> 2.3.2

### DIFF
--- a/pkgs/by-name/wa/watchexec/package.nix
+++ b/pkgs/by-name/wa/watchexec/package.nix
@@ -44,6 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = with lib.licenses; [ asl20 ];
     maintainers = with lib.maintainers; [
       michalrus
+      prince213
     ];
     mainProgram = "watchexec";
   };

--- a/pkgs/by-name/wa/watchexec/package.nix
+++ b/pkgs/by-name/wa/watchexec/package.nix
@@ -38,11 +38,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellCompletion --zsh --name _watchexec completions/zsh
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Executes commands in response to file modifications";
     homepage = "https://watchexec.github.io/";
-    license = with licenses; [ asl20 ];
-    maintainers = [ maintainers.michalrus ];
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [
+      michalrus
+    ];
     mainProgram = "watchexec";
   };
 })

--- a/pkgs/by-name/wa/watchexec/package.nix
+++ b/pkgs/by-name/wa/watchexec/package.nix
@@ -8,17 +8,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "watchexec";
-  version = "2.3.1";
+  version = "2.3.2";
 
   src = fetchFromGitHub {
     owner = "watchexec";
     repo = "watchexec";
     rev = "v${version}";
-    hash = "sha256-ldxB1/WgOe1uGfKXkMEtGHIlWiKJgnZz6j/7eCOGD8s=";
+    hash = "sha256-BJRvz3rFLaOCNhOsEo0rSOgB9BCJ2LMB9XEw8RBWXXs=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-LdjJlf4HPN+kZOQKPNSdbYApGBD4Z6tKV9Y0FFKpAf0=";
+  cargoHash = "sha256-VtSRC4lyjMo2O9dNbVllcDEx08zQWJMQmQ/2bNMup6U=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/wa/watchexec/package.nix
+++ b/pkgs/by-name/wa/watchexec/package.nix
@@ -35,7 +35,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall = ''
     installManPage doc/watchexec.1
-    installShellCompletion --zsh --name _watchexec completions/zsh
+    installShellCompletion --cmd watchexec \
+      --bash completions/bash \
+      --fish completions/fish \
+      --zsh completions/zsh
   '';
 
   meta = {

--- a/pkgs/by-name/wa/watchexec/package.nix
+++ b/pkgs/by-name/wa/watchexec/package.nix
@@ -4,6 +4,7 @@
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -40,6 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --fish completions/fish \
       --zsh completions/zsh
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Executes commands in response to file modifications";

--- a/pkgs/by-name/wa/watchexec/package.nix
+++ b/pkgs/by-name/wa/watchexec/package.nix
@@ -6,14 +6,14 @@
   installShellFiles,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "watchexec";
   version = "2.3.2";
 
   src = fetchFromGitHub {
     owner = "watchexec";
     repo = "watchexec";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-BJRvz3rFLaOCNhOsEo0rSOgB9BCJ2LMB9XEw8RBWXXs=";
   };
 
@@ -45,4 +45,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ maintainers.michalrus ];
     mainProgram = "watchexec";
   };
-}
+})


### PR DESCRIPTION
Release notes: https://github.com/watchexec/watchexec/releases/tag/v2.3.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
