### PR TITLE
nixos/limine: add support for secure boot through sbctl

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -34,4 +34,3 @@
 ### Additions and Improvements {#sec-nixpkgs-release-25.11-lib-additions-improvements}
 
 - Create the first release note entry in this section!
-

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -4,7 +4,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- Secure boot support can now be enabled for the Limine bootloader through {option}`boot.loader.limine.secureBoot.enable`. Bootloader install script signs the bootloader, then kernels are hashed during system rebuild and written to a config. This allows Limine to boot only the kernels installed through NixOS system.
 
 ## New Modules {#sec-release-25.11-new-modules}
 

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -18,6 +18,7 @@ let
       canTouchEfiVariables = efi.canTouchEfiVariables;
       efiSupport = cfg.efiSupport;
       efiRemovable = cfg.efiInstallAsRemovable;
+      secureBoot = cfg.secureBoot;
       biosSupport = cfg.biosSupport;
       biosDevice = cfg.biosDevice;
       partitionIndex = cfg.partitionIndex;
@@ -175,6 +176,41 @@ in
       description = ''
         Force MBR detection to work even if the safety checks fail, use absolutely only if necessary!
       '';
+    };
+
+    secureBoot = {
+      enable = lib.mkEnableOption null // {
+        description = ''
+          Whether to use sign the limine binary with sbctl.
+
+          ::: {.note}
+          This requires you to already have generated the keys and enrolled them with {command}`sbctl`.
+
+          To create keys use {command}`sbctl create-keys`.
+
+          To enroll them first reset secure boot to "Setup Mode". This is device specific.
+          Then enroll them using {command}`sbctl enroll-keys -m -f`.
+
+          You can now rebuild your system with this option enabled.
+
+          Afterwards turn setup mode off and enable secure boot.
+          :::
+        '';
+      };
+
+      createAndEnrollKeys = lib.mkEnableOption null // {
+        internal = true;
+        description = ''
+          Creates secure boot signing keys and enrolls them during bootloader installation.
+
+          ::: {.note}
+          This is used for automated nixos tests.
+          NOT INTENDED to be used on a real system.
+          :::
+        '';
+      };
+
+      sbctl = lib.mkPackageOption pkgs "sbctl" { };
     };
 
     style = {
@@ -366,6 +402,58 @@ in
             configPath = limineInstallConfig;
           };
         };
+      };
+    })
+    (lib.mkIf (cfg.enable && cfg.secureBoot.enable) {
+      assertions = [
+        {
+          assertion = cfg.enrollConfig;
+          message = "Disabling enrollConfig allows bypassing secure boot.";
+        }
+        {
+          assertion = cfg.validateChecksums;
+          message = "Disabling validateChecksums allows bypassing secure boot.";
+        }
+        {
+          assertion = cfg.panicOnChecksumMismatch;
+          message = "Disabling panicOnChecksumMismatch allows bypassing secure boot.";
+        }
+        {
+          assertion = cfg.efiSupport;
+          message = "Secure boot is only supported on EFI systems.";
+        }
+      ];
+
+      boot.loader.limine.enrollConfig = true;
+      boot.loader.limine.validateChecksums = true;
+      boot.loader.limine.panicOnChecksumMismatch = true;
+    })
+
+    # Fwupd binary needs to be signed in secure boot mode
+    (lib.mkIf (cfg.enable && cfg.secureBoot.enable && config.services.fwupd.enable) {
+      systemd.services.fwupd = {
+        environment.FWUPD_EFIAPPDIR = "/run/fwupd-efi";
+      };
+
+      systemd.services.fwupd-efi = {
+        description = "Sign fwupd EFI app for secure boot";
+        wantedBy = [ "fwupd.service" ];
+        partOf = [ "fwupd.service" ];
+        before = [ "fwupd.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          RuntimeDirectory = "fwupd-efi";
+        };
+        script = ''
+          cp ${config.services.fwupd.package.fwupd-efi}/libexec/fwupd/efi/fwupd*.efi /run/fwupd-efi/
+          chmod +w /run/fwupd-efi/fwupd*.efi
+          ${lib.getExe pkgs.sbctl} sign /run/fwupd-efi/fwupd*.efi
+        '';
+      };
+
+      services.fwupd.uefiCapsuleSettings = {
+        DisableShimForSecureBoot = true;
       };
     })
   ];

--- a/nixos/tests/limine/default.nix
+++ b/nixos/tests/limine/default.nix
@@ -4,5 +4,6 @@
 }:
 {
   checksum = runTest ./checksum.nix;
+  secureBoot = runTest ./secure-boot.nix;
   uefi = runTest ./uefi.nix;
 }

--- a/nixos/tests/limine/secure-boot.nix
+++ b/nixos/tests/limine/secure-boot.nix
@@ -1,0 +1,34 @@
+{ lib, ... }:
+{
+  name = "secureBoot";
+  meta.maintainers = with lib.maintainers; [
+    programmerlexi
+  ];
+  meta.platforms = [
+    "aarch64-linux"
+    "i686-linux"
+    "x86_64-linux"
+  ];
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      virtualisation.useBootLoader = true;
+      virtualisation.useEFIBoot = true;
+      virtualisation.useSecureBoot = true;
+      virtualisation.efi.OVMF = pkgs.OVMFFull.fd;
+      virtualisation.efi.keepVariables = true;
+
+      boot.loader.efi.canTouchEfiVariables = true;
+
+      boot.loader.limine.enable = true;
+      boot.loader.limine.efiSupport = true;
+      boot.loader.limine.secureBoot.enable = true;
+      boot.loader.limine.secureBoot.createAndEnrollKeys = true;
+      boot.loader.timeout = 0;
+    };
+
+  testScript = ''
+    machine.start()
+    assert "Secure Boot: enabled (user)" in machine.succeed("bootctl status")
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds support for signing limine for use with secure boot.

Feedback is appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Added a release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
