### PR TITLE
katrain: init at v1.17.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11371,6 +11371,11 @@
     githubId = 7348004;
     name = "Benjamin Levy";
   };
+  iofq = {
+    github = "iofq";
+    githubId = 38452426;
+    name = "iofq";
+  };
   ionutnechita = {
     email = "ionut_n2001@yahoo.com";
     github = "ionutnechita";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -247,6 +247,7 @@
   ./programs/joycond-cemuhook.nix
   ./programs/k3b.nix
   ./programs/k40-whisperer.nix
+  ./programs/katrain.nix
   ./programs/kbdlight.nix
   ./programs/kclock.nix
   ./programs/kde-pim.nix

--- a/nixos/modules/programs/katrain.nix
+++ b/nixos/modules/programs/katrain.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.katrain;
+in
+{
+  options.programs.katrain = {
+    enable = lib.mkEnableOption "katrain";
+
+    withXClip = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to include xclip for copy-paste functions on X11";
+    };
+
+    withWlClipboard = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to include wl-clipboard-x11 for copy-paste functions on Wayland";
+    };
+
+    katago = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether to include and patch katago into katrain";
+      };
+
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        defaultText = "pkgs.katagoCPU";
+        description = "The katago package to patch into katrain";
+      };
+    };
+  };
+
+  config =
+    let
+      katagoPkg = if cfg.katago.package != null then cfg.katago.package else pkgs.katagoCPU;
+    in
+    lib.mkIf cfg.enable {
+      environment.systemPackages = [
+        (pkgs.katrain.overrideAttrs (
+          old:
+          (lib.optionalAttrs cfg.katago.enable {
+            patchPhase = ''
+              ${old.patchPhase or ""}
+              echo "patching katago binary path..."
+
+              substituteInPlace katrain/core/engine.py \
+                --replace-fail 'exe = self.get_engine_path(config.get("katago", "").strip())' \
+                'exe = self.get_engine_path("${katagoPkg}/bin/katago")'
+
+              substituteInPlace katrain/core/contribute_engine.py \
+                --replace-fail 'exe = self.get_engine_path(self.config.get("katago"))' \
+                'exe = self.get_engine_path("${katagoPkg}/bin/katago")'
+            '';
+          })
+          // {
+            propagatedBuildInputs =
+              (old.propagatedBuildInputs or [ ])
+              ++ lib.optionals cfg.katago.enable [ katagoPkg ]
+              ++ lib.optionals cfg.withXClip [ pkgs.xclip ]
+              ++ lib.optionals cfg.withWlClipboard [ pkgs.wl-clipboard-x11 ];
+          }
+        ))
+      ];
+    };
+}

--- a/pkgs/by-name/ka/katrain/package.nix
+++ b/pkgs/by-name/ka/katrain/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  stdenv,
+}:
+let
+  kivymd_0_104_1 = python3.pkgs.kivymd.overridePythonAttrs (old: {
+    src = (
+      old.src.override {
+        rev = "0.104.1";
+        hash = "sha256-qWiZ5bKw4gQtTvhe4w0Cadk17TbFFQWC0hvSFz9K4xA=";
+      }
+    );
+  });
+in
+with python3.pkgs;
+buildPythonApplication rec {
+  pname = "katrain";
+  version = "v1.17.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sanderland";
+    repo = "katrain";
+    tag = version;
+    hash = "sha256-rc8tU0DnHEp2WmFROkETIMU9/iGDAL5W9fLxRa1jJDM=";
+  };
+
+  POETRY_DYNAMIC_VERSIONING_BYPASS = version;
+
+  build-system = [
+    hatchling
+    uv-dynamic-versioning
+  ];
+
+  dependencies = [
+    chardet
+    docutils
+    ffpyplayer
+    kivy
+    kivymd_0_104_1
+    urllib3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ pygame ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ screeninfo ];
+
+  meta = with lib; {
+    homepage = "https://github.com/sanderland/katrain";
+    description = "Improve your Baduk skills by training with KataGo!";
+    longDescription = ''
+      Katrain is a Baduk (Go) GUI built around the KataGo GTP engine.
+
+      To fully utilize it, you should have:
+      - `xclip`: For clipboard integration with SGF files.
+      - `katago`: The actual AI engine that powers the analysis.
+
+      Both can be installed separately as:
+      pkgs.xclip (or pkgs.wl-clipboard-x11 for Wayland)
+      pkgs.katago
+
+      You'll need to point the katrain config file at katago yourself.
+
+      Alternatively, you can use the nixos module:
+      programs.katrain = {
+        enable = true;
+        withXClip = true; # or withWlClipboard for wayland
+      }
+    '';
+    mainProgram = "katrain";
+    license = "https://github.com/sanderland/katrain/blob/master/LICENSE";
+    maintainers = with maintainers; [ iofq ];
+  };
+}

--- a/pkgs/development/python-modules/asyncgui/default.nix
+++ b/pkgs/development/python-modules/asyncgui/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  poetry-core,
+  exceptiongroup,
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "asyncgui";
+  version = "0.9.3";
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "asyncgui";
+    repo = "asyncgui";
+    rev = version;
+    hash = "sha256-WeB7E9p3fVeMeuPsc20SFNDyo8oojZ6KcrXTQmOyFIU=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  dependencies = [
+    exceptiongroup
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "asyncgui" ];
+
+  meta = with lib; {
+    description = "A minimalistic async library that focuses on fast responsiveness";
+    homepage = "https://asyncgui.github.io/asyncgui";
+    license = licenses.mit;
+    maintainers = with maintainers; [ iofq ];
+  };
+}

