### PR TITLE
tigervnc: 1.14.0 -> 1.15.0, also use `tag` / `hash` / `finalAttrs`

### DIFF
--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "TigerVNC";
     repo = "tigervnc";
-    rev = "v${version}";
-    sha256 = "sha256-TgVV/4MRsQHYKpDf9L5eHMLVpdwvNy1KPDIe7xMlQ9o=";
+    tag = "v${version}";
+    hash = "sha256-TgVV/4MRsQHYKpDf9L5eHMLVpdwvNy1KPDIe7xMlQ9o=";
   };
 
   patches = [

--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -25,14 +25,14 @@
   ffmpeg,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "1.14.0";
   pname = "tigervnc";
 
   src = fetchFromGitHub {
     owner = "TigerVNC";
     repo = "tigervnc";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-TgVV/4MRsQHYKpDf9L5eHMLVpdwvNy1KPDIe7xMlQ9o=";
   };
 
@@ -125,10 +125,10 @@ stdenv.mkDerivation rec {
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p $out/Applications
-      mv 'TigerVNC Viewer ${version}.app' $out/Applications/
+      mv 'TigerVNC Viewer ${finalAttrs.version}.app' $out/Applications/
       rm $out/bin/vncviewer
       echo "#!/usr/bin/env bash
-      open $out/Applications/TigerVNC\ Viewer\ ${version}.app --args \$@" >> $out/bin/vncviewer
+      open $out/Applications/TigerVNC\ Viewer\ ${finalAttrs.version}.app --args \$@" >> $out/bin/vncviewer
       chmod +x $out/bin/vncviewer
     '';
 
@@ -198,4 +198,4 @@ stdenv.mkDerivation rec {
     # Prevent a store collision.
     priority = 4;
   };
-}
+})

--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -194,6 +194,7 @@ stdenv.mkDerivation rec {
     description = "Fork of tightVNC, made in cooperation with VirtualGL";
     maintainers = [ ];
     platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
     # Prevent a store collision.
     priority = 4;
   };

--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   xorg,
   xkeyboard_config,
   zlib,
@@ -26,23 +25,15 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.14.0";
+  version = "1.15.0";
   pname = "tigervnc";
 
   src = fetchFromGitHub {
     owner = "TigerVNC";
     repo = "tigervnc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TgVV/4MRsQHYKpDf9L5eHMLVpdwvNy1KPDIe7xMlQ9o=";
+    hash = "sha256-ZuuvRJe/lAqULWObPxGHVJrDPCTK4IVSqX0K1rWOctw=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "vncauth-security-type.patch";
-      url = "https://github.com/TigerVNC/tigervnc/commit/4f6a3521874da5a67fd746389cfa9b6199eb3582.diff";
-      hash = "sha256-lSkR8e+jsBwkQUJZmA0tb8nM5iSbYtO8uVXtgk5wdF8=";
-    })
-  ];
 
   postPatch =
     lib.optionalString stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
*   [switch from `rev` to `tag` in `fetchFromGitHub`](https://github.com/NixOS/nixpkgs/pull/355973)
*   replace `rec` with `finalAttrs`
*   update to [current release](https://github.com/TigerVNC/tigervnc/releases/tag/v1.15.0)

`tigervnc` has no maintainer, notifying previous non-treewide contributor @Artturin

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` tries to rebuild 5,800+ packages and was therefore skipped.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc