### PR TITLE
thunderbird-esr(-bin): 128.10.0 -> 128.10.1, thunderbird-latest: 138.0 -> 138.0.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
@@ -1,1193 +1,797 @@
 {
-  version = "128.10.0esr";
+  version = "128.10.1esr";
   sources = [
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/af/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/af/thunderbird-128.10.1esr.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "857282503e2c867929b387137be486c5cc428968e59a66665eed50eb04d353f2";
+      sha256 = "c66c686e94343eeb53ad0e202127becfb529cb3da2dca1b77b2420419e1fbe73";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ar/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ar/thunderbird-128.10.1esr.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "f65c2a73f9eb5b6d990d2f2ea3cbf769a521eb0297bee170bc233713d1baba89";
+      sha256 = "326c20ed0e8bea525cbfe385236efbddde2db7b5aabbda09081ff3a5aa21ddc9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ast/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ast/thunderbird-128.10.1esr.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "1182efca5b9c93ebd05cd7ed47a549c8eb4e2e9d38f2d38740f191881f256c30";
+      sha256 = "d01bff98fda18ff648ddd57601c5f26e8b11e9df410f01192fbf7ba57732184e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/be/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/be/thunderbird-128.10.1esr.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "fb5e8d1f332ec10b38c43ba7690ec749d898c7d1b2a38d9583d0f16c5f0608f3";
+      sha256 = "c485a68ca28fedd45ce93e17180ef3122305d3ebac49028e001bf91c466fa701";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/bg/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/bg/thunderbird-128.10.1esr.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "5946dd6688341107bbf7bf99eabe9ffe3686f8a6b64f6d24fd0af8782dbfb883";
+      sha256 = "f31be4e8e2da5ae9390a99adce920b579db0bbb55d7ae9a0aee552af02149f10";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/br/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/br/thunderbird-128.10.1esr.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "cef7fc19a7a3903575a3c2ad8f9bde16880e5a916d921c891137d68390ae07da";
+      sha256 = "134cbb02c9023c66a46b3083b6f5751f6865f1d19b3e068571a92b341a264a8b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ca/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ca/thunderbird-128.10.1esr.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "909fe5327d08a3fcaf8845087e5ea210e17e61c7a050793fcc537f38b871bcce";
+      sha256 = "2b81952163805134cc65b21151958e1fd6c1ce3fb312917769ced340735baa48";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/cak/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/cak/thunderbird-128.10.1esr.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "efeec0a1ac7bebddf841e938ce34b830634a8c542839b8ff1c662b4c2eaa0d16";
+      sha256 = "9c0156e6ff149c311d755123bd9f92d98e8cb41f05d54159d1fe12ce9a1c8f46";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/cs/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/cs/thunderbird-128.10.1esr.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "15403d469bf30379b15e14ec9be44f33507977c6346ed440e361729b7d385af7";
+      sha256 = "76017bfa968079e3b48e36525e2d19f01a40b854a8d6ce2494a654d442296a6d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/cy/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/cy/thunderbird-128.10.1esr.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "9c36982d3475fa3f03d7a47d102afeecda5567588b4597bd04edd5ca5620d646";
+      sha256 = "067388baab68d54aca5fd4b105350871b4ed89e42763641b29e728c87312412c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/da/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/da/thunderbird-128.10.1esr.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "4bd6f4f660c2ae60ec4d6067ce87d7e841cd00d38f35d1291e95525780613bff";
+      sha256 = "452e57612838e0d6a65162a66bd5347a694f46fb06f00ad522e6d331f314fe7a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/de/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/de/thunderbird-128.10.1esr.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "2dfe11da23805896714d5918ba054d174402758c457d5172241c9c2e38f82cbf";
+      sha256 = "bda05607655b09504f07888e42e670346c4fb75c5105f4f01123fd9e0f2e5136";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/dsb/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/dsb/thunderbird-128.10.1esr.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "d9777017e578d7ac82e93cf59ba978c4b67dd2d36928f5629fc33f602bf12c7e";
+      sha256 = "1040cfbe784ce251a0ae00a210b5d3d6c9ef388f2292d1f4a855b4ec2e1158d8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/el/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/el/thunderbird-128.10.1esr.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "cacff9ee3ae37c81db51abc99357223664b865315f2776ac36ea443ab9637cef";
+      sha256 = "28b9c47b2ee873b2fdec84bff22ff834a86f90c85f7057711c79001e95d39ac5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/en-CA/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/en-CA/thunderbird-128.10.1esr.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "c389f71b4b2e944d6d38d5cabd803f67aac885aced035c0c801f2129cbda0afb";
+      sha256 = "3d8b86bf5e774503a1d05ff94bd56d763c1c858b139f980faacfe23dff14f105";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/en-GB/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/en-GB/thunderbird-128.10.1esr.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "7533e0830f276086727c48ae7d94fa0b87332d46baef5276a4351051e49bddf8";
+      sha256 = "c6bcf2b3bbf223c3a5fb90889945fd7da17431b9f545ca65c48bc617b2b8febb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/en-US/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/en-US/thunderbird-128.10.1esr.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "04d28cae6d4286fa5d37b1ba8d0895db216c21175d48ecacc50365c5046a0fff";
+      sha256 = "5eec0dd693b7fc90712c885bcad230eccd7f3450b46d87963b7782b07a79c02b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/es-AR/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/es-AR/thunderbird-128.10.1esr.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "24ef9e4a2a9b348eb0b10cfa175d70d0825235e751acb7abe5667a86647b56b7";
+      sha256 = "9d419222115f4a44d8043abc53c76e68c36971a3c9d81a668c716495446dd505";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/es-ES/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/es-ES/thunderbird-128.10.1esr.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "96cc5ed02c6ed6e46e8b7dcd628a564acb987e73849d84fb328b7ef3a9e9cc49";
+      sha256 = "9ad29f1a7b2025fa00b2a16f4dbddd07a4c6c589e92be458215e909493d64d71";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/es-MX/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/es-MX/thunderbird-128.10.1esr.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "8445c38081b8392b6e2de98982117d3000bf368f6da1e681945193f566b4f01b";
+      sha256 = "8aed538779e334bedb084d8e23c76424f8c38c59f924fc616a216dff0f466572";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/et/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/et/thunderbird-128.10.1esr.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e6fd5134f91507fbfac03c2f859e0d038f506c99d5925fff98c41dd40dd34915";
+      sha256 = "d6fe82c59bbd7f22ff2e14459f5730d04a81bd066d04a35872223d598c46f8ef";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/eu/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/eu/thunderbird-128.10.1esr.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "2c8307a960038bb4edca8406c07a7fa8bc15f6b8d681393996541199470a30a5";
+      sha256 = "2d46d7e535dfc8ca89cfec8e646e2ca1bd0ca67cfea4ed489ef50c7403e44cc8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/fi/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/fi/thunderbird-128.10.1esr.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "f71ba700f6271a1998dd093bb251082ddfc59ff885ac67f70f8b50433fc39859";
+      sha256 = "6ffe726c6221ea49cf45f0eab6887a6c4c4ede2efaa8776ecf990c52f2dddd2b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/fr/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/fr/thunderbird-128.10.1esr.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "e56a3f73db1e7ae82c2063a663a4f278850fc13c4b6dfba4eefed2062f73b41c";
+      sha256 = "7bbd0326d37d529631030fa8e9990ebaeec188014704dc3c2494514337cb5209";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/fy-NL/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/fy-NL/thunderbird-128.10.1esr.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "78032171968489377c7e2cf2ec0715877a2294113523f1dc7f63edaf46471828";
+      sha256 = "63812daf0ef31b5906bc99e30369d268eb95e0c7c7e9754d4ff203106b891c9e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ga-IE/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ga-IE/thunderbird-128.10.1esr.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "67691b7d441c918cab3c5cbce5b79e0ef05741f5f90d49e2e4a166e898fbd500";
+      sha256 = "a8694a13da1a05930746ce240c88c8c4a015bf4d81a0e013f27a2b86426fb421";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/gd/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/gd/thunderbird-128.10.1esr.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "26a06b0f88b3b16554fe27a3ff8726699e72d1aa2789e3c53cc0bb92a69413ec";
+      sha256 = "56dcd6b3d652508e3fa81b29171c7b108a878364e3e18d53d0d2a762ac0bfa71";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/gl/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/gl/thunderbird-128.10.1esr.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "7575ac6c7be6f3dc82fdcd5005d70eee3e13e1b82d8a79dc1eb7bb7d24c93f78";
+      sha256 = "e3bc784bc66dcabc874ef29ccc129c2b6ed658f8babb963207087a84b70341c1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/he/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/he/thunderbird-128.10.1esr.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "e7381bfba44df175372e05cd3efe2e3287389f1324854ab5cc7bb0ed9d081db1";
+      sha256 = "2423696c56c56210b8a0f3d29b8813317d5eaf8ceb366a02134f33454a8b77dc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/hr/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/hr/thunderbird-128.10.1esr.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "f3e1bf2b4929e31b3c4c736a1f685130619e42ff0e215ac838e9cd00a9c61e68";
+      sha256 = "56f8fd040b2ef3d116e3eed9e8a59d7831d11d366a398f2019486bddfc9a2798";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/hsb/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/hsb/thunderbird-128.10.1esr.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "bc9af027c0a67910472adb5e4cdb5b9a24b31659b60bf3c7a6cd4a54f3a73ea8";
+      sha256 = "2b3acab919c76d89a51601e6363697ab83c2c90c45c3b81b9da7c294907df776";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/hu/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/hu/thunderbird-128.10.1esr.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "80228607792dab475c9cf85932ad84a0c57a12bb87dd7f0748304c06d5a03ce5";
+      sha256 = "6945c86d683259e113be15938749165ea388152550ca25c7757c7f0561365596";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/hy-AM/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/hy-AM/thunderbird-128.10.1esr.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "bd96c347447840d8d79967cacd8e748edcba01cbec5fb3ac7b4c93d33c6ec094";
+      sha256 = "535162246c252993dab09118458fe9100138cda68e0864d0f74b607517d67ed5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/id/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/id/thunderbird-128.10.1esr.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "96b51fb41195a83ad216851742c8af4d923aee60dcf5b362e6bdeeea1f5e926b";
+      sha256 = "60e05c5848428f87f5c2506fae299a1501482ff1d59e38bea37037f5352f048f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/is/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/is/thunderbird-128.10.1esr.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "f4168470a02f6bbf3e5f05317ff419ebf2b7ced0f653ecb12924094bc20f2151";
+      sha256 = "5f71154d1a5c0fa2979b27dab349d0818ba47d4a98c1ff1dc8981542682dc46f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/it/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/it/thunderbird-128.10.1esr.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "4edb1699a3dfc4fc4ef76d535d69480b5d2a0367e2b2eaddbbf60ba8f3e64d99";
+      sha256 = "9d53fcea9a6b7a530a418ed7dce16edf6e5e4380e24063a8596bfde39bfb1649";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ja/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ja/thunderbird-128.10.1esr.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "0c0bfbfcca5c0c20ba5ff9a7d6ff6f640479fba165b054075d4513dd7f5bd00f";
+      sha256 = "a0b26ef38e894fab1e9ba61e8f91fb40fa8e7fe98e612541ce41c637a01cfff0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ka/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ka/thunderbird-128.10.1esr.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "c76dd2b4569ff8bc75080ced7f1fe6af2c08447ede9d8c6c0b9cb6827dc42ffb";
+      sha256 = "6a9a3b21ecb587ca7c551b266f85daaa8f67c9a4dc4d848e0797aa5d7345c5e9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/kab/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/kab/thunderbird-128.10.1esr.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "29de0bfc1cec81ff96535e3ab4ab4ff1ceadc72c6b5947abd40ae11dcd7423bb";
+      sha256 = "ca407f60e6c72ad586169b75c2423fd4494a514eae24d11e3dcc3c8ba0e20e13";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/kk/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/kk/thunderbird-128.10.1esr.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "42087039b4a255e059659b316a9ed1a7b0a452bd5dc5500e448ebb39cd29f3cb";
+      sha256 = "43cb9688f7135044915b6b0d6f3d1d9ae72d99477a488b1d921e00f342e2277e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ko/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ko/thunderbird-128.10.1esr.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "de46b8dab434539a4c5a789d73ea969da0e8427b71423d1fbf6c0de6d1026907";
+      sha256 = "0d7ca9cda728fa9d1bbd7698ba02a209ed9e78ac077d1eedfbf979f00fb942e7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/lt/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/lt/thunderbird-128.10.1esr.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "413fb6852be1c7ee59a2fef64a7eadd28d043ce42b3f3c3728d1738357279010";
+      sha256 = "327829ce42e78a417a84d285a356ed3ac7c8d09ca755da7f8473eb226cdc6162";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/lv/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/lv/thunderbird-128.10.1esr.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "917079f72fd2b99c790cb2f3f8d52096c39681508d0d37db7e2699261fd8d361";
+      sha256 = "05674ac21a82566afafd3da5b15c5b59f18a24b198c4c9dd33af2f1ca28c3e8f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ms/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ms/thunderbird-128.10.1esr.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "b9f4f986c13da6365796c40de7201cfd87447b64176d34f562910eca94ad4996";
+      sha256 = "ebbca65958ca8355066f9d57885140fedecf8d3a661b387016f3459e3d3c2f25";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/nb-NO/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/nb-NO/thunderbird-128.10.1esr.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "1c28bc077c84f767aa9d8d7eca42cc240b268453c53663b91d789ded3933b8de";
+      sha256 = "a6735c6517e0450f275f6efeed060d08e8dbbf0879e9158ad87f6e32eb31cd72";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/nl/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/nl/thunderbird-128.10.1esr.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "5d5e11a586d7a02b0891594edc36e80db2f8b174e6688c591a6fe3703e98755d";
+      sha256 = "1064929fae022194bdc0d413e2c61f92b019da274c30d355bd2f445bee0395ba";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/nn-NO/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/nn-NO/thunderbird-128.10.1esr.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "9c9773e9e881068521c655523c80fc65d08119b424fe995edb930d669eaaa3ac";
+      sha256 = "b87d37697efd424b6e5eee73566bda7d90be61794f2db48b9ff37ae14e309c2c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/pa-IN/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/pa-IN/thunderbird-128.10.1esr.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "655eeb22bd08e292aee649c99bf1c9568fba047d97065c4f3f783a7a813aa809";
+      sha256 = "851f84982228db5f2100d38cc641d1dbb676efcff5df120dfa7aa7b048ff78eb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/pl/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/pl/thunderbird-128.10.1esr.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "199a2af3ff6e867df88d5c104bebaf0c1b2143c7b531302258a37f37f8970102";
+      sha256 = "793a8f56f6a0ba9f9a848d1752d22cf7fffc45737ae37190467a9c3de3586b1e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/pt-BR/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/pt-BR/thunderbird-128.10.1esr.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "72ca3377228e4ee621a5c0e867f5cf8ec21d1b3347419cbd78c0582a6f3b7226";
+      sha256 = "149c387b3209434d17baee97c89527c3ee428f418ebc561c58f86d74cba297eb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/pt-PT/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/pt-PT/thunderbird-128.10.1esr.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "f5774a5dc875b8af31e59c37f32e355b6b204dcc1228727ec1d999e1f310c08a";
+      sha256 = "e525d2ef04133448f6dd261d87c7f53e528af1ccfe0b7367a643525efbb4f811";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/rm/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/rm/thunderbird-128.10.1esr.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "c46b7afc9e8f73d385d868601a99690cf078663cec9c8e92413d8ec076e01f94";
+      sha256 = "e081b4ec691b8abdd1470a0ba7712f2cbb65aebcaadf1b3a6f52e2a7f3d2b6d2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ro/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ro/thunderbird-128.10.1esr.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "f085eecb919959f5496ae205c204619dad529f46c61b718e783760a5a127443e";
+      sha256 = "140d956ff1e311d39e7abe3b5e1ee4cfad4262f9bf649b0554f103596140a6b6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/ru/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/ru/thunderbird-128.10.1esr.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "395292e3c38886508140350dc9d75800f5bde25c28c38e40488e291e8cc963b6";
+      sha256 = "c4fcc311d93215086b0e2e920ae03b4f89fbc1ea2a624987989fbafb1a1db88c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sk/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/sk/thunderbird-128.10.1esr.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "8c80aec4d51ca07a54401b1f18f41c5fbe618c3b968d68799d8311ca4b0aaf03";
+      sha256 = "ef2f660a4a60fdab36ffe91786bf11caebc2b1886eb6e075da3e03b89335579a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sl/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/sl/thunderbird-128.10.1esr.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "f1f16bc225f3e002075da005ca6d8045a81d8dfce898d70aac5f978a40323209";
+      sha256 = "6be2fce1cc5b0c16b897b8d027c6492b49e34239b44765a14bc30bdd7bf49a40";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sq/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/sq/thunderbird-128.10.1esr.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "dd66306bbbad030532b582c177b706ceee9805ad51123999c3c27bdb5a25e8ce";
+      sha256 = "151a5223e5dbe923d93dcd9ac580c719ee0fa32b52afb3adfe1ba61f8aea7948";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sr/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/sr/thunderbird-128.10.1esr.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "a315196619380a621ffe9d666dbd00210ca84a144aedd599fee702444ce25143";
+      sha256 = "49e855e882a95a961d1bc28e71660e1c5fe60fd86ed3b24a07a56687607e28b9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/sv-SE/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/sv-SE/thunderbird-128.10.1esr.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e925948d64771385e546beb69bb4a7f67d0dd61db67bc4b777c42b464c6697e6";
+      sha256 = "820a5c60c3b451b1f0771cd9fd65e21a5c47b9a3ecce96dbc6aea6814396884c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/th/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/th/thunderbird-128.10.1esr.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "ec7ad345ea2d2f8739b361b9c3fffe49d977938bff7748e060a4a52f044ba3ed";
+      sha256 = "0296358fe306d8b072a603c8fe8b1d63047b2c60dbb04437ea8608b32217bef7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/tr/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/tr/thunderbird-128.10.1esr.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "5e26c74749cbe0bc8ea012fb8014b5eea288c0dcecba2dee525df873248bf597";
+      sha256 = "1291db7b68decfa7fabf948f011c3d21882a1585eb8084560269f3e97e856306";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/uk/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/uk/thunderbird-128.10.1esr.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "b37a1a9a96300e094a0716f4319acda6abb2cd48a9e68b019a0b98c7d11a008a";
+      sha256 = "dd73ee6027c1d15c4231adc7eb1a7fb8cf2a482541e3bb53ad06d3027c59ff51";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/uz/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/uz/thunderbird-128.10.1esr.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "b419a20dcc2963f9ad1826ed2a7507433ba9bd5ac1faf354fd9bc7ce92a7b681";
+      sha256 = "786cd211a5775d41df5c3a9afd454f7e0f4e2af3daa0b94f2d097fe9a9b50a7b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/vi/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/vi/thunderbird-128.10.1esr.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "b1c13f9c5343823a7c5e98e9801467531ab85c368b27b90a8bcd4d43f11b3edd";
+      sha256 = "4b19b4ddc22173654c58f272a32deb17ee60ca3b57b83043ffb7d2697b5264e1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/zh-CN/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/zh-CN/thunderbird-128.10.1esr.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "125c0d0dc02f8ce49aff83788bdfa5fba79287e42456169dd51f8281813e8bde";
+      sha256 = "4afe9daa8c5c45488385bbb25dc6653b4371d92c36878247f52c81eec5abbc0b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-x86_64/zh-TW/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-x86_64/zh-TW/thunderbird-128.10.1esr.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "b1b7a5ae07bf55d0b80d5142fd85af8d6c9fb270b7f9e6c43800a59b1f40cab2";
+      sha256 = "b290660b0dbbb0b7a73ba02a0e63c9314a5e739bdde4af14fe2f22dff6848fd5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/af/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/af/thunderbird-128.10.1esr.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "ff991035f96f687b39e355103130d15fbc9f195e94a30f4829337b7ad8444112";
+      sha256 = "3120f8ac696695c340f7958bf34a08c459d9c058cc82e0042aa1470c75800a17";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ar/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ar/thunderbird-128.10.1esr.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "dda0e89b7a93f9acc90232219ccffb9f5cd62e2cc926acb4594c3c931c965078";
+      sha256 = "98298b3a274d6324845317b87eb16a3013c5f571bf4aa153f92519b808b1c9ab";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ast/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ast/thunderbird-128.10.1esr.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "976922071e429a44a07c9117317c0de37aed07c6aac459713c45d72594d53de9";
+      sha256 = "cf570ea3dda592063a3ac3c94b0e19589957fb41e2d0d9876a911bfe0d093a5e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/be/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/be/thunderbird-128.10.1esr.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "2834e35f572827392f8f4c05fde6e5d528dcb9e3aeaca9814682bd57f8798116";
+      sha256 = "54f5cbe1eb765a1f3a5044b15995247d93af65d52d77575978a4266e8c92dfa1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/bg/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/bg/thunderbird-128.10.1esr.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "2233ee89097b86eca8eaac6652ace0122822ae321b73afd6f7770a2d2b9b18aa";
+      sha256 = "e6ed815e487bbb3cbcda3521e7e5dc2155cda8c2403712d5312ea479ee910689";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/br/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/br/thunderbird-128.10.1esr.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "6edc20cb551706417f63615da513db332e6840b241f3a7f299ca155b8ba53082";
+      sha256 = "f86cf16e950897632b5ee19069e0ea270a432dae64c6ee2808cad28dfc4c9891";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ca/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ca/thunderbird-128.10.1esr.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "11d95d508d04a4dfeb5cf7fa7b6783aa632d12d5f054c5cb036c5c8e4c77aea1";
+      sha256 = "4f04ba3090f600e7634d88f29c8568eb8ccd20998cb8bd196eea3e1b14b2301f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/cak/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/cak/thunderbird-128.10.1esr.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "8210634b2156f2d7a8f16fa72fb93e0201060c4f6aec3530c9bca74c86f6a9a5";
+      sha256 = "f0f6d125325922bb5bdd8c66b14d9fe879918798fdf156f0526e9825f37435e7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/cs/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/cs/thunderbird-128.10.1esr.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "2220fb0a8d27b1fdd836e5c2dfcb119e211f2741f04a48f275b3d1cc53165bb5";
+      sha256 = "da7718c38abfb5c64c0f3f75cc4d4c3c5c510532f0a5e4ff4cba0f9bf6fce42d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/cy/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/cy/thunderbird-128.10.1esr.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "a09c203e506a6e535421d945459aa11553e0c1e9ad6277507361a99b48c65e88";
+      sha256 = "830c07d56bd642c291f1c3deb7650c565e620a4d17c33f561fc20b8f6c5fba43";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/da/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/da/thunderbird-128.10.1esr.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "8ef44025501713220ea38e85a2105cf2817e63bdaa0db025f840da482c0c05fe";
+      sha256 = "93f7b3cf5ea839f120a20f9a8accbf801676a2644d6f9bb74c0854da8c1c8be2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/de/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/de/thunderbird-128.10.1esr.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "a74b5e6dde808ce1bd630084bd58ad8dd10fc8944d80dff9f8d225a4593a40db";
+      sha256 = "f224696b2b5b9a68d139d8262441cf03c166e9cc99d9bf9cbda526eb834bf467";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/dsb/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/dsb/thunderbird-128.10.1esr.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "b52feb7ed9693992fc00257cf2c984a9113177ac30d442d75471af3ba60de64b";
+      sha256 = "6816f08e9f4df65be9606ed7e14b629f94023207d381636402473e91de632659";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/el/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/el/thunderbird-128.10.1esr.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "b3548609b4bc6b57735b63cd06a0ee8ddb77afaa180ebeae63174a8a00950da4";
+      sha256 = "02150793596918b5080fccc8790ee28f1711ceb146d93cadc241dc870647f68e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/en-CA/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/en-CA/thunderbird-128.10.1esr.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "33d18c502cbcf78bd63d2f340085c2f60eb7b60e04eb695e69c24ddd42c72fe9";
+      sha256 = "da1cb2b3f036c36eb54c599f198d6f6362b8f58979f637effd3468894820ce63";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/en-GB/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/en-GB/thunderbird-128.10.1esr.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "8ce155991bf4ebc65726656a8349eaee3c8c5fb70f2949b9df73170c04bc0714";
+      sha256 = "35155fc9cbaaa5cda207cfa2ee7919a7a74f63cef37ebd9d3f6aced65af61d9e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/en-US/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/en-US/thunderbird-128.10.1esr.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "1be8a49543eb74101cb6f3f8adf8486d364fbc38bb0a29db93dcb28e6f1eaf89";
+      sha256 = "0b0041736a42409810dcfefaaa842058f2ca31adba240e63ea996e5a51d08aa3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/es-AR/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/es-AR/thunderbird-128.10.1esr.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "03d1232f34cf044f2a24d5daae731a74d43b538f8d794f30761edfca49ca201a";
+      sha256 = "5941f02ecc5891569619d8d2f5aa05dc64ae4a26e53b335ca48ea0d208da6ae7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/es-ES/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/es-ES/thunderbird-128.10.1esr.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "0c6e407a3314bf6e7c385dd7fbdbcf7eb4ad66d60afabf1ab2eac69492c90a9a";
+      sha256 = "144a8bc1710bad7cab3c06e274ecd9fdef8029dcf0253368264eec9bea3c3101";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/es-MX/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/es-MX/thunderbird-128.10.1esr.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "8aaa9a19b96801f4b1730b5e8a3d647473d893ad43ac1710a27e80f39cd30b7b";
+      sha256 = "df8768efbdfe3be8add56d2347428465bb1510cb98ecada28996c1a1f671ac02";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/et/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/et/thunderbird-128.10.1esr.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "47a4f7f35e7f089a5a0daacf7baa18ed37c3617feb76fbb6eddb648e9539d0d7";
+      sha256 = "8eb4caec1b71fc19061d4217f50e623bd10114e0ffeca84f2cb5d15f270a81b4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/eu/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/eu/thunderbird-128.10.1esr.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "5c803d4a340968111aa94f222d94ba232d2dfb490d57ae854812b36e99dbbfeb";
+      sha256 = "c976f0c92887eeb78044f9aad071d9bf91abdb18152134c76c88d07f0eb352fb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/fi/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/fi/thunderbird-128.10.1esr.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "442d7deb0d1189878f217895acad1349e2a7b4cc4fc6c817e624961a2f9b092b";
+      sha256 = "781f489050cce136fd3f044c6f117825bd792a393798571a2286d2a428d10599";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/fr/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/fr/thunderbird-128.10.1esr.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "a888b7c00bdaa2eb4df8bd34294eb5cd938c2f68d2e7742f798fd47e942c800e";
+      sha256 = "6669e5f865255ec0518980dae774acd169630e396e5473ea291d1dedcf872f99";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/fy-NL/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/fy-NL/thunderbird-128.10.1esr.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "bcde00737fdf4da0d3bc38a9a888143cf33ddef815c5ee88be266a644f24b4b3";
+      sha256 = "0c022a1c0b15f2cf33878aec58d96af20c0edea3ba219e1b1f6f4659607e8899";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ga-IE/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ga-IE/thunderbird-128.10.1esr.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "8eae62c0a8cccb536d485085c6a610e77391adf9f62c54188b1db1722271fa6d";
+      sha256 = "5d254425d10ec0eb250368cc64415a08888e4d36fb5a96115daae20c5b568601";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/gd/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/gd/thunderbird-128.10.1esr.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "6e9ffce6cabee76803b99392c47fbd6af840c73ecf001fd28839e98a6a658467";
+      sha256 = "d7f72b5564c7d6d3b0479494c5db39b43ba6c97ea891b4724a5ab879a7443673";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/gl/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/gl/thunderbird-128.10.1esr.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "655185f0f53bfe21a09d8f484aa33bb0e690ad5baa0e55b1b0d3b5ecd3781631";
+      sha256 = "9962bdc0865fe15c128ec930e06eadbfa61eb3e922f3ff01e2d7ea4b1d263637";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/he/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/he/thunderbird-128.10.1esr.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "4333b6e93320d541f99b62e904d5324d9f370753eafa0e38ee632dbe0e3e1685";
+      sha256 = "835ed155d2ee97845b8c53767875940713fd712657c9a1254671061026baf089";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/hr/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/hr/thunderbird-128.10.1esr.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "7d5d76b79acc21fd3badd1b5b7b2416a433506c9af63e702a0db86b5dde61961";
+      sha256 = "6381cd944832df7b023773c53ebf6170b1852b8723a43260ee2f1f87b97889d3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/hsb/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/hsb/thunderbird-128.10.1esr.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "698f507a3249a9620454eb519a5d22f3f86717e10545b1674c1c7c2fac34f9d4";
+      sha256 = "b142d349ee7910d3932c266f0f8f19b90709c87938f7d0e254cfe5cbf5070d6d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/hu/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/hu/thunderbird-128.10.1esr.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "b7b2ccfbe267c6ab9e7f53658633a2f9766287aefa88601139b211e6e391d66a";
+      sha256 = "3520b52f83dc364e587f80e8074bc3814f5b4d7c0dbe0c6e8261f8e78b9983a9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/hy-AM/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/hy-AM/thunderbird-128.10.1esr.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "e317a0367d5f3d8e685ae8b9ee51e15c2c5016a9906db45bd7c869ad4ec0829c";
+      sha256 = "1b58df19a19a955d52ea0b54944ce2a83d29a012eff58064eed0ca22ecd89343";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/id/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/id/thunderbird-128.10.1esr.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d9dfcb75b9f50d7d9dab47c52879a73b7863235253b0246986421189b154adc4";
+      sha256 = "f4bada34a7953b14d7c59ec335541d75f3b5f749aaccf15f86e26e7b82ac4700";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/is/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/is/thunderbird-128.10.1esr.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "fb3b2f9c82a0fadf5ea85cb7523a2f15bb540dab7bc601d90b7fd6eb852011b3";
+      sha256 = "47a45bf4c9be0d8c7cffb386e507319e9cef741eedd8f94d21a46133e745a5d9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/it/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/it/thunderbird-128.10.1esr.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "5719d8422de1d249fa53dbe9ba5b07751d062c7f8911cadfc49c61a5f550a66d";
+      sha256 = "ed7ed6804e7b088699e40fb0afc2da260f4a6dd920d40fb7caae57a2823bea48";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ja/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ja/thunderbird-128.10.1esr.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "eaf4aa599c39a64a8d4bfd357f4660e1d663c8db3be27d729c10037ef48a2334";
+      sha256 = "e5f5677a0f10c281d04c32d17eb8c4cd7832bab665d4bd0b5bc4301b81fe86ac";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ka/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ka/thunderbird-128.10.1esr.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "1e0c2c0bd1d8f99bbc3fd980bb2e949893e5c85c810e3af08d8d5ced783763a1";
+      sha256 = "96cde5975473758908acc179ff99f8b2309b8187a8f4e5a10361e27c27f8a28c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/kab/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/kab/thunderbird-128.10.1esr.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "a51daf65157a5588601395fea930a2a4766605d61bffaa1fadc1f357414937fa";
+      sha256 = "94f716b78c04609de727aa700019e6b22df2b3ee95597138d4c513891b930c68";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/kk/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/kk/thunderbird-128.10.1esr.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "9f5d8cf7a99136e5af0dbfd6859536fd4fd647665a73165263efee8f65ec3f7e";
+      sha256 = "b33ce1636d5d4a550ee752430273bf29dca5cf51f5d8ea2c9295a53a6b774659";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ko/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ko/thunderbird-128.10.1esr.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "7e7b9e0f1926cd8c6b2a1cf225e60386873b6b3a2d5de3204a299a2bee22a593";
+      sha256 = "834e2fef5417538c9b1c04329ea95a51685ffe196e12c7b92b115f1d6ef89845";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/lt/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/lt/thunderbird-128.10.1esr.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "b15c7e47e949bf077174672d58882856a2b18b4504bc0a63f3b8dafc967f062b";
+      sha256 = "7a0f1cf847a088dbbe3a57a11e953530169974016321c0d8661872bee41b3568";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/lv/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/lv/thunderbird-128.10.1esr.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "bee19390769fd64880b1d31096dc652748dd528f81deba28eeb5b70615a062a8";
+      sha256 = "2bec40989bf5a78a6635df103dba0d95b816a0baed1a52804cf144cfd1203a27";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ms/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ms/thunderbird-128.10.1esr.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "c008f1fc71ae173c236bdcae25a830efa66f72559ba4bc8d4324a6664bd3d013";
+      sha256 = "aefd6fe512f45dde9d429ad69e776006e1be7266d140e6501414cf9610f71ec4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/nb-NO/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/nb-NO/thunderbird-128.10.1esr.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "f4df94012ef725e4ac5d69f1e5a7ec67dfd48883bc872cd47a428f92179758bd";
+      sha256 = "dcc352bac76311990eecae929219a48647972837a0251b22ecd1bc282ad97721";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/nl/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/nl/thunderbird-128.10.1esr.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "fb7ec4da9767576b93b7292d6292447195c9737b4a0face27007e1fbcf0cd5aa";
+      sha256 = "341b5d01749e8755820cc689b624b6d38520e80b79b644f529afd077d438c5a6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/nn-NO/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/nn-NO/thunderbird-128.10.1esr.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "18480e6e5ecbed8fd55ab2747421b88cdd1374557f570669f10dd1ff72085576";
+      sha256 = "53b878080dce821a4b843e50ab4fe96517e1fe7cbf2a100746b6f94f2f73098d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/pa-IN/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/pa-IN/thunderbird-128.10.1esr.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "b2781354f750d0267ae057c8a15b3e9dccd9c9ae6cfbc874e153f4fb759b4da4";
+      sha256 = "753e4cc0548e6c457ca15d85126ec98d9b01eb1656dcc08d6223812d60141925";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/pl/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/pl/thunderbird-128.10.1esr.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "bc45df44d297fd431c6d2e43df0d187302150b1af4d4f275eb35551c4bfb474c";
+      sha256 = "9635b166c9b176b4afd64fe3595ab9f9597520549aaa04e467eb9b53b33398c4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/pt-BR/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/pt-BR/thunderbird-128.10.1esr.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "f95eaaf90935edd67334bb712c084a31641133d44ef5b952470164afef50fe45";
+      sha256 = "350b85a3392484604beb5bd7be1bdf9c451090bb769346605a922ae5cbceb8b1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/pt-PT/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/pt-PT/thunderbird-128.10.1esr.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "9f98a979c83ea71f1f2377c541c67a369bea29d0bc3058d9ff6d5dde905e9d59";
+      sha256 = "e7d34eec2294663aa0393aa075a352ade8ea77a24853cf312c80a510229b0b7b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/rm/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/rm/thunderbird-128.10.1esr.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "97ff3302535dfd38aa5882af8d8cff3d50a6754dd841d650f6106fc74f0b7438";
+      sha256 = "78cd5c7efb68b006ff90061a6daa81e49edeb010980d2759cc09d339b04e5158";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ro/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ro/thunderbird-128.10.1esr.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "7c714cd1b17e92eca91a068a39173cb693476639b68ba9f339f510d08ca685bc";
+      sha256 = "4d4b27ed02fbc0c50cdb48ef1c4b31978365ad11067893d78c1c1602f6379da5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/ru/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/ru/thunderbird-128.10.1esr.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "123a695a4764e19ce415c29e6d5352c445a105cb8d87916b21cd034a2649185b";
+      sha256 = "13db14980489b69efbf5958b0344591cc499c9cebd150b94acfbd52f7cc05fa1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sk/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/sk/thunderbird-128.10.1esr.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "119d068c96a7bbd5cfe105b8e38989e949b04e21664a7a1266829daa57763f0e";
+      sha256 = "9569c6a344593ef330c0a474faee7481339ce5f47ec9e7a46d7676b736c3dc33";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sl/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/sl/thunderbird-128.10.1esr.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "6e94f70c01c932655464cca415504054e30b8c0a9ffa2b1ade7b5e67243cfbda";
+      sha256 = "0adf5e860d7c044c1044da715472b5e7524c34398ec376f68048c3e7e861835f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sq/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/sq/thunderbird-128.10.1esr.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "d8a064c2ed903f353a705bc734a4d16c4761abd099c1c20eb211d13f5d94dda7";
+      sha256 = "f4b37f6f8f8522f06bd30444c73c08e57cf8618180768e1958aebb4a6c29dbc1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sr/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/sr/thunderbird-128.10.1esr.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "2e841685380d839f879a26b8ccbb04949f5670f38332e6011c7fce2d7bb7f036";
+      sha256 = "f1b6f5fa94ba80b3e0d14a53207e1ca70ffca67ee0305ee6c1b1f22c067d4135";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/sv-SE/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/sv-SE/thunderbird-128.10.1esr.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "39c3f998f46758fded9fcffef4f24f03b48ccb61172e6ed71db7a5636b9b6eff";
+      sha256 = "4c8d109285e12ba5a3b7f3096337426874de46da653d21f87f794859c362a8d3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/th/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/th/thunderbird-128.10.1esr.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "90ac6a733e5639a6265808b4e560e900a89065d673179ab9bc7b9df95469d0ae";
+      sha256 = "b8ecad961311e092a46388db028ed794c2f9ce61bad661f371e7886c157ee41e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/tr/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/tr/thunderbird-128.10.1esr.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "d2f89f9cf312e5653af3925bf883051487bc5769866f6be12157f1983643202f";
+      sha256 = "bf5cc9251b3b6c7979aa4f14e4365ec9c04c737df943c03346563429fd8a0e00";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/uk/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/uk/thunderbird-128.10.1esr.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "048575c86d22f25e883cd0f65aa66eab26c5d6d6b562ad55eb60b19bb14dfdec";
+      sha256 = "aebf3219802af5e6e8697dc1c6a9bee89b0166627844ec45b11d469debac780b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/uz/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/uz/thunderbird-128.10.1esr.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "7fd2cb036ea84171abe02e0619096c2483466f313fc56b45678bfef0200ff37a";
+      sha256 = "4da45bae60f6b5f2b129f5795f4b7128afd590eb7615d0c9e5e674513c32f49f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/vi/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/vi/thunderbird-128.10.1esr.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "bd69f2da2e23e8db9f9f056316d54be1d1c396a8a7b36d8b6da31c5ecad5b926";
+      sha256 = "1fe9e15fb4b825884e0b0a1daa1857ec387833694e180800cde206dda6d33f31";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/zh-CN/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/zh-CN/thunderbird-128.10.1esr.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "9f4ae9e5a002b7a34916740d784f652c867ea0e32bc3a86806f895063533e3db";
+      sha256 = "0146dfc5ee0b29a3c34d655c66451a3ee1887e71add898ef36b5dd415726d62e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/linux-i686/zh-TW/thunderbird-128.10.0esr.tar.bz2";
+      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.1esr/linux-i686/zh-TW/thunderbird-128.10.1esr.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "b393121d160954913639e44989da42e1f60d3828310df57ba7d67dfae9e3c871";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/af/Thunderbird%20128.10.0esr.dmg";
-      locale = "af";
-      arch = "mac";
-      sha256 = "e11d4a6d9d232acbeeb29498878d02af0e4c677f44a4e278299b87bf0200be6a";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ar/Thunderbird%20128.10.0esr.dmg";
-      locale = "ar";
-      arch = "mac";
-      sha256 = "dae7d70a23922d05cf5050d2fccafe137e7a148856a6b544b27dafb9095167f8";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ast/Thunderbird%20128.10.0esr.dmg";
-      locale = "ast";
-      arch = "mac";
-      sha256 = "47dc8fb511d0372f9ba2e01bdd6286231676258a9eac43bc909f8a0cb56b6b78";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/be/Thunderbird%20128.10.0esr.dmg";
-      locale = "be";
-      arch = "mac";
-      sha256 = "98acb0839cb639d38bccffb8eed2715c44064ab9d250ed834c73f45b3c3e1cb9";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/bg/Thunderbird%20128.10.0esr.dmg";
-      locale = "bg";
-      arch = "mac";
-      sha256 = "1ea24914a33b623991b1698568d093d0a12912bbfeac50212d1a0ab8f50b0c05";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/br/Thunderbird%20128.10.0esr.dmg";
-      locale = "br";
-      arch = "mac";
-      sha256 = "07cf654bc1fc9453d9af96cd8bea0561b39df05cd1c221f9e517f8c941f380b9";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ca/Thunderbird%20128.10.0esr.dmg";
-      locale = "ca";
-      arch = "mac";
-      sha256 = "9321a161406268e3d77a27dde9b84ec4d0d03ba4dafb66dc0b75df75911985cb";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/cak/Thunderbird%20128.10.0esr.dmg";
-      locale = "cak";
-      arch = "mac";
-      sha256 = "c794090a04b7be0914e08c3b0d6251f95a1290a8f44163513f7e1565f65bbe11";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/cs/Thunderbird%20128.10.0esr.dmg";
-      locale = "cs";
-      arch = "mac";
-      sha256 = "cbdb25ef092f89ecd42409869c90329c1abb53f37d7e81911e228f6f46af59b6";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/cy/Thunderbird%20128.10.0esr.dmg";
-      locale = "cy";
-      arch = "mac";
-      sha256 = "bb295f6f00102d9ddb4ca4b7d14aebac811d6f575e3ade0e6deaa88d7d9fffac";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/da/Thunderbird%20128.10.0esr.dmg";
-      locale = "da";
-      arch = "mac";
-      sha256 = "6edffdea7e8e2075c7c616a8fd4bc3a9dad2a89322c107480ae34aadcb4c3f69";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/de/Thunderbird%20128.10.0esr.dmg";
-      locale = "de";
-      arch = "mac";
-      sha256 = "f6bf2a01304c31f60813821d7cd2d1d6acfae1409b650b3c5d12b3c43f1a7930";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/dsb/Thunderbird%20128.10.0esr.dmg";
-      locale = "dsb";
-      arch = "mac";
-      sha256 = "527122dd96f80c6428e43000e7266ea85b329aea08d72d0e5738f96a1d4f6c08";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/el/Thunderbird%20128.10.0esr.dmg";
-      locale = "el";
-      arch = "mac";
-      sha256 = "2a04e5c92989ced451b13e6c7b1273e614c7ee7ad93eaa9d77c7f193f3b09809";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/en-CA/Thunderbird%20128.10.0esr.dmg";
-      locale = "en-CA";
-      arch = "mac";
-      sha256 = "dc01bb4e61a60ed082f55e64d086c09b2b9d2eed38bbd8bb376af17fe9214db5";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/en-GB/Thunderbird%20128.10.0esr.dmg";
-      locale = "en-GB";
-      arch = "mac";
-      sha256 = "f64aba7465d196f8d55c31093b06c9939383fdf8b1f63162f48aacf2547af341";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/en-US/Thunderbird%20128.10.0esr.dmg";
-      locale = "en-US";
-      arch = "mac";
-      sha256 = "e7402777cc58fea6534c8548244993415fd215b97cad6952a8e3459f90f5810d";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/es-AR/Thunderbird%20128.10.0esr.dmg";
-      locale = "es-AR";
-      arch = "mac";
-      sha256 = "fc6beb6a254559d7b1a20cc0e5abe636ba218a7567d571ccc66c564b5fdc1b71";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/es-ES/Thunderbird%20128.10.0esr.dmg";
-      locale = "es-ES";
-      arch = "mac";
-      sha256 = "059d77bad5e26477cfb3527c82fbaf5c9524c711e99c08d86badb7658eeeab4e";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/es-MX/Thunderbird%20128.10.0esr.dmg";
-      locale = "es-MX";
-      arch = "mac";
-      sha256 = "ebbeb8cc79023bced82f2429fcc17538ff1f3c77886b8a41f0297543f52bb403";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/et/Thunderbird%20128.10.0esr.dmg";
-      locale = "et";
-      arch = "mac";
-      sha256 = "766a0398e073d912b118c744d6b8af1faa35bf7de3875f3afddd921de11779e2";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/eu/Thunderbird%20128.10.0esr.dmg";
-      locale = "eu";
-      arch = "mac";
-      sha256 = "713f026166781770021952013588aa80be34fc9f974af363f9a8d34dbc9a1a7c";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/fi/Thunderbird%20128.10.0esr.dmg";
-      locale = "fi";
-      arch = "mac";
-      sha256 = "8f308fb87f9929ac173a7c9213f1c117cb719a260075d97e6573c0171b1da5d5";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/fr/Thunderbird%20128.10.0esr.dmg";
-      locale = "fr";
-      arch = "mac";
-      sha256 = "91f6788d05d12b37775717a2e6b48a4494b043ef4a0093ccf13fbd41bb4f6a96";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/fy-NL/Thunderbird%20128.10.0esr.dmg";
-      locale = "fy-NL";
-      arch = "mac";
-      sha256 = "64e5cd0d29521664dff55590f7b45e1820a518eb01ee4d6caac240fb6eeebd11";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ga-IE/Thunderbird%20128.10.0esr.dmg";
-      locale = "ga-IE";
-      arch = "mac";
-      sha256 = "49d06f924a865fe5451671092f17f804738d8e8bcfb5195b693441c0eb6a88bd";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/gd/Thunderbird%20128.10.0esr.dmg";
-      locale = "gd";
-      arch = "mac";
-      sha256 = "ec9f693a14accb7674638b9239d5a2a7c2026ac0e5f15b830994542bf8dc52b5";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/gl/Thunderbird%20128.10.0esr.dmg";
-      locale = "gl";
-      arch = "mac";
-      sha256 = "7aa85c6186f7209df572098678fffb94cc0cd486f39f45af5281469bd8de174a";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/he/Thunderbird%20128.10.0esr.dmg";
-      locale = "he";
-      arch = "mac";
-      sha256 = "54ca168d07d80a9fa82d2734538206c3f7e0eed78b81741f4adfe2c5cc1322a7";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/hr/Thunderbird%20128.10.0esr.dmg";
-      locale = "hr";
-      arch = "mac";
-      sha256 = "99bb5eeaa30b7e32bd11a721bef44d41d0d14d88999214e99404886f32c7f1f9";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/hsb/Thunderbird%20128.10.0esr.dmg";
-      locale = "hsb";
-      arch = "mac";
-      sha256 = "af9d4522773d02e0ef7ee14d2bd7820aa2ce43f759f2ef5a74c2ec3e23d8e936";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/hu/Thunderbird%20128.10.0esr.dmg";
-      locale = "hu";
-      arch = "mac";
-      sha256 = "80a8d22ad72eed7c312e6246ab76fdeae8dca20d52e2111d0677c131fa75b8b8";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/hy-AM/Thunderbird%20128.10.0esr.dmg";
-      locale = "hy-AM";
-      arch = "mac";
-      sha256 = "2124196d6ee539ff8ef0033f550029a18dc757bb3c641d0e997eaa6e8fa41a65";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/id/Thunderbird%20128.10.0esr.dmg";
-      locale = "id";
-      arch = "mac";
-      sha256 = "83688c89878513397d5ffd1c8c53b8746f9b7906e565590b9ca6190d28443847";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/is/Thunderbird%20128.10.0esr.dmg";
-      locale = "is";
-      arch = "mac";
-      sha256 = "9b7ff4011adc8ef704ebb8243b1948460b3ae38ca56441e7a027de7710ceaa75";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/it/Thunderbird%20128.10.0esr.dmg";
-      locale = "it";
-      arch = "mac";
-      sha256 = "5b4e5e6d75c70278719186a9464e9ce988e6ad1f28e98e4e200bbcb9772d8d3b";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ja-JP-mac/Thunderbird%20128.10.0esr.dmg";
-      locale = "ja-JP-mac";
-      arch = "mac";
-      sha256 = "12f8910af78365ca6527017f4124ca0f0f4c909675a55898e7a093ff0d7b6e0a";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ka/Thunderbird%20128.10.0esr.dmg";
-      locale = "ka";
-      arch = "mac";
-      sha256 = "11b4c6aa91bdb0966e93e8e5527c81098f3900a28f0803b5aa899934b6214de1";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/kab/Thunderbird%20128.10.0esr.dmg";
-      locale = "kab";
-      arch = "mac";
-      sha256 = "61f105425d800c80f9ff8c4bb27c20a91e95ae7586d019f558b24c7f992bc83b";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/kk/Thunderbird%20128.10.0esr.dmg";
-      locale = "kk";
-      arch = "mac";
-      sha256 = "eb2d8514a7191500add449bcb4faef6b6952d1afefd8178aa98c83248ee37282";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ko/Thunderbird%20128.10.0esr.dmg";
-      locale = "ko";
-      arch = "mac";
-      sha256 = "f6855562c14119e5a5a81c2c978eecdfdcf644b22255fc3a3fb9f5e4828faab1";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/lt/Thunderbird%20128.10.0esr.dmg";
-      locale = "lt";
-      arch = "mac";
-      sha256 = "e596276341034db477457da788b613131efe59f378b95d72495effbea45bbf75";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/lv/Thunderbird%20128.10.0esr.dmg";
-      locale = "lv";
-      arch = "mac";
-      sha256 = "73c5c1bbd31fbe3853a3636a4b1f39ca736d7c5dfc2113a10d5f202eb1a7a649";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ms/Thunderbird%20128.10.0esr.dmg";
-      locale = "ms";
-      arch = "mac";
-      sha256 = "a885b5b087e36b0f8f4b3846aee2ae9fe2bd7942a382503cb64d609b28741f3d";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/nb-NO/Thunderbird%20128.10.0esr.dmg";
-      locale = "nb-NO";
-      arch = "mac";
-      sha256 = "a58d895364ed606a572c8b3d553db4951d19110084725c2042c66b12d46d026f";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/nl/Thunderbird%20128.10.0esr.dmg";
-      locale = "nl";
-      arch = "mac";
-      sha256 = "fc8d052a87038890014d7185417825bca0d75255e72188df1dda7887ed65db2d";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/nn-NO/Thunderbird%20128.10.0esr.dmg";
-      locale = "nn-NO";
-      arch = "mac";
-      sha256 = "53082cb0e30dae180ea706a4c68f84cf5d9c26b00ae48973d5823481ce5790cb";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/pa-IN/Thunderbird%20128.10.0esr.dmg";
-      locale = "pa-IN";
-      arch = "mac";
-      sha256 = "5e0a4f0acf75a37540c344f1d23171d5e25d755e0ed919b2554518300bdce9ac";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/pl/Thunderbird%20128.10.0esr.dmg";
-      locale = "pl";
-      arch = "mac";
-      sha256 = "0b204994c027d3ac83827b0f07f2c6525cfef45e7e26af7f5449e8bbd18702b0";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/pt-BR/Thunderbird%20128.10.0esr.dmg";
-      locale = "pt-BR";
-      arch = "mac";
-      sha256 = "d1c7b12933bd71b28f24aaa7df88a1828d568b3773ed5ee14be2edbde85cea5c";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/pt-PT/Thunderbird%20128.10.0esr.dmg";
-      locale = "pt-PT";
-      arch = "mac";
-      sha256 = "03f81c3a9049c11f339472b2eb9f55916e8ff9fe5b5b21679ed005033105807d";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/rm/Thunderbird%20128.10.0esr.dmg";
-      locale = "rm";
-      arch = "mac";
-      sha256 = "75c59efc07f3f34bdab257e0f0c9047694f9419020b6c22378780c422d9e291e";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ro/Thunderbird%20128.10.0esr.dmg";
-      locale = "ro";
-      arch = "mac";
-      sha256 = "7dffff8c220907a66985e5d8c5a617094be9f1a030809dd12912f0af9ccc71c8";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/ru/Thunderbird%20128.10.0esr.dmg";
-      locale = "ru";
-      arch = "mac";
-      sha256 = "1da096f8c0990c5e44c3bfdf4f60a127593a78ece9298830cfe8ddd76001f464";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sk/Thunderbird%20128.10.0esr.dmg";
-      locale = "sk";
-      arch = "mac";
-      sha256 = "6c2b8e2925bb8531f7b76157a044722ebd07edc3c65ee3d7fdd9e3939724b619";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sl/Thunderbird%20128.10.0esr.dmg";
-      locale = "sl";
-      arch = "mac";
-      sha256 = "cc8abcaba5002b56c279e2019ac13766d5ba24f035bf71446a3afcc9eccbd5c9";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sq/Thunderbird%20128.10.0esr.dmg";
-      locale = "sq";
-      arch = "mac";
-      sha256 = "477048d3633f85cc0e533e7d30b066814d3a88553a45c2a92ebcf8480a9f4544";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sr/Thunderbird%20128.10.0esr.dmg";
-      locale = "sr";
-      arch = "mac";
-      sha256 = "0c148dcb61d99af28c81bc816abb3851947169985600af7a69f4a85d363aaf1f";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/sv-SE/Thunderbird%20128.10.0esr.dmg";
-      locale = "sv-SE";
-      arch = "mac";
-      sha256 = "060017afa379d82ad65f8b48a7573d134dd18adb51960cc271458ba9c1406208";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/th/Thunderbird%20128.10.0esr.dmg";
-      locale = "th";
-      arch = "mac";
-      sha256 = "c01b8831299731d5dd6c3b0aca1aa44ae7e8c49e7f949bb1fbadca3341106912";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/tr/Thunderbird%20128.10.0esr.dmg";
-      locale = "tr";
-      arch = "mac";
-      sha256 = "9b7e7d43f56fbc3cf92bd8cf03f119a8a7d9398e7560320e947e99d6ce5a1924";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/uk/Thunderbird%20128.10.0esr.dmg";
-      locale = "uk";
-      arch = "mac";
-      sha256 = "cf46b4d96b61280bb39c5dd5c3ea99d0ab34b7feb913515573b2c8fab5e116bc";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/uz/Thunderbird%20128.10.0esr.dmg";
-      locale = "uz";
-      arch = "mac";
-      sha256 = "ffef659e6962dd70b6b77b9f9a0bc77e922df96a55cc8c1a53ba262f57cc0685";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/vi/Thunderbird%20128.10.0esr.dmg";
-      locale = "vi";
-      arch = "mac";
-      sha256 = "eae5e91866f787e32ff88df412fa0ec137f3531067cfe1886938e91d2a67c0d8";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/zh-CN/Thunderbird%20128.10.0esr.dmg";
-      locale = "zh-CN";
-      arch = "mac";
-      sha256 = "5eb7fd21a86126a7fafcd8c893dbe4ae00c7539fe73298cf7b98450cc58af27c";
-    }
-    {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/128.10.0esr/mac/zh-TW/Thunderbird%20128.10.0esr.dmg";
-      locale = "zh-TW";
-      arch = "mac";
-      sha256 = "7f3ff91dfe65d5fd044334909d6041e4776440dc550be92995c992c0493d50d1";
+      sha256 = "af6b63b013ea7b518e2e950cf9a824d3cf451bd1fd9aaeca4f19ca8356bc67bd";
     }
   ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -92,8 +92,8 @@ rec {
   thunderbird = thunderbird-latest;
 
   thunderbird-latest = common {
-    version = "138.0";
-    sha512 = "923d76cf0a14f29146e5dcfc75dd9522d465512f6c604de6e0acc0812d4240331c170913a821fc0aa03d5945019577f996053498c9a7c691b21a2678a622ac02";
+    version = "138.0.1";
+    sha512 = "2e71ee537292ec1a49237e93c43ed4c1a9eae58becfc7fa9ca0daf1e982c38704cb6d44e92b1bf7b45c5b8c27b23eb3aa7f48b375580f49ee60884dadc5d85b5";
 
     updateScript = callPackage ./update.nix {
       attrPath = "thunderbirdPackages.thunderbird-latest";

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -106,8 +106,8 @@ rec {
   thunderbird-128 = common {
     applicationName = "Thunderbird ESR";
 
-    version = "128.10.0esr";
-    sha512 = "b02582ea4fa0297a06d30eda1555bbf3ed79ae7a35a8993f2a70b0ec84af28a4d084cd7ebe1c73676e689ff9366e779cc5ef67a197638949bf232a40b740d1b6";
+    version = "128.10.1esr";
+    sha512 = "09b54450928c6e0d948cd79a56c28bdb5fe5a81d7c710470a1ec195dd295c433b872682102c74930f19b1184391c30115293dadcd7dc8a08ae8baeb12770ef9c";
 
     updateScript = callPackage ./update.nix {
       attrPath = "thunderbirdPackages.thunderbird-128";


### PR DESCRIPTION
Fixes: CVE-2025-3875, CVE-2025-3877, CVE-2025-3909, CVE-2025-3932
https://www.mozilla.org/en-US/security/advisories/mfsa2025-34/
https://www.mozilla.org/en-US/security/advisories/mfsa2025-35/

https://www.thunderbird.net/en-US/thunderbird/128.10.1esr/releasenotes/
https://www.thunderbird.net/en-US/thunderbird/138.0.1/releasenotes/

## Things done

Tested the bin versions, I'm a bit too short on the RAM side to complete the source builds ATM.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
