### PR TITLE
rustc: put the linker for the target platform first

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -182,9 +182,38 @@ stdenv.mkDerivation (finalAttrs: {
       "${setHost}.cc=${ccForHost}"
       "${setTarget}.cc=${ccForTarget}"
 
+      # The Rust compiler build identifies platforms by Rust target
+      # name, and later arguments override previous arguments. This
+      # means that when platforms differ in configuration but overlap
+      # in Rust target name (for instance, `pkgsStatic`), only one
+      # setting will be applied for any given option.
+      #
+      # This is usually mostly harmless, especially as `fastCross`
+      # means that we usually only compile `std` in such cases.
+      # However, the build does still need to link helper tools for the
+      # build platform in that case. This was breaking the Darwin
+      # `pkgsStatic` build, as it was attempting to link build tools
+      # with the target platform’s static linker, and failing to locate
+      # an appropriate static library for `-liconv`.
+      #
+      # Since the static build does not link anything for the target
+      # platform anyway, we put the target linker first so that the
+      # build platform linker overrides it when the Rust target names
+      # overlap, allowing the helper tools to build successfully.
+      #
+      # Note that Rust does not remember these settings in the built
+      # compiler, so this does not compromise any functionality of the
+      # resulting compiler.
+      #
+      # The longer‐term fix would be to get Rust to use a more nuanced
+      # understanding of platforms, such as by explicitly constructing
+      # and passing Rust JSON target definitions that let us
+      # distinguish the platforms in cases like these. That would also
+      # let us supplant various hacks around the wrappers and hooks
+      # that we currently need.
+      "${setTarget}.linker=${ccForTarget}"
       "${setBuild}.linker=${ccForBuild}"
       "${setHost}.linker=${ccForHost}"
-      "${setTarget}.linker=${ccForTarget}"
 
       "${setBuild}.cxx=${cxxForBuild}"
       "${setHost}.cxx=${cxxForHost}"


### PR DESCRIPTION
Fix `pkgsStatic.buildPackages.rustc` on Darwin.

Closes: #405969

---

I think this might be a nicer solution than https://github.com/NixOS/nixpkgs/pull/407790, as it avoids elaborate platform‐inspecting logic ~~and the build shouldn’t be using this linker to begin with~~.

---

**Note:** This work was funded by Determinate Systems.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
