### PR TITLE
fetchurl: remove most mirrors

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -29,18 +29,10 @@
     "ftp://ftp.funet.fi/pub/mirrors/apache.org/"
   ];
 
-  # Bioconductor mirrors (from https://bioconductor.org/about/mirrors/)
-  # The commented-out ones don't seem to allow direct package downloads;
-  # they serve error messages that result in hash mismatches instead
+  # Bioconductor mirrors
   bioc = [
-    # http://bioc.ism.ac.jp/
-    # http://bioc.openanalytics.eu/
-    # http://bioconductor.fmrp.usp.br/
-    # http://mirror.aarnet.edu.au/pub/bioconductor/
-    # http://watson.nci.nih.gov/bioc_mirror/
-    "https://bioconductor.statistik.tu-dortmund.de/packages/"
-    "https://mirrors.ustc.edu.cn/bioc/"
-    "http://bioconductor.jp/packages/"
+    # Served via CloudFront
+    "https://bioconductor.org/packages/"
   ];
 
   # CRAN mirrors

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -18,7 +18,7 @@
 
   # Apache
   apache = [
-    "https://dlcdn.apache.org/"
+    "https://downloads.apache.org/"
     "https://www-eu.apache.org/dist/"
     "https://ftp.wayne.edu/apache/"
     "https://www.apache.org/dist/"
@@ -62,7 +62,7 @@
     "ftp://ftp.nluug.nl/mirror/languages/gcc/"
     "ftp://ftp.fu-berlin.de/unix/languages/gcc/"
     "ftp://ftp.irisa.fr/pub/mirrors/gcc.gnu.org/gcc/"
-    "ftp://gcc.gnu.org/pub/gcc/"
+    "https://gcc.gnu.org/pub/gcc/"
   ];
 
   # GNOME
@@ -277,7 +277,7 @@
 
   # X.org
   xorg = [
-    "https://xorg.freedesktop.org/releases/"
+    "https://www.x.org/releases/"
     "https://ftp.x.org/archive/"
   ];
 
@@ -286,7 +286,7 @@
   # Perl CPAN
   cpan = [
     "https://cpan.metacpan.org/"
-    "https://cpan.perl.org/"
+    "https://www.cpan.org/"
     "https://mirrors.kernel.org/CPAN/"
     "https://backpan.perl.org/" # for old releases
   ];

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -114,15 +114,6 @@
     "ftp://ftp.metalab.unc.edu/pub/linux/"
   ];
 
-  # ImageMagick mirrors, see https://www.imagemagick.org/script/mirror.php
-  imagemagick = [
-    "https://www.imagemagick.org/download/"
-    "https://mirror.checkdomain.de/imagemagick/"
-    "https://ftp.nluug.nl/ImageMagick/"
-    "https://ftp.sunet.se/mirror/imagemagick.org/ftp/"
-    "ftp://ftp.sunet.se/mirror/imagemagick.org/ftp/" # also contains older versions removed from most mirrors
-  ];
-
   kde = [
     "https://download.kde.org/"
     "https://ftp.funet.fi/pub/mirrors/ftp.kde.org/pub/kde/"
@@ -158,11 +149,6 @@
     "https://mirrors.gigenet.com/OSDN/"
     "https://osdn.dl.sourceforge.jp/"
     "https://jaist.dl.sourceforge.jp/"
-  ];
-
-  # PostgreSQL
-  postgresql = [
-    "https://ftp.postgresql.org/pub/"
   ];
 
   # Qt
@@ -266,12 +252,6 @@
     "https://osdn.dl.sourceforge.net/sourceforge/"
   ];
 
-  # Steam Runtime
-  steamrt = [
-    "https://repo.steampowered.com/steamrt/"
-    "https://public.abbradar.moe/steamrt/"
-  ];
-
   # TCSH shell
   tcsh = [
     "https://astron.com/pub/tcsh/"
@@ -338,25 +318,7 @@
     "https://pypi.io/packages/source/"
   ];
 
-  # Python Test-PyPI
-  testpypi = [
-    "https://test.pypi.io/packages/source/"
-  ];
-
   ### Linux distros
