### PR TITLE
nixos/tests: don't explicitly set meta.platforms

### DIFF
--- a/nixos/tests/bitbox-bridge.nix
+++ b/nixos/tests/bitbox-bridge.nix
@@ -5,13 +5,10 @@ let
 in
 {
   name = "bitbox-bridge";
-  meta = {
-    platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [
-      izelnakri
-      tensor5
-    ];
-  };
+  meta.maintainers = with lib.maintainers; [
+    izelnakri
+    tensor5
+  ];
 
   nodes.machine = {
     services.bitbox-bridge = {

--- a/nixos/tests/cosmic.nix
+++ b/nixos/tests/cosmic.nix
@@ -10,10 +10,7 @@
 {
   name = testName;
 
-  meta = {
-    platforms = lib.platforms.linux;
-    maintainers = lib.teams.cosmic.members;
-  };
+  meta.maintainers = lib.teams.cosmic.members;
 
   nodes.machine = {
     imports = [ ./common/user-account.nix ];

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -651,14 +651,11 @@ let
         # put global maintainers here, individuals go into makeInstallerTest fkt call
         maintainers = (meta.maintainers or [ ]);
         # non-EFI tests can only run on x86
-        platforms =
-          if isEfi then
-            platforms.linux
-          else
-            [
-              "x86_64-linux"
-              "i686-linux"
-            ];
+        platforms = lib.mkIf (!isEfi) [
+          "x86_64-linux"
+          "x86_64-darwin"
+          "i686-linux"
+        ];
       };
       nodes =
         let

--- a/nixos/tests/limine/checksum.nix
+++ b/nixos/tests/limine/checksum.nix
@@ -6,11 +6,6 @@
     phip1611
     programmerlexi
   ];
-  meta.platforms = [
-    "aarch64-linux"
-    "i686-linux"
-    "x86_64-linux"
-  ];
   nodes.machine =
     { ... }:
     {

--- a/nixos/tests/limine/uefi.nix
+++ b/nixos/tests/limine/uefi.nix
@@ -6,11 +6,6 @@
     phip1611
     programmerlexi
   ];
-  meta.platforms = [
-    "aarch64-linux"
-    "i686-linux"
-    "x86_64-linux"
-  ];
   nodes.machine =
     { ... }:
     {

--- a/nixos/tests/lomiri-calendar-app.nix
+++ b/nixos/tests/lomiri-calendar-app.nix
@@ -1,11 +1,7 @@
 { pkgs, lib, ... }:
 {
   name = "lomiri-calendar-app-standalone";
-  meta = {
-    maintainers = lib.teams.lomiri.members;
-    # This needs a Linux VM
-    platforms = lib.platforms.linux;
-  };
+  meta.maintainers = lib.teams.lomiri.members;
 
   nodes.machine =
     { config, pkgs, ... }:

--- a/nixos/tests/lomiri-music-app.nix
+++ b/nixos/tests/lomiri-music-app.nix
@@ -8,11 +8,7 @@ let
 in
 {
   name = "lomiri-music-app-standalone";
-  meta = {
-    maintainers = lib.teams.lomiri.members;
-    # This needs a Linux VM
-    platforms = lib.platforms.linux;
-  };
+  meta.maintainers = lib.teams.lomiri.members;
 
   nodes.machine =
     { config, pkgs, ... }:

--- a/nixos/tests/shadps4.nix
+++ b/nixos/tests/shadps4.nix
@@ -3,7 +3,6 @@
   name = "shadps4-openorbis-example";
   meta = {
     inherit (pkgs.shadps4.meta) maintainers;
-    platforms = lib.intersectLists lib.platforms.linux pkgs.shadps4.meta.platforms;
   };
 
   nodes.machine =

--- a/nixos/tests/velocity.nix
+++ b/nixos/tests/velocity.nix
@@ -1,13 +1,7 @@
 { lib, pkgs, ... }:
 {
   name = "velocity";
-  meta = {
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
-    maintainers = [ lib.maintainers.Tert0 ];
-  };
+  meta.maintainers = [ lib.maintainers.Tert0 ];
 
   nodes.server =
     { ... }:

--- a/nixos/tests/wstunnel.nix
+++ b/nixos/tests/wstunnel.nix
@@ -8,8 +8,6 @@ in
 {
   name = "wstunnel";
 
-  meta.platforms = lib.platforms.linux;
-
   nodes = {
     server = {
       virtualisation.vlans = [ 1 ];


### PR DESCRIPTION
This prevents the tests from running on Darwin for no real reason.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
