### PR TITLE
python3Packages.magika: correct meta.mainProgram

### DIFF
--- a/pkgs/development/python-modules/magika/default.nix
+++ b/pkgs/development/python-modules/magika/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/google/magika";
     license = licenses.asl20;
     maintainers = with maintainers; [ mihaimaruseac ];
-    mainProgram = "magika";
+    mainProgram = "magika-python-client";
     # Currently, disabling on AArch64 as it onnx runtime crashes on ofborg
     broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux;
   };

--- a/pkgs/development/python-modules/magika/default.nix
+++ b/pkgs/development/python-modules/magika/default.nix
@@ -44,6 +44,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Magika: Detect file content types with deep learning";
     homepage = "https://github.com/google/magika";
+    changelog = "https://github.com/google/magika/blob/python-v${version}/python/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ mihaimaruseac ];
     mainProgram = "magika-python-client";


### PR DESCRIPTION
`magika` only prints a warning that you should use `magika-python-client` instead.
I'm not sure what the status of the new Rust CLI tool is.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and the test
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).