### PR TITLE
botan: various improvements

### DIFF
--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -75,12 +75,10 @@ let
         ];
 
       buildTargets =
-        lib.optionals finalAttrs.finalPackage.doCheck [ "tests" ]
+        [ "cli" ]
+        ++ lib.optionals finalAttrs.finalPackage.doCheck [ "tests" ]
         ++ lib.optionals static [ "static" ]
-        ++ lib.optionals (!static) [
-          "cli"
-          "shared"
-        ];
+        ++ lib.optionals (!static) [ "shared" ];
 
       botanConfigureFlags =
         [
@@ -133,7 +131,7 @@ let
         ln -s botan-*.pc botan.pc || true
       '';
 
-      doCheck = !static;
+      doCheck = true;
 
       meta = with lib; {
         description = "Cryptographic algorithms library";

--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -14,9 +14,9 @@
   static ? stdenv.hostPlatform.isStatic, # generates static libraries *only*
 
   # build ESDM RNG plugin
-  with_esdm ? false,
+  withEsdm ? false,
   # useful, but have to disable tests for now, as /dev/tpmrm0 is not accessible
-  with_tpm2 ? false,
+  withTpm2 ? false,
   policy ? null,
 }:
 
@@ -69,13 +69,13 @@ let
           bzip2
           zlib
         ]
-        ++ lib.optionals (stdenv.hostPlatform.isLinux && with_tpm2) [
+        ++ lib.optionals (stdenv.hostPlatform.isLinux && withTpm2) [
           tpm2-tss
         ]
         ++ lib.optionals (lib.versionAtLeast version "3.6.0") [
           jitterentropy
         ]
-        ++ lib.optionals (lib.versionAtLeast version "3.7.0" && with_esdm) [
+        ++ lib.optionals (lib.versionAtLeast version "3.7.0" && withEsdm) [
           esdm
         ];
 
@@ -101,13 +101,13 @@ let
         ++ lib.optionals stdenv.cc.isClang [
           "--cc=clang"
         ]
-        ++ lib.optionals (stdenv.hostPlatform.isLinux && with_tpm2) [
+        ++ lib.optionals (stdenv.hostPlatform.isLinux && withTpm2) [
           "--with-tpm2"
         ]
         ++ lib.optionals (lib.versionAtLeast version "3.6.0") [
           "--enable-modules=jitter_rng"
         ]
-        ++ lib.optionals (lib.versionAtLeast version "3.7.0" && with_esdm) [
+        ++ lib.optionals (lib.versionAtLeast version "3.7.0" && withEsdm) [
           "--enable-modules=esdm_rng"
         ]
         ++ lib.optionals (lib.versionAtLeast version "3.8.0" && policy != null) [

--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -145,6 +145,7 @@ let
         maintainers = with maintainers; [
           raskin
           thillux
+          nikstur
         ];
         platforms = platforms.unix;
         license = licenses.bsd2;

--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  pkgsStatic,
   python3,
   docutils,
   bzip2,
@@ -132,6 +133,10 @@ let
       '';
 
       doCheck = true;
+
+      passthru.tests = lib.optionalAttrs (lib.versionAtLeast version "3") {
+        static = pkgsStatic.botan3;
+      };
 
       meta = with lib; {
         description = "Cryptographic algorithms library";

--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -27,6 +27,8 @@ assert lib.assertOneOf "policy" policy [
   "bsi"
   # only allow NIST approved algorithms in FIPS 140
   "fips140"
+  # only allow "modern" algorithms
+  "modern"
 ];
 
 let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7847,7 +7847,11 @@ with pkgs;
 
   boost = boost187;
 
-  inherit (callPackages ../development/libraries/botan { })
+  inherit
+    (callPackages ../development/libraries/botan {
+      # botan3 only sensibly works with libcxxStdenv when building static binaries
+      stdenv = if stdenv.hostPlatform.isStatic then buildPackages.libcxxStdenv else stdenv;
+    })
     botan2
     botan3
     ;


### PR DESCRIPTION
Review commit by commit might be useful. Find more explanation in each commit message.

Most notably, this change makes proper static compilaton with musl possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
