### PR TITLE
bird-lg: disable frontend checks on darwin

### DIFF
--- a/pkgs/by-name/bi/bird-lg/package.nix
+++ b/pkgs/by-name/bi/bird-lg/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   lib,
@@ -6,42 +7,44 @@
 }:
 let
   generic =
-    { modRoot, vendorHash }:
-    buildGoModule rec {
-      pname = "bird-lg-${modRoot}";
-      version = "1.3.8";
+    { modRoot, vendorHash, ... }@attrs:
+    buildGoModule (
+      rec {
+        pname = "bird-lg-${modRoot}";
+        version = "1.3.8";
 
-      src = fetchFromGitHub {
-        owner = "xddxdd";
-        repo = "bird-lg-go";
-        rev = "v${version}";
-        hash = "sha256-j81cfHqXNsTM93ofxXz+smkjN8OdJXxtm9z5LdzC+r8=";
-      };
+        src = fetchFromGitHub {
+          owner = "xddxdd";
+          repo = "bird-lg-go";
+          rev = "v${version}";
+          hash = "sha256-j81cfHqXNsTM93ofxXz+smkjN8OdJXxtm9z5LdzC+r8=";
+        };
 
-      doDist = false;
+        doDist = false;
 
-      ldflags = [
-        "-s"
-        "-w"
-      ];
-
-      inherit modRoot vendorHash;
-
-      meta = with lib; {
-        description = "Bird Looking Glass";
-        homepage = "https://github.com/xddxdd/bird-lg-go";
-        changelog = "https://github.com/xddxdd/bird-lg-go/releases/tag/v${version}";
-        license = licenses.gpl3Plus;
-        maintainers = with maintainers; [
-          tchekda
-          e1mo
+        ldflags = [
+          "-s"
+          "-w"
         ];
-      };
-    };
+
+        meta = with lib; {
+          description = "Bird Looking Glass";
+          homepage = "https://github.com/xddxdd/bird-lg-go";
+          changelog = "https://github.com/xddxdd/bird-lg-go/releases/tag/v${version}";
+          license = licenses.gpl3Plus;
+          maintainers = with maintainers; [
+            tchekda
+            e1mo
+          ];
+        };
+      }
+      // attrs
+    );
 
   bird-lg-frontend = generic {
     modRoot = "frontend";
     vendorHash = "sha256-luJuIZ0xN8mdtWwTlfEDnAwMgt+Tzxlk2ZIDPIwHpcY=";
+    doCheck = !stdenv.isDarwin;
   };
 
   bird-lg-proxy = generic {


### PR DESCRIPTION
Disable the checks of bird-lg-frontend on darwin as this tries to create a localhost proxy which is forbidden by the nix build mechanism.

The produced error on aarch64-darwin is:
```
--- FAIL: TestWhoisConnectionError (0.00s)
    whois_test.go:94: Whois AS6939 without server produced output, got dial tcp 127.0.0.1:0: connect: can't assign requested address
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

ZHF: https://github.com/NixOS/nixpkgs/issues/403336

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
