### PR TITLE
nvim-treesitter grammars updater: avoid silent fails

### DIFF
--- a/pkgs/applications/editors/vim/plugins/utils/nvim-treesitter/update.py
+++ b/pkgs/applications/editors/vim/plugins/utils/nvim-treesitter/update.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env nix-shell
-#!nix-shell update-shell.nix -i python
+#!nix-shell ./update-shell.nix -i python
 
 import json
 import logging
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import requests
 
 log = logging.getLogger("vim-updater")
 
-NURR_JSON_URL = "https://raw.githubusercontent.com/nvim-neorocks/nurr/main/tree-sitter-parsers.json"
+NURR_JSON_URL = (
+    "https://raw.githubusercontent.com/nvim-neorocks/nurr/main/tree-sitter-parsers.json"
+)
+
 
 def generate_grammar(lang, parser_info):
     """Generate grammar for a language based on the parser info"""
@@ -30,7 +34,9 @@ def generate_grammar(lang, parser_info):
     version = "0.0.0+rev={rev[:7]}";
     src = """
 
-        generated += subprocess.check_output(["nurl", url, rev, "--indent=4"], text=True)
+        generated += subprocess.check_output(
+            ["nurl", url, rev, "--indent=4"], text=True
+        )
         generated += ";"
 
         location = install_info.get("location", "")
@@ -82,8 +88,7 @@ def fetch_nurr_parsers():
 def process_parser_info(parser_info):
     """Process a single parser info entry and generate grammar for it"""
     try:
-        lang = parser_info["lang"]
-        return generate_grammar(lang, parser_info)
+        return generate_grammar(parser_info["lang"], parser_info)
     except Exception as e:
         log.error(f"Error processing parser: {e}")
         return ""
@@ -119,13 +124,10 @@ def update_grammars():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     generated = update_grammars()
-    output_path = os.path.join(
-        os.path.dirname(__file__),
-        "../../nvim-treesitter/generated.nix"
-    )
+    output_path = Path(__file__).parent.parent / "nvim-treesitter/generated.nix"
     log.info("Writing output to %s", output_path)
     with open(output_path, "w") as f:
         f.write(generated)

--- a/pkgs/applications/editors/vim/plugins/utils/nvim-treesitter/update.py
+++ b/pkgs/applications/editors/vim/plugins/utils/nvim-treesitter/update.py
@@ -19,44 +19,40 @@ NURR_JSON_URL = (
 
 def generate_grammar(lang, parser_info):
     """Generate grammar for a language based on the parser info"""
-    try:
-        if "install_info" not in parser_info:
-            log.warning(f"Parser {lang} does not have install_info, skipping")
-            return ""
+    if "install_info" not in parser_info:
+        log.warning(f"Parser {lang} does not have install_info, skipping")
+        return ""
 
-        install_info = parser_info["install_info"]
+    install_info = parser_info["install_info"]
 
-        url = install_info["url"]
-        rev = install_info["revision"]
+    url = install_info["url"]
+    rev = install_info["revision"]
 
-        generated = f"""  {lang} = buildGrammar {{
+    generated = f"""  {lang} = buildGrammar {{
     language = "{lang}";
     version = "0.0.0+rev={rev[:7]}";
     src = """
 
-        generated += subprocess.check_output(
-            ["nurl", url, rev, "--indent=4"], text=True
-        )
-        generated += ";"
+    generated += subprocess.check_output(
+        ["nurl", url, rev, "--indent=4"], text=True
+    )
+    generated += ";"
 
-        location = install_info.get("location", "")
-        if location:
-            generated += f"""
+    location = install_info.get("location", "")
+    if location:
+        generated += f"""
     location = "{location}";"""
 
-        if install_info.get("generate", False):
-            generated += """
+    if install_info.get("generate", False):
+        generated += """
     generate = true;"""
 
-        generated += f"""
+    generated += f"""
     meta.homepage = "{url}";
   }};
 """
 
-        return generated
-    except Exception as e:
-        log.error(f"Error generating grammar for {lang}: {e}")
-        return ""
+    return generated
 
 
 def fetch_nurr_parsers():
@@ -87,11 +83,7 @@ def fetch_nurr_parsers():
 
 def process_parser_info(parser_info):
     """Process a single parser info entry and generate grammar for it"""
-    try:
-        return generate_grammar(parser_info["lang"], parser_info)
-    except Exception as e:
-        log.error(f"Error processing parser: {e}")
-        return ""
+    return generate_grammar(parser_info["lang"], parser_info)
 
 
 def update_grammars():


### PR DESCRIPTION
What if some grammar fails to update? Well, it gets removed from the generated file. How would we know that the grammar failed? By reading logs. Who reads logs if the command didn't crash? Right, nobody. Or even if someone examines the logs, it is too easy to overlook the failure (are you sure you read every single line of code? It is not even colored)

### Logs should be treated as noise that nobody will ever read.

They are useful only in two cases:

- During debugging, this happens rarely
- Let's print something to keep the user informed that we are doing something

  It should not to be a mistake to overlook one line from the logs, because when you run the same script hundreds of times (we do updates weekly), you barely look at logs; you scan them, at most.

By treating logs this way, we can inform ourselves about possible breakages before it gets even reviewed by another person, not by a user opening a bug report months later.

---

That was a rant about logs in general, but consider this: most of our logs are just noise from nurl.


![image](https://github.com/user-attachments/assets/608dad73-626a-4e06-9122-38d2a085d473)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
