### PR TITLE
litra: init at 2.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23338,6 +23338,13 @@
     githubId = 5512096;
     name = "Sébastien Guimmara";
   };
+  sh3rm4n = {
+    name = "Fabian Viöl";
+    email = "f.vioel@gmail.com";
+    matrix = "@Sh3Rm4n:matrix.org";
+    github = "Sh3Rm4n";
+    githubId = 29653149;
+  };
   shackra = {
     name = "Jorge Javier Araya Navarro";
     email = "jorge@esavara.cr";

--- a/nixos/modules/services/hardware/litra-autotoggle.nix
+++ b/nixos/modules/services/hardware/litra-autotoggle.nix
@@ -1,0 +1,160 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.litra-autotoggle;
+
+  natural = with lib.types; addCheck int (x: x >= 0);
+in
+{
+  options = {
+    services.litra-autotoggle = {
+      enable = lib.mkEnableOption ''
+        Automatically turn your Logitech Litra device on when your webcam turns on,
+        and off when your webcam turns off.
+      '';
+
+      serialNumber = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        description = ''
+          The serial number of the Logitech Litra device.
+          You can get the serial number using the litra devices command in the litra CLI.
+        '';
+        example = "1234AB567CD8";
+        default = null;
+      };
+      requireDevice = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        description = ''
+          To enforce that a Litra device must be connected.
+          By default, the listener will keep running even if no Litra device is found.
+          With this set, the listener will exit whenever it looks for a Litra device and none is found.
+        '';
+        default = null;
+      };
+      videoDevice = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        description = ''
+          (linuxOnly) Watch a specific video device (e.g. /dev/video0).
+          By default, all video devices will be watched.
+        '';
+        example = "/dev/video0";
+        default = null;
+      };
+      delay = lib.mkOption {
+        type = lib.types.nullOr natural;
+        description = ''
+          To customize the delay (in milliseconds) between a webcam event being detected and toggling your Litra.
+          When your webcam turns on or off, multiple events may be generated in quick succession.
+          Setting a delay allows the program to wait for all events before taking action, avoiding flickering.
+          Defaults to 1.5 seconds (1500 milliseconds).
+        '';
+        example = 1500;
+        default = null;
+      };
+      package = lib.mkPackageOption pkgs "litra-autotoggle" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.videoDevice == null || pkgs.stdenv.hostPlatform.isLinux;
+        message = "Option videoDevice is only supported on Linux";
+      }
+    ];
+
+    environment.systemPackages = [
+      cfg.package
+    ];
+
+    services.udev.packages = [
+      cfg.package
+    ];
+
+    systemd.services.litra-autotoggle = {
+      description = "Turn your Logitech Litra device on when your webcam turns on";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Restart = "on-failure";
+        ExecStart = lib.concatStringsSep " " [
+          "${cfg.package}/bin/litra-autotoggle"
+
+          (lib.optionalString (cfg.serialNumber != null) "--serial-number ${cfg.serialNumber}")
+          (lib.optionalString (cfg.requireDevice != null && cfg.requireDevice) "--require-device")
+          (lib.optionalString (cfg.videoDevice != null) "--video-device ${cfg.videoDevice}")
+          (lib.optionalString (cfg.delay != null) "--delay ${builtins.toString cfg.delay}")
+        ];
+
+        # Hardening
+        PrivateTmp = "disconnected";
+        PrivateDevices = true;
+        PrivateMounts = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        ProtectClock = true;
+        MemoryDenyWriteExecute = true;
+        RestrictAddressFamilies = "none";
+        SocketBindDeny = [
+          "ipv4:tcp"
+          "ipv4:udp"
+          "ipv6:tcp"
+          "ipv6:udp"
+        ];
+        CapabilityBoundingSet = [
+          "~CAP_BLOCK_SUSPEND"
+          "CAP_BPF"
+          "CAP_CHOWN"
+          "CAP_MKNOD"
+          "CAP_NET_RAW"
+          "CAP_PERFMON"
+          "CAP_SYS_BOOT"
+          "CAP_SYS_CHROOT"
+          "CAP_SYS_MODULE"
+          "CAP_SYS_NICE"
+          "CAP_SYS_PACCT"
+          "CAP_SYS_PTRACE"
+          "CAP_SYS_TIME"
+          "CAP_SYS_TTY_CONFIG"
+          "CAP_SYSLOG"
+          "CAP_WAKE_ALARM"
+        ];
+        SystemCallFilter = [
+          "~@aio:EPERM"
+          "@chown:EPERM"
+          "@clock:EPERM"
+          "@cpu-emulation:EPERM"
+          "@debug:EPERM"
+          "@ipc:EPERM"
+          "@keyring:EPERM"
+          "@memlock:EPERM"
+          "@module:EPERM"
+          "@mount:EPERM"
+          "@obsolete:EPERM"
+          "@pkey:EPERM"
+          "@privileged:EPERM"
+          "@raw-io:EPERM"
+          "@reboot:EPERM"
+          "@resources:EPERM"
+          "@sandbox:EPERM"
+          "@setuid:EPERM"
+          "@swap:EPERM"
+          "@sync:EPERM"
+          "@timer:EPERM"
+        ];
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    sh3rm4n
+  ];
+}

--- a/pkgs/by-name/li/litra-autotoggle/package.nix
+++ b/pkgs/by-name/li/litra-autotoggle/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  udev,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "litra-autotoggle";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "timrogers";
+    repo = "litra-autotoggle";
+    tag = "v${version}";
+    hash = "sha256-CoP9t8uvErvP3sU51pfsjsY/xp/zXNVcgXP8WmONz60=";
+  };
+
+  cargoHash = "sha256-MCabivlj8ye8WKMFJ9oP5+J72D8Ib0xlYEOjLCUKjYg=";
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    udev
+  ];
+
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d
+    cp *.rules $out/etc/udev/rules.d
+  '';
+
+  meta = {
+    description = "Automatically sync your Logitech Litra light with your webcam";
+    homepage = "https://github.com/timrogers/litra-autotoggle";
+    license = lib.licenses.mit;
+    mainProgram = "litra-autotoggle";
+    maintainers = with lib.maintainers; [
+      sh3rm4n
+    ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/by-name/li/litra/package.nix
+++ b/pkgs/by-name/li/litra/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  rustPlatform,
+  udev,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "litra";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "timrogers";
+    repo = "litra-rs";
+    tag = "v${version}";
+    hash = "sha256-0BwtC2gFdt8rri5WGGdqMThPdax/UrZRfpCykWMydhA=";
+  };
+
+  cargoHash = "sha256-0T2oq+f7KwNn2nZVEsFBDEt2sRHe/Loq4zVx6jT7/us=";
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    udev
+  ];
+
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d
+    cp *.rules $out/etc/udev/rules.d
+  '';
+
+  meta = {
+    description = "Control your Logitech Litra light from the command line";
+    homepage = "https://github.com/timrogers/litra-rs";
+    license = lib.licenses.mit;
+    mainProgram = "litra";
+    maintainers = with lib.maintainers; [
+      sh3rm4n
+    ];
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+}


### PR DESCRIPTION
Add [litra-rs](https://github.com/timrogers/litra-rs), [litra-autotoggle](https://github.com/timrogers/litra-autotoggle) and add a basic service, which configures a systemd service, so that litra-autotoggle automatically starts as configured.

First time contribution! :) If I've overlooked anything regarding adding a new package, please feel free to point out!  

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
