### PR TITLE
k3s: k3s_1_32 -> k3s_1_33

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12973,7 +12973,7 @@ with pkgs;
     k3s_1_32
     k3s_1_33
     ;
-  k3s = k3s_1_32;
+  k3s = k3s_1_33;
 
   kapow = libsForQt5.callPackage ../applications/misc/kapow { };
 


### PR DESCRIPTION
k3s: k3s_1_32 -> k3s_1_33

- Tested k3s_1_33 version in my RPi4 (aarch64-linux) cluster for a week. No problems reported so far.

CC @NixOS/k3s 