### PR TITLE
amazon-image: Increase disk size, Remove tags from label - use version only

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -140,7 +140,7 @@ in
            echo "file ${cfg.format} $rootDisk" >> $out/nix-support/hydra-build-products
 
           ${pkgs.jq}/bin/jq -n \
-            --arg system_label ${lib.escapeShellArg config.system.nixos.label} \
+            --arg system_version ${lib.escapeShellArg config.system.nixos.version} \
             --arg system ${lib.escapeShellArg pkgs.stdenv.hostPlatform.system} \
             --arg root_logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$rootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
             --arg boot_logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$bootDisk" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
@@ -148,7 +148,7 @@ in
             --arg root "$rootDisk" \
             --arg boot "$bootDisk" \
            '{}
-             | .label = $system_label
+             | .label = $system_version
              | .boot_mode = $boot_mode
              | .system = $system
              | .disks.boot.logical_bytes = $boot_logical_bytes
@@ -181,13 +181,13 @@ in
            echo "file ${cfg.format} $diskImage" >> $out/nix-support/hydra-build-products
 
           ${pkgs.jq}/bin/jq -n \
-            --arg system_label ${lib.escapeShellArg config.system.nixos.label} \
+            --arg system_version ${lib.escapeShellArg config.system.nixos.version} \
             --arg system ${lib.escapeShellArg pkgs.stdenv.hostPlatform.system} \
             --arg logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$diskImage" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
             --arg boot_mode "${amiBootMode}" \
             --arg file "$diskImage" \
              '{}
-             | .label = $system_label
+             | .label = $system_version
              | .boot_mode = $boot_mode
              | .system = $system
              | .logical_bytes = $logical_bytes

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -83,7 +83,7 @@ in
 
   # Use a priority just below mkOptionDefault (1500) instead of lib.mkDefault
   # to avoid breaking existing configs using that.
-  config.virtualisation.diskSize = lib.mkOverride 1490 (3 * 1024);
+  config.virtualisation.diskSize = lib.mkOverride 1490 (4 * 1024);
   config.virtualisation.diskSizeAutoSupported = !config.ec2.zfs.enable;
 
   config.system.nixos.tags = [ "amazon" ];


### PR DESCRIPTION
* Disk usage of the image has risen considerably since last release. We still need to investigate the cause in detail. Increasing it for now prevents build failures at least.

* By default, `system.nixos.label` includes `system.nixos.tags` which
historically was not set for the amazon image.

Keeping the tag in the label of the generated disk image inside the derivation (i.e. `image.filePath`) makes it easier to tell that the file is for amazon (i.e. `nixos-image-amazon-25.11pre-git-x86_64-linux.vpc`) while the "label" in `image-info.json` for users of the AWS api stays stable (i.e. `/25.05pre-git-x86_64-linux`).


Alternative to https://github.com/NixOS/nixpkgs/pull/408317

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
