### PR TITLE
pkgs/phosh,phoc: 0.44.1 → 0.48.0 & pkgs/phrog: init

### DIFF
--- a/pkgs/applications/display-managers/greetd/phrog/0001-nixos-Use-XDG_DATA_DIRS-instead-of-hardcoded-paths-t.patch
+++ b/pkgs/applications/display-managers/greetd/phrog/0001-nixos-Use-XDG_DATA_DIRS-instead-of-hardcoded-paths-t.patch
@@ -1,0 +1,108 @@
+From 649ea7ca0359f6b25d3bfa6e6b790c3287413e87 Mon Sep 17 00:00:00 2001
+From: hustlerone <nine-ball@tutanota.com>
+Date: Mon, 19 May 2025 16:48:24 +0200
+Subject: [PATCH] nixos: Use XDG_DATA_DIRS instead of hardcoded paths to
+ sessions
+
+---
+ Cargo.lock      |  7 +++++++
+ Cargo.toml      |  1 +
+ src/sessions.rs | 40 +++++++++++++++++++++++++++++++++-------
+ 3 files changed, 41 insertions(+), 7 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index bd9ee40..9afa306 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -940,6 +940,12 @@ version = "1.0.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+ 
++[[package]]
++name = "lazy_static"
++version = "1.5.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
++
+ [[package]]
+ name = "libc"
+ version = "0.2.158"
+@@ -1124,6 +1130,7 @@ dependencies = [
+  "greetd_ipc",
+  "gtk",
+  "input-event-codes",
++ "lazy_static",
+  "libhandy",
+  "libphosh",
+  "log",
+diff --git a/Cargo.toml b/Cargo.toml
+index d963e09..a25f513 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -16,6 +16,7 @@ nix = { version = "0.29", features = ["signal"] }
+ async-global-executor = "2.4.1"
+ futures-util = "0.3.30"
+ log = "0.4.22"
++lazy_static = "^1.4"
+ 
+ [dependencies.glib]
+ version = "0.18"
+diff --git a/src/sessions.rs b/src/sessions.rs
+index d12198c..79a2b3c 100644
+--- a/src/sessions.rs
++++ b/src/sessions.rs
+@@ -3,18 +3,44 @@ use glib::warn;
+ use glob::glob;
+ use gtk::gio::DesktopAppInfo;
+ use gtk::prelude::*;
+-use std::collections::HashMap;
++use lazy_static::lazy_static;
++use std::{
++  collections::HashMap,
++  path::{Path, PathBuf},
++  env,
++};
+ 
+ static G_LOG_DOMAIN: &str = "phrog-sessions";
+ 
++lazy_static! {
++    // Snippet copied from https://github.com/apognu/tuigreet
++
++    static ref XDG_DATA_DIRS: Vec<PathBuf> = {
++        let value = env::var("XDG_DATA_DIRS").unwrap_or("/usr/local/share:/usr/share".to_string());
++        env::split_paths(&value).filter(|p| p.is_absolute()).collect()
++    };
++}
++
+ pub fn sessions() -> Vec<SessionObject> {
+     let mut sessions = HashMap::new();
+-    session_list(
+-        "/usr/share/wayland-sessions/*.desktop",
+-        "wayland",
+-        &mut sessions,
+-    );
+-    session_list("/usr/share/xsessions/*.desktop", "x11", &mut sessions);
++
++    for DIR in XDG_DATA_DIRS.iter() {
++        let wl_dir = DIR.join("wayland-sessions/*.desktop");
++        let x11_dir = DIR.join("wayland-sessions/*.desktop");
++
++        session_list(
++            &wl_dir.into_os_string().into_string().unwrap(),
++            "wayland",
++            &mut sessions,
++        );
++
++        session_list(
++            &x11_dir.into_os_string().into_string().unwrap(),
++            "wayland",
++            &mut sessions,
++        );        
++    };
++
+     sessions.values().cloned().collect()
+ }
+ 
+-- 
+2.49.0
+

--- a/pkgs/applications/display-managers/greetd/phrog/0001-nixos-phrog-contain-schema-dir-within-drv.patch
+++ b/pkgs/applications/display-managers/greetd/phrog/0001-nixos-phrog-contain-schema-dir-within-drv.patch
@@ -1,0 +1,25 @@
+From 6e8d04051ef4e40e64b3daba998a57f66a224cf7 Mon Sep 17 00:00:00 2001
+From: hustlerone <nine-ball@tutanota.com>
+Date: Mon, 19 May 2025 12:02:37 +0200
+Subject: [PATCH] nixos/phrog: contain schema dir within drv
+
+---
+ build.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build.rs b/build.rs
+index 4cecdb0..0f8d8ea 100644
+--- a/build.rs
++++ b/build.rs
+@@ -9,7 +9,7 @@ fn main() {
+     );
+ 
+     let schema_path =
+-        PathBuf::from(std::env::var("HOME").unwrap()).join(".local/share/glib-2.0/schemas");
++        PathBuf::from("{interp}");
+     std::fs::create_dir_all(&schema_path).expect("failed to create schema dir");
+ 
+     let phrog_gschema = PathBuf::from("data/mobi.phosh.phrog.gschema.xml");
+-- 
+2.49.0
+

--- a/pkgs/applications/display-managers/greetd/phrog/package.nix
+++ b/pkgs/applications/display-managers/greetd/phrog/package.nix
@@ -1,0 +1,129 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenv,
+  nixosTests,
+  makeDesktopItem,
+  installShellFiles,
+
+  dbus,
+  polkit,
+
+  phosh,
+  pkg-config,
+  gobject-introspection,
+  gdk-pixbuf,
+  atkmm,
+  gtk3,
+  gtk4,
+  libhandy,
+  glib,
+  wrapGAppsHook4,
+  gsettings-desktop-schemas,
+  gnome-settings-daemon,
+  gnome-session,
+  accountsservice,
+  squeekboard,
+  calls,
+}:
+let
+  oskItem = makeDesktopItem {
+    name = "sm.puri.OSK0";
+    desktopName = "On-screen keyboard";
+    exec = "${squeekboard}/bin/squeekboard";
+    categories = [
+      "GNOME"
+      "Core"
+    ];
+    onlyShowIn = [ "GNOME" ];
+    noDisplay = true;
+    extraConfig = {
+      X-GNOME-Autostart-Phase = "Panel";
+      X-GNOME-Provides = "inputmethod";
+      X-GNOME-Autostart-Notify = "true";
+      X-GNOME-AutoRestart = "true";
+    };
+  };
+in
+rustPlatform.buildRustPackage rec {
+  pname = "phrog";
+  version = "0.46.0";
+
+  src = fetchFromGitHub {
+    owner = "samcday";
+    repo = "phrog";
+    rev = version;
+    hash = "sha256-dhoBGlg/UyvO60Kd8BMnVWxDXVSiM+fUnA9ef/oOcMA=";
+  };
+
+  cargoHash = "sha256-Obz/pnNmMbZjkwerNxqu3/O9pYfaCjYJHOvSF72VEwM=";
+
+  doCheck = false; # There's no access to dbus daemon anyway, so we can't run `test_accent_colours`. The unit tests also require GNOME and a Wayland session.
+
+  nativeBuildInputs = [
+    pkg-config
+    gobject-introspection
+    wrapGAppsHook4
+    installShellFiles
+  ];
+
+  buildInputs = [
+    phosh
+    gdk-pixbuf
+    atkmm
+    gtk4
+    gtk3
+    libhandy
+    gsettings-desktop-schemas
+    gnome-settings-daemon
+    gnome-session
+    glib
+    accountsservice
+    squeekboard
+    oskItem
+    calls
+    polkit
+  ];
+
+  # Phrog wants to access $XDG_HOME. This is not allowed.
+  # It also has hardcoded paths for sessions. This is also not allowed.
+
+  patches = [
+    ./0001-nixos-phrog-contain-schema-dir-within-drv.patch
+  ];
+
+  cargoPatches = [
+    ./0001-nixos-Use-XDG_DATA_DIRS-instead-of-hardcoded-paths-t.patch
+  ];
+
+  preConfigure = ''
+    mkdir $out/share/glib-2.0/schemas/ -p
+
+    substituteInPlace build.rs \
+    --replace-fail "{interp}" "$out/share/glib-2.0/schemas" \
+  '';
+
+  postFixup = ''
+    mkdir $out/share/gnome-session/sessions -p
+    mkdir $out/share/wayland-sessions -p
+
+    cp data/phrog.session $out/share/gnome-session/sessions/phrog.session
+    cp data/mobi.phosh.Phrog.desktop $out/share/wayland-sessions
+  '';
+
+  passthru = {
+    providedSessions = [ "mobi.phosh.Phrog" ];
+    tests.phosh = nixosTests.phosh;
+  };
+
+  meta = {
+    description = "A greeter that works on mobile devices and also other kinds of computers";
+    homepage = "https://github.com/samcday/phrog";
+    changelog = "https://github.com/samcday/phrog/releases/tag/${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ hustlerone ];
+    platforms = lib.platforms.linux;
+    mainProgram = "phrog";
+  };
+}

