### PR TITLE
obs-studio-plugins.obs-markdown: init at 0.2.7

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -42,6 +42,8 @@
 
   obs-livesplit-one = callPackage ./obs-livesplit-one { };
 
+  obs-markdown = callPackage ./obs-markdown.nix { };
+
   obs-media-controls = qt6Packages.callPackage ./obs-media-controls.nix { };
 
   obs-move-transition = callPackage ./obs-move-transition.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-markdown.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-markdown.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  obs-studio,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-markdown";
+  version = "0.2.7";
+
+  src = fetchFromGitHub {
+    owner = "exeldro";
+    repo = "obs-markdown";
+    rev = version;
+    sha256 = "sha256-5ajX/cEa0n12Putx1k3ctl1v9wRzJRhyJNDlmjSMbeU=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ obs-studio ];
+
+  postInstall = ''
+    rm -rf $out/obs-plugins $out/data
+  '';
+
+  meta = with lib; {
+    description = "Plugin for OBS Studio to add Markdown sources";
+    homepage = "https://github.com/exeldro/obs-markdown";
+    maintainers = with maintainers; [ flexiondotorg ];
+    license = licenses.gpl2Only;
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+  };
+}


### PR DESCRIPTION
Add obs-markdown plugin 0.2.7

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-markdown</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
