### PR TITLE
tabby-terminal-bin: init at 1.0.223

### DIFF
--- a/pkgs/by-name/ta/tabby-terminal-bin/package.nix
+++ b/pkgs/by-name/ta/tabby-terminal-bin/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  appimageTools,
+  fetchurl,
+  asar,
+}:
+let
+  pname = "tabby-terminal-bin";
+  version = "1.0.223";
+
+  src =
+    {
+      x86_64-linux = fetchurl {
+        url = "https://github.com/Eugeny/tabby/releases/download/v${version}/tabby-${version}-linux-x64.AppImage";
+        hash = "sha256-qHHodFgRt+t1ACq9aSgn15PkZihpD084VP0A4YqZ95o=";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://github.com/Eugeny/tabby/releases/download/v${version}/tabby-${version}-linux-arm64.AppImage";
+        hash = "sha256-fO8E9BKKV4GJFRuJX0Lza/8wGm46EIwd8F2ZGABoaqg=";
+      };
+    }
+    .${stdenv.hostPlatform.system}
+      or (throw "${pname}-${version}: ${stdenv.hostPlatform.system} is unsupported.");
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+    postExtract = ''
+      # Get rid of the autoupdater
+      ${asar}/bin/asar extract $out/resources/app.asar app
+      sed -i 's/async isUpdateAvailable.*/async isUpdateAvailable(updateInfo) { return false;/g' app/node_modules/electron-updater/out/AppUpdater.js
+      ${asar}/bin/asar pack app $out/resources/app.asar
+    '';
+  };
+
+in
+appimageTools.wrapAppImage {
+  inherit pname version;
+  src = appimageContents;
+
+  extraPkgs = pkgs: [ pkgs.hidapi ];
+
+  extraInstallCommands = ''
+    # Add desktop convencience stuff
+    install -Dm444 ${appimageContents}/tabby.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/tabby.png -t $out/share/pixmaps
+    mv $out/bin/${pname} $out/bin/tabby
+    substituteInPlace $out/share/applications/tabby.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=tabby'
+  '';
+
+  meta = {
+    homepage = "https://tabby.sh";
+    description = "Terminal for the modern age";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      pokon548
+    ];
+    # https://www.electronjs.org/docs/latest/tutorial/electron-timelines
+    knownVulnerabilities = [ "Electron version 32 is EOL" ];
+    mainProgram = "tabby";
+  };
+}


### PR DESCRIPTION
Introduce [tabby](https://tabby.sh/), a terminal for a more modern age... in binary form!

There is indeed another pr https://github.com/NixOS/nixpkgs/pull/368048 that is trying to compile `tabby`  from source code, but it seems too difficult to maintain on the current codebase. So I would like to package `tabby-terminal-bin` to make it just works and hassle-free to maintain.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
