### PR TITLE
cppfront: init at 0.8.1

### DIFF
--- a/pkgs/by-name/cp/cppfront/package.nix
+++ b/pkgs/by-name/cp/cppfront/package.nix
@@ -1,0 +1,105 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cppfront";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "hsutter";
+    repo = "cppfront";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QYjon2EpNexYa2fl09AePkpq0LkRVBOQM++eldcVMvI=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  # Remove with next release
+  postPatch = ''
+    substituteInPlace source/version.info \
+      --replace-fail "0.8.0" "0.8.1"
+  '';
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CXX source/cppfront.cpp -std=c++20 -o cppfront
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin cppfront
+    cp -r include $out/include
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "-version";
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.hello-world = stdenv.mkDerivation (finalAttrs': {
+      pname = "${finalAttrs.pname}-hello-world-test";
+      inherit (finalAttrs) version src;
+
+      sourceRoot = "${finalAttrs'.src.name}/regression-tests";
+
+      nativeBuildInputs = [
+        finalAttrs.finalPackage
+        installShellFiles
+      ];
+
+      postBuild = ''
+        cppfront pure2-hello.cpp2
+        $CXX -std=c++20 -o pure2-hello{,.cpp}
+      '';
+
+      postInstall = ''
+        installBin pure2-hello
+      '';
+
+      doInstallCheck = true;
+      postInstallCheck = ''
+        $out/bin/pure2-hello | grep '^Hello \[world\]$' > /dev/null
+      '';
+
+      meta = {
+        inherit (finalAttrs.meta) maintainers platforms;
+        mainProgram = "pure2-hello";
+      };
+    });
+  };
+
+  meta = {
+    description = "Experimental compiler from a potential C++ 'syntax 2' (Cpp2) to today's 'syntax 1' (Cpp1)";
+    homepage = "https://hsutter.github.io/cppfront/";
+    changelog = "https://github.com/hsutter/cppfront/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "cppfront";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [
+      marcin-serwin
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Revival of #232736

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
