### PR TITLE
apple-sdk: Include man pages starting from version 15

### DIFF
--- a/pkgs/by-name/ap/apple-sdk/common/fetch-sdk.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/fetch-sdk.nix
@@ -9,6 +9,9 @@
   urls,
   version,
   hash,
+
+  # Include man pages
+  includeMan ? lib.toInt (lib.versions.major version) >= 15,
 }:
 
 fetchurl {
@@ -29,10 +32,17 @@ fetchurl {
 
     src=Library/Developer/CommandLineTools/SDKs/MacOSX${lib.versions.majorMinor version}.sdk
 
-    # Remove unwanted binaries, man pages, and folders from the SDK.
-    rm -rf $src/usr/bin $src/usr/share $src/System/Library/Perl
+    # Remove unwanted binaries and folders from the SDK.
+    rm -rf $src/usr/bin $src/System/Library/Perl
+    if [[ -z "${toString includeMan}" ]]; then
+      rm -rf $src/usr/share
+    fi
 
     mkdir -p "$out"
     cp -rd $src/* "$out"
   '';
+
+  passthru = {
+    inherit includeMan;
+  };
 }

--- a/pkgs/by-name/ap/apple-sdk/common/split-man-pages-output.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/split-man-pages-output.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenv,
+}:
+
+self: super: {
+  # The SDK includes man pages for basic command-line utilities
+  # shipped with macOS as well as others that may conflict with
+  # those provided by Nixpkgs.
+  #
+  # We split them out into a separate output to prevent poluting
+  # devShells. Furthermore, we name this output `sdkman` rather than
+  # the regular `man`/`devman` in preparation for this issue being
+  # solved:
+  #
+  # <https://github.com/NixOS/nix/issues/9550>
+  outputs = (super.outputs or [ "out" ]) ++ [ "sdkman" ];
+  outputMan = "sdkman";
+
+  buildPhase =
+    super.buildPhase or ""
+    + ''
+      if [[ -d "usr/share/man" ]]; then
+        echo "Moving man pages to sdkman output"
+        mkdir -p "$sdkman/share"
+        mv usr/share/man $sdkman/share/
+      fi
+    '';
+}

--- a/pkgs/by-name/ap/apple-sdk/metadata/versions.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/versions.json
@@ -37,6 +37,6 @@
       "https://web.archive.org/web/20250210234739/https://swcdn.apple.com/content/downloads/36/33/072-44426-A_G1AII30AST/ddbss9h6gse6a32rg6luosbrm6vgniu033/CLTools_macOSNMOS_SDK.pkg"
     ],
     "version": "15.2",
-    "hash": "sha256-OP5Ah/JnSZ6sD42BD5vGDmikgFzjsfFBmz1hvQD1dOI="
+    "hash": "sha256-8L4CEkGlG5xDHLQX5dbublnCPI0RuMzso+v+QVQea5Y="
   }
 }

--- a/pkgs/by-name/ap/apple-sdk/package.nix
+++ b/pkgs/by-name/ap/apple-sdk/package.nix
@@ -23,7 +23,10 @@ in
 
 let
   sdkInfo =
-    sdkVersions.${darwinSdkMajorVersion}
+    {
+      includeMan = lib.toInt (lib.versions.major sdkVersion) >= 15;
+    }
+    // sdkVersions.${darwinSdkMajorVersion}
       or (lib.throw "Unsupported SDK major version: ${darwinSdkMajorVersion}");
   sdkVersion = sdkInfo.version;
 

--- a/pkgs/by-name/ap/apple-sdk/package.nix
+++ b/pkgs/by-name/ap/apple-sdk/package.nix
@@ -23,12 +23,10 @@ in
 
 let
   sdkInfo =
-    {
-      includeMan = lib.toInt (lib.versions.major sdkVersion) >= 15;
-    }
-    // sdkVersions.${darwinSdkMajorVersion}
+    sdkVersions.${darwinSdkMajorVersion}
       or (lib.throw "Unsupported SDK major version: ${darwinSdkMajorVersion}");
   sdkVersion = sdkInfo.version;
+  src = fetchSDK sdkInfo;
 
   fetchSDK = callPackage ./common/fetch-sdk.nix { };
 
@@ -40,6 +38,9 @@ let
       (callPackage ./common/passthru-source-release-files.nix { inherit sdkVersion; })
       (callPackage ./common/remove-disallowed-packages.nix { })
       (callPackage ./common/process-stubs.nix { })
+    ]
+    ++ lib.optionals (src.passthru.includeMan) [
+      (callPackage ./common/split-man-pages-output.nix { })
     ]
     # Avoid infinite recursions by not propagating certain packages, so they can themselves build with the SDK.
     ++ lib.optionals (!enableBootstrap) [
@@ -56,8 +57,7 @@ stdenvNoCC.mkDerivation (
   lib.extends phases (finalAttrs: {
     pname = "apple-sdk";
     inherit (sdkInfo) version;
-
-    src = fetchSDK sdkInfo;
+    inherit src;
 
     dontConfigure = true;
 


### PR DESCRIPTION
Apple SDKs include man pages for command-line utilities shipped with macOS as well as APIs, many of which are not available in source releases. It would be nice to have them in `apple-sdk`.

Since those man pages may conflict with those provided by Nixpkgs, we split them into a separate output named `sdkman` to avoid polluting devShells by default. In order to minimize rebuilds, the change is also gated to SDKs starting from version 15.

The man pages themselves appear to be compressible:

```
$ nix-store --dump /nix/store/26940l0019wnn7sg41x7zcz5ywimaxl3-apple-sdk-15.2-sdkman > apple-sdk-15.2-sdkman.nar
$ zstd apple-sdk-15.2-sdkman.nar -o apple-sdk-15.2-sdkman.nar.zst
apple-sdk-15.2-sdkman.nar : 58.24%   (  46.6 MiB =>   27.1 MiB, apple-sdk-15.2-sdkman.nar.zst)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
