### PR TITLE
dsnet: init at 0.8.1, nixos/dsnet: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16928,6 +16928,12 @@
     githubId = 1131571;
     name = "naelstrof";
   };
+  naggie = {
+    name = "Cal Bryant";
+    email = "callan.bryant@gmail.com";
+    github = "naggie";
+    githubId = 208440;
+  };
   nagisa = {
     name = "Simonas Kazlauskas";
     email = "nixpkgs@kazlauskas.me";

--- a/nixos/modules/services/networking/dsnet.md
+++ b/nixos/modules/services/networking/dsnet.md
@@ -1,0 +1,31 @@
+# dsnet {#module-services-dsnet}
+
+dsnet is a CLI tool to manage a centralised wireguard server. It allows easy
+generation of client configuration, handling key generation, IP allocation etc.
+
+It keeps its own configuration at `/etc/dsnetconfig.json`, which is more of a
+database. It contains key material too.
+
+The way this module works is to patch this database with whatever is configured
+in the nix service instantiation. This happens automatically when required.
+
+This way it is possible to decide what to let dnset manage and what parts you
+want to keep declaratively.
+
+```
+services.dsnet = {
+  enable = true;
+  settings = {
+    ExternalHostname = "vpn.example.com";
+    Network = "10.171.90.0/24";
+    Network6 = "";
+    IP = "10.171.90.1";
+    IP6 = "";
+    DNS = "10.171.90.1";
+    Networks = [ "0.0.0.0/0" ];
+  };
+
+```
+
+
+See <https://github.com/naggie/dsnet> for more information.

--- a/nixos/modules/services/networking/dsnet.nix
+++ b/nixos/modules/services/networking/dsnet.nix
@@ -1,0 +1,184 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.dsnet;
+  settingsFormat = pkgs.formats.json { };
+  patchFile = settingsFormat.generate "dsnet-patch.json" cfg.settings;
+in
+{
+  options.services.dsnet = {
+    enable = lib.mkEnableOption "dsnet, a centralised Wireguard VPN manager";
+
+    package = lib.mkPackageOption pkgs "dsnet" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+
+        freeformType = settingsFormat.type;
+
+        options = {
+          ExternalHostname = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "vpn.example.com";
+            description = ''
+              The hostname that clients should use to connect to this server.
+              This is used to generate the client configuration files.
+
+              This is preferred over ExternalIP, as it allows for IPv4 and
+              IPv6, as well as enabling the ability tp change IP.
+            '';
+          };
+
+          ExternalIP = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "192.0.2.1";
+            description = ''
+              The external IP address of the server. This is used to generate
+              the client configuration files for when an ExternalHostname is not set.
+
+              Leaving this empty will cause dsnet to use the IP address of
+              what looks like the WAN interface.
+            '';
+          };
+
+          ExternalIP6 = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "2001:db8::1";
+            description = ''
+              The external IPv6 address of the server. This is used to generate
+              the client configuration files for when an ExternalHostname is
+              not set. Used in preference to ExternalIP.
+
+              Leaving this empty will cause dsnet to use the IP address of
+              what looks like the WAN interface.
+            '';
+          };
+
+          Network = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "172.18.0.0/24";
+            description = ''
+              The IPv4 network that the server will use to allocate IPs on the network.
+              Leave this empty to let dsnet choose a network.
+            '';
+          };
+
+          Network6 = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "2001:db8::1/64";
+            description = ''
+              The IPv6 network that the server will use to allocate IPs on the
+              network.
+              Leave this empty to let dsnet choose a network.
+            '';
+          };
+
+          IP = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "172.18.0.1";
+            description = ''
+              The IPv4 address that the server will use on the network.
+              Leave this empty to let dsnet choose an address.
+            '';
+          };
+
+          IP6 = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "2001:db8::1";
+            description = ''
+              The IPv6 address that the server will use on the network
+              Leave this empty to let dsnet choose an address.
+            '';
+          };
+
+          Networks = lib.mkOption {
+            type = lib.types.nullOr (lib.types.listOf lib.types.str);
+            default = null;
+            example = [
+              "0.0.0.0/0"
+              "192.168.0.0/24"
+            ];
+            description = ''
+              The CIDR networks that should route through this server. Clients
+              will be configured to route traffic for these networks through
+              the server peer.
+            '';
+          };
+        };
+      };
+
+      default = { };
+      description = ''
+        The settings to use for dsnet. This will be converted to a JSON
+        object that will be passed to dsnet as a patch, using the patch
+        command when the service is started. See the dsnet documentation for
+        more information on the additional options.
+
+        Note that the resulting /etc/dsnetconfg.json is more of a database
+        than it is a configuration file. It is therefore recommended that
+        system specific values are configured here, rather than the full
+        configuration including peers.
+
+        Peers may be managed via the dsnet add/remove commands, negating the
+        need to manage key material and cumbersom configuration with nix. If
+        you want peer configuration in nix, you may as well use the regular
+        wireguard module.
+      '';
+      example = {
+        ExternalHostname = "vpn.example.com";
+        ExternalIP = "127.0.0.1";
+        ExternalIP6 = "";
+        ListenPort = 51820;
+        Network = "10.3.148.0/22";
+        Network6 = "";
+        IP = "10.3.148.1";
+        IP6 = "";
+        DNS = "8.8.8.8";
+        Networks = [ "0.0.0.0/0" ];
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.dsnet = {
+      description = "dsnet VPN Management";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      preStart = ''
+        test ! -f /etc/dsnetconfig.json && ${lib.getExe cfg.package} init
+        ${lib.getExe cfg.package} patch < ${patchFile}
+      '';
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} up";
+        ExecStop = "${lib.getExe cfg.package} down";
+        Type = "oneshot";
+        # consider the service to be active after process exits, so it can be
+        # reloaded
+        RemainAfterExit = true;
+      };
+
+      reload = ''
+        ${lib.getExe cfg.package} patch < ${patchFile}
+        ${lib.getExe cfg.package} sync < ${patchFile}
+      '';
+
+      # reload _instead_ of restarting on change
+      reloadIfChanged = true;
+    };
+  };
+}

