### PR TITLE
home-assistant-custom-components.home_connect_alt: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/aiohttp-sse-client/default.nix
+++ b/pkgs/development/python-modules/aiohttp-sse-client/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  wheel,
+  aiohttp,
+  attrs,
+  multidict,
+  yarl,
+}:
+
+buildPythonPackage rec {
+  pname = "aiohttp-sse-client";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-UATiknFiSvWGFY3HFmywaHp6WZeqtbgI9LU0AOG3Ljs=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "pytest-runner" ""
+  '';
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    aiohttp
+    attrs
+    multidict
+    yarl
+  ];
+
+  pythonImportsCheck = [
+    "aiohttp_sse_client"
+  ];
+
+  meta = {
+    description = "A Server-Sent Event python client base on aiohttp";
+    homepage = "https://pypi.org/project/aiohttp-sse-client/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kranzes ];
+  };
+}

--- a/pkgs/development/python-modules/home-connect-async/default.nix
+++ b/pkgs/development/python-modules/home-connect-async/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  wheel,
+  aiohttp,
+  aiohttp-sse-client,
+  charset-normalizer,
+  dataclasses-json,
+  oauth2-client,
+}:
+
+buildPythonPackage rec {
+  pname = "home-connect-async";
+  version = "0.8.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "home_connect_async";
+    inherit version;
+    hash = "sha256-npVMEiwclKr9HR2M03GNkyJULeLEE9BAnIw8Zoy98nQ=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    aiohttp
+    aiohttp-sse-client
+    charset-normalizer
+    dataclasses-json
+    oauth2-client
+  ];
+
+  pythonImportsCheck = [
+    "home_connect_async"
+  ];
+
+  meta = {
+    description = "Async SDK for BSH Home Connect API";
+    homepage = "https://pypi.org/project/home-connect-async";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kranzes ];
+  };
+}

--- a/pkgs/development/python-modules/oauth2-client/default.nix
+++ b/pkgs/development/python-modules/oauth2-client/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  wheel,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "oauth2-client";
+  version = "1.4.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-U4GQBEj/Gudi63xlxQEALqxGu1yi9JR3/f6vnplp8oQ=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "oauth2_client"
+  ];
+
+  meta = {
+    description = "A client library for OAuth2";
+    homepage = "https://pypi.org/project/oauth2-client/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kranzes ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/home_connect_alt/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/home_connect_alt/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  home-connect-async,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "ekutner";
+  domain = "home_connect_alt";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ekutner";
+    repo = "home-connect-hass";
+    tag = version;
+    hash = "sha256-v/C4KV/WddaXQIO709nHP4DJM/K3J3WQSrJnVaXQDSY=";
+  };
+
+  dependencies = [ home-connect-async ];
+
+  meta = with lib; {
+    description = "Alternative (and improved) Home Connect integration for Home Assistant";
+    homepage = "https://github.com/ekutner/home-connect-hass";
+    maintainers = with maintainers; [ kranzes ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10183,6 +10183,8 @@ self: super: with self; {
 
   oath = callPackage ../development/python-modules/oath { };
 
+  oauth2-client = callPackage ../development/python-modules/oauth2-client { };
+
   oauth2client = callPackage ../development/python-modules/oauth2client { };
 
   oauthenticator = callPackage ../development/python-modules/oauthenticator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6390,6 +6390,8 @@ self: super: with self; {
     callPackage ../development/python-modules/home-assistant-chip-wheels { }
   );
 
+  home-connect-async = callPackage ../development/python-modules/home-connect-async { };
+
   homeassistant-stubs = callPackage ../servers/home-assistant/stubs.nix { };
 
   homeconnect = callPackage ../development/python-modules/homeconnect { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -317,6 +317,8 @@ self: super: with self; {
 
   aiohttp-sse = callPackage ../development/python-modules/aiohttp-sse { };
 
+  aiohttp-sse-client = callPackage ../development/python-modules/aiohttp-sse-client { };
+
   aiohttp-sse-client2 = callPackage ../development/python-modules/aiohttp-sse-client2 { };
 
   aiohttp-swagger = callPackage ../development/python-modules/aiohttp-swagger { };


### PR DESCRIPTION
Adds home_connect_alt which is an alternative home-connect integration for home-assistant. I tested it on my dishwasher. Some python packages needed packaging for it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
