### PR TITLE
flashinfer: init at 0.2.5

### DIFF
--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -88,13 +88,13 @@ buildPythonPackage {
 
   meta = with lib; {
     homepage = "https://flashinfer.ai/";
-    description = ''
-      ;
-            FlashInfer is a library and kernel generator for Large Language Models
-            that provides high-performance implementation of LLM GPU kernels such as
-            FlashAttention, PageAttention and LoRA. FlashInfer focus on LLM serving
-            and inference, and delivers state-of-the-art performance across diverse
-            scenarios.
+    description = "Library and kernel generator for Large Language Models";
+    longDescription = ''
+      FlashInfer is a library and kernel generator for Large Language Models
+      that provides high-performance implementation of LLM GPU kernels such as
+      FlashAttention, PageAttention and LoRA. FlashInfer focus on LLM serving
+      and inference, and delivers state-of-the-art performance across diverse
+      scenarios.
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ breakds ];

--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -46,9 +46,15 @@ buildPythonPackage {
     cmake
     ninja
     (lib.getBin cudaPackages.cuda_nvcc)
-    (lib.getLib cudaPackages.cuda_cudart)
   ];
   dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    cudaPackages.cuda_cudart
+    cudaPackages.libcublas
+    cudaPackages.cuda_cccl
+    cudaPackages.libcurand
+  ];
 
   postPatch = ''
     rmdir 3rdparty/cutlass

--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -1,0 +1,99 @@
+# NOTE: At runtime, FlashInfer will fall back to PyTorch’s JIT compilation if a
+# requested kernel wasn’t pre-compiled in AOT mode, and JIT compilation always
+# requires the CUDA toolkit (via nvcc) to be available.
+#
+# This means that if you plan to use flashinfer, you will need to set the
+# environment varaible `CUDA_HOME` to `cudatoolkit`.
+{ lib,
+  buildPythonPackage,
+  symlinkJoin,
+  fetchFromGitHub,
+  setuptools,
+  cmake,
+  ninja,
+  numpy,
+  torch
+}:
+
+assert torch.cudaSupport;
+
+let
+  pname = "flashinfer";
+  version = "0.2.5";
+
+  inherit (torch) cudaPackages;
+  inherit (cudaPackages) cudaMajorMinorVersion;
+
+  cudaMajorMinorVersionString = lib.replaceStrings [ "." ] [ "" ] cudaMajorMinorVersion;
+
+  src_cutlass = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "cutlass";
+    # Using the revision obtained in submodule inside flashinfer's `3rdparty`.
+    rev = "df8a550d3917b0e97f416b2ed8c2d786f7f686a3";
+    hash = "sha256-d4czDoEv0Focf1bJHOVGX4BDS/h5O7RPoM/RrujhgFQ=";
+  };
+
+in buildPythonPackage {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "flashinfer-ai";
+    repo = "flashinfer";
+    tag = "v${version}";
+    hash = "sha256-YrYfatkI9DQkFEEGiF8CK/bTafaNga4Ufyt+882C0bQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    cudaPackages.cudatoolkit
+  ];
+  dontUseCmakeConfigure = true;
+
+  postPatch = ''
+    rmdir 3rdparty/cutlass
+    ln -s ${src_cutlass} 3rdparty/cutlass
+  '';
+
+  # FlashInfer offers two installation modes:
+  #
+  # JIT mode: CUDA kernels are compiled at runtime using PyTorch’s JIT, with
+  # compiled kernels cached for future use. JIT mode allows fast installation,
+  # as no CUDA kernels are pre-compiled, making it ideal for development and
+  # testing. JIT version is also available as a sdist in PyPI.
+  # 
+  # AOT mode: Core CUDA kernels are pre-compiled and included in the library,
+  # reducing runtime compilation overhead. If a required kernel is not
+  # pre-compiled, it will be compiled at runtime using JIT. AOT mode is
+  # recommended for production environments.
+  #
+  # Here we use opt for the AOT version.
+  preConfigure = ''
+    export FLASHINFER_ENABLE_AOT=1
+    export TORCH_NVCC_FLAGS="--maxrregcount=64"
+  '';
+
+  CUDA_HOME = "${cudaPackages.cudatoolkit}";
+  TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" torch.cudaCapabilities}";
+
+  dependencies = [
+    numpy
+    torch
+  ];
+
+  meta = with lib; {
+    homepage = "https://flashinfer.ai/";
+    description = '';
+      FlashInfer is a library and kernel generator for Large Language Models
+      that provides high-performance implementation of LLM GPU kernels such as
+      FlashAttention, PageAttention and LoRA. FlashInfer focus on LLM serving
+      and inference, and delivers state-of-the-art performance across diverse
+      scenarios.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ breakds ];
+  };
+}

--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -16,8 +16,6 @@
   torch,
 }:
 
-assert torch.cudaSupport;
-
 let
   pname = "flashinfer";
   version = "0.2.5";

