### PR TITLE
station: 1.52.2 -> 3.3.0

### DIFF
--- a/pkgs/by-name/st/station/package.nix
+++ b/pkgs/by-name/st/station/package.nix
@@ -1,43 +1,50 @@
 {
+  lib,
   appimageTools,
   fetchurl,
-  lib,
+  makeWrapper,
+  nix-update-script,
 }:
-
 let
+  version = "3.3.0";
   pname = "station";
-  version = "1.52.2";
-
   src = fetchurl {
-    url = "https://github.com/getstation/desktop-app-releases/releases/download/${version}/Station-${version}-x86_64.AppImage";
-    sha256 = "0lhiwvnf94is9klvzrqv2wri53gj8nms9lg2678bs4y58pvjxwid";
+    url = "https://github.com/getstation/desktop-app/releases/download/v${version}/Station-x86_64.AppImage";
+    hash = "sha256-OiUVRKpU2W1dJ6z9Dqvxd+W4/oNpG+Zolj43ZHpKaO0=";
   };
-
   appimageContents = appimageTools.extractType2 {
     inherit pname version src;
   };
 in
-appimageTools.wrapType2 rec {
+appimageTools.wrapType2 {
   inherit pname version src;
-
-  profile = ''
-    export LC_ALL=C.UTF-8
-  '';
-
   extraInstallCommands = ''
-    install -m 444 -D ${appimageContents}/browserx.desktop $out/share/applications/browserx.desktop
-    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/browserx.png \
-      $out/share/icons/hicolor/512x512/apps/browserx.png
-    substituteInPlace $out/share/applications/browserx.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
+    source "${makeWrapper}/nix-support/setup-hook"
+    wrapProgram $out/bin/${pname} \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+    install -m 444 -D ${appimageContents}/station-desktop-app.desktop \
+      $out/share/applications/station-desktop-app.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/station-desktop-app.png \
+      $out/share/icons/hicolor/512x512/apps/station-desktop-app.png
+    substituteInPlace $out/share/applications/station-desktop-app.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=station'
   '';
 
-  meta = with lib; {
-    description = "Single place for all of your web applications";
-    homepage = "https://getstation.com";
-    license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
-    maintainers = [ ];
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--url=https://github.com/getstation/desktop-app" ];
+    };
+  };
+
+  meta = {
+    changelog = "https://github.com/getstation/desktop-app/releases/tag/v${version}";
+    description = "A single place for all of your web applications";
+    downloadPage = "https://github.com/getstation/desktop-app/releases";
+    homepage = "https://getstation.com/";
+    license = lib.licenses.asl20;
     mainProgram = "station";
+    maintainers = with lib.maintainers; [ flexiondotorg ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }


### PR DESCRIPTION
Update Station from 1.52.2 (*from Oct 2019*) to 3.3.0. Added `updateScript`. Corrected the license. Added myself as maintainer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>station</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
