### PR TITLE
better-control: init at 6.11.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20979,6 +20979,12 @@
     githubId = 807447;
     name = "Robert Scott";
   };
+  Rishabh5321 = {
+    name = "Rishabh Singh";
+    email = "rishabh98818@gmail.com";
+    github = "Rishabh5321";
+    githubId = 40533251;
+  };
   Rishik-Y = {
     name = "Rishik Yalamanchili";
     email = "202301258@daiict.ac.in";

--- a/pkgs/by-name/be/better-control/package.nix
+++ b/pkgs/by-name/be/better-control/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  gtk3,
+  bash,
+  networkmanager,
+  bluez,
+  brightnessctl,
+  power-profiles-daemon,
+  gammastep,
+  libpulseaudio,
+  desktop-file-utils,
+  wrapGAppsHook3,
+  gobject-introspection,
+  upower,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "better-control";
+  version = "v6.11.6";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "quantumvoid0";
+    repo = "better-control";
+    tag = version;
+    hash = "sha256-+2hY+o+GPyJHXpQFVW8BOUEiIBGQ1hItOVpA/AVas2Q=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    wrapGAppsHook3
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    bash
+    gtk3
+  ];
+
+  # Check src/utils/dependencies.py
+  runtimeDeps = [
+    libpulseaudio
+    networkmanager
+    bluez
+    brightnessctl
+    power-profiles-daemon
+    gammastep
+    upower
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    dbus-python
+    psutil
+    qrcode
+    requests
+    setproctitle
+    pillow
+    pycairo
+  ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  dontWrapGApps = true;
+
+  makeWrapperArgs = [
+    "\${gappsWrapperArgs[@]}"
+    "--prefix PATH : ${lib.makeBinPath runtimeDeps}"
+  ];
+
+  postInstall = ''
+    rm $out/bin/betterctl
+    chmod +x $out/share/better-control/better_control.py
+    substituteInPlace $out/bin/* \
+      --replace-fail "python3 " ""
+    substituteInPlace $out/share/applications/better-control.desktop \
+      --replace-fail "/usr/bin/" ""
+  '';
+
+  # Project has no tests
+  doCheck = false;
+
+  postFixup = ''
+    wrapPythonProgramsIn "$out/share/better-control" "$out $pythonPath"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple control panel for linux based on GTK";
+    homepage = "https://github.com/quantumvoid0/better-control";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ Rishabh5321 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "control"; # Users use both "control" and "better-control" to launch
+  };
+}


### PR DESCRIPTION
Pkg for better-control: A sleek GTK-themed control panel for Linux 🐧

Link: https://github.com/quantumvoid0/better-control


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