-
-  # CentOS
-  centos = [
-    # For old releases
-    "https://vault.centos.org/"
-    "https://archive.kernel.org/centos-vault/"
-    "https://ftp.jaist.ac.jp/pub/Linux/CentOS-vault/"
-    "https://mirrors.aliyun.com/centos-vault/"
-    "https://mirror.chpc.utah.edu/pub/vault.centos.org/"
-    "https://mirror.math.princeton.edu/pub/centos-vault/"
-    "https://mirrors.tripadvisor.com/centos-vault/"
-    "http://mirror.centos.org/centos/"
-  ];
 
   # Debian
   debian = [
@@ -369,37 +331,6 @@
     "ftp://ftp.ru.debian.org/debian/"
     "http://archive.debian.org/debian-archive/debian/"
     "ftp://ftp.funet.fi/pub/mirrors/ftp.debian.org/debian/"
-  ];
-
-  # Fedora
-  # Please add only full mirrors that carry old Fedora distributions as well
-  # See: https://mirrors.fedoraproject.org/publiclist (but not all carry old content)
-  fedora = [
-    "https://archives.fedoraproject.org/pub/fedora/"
-    "https://fedora.osuosl.org/"
-    "https://ftp.funet.fi/pub/mirrors/ftp.redhat.com/pub/fedora/"
-    "https://ftp.linux.cz/pub/linux/fedora/"
-    "https://archives.fedoraproject.org/pub/archive/fedora/"
-    "http://ftp.nluug.nl/pub/os/Linux/distr/fedora/"
-    "http://mirror.csclub.uwaterloo.ca/fedora/"
-    "http://mirror.1000mbps.com/fedora/"
-  ];
-
-  # Gentoo
-  gentoo = [
-    "https://ftp.snt.utwente.nl/pub/os/linux/gentoo/"
-    "https://distfiles.gentoo.org/"
-    "https://mirrors.kernel.org/gentoo/"
-  ];
-
-  # openSUSE
-  opensuse = [
-    "https://opensuse.hro.nl/opensuse/distribution/"
-    "https://ftp.funet.fi/pub/linux/mirrors/opensuse/distribution/"
-    "https://ftp.opensuse.org/pub/opensuse/distribution/"
-    "https://ftp5.gwdg.de/pub/opensuse/discontinued/distribution/"
-    "https://mirrors.edge.kernel.org/opensuse/distribution/"
-    "http://ftp.hosteurope.de/mirror/ftp.opensuse.org/discontinued/"
   ];
 
   # Ubuntu

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -278,32 +278,21 @@
 
   # Debian
   debian = [
-    "https://httpredir.debian.org/debian/"
-    "https://ftp.debian.org/debian/"
-    "https://mirrors.edge.kernel.org/debian/"
-    "ftp://ftp.de.debian.org/debian/"
-    "ftp://ftp.fr.debian.org/debian/"
-    "ftp://ftp.nl.debian.org/debian/"
-    "ftp://ftp.ru.debian.org/debian/"
-    "http://archive.debian.org/debian-archive/debian/"
-    "ftp://ftp.funet.fi/pub/mirrors/ftp.debian.org/debian/"
+    "https://deb.debian.org/debian/"
+    # For old releases
+    "https://archive.debian.org/debian-archive/debian/"
   ];
 
   # Ubuntu
   ubuntu = [
-    "https://nl.archive.ubuntu.com/ubuntu/"
+    "https://archive.ubuntu.com/ubuntu/"
     "https://old-releases.ubuntu.com/ubuntu/"
-    "https://mirrors.edge.kernel.org/ubuntu/"
-    "http://de.archive.ubuntu.com/ubuntu/"
-    "http://archive.ubuntu.com/ubuntu/"
   ];
 
   # ... and other OSes in general
 
   # OpenBSD
   openbsd = [
-    "https://ftp.openbsd.org/pub/OpenBSD/"
-    "ftp://ftp.nluug.nl/pub/OpenBSD/"
-    "ftp://ftp-stud.fht-esslingen.de/pub/OpenBSD/"
+    "https://cdn.openbsd.org/pub/OpenBSD/"
   ];
 }

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -148,7 +148,6 @@
     # Asia (HTTPS)
     "https://mirrors.tuna.tsinghua.edu.cn/sagemath/spkg/upstream/"
     "https://mirrors.ustc.edu.cn/sagemath/spkg/upstream/"
-    "http://ftp.tsukuba.wide.ad.jp/software/sage/spkg/upstream/"
     "https://ftp.yz.yamagata-u.ac.jp/pub/math/sage/spkg/upstream/"
     "https://mirror.yandex.ru/mirrors/sage.math.washington.edu/spkg/upstream/"
 
