### PR TITLE
doc: add `treefmt` reference for functions & options

### DIFF
--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -14,6 +14,7 @@
   nixpkgs ? { },
   markdown-code-runner,
   roboto,
+  treefmt,
 }:
 
 stdenvNoCC.mkDerivation (
@@ -47,6 +48,7 @@ stdenvNoCC.mkDerivation (
 
     postPatch = ''
       ln -s ${optionsJSON}/share/doc/nixos/options.json ./config-options.json
+      ln -s ${treefmt.functionsDoc.markdown} ./packages/treefmt-functions.section.md
     '';
 
     buildPhase = ''

--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -49,6 +49,7 @@ stdenvNoCC.mkDerivation (
     postPatch = ''
       ln -s ${optionsJSON}/share/doc/nixos/options.json ./config-options.json
       ln -s ${treefmt.functionsDoc.markdown} ./packages/treefmt-functions.section.md
+      ln -s ${treefmt.optionsDoc.optionsJSON}/share/doc/nixos/options.json ./treefmt-options.json
     '';
 
     buildPhase = ''

--- a/doc/packages/index.md
+++ b/doc/packages/index.md
@@ -25,6 +25,7 @@ nginx.section.md
 opengl.section.md
 shell-helpers.section.md
 python-tree-sitter.section.md
+treefmt.section.md
 steam.section.md
 cataclysm-dda.section.md
 urxvt.section.md

--- a/doc/packages/treefmt.section.md
+++ b/doc/packages/treefmt.section.md
@@ -1,0 +1,8 @@
+# treefmt {#treefmt}
+
+[treefmt](https://github.com/numtide/treefmt) streamlines the process of applying formatters to your project, making it a breeze with just one command line.
+
+The [`treefmt` package](https://search.nixos.org/packages?channel=unstable&show=treefmt)
+provides functions for configuring treefmt using the module system.
+
+Alternatively, treefmt can be configured using [treefmt-nix](https://github.com/numtide/treefmt-nix).

--- a/doc/packages/treefmt.section.md
+++ b/doc/packages/treefmt.section.md
@@ -3,10 +3,21 @@
 [treefmt](https://github.com/numtide/treefmt) streamlines the process of applying formatters to your project, making it a breeze with just one command line.
 
 The [`treefmt` package](https://search.nixos.org/packages?channel=unstable&show=treefmt)
-provides functions for configuring treefmt using the module system, which are [documented below](#sec-functions-library-treefmt).
+provides functions for configuring treefmt using the module system, which are [documented below](#sec-functions-library-treefmt), along with [their options](#sec-treefmt-options-reference).
 
 Alternatively, treefmt can be configured using [treefmt-nix](https://github.com/numtide/treefmt-nix).
 
 ```{=include=} sections auto-id-prefix=auto-generated-treefmt-functions
 treefmt-functions.section.md
 ```
+
+## Options Reference {#sec-treefmt-options-reference}
+
+The following attributes can be passed to [`withConfig`](#pkgs.treefmt.withConfig) or [`evalConfig`](#pkgs.treefmt.evalConfig):
+
+```{=include=} options
+id-prefix: opt-treefmt-
+list-id: configuration-variable-list
+source: ../treefmt-options.json
+```
+

--- a/doc/packages/treefmt.section.md
+++ b/doc/packages/treefmt.section.md
@@ -3,6 +3,10 @@
 [treefmt](https://github.com/numtide/treefmt) streamlines the process of applying formatters to your project, making it a breeze with just one command line.
 
 The [`treefmt` package](https://search.nixos.org/packages?channel=unstable&show=treefmt)
-provides functions for configuring treefmt using the module system.
+provides functions for configuring treefmt using the module system, which are [documented below](#sec-functions-library-treefmt).
 
 Alternatively, treefmt can be configured using [treefmt-nix](https://github.com/numtide/treefmt-nix).
+
+```{=include=} sections auto-id-prefix=auto-generated-treefmt-functions
+treefmt-functions.section.md
+```

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -420,6 +420,9 @@
   "sec-tools-of-stdenv": [
     "index.html#sec-tools-of-stdenv"
   ],
+  "sec-treefmt-options-reference": [
+    "index.html#sec-treefmt-options-reference"
+  ],
   "ssec-cosmic-common-issues": [
     "index.html#ssec-cosmic-common-issues"
   ],

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -72,6 +72,15 @@
   "part-toolchains": [
     "index.html#part-toolchains"
   ],
+  "pkgs.treefmt.buildConfig": [
+    "index.html#pkgs.treefmt.buildConfig"
+  ],
+  "pkgs.treefmt.evalConfig": [
+    "index.html#pkgs.treefmt.evalConfig"
+  ],
+  "pkgs.treefmt.withConfig": [
+    "index.html#pkgs.treefmt.withConfig"
+  ],
   "preface": [
     "index.html#preface"
   ],
@@ -110,6 +119,9 @@
   ],
   "sec-building-packages-with-llvm-using-clang-stdenv": [
     "index.html#sec-building-packages-with-llvm-using-clang-stdenv"
+  ],
+  "sec-functions-library-treefmt": [
+    "index.html#sec-functions-library-treefmt"
   ],
   "sec-inkscape": [
     "index.html#sec-inkscape"

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -483,6 +483,9 @@
   "tester-testEqualArrayOrMap-return": [
     "index.html#tester-testEqualArrayOrMap-return"
   ],
+  "treefmt": [
+    "index.html#treefmt"
+  ],
   "typst": [
     "index.html#typst",
     "doc/languages-frameworks/typst.section.md#typst"

--- a/pkgs/by-name/tr/treefmt/functions-doc.nix
+++ b/pkgs/by-name/tr/treefmt/functions-doc.nix
@@ -1,8 +1,45 @@
 {
+  lib,
+  writers,
   nixdoc,
   runCommand,
+  treefmt,
 }:
+let
+  root = toString ./.;
+  revision = lib.trivial.revisionWithDefault "master";
+  removeRoot = file: lib.removePrefix "/" (lib.removePrefix root file);
+
+  # Import and apply `./lib.nix`, which contains treefmt's public functions
+  #
+  # NOTE: we cannot access them via `treefmt.passthru` or `callPackages ./lib.nix { }`,
+  # because that would be opaque to `unsafeGetAttrPos`.
+  attrs =
+    let
+      fn = import ./lib.nix;
+      args = builtins.mapAttrs (_: _: null) (builtins.functionArgs fn);
+    in
+    fn args;
+in
 {
+  locations = lib.pipe attrs [
+    builtins.attrNames
+    (builtins.map (
+      name:
+      let
+        pos = builtins.unsafeGetAttrPos name attrs;
+        file = removeRoot pos.file;
+        line = toString pos.line;
+        subpath = "pkgs/by-name/tr/treefmt/${file}";
+        url = "https://github.com/NixOS/nixpkgs/blob/${revision}/${subpath}#L${line}";
+      in
+      assert lib.hasPrefix root pos.file;
+      lib.nameValuePair "pkgs.treefmt.${name}" "[${subpath}:${line}](${url}) in `<nixpkgs>`"
+    ))
+    builtins.listToAttrs
+    (writers.writeJSON "treefmt-function-locations")
+  ];
+
   markdown =
     runCommand "treefmt-functions-doc"
       {
@@ -10,6 +47,7 @@
       }
       ''
         nixdoc --file ${./lib.nix} \
+          --locs ${treefmt.functionsDoc.locations} \
           --description "Functions Reference" \
           --prefix "pkgs" \
           --category "treefmt" \

--- a/pkgs/by-name/tr/treefmt/functions-doc.nix
+++ b/pkgs/by-name/tr/treefmt/functions-doc.nix
@@ -1,0 +1,19 @@
+{
+  nixdoc,
+  runCommand,
+}:
+{
+  markdown =
+    runCommand "treefmt-functions-doc"
+      {
+        nativeBuildInputs = [ nixdoc ];
+      }
+      ''
+        nixdoc --file ${./lib.nix} \
+          --description "Functions Reference" \
+          --prefix "pkgs" \
+          --category "treefmt" \
+          --anchor-prefix "" \
+           > $out
+      '';
+}

--- a/pkgs/by-name/tr/treefmt/lib.nix
+++ b/pkgs/by-name/tr/treefmt/lib.nix
@@ -15,9 +15,8 @@
 
     # Inputs
 
-    : A treefmt module. See [options reference].
-
-    [options reference]: https://nixos.org/manual/nixpkgs/unstable#sec-treefmt-options-reference
+    `module`
+    : A treefmt module. See [options reference](#sec-treefmt-options-reference).
   */
   evalConfig =
     module:
@@ -49,9 +48,8 @@
 
     # Inputs
 
-    : A treefmt module. See [options reference].
-
-    [options reference]: https://nixos.org/manual/nixpkgs/unstable#sec-treefmt-options-reference
+    `module`
+    : A treefmt module. See [options reference](#sec-treefmt-options-reference).
   */
   withConfig =
     module:
@@ -75,7 +73,8 @@
     # Inputs
 
     `settings`
-    : A settings module, used to build a treefmt config file
+    : A settings module, used to build a treefmt config file.
+      See [`settings` option reference](#opt-treefmt-settings).
   */
   buildConfig =
     module:

--- a/pkgs/by-name/tr/treefmt/lib.nix
+++ b/pkgs/by-name/tr/treefmt/lib.nix
@@ -15,11 +15,9 @@
 
     # Inputs
 
-    `module`
-    : A treefmt module, configuring options that include:
-      - `name`: `String` (default `"treefmt-with-config"`)
-      - `settings`: `Module` (default `{ }`)
-      - `runtimeInputs`: `[Derivation]` (default `[ ]`)
+    : A treefmt module. See [options reference].
+
+    [options reference]: https://nixos.org/manual/nixpkgs/unstable#sec-treefmt-options-reference
   */
   evalConfig =
     module:
@@ -51,11 +49,9 @@
 
     # Inputs
 
-    `module`
-    : A treefmt module, configuring options that include:
-      - `name`: `String` (default `"treefmt-with-config"`)
-      - `settings`: `Module` (default `{ }`)
-      - `runtimeInputs`: `[Derivation]` (default `[ ]`)
+    : A treefmt module. See [options reference].
+
+    [options reference]: https://nixos.org/manual/nixpkgs/unstable#sec-treefmt-options-reference
   */
   withConfig =
     module:

--- a/pkgs/by-name/tr/treefmt/options-doc.nix
+++ b/pkgs/by-name/tr/treefmt/options-doc.nix
@@ -1,0 +1,31 @@
+# To build this derivation, run `nix-build -A treefmt.optionsDoc`
+{
+  lib,
+  treefmt,
+  nixosOptionsDoc,
+}:
+
+let
+  configuration = treefmt.evalConfig [ ];
+
+  root = toString configuration._module.specialArgs.modulesPath;
+  revision = lib.trivial.revisionWithDefault "master";
+  removeRoot = file: lib.removePrefix "/" (lib.removePrefix root file);
+
+  transformDeclaration =
+    file:
+    let
+      fileStr = toString file;
+      subpath = "pkgs/by-name/tr/treefmt/modules/" + removeRoot fileStr;
+    in
+    assert lib.hasPrefix root fileStr;
+    {
+      url = "https://github.com/NixOS/nixpkgs/blob/${revision}/${subpath}";
+      name = subpath;
+    };
+in
+nixosOptionsDoc {
+  documentType = "none";
+  options = builtins.removeAttrs configuration.options [ "_module" ];
+  transformOptions = opt: opt // { declarations = map transformDeclaration opt.declarations; };
+}

--- a/pkgs/by-name/tr/treefmt/package.nix
+++ b/pkgs/by-name/tr/treefmt/package.nix
@@ -36,6 +36,9 @@ buildGoModule rec {
       ;
 
     tests = callPackages ./tests.nix { };
+
+    # Documentation for functions defined in `./lib.nix`
+    functionsDoc = callPackages ./functions-doc.nix { };
   };
 
   meta = {

--- a/pkgs/by-name/tr/treefmt/package.nix
+++ b/pkgs/by-name/tr/treefmt/package.nix
@@ -39,6 +39,9 @@ buildGoModule rec {
 
     # Documentation for functions defined in `./lib.nix`
     functionsDoc = callPackages ./functions-doc.nix { };
+
+    # Documentation for options declared in `treefmt.evalConfig` configurations
+    optionsDoc = callPackages ./options-doc.nix { };
   };
 
   meta = {

--- a/pkgs/by-name/tr/treefmt/package.nix
+++ b/pkgs/by-name/tr/treefmt/package.nix
@@ -46,6 +46,19 @@ buildGoModule rec {
 
   meta = {
     description = "one CLI to format the code tree";
+    longDescription = ''
+      [treefmt](${meta.homepage}) streamlines the process of applying formatters
+      to your project, making it a breeze with just one command line.
+
+      The `treefmt` package provides functions for configuring treefmt using
+      the module system, which are documented in the [treefmt section] of the
+      Nixpkgs Manual.
+
+      Alternatively, treefmt can be configured using [treefmt-nix].
+
+      [treefmt section]: https://nixos.org/manual/nixpkgs/unstable#treefmt
+      [treefmt-nix]: https://github.com/numtide/treefmt-nix
+    '';
     homepage = "https://github.com/numtide/treefmt";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
Followup to #406685

Introduce a `treefmt` package section to the nixpkgs manual, where its functions and options can be documented.

Currently `treefmt` has three public functions, `evalConfig`, `buildConfig`, and `withConfig`. These evaluate "treefmt modules", for configuring and/or wrapping treefmt.

They are documented in [pkgs/by-name/tr/treefmt/lib.nix](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/tr/treefmt/lib.nix) using RFC145 doc-comments. The default modules included in their module eval are in [pkgs/by-name/tr/treefmt/modules](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/tr/treefmt/modules), and are documented using option descriptions.

This PR includes the doc-comments in the manual in the same way that [`lib` is documented](https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library); using [`nixdoc`](https://github.com/nix-community/nixdoc). The module options are documented in the same way as [top-level pkgs config](https://nixos.org/manual/nixpkgs/unstable/#sec-config-options-reference), using `nixosOptionsDoc`.

<details><summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/3e4d3907-3c17-4b80-a5b8-62b6d749e0bb)


</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## cc

`treefmt` maintainers: @brianmcgee @zimbatm
formatting team: @NixOS/nix-formatting

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
