### PR TITLE
freecad: build with netgen enabled (fixes #382847)

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -18,6 +18,7 @@
   libXmu,
   medfile,
   mpi,
+  netgen,
   ninja,
   ode,
   opencascade-occt_7_6,
@@ -78,6 +79,7 @@ freecad-utils.makeCustomizable (
       [
         cmake
         ninja
+        netgen
         pkg-config
         gfortran
         wrapGAppsHook3
@@ -104,6 +106,7 @@ freecad-utils.makeCustomizable (
         matplotlib
         medfile
         mpi
+        netgen
         ode
         opencamlib
         pivy
@@ -163,6 +166,9 @@ freecad-utils.makeCustomizable (
         "-DBUILD_FLAT_MESH:BOOL=ON"
         "-DINSTALL_TO_SITEPACKAGES=OFF"
         "-DFREECAD_USE_PYBIND11=ON"
+        "-DBUILD_NETGEN=ON"
+        "-DBUILD_FEM_NETGEN=ON"
+
       ]
       ++ lib.optionals (qtVersion == 5) [
         "-DBUILD_QT5=ON"

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -24,7 +24,7 @@
   opencascade-occt_7_6,
   opencascade-occt,
   pkg-config,
-  python311Packages,
+  python312Packages,
   spaceNavSupport ? stdenv.hostPlatform.isLinux,
   ifcSupport ? false,
   stdenv,
@@ -40,7 +40,7 @@
   qt6,
 }:
 let
-  inherit (python311Packages)
+  inherit (python312Packages)
     boost
     gitpython
     ifcopenshell


### PR DESCRIPTION
This is a fix to the freecad package.nix that I think closes #382847 - note that the first step that sent me down this path was from @dyfrgi
 in https://github.com/NixOS/nixpkgs/issues/382847#issuecomment-2778602516, so I added their commit from that comment as the first commit in this PR (credit where credit is due!).

Now the more iffy parts:

- This is my first PR to nixos/nixpkgs/nix anything really... I did read through CONTRIBUTING but there's a lot there so I might need some handholding if I missed something important...
- I don't really know how to do any testing for the problem this actually fixes.  The core problem from #382847 requires going through several GUI steps to trigger the error, and while I tested locally and this prevents the error, I don't have any idea how to add a regression test for that (or even if I'm supposed to...)
- The python312 change was necessary for a lot of the freecad features (including but not exclusively the one in ##382847), which is a bit mysterious because it seems unrelated... perhaps this implies the buildInputs should be `python312` instead  of `python`?  But that might cause more mucking up of the dependency tree.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
