### PR TITLE
velocity: make Nix register dependencies of native libraries

### DIFF
--- a/pkgs/by-name/ve/velocity/package.nix
+++ b/pkgs/by-name/ve/velocity/package.nix
@@ -44,19 +44,21 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-CJVUEwYnpXDaYgXoi1Qk0uyB/CHM3UDQzQfhtDxDKdE=";
   };
 
-  nativeBuildInputs =
-    [
-      gradle_jdk17
-      makeBinaryWrapper
-    ]
-    ++ lib.optionals withVelocityNative [
-      # libraries for velocity-native
-      openssl
-      libdeflate
+  nativeBuildInputs = [
+    gradle_jdk17
+    makeBinaryWrapper
+  ];
 
-      # needed for building velocity-native jni
-      jdk17
-    ];
+  buildInputs = lib.optionals withVelocityNative [
+    # libraries for velocity-native
+    openssl
+    libdeflate
+
+    # needed for building velocity-native jni
+    jdk17
+  ];
+
+  strictDeps = true;
 
   mitmCache = gradle_jdk17.fetchDeps {
     inherit (finalAttrs) pname;
@@ -98,6 +100,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper ${lib.getExe jre_headless} "$out/bin/velocity" \
       --append-flags "-jar $out/share/velocity/velocity.jar"
+
+    ${lib.optionalString withVelocityNative ''
+      # Nix doesn't pick up references in compressed JAR file
+      mkdir $out/nix-support
+      echo ${lib.getLib openssl} >> $out/nix-support/runtime-dependencies
+      echo ${lib.getLib libdeflate} >> $out/nix-support/runtime-dependencies
+    ''}
 
     runHook postInstall
   '';


### PR DESCRIPTION
Also fix and enable strictDeps (ref. #178468)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).