### PR TITLE
python313Packages.totalsegmentator: init at 2.5.0

### DIFF
--- a/pkgs/by-name/nn/nnunetv2/package.nix
+++ b/pkgs/by-name/nn/nnunetv2/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication nnunetv2

--- a/pkgs/by-name/to/totalsegmentator/package.nix
+++ b/pkgs/by-name/to/totalsegmentator/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication totalsegmentator

--- a/pkgs/development/python-modules/acvl-utils/default.nix
+++ b/pkgs/development/python-modules/acvl-utils/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  batchgenerators,
+  blosc2,
+  connected-components-3d,
+  numpy,
+  scikit-image,
+  simpleitk,
+  torch,
+  tqdm,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "acvl-utils";
+  version = "0.2.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MIC-DKFZ";
+    repo = "acvl_utils";
+    tag = "v${version}";
+    hash = "sha256-52cPL5P6cJo4uqvm5pfYInyDmunATimkYDQ+JL/Mhu4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    batchgenerators
+    blosc2
+    connected-components-3d
+    numpy
+    scikit-image
+    simpleitk
+    torch
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "acvl_utils" ];
+
+  pytestFlagsArray = [ "tests" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Utilities for medical imaging and deep learning from the ACVL lab";
+    homepage = "https://github.com/MIC-DKFZ/acvl_utils";
+    changelog = "https://github.com/MIC-DKFZ/acvl_utils/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/batchgenerators/default.nix
+++ b/pkgs/development/python-modules/batchgenerators/default.nix
@@ -5,8 +5,8 @@
   fetchFromGitHub,
   setuptools,
   pytestCheckHook,
-  future,
   numpy,
+  pandas,
   pillow,
   scipy,
   scikit-learn,
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "batchgenerators";
-  version = "0.25";
+  version = "0.25.1";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -25,14 +25,14 @@ buildPythonPackage rec {
     owner = "MIC-DKFZ";
     repo = "batchgenerators";
     rev = "v${version}";
-    hash = "sha256-L2mWH2t8PN9o1M67KDdl1Tj2ZZ02MY4icsJY2VNrj3A=";
+    hash = "sha256-lvsen2AFRwFjLMgxXBQ9/xxmCOBx2D2PBIl0KpOzR70=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
-    future
     numpy
+    pandas
     pillow
     scipy
     scikit-learn
@@ -40,8 +40,12 @@ buildPythonPackage rec {
     threadpoolctl
   ];
 
-  # see https://github.com/MIC-DKFZ/batchgenerators/pull/78
-  pythonRemoveDeps = [ "unittest2" ];
+  # see https://github.com/MIC-DKFZ/batchgenerators/pull/78 and
+  # https://github.com/MIC-DKFZ/batchgenerators/pull/130
+  pythonRemoveDeps = [
+    "unittest2"
+    "future"
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/batchgeneratorsv2/default.nix
+++ b/pkgs/development/python-modules/batchgeneratorsv2/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  batchgenerators,
+  fft-conv-pytorch,
+  numpy,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "batchgeneratorsv2";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MIC-DKFZ";
+    repo = "batchgeneratorsv2";
+    tag = "v${version}";
+    hash = "sha256-UoEYSuDD+6ResA0luCZ3LxKGp9H9Mkcnvok/O673ITk=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    batchgenerators
+    fft-conv-pytorch
+    numpy
+    torch
+  ];
+
+  pythonImportsCheck = [
+    "batchgeneratorsv2"
+  ];
+
+  meta = {
+    description = "2D and 3D image data augmentation for deep learning";
+    homepage = "https://github.com/MIC-DKFZ/batchgeneratorsv2";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/dynamic-network-architectures/default.nix
+++ b/pkgs/development/python-modules/dynamic-network-architectures/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  einops,
+  numpy,
+  timm,
+  torch,
+}:
+
+buildPythonPackage rec {
+  pname = "dynamic-network-architectures";
+  version = "0.4.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MIC-DKFZ";
+    repo = "dynamic-network-architectures";
+    tag = "v${version}";
+    hash = "sha256-n458ZRaQqp9Wa4PbT/aoGrsPXOKdNmeah97YDtwXj6c=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    einops
+    numpy
+    timm
+    torch
+  ];
+
+  doCheck = false; # no tests (as of v0.3.1)
+
+  pythonImportsCheck = [ "dynamic_network_architectures" ];
+
+  meta = {
+    description = "Neural network architectures in Pytorch for varying image dimensions and channels";
+    homepage = "https://github.com/MIC-DKFZ/dynamic-network-architectures";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/fft-conv-pytorch/default.nix
+++ b/pkgs/development/python-modules/fft-conv-pytorch/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  numpy,
+  torch,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "fft-conv-pytorch";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fkodom";
+    repo = "fft-conv-pytorch";
+    tag = version;
+    hash = "sha256-SPoGmJ3cooztDsJl9jTzcSREhAHA8W4AIeHWbj9w8oM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+    torch
+  ];
+
+  env.FFT_CONV_PYTORCH_VERSION = version;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "fft_conv_pytorch"
+  ];
+
+  meta = {
+    description = "Implementation of 1D, 2D, and 3D FFT convolutions in PyTorch";
+    homepage = "https://github.com/fkodom/fft-conv-pytorch";
+    changelog = "https://github.com/fkodom/fft-conv-pytorch/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/nnunetv2/default.nix
+++ b/pkgs/development/python-modules/nnunetv2/default.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  acvl-utils,
+  batchgenerators,
+  batchgeneratorsv2,
+  dicom2nifti,
+  dynamic-network-architectures,
+  einops,
+  graphviz,
+  matplotlib,
+  nibabel,
+  numpy,
+  pandas,
+  requests,
+  scikit-image,
+  scikit-learn,
+  scipy,
+  seaborn,
+  simpleitk,
+  tifffile,
+  torch,
+  tqdm,
+  yacs,
+}:
+
+buildPythonPackage rec {
+  pname = "nnunetv2";
+  version = "2.6.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MIC-DKFZ";
+    repo = "nnUNet";
+    tag = "v${version}";
+    hash = "sha256-7z7fymvvP+FekltslreM6hRiRYmdHgTZyCThVKmkjYA=";
+  };
+
+  # imagecodecs and several of its dependencies are not in Nixpkgs,
+  # but it's not actually imported by nnunet
+  # (probably used indirectly to allow reading from additional TIFF/JPEG formats)
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail '"imagecodecs",' ""
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    acvl-utils
+    batchgenerators
+    batchgeneratorsv2
+    dicom2nifti
+    dynamic-network-architectures
+    einops
+    graphviz
+    matplotlib
+    nibabel
+    numpy
+    pandas
+    requests
+    scikit-image
+    scikit-learn
+    scipy
+    seaborn
+    simpleitk
+    tifffile
+    torch
+    tqdm
+    yacs
+  ];
+
+  pythonImportsCheck = [
+    "nnunetv2"
+    "nnunetv2.batch_running"
+    "nnunetv2.dataset_conversion"
+    "nnunetv2.ensembling"
+    "nnunetv2.evaluation"
+    "nnunetv2.experiment_planning"
+    "nnunetv2.imageio"
+    "nnunetv2.inference"
+    "nnunetv2.model_sharing"
+    "nnunetv2.postprocessing"
+    "nnunetv2.preprocessing"
+    "nnunetv2.run"
+    "nnunetv2.training"
+    "nnunetv2.utilities"
+  ];
+
+  doCheck = false; # see nnunetv2/tests/integration_tests, but too expensive to run
+
+  meta = {
+    description = "Automated pipeline for semantic segmentation of medical images";
+    homepage = "https://github.com/MIC-DKFZ/nnUNet";
+    changelog = "https://github.com/MIC-DKFZ/nnUNet/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/totalsegmentator/default.nix
+++ b/pkgs/development/python-modules/totalsegmentator/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  addBinToPathHook,
+  writableTmpDirAsHomeHook,
+  pytest,
+  dicom2nifti,
+  nibabel,
+  nnunetv2,
+  numpy,
+  pyarrow,
+  requests,
+  torch,
+  tqdm,
+  simpleitk,
+  xvfbwrapper,
+  xgboost,
+}:
+
+buildPythonPackage rec {
+  pname = "totalsegmentator";
+  version = "2.11.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "wasserth";
+    repo = "TotalSegmentator";
+    tag = "v${version}";
+    hash = "sha256-Tg739ww3EYdPTWxfNdAylwXXkVSLUvsmZ41NqSq90CQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    dicom2nifti
+    nibabel
+    nnunetv2
+    numpy
+    pyarrow
+    requests
+    torch
+    tqdm
+    simpleitk
+    xvfbwrapper
+    xgboost # not listed in setup.py, but required for totalsegmentator_get_{modality,phase}
+  ];
+
+  pythonImportsCheck = [
+    "totalsegmentator"
+    "totalsegmentator.python_api"
+  ];
+
+  nativeCheckInputs = [
+    pytest
+    addBinToPathHook
+    writableTmpDirAsHomeHook
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    bash tests/tests.sh
+    runHook postCheck
+  '';
+
+  doCheck = false; # tests try to download data
+
+  meta = {
+    description = "Tool for robust segmentation of anatomical structures in CT and MR images";
+    homepage = "https://github.com/wasserth/TotalSegmentator";
+    mainProgram = "TotalSegmentator";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5308,6 +5308,8 @@ self: super: with self; {
 
   ffmpy = callPackage ../development/python-modules/ffmpy { };
 
+  fft-conv-pytorch = callPackage ../development/python-modules/fft-conv-pytorch { };
+
   fhir-py = callPackage ../development/python-modules/fhir-py { };
 
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -63,6 +63,8 @@ self: super: with self; {
 
   acunetix = callPackage ../development/python-modules/acunetix { };
 
+  acvl-utils = callPackage ../development/python-modules/acvl-utils { };
+
   adafruit-board-toolkit = callPackage ../development/python-modules/adafruit-board-toolkit { };
 
   adafruit-io = callPackage ../development/python-modules/adafruit-io { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1782,6 +1782,8 @@ self: super: with self; {
 
   batchgenerators = callPackage ../development/python-modules/batchgenerators { };
 
+  batchgeneratorsv2 = callPackage ../development/python-modules/batchgeneratorsv2 { };
+
   batchspawner = callPackage ../development/python-modules/batchspawner { };
 
   batinfo = callPackage ../development/python-modules/batinfo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10806,6 +10806,8 @@ self: super: with self; {
 
   nnpdf = toPythonModule (pkgs.nnpdf.override { python3 = python; });
 
+  nnunetv2 = callPackage ../development/python-modules/nnunetv2 { };
+
   noaa-coops = callPackage ../development/python-modules/noaa-coops { };
 
   nocasedict = callPackage ../development/python-modules/nocasedict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4680,6 +4680,10 @@ self: super: with self; {
 
   dynalite-panel = callPackage ../development/python-modules/dynalite-panel { };
 
+  dynamic-network-architectures =
+    callPackage ../development/python-modules/dynamic-network-architectures
+      { };
+
   dynd = callPackage ../development/python-modules/dynd { };
 
   e2b = callPackage ../development/python-modules/e2b { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18971,6 +18971,8 @@ self: super: with self; {
 
   total-connect-client = callPackage ../development/python-modules/total-connect-client { };
 
+  totalsegmentator = callPackage ../development/python-modules/totalsegmentator { };
+
   touying = callPackage ../development/python-modules/touying { };
 
   towncrier = callPackage ../development/python-modules/towncrier { inherit (pkgs) git; };


### PR DESCRIPTION
python313Packages.nnunetv2: init at 2.6.2
python313Packages.dynamic-network-architectures: init at 0.4.2
python313Packages.acvl-utils: init at 0.2.5
python313Packages.fft-conv-pytorch: init at 1.2.0
python313Packages.batchgeneratorsv2: init at 0.3.0
python312Packages.batchgenerators: 0.25 -> 0.25.1; also remove unused `future` dependency (allowing build with Python 3.13)

Init [totalsegmentator](https://github.com/wasserth/TotalSegmentator), a Python application/API for automatic segmentation of medical images, [nnunetv2](https://github.com/MIC-DKFZ/nnUNet), a well-known Python package/CLI tool for semantic segmentation of medical images via optimized deep learning architectures/training plans, and its remaining previously unpackaged dependencies.

I had to disable the totalsegmentator tests since it tries to download data. NN-UNet has no unit tests and the integration tests are a bit tedious to set up due to data requirements but I have run a number of the more important scripts such as `nnUNetv2_plan_and_preprocess`, `nnUNetv2_train`, `nnUNetv2_convert_MSD_dataset`, `nnUNetv2_accumulate_crossval_results`, `nnUNetv2_extract_fingerprint` to completion on datasets from the medical segmentation decathlon and elsewhere, without issue. Note however that I have only tested datasets composed of NIfTI files; it's certainly possible that the removal of the `imagecodecs` dependency has removed the ability to train/infer on certain DICOM or other datasets.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
