### PR TITLE
ci/eval: remove left-over stats.json

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -8,7 +8,6 @@
   procps,
   nixVersions,
   jq,
-  sta,
   python3,
 }:
 
@@ -188,10 +187,7 @@ let
           rm "$chunkOutputDir"/stats/"$seq_end"
         fi
 
-        # Make sure the glob doesn't break when there's no files
-        shopt -s nullglob
         cat "$chunkOutputDir"/result/* > $out/paths
-        cat "$chunkOutputDir"/stats/* > $out/stats.jsonstream
       '';
 
   combine =
@@ -202,7 +198,6 @@ let
       {
         nativeBuildInputs = [
           jq
-          sta
         ];
       }
       ''
@@ -224,39 +219,6 @@ let
                   end) | from_entries}
             ) | from_entries
           ' > $out/outpaths.json
-
-        # Computes min, mean, error, etc. for a list of values and outputs a JSON from that
-        statistics() {
-          local stat=$1
-          sta --transpose |
-            jq --raw-input --argjson stat "$stat" -n '
-              [
-                inputs |
-                  split("\t") |
-                  { key: .[0], value: (.[1] | fromjson) }
-              ] |
-                from_entries |
-                {
-                  key: ($stat | join(".")),
-                  value: .
-                }'
-        }
-
-        # Gets all available number stats (without .sizes because those are constant and not interesting)
-        readarray -t stats < <(jq -cs '.[0] | del(.sizes) | paths(type == "number")' ${resultsDir}/*/stats.jsonstream)
-
-        # Combines the statistics from all evaluations
-        {
-          echo "{ \"key\": \"minAvailMemory\", \"value\": $(cat ${resultsDir}/*/min-avail-memory | sta --brief --min) }"
-          echo "{ \"key\": \"minFreeSwap\", \"value\": $(cat ${resultsDir}/*/min-free-swap | sta --brief --min) }"
-          cat ${resultsDir}/*/total-time | statistics '["totalTime"]'
-          for stat in "''${stats[@]}"; do
-            cat ${resultsDir}/*/stats.jsonstream |
-              jq --argjson stat "$stat" 'getpath($stat)' |
-              statistics "$stat"
-          done
-        } |
-          jq -s from_entries > $out/stats.json
 
         mkdir -p $out/stats
 


### PR DESCRIPTION
This seems to be a left-over from before the performance comparison was changed to a difference-per-chunk analysis.

It was introduced in #356023, but is imho superseded by #395113. The `stats.json` file is not used and I doubt that anyone is looking at it by downloading the artifacts manually instead of looking at the nice markdown table in the workflow summary.

The same numbers are still available in the intermediate artifacts, just not aggregated across the four systems anymore.

This helps my work on restructuring the combine/comparison steps to squeeze out a bit more performance.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
