### PR TITLE
defold-bob: init at 1.10.1

### DIFF
--- a/pkgs/by-name/de/defold-bob/package.nix
+++ b/pkgs/by-name/de/defold-bob/package.nix
@@ -1,0 +1,58 @@
+{
+  fetchurl,
+  lib,
+  makeWrapper,
+  stdenv,
+  writeScript,
+  jdk21,
+  libXext,
+  libXtst,
+}:
+stdenv.mkDerivation rec {
+  pname = "defold-bob";
+  version = "1.10.1";
+
+  src = fetchurl {
+    url = "https://github.com/defold/defold/releases/download/${version}/bob.jar";
+    hash = "sha256-DlLfzQ+dztPJ1n/Nx1een8Z5h6SQK+cwegDeSW/tVI4=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    jdk21
+    libXext
+    libXtst
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -m 444 -D $src $out/bob.jar
+    makeWrapper ${jdk21}/bin/java $out/bin/defold-bob \
+      --add-flags "-jar $out/bob.jar"
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = writeScript "update.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq nix-update
+      version=$(curl -s https://d.defold.com/editor-alpha/info.json | jq -r .version)
+      nix-update defold-bob --version "$version"
+    '';
+  };
+
+  meta = {
+    description = "Bob is a command line tool for building Defold projects outside of the normal editor workflow.";
+    homepage = "https://defold.com/manuals/bob/";
+    license = lib.licenses.free;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ flexiondotorg ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "defold-bob";
+  };
+}


### PR DESCRIPTION
Add ["Bob the builder"](https://defold.com/manuals/bob/) 1.10.1 from the Defold project - Bob is a command line tool for building Defold projects outside of the normal editor workflow.

- Added as `defold-bob` due to pre-existing `bob` package.
- Includes `updateScript`
- Reference: #408992

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>defold-bob</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
