### PR TITLE
[Backport 24.11] teleport_17: 17.4.5 -> 17.4.8; teleport_16: 16.5.3 -> 16.5.8

### DIFF
--- a/pkgs/servers/teleport/16/default.nix
+++ b/pkgs/servers/teleport/16/default.nix
@@ -2,11 +2,11 @@
 import ../generic.nix (
   args
   // {
-    version = "16.5.3";
-    hash = "sha256-yaHy75oS+HuO++qHEDaGByz11vwAqfaDT9qb94iKs3Y=";
-    vendorHash = "sha256-pHAiJ080lyWtb7xbwSeD9g8JlyXZyqtZC2IpsUJ7YaY=";
+    version = "16.5.9";
+    hash = "sha256-lIWJV3AQ+XWApfjtdUL8ZlHAXCyvwVAGsZjjvXul36I=";
+    vendorHash = "sha256-DdVBtMwz0AIGCYj/QLczG8GPP9mqKrdF+M0NqmM6J0I=";
     pnpmHash = "sha256-JQca2eFxcKJDHIaheJBg93ivZU95UWMRgbcK7QE4R10=";
-    cargoHash = "sha256-04zykCcVTptEPGy35MIWG+tROKFzEepLBmn04mSbt7I=";
+    cargoHash = "sha256-04zykCcVTptEPGy35MIWG+tROKFzEepLBmn04mSbt7I";
 
     # wasm-bindgen-cli version must match the version of wasm-bindgen in Cargo.lock
     wasm-bindgen-cli = wasm-bindgen-cli.override {

--- a/pkgs/servers/teleport/17/default.nix
+++ b/pkgs/servers/teleport/17/default.nix
@@ -2,10 +2,10 @@
 import ../generic.nix (
   args
   // {
-    version = "17.4.5";
-    hash = "sha256-VsgwX/ffHY4640FsXLtEht5acUX4bnaAlLDxMnLb0Mg=";
-    vendorHash = "sha256-3G7Vw/R08vG/tC16RBNPM0oOu6lLOgNpRLN/FAaKvuQ=";
-    pnpmHash = "sha256-gc1m76w3o0N1F6xYr2ZS6DOGvwbjK8k6bC8G8+xVFVQ=";
+    version = "17.4.8";
+    hash = "sha256-BMiV4xMDy/21B2kl/vkXD14LKQ9t/qj6K8HFnU9Td7w=";
+    vendorHash = "sha256-/JP0/4fFdCuDFLQ+mh7CQNMJ4n3yDNyvnLfbmRl/TBA=";
+    pnpmHash = "sha256-TZb1nABTbR+SPgykc/KMRkHW7oLawem6KWmdOFAbLbk=";
     cargoHash = "sha256-qz8gkooQTuBlPWC4lHtvBQpKkd+nEZ0Hl7AVg9JkPqs=";
   }
 )


### PR DESCRIPTION
Manual backport of #401973

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
