### PR TITLE
bottles: update patches, add `gamemode` to `propagatedBuildInputs`

### DIFF
--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -26,7 +26,7 @@
   vmtouch,
   libportal,
   nix-update-script,
-  removeWarningPopup ? false, # Final reminder to report any issues on nixpkgs' bugtracker
+  removeWarningPopup ? false,
 }:
 
 python3Packages.buildPythonApplication rec {

--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -20,6 +20,7 @@
   lsb-release,
   pciutils,
   procps,
+  gamemode,
   gamescope,
   mangohud,
   vkbasalt-cli,
@@ -103,6 +104,7 @@ python3Packages.buildPythonApplication rec {
       imagemagick
       vkbasalt-cli
 
+      gamemode
       gamescope
       mangohud
       vmtouch

--- a/pkgs/by-name/bo/bottles-unwrapped/remove-unsupported-warning.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/remove-unsupported-warning.patch
@@ -1,10 +1,8 @@
-diff --git a/bottles/frontend/windows/main_window.py b/bottles/frontend/windows/main_window.py
-index 79bf0d72..e37ca43e 100644
---- a/bottles/frontend/windows/main_window.py
-index 79bf0d72..e37ca43e 100644
---- a/bottles/frontend/windows/main_window.py
-+++ b/bottles/frontend/windows/main_window.py
-@@ -104,29 +104,15 @@ class MainWindow(Adw.ApplicationWindow):
+diff --git a/bottles/frontend/windows/window.py b/bottles/frontend/windows/window.py
+index 802b08b5..c4cada1d 100644
+--- a/bottles/frontend/windows/window.py
++++ b/bottles/frontend/windows/window.py
+@@ -102,29 +102,15 @@ class BottlesWindow(Adw.ApplicationWindow):
  
              def response(dialog, response, *args):
                  if response == "close":

--- a/pkgs/by-name/bo/bottles-unwrapped/warn-unsupported.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/warn-unsupported.patch
@@ -1,8 +1,8 @@
 diff --git a/bottles/frontend/windows/window.py b/bottles/frontend/windows/window.py
-index 79bf0d72..e3a15cb5 100644
+index 802b08b5..e3de0536 100644
 --- a/bottles/frontend/windows/window.py
 +++ b/bottles/frontend/windows/window.py
-@@ -104,29 +104,29 @@ class MainWindow(Adw.ApplicationWindow):
+@@ -102,29 +102,30 @@ class BottlesWindow(Adw.ApplicationWindow):
  
              def response(dialog, response, *args):
                  if response == "close":
@@ -15,15 +15,15 @@ index 79bf0d72..e3a15cb5 100644
              )
 -            download_url = "usebottles.com/download"
 +            bugtracker_url = "github.com/NixOS/nixpkgs/issues"
++
  
              error_dialog = Adw.AlertDialog.new(
                  _("Unsupported Environment"),
 -                f"{body} <a href='https://{download_url}' title='https://{download_url}'>{download_url}.</a>",
-+                f"{body} <a href='https://{bugtracker_url}' title='https://{bugtracker_url}'>{bugtracker_url}.</a>",
++                f"{body} <a href='https://{bugtracker_url}' title='https://{bugtracker_url}'>{bugtracker_url}.</a> \nThis warning can be disabled by overriding the package: `(pkgs.bottles.override {{ removeWarningPopup = false; }})`",
              )
  
--            error_dialog.add_response("close", _("Close"))
-+            error_dialog.add_response("close", _("Understood"))
+             error_dialog.add_response("close", _("Close"))
              error_dialog.set_body_use_markup(True)
              error_dialog.connect("response", response)
              error_dialog.present(self)


### PR DESCRIPTION
`remove-unsupported-warning.patch` was not updated in the last bump, bottles won't compile if `removeWarningPopup = true` is used.

I also added an explanation in the popup on how to disable it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