@@ -158,24 +157,6 @@
     # Europe (HTTPS)
     "https://sage.mirror.garr.it/mirrors/sage/spkg/upstream/"
     "https://www-ftp.lip6.fr/pub/math/sagemath/spkg/upstream/"
-
-    # Africa (non-HTTPS)
-    "ftp://ftp.sun.ac.za/pub/mirrors/www.sagemath.org/spkg/upstream/"
-
-    # America, North (non-HTTPS)
-    "http://www.cecm.sfu.ca/sage/spkg/upstream/"
-
-    # America, South (non-HTTPS)
-    "http://sagemath.c3sl.ufpr.br/spkg/upstream/"
-    "http://linorg.usp.br/sage/spkg/upstream"
-
-    # Asia (non-HTTPS)
-    "http://ftp.kaist.ac.kr/sage/spkg/upstream/"
-    "http://ftp.riken.jp/sagemath/spkg/upstream/"
-
-    # Europe (non-HTTPS)
-    "http://mirrors.fe.up.pt/pub/sage/spkg/upstream/"
-    "http://ftp.ntua.gr/pub/sagemath/spkg/upstream/"
   ];
 
   # SAMBA

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -144,11 +144,10 @@
 
   # OSDN (formerly SourceForge.jp)
   osdn = [
-    "https://osdn.dl.osdn.jp/"
-    "https://osdn.mirror.constant.com/"
-    "https://mirrors.gigenet.com/OSDN/"
-    "https://osdn.dl.sourceforge.jp/"
-    "https://jaist.dl.sourceforge.jp/"
+    # The official servers are dead; packages should be moved off
+    # or considered for dropping, but mirrors.dotsrc.org seems to
+    # work for now.
+    "https://mirrors.dotsrc.org/osdn/"
   ];
 
   # Qt

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -79,20 +79,8 @@
 
   # GNU (https://www.gnu.org/prep/ftp.html)
   gnu = [
-    # This one redirects to a (supposedly) nearby and (supposedly) up-to-date
-    # mirror
-    "https://ftpmirror.gnu.org/"
-
-    "https://ftp.nluug.nl/pub/gnu/"
-    "https://mirrors.kernel.org/gnu/"
-    "https://mirror.ibcp.fr/pub/gnu/"
-    "https://mirror.dogado.de/gnu/"
-    "https://mirror.tochlab.net/pub/gnu/"
-
     # This one is the master repository, and thus it's always up-to-date
     "https://ftp.gnu.org/pub/gnu/"
-
-    "ftp://ftp.funet.fi/pub/mirrors/ftp.gnu.org/gnu/"
   ];
 
   # GnuPG
@@ -206,39 +194,8 @@
 
   # GNU Savannah
   savannah = [
-    # Try the official HTTP(S) dispatchers first.
-    # These generate redirects to mirrors appropriate for the user.
-    "https://download.savannah.gnu.org/releases/"
-    "https://download.savannah.nongnu.org/releases/"
-
-    # If the above fail, try some individual mirrors.
-    # These are taken from https://download-mirror.savannah.gnu.org/releases/00_MIRRORS.html
-    "https://mirror.easyname.at/nongnu/"
-    "https://savannah.c3sl.ufpr.br/"
-    "https://mirror.csclub.uwaterloo.ca/nongnu/"
-    "https://mirror.cedia.org.ec/nongnu/"
-    "https://ftp.igh.cnrs.fr/pub/nongnu/"
-    "https://mirror6.layerjet.com/nongnu"
-    "https://mirror.netcologne.de/savannah/"
-    "https://ftp.cc.uoc.gr/mirrors/nongnu.org/"
-    "https://nongnu.uib.no/"
-    "https://ftp.acc.umu.se/mirror/gnu.org/savannah/"
-    "http://mirror2.klaus-uwe.me/nongnu/"
-    "http://mirrors.fe.up.pt/pub/nongnu/"
-    "http://ftp.twaren.net/Unix/NonGNU/"
-    "http://savannah-nongnu-org.ip-connect.vn.ua/"
-    "http://www.mirrorservice.org/sites/download.savannah.gnu.org/releases/"
-    "http://gnu.mirrors.pair.com/savannah/savannah/"
-    "ftp://mirror.easyname.at/nongnu/"
-    "ftp://mirror2.klaus-uwe.me/nongnu/"
-    "ftp://mirror.csclub.uwaterloo.ca/nongnu/"
-    "ftp://ftp.igh.cnrs.fr/pub/nongnu/"
-    "ftp://mirror.netcologne.de/savannah/"
-    "ftp://nongnu.uib.no/pub/nongnu/"
-    "ftp://mirrors.fe.up.pt/pub/nongnu/"
-    "ftp://ftp.twaren.net/Unix/NonGNU/"
-    "ftp://savannah-nongnu-org.ip-connect.vn.ua/mirror/savannah.nongnu.org/"
-    "ftp://ftp.mirrorservice.org/sites/download.savannah.gnu.org/releases/"
+    # Canonical upstream mirror without redirects
+    "https://download-mirror.savannah.gnu.org/releases/"
   ];
 
   # SourceForge

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -11,22 +11,12 @@
   # Alsa Project
   alsa = [
     "https://www.alsa-project.org/files/pub/"
-    "ftp://ftp.alsa-project.org/pub/"
-    "http://alsa.cybermirror.org/"
-    "http://www.mirrorservice.org/sites/ftp.alsa-project.org/pub/"
   ];
 
   # Apache
   apache = [
     "https://downloads.apache.org/"
-    "https://www-eu.apache.org/dist/"
-    "https://ftp.wayne.edu/apache/"
-    "https://www.apache.org/dist/"
     "https://archive.apache.org/dist/" # fallback for old releases
-    "https://apache.cs.uu.nl/"
-    "https://apache.cs.utah.edu/"
-    "http://ftp.tudelft.nl/apache/"
-    "ftp://ftp.funet.fi/pub/mirrors/apache.org/"
   ];
 
   # Bioconductor mirrors