--- a/pkgs/applications/window-managers/phosh/0001-plugins-scaling-quick-setting-specify-missing-depend.patch
+++ b/pkgs/applications/window-managers/phosh/0001-plugins-scaling-quick-setting-specify-missing-depend.patch
@@ -1,0 +1,24 @@
+From d54a6ffc50354a975491f1aa672f44a17babe6e0 Mon Sep 17 00:00:00 2001
+From: hustlerone <nine-ball@tutanota.com>
+Date: Sun, 18 May 2025 15:20:31 +0200
+Subject: [PATCH] plugins/scaling-quick-setting: specify missing dependency
+
+---
+ plugins/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/plugins/meson.build b/plugins/meson.build
+index e9fffe64..1937e7c0 100644
+--- a/plugins/meson.build
++++ b/plugins/meson.build
+@@ -87,6 +87,7 @@ if get_option('lockscreen-plugins') or get_option('quick-setting-plugins')
+       libhandy_dep,
+       libnm_dep,
+       phosh_plugins_dep,
++      gio_unix_dep
+     ],
+   )
+ 
+-- 
+2.49.0
+

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -19,6 +19,7 @@
   glib,
   modemmanager,
   gtk4,
+  gtk3,
   gnome-bluetooth,
   gnome-control-center,
   gnome-desktop,
