### PR TITLE
python3Packages.python-sat: 0.1.7.dev1 -> 0.1.8.dev17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4547,6 +4547,13 @@
     githubId = 2245737;
     name = "Christopher Mark Poole";
   };
+  chrjabs = {
+    email = "contact@christophjabs.info";
+    github = "chrjabs";
+    githubId = 98587286;
+    name = "Christoph Jabs";
+    keys = [ { fingerprint = "47D6 1FEB CD86 F3EC D2E3  D68A 83D0 74F3 48B2 FD9D"; } ];
+  };
   chrpinedo = {
     github = "chrpinedo";
     githubId = 2324630;

--- a/pkgs/development/python-modules/python-sat/default.nix
+++ b/pkgs/development/python-modules/python-sat/default.nix
@@ -6,17 +6,16 @@
   pypblib,
   pytestCheckHook,
 }:
-
 buildPythonPackage rec {
   pname = "python-sat";
-  version = "0.1.7.dev1";
+  version = "0.1.8.dev17";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "pysathq";
     repo = "pysat";
-    rev = version;
-    hash = "sha256-zGdgD+SgoMB7/zDQI/trmV70l91TB7OkDxaJ30W3dkI=";
+    rev = "a04763de6dafb8d3a0d7f1b231fc0d30be1de4c0"; # upstream does not tag releases
+    hash = "sha256-FG6oAAI8XKXumj6Ys2QjjYcRp1TpwkUZzyfpkdq5V6E=";
   };
 
   propagatedBuildInputs = [
@@ -26,23 +25,18 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  # https://github.com/pysathq/pysat/pull/102
-  postPatch = ''
-        # Fix for case-insensitive filesystem
-        cat >>solvers/patches/cadical.patch <<EOF
-    diff --git solvers/cadical/VERSION solvers/cdc/VERSION
-    deleted file mode 100644
-    --- solvers/cadical/VERSION
-    +++ /dev/null
-    @@ -1 +0,0 @@
-    -1.0.3
-    EOF
-  '';
+  disabledTestPaths = [ "tests/test_unique_mus.py" ];
 
   meta = with lib; {
     description = "Toolkit to provide interface for various SAT (without optional dependancy py-aiger-cnf)";
     homepage = "https://github.com/pysathq/pysat";
+    changelog = "https://pysathq.github.io/updates/";
     license = licenses.mit;
-    maintainers = [ maintainers.marius851000 ];
+    maintainers = [
+      maintainers.marius851000
+      maintainers.chrjabs
+    ];
+    platforms = lib.platforms.all;
+    badPlatforms = lib.platforms.darwin ++ [ "i686-linux" ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Changelog](https://pysathq.github.io/updates/).

Unfortunately [upstream](https://github.com/pysathq/pysat) does not tag releases, so the revision is manually specified. See [the commit here](https://github.com/pysathq/pysat/commit/e6a6a2bf78aa7ad806f47a84aecd1b7bfd5b3b89) which updates the version data.

I also added myself as a maintainer, as I'm willing to every now and then check where  a new release is available.

The patch fix for pysathq/pysat#102 is not required anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
