### PR TITLE
ocamlPackages.ocaml_intrinsics: fix ARM CRC32 intrinsics

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -937,6 +937,13 @@ with self;
       dune-configurator
       ocaml_intrinsics_kernel
     ];
+    patches = [
+      # This patch is needed because of an issue with the aarch64 CRC32
+      # intrinsics that was introduced with ocaml_intrinsics v0.17. It should
+      # be removed as soon as
+      # https://github.com/janestreet/ocaml_intrinsics/pull/11 is merged.
+      ./ocaml_intrinsics-fix-aarch64-crc32-intrinsics.patch
+    ];
   };
 
   ocaml_openapi_generator = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/ocaml_intrinsics-fix-aarch64-crc32-intrinsics.patch
+++ b/pkgs/development/ocaml-modules/janestreet/ocaml_intrinsics-fix-aarch64-crc32-intrinsics.patch
@@ -1,0 +1,28 @@
+From fa7d611d326eaec5b34d8686975aaf2238a85996 Mon Sep 17 00:00:00 2001
+From: alyaeanyx <alyaeanyx@mailbox.org>
+Date: Sun, 18 May 2025 15:46:31 +0200
+Subject: [PATCH] Fix aarch64 CRC32 intrinsics configure test program
+
+The test program was checking for the nonexistent __crc32ud and __crc32uw instead of
+__crc32cd __crc32cw (as used in src/crc_stubs.c).
+
+Signed-off-by: alyaeanyx <alyaeanyx@mailbox.org>
+---
+ src/discover/discover.ml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/discover/discover.ml b/src/discover/discover.ml
+index d2b4039..8fe89a4 100644
+--- a/src/discover/discover.ml
++++ b/src/discover/discover.ml
+@@ -12,8 +12,8 @@ let prog_aarch64 =
+ int main() {
+     int64_t i64, d64;
+     int32_t i32, d32;
+-    __crc32ud(i64, d64);
+-    __crc32uw(i32, d32);
++    __crc32cd(i64, d64);
++    __crc32cw(i32, d32);
+     return 0;
+ }|}
+ ;;


### PR DESCRIPTION
This fixes the aarch64 build of ocaml_intrinsics. The patch is needed because of an issue with the aarch64 CRC32 intrinsics that was introduced with ocaml_intrinsics v0.17. It should be removed as soon as https://github.com/janestreet/ocaml_intrinsics/pull/11 is merged.

#403336 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