--- a/pkgs/development/python-modules/asynckivy/default.nix
+++ b/pkgs/development/python-modules/asynckivy/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  uv-build,
+  asyncgui,
+  kivy,
+}:
+buildPythonPackage rec {
+  pname = "asynckivy";
+  version = "v0.9.3";
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "asyncgui";
+    repo = "asynckivy";
+    rev = version;
+    hash = "sha256-azGeruQQ6Ghg+P9AEyNrIgxB+RtF9U1BY+5hMXSJ8uc=";
+  };
+
+  build-system = [
+    uv-build
+  ];
+
+  dependencies = [
+    asyncgui
+    kivy
+  ];
+  pythonRelaxDeps = [ "asyncgui" ];
+
+  doChecks = false; # Tests require an available video device
+
+  meta = with lib; {
+    description = "Async library for Kivy";
+    homepage = "https://asyncgui.github.io/asynckivy";
+    license = licenses.mit;
+    maintainers = with maintainers; [ iofq ];
+  };
+}

--- a/pkgs/development/python-modules/ffpyplayer/default.nix
+++ b/pkgs/development/python-modules/ffpyplayer/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchurl,
+  stdenv,
+}:
+let
+  wheel =
+    if stdenv.hostPlatform.isDarwin then
+      "macosx_10_13_universal2.whl"
+    else if stdenv.hostPlatform.isAarch64 then
+      "manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+    else
+      "manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+in
+buildPythonPackage rec {
+  pname = "ffpyplayer";
+  version = "4.5.3";
+  format = "wheel";
+  disabled = pythonOlder "3.9";
+
+  src = fetchurl {
+    url = "https://github.com/matham/ffpyplayer/releases/download/v${version}/ffpyplayer-${version}-cp313-cp313-${wheel}";
+    hash =
+      if stdenv.hostPlatform.isDarwin then
+        "sha256-RBiI9Ct229fDAF9E1xRfcTodjOIzUbvEgLn6BeRmKvs="
+      else if stdenv.hostPlatform.isAarch64 then
+        "sha256-PgEswclDVwAJ+tAkpnW99Dsx6OHQwHCXFeYRvfWrOVk="
+      else
+        "sha256-WGsEzVmxvDp1nZdy3igRckgOFmd4aTR0JJrh4SVKQn8=";
+  };
+
+  pythonImportsCheck = [ "ffpyplayer" ];
+
+  meta = with lib; {
+    description = "A cython implementation of an ffmpeg based player.";
+    homepage = "https://matham.github.io/ffpyplayer/index.html";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ iofq ];
+  };
+}

--- a/pkgs/development/python-modules/kivymd/default.nix
+++ b/pkgs/development/python-modules/kivymd/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  setuptools,
+  kivy,
+  pillow,
+  materialyoucolor,
+  asynckivy,
+}:
+buildPythonPackage rec {
+  pname = "kivymd";
+  version = "1.1.1";
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "kivymd";
+    repo = "KivyMD";
+    rev = version;
+    hash = "sha256-svCBtdqGTW9aIG/MEZEsZ/w6nRiL/uP4Wh6TUlmj+do=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    kivy
+    pillow
+    materialyoucolor
+    asynckivy
+  ];
+
+  # Ensure kivy does not try to create files on disk when imported during check
+  KIVY_NO_CONFIG = 1;
+  KIVY_NO_FILELOG = 1;
+  pythonImportsCheck = [ "kivymd" ];
+
+  meta = with lib; {
+    description = "A collection of Material Design compliant widgets for use with Kivy, a framework for cross-platform, touch-enabled graphical applications.";
+    homepage = "https://kivymd.readthedocs.io/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ iofq ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5416,6 +5416,8 @@ self: super: with self; {
 
   ffmpy = callPackage ../development/python-modules/ffmpy { };
 
+  ffpyplayer = callPackage ../development/python-modules/ffpyplayer { };
+
   fhir-py = callPackage ../development/python-modules/fhir-py { };
 
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8186,6 +8186,8 @@ self: super: with self; {
 
   kivy-garden = callPackage ../development/python-modules/kivy-garden { };
 
+  kivymd = callPackage ../development/python-modules/kivymd { };
+
   kiwiki-client = callPackage ../development/python-modules/kiwiki-client { };
 
   kiwisolver = callPackage ../development/python-modules/kiwisolver { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1104,6 +1104,8 @@ self: super: with self; {
 
   asyncer = callPackage ../development/python-modules/asyncer { };
 
+  asyncgui = callPackage ../development/python-modules/asyncgui { };
+
   asyncinotify = callPackage ../development/python-modules/asyncinotify { };
 
   asyncio-dgram = callPackage ../development/python-modules/asyncio-dgram { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1114,6 +1114,8 @@ self: super: with self; {
 
   asyncio-throttle = callPackage ../development/python-modules/asyncio-throttle { };
 
+  asynckivy = callPackage ../development/python-modules/asynckivy { };
+
   asyncmy = callPackage ../development/python-modules/asyncmy { };
 
   asyncpg = callPackage ../development/python-modules/asyncpg { };


### PR DESCRIPTION
Adding [katrain](https://github.com/sanderland/katrain) as it's becoming difficult to build on a modern Linux system such as ubuntu and nix could help :)

To do so, I had to add 2 new python modules, kivymd and ffpyplayer. ffpyplayer was difficult because the project needs ffmpeg C bindings; after troubleshooting for a few hours, I still wasn't able to get it to compile against any version of ffmpeg, and fell back to the wheel from pypi (which appears to be built with ffmpeg 6).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] ** Only tested x86_64, do not have a darwin machine **
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