@@ -43,17 +33,10 @@
   # BitlBee mirrors, see https://www.bitlbee.org/main.php/mirrors.html
   bitlbee = [
     "https://get.bitlbee.org/"
-    "https://ftp.snt.utwente.nl/pub/software/bitlbee/"
-    "http://bitlbee.intergenia.de/"
   ];
 
   # GCC
   gcc = [
-    "https://mirror.koddos.net/gcc/"
-    "https://bigsearcher.com/mirrors/gcc/"
-    "ftp://ftp.nluug.nl/mirror/languages/gcc/"
-    "ftp://ftp.fu-berlin.de/unix/languages/gcc/"
-    "ftp://ftp.irisa.fr/pub/mirrors/gcc.gnu.org/gcc/"
     "https://gcc.gnu.org/pub/gcc/"
   ];
 
@@ -61,12 +44,6 @@
   gnome = [
     # This one redirects to some mirror closeby, so it should be all you need
     "https://download.gnome.org/"
-
-    "https://fr2.rpmfind.net/linux/gnome.org/"
-    "https://ftp.acc.umu.se/pub/GNOME/"
-    "https://ftp.belnet.be/mirror/ftp.gnome.org/"
-    "ftp://ftp.cse.buffalo.edu/pub/Gnome/"
-    "ftp://ftp.nara.wide.ad.jp/pub/X11/GNOME/"
   ];
 
   # GNU (https://www.gnu.org/prep/ftp.html)
@@ -78,10 +55,6 @@
   # GnuPG
   gnupg = [
     "https://gnupg.org/ftp/gcrypt/"
-    "https://mirrors.dotsrc.org/gcrypt/"
-    "https://ftp.heanet.ie/mirrors/ftp.gnupg.org/gcrypt/"
-    "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/"
-    "http://www.ring.gr.jp/pub/net/"
   ];
 
   # IBiblio (former metalab/sunsite)
@@ -89,21 +62,15 @@
   # however there are other useful files outside it
   ibiblioPubLinux = [
     "https://www.ibiblio.org/pub/Linux/"
-    "ftp://ftp.ibiblio.org/pub/linux/"
-    "ftp://ftp.gwdg.de/pub/linux/metalab/"
-    "ftp://ftp.metalab.unc.edu/pub/linux/"
   ];
 
   kde = [
     "https://download.kde.org/"
-    "https://ftp.funet.fi/pub/mirrors/ftp.kde.org/pub/kde/"
   ];
 
   # kernel.org's /pub (/pub/{linux,software}) tree
   kernel = [
     "https://cdn.kernel.org/pub/"
-    "http://linux-kernel.uio.no/pub/"
-    "ftp://ftp.funet.fi/pub/mirrors/ftp.kernel.org/pub/"
   ];
 
   # MySQL
