### PR TITLE
libFreeImage: init at 0-unstable-2024-11-28

### DIFF
--- a/pkgs/by-name/li/libFreeImage/package.nix
+++ b/pkgs/by-name/li/libFreeImage/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  libjpeg,
+  libpng,
+  libtiff,
+  libwebp,
+  openexr,
+  zlib,
+  libraw,
+  openjpeg,
+  jxrlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libfreeimage";
+  version = "0-unstable-2024-11-28";
+
+  src = fetchFromGitHub {
+    owner = "WohlSoft";
+    repo = "libFreeImage";
+    rev = "2666dee8132384885dd501a6a6db1bd86016ce0e";
+    hash = "sha256-aLIDhAMSE9ESepWeEOPFu6Ry2WSiS9M43GXOKuTcft8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libjpeg
+    libpng
+    libtiff
+    libwebp
+    openexr
+    zlib
+    libraw
+    openjpeg
+    jxrlib
+  ];
+
+  # Disable treating warnings as errors
+  NIX_CFLAGS_COMPILE = "-Wno-error -Wno-format -Wno-format-security -fpermissive";
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DFREEIMAGE_DYNAMIC_C_RUNTIME=ON"
+  ];
+
+  # More thorough patching of build files
+  preConfigure = ''
+    # Find and modify CMakeLists.txt to remove -Werror flags
+    find . -name CMakeLists.txt -exec sed -i 's/-Werror//g' {} \;
+    find . -name "*.cmake" -exec sed -i 's/-Werror//g' {} \;
+
+    # Add compiler flags to disable warnings as errors
+    echo 'add_compile_options(-Wno-error -Wno-format -Wno-format-security -fpermissive)' >> CMakeLists.txt
+
+    # If there's a specific compiler flags setup file, modify it
+    if [ -f CMake/CompilerFlags.cmake ]; then
+      sed -i 's/add_compile_options(-Werror)//g' CMake/CompilerFlags.cmake
+      echo 'add_compile_options(-Wno-error -Wno-format -Wno-format-security -fpermissive)' >> CMake/CompilerFlags.cmake
+    fi
+  '';
+
+  meta = {
+    description = "Open source library to work with graphical file formats";
+    longDescription = ''
+      FreeImage is an Open Source library project for developers who would like
+      to support popular graphics image formats like PNG, BMP, JPEG, TIFF and
+      others as needed by today's multimedia applications. FreeImage is easy to
+      use, fast, multithreading safe, compatible with all 32-bit or 64-bit
+      versions of Windows, and cross-platform (works both with Linux and Mac
+      OS X).
+    '';
+    homepage = "https://github.com/WohlSoft/libFreeImage";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ guelakais ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
