### PR TITLE
harlequin: 2.0.0 -> 2.1.2

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -26,6 +26,7 @@ python3Packages.buildPythonApplication rec {
     "pyarrow"
     "textual"
     "syrupy"
+    "tree-sitter-sql"
   ];
 
   build-system = with python3Packages; [ poetry-core ];
@@ -48,6 +49,7 @@ python3Packages.buildPythonApplication rec {
       textual-fastdatatable
       textual-textarea
       tomlkit
+      tree-sitter-sql
     ]
     ++ lib.optionals withPostgresAdapter [ harlequin-postgres ]
     ++ lib.optionals withBigQueryAdapter [ harlequin-bigquery ];

--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -11,21 +11,20 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "harlequin";
-  version = "2.0.0";
+  version = "2.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tconbeer";
     repo = "harlequin";
     tag = "v${version}";
-    hash = "sha256-IUzN+rWL69TUUS9npcmfSAPqy/8SYNusNAN/muCMqNI=";
+    hash = "sha256-uHzhAI8ppp6aoveMPcLCQX2slhbor5Qy+IoTui+RP7M=";
   };
 
   pythonRelaxDeps = [
     "numpy"
     "pyarrow"
     "textual"
-    "syrupy"
     "tree-sitter-sql"
   ];
 
@@ -42,6 +41,7 @@ python3Packages.buildPythonApplication rec {
       numpy
       packaging
       platformdirs
+      pyarrow
       questionary
       rich-click
       sqlfmt


### PR DESCRIPTION
Harlequin on the master branch is crashing at runtime with:

```
│ │ error = LanguageDoesNotExist("tree-sitter is available, but no built-in or user-registered language called 'sql'.\nEnsure the language is installed (e.g. `pip install                 │ │
│ │         tree-sitter-ruby`)\nFalling back to plain text.")                                                                                                                              │ │
│ │  self = CodeEditor(id='buffer-1')                                                                                                                                                      │ │
```

This is due it seems to some recent updates around tree-sitter on nixpkgs master branch.  

So in order to do this I had to add tree-sitter-sql. I'm not sure this is the right way but the final binary works. Open to suggestions.

PR for the python3Packages.tree-sitter-sql https://github.com/NixOS/nixpkgs/pull/413616 (need to be merged first)


## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