@@ -118,7 +85,6 @@
 
   # Mozilla projects
   mozilla = [
-    "https://download.cdn.mozilla.net/pub/mozilla.org/"
     "https://archive.mozilla.org/pub/"
   ];
 
@@ -162,7 +128,6 @@
   # SAMBA
   samba = [
     "https://download.samba.org/pub/"
-    "http://download.samba.org/pub/"
   ];
 
   # GNU Savannah
@@ -174,57 +139,35 @@
   # SourceForge
   sourceforge = [
     "https://downloads.sourceforge.net/"
-    "https://prdownloads.sourceforge.net/"
-    "https://netcologne.dl.sourceforge.net/sourceforge/"
-    "https://versaweb.dl.sourceforge.net/sourceforge/"
-    "https://freefr.dl.sourceforge.net/sourceforge/"
-    "https://osdn.dl.sourceforge.net/sourceforge/"
   ];
 
   # TCSH shell
   tcsh = [
     "https://astron.com/pub/tcsh/"
     "https://astron.com/pub/tcsh/old/"
-    "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/"
-    "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/old/"
-    "ftp://ftp.astron.com/pub/tcsh/"
-    "ftp://ftp.astron.com/pub/tcsh/old/"
-    "ftp://ftp.funet.fi/pub/unix/shells/tcsh/"
-    "ftp://ftp.funet.fi/pub/unix/shells/tcsh/old/"
   ];
 
   # XFCE
   xfce = [
     "https://archive.xfce.org/"
-    "https://mirror.netcologne.de/xfce/"
-    "https://archive.be.xfce.org/xfce/"
-    "https://archive.al-us.xfce.org/"
-    "http://archive.se.xfce.org/xfce/"
-    "http://mirror.perldude.de/archive.xfce.org/"
-    "http://archive.be2.xfce.org/"
-    "http://ftp.udc.es/xfce/"
   ];
 
   # X.org
   xorg = [
     "https://www.x.org/releases/"
-    "https://ftp.x.org/archive/"
   ];
 
   ### Programming languages' package repos
 
   # Perl CPAN
   cpan = [
-    "https://cpan.metacpan.org/"
     "https://www.cpan.org/"
-    "https://mirrors.kernel.org/CPAN/"
     "https://backpan.perl.org/" # for old releases
   ];
 
   # D DUB
   dub = [
     "https://code.dlang.org/packages/"
-    "https://codemirror.dlang.org/packages/"
   ];
 
   # Haskell Hackage
@@ -235,16 +178,11 @@
   # Lua Rocks
   luarocks = [
     "https://luarocks.org/"
-    "https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/master/"
-    "https://luafr.org/moonrocks/"
   ];
 
   # Python PyPI
   pypi = [
     "https://files.pythonhosted.org/packages/source/"
-    # pypi.io is a more semantic link, but atm it’s referencing
-    # files.pythonhosted.org over two redirects
-    "https://pypi.io/packages/source/"
   ];
 
   ### Linux distros


### PR DESCRIPTION
Unencrypted, outdated, and broken mirrors are a general nuisance. Most canonical upstreams are behind CDNs these days, and even when they’re not, I think the amount of load caused by Nixpkgs downloads should be negligible. The source FODs are cached on cache.nixos.org, so most users never end up downloading from upstream mirrors at all. When they do, it’s often in a corporate environment avoiding the cache, where FTP mirrors can cause firewall issues. Many sources don’t use the mirrors mechanism at all, so such users will probably want to cache FODs via the usual Nix store mechanisms or set up a caching HTTPS proxy.

There’s just no excuse for unencrypted mirrors in general in 2025, especially when they’re only fallbacks. (Yes, a passive observer can probably deduce information about what files are being downloaded by the amount of data transmitted anyway, but HTTPS still avoids our first‐download TOFU process being MITM’d, and helps with dodgy middleboxes rewriting things.)

I am not sure whether the mirrors mechanism makes sense to keep at all, but I leave deciding that to future work.

---

Depends on https://github.com/NixOS/nixpkgs/pull/409063 and https://github.com/NixOS/nixpkgs/pull/409108.

cc @alyssais who had opinions on Hydra FOD caching so may have opinions on this (though I think even if Hydra didn’t cache FODs this change would be fine, as it only applies to a relatively small subset of sources anyway, and the binary packages that most users download would still be cached)

cc @jherland

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
