### PR TITLE
nut: add override for apc_modbus+libmodbus, nixos/ups: add package option

### DIFF
--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -359,7 +359,7 @@ let
           {
             MINSUPPLIES = 1;
             MONITOR = <generated from config.power.ups.upsmon.monitor>
-            NOTIFYCMD = "''${pkgs.nut}/bin/upssched";
+            NOTIFYCMD = "''${cfg.package}/bin/upssched";
             POWERDOWNFLAG = "/run/killpower";
             SHUTDOWNCMD = "''${pkgs.systemd}/bin/shutdown now";
           }
@@ -396,7 +396,7 @@ let
             type
           ]
         );
-        NOTIFYCMD = lib.mkDefault "${pkgs.nut}/bin/upssched";
+        NOTIFYCMD = lib.mkDefault "${cfg.package}/bin/upssched";
         POWERDOWNFLAG = lib.mkDefault "/run/killpower";
         SHUTDOWNCMD = lib.mkDefault "${pkgs.systemd}/bin/shutdown now";
       };
@@ -458,6 +458,8 @@ in
         support for Power Devices, such as Uninterruptible Power
         Supplies, Power Distribution Units and Solar Controllers
       '';
+
+      package = lib.mkPackageOption pkgs "nut" { };
 
       mode = lib.mkOption {
         default = "standalone";
@@ -577,7 +579,7 @@ in
     ];
 
     # For interactive use.
-    environment.systemPackages = [ pkgs.nut ];
+    environment.systemPackages = [ cfg.package ];
     environment.variables = envVars;
 
     networking.firewall = lib.mkIf cfg.openFirewall {
@@ -606,8 +608,8 @@ in
         serviceConfig = {
           Type = "forking";
           ExecStartPre = "${createUpsmonConf}";
-          ExecStart = "${pkgs.nut}/sbin/upsmon -u ${cfg.upsmon.user}";
-          ExecReload = "${pkgs.nut}/sbin/upsmon -c reload";
+          ExecStart = "${cfg.package}/sbin/upsmon -u ${cfg.upsmon.user}";
+          ExecReload = "${cfg.package}/sbin/upsmon -c reload";
           LoadCredential = lib.mapAttrsToList (
             name: monitor: "upsmon_password_${name}:${monitor.passwordFile}"
           ) cfg.upsmon.monitor;
@@ -633,8 +635,8 @@ in
           Type = "forking";
           ExecStartPre = "${createUpsdUsers}";
           # TODO: replace 'root' by another username.
-          ExecStart = "${pkgs.nut}/sbin/upsd -u root";
-          ExecReload = "${pkgs.nut}/sbin/upsd -c reload";
+          ExecStart = "${cfg.package}/sbin/upsd -u root";
+          ExecReload = "${cfg.package}/sbin/upsd -c reload";
           LoadCredential = lib.mapAttrsToList (
             name: user: "upsdusers_password_${name}:${user.passwordFile}"
           ) cfg.users;
@@ -655,7 +657,7 @@ in
         Type = "oneshot";
         RemainAfterExit = true;
         # TODO: replace 'root' by another username.
-        ExecStart = "${pkgs.nut}/bin/upsdrvctl -u root start";
+        ExecStart = "${cfg.package}/bin/upsdrvctl -u root start";
         Slice = "system-ups.slice";
       };
       environment = envVars;
@@ -677,7 +679,7 @@ in
       environment = envVars;
       serviceConfig = {
         Type = "oneshot";
-        ExecStart = "${pkgs.nut}/bin/upsdrvctl shutdown";
+        ExecStart = "${cfg.package}/bin/upsdrvctl shutdown";
         Slice = "system-ups.slice";
       };
     };
@@ -702,14 +704,14 @@ in
       "nut/upsmon.conf".source = "/run/nut/upsmon.conf";
     };
 
-    power.ups.schedulerRules = lib.mkDefault "${pkgs.nut}/etc/upssched.conf.sample";
+    power.ups.schedulerRules = lib.mkDefault "${cfg.package}/etc/upssched.conf.sample";
 
     systemd.tmpfiles.rules = [
       "d /var/state/ups -"
       "d /var/lib/nut 700"
     ];
 
-    services.udev.packages = [ pkgs.nut ];
+    services.udev.packages = [ cfg.package ];
 
     users.users.nutmon = lib.mkIf (cfg.upsmon.user == "nutmon") {
       isSystemUser = true;


### PR DESCRIPTION
 <!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added an override to `nut` to build dep `libmodbus` using the downstream networkupstools fork in order to enable the `apc_modbus` over usb driver feature. This feature is off by default. 
Also added a package option to `power.ups` to enable use of the overridden package with the options.

~~Depends on the update at https://github.com/NixOS/nixpkgs/pull/404418 due to use of the new configure option, `--with-modbus+usb`.~~  Dependency now merged.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Maintainer is listed as @pierron but that account seems inactive/blank.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
