### PR TITLE
Allow customizing fetchurl hashedMirrors

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -225,6 +225,7 @@
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - Added `rewriteURL` attribute to the nixpkgs `config`, to allow for rewriting the URLs downloaded by `fetchurl`.
+- Added `hashedMirrors` attribute to the nixpkgs `config`, to allow for customization of the hashed mirrors used by `fetchurl`.
 
 - Added `gitConfig` and `gitConfigFile` option to the nixpkgs `config`, to allow for setting a default `gitConfigFile` for all `fetchgit` invocations.
 

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -7,11 +7,14 @@
   curl, # Note that `curl' may be `null', in case of the native stdenvNoCC.
   cacert ? null,
   rewriteURL,
+  hashedMirrors,
 }:
 
 let
 
-  mirrors = import ./mirrors.nix;
+  mirrors = import ./mirrors.nix // {
+    inherit hashedMirrors;
+  };
 
   # Write the list of mirrors to a file that we can reuse between
   # fetchurl instantiations, instead of passing the mirrors to

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -1,9 +1,6 @@
 {
 
-  # Content-addressable Nix mirrors
-  hashedMirrors = [
-    "https://tarballs.nixos.org"
-  ];
+  hashedMirrors = throw "Use config.hashedMirrors instead of (import ./pkgs/build-support/fetchurl/mirrors.nix).hashedMirrors";
 
   # Mirrors for mirror://site/filename URIs, where "site" is
   # "sourceforge", "gnu", etc.

--- a/pkgs/build-support/fetchurl/tests.nix
+++ b/pkgs/build-support/fetchurl/tests.nix
@@ -22,6 +22,21 @@
         ${jq}/bin/jq -r '.headers.Hello' $out | ${moreutils}/bin/sponge $out
       '';
     };
+
+  # Tests that hashedMirrors works
+  hashedMirrors = testers.invalidateFetcherByDrvHash fetchurl {
+    # Make sure that we can only download from hashed mirrors
+    url = "http://broken";
+    # A file with this hash is definitely on tarballs.nixos.org
+    sha256 = "1j1y3cq6ys30m734axc0brdm2q9n2as4h32jws15r7w5fwr991km";
+
+    # No chance
+    curlOptsList = [
+      "--retry"
+      "0"
+    ];
+  };
+
   # Tests that downloadToTemp works with hashedMirrors
   no-skipPostFetch = testers.invalidateFetcherByDrvHash fetchurl {
     # Make sure that we can only download from hashed mirrors
@@ -40,6 +55,5 @@
     # $downloadedFile, but here we know that because the URL is broken, it will
     # have to fallback to fetching the previously-built derivation from
     # tarballs.nixos.org, which provides pre-built derivation outputs.
-
   };
 }

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -188,7 +188,7 @@ let
           inherit lib;
           stdenvNoCC = prevStage.ccWrapperStdenv or thisStdenv;
           curl = bootstrapTools;
-          inherit (config) rewriteURL;
+          inherit (config) hashedMirrors rewriteURL;
         };
 
         inherit cc;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -404,7 +404,7 @@ let
       fetchurlBoot = import ../../build-support/fetchurl {
         inherit lib stdenvNoCC;
         inherit (prevStage) curl;
-        inherit (config) rewriteURL;
+        inherit (config) hashedMirrors rewriteURL;
       };
       stdenv = import ../generic {
         inherit
@@ -502,7 +502,7 @@ in
           inherit lib;
           inherit (self) stdenvNoCC;
           inherit (prevStage) curl;
-          inherit (config) rewriteURL;
+          inherit (config) hashedMirrors rewriteURL;
         };
         gettext = super.gettext.overrideAttrs {
           NIX_CFLAGS_COMPILE = "-DHAVE_ICONV=1"; # we clearly have iconv. what do you want?

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -192,7 +192,7 @@ in
         inherit lib stdenvNoCC;
         # Curl should be in /usr/bin or so.
         curl = null;
-        inherit (config) rewriteURL;
+        inherit (config) hashedMirrors rewriteURL;
       };
 
     }

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -192,6 +192,7 @@ in
         inherit lib stdenvNoCC;
         # Curl should be in /usr/bin or so.
         curl = null;
+        inherit (config) rewriteURL;
       };
 
     }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -591,7 +591,7 @@ with pkgs;
       makeOverridable (import ../build-support/fetchurl) {
         inherit lib stdenvNoCC buildPackages;
         inherit cacert;
-        inherit (config) rewriteURL;
+        inherit (config) hashedMirrors rewriteURL;
         curl = buildPackages.curlMinimal.override (old: rec {
           # break dependency cycles
           fetchurl = stdenv.fetchurlBoot;

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -288,6 +288,19 @@ let
       '';
     };
 
+    hashedMirrors = mkOption {
+      type = types.listOf types.str;
+      default = [ "https://tarballs.nixos.org" ];
+      description = ''
+        The set of content-addressed/hashed mirror URLs used by [`pkgs.fetchurl`](#sec-pkgs-fetchers-fetchurl).
+        In case `pkgs.fetchurl` can't download from the given URLs,
+        it will try the hashed mirrors based on the expected output hash.
+
+        See [`copy-tarballs.pl`](https://github.com/NixOS/nixpkgs/blob/a2d829eaa7a455eaa3013c45f6431e705702dd46/maintainers/scripts/copy-tarballs.pl)
+        for more details on how hashed mirrors are constructed.
+      '';
+    };
+
     rewriteURL = mkOption {
       type = types.functionTo (types.nullOr types.str);
       description = ''


### PR DESCRIPTION
Nix users behind a firewall may have difficulties reaching the default mirrors referenced from `pkgs/build-support/fetchurl/mirrors.nix`. Additionally, Nix users inside corporations may need to prefer company-internal mirrors.

This PR exposes the set of mirrors used by `fetchurl` via the nixpkgs config, allowing users to customize it via their `~/.config/nixpkgs/config.nix`. The default mirror list is made available in `config.mirrors`, and users may remove/add/replace/adjust the mirrors via the module system, as shown in the documented example.

@infinisil edit: This PR is now changed to only allow customisation of `hashedMirrors`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] Added a release notes entry about the new `config.mirrors` attribute
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