@@ -39,26 +40,29 @@
   evolution-data-server,
   nixosTests,
   gmobile,
+  gobject-introspection,
+  appstream,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "phosh";
-  version = "0.44.1";
+  version = "0.48.0";
 
   src = fetchurl {
     # Release tarball which includes subprojects gvc and libcall-ui
     url = with finalAttrs; "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-rczGr7YSmVFu13oa3iSTmSQ4jsjl7lv38zQtD7WmDis=";
+    hash = "sha256-GZKxIQgEudCabSC40UqbXgrwjPjdz8X+aoyXNdFzL20=";
   };
 
   nativeBuildInputs = [
-    libadwaita
+    libadwaita.dev
     meson
     ninja
     pkg-config
     python3
     wayland-scanner
     wrapGAppsHook4
+    gobject-introspection
   ];
 
   buildInputs = [
@@ -71,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     callaudiod
     evolution-data-server
     pulseaudio
-    glib
+    glib.dev
     modemmanager
     gcr
     networkmanager
@@ -81,12 +85,19 @@ stdenv.mkDerivation (finalAttrs: {
     gnome-control-center
     gnome-desktop
     gnome-session
-    gtk4
+    gtk4.dev
+    gtk3.dev
     pam
     systemd
     upower
     wayland
     feedbackd
+    appstream
+  ];
+
+  patches = [
+    # https://gitlab.gnome.org/World/Phosh/phosh/-/merge_requests/1742
+    ./0001-plugins-scaling-quick-setting-specify-missing-depend.patch
   ];
 
   nativeCheckInputs = [
@@ -101,6 +112,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dcompositor=${phoc}/bin/phoc"
     # Save some time building if tests are disabled
     "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
+    # We need this for phrog
+    "-Dbindings-lib=true"
   ];
 
   checkPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12342,6 +12342,7 @@ with pkgs;
       regreet = callPackage ../applications/display-managers/greetd/regreet.nix { };
       tuigreet = callPackage ../applications/display-managers/greetd/tuigreet.nix { };
       wlgreet = callPackage ../applications/display-managers/greetd/wlgreet.nix { };
+      phrog = callPackage ../applications/display-managers/greetd/phrog/package.nix { };
     }
     // lib.optionalAttrs config.allowAliases {
       dlm = throw "greetd.dlm has been removed as it is broken and abandoned upstream"; # Added 2024-07-15


### PR DESCRIPTION
Bumps phosh and phoc to the latest release, being as of writing 0.48.0

This PR is aimed at adding phrog into nixpkgs, a greeter for greetd that is designed for use in touchscreens.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
