### PR TITLE
nixos/davis: fix several outstanding bugs

### DIFF
--- a/nixos/modules/services/web-apps/davis.md
+++ b/nixos/modules/services/web-apps/davis.md
@@ -24,9 +24,10 @@ After that, `davis` can be deployed like this:
     adminLogin = "admin";
     adminPasswordFile = "/run/secrets/davis-admin-password";
     appSecretFile = "/run/secrets/davis-app-secret";
-    nginx = {};
   };
 }
 ```
 
 This deploys Davis using a sqlite database running out of `/var/lib/davis`.
+
+Logs can be found in `/var/lib/davis/var/log/`.

--- a/nixos/modules/services/web-apps/davis.nix
+++ b/nixos/modules/services/web-apps/davis.nix
@@ -220,10 +220,13 @@ in
     };
 
     nginx = lib.mkOption {
-      type = lib.types.submodule (
-        lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
+      type = lib.types.nullOr (
+        lib.types.submodule (
+          lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {
+          }
+        )
       );
-      default = null;
+      default = { };
       example = ''
         {
           serverAliases = [
@@ -235,7 +238,7 @@ in
         }
       '';
       description = ''
-        With this option, you can customize the nginx virtualHost settings.
+        Use this option to customize an nginx virtual host. To disable the nginx set this to null.
       '';
     };
 
@@ -308,18 +311,16 @@ in
           message = "One of services.davis.database.urlFile or services.davis.database.createLocally must be set.";
         }
         {
-          assertion = (mail.dsn != null) != (mail.dsnFile != null);
-          message = "One of (and only one of) services.davis.mail.dsn or services.davis.mail.dsnFile must be set.";
+          assertion = !(mail.dsn != null && mail.dsnFile != null);
+          message = "services.davis.mail.dsn and services.davis.mail.dsnFile cannot both be set.";
         }
       ];
       services.davis.config =
         {
           APP_ENV = "prod";
           APP_CACHE_DIR = "${cfg.dataDir}/var/cache";
-          # note: we do not need the log dir (we log to stdout/journald), by davis/symfony will try to create it, and the default value is one in the nix-store
-          #       so we set it to a path under dataDir to avoid something like: Unable to create the "logs" directory (/nix/store/5cfskz0ybbx37s1161gjn5klwb5si1zg-davis-4.4.1/var/log).
           APP_LOG_DIR = "${cfg.dataDir}/var/log";
-          LOG_FILE_PATH = "/dev/stdout";
+          LOG_FILE_PATH = "%kernel.logs_dir%/%kernel.environment%.log";
           DATABASE_DRIVER = db.driver;
           INVITE_FROM_ADDRESS = mail.inviteFromAddress;
           APP_SECRET._secret = cfg.appSecretFile;
@@ -330,7 +331,14 @@ in
           CALDAV_ENABLED = true;
           CARDDAV_ENABLED = true;
         }
-        // (if mail.dsn != null then { MAILER_DSN = mail.dsn; } else { MAILER_DSN._secret = mail.dsnFile; })
+        // (
+          if mail.dsn != null then
+            { MAILER_DSN = mail.dsn; }
+          else if mail.dsnFile != null then
+            { MAILER_DSN._secret = mail.dsnFile; }
+          else
+            { }
+        )
         // (
           if db.createLocally then
             {

--- a/nixos/tests/davis.nix
+++ b/nixos/tests/davis.nix
@@ -1,10 +1,14 @@
-{ pkgs, ... }:
+{
+  pkgs,
+  config,
+  ...
+}:
 {
   name = "davis";
 
   meta.maintainers = pkgs.davis.meta.maintainers;
 
-  nodes.machine =
+  nodes.machine1 =
     { config, ... }:
     {
       virtualisation = {
@@ -24,33 +28,67 @@
         adminLogin = "admin";
         appSecretFile = "${pkgs.writeText "davisAppSecret" "52882ef142066e09ab99ce816ba72522e789505caba224"}";
         adminPasswordFile = "${pkgs.writeText "davisAdminPass" "nixos"}";
-        nginx = { };
+      };
+    };
+  nodes.machine2 =
+    { nodes, config, ... }:
+    {
+      virtualisation = {
+        memorySize = 512;
+      };
+      environment.systemPackages = [ pkgs.fcgi ];
+
+      # no nginx, and no mail dsn
+      services.davis = {
+        enable = true;
+        hostname = "davis.example.com";
+        database = {
+          driver = "postgresql";
+        };
+        adminLogin = "admin";
+        appSecretFile = "${pkgs.writeText "davisAppSecret" "52882ef142066e09ab99ce816ba72522e789505caba224"}";
+        adminPasswordFile = "${pkgs.writeText "davisAdminPass" "nixos"}";
+        nginx = null;
       };
     };
 
   testScript = ''
     start_all()
-    machine.wait_for_unit("postgresql.service")
-    machine.wait_for_unit("davis-env-setup.service")
-    machine.wait_for_unit("davis-db-migrate.service")
-    machine.wait_for_unit("nginx.service")
-    machine.wait_for_unit("phpfpm-davis.service")
+
+    machine1.wait_for_unit("postgresql.service")
+    machine1.wait_for_unit("davis-env-setup.service")
+    machine1.wait_for_unit("davis-db-migrate.service")
+    machine1.wait_for_unit("phpfpm-davis.service")
 
     with subtest("welcome screen loads"):
-        machine.succeed(
+        machine1.succeed(
             "curl -sSfL --resolve davis.example.com:80:127.0.0.1 http://davis.example.com/ | grep '<title>Davis</title>'"
         )
 
     with subtest("login works"):
-        csrf_token = machine.succeed(
+        csrf_token = machine1.succeed(
             "curl -c /tmp/cookies -sSfL --resolve davis.example.com:80:127.0.0.1 http://davis.example.com/login | grep '_csrf_token' | sed -E 's,.*value=\"(.*)\".*,\\1,g'"
         )
-        r = machine.succeed(
+        r = machine1.succeed(
             f"curl -b /tmp/cookies --resolve davis.example.com:80:127.0.0.1 http://davis.example.com/login -X POST -F _username=admin -F _password=nixos -F _csrf_token={csrf_token.strip()} -D headers"
         )
         print(r)
-        machine.succeed(
+        machine1.succeed(
           "[[ $(grep -i 'location: ' headers | cut -d: -f2- | xargs echo) == /dashboard* ]]"
         )
+    machine2.wait_for_unit("davis-env-setup.service")
+    machine2.wait_for_unit("davis-db-migrate.service")
+    machine2.wait_for_unit("phpfpm-davis.service")
+    r = machine2.succeed(
+        "find /var/lib/davis/var/log"
+    )
+    print(r)
+    env = (
+      "SCRIPT_NAME=/index.php",
+      "SCRIPT_FILENAME=${config.nodes.machine2.services.davis.package}/public/index.php",
+      "REMOTE_ADDR=127.0.0.1",
+      "REQUEST_METHOD=GET",
+    );
+    page = machine2.succeed(f"{' '.join(env)} ${pkgs.fcgi}/bin/cgi-fcgi -bind -connect ${config.nodes.machine2.services.phpfpm.pools.davis.socket}")
   '';
 }


### PR DESCRIPTION
As reported in #317303, this fixes:

- nginx config is now actually optional
- mail dsn options are now optional
- broken stdout logging has been replaced with default file logging in
  state dir

fixes #317303


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
