### PR TITLE
owncast: 0.2.0 -> 0.2.3

### DIFF
--- a/pkgs/by-name/ow/owncast/package.nix
+++ b/pkgs/by-name/ow/owncast/package.nix
@@ -5,12 +5,11 @@
   nixosTests,
   bash,
   which,
-  ffmpeg,
+  ffmpeg-full,
   makeBinaryWrapper,
 }:
-
 let
-  version = "0.2.0";
+  version = "0.2.3";
 in
 buildGoModule {
   pname = "owncast";
@@ -19,13 +18,19 @@ buildGoModule {
     owner = "owncast";
     repo = "owncast";
     rev = "v${version}";
-    hash = "sha256-MdquhDdbOdP1shnKHBlzQrSDe41fp0qnMzgaqL89jTk=";
+    hash = "sha256-JCIB4G3cOSkEEO/jcsj4mUP+HeQfgn0jX4OL8NX9/C0=";
   };
-  vendorHash = "sha256-ERilQZ8vnhGW1IEcLA4CcmozDooHKbnmASMw87tjYD4=";
+  vendorHash = "sha256-FuynEBoPS0p1bRgmaeCxn1RPqbYHcltZpQ9SE71xHEE=";
 
-  propagatedBuildInputs = [ ffmpeg ];
+  propagatedBuildInputs = [ ffmpeg-full ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];
+
+  # lefthook is included as a tool in go.mod for a pre-commit hook, but causes the build to fail
+  preBuild = ''
+    # Remove lefthook from tools section in go.mod
+    sed -i '/tool (/,/)/{ /[[:space:]]*github.com\/evilmartians\/lefthook[[:space:]]*$/d; }' go.mod
+  '';
 
   postInstall = ''
     wrapProgram $out/bin/owncast \
@@ -33,7 +38,7 @@ buildGoModule {
         lib.makeBinPath [
           bash
           which
-          ffmpeg
+          ffmpeg-full
         ]
       }
   '';
@@ -51,8 +56,10 @@ buildGoModule {
     homepage = "https://owncast.online";
     license = licenses.mit;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ MayNiklas ];
+    maintainers = with maintainers; [
+      flexiondotorg
+      MayNiklas
+    ];
     mainProgram = "owncast";
   };
-
 }


### PR DESCRIPTION
Updated to owncast 0.2.3. Now uses `ffmpeg-full` to expose hardware-accelerated video encoder improvements for NVENC, VA-API, and QuickSync introduced in Owncast 0.2.2, which I contributed upstream. Disables lefthook in `go.mod` tool to prevent FTBFS. Formatted with `nixfmt`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>owncast</li>
  </ul>
</details>

---

Tagging @MayNiklas 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
