### PR TITLE
home-manager: add a test to track upstream's packaging

### DIFF
--- a/pkgs/by-name/ho/home-manager/package.nix
+++ b/pkgs/by-name/ho/home-manager/package.nix
@@ -85,15 +85,25 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     };
     tests = {
       /**
-        Ensure that upstream's packaging code has not changed.
-        Otherwise we might have to modify ours accordingly.
         This is a fixed-output derivation triggered by version bumps.
+        The `outputHash` below would need to be updated manually from time
+        to time. It records the hash of upstream's packaging file, i.e.
+
+          $src/home-manager/default.nix
+
+        The test will fail (by design) once this packaging file is changed
+        upstream. The failure serves as an indicator that we should probably
+        update the `package.nix` here in Nixpkgs as well.
+
+        Once the changes from $src/home-manager/default.nix is incorporated
+        here, we can update the `outputHash` below to silence the test
+        failure.
       */
       upstreamPackaging =
-        runCommand "home-manager-${finalAttrs.version}.nix"
+        runCommand "home-manager-upstream-package-${finalAttrs.version}.nix"
           {
-            outputHashMode = "recursive";
             outputHash = "sha256-O290IaZj50YwuCPtzyeAK9pMSseZpBwgXHG/lpVfzFY=";
+            outputHashMode = "recursive";
           }
           ''
             echo "# upstream packaging code (for reference only)" > $out


### PR DESCRIPTION
- ~~This removes the big red 25.05 version bump warnings.~~
	Superseded by #410405
- Also, we add `passthru.tests.upstreamPackaging` to keep track of upstream packaging code at https://github.com/nix-community/home-manager/blob/master/home-manager/default.nix. Failure of `passthru.tests.upstreamPackaging` would remind us to keep the packaging here in sync with upstream.

See more explanation below from https://github.com/NixOS/nixpkgs/pull/408653#discussion_r2095399096.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
