### PR TITLE
logseq: 0.10.9-unstable-2025-03-11 -> 0.10.11

### DIFF
--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "logseq";
-  version = "0.10.10";
+  version = "0.10.11";
 
   src = fetchFromGitHub {
     owner = "logseq";
     repo = "logseq";
     tag = "${finalAttrs.version}";
-    hash = "sha256-eqs6yTooN40b30jwftXMXpIt6JA9zghVb39XXXsh3Ps=";
+    hash = "sha256-FtS+G+EyQYTZMj1ZEhd51xMWl67Xi5JW5JHokPTWQxE=";
   };
 
   patches = [
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
   yarnOfflineCacheRoot = fetchYarnDeps {
     name = "logseq-${finalAttrs.version}-yarn-deps-root";
     inherit (finalAttrs) src;
-    hash = "sha256-bPhBvVFN7Vii5p2v3aBOkan6lsqWeYGhs4LnBdN/ETc=";
+    hash = "sha256-Lz63rtah5DHkxJhXgSSwsLlrPVTHm1OuT5TeTuTvp+I=";
   };
 
   # ./static and ./resources are combined into ./static by the build process
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
     name = "logseq-${finalAttrs.version}-yarn-deps-static-resources";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/static";
-    hash = "sha256-xuZj2EKHxvkiDPKMLh3ZSvLT54k+buHqg9lRTFv8rNI=";
+    hash = "sha256-BXQu+j6RsoMsKQt4GI0V1RO4sLGJzcG46UtNCRsjsY0=";
   };
 
   yarnOfflineCacheAmplify = fetchYarnDeps {

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   fetchYarnDeps,
   replaceVars,
-  runCommand,
   writeShellScriptBin,
 
   copyDesktopItems,

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "logseq";
     repo = "logseq";
-    rev = "${finalAttrs.version}";
+    tag = "${finalAttrs.version}";
     hash = "sha256-eqs6yTooN40b30jwftXMXpIt6JA9zghVb39XXXsh3Ps=";
   };
 

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "logseq";
-  version = "0.10.9-unstable-2025-03-11";
+  version = "0.10.10";
 
   src = fetchFromGitHub {
     owner = "logseq";
     repo = "logseq";
-    rev = "ac0a0dae727c46b348d0f1410138d5e49d446692";
-    hash = "sha256-esCB51BeWnni/JFL4yMKcJj5lka2+hLpcvWGify0T2o=";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-eqs6yTooN40b30jwftXMXpIt6JA9zghVb39XXXsh3Ps=";
   };
 
   patches = [
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
   yarnOfflineCacheRoot = fetchYarnDeps {
     name = "logseq-${finalAttrs.version}-yarn-deps-root";
     inherit (finalAttrs) src;
-    hash = "sha256-z4G675kxfpmG2AJlbK5bfeUUgX7jz1ys2FlMNHJqrQ4=";
+    hash = "sha256-bPhBvVFN7Vii5p2v3aBOkan6lsqWeYGhs4LnBdN/ETc=";
   };
 
   # ./static and ./resources are combined into ./static by the build process


### PR DESCRIPTION
Todo right now, as the tag is not in place yet. Fairly certain it will be set to https://github.com/logseq/logseq/commit/f9834d95c61574cff7b6fa800ea2adeb8740815c, so I assumed that while testing.

Builds and runs correctly.

Changelog: https://github.com/logseq/logseq/compare/0.10.9...f9834d95c61574cff7b6fa800ea2adeb8740815c

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
