### PR TITLE
kanidm: fix to actually work on Linux again

### DIFF
--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -23,7 +23,7 @@ import ./make-test-python.nix (
       { pkgs, lib, ... }:
       {
         services.kanidm = {
-          package = pkgs.kanidmWithSecretProvisioning;
+          package = pkgs.kanidmWithSecretProvisioning_1_6;
           enableServer = true;
           serverSettings = {
             origin = "https://${serverDomain}";

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -26,6 +26,7 @@ import ./make-test-python.nix (
       { pkgs, ... }:
       {
         services.kanidm = {
+          package = pkgs.kanidm_1_6;
           enableServer = true;
           serverSettings = {
             origin = "https://${serverDomain}";
@@ -55,6 +56,7 @@ import ./make-test-python.nix (
       { nodes, ... }:
       {
         services.kanidm = {
+          package = pkgs.kanidm_1_6;
           enableClient = true;
           clientSettings = {
             uri = "https://${serverDomain}";

--- a/pkgs/by-name/ka/kanidm/generic.nix
+++ b/pkgs/by-name/ka/kanidm/generic.nix
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage rec {
     inherit hash;
   };
 
-  KANIDM_BUILD_PROFILE = "release_nixpgs_${arch}";
+  KANIDM_BUILD_PROFILE = "release_nixpkgs_${arch}";
 
   patches = lib.optionals enableSecretProvisioning [
     "${patchDir}/oauth2-basic-secret-modify.patch"
@@ -59,7 +59,7 @@ rustPlatform.buildRustPackage rec {
   postPatch =
     let
       format = (formats.toml { }).generate "${KANIDM_BUILD_PROFILE}.toml";
-      socket_path = if stdenv.hostPlatform.isLinux then "/run/kanidm/sock" else "/var/run/kanidm.socket";
+      socket_path = if stdenv.hostPlatform.isLinux then "/run/kanidmd/sock" else "/var/run/kanidm.socket";
       profile =
         {
           cpu_flags = if stdenv.hostPlatform.isx86_64 then "x86_64_legacy" else "none";


### PR DESCRIPTION
Fixes #402861. Fixes tests. Come on people.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