--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -6,10 +6,11 @@
 # environment varaible `CUDA_HOME` to `cudatoolkit`.
 {
   lib,
+  config,
   buildPythonPackage,
-  symlinkJoin,
   fetchFromGitHub,
   setuptools,
+  cudaPackages,
   cmake,
   ninja,
   numpy,
@@ -19,11 +20,6 @@
 let
   pname = "flashinfer";
   version = "0.2.5";
-
-  inherit (torch) cudaPackages;
-  inherit (cudaPackages) cudaMajorMinorVersion;
-
-  cudaMajorMinorVersionString = lib.replaceStrings [ "." ] [ "" ] cudaMajorMinorVersion;
 
   src_cutlass = fetchFromGitHub {
     owner = "NVIDIA";
@@ -49,7 +45,7 @@ buildPythonPackage {
   nativeBuildInputs = [
     cmake
     ninja
-    cudaPackages.cudatoolkit
+    (lib.getBin cudaPackages.cuda_nvcc)
   ];
   dontUseCmakeConfigure = true;
 
@@ -76,7 +72,6 @@ buildPythonPackage {
     export TORCH_NVCC_FLAGS="--maxrregcount=64"
   '';
 
-  CUDA_HOME = "${cudaPackages.cudatoolkit}";
   TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" torch.cudaCapabilities;
 
   dependencies = [

--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -4,7 +4,8 @@
 #
 # This means that if you plan to use flashinfer, you will need to set the
 # environment varaible `CUDA_HOME` to `cudatoolkit`.
-{ lib,
+{
+  lib,
   buildPythonPackage,
   symlinkJoin,
   fetchFromGitHub,
@@ -12,7 +13,7 @@
   cmake,
   ninja,
   numpy,
-  torch
+  torch,
 }:
 
 assert torch.cudaSupport;
@@ -34,7 +35,8 @@ let
     hash = "sha256-d4czDoEv0Focf1bJHOVGX4BDS/h5O7RPoM/RrujhgFQ=";
   };
 
-in buildPythonPackage {
+in
+buildPythonPackage {
   inherit pname version;
 
   src = fetchFromGitHub {
@@ -64,7 +66,7 @@ in buildPythonPackage {
   # compiled kernels cached for future use. JIT mode allows fast installation,
   # as no CUDA kernels are pre-compiled, making it ideal for development and
   # testing. JIT version is also available as a sdist in PyPI.
-  # 
+  #
   # AOT mode: Core CUDA kernels are pre-compiled and included in the library,
   # reducing runtime compilation overhead. If a required kernel is not
   # pre-compiled, it will be compiled at runtime using JIT. AOT mode is
@@ -86,12 +88,13 @@ in buildPythonPackage {
 
   meta = with lib; {
     homepage = "https://flashinfer.ai/";
-    description = '';
-      FlashInfer is a library and kernel generator for Large Language Models
-      that provides high-performance implementation of LLM GPU kernels such as
-      FlashAttention, PageAttention and LoRA. FlashInfer focus on LLM serving
-      and inference, and delivers state-of-the-art performance across diverse
-      scenarios.
+    description = ''
+      ;
+            FlashInfer is a library and kernel generator for Large Language Models
+            that provides high-performance implementation of LLM GPU kernels such as
+            FlashAttention, PageAttention and LoRA. FlashInfer focus on LLM serving
+            and inference, and delivers state-of-the-art performance across diverse
+            scenarios.
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ breakds ];

--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -46,6 +46,7 @@ buildPythonPackage {
     cmake
     ninja
     (lib.getBin cudaPackages.cuda_nvcc)
+    (lib.getLib cudaPackages.cuda_cudart)
   ];
   dontUseCmakeConfigure = true;
 

--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -87,6 +87,7 @@ buildPythonPackage {
   ];
 
   meta = with lib; {
+    broken = !torch.cudaSupport || !config.cudaSupport;
     homepage = "https://flashinfer.ai/";
     description = "Library and kernel generator for Large Language Models";
     longDescription = ''

--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage {
   '';
 
   CUDA_HOME = "${cudaPackages.cudatoolkit}";
-  TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" torch.cudaCapabilities}";
+  TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" torch.cudaCapabilities;
 
   dependencies = [
     numpy

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5015,6 +5015,8 @@ self: super: with self; {
 
   flasgger = callPackage ../development/python-modules/flasgger { };
 
+  flashinfer = callPackage ../development/python-modules/flashinfer { };
+
   flashtext = callPackage ../development/python-modules/flashtext { };
 
   flask = callPackage ../development/python-modules/flask { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

FlashInfer is an open-source library and kernel generator for large language model (LLM) inference, offering high-performance GPU kernels such as FlashAttention, SparseAttention, and PageAttention, with both just-in-time (JIT) and ahead-of-time (AOT) compilation modes, and is integrated into major serving frameworks including [SGLang](https://github.com/sgl-project/sglang) and [vLLM](https://github.com/vllm-project/vllm).

I am packaging it as part of the effort to eventually package `sglang`.

NOTE: I’m new to packaging `CUDA`-enabled Python libraries in nixpkgs and I’d greatly appreciate any guidance on best practices of this. Thanks!

## Things done

I have verified locally that the built package can be used to run a simple `flashinfer` program, given that I have specified `CUDA_HOME` in my devshell.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
