### PR TITLE
defold: init at 1.10.1

### DIFF
--- a/pkgs/by-name/de/defold/package.nix
+++ b/pkgs/by-name/de/defold/package.nix
@@ -1,0 +1,169 @@
+{
+  addDriverRunpath,
+  buildFHSEnv,
+  copyDesktopItems,
+  fetchurl,
+  lib,
+  makeDesktopItem,
+  makeWrapper,
+  stdenv,
+  writeScript,
+  cairo,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  git,
+  glib,
+  gnused,
+  gobject-introspection,
+  gtk3,
+  jdk21,
+  libGL,
+  libGLU,
+  libX11,
+  libXcursor,
+  libXext,
+  libXi,
+  libXrandr,
+  libXrender,
+  libXtst,
+  libXxf86vm,
+  openal,
+  pango,
+  zlib,
+  uiScale ? "1.0",
+}:
+let
+  pname = "defold";
+  version = "1.10.1";
+
+  defold = stdenv.mkDerivation {
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://github.com/defold/defold/releases/download/${version}/Defold-x86_64-linux.tar.gz";
+      hash = "sha256-z6jlSXiQKO+QWPgtRmP7v3GTuI3+uCSbm7Y0GkqjpUA=";
+    };
+
+    dontBuild = true;
+    dontConfigure = true;
+    dontStrip = true;
+
+    nativeBuildInputs = [
+      addDriverRunpath
+      copyDesktopItems
+      gnused
+      (jdk21.override { enableJavaFX = true; })
+      makeWrapper
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      # Install Defold assets, but not the bundled JDK
+      install -m 755 -D Defold $out/share/defold/Defold
+      install -m 644 -D config $out/share/defold/config
+      install -m 444 -D logo_blue.png $out/share/defold/logo_blue.png
+      install -m 444 -D logo_blue.png \
+          $out/share/icons/hicolor/512x512/apps/defold.png
+      mkdir -p $out/share/defold/packages
+      cp -a packages/defold-*.jar $out/share/defold/packages/
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      # Devendor bundled JDK; it segfaults on NixOS
+      JDK_VER=$(sed -n 's/.*\/\(jdk-[^/]*\).*/\1/p' $out/share/defold/config)
+      ln -s ${jdk21} $out/share/defold/packages/${jdk21.name}
+      sed -i "s|packages/$JDK_VER|packages/${jdk21.name}|" $out/share/defold/config
+      # Disable editor updates; Nix will handle updates
+      sed -i 's/\(channel = \).*/\1/' $out/share/defold/config
+      # Scale the UI
+      sed -i "s|^linux =|linux = -Dglass.gtk.uiScale=${uiScale}|" $out/share/defold/config
+      addDriverRunpath $out/share/defold/Defold
+      makeWrapper "$out/share/defold/Defold" "$out/bin/Defold"
+    '';
+
+    desktopItems = [
+      (makeDesktopItem rec {
+        name = "defold-editor";
+        desktopName = "Defold";
+        comment = "An out of the box, turn-key solution for multi-platform game development";
+        keywords = [
+          "Game"
+          "Development"
+        ];
+        exec = "defold";
+        terminal = false;
+        type = "Application";
+        icon = "defold";
+        categories = [
+          "Development"
+          "IDE"
+        ];
+        startupNotify = true;
+        startupWMClass = "com.defold.editor.Start";
+      })
+    ];
+  };
+in
+buildFHSEnv {
+  name = pname;
+  targetPkgs = pkgs: [
+    cairo
+    defold
+    fontconfig
+    freetype
+    gdk-pixbuf
+    git
+    glib
+    gobject-introspection
+    gtk3
+    libGL
+    libGLU
+    libX11
+    libXcursor
+    libXext
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libXxf86vm
+    openal
+    pango
+    zlib
+  ];
+  runScript = "Defold";
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications $out/share/icons/hicolor/512x512/apps
+    ln -s ${defold}/share/applications/*.desktop \
+      $out/share/applications/
+    ln -s ${defold}/share/icons/hicolor/512x512/apps/defold.png \
+      $out/share/icons/hicolor/512x512/apps/defold.png
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-defold" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq nix-update
+      version=$(curl -s https://d.defold.com/editor-alpha/info.json | jq -r .version)
+      nix-update defold --version "$version"
+    '';
+  };
+
+  meta = {
+    description = "The game engine for high-performance cross-platform games";
+    homepage = "https://www.defold.com";
+    license = lib.licenses.free;
+    longDescription = ''
+      Defold is a completely free to use game engine for development of desktop, mobile, console and web games.
+    '';
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [ flexiondotorg ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "defold";
+  };
+}


### PR DESCRIPTION
Add Defold 1.10.1 - Defold is a completely free to use game engine for development of desktop, mobile and web games.

- Devendors the bundled JDK.
  - The [bundled JDK has a history of segfaulting on NixOS](https://github.com/defold/defold/issues/8150).
- Disables the Defold auto-update so that updates are only provided via Nixpkgs
  - This protects against an OTA update downloading the vendor's JDK, which results in segfaults on start-up.
- Includes `updateScript`.

Closes #95761

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>defold</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