--- a/pkgs/by-name/ds/dsnet/package.nix
+++ b/pkgs/by-name/ds/dsnet/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "dsnet";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "naggie";
+    repo = "dsnet";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CKDtILZMWFeSU5nTSguM2fi0BCFdvR2LqELIZ6LYOMk=";
+  };
+  vendorHash = "sha256-Q2Ipj9yZ+/GUBEmDvgwFLLww7EXnbvdvj/shGQnh1G8=";
+
+  subPackages = [ "cmd" ];
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/dsnet
+  '';
+
+  # The ldflags reduce the executable size by stripping some debug stuff.
+  # The other variables are set so that the output of dsnet version shows the
+  # git ref and the release version from github.
+  # Ref <https://github.com/NixOS/nixpkgs/pull/87383#discussion_r432097657>
+  ldflags = [
+    "-w"
+    "-s"
+    "-X github.com/naggie/dsnet.VERSION=${finalAttrs.src.tag}"
+    "-X github.com/naggie/dsnet.GIT_COMMIT=${finalAttrs.src.tag}"
+  ];
+
+  meta = {
+    description = "Fast command to manage a centralised Wireguard VPN";
+    homepage = "https://github.com/naggie/dsnet";
+    changelog = "https://github.com/naggie/dsnet/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.naggie ];
+    mainProgram = "dsnet";
+  };
+
+})


### PR DESCRIPTION
dsnet is a CLI tool to manage a centralised wireguard server. It allows easy
generation of client configuration, handling key generation, IP allocation etc.

This change packages [dsnet](https://github.com/naggie/dsnet] for linux, and
adds a module to make dsnet a proper NixOS module allowing direct configuration.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---
I have tested this fairly extensively at home. @botto has tested some basic configuration too.


My first PR into nixpkgs -- thanks for considering!


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
