### PR TITLE
cubeb: add myself to maintainers and make more cusomizable, signal-desktop.ringrtc: use cubeb from nixpkgs

### DIFF
--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -64,6 +64,9 @@ stdenv.mkDerivation {
     homepage = "https://github.com/mozilla/cubeb";
     license = licenses.isc;
     platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ zhaofengli ];
+    maintainers = with maintainers; [
+      zhaofengli
+      marcin-serwin
+    ];
   };
 }

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -62,6 +62,18 @@ stdenv.mkDerivation {
     backendLibs = lib.optionals lazyLoad backendLibs;
   };
 
+  postInstall = ''
+    # TODO: remove after https://github.com/mozilla/cubeb/pull/813 is merged
+    mkdir -p $out/lib/pkgconfig/
+    echo > $out/lib/pkgconfig/libcubeb.pc \
+    "Name: libcubeb
+    Description: Cross platform audio library
+    Version: 0.0.0
+    Requires.private: libpulse
+    Libs: -L"$out/lib" -lcubeb
+    Libs.private: -lstdc++"
+  '';
+
   meta = with lib; {
     description = "Cross platform audio library";
     mainProgram = "cubeb-test";

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -5,8 +5,19 @@
   cmake,
   protobuf,
   webrtc,
+  pkg-config,
+  cubeb,
+  libpulseaudio,
 }:
-
+let
+  cubeb' = cubeb.override {
+    alsaSupport = false;
+    pulseSupport = true;
+    jackSupport = false;
+    sndioSupport = false;
+    buildSharedLibs = false;
+  };
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringrtc";
   version = "2.51.0";
@@ -28,12 +39,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
   doCheck = false;
 
+  env = {
+    LIBCUBEB_SYS_USE_PKG_CONFIG = 1;
+    LIBCUBEB_STATIC = 1;
+  };
+
   nativeBuildInputs = [
     protobuf
     cmake
+    pkg-config
   ];
   buildInputs = [
     webrtc
+    cubeb'
+    libpulseaudio
   ];
 
   meta = {

--- a/pkgs/by-name/si/signal-desktop/webrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/webrtc.nix
@@ -74,7 +74,11 @@ stdenv.mkDerivation (finalAttrs: {
   ninjaFlags = [ "webrtc" ];
 
   installPhase = ''
+    runHook preInstall
+
     install -D obj/libwebrtc${stdenv.hostPlatform.extensions.staticLibrary} $out/lib/libwebrtc${stdenv.hostPlatform.extensions.staticLibrary}
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/si/signal-desktop/webrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/webrtc.nix
@@ -19,14 +19,6 @@ stdenv.mkDerivation (finalAttrs: {
   gclientDeps = gclient2nix.importGclientDeps ./webrtc-sources.json;
   sourceRoot = "src";
 
-  preConfigure = ''
-    echo "$SOURCE_DATE_EPOCH" > build/util/LASTCHANGE.committime
-    echo "generate_location_tags = true" >> build/config/gclient_args.gni
-    substituteInPlace build/toolchain/linux/BUILD.gn \
-      --replace-fail 'toolprefix = "aarch64-linux-gnu-"' 'toolprefix = ""'
-    patchShebangs build/mac/should_use_hermetic_xcode.py
-  '';
-
   nativeBuildInputs = [
     gn
     ninja
@@ -43,6 +35,22 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
     pulseaudio
   ];
+
+  postPatch = ''
+    substituteInPlace build/toolchain/linux/BUILD.gn \
+      --replace-fail 'toolprefix = "aarch64-linux-gnu-"' 'toolprefix = ""'
+    patchShebangs build/mac/should_use_hermetic_xcode.py
+
+    substituteInPlace modules/audio_device/linux/pulseaudiosymboltable_linux.cc \
+      --replace-fail "libpulse.so.0" "${pulseaudio}/lib/libpulse.so.0"
+    substituteInPlace modules/audio_device/linux/alsasymboltable_linux.cc \
+      --replace-fail "libasound.so.2" "${alsa-lib}/lib/libasound.so.2"
+  '';
+
+  preConfigure = ''
+    echo "$SOURCE_DATE_EPOCH" > build/util/LASTCHANGE.committime
+    echo "generate_location_tags = true" >> build/config/gclient_args.gni
+  '';
 
   gnFlags = [
     ''target_os="linux"''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This fixes #407967

The `cubeb` derivation needs to be updated and modernized, but I kept the changes in this PR to minimum to avoid breaking changes when backporting to 25.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
