### PR TITLE
[backport] py3P.{griffe,mkdocs-autorefs,mkdocstrings}: update

### DIFF
--- a/pkgs/development/python-modules/griffe/default.nix
+++ b/pkgs/development/python-modules/griffe/default.nix
@@ -6,32 +6,25 @@
   fetchFromGitHub,
   git,
   jsonschema,
-  mkdocstrings,
   pdm-backend,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "griffe";
-  version = "1.6.0";
+  version = "1.7.3";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "mkdocstrings";
     repo = "griffe";
     tag = version;
-    hash = "sha256-Cs3qJlF1k1cKmbH7bXkn8+XDRC0sZqVdrMPIw0dSWD8=";
+    hash = "sha256-H5bkS8NK96M2W+kH1KijmzVL5Y04KY9xc5Vw5l1lfws=";
   };
 
   build-system = [ pdm-backend ];
 
-  dependencies = [
-    colorama
-    mkdocstrings
-  ];
+  dependencies = [ colorama ];
 
   nativeCheckInputs = [
     git
@@ -45,12 +38,17 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "griffe" ];
 
-  meta = with lib; {
+  disabledTestPaths = [
+    # Circular dependencies
+    "tests/test_api.py"
+  ];
+
+  meta = {
     description = "Signatures for entire Python programs";
     homepage = "https://github.com/mkdocstrings/griffe";
     changelog = "https://github.com/mkdocstrings/griffe/blob/${src.tag}/CHANGELOG.md";
-    license = licenses.isc;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "griffe";
   };
 }

--- a/pkgs/development/python-modules/mkdocs-autorefs/default.nix
+++ b/pkgs/development/python-modules/mkdocs-autorefs/default.nix
@@ -3,24 +3,22 @@
   buildPythonPackage,
   fetchFromGitHub,
   markdown,
-  mkdocs,
+  mkdocs-material,
   pytestCheckHook,
   pdm-backend,
-  pythonOlder,
+  markupsafe,
 }:
 
 buildPythonPackage rec {
   pname = "mkdocs-autorefs";
-  version = "1.3.1";
+  version = "1.4.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "mkdocstrings";
     repo = "autorefs";
     tag = version;
-    hash = "sha256-YVkj4D7JK0GOqnGlg5L3uqFsBB5C0OnlXX+wYW4GpkQ=";
+    hash = "sha256-l8COGf4EWDvIQcrf8lQF/TROhp1uCb+mv0CDND3xiUg=";
   };
 
   postPatch = ''
@@ -32,10 +30,16 @@ buildPythonPackage rec {
 
   dependencies = [
     markdown
-    mkdocs
+    markupsafe
+    mkdocs-material
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # Circular dependencies
+    "tests/test_api.py"
+  ];
 
   disabledTests = [
     # missing pymdownx
@@ -45,11 +49,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "mkdocs_autorefs" ];
 
-  meta = with lib; {
+  meta = {
     description = "Automatically link across pages in MkDocs";
     homepage = "https://github.com/mkdocstrings/autorefs/";
     changelog = "https://github.com/mkdocstrings/autorefs/blob/${src.tag}/CHANGELOG.md";
-    license = licenses.isc;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/mkdocstrings-python/default.nix
+++ b/pkgs/development/python-modules/mkdocstrings-python/default.nix
@@ -10,21 +10,18 @@
   mkdocstrings,
   pdm-backend,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "mkdocstrings-python";
-  version = "1.13.0";
+  version = "1.16.10";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "mkdocstrings";
     repo = "python";
     tag = version;
-    hash = "sha256-NgVCKV3AWk4pRT7/+6YGXmKSZETL4ZOWDWGeb/qjdng=";
+    hash = "sha256-HwGo+o78SDo+RM2UxQB4A8OTY5FVuav1TS6J+aVVWdc=";
   };
 
   build-system = [ pdm-backend ];
@@ -51,11 +48,11 @@ buildPythonPackage rec {
     "test_format_code"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python handler for mkdocstrings";
     homepage = "https://github.com/mkdocstrings/python";
     changelog = "https://github.com/mkdocstrings/python/blob/${version}/CHANGELOG.md";
-    license = licenses.isc;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/mkdocstrings/default.nix
+++ b/pkgs/development/python-modules/mkdocstrings/default.nix
@@ -12,21 +12,19 @@
   pymdown-extensions,
   pytestCheckHook,
   pythonOlder,
-  typing-extensions,
+  dirty-equals,
 }:
 
 buildPythonPackage rec {
   pname = "mkdocstrings";
-  version = "0.27.0";
+  version = "0.29.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "mkdocstrings";
     repo = "mkdocstrings";
     tag = version;
-    hash = "sha256-L86aFq1S7Hfp+1MHwliCSz0mfgAFD/5AHbeqL1aZ5XM=";
+    hash = "sha256-i3rGPKptsFD/IE4vGpWC0HTKoqAtjQ6gkVhZbfYn2bo=";
   };
 
   postPatch = ''
@@ -47,15 +45,18 @@ buildPythonPackage rec {
     ]
     ++ lib.optionals (pythonOlder "3.10") [
       importlib-metadata
-      typing-extensions
     ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    dirty-equals
+  ];
 
   pythonImportsCheck = [ "mkdocstrings" ];
 
   disabledTestPaths = [
     # Circular dependencies
+    "tests/test_api.py"
     "tests/test_extension.py"
   ];
 
@@ -64,13 +65,14 @@ buildPythonPackage rec {
     "test_disabling_plugin"
     # Circular dependency on mkdocstrings-python
     "test_extended_templates"
+    "test_nested_autodoc[ext_markdown0]"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Automatic documentation from sources for MkDocs";
     homepage = "https://github.com/mkdocstrings/mkdocstrings";
     changelog = "https://github.com/mkdocstrings/mkdocstrings/blob/${version}/CHANGELOG.md";
-    license = licenses.isc;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
Backport of #403354

Depends on https://github.com/NixOS/nixpkgs/pull/408669

CC @hsjobeki

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
