### PR TITLE
nixos/prowlarr: add configurable dataDir and user/group options

### DIFF
--- a/nixos/modules/services/misc/servarr/prowlarr.nix
+++ b/nixos/modules/services/misc/servarr/prowlarr.nix
@@ -13,6 +13,12 @@ in
     services.prowlarr = {
       enable = lib.mkEnableOption "Prowlarr, an indexer manager/proxy for Torrent trackers and Usenet indexers";
 
+      dataDir = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/prowlarr";
+        description = "The directory where Prowlarr stores its data files.";
+      };
+
       package = lib.mkPackageOption pkgs "prowlarr" { };
 
       openFirewall = lib.mkOption {
@@ -24,30 +30,63 @@ in
       settings = servarr.mkServarrSettingsOptions "prowlarr" 9696;
 
       environmentFiles = servarr.mkServarrEnvironmentFiles "prowlarr";
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "prowlarr";
+        description = ''
+          User account under which Prowlarr runs.
+        '';
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "prowlarr";
+        description = ''
+          Group under which Prowlarr runs.
+        '';
+      };
     };
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.services.prowlarr = {
-      description = "Prowlarr";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      environment = servarr.mkServarrSettingsEnvVars "PROWLARR" cfg.settings // {
-        HOME = "/var/empty";
+    systemd = {
+      services.prowlarr = {
+        description = "Prowlarr";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        environment = servarr.mkServarrSettingsEnvVars "PROWLARR" cfg.settings;
+
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          EnvironmentFile = cfg.environmentFiles;
+          ExecStart = "${lib.getExe cfg.package} -nobrowser -data='${cfg.dataDir}'";
+          Restart = "on-failure";
+        };
       };
 
-      serviceConfig = {
-        Type = "simple";
-        DynamicUser = true;
-        StateDirectory = "prowlarr";
-        EnvironmentFile = cfg.environmentFiles;
-        ExecStart = "${lib.getExe cfg.package} -nobrowser -data=/var/lib/prowlarr";
-        Restart = "on-failure";
+      tmpfiles.settings."10-prowlarr".${cfg.dataDir}.d = {
+        inherit (cfg) user group;
+        mode = "0700";
       };
     };
 
     networking.firewall = lib.mkIf cfg.openFirewall {
       allowedTCPPorts = [ cfg.settings.server.port ];
+    };
+
+    users.users = lib.mkIf (cfg.user == "prowlarr") {
+      prowlarr = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.dataDir;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "prowlarr") {
+      prowlarr = { };
     };
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Refactors the prowlarr model, modeled after lidarr and other servarr modules. Adds configurable dataDir option, as well as user and group options (as with lidarr and other *arrs).

Also informed by this comment on an old prowlarr bug report: https://github.com/NixOS/nixpkgs/issues/155475#issuecomment-2646627799

My only hesitation is that I am not sure how migration should work and if/how we should address that. Since prowlarr currently uses a dynamic user where the actual files are in /var/lib/private/prowlarr, and symlinked to /var/lib/prowlarr. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
