### PR TITLE
obs-studio-plugins.obs-urlsource: init at 0.3.7

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -74,6 +74,8 @@
 
   obs-tuna = qt6Packages.callPackage ./obs-tuna { };
 
+  obs-urlsource = qt6Packages.callPackage ./obs-urlsource.nix { };
+
   obs-vaapi = callPackage ./obs-vaapi { };
 
   obs-vertical-canvas = qt6Packages.callPackage ./obs-vertical-canvas.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-urlsource.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-urlsource.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  curl,
+  git,
+  obs-studio,
+  pugixml,
+  qtbase,
+  writeScript,
+}:
+
+let
+  websocketpp = fetchFromGitHub {
+    owner = "zaphoyd";
+    repo = "websocketpp";
+    rev = "0.8.2";
+    sha256 = "sha256-9fIwouthv2GcmBe/UPvV7Xn9P2o0Kmn2hCI4jCh0hPM=";
+  };
+
+  lexbor = fetchFromGitHub {
+    owner = "lexbor";
+    repo = "lexbor";
+    rev = "v2.3.0";
+    sha256 = "sha256-s5fZWBhXC0fuHIUk1YX19bHagahOtSLlKQugyHCIlgI=";
+  };
+
+  asio = fetchFromGitHub {
+    owner = "chriskohlhoff";
+    repo = "asio";
+    rev = "asio-1-28-0";
+    sha256 = "sha256-dkiUdR8FgDnnqdptaJjE4rvNlgpC5HZl6SQQ5Di2C2s=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "obs-urlsource";
+  version = "0.3.7";
+
+  src = fetchFromGitHub {
+    owner = "locaal-ai";
+    repo = "obs-urlsource";
+    rev = version;
+    sha256 = "sha256-ZWwD8jJkL1rAUeanD4iChcgpnJaC5pPo36Ot36XOSx8=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    git
+  ];
+  buildInputs = [
+    curl
+    obs-studio
+    pugixml
+    qtbase
+  ];
+  dontWrapQtApps = true;
+
+  # Update websocketpp and lexabor configurations to use pre-fetched sources
+  postPatch = ''
+    sed -i 's|URL .*|SOURCE_DIR "${websocketpp}"\n    DOWNLOAD_COMMAND ""|' cmake/FetchWebsocketpp.cmake
+    sed -i \
+      -e 's|GIT_REPOSITORY .*|SOURCE_DIR "${lexbor}"|' \
+      -e 's|GIT_TAG .*|DOWNLOAD_COMMAND ""\n    UPDATE_COMMAND ""|' \
+      cmake/BuildLexbor.cmake
+  '';
+
+  postInstall = ''
+    rm -rf $out/lib/cmake
+  '';
+
+  NIX_CFLAGS_COMPILE = [
+    "-I${websocketpp}"
+    "-I${asio}/asio/include"
+  ];
+
+  cmakeFlags = [
+    # Prevent deprecation warnings from failing the build
+    (lib.cmakeOptionType "string" "CMAKE_CXX_FLAGS" "-Wno-error=deprecated-declarations")
+    (lib.cmakeBool "ENABLE_QT" true)
+    (lib.cmakeBool "USE_SYSTEM_CURL" true)
+    (lib.cmakeBool "USE_SYSTEM_PUGIXML" true)
+    (lib.cmakeBool "CMAKE_COMPILE_WARNING_AS_ERROR" false)
+    "-Wno-dev"
+  ];
+
+  meta = with lib; {
+    description = "OBS plugin to fetch data from a URL or file, connect to an API or AI service, parse responses and display text, image or audio on scene";
+    homepage = "https://github.com/locaal-ai/obs-urlsource";
+    maintainers = with maintainers; [ flexiondotorg ];
+    license = licenses.gpl2Only;
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+  };
+}


### PR DESCRIPTION
Add obs-urlsource plugin 0.3.7
- Devendor `websocketpp`, `lexbor`, and `asio` by prefetching the correct source versions to prevent FTBFS when `cmake` tries to download them inside the sandbox at build-time.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-urlsource</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc