### PR TITLE
firefox-{beta,devedition}-bin-unwrapped: 139.0b3 -> 139.0b10

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,2477 +1,2477 @@
 {
-  version = "139.0b4";
+  version = "139.0b9";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ach/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ach/firefox-139.0b9.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "709fe8a024c4531f515eb01a6b267a56029a03166ac5d6de413019fe0a8ba45e";
+      sha256 = "c4e81317b6885f444c2ef81a70c3e061a47850072a9ad711313f4e7264b70927";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/af/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/af/firefox-139.0b9.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "a62c1d62f6e2dfce5225df31b215f1227c7eabb220dc12043c8a5ad4c8f417f5";
+      sha256 = "90adff56f07c8a56fb6065ac4118bad03c22e8edbe24151c42228e0a910879ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/an/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/an/firefox-139.0b9.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "63cc13f04ea6f0c77a6855cfad11f4f6f35bdaa3d5fc06edcf030a8ffcad7a6e";
+      sha256 = "0c63850e8bb8eca3a65b76e048497a52dece767c8be6f1acdee4f543933aecc7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ar/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ar/firefox-139.0b9.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "0298c9c247c673847b8154d19b35b7379345409dfb9a5d80f2a6239e972e7cdc";
+      sha256 = "b68a14a3b9bf79e07d36b1ee7eccb31c50d30e02ace6c42765a634080fdbed30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ast/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ast/firefox-139.0b9.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "f48ab573fdad0eeb69b4c70a99e8cf7af87783f6698c591d01739ed3ea870723";
+      sha256 = "3e2bb8860e2e294d5db09ed6f4ce8699845480e5786445e1957e4d7e06bbf708";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/az/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/az/firefox-139.0b9.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "add78dfa402bf925f4834c4e0b698b5dbe01d99e1838de9c03272f819404b8d8";
+      sha256 = "00df33424bf184d933a7b0d03be0a7adc7ea0b9d3862dda6298d25cf086cc4ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/be/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/be/firefox-139.0b9.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "0500f7ce071b2867a712f32a830ae65a98cfd7b4beb28ea9623361affca11e62";
+      sha256 = "e29fa9984dd0732174f9da50c56b897d1493e9bbd1cc2fb994e803f1937e5c26";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/bg/firefox-139.0b9.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a32e773d73f2a10cf17292c65f21e0e3fc1516dd4093111ddbe54d4fd553a26b";
+      sha256 = "38c02ba1e82aab3cfbf2985880996c9f789a19ae9d2211e566ab158963519ea3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/bn/firefox-139.0b9.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "dc1386c1677b429980463325db93c9a96c1a4178bd2604adf3e943ae6a5890a1";
+      sha256 = "b4bc3a4bc1c669f33545d3b45f5308fe19ea5768fe7dc8bd569a6dbc300cf19e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/br/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/br/firefox-139.0b9.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "26ec0871ac96b3ce28d7953d4ead1df0d2826b5c2650fe1db2af238753edfc9c";
+      sha256 = "fb4f38bce4f61fc3a7129b047dd2ab7c760a29ab256d36640263994d4f802f32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/bs/firefox-139.0b9.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "6a2ab79e63632932b673e7d22a98767b7e923094ead8ecd48511444b46be6dcc";
+      sha256 = "629b45d5362783adca1b1218f805eb3f9f6d01fc1ef2bf9365ba7f1a96f4148b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ca-valencia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ca-valencia/firefox-139.0b9.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "fb19289c0f3d03d5f66467ad740d753f43e6fc2601f87d130209ec0c836fe718";
+      sha256 = "5ba911f4ac9b89b930f2e0ce198cd329bba0b9927d0246e68f6e8ea4fca23af1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ca/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ca/firefox-139.0b9.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "6380ca078dfec8f821f537a685b2b5f7b4ff9e328ef0a5acbf6257069c0b27e5";
+      sha256 = "648f7ea36b2aa304dd83c151000d97be8f9e7f8ee6edd85d31fff18a39b1a70e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cak/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/cak/firefox-139.0b9.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "4947e4d6c8433efa7379115eb0523f75ec3c00bcdfa8179f97ae97ef662bd8a4";
+      sha256 = "1f5e05cadfc175f31b45d4a53cb6d4352459ccdb7c84b1118049f3f282df4c44";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/cs/firefox-139.0b9.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "49b157447c444099afa5177aa7179d98f71171fee8a89f0ce14c65fd9af58214";
+      sha256 = "91b2e32c931dce9aa6d08ce6f1abe7890d1bb82146829282035c0cdcc1a07afa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cy/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/cy/firefox-139.0b9.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "f440960100c6685444e6507a4e0f072871b410784967e2f00c04ef9427609a78";
+      sha256 = "63424f47d8e5002e7a072f0d8bb4816677a1bb9382269e88c39bd26e1f49a49f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/da/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/da/firefox-139.0b9.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "ea2cefb990e4bd8f283c45a14bbf7a5ca420b69542692d2bb86093c885a1f627";
+      sha256 = "0a0945495765c827625c20b1ed5614462c10c6d4dec6b512905f98f8a21bcaea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/de/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/de/firefox-139.0b9.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "5bacffc6c87f049f865c2a6ad00e5d26a4b4ba879092902165db0a345daaf77e";
+      sha256 = "033654d94a9aa2fe8fae4d2a994335a27a639eb3ec99b428c2414182882672dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/dsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/dsb/firefox-139.0b9.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "f93de9c31f9d63d41fbe7635103500a81144888518bc8c2f698e39d4b0357028";
+      sha256 = "147dfca52dba268a9278f2dd85ee1ba9ce2ebfc64bc3eaedcc30d16eed7b27ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/el/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/el/firefox-139.0b9.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "201f51c2f4f30618d8e9f614cf27b3e07e899f852504becdf46f6a15220309c7";
+      sha256 = "b651fe08b6aa9a36ca5ef9f7869b4ad826f9df7aa4fa035f1d3c1d04722bcdc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-CA/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/en-CA/firefox-139.0b9.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ef5403be996abf97e9c58c5ebcd0c74fe9a14122119c33266e30428a60c4c944";
+      sha256 = "48f78c166970e605551939c4e3e06b69b316fb586aafc1c65883a0c64a1abf6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-GB/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/en-GB/firefox-139.0b9.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "64b2ce817ac1cfb314a9f22456716f9e1e5d7893bf46fd6b55d203c718df6c9a";
+      sha256 = "ff3ad82f463cb5268618c3a8e2e6fd65a2b8c46e3d17e77aa3cbcbdd59dad6f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-US/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/en-US/firefox-139.0b9.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "21bfb99fe445e64ad8fb86822fd6d77c9c0d387530b787f3c3fc99b97723d664";
+      sha256 = "3894cba2cf405744d8774acb746827137d59688c1af041c7c1bd7582bb3851ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/eo/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/eo/firefox-139.0b9.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "531b94cf1b0a20de877bbe1cc9e3ab3ae9b7dd8729586a70a43f04576909c99e";
+      sha256 = "0a78de2cbadaf8f0b4dad3511b81bd3ca1b1dd45ef5ea53dcd133604a7bf61fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-AR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/es-AR/firefox-139.0b9.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "f80d18dca3009011d97bb89726d9b09c548e239383412615c4a341537e157165";
+      sha256 = "2154cc54a69e34349dde6d1701c7bbca31138db3347af7dcdac082045a6e3739";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-CL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/es-CL/firefox-139.0b9.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f2144b0b492eff30dbd95ab92ef9523d3d7d48dbad2efc52e8401a4e4f85d561";
+      sha256 = "7bdfbd1ae4182b5abce580f914389dadc6fe16a38b26b21682c3cd825d4347ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-ES/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/es-ES/firefox-139.0b9.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "895b92176b7dc1a492574bb625e6264548377adabd1655c6ba07eb24a786c1a6";
+      sha256 = "89e6dda59d1ae390358c91ec59888afa14a75a8a500173366dba0f4c6bd6afde";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-MX/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/es-MX/firefox-139.0b9.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "b770be36d7b93925baf0c85fcccecb73f1c1b8845615e7631f3d83e8fafe10ce";
+      sha256 = "bf00aceee85d9b67e27109da6d048d2006d2f2487abccb400a0daec0bd3e0de1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/et/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/et/firefox-139.0b9.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e88a52d747dc3d6c5a449c5449fb2b412441f41da64c496da22f5880ba5c4752";
+      sha256 = "10d183e513593fb1e42b31440d80a5d8671e45b448cf4c4dcc5b10b2f0a8d33d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/eu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/eu/firefox-139.0b9.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "4d7d7fe2f695c79418a746c875cfd9357cb290ad8b6d253774a3ab92fe235210";
+      sha256 = "2c05936098ac06b3a631b215fdfb4c27b766b8907851b29a88bed7f53dc1c1ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fa/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/fa/firefox-139.0b9.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8cb53568f15e61491f0b3c03a1e71599cac3ce278f145f638830b9d22b789ff4";
+      sha256 = "9fce25d000f3cf1c0a6c8fdda15ab6c99a6b384e488d28e71775a802629fda53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ff/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ff/firefox-139.0b9.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "2f229d6811bbc2bde175dc9b6fea0b1fdf4221f9f8042cf50d67513074a45a5e";
+      sha256 = "d7922d10849005344216c48e2e7ed3e66d2482b33266e5a8ebd7f011d9bbfe05";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/fi/firefox-139.0b9.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "316ac34c897feb1b98f677436d4dbac7b4a5c5fc29cf07bb55341736b156ae0a";
+      sha256 = "6ae5ea6ce64aa974be37c28d6bdae1a0627f54e4ac8cfb2132d493e704745099";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/fr/firefox-139.0b9.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2b1e4ab91f25e9b95fb894231709d086d9645eb76a64e0db194dd386e8f362ac";
+      sha256 = "a18ebbce36e1b7d6a1929157633608e3f2641c7a2d4b3f6c518fa3cdb86c3e93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/fur/firefox-139.0b9.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "1a2c3b4e20c5cbbd6531c53516bcd97478cd86f6bc8b2761fd7074cc9e0429d0";
+      sha256 = "204f9961ff82fd3416113dec060f4809b10ac5b53146ed81a43b832a5ed8625e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fy-NL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/fy-NL/firefox-139.0b9.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "ca55a18278f39416d4982834357d8ee4e9dbb47e129feb3d45b4912f411dcfc6";
+      sha256 = "5b804fbea67f88bc95ef5b7d94a2a43601732c71d3c0b425943738631f84f3e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ga-IE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ga-IE/firefox-139.0b9.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "34594aded12da96b71053623e9bdc09367d8d28281f6ea31be81dc1eab4d76f1";
+      sha256 = "96e27459e887532b81c1a566e73eedbe1e08a03abf1eb364b4e382cf80d9299c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gd/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/gd/firefox-139.0b9.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "a6dffbb23c3b61f25a913933d700ace50954ae6e879a9d7d4b73c1a864954523";
+      sha256 = "7267569cc495c4789b2fb7d0a62694316bd9fe99e3a52536f1dc1caebfaaeedc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/gl/firefox-139.0b9.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "a629a7d61624ade963df689fbee4add6f3eca0f603bd8fcc75563480642e7e97";
+      sha256 = "d036dbe5ad04114d46d3452afdd414e079a879924f35cb0283cba4d1c20c02c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/gn/firefox-139.0b9.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "fb827103cafe3179b1b17f8fdc21e2008a5ff24f4502b923c7426ae91fc26c91";
+      sha256 = "2c2d234691b2f0894ee865e91a4504af191ddba99bf5e3b56da03a9b1762708c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gu-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/gu-IN/firefox-139.0b9.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "e9f4437d6f8959aa9270e6cc8eb7070165a8418f4ed28c2a31e1b955948c7837";
+      sha256 = "3fa3e8073c533dd47fb1236b3cd00bcd04c821fed65998160fd99b2b1c6141a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/he/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/he/firefox-139.0b9.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "5eedd55e647c494461a013912eaac5b1d40b20acef64a0810e74fdd72083e5df";
+      sha256 = "8cdadf0d7d3e6d5a2190517474d8ac4bf0b7b455c8e8dcce620cf791756ba97b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hi-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/hi-IN/firefox-139.0b9.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "3a1e543d88f0103776397decc1ae9fa2b5a96b68fddadea56c60e1d76b1120d5";
+      sha256 = "0c19da656cbbc3fc5fd581b6aad2153c4be07b0939a00dc15e4391e1eba419e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/hr/firefox-139.0b9.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "4dbfbb04729a97c82b4eb123d1a6623867b6ece4f26777ed12c81a9bc5f4b88e";
+      sha256 = "c356fe83784a54e7799119a93ece2845c24453c5828948c95a3626d4d94a5b19";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/hsb/firefox-139.0b9.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "1cca8fe6f46c797b8e03923d9b4a317cab0e011c34a44feabcaea6767a4054b8";
+      sha256 = "c97f84b979969d9517801df98c817b7917fcbc595d851bc720268d333a0308ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/hu/firefox-139.0b9.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "ddbb8a9b6fd89f496c47398f09cb2a56ecf51299138cdf1dff659d027f1f8055";
+      sha256 = "cdd47fc6dc1c72dcf263ae0004f66804c98a3181d95c1ba182f0284f78fbc1d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hy-AM/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/hy-AM/firefox-139.0b9.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "e819ccd80cfe1446cd60398e788931d12060766fbd23539932efc6e16a0a59a0";
+      sha256 = "8f9d042e20fa8ff96a65379c2d75a44067766dd4367ad8ce5a4714cc5be18370";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ia/firefox-139.0b9.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "bb5dc9c1a4cb919a2f6207fe171fe0e2c9345d038cf7a7d969fc72f6c0d9aa94";
+      sha256 = "3fd23a592095b19916d5e3cfcef420b66d544f17ac1cd4579fc3bc7a099d6c82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/id/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/id/firefox-139.0b9.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "04f8e8f738dad42e6c0daca2ada66ea01f7d994c2ef4f2ec329070f740a2bd0d";
+      sha256 = "1d20bf99e1c444cef1b3e1be643eed1e8b94dbbbbd681f9a382546f22f6fae4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/is/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/is/firefox-139.0b9.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "140e3f7a50a57f415913465372b3c0cb026f648d587eab2e2406361430c1d81e";
+      sha256 = "b154adbb0dba88a2212ca1c7c3b83f5295bef3d671e392b5a965a8d71a9e146d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/it/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/it/firefox-139.0b9.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "81eaf1ea39d5792ce31388a3936cc9597f7873eddbb6ab34ed78acf688598272";
+      sha256 = "a15bb58cc429610e25ce63fe438df7f312ca44d050579613b1b0e35a968476a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ja/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ja/firefox-139.0b9.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "5eb2dad48c1fdd9b869c89009f83433c7c43ecfbb85c6489a46bde89e935b534";
+      sha256 = "f8144de519ac49cdbd1affa83aa34c1a2508d5264df20f5c0625660bdf6f883c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ka/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ka/firefox-139.0b9.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "16cd1d3352195a758bb256d9f201d50934c016f772c4ae01133f7ff25f86f2fd";
+      sha256 = "668f084fb05c124a85e7194ca4657201d450feb5aabb3eebec704224c74086f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kab/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/kab/firefox-139.0b9.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "e9390977f31c11d995d3748329da38c45300aa43ac5639c11cc90db9cd5b8d4f";
+      sha256 = "db585ddbfc4dbc1326a3cc8b082a1e31bac6677ec026863bf5f0e6903266d7dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/kk/firefox-139.0b9.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "7d13ee5bf4718468f8ea20a5fc6aceff58ac0be84fa7659932e85dbbaeed867d";
+      sha256 = "297948d50687f51536c363eb23511487629e0d1dbab8182bd485f29e644b354f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/km/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/km/firefox-139.0b9.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "999eff92897c3cb7597abef1e2c86eb962204dfa4ebd0d86842b3f2cbc7fe957";
+      sha256 = "083e6f73a9d796e366e2572aadcf64af72522956398766cd7e520bf8f70fb424";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/kn/firefox-139.0b9.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "a2d45d1ffe1a46c8178f460ac30c394a7f4177ecc8cdb4c130bf3e5c49bc2ad7";
+      sha256 = "4ff1d36d61c08d42d7e259bf89ae5b13ab4c8e55852ab2bdcdad0a86d9d64b82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ko/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ko/firefox-139.0b9.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "f847db77a08952229d6ef998c7157f0c75850f06cc96953ad66fd3a024ad1713";
+      sha256 = "fbedbfa6d0079079cbcd3dc24c6caca201d8539e0f8b7b0d9f88abdcb7b42456";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lij/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/lij/firefox-139.0b9.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "5e82c700fc49d454496199107a8fcb752847cd46981754a8413af64777ba9d5f";
+      sha256 = "18af5f7abf3359df0c9616ef730109a407500e3b1a8e35138c22de0c2179930e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lt/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/lt/firefox-139.0b9.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "5d60fd80069d73d12e285b65da1e3af0eca6824c27cb80e946c856f5c3028879";
+      sha256 = "5519ea40d36009b8fd9a822ea2a4e2c93e5ed8a36e8eaac2d34c28dc13dee2a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lv/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/lv/firefox-139.0b9.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "28e9eba64a0662004171f87e2ccf23308d259bc78b2184ffdfec398ef08f89f6";
+      sha256 = "2ee12589c5f24556b8e32814cb56df762d4d99caa4927e6054e04f2cef295729";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/mk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/mk/firefox-139.0b9.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "83df7f0457e3ecc36c1a6376ec595f3df04543ba36d80d896cd7d68fdf6d9de5";
+      sha256 = "0377c89e5d898a010b70d7be0a1cbfbfda992bc5bc3d2f01e7b7923d7b4a3fc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/mr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/mr/firefox-139.0b9.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "879ae358c38367b634154936a9e8d093813ac8e410f8f533f7c32227845d3bb4";
+      sha256 = "3a09f35d98fc33bc93b9a57ddfe142f1c066c15cb9c11fbdb8a07a6bc4d86dab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ms/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ms/firefox-139.0b9.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "ec20aeaf31cd2f4b16b94ab16c62a0ebde70b738b86c739dd4deca7b50feb95b";
+      sha256 = "537db993e4490d0eb5a00542209972ce1c70a0f2672d41ebbdb8d19c9f7e9445";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/my/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/my/firefox-139.0b9.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "90468dd5c6db813612f69f2b646be26db909dcaa92e66b3c3250823baea81de6";
+      sha256 = "5a7f5684b1790486c9e5f4296eef5a98e467cc71af9dc3ed632b08a1bbabdd5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nb-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/nb-NO/firefox-139.0b9.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "904f3f3760506b6feb246397caab176e6dd884e982dcb07274605bc067113d95";
+      sha256 = "ad0210617413423f67bc492ac7b14a6e55195071b67273b50d3e49e9a138962f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ne-NP/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ne-NP/firefox-139.0b9.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "0181214f14fd5e88381952ad07df7a37efa293e8fbe903db0029e773ff1e50f9";
+      sha256 = "71d9de70dce2d715058276e4f4cd2cd88a0c3bed08ee3389a21f8723e5098ee4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/nl/firefox-139.0b9.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "cd1f662dcc64190d00c84b0c02d67558626246470c5cdac78fdee1408ec88cac";
+      sha256 = "705808dc3b6f8757fd2178b7246c1f910d78934709143b6aff1df3a1bd3bb72d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nn-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/nn-NO/firefox-139.0b9.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "c20d2ea023e5eb1a60863cadd085db28f616dfa79c79652dc1f38c2efd2e4f49";
+      sha256 = "ea49f8c4fca24b55ed4f56032b91f4b8c78d3af121f396eda89ebb7dba2d2d87";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/oc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/oc/firefox-139.0b9.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "6f387a7892a61b623ec1696adec24f5836dce98a4157c59cc47a987f11e8dfec";
+      sha256 = "abbc1640dfe33253101b64b4ac5f59dfd33d51f9b054b5dd69c558524a96fd73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pa-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/pa-IN/firefox-139.0b9.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "1973852bbe05fc0207834a6271858a8b6585254635854cc2302b45d0a10f8b07";
+      sha256 = "3d88dfc7af9c2e49cb23aaae7cf0907180c7dfea209856eda74c246b8e533dde";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/pl/firefox-139.0b9.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "9919cc6421b35798c2df90729d2d25e200e24d1450003ce30794124fb88ac21d";
+      sha256 = "e472ea21225f4be579f899ed4a7e96feeb86e57d62148e0f36cd53741e02f55d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pt-BR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/pt-BR/firefox-139.0b9.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "0ca06936133a86645d2975acb69fd01d3b80fdfcbc1ab003561ecd9fc85d4467";
+      sha256 = "3a0b96dad652591f2b7bce9b1e186a346a8c0bc9b9f1616551b07e8c4c18dbd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pt-PT/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/pt-PT/firefox-139.0b9.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "48dfb1081c2bee39a5bb2729d4aa83860d29435c818bef4b80c53e02efafb807";
+      sha256 = "62275a36496bcdc7e6af2a7f5af1d0129d64c3df8fcadd76c2d8cdccff51d244";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/rm/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/rm/firefox-139.0b9.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "4cb0f6115a83a9e30d5800f2d7c4709431c3617fba9fa43073bfd169c7a61266";
+      sha256 = "b0c8efb28aedb0478ca640fd65067bbbabbed1694d1d7b71da1109d800105b3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ro/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ro/firefox-139.0b9.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "cf18a73a2170ab3fc5934adab6ef6142779f8f3c1fd949b1a1051bf2ea9795b8";
+      sha256 = "b48d0e980409a5411a1b26eafd06de9d6982d887af9cd6bd7c5c80adf9dd6112";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ru/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ru/firefox-139.0b9.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "85ea9ba70d407d009aced7ab3d1b8552b0cf1a44cb0df5d3cae35bbefec3bc8a";
+      sha256 = "c868dd2d6e772b3aa6db9de517a57a17ac87804822f8570e81b2863fc201b013";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sat/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/sat/firefox-139.0b9.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "693a3a17e376381dba4439a35eb8b7cf03ea59dbd6c8030b4da15466475f23b1";
+      sha256 = "a00a5ee1baa877c39db7cd4885fd3eba673dc1add8ea868adbd84798be69c680";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/sc/firefox-139.0b9.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "0d031bb02cef10ec8ee44376f384df868c20a6ae96138011adcfe577a132d788";
+      sha256 = "0b95f7bf61431e2c8d39b3acecb5d15e62032657ec05e8abe4c1c72dea93735b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sco/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/sco/firefox-139.0b9.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "e38e1b62fdbf65b5893c448a8df763da3e04436ad75db1531023a800bb2fd186";
+      sha256 = "1c20c7e56c4b1147799e7eb370b6ef23013555e4459a3210d17b2061f2174188";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/si/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/si/firefox-139.0b9.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "efaac36b3c3a6da5958563d682936413851f76134eff15652cab0260038affca";
+      sha256 = "84d2c592c9d7761a5e930cf339e2b82906878c31eb6c9b72cb8c67759f90e02a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/sk/firefox-139.0b9.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "e60387517f08d43b27179b08a0f9f8280d9e5e1d72ebd200f1794d37ecbb7b42";
+      sha256 = "f1e5c5fff06657154509658ad2b95479a9c2996ce23528336ce1e144395547a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/skr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/skr/firefox-139.0b9.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "834d207793100f06741459b12203ebf73750abeaffb43524564562bbb7160779";
+      sha256 = "747464f79f2b27ca40a7bef09b0bf0383f1c4f32d3b485664f626d456385aed7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/sl/firefox-139.0b9.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "9f0f2d2d7b22a2c2eb7ba28974d41d6db63fea0e66491753eea7e009ee7dd23f";
+      sha256 = "e355df1aa79c38b873ac757d03ac762b072d80d47d413be8130e1da6519c0b39";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/son/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/son/firefox-139.0b9.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "bb57306e0b721a99b3d916ead2ca6c813315d010f51076dd6d415d53dc1e1847";
+      sha256 = "d451c91496d0997a56984f7cc2767c8466feb3c78abc65aaa4ed291a0391cdf7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sq/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/sq/firefox-139.0b9.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "64e95983086221f6f01d19fe37282ebce21f93516a43905dc29d3006d59b7847";
+      sha256 = "fa2b28b1d0edb3fa3ec1753249e206199f51cf17323ce457eaa943f69e069553";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/sr/firefox-139.0b9.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "456423a6a6c0c49b643d25bb3d32866c177a7856110c3cc94494f44296a836b2";
+      sha256 = "99c437f79b8758b65c344c634523fc56fa40e37f7a55bbd00cda378acea96083";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sv-SE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/sv-SE/firefox-139.0b9.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "960c1aade2e27b872e648f61944ea5421cfe4f7f09205dac2693cf5d6f3840af";
+      sha256 = "d0cc7225f0bf50ecb819b77cbc903c778a321c6912ef28d0ce5723e1c6e12a16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/szl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/szl/firefox-139.0b9.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "2966c66c503b0fbdd8cf0fb141549cac9a8f34af9eb107b65aa7ed9409a629e5";
+      sha256 = "ac8573db495b0a6d95402126148d8978348cb00627ee2183ea4e626c47b55ed4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ta/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ta/firefox-139.0b9.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "afa115d8acfa334d69f8baf6159ffbb02165dcde6593b0b9132086bebd274714";
+      sha256 = "a263c7577bf5eecb4af63bbbe87cf61c5919e95d2ad7430b5b85bb2ae5b4554a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/te/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/te/firefox-139.0b9.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "215cf233c79f4d33e0de76e4dd11f270a908b8f1fa55c6744200e86b6c862f9c";
+      sha256 = "a8c7b9f7d5a5a6dc2d28c76a4e7d454c773e84104ee233bacae1f2ac59117a32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/tg/firefox-139.0b9.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "e88ab65a2a477f5ad36ec77e334c2bbe9fc39e60fdd44b5ac705ff60f01dd8b9";
+      sha256 = "81b4d7878a0b45365c46c3940d06a19cbf2064a6b12fca7629395c74e5ac991d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/th/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/th/firefox-139.0b9.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "ba4f17f2fc2d86486dda6acaea1acfabcf4157f23c2aa39a858c35c78be3b20b";
+      sha256 = "7f44005ac755621f5d5a636a0c040e54ca44346f1b97d65af392f98325f59935";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/tl/firefox-139.0b9.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "e123514d141c959e8f29b2dfc1c8152cb9c978267aca5cfa647ca79fcfd67563";
+      sha256 = "7e45116c4f071738a533beee799ac30cb3825ae194f1f76c6ca500e46ba4802d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/tr/firefox-139.0b9.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "73988d7cc818bfbed084a626727d1bbbbb378daf849fbaa8b23f3f5a76315f63";
+      sha256 = "56b0c2a7331f6f1984ea79b12301f6bd6251bab9996e4dee83c34654f861fdbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/trs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/trs/firefox-139.0b9.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "2b9022ed251f2e72bc0a7f7c319e7169eaddeec9cba230ceb9789ccd6c2a4c20";
+      sha256 = "3826e5073047fea6bbcf50d142c3087a9354d51c058d6c0fe7a68d3e82c35efa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/uk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/uk/firefox-139.0b9.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "f721779da0e1c681ae7ef66e789a81a3655ed7be116357c518d4eb0401937fe1";
+      sha256 = "727c07b7c2881006a8ed361ca74190f6020445502eff089660ffc867ae2f43cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/ur/firefox-139.0b9.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "080b7d053124ec03e821b5db14544de1a76e0b8d1aad4cbf6a5bfe7a721debba";
+      sha256 = "1084c0219633a6946f6d85b8f3ae17150c2aa4feeaa06256005c9fc6c5177d3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/uz/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/uz/firefox-139.0b9.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "7fb7b3fd94aabaa611c53c6d8b75e0908c5bb93b0bdaa73a3e6e030a204d0bbc";
+      sha256 = "8e775b73d715fab699a4a728dc48bcbb76b70e324eec07b5affd5565984fa418";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/vi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/vi/firefox-139.0b9.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "27d15b1434b9aae896a3915eb647c1078a1663b1dfd6ce4c05d8e77bc21232f5";
+      sha256 = "80ad3a52913654262ea06d6d659a4060719968f77ee96178d1317ad3374151cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/xh/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/xh/firefox-139.0b9.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "642d2ce475f6b2662ae13a54775fb4e5a01a1d25a5cec6e95bc341e8505c4856";
+      sha256 = "72c46c1976ed392195e49bba04429c370df2e804675ee4d839e1f9a4f929e22f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/zh-CN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/zh-CN/firefox-139.0b9.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "1c07356d7c142aed0c17df737aa7b3e0ad38d9d4897d7df7bfd0a79a367d8ca1";
+      sha256 = "74ee83639ffb8b7eef07a4dd4b41d47fa198cd06900723858df0f8f93233c0b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/zh-TW/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-x86_64/zh-TW/firefox-139.0b9.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "d20921bd3d75051a61de3890349bf65280a539824403074f51d14332cb33b3df";
+      sha256 = "030b245fc4d5237dcf5fc1112a6b7bff52a2a4140593b658a838bbda933357b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ach/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ach/firefox-139.0b9.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "87a70f57297d5b0c01492da28bc80d74f290682f37b19a43fc6126efd85c6079";
+      sha256 = "6cda474b018bc94112f1ae4db34cb5f2822b6bd6ba1c2ca8c57dc848b9bb9377";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/af/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/af/firefox-139.0b9.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "c14ea82b75e114e01bad4b6e0b405c9611330105659b88bf8455857e181b4913";
+      sha256 = "6ae2ad47388dc0d867fdb805df267d58d666b9257a78128a3f66f80712ada37c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/an/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/an/firefox-139.0b9.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "233822a13e7ddc7eb437a6fa48b95f57c4c1d7da7a6ca54e84015b6d6cc16f8f";
+      sha256 = "95f89538b6e0bbc0eaa48f9d6ab1bfffbfd1c313860752a168270cfb73c64e2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ar/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ar/firefox-139.0b9.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "c0cd5c0d31333a5a6ba6af3de586df838adbf7da09b2d85f8310757b3c9c8253";
+      sha256 = "0520728a497ac353fee4cce6bd34c586fe2de7c34456c4e15d42aefe032c9165";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ast/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ast/firefox-139.0b9.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "e38ac58bff96c8396df39b1fe090abd67bdf9b3e410f504f25e0d24482a2d1ed";
+      sha256 = "8f208df419ce58a9e8c7b6cdf337331ae0341ad2c186e7d8903245967b20214a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/az/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/az/firefox-139.0b9.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "2c7a74321548b4d3c3c07e2c0f1127c4f54c55d1af0dabfc6704fa7eaa02b102";
+      sha256 = "645b1076b775b8b6264e4e214e81b513b2f582913aba815bdfbca309b51e2422";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/be/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/be/firefox-139.0b9.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "624589d8c29240678a85b5b0978b4de1c43ea7850960bab85f7c7f7a172cb4f4";
+      sha256 = "7019ab5e5247dcb792177157af04456bb5f8ffd80f8756c8a7a8ee2e42be1217";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/bg/firefox-139.0b9.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "84b144c5d7ae2cbc95dbb4fa262b6e0653000c645c9a604022aca70ead9282d8";
+      sha256 = "6adee658253c9bf0ea6a5f3b41807bf765b63183c9bd8301df3bcc0da5367cfe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/bn/firefox-139.0b9.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "b7273dc41403f54eff659a67c8a4b70f2a4df61f62a1dd4c562b0bc75c08f909";
+      sha256 = "450e9c569d9d3e01eca21bfd61b11285995ee96bef435a0cbf4aece195e1deb9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/br/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/br/firefox-139.0b9.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "0815292d40fb6ebe791d7de8d699ccc0d5096c0999fd498fe30ceb55aeb7292d";
+      sha256 = "cd415fea345811e7733e8f84f8e37d7866c27a8bff0a8634336c8a764ef5448c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/bs/firefox-139.0b9.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "24de75d8e893acefc305717a2f8ba2decdb722e2505385d6cddb04ad43d7fe5b";
+      sha256 = "61ccb6cee2a2f1a48e86dbb3f5616d738ce5f5e00fd25b1256be72f902df415e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ca-valencia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ca-valencia/firefox-139.0b9.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "2ba91787e8af61cb24de5c122a5ff57c6081e9680f7594d02e2b363f28e16a4b";
+      sha256 = "7c769fc0c4d0e85fb01a145f22aec64a75024d9edb318a1cf8fc71a299045e64";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ca/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ca/firefox-139.0b9.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "da9e7f0f9a0730b2a9c4bc467da5f5c2349f98e22f683db02b5651df4a202251";
+      sha256 = "b9505dc22235e2b73fec46eb4e61e38abab09e9c9c65c5aea51b7058415e358e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cak/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/cak/firefox-139.0b9.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "8e77e88d9fc94f819d450ca6c7a78c618d881a97aabae5b997f7a6d69290e29f";
+      sha256 = "b828a65178bad688b9ff046357b31d288111816f509b3b794ad0019d7f7b3038";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/cs/firefox-139.0b9.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "a79b45aaf0e6e8f412e21e746265c1d43e7de9046a050b670ba3667b1462c620";
+      sha256 = "6cb94421cc1a404e2c8a9e84049c6404c7438764780cde9a4fce728046b8365e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cy/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/cy/firefox-139.0b9.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "2a436e2d6a9eba59a8bcb448cb61c5730772e204665416c4c2e04564c19ac23a";
+      sha256 = "5062859b65b885854a827e04fc5167e09380bd55f9c91c8983bfd1d61b118418";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/da/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/da/firefox-139.0b9.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "c055660cefb5fe09c71ea087de51efbd4d0b8c2a349f78f2ec5d4349116ad694";
+      sha256 = "c09e700336978ecb954c5e02d21d5d1442354c21576a7531747a48c01a5a1983";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/de/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/de/firefox-139.0b9.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "e3d546c3a20067ea5c710e6af065bcd11e6ab49a803f730873affa229a1badc8";
+      sha256 = "b4ce518fe0a587e3dfc85f7a0092b0995259f7c44762f77f0b68c5b14d91968e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/dsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/dsb/firefox-139.0b9.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "50b1be16d8856605e37078f0cb87bce59f621a76c354a8d64d2f9a68e626405a";
+      sha256 = "7158316cbe6a0bf13a278abdf3019f8eadb773466f52e9f8d1180ceb2e2193a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/el/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/el/firefox-139.0b9.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "7f85663812934905be421c0bc3bb0ebcf22c5a497db7fbcf91a21b8174bdad0b";
+      sha256 = "e890a2e4f6788edb212b7e0a8d5671dc26c9e2373dca51fc92a5f8c5dd46383a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-CA/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/en-CA/firefox-139.0b9.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "e5304a3d0557d7ec259e41e989ae191c14e7aa72203eea1ea2c180ba8aec1913";
+      sha256 = "e3bb8f687cdcbfb422f971f7218ea16520c55835c5143cb042063cc4a6b127fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-GB/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/en-GB/firefox-139.0b9.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "393f92153a7935bc161badc7d81b23803f1d6cf9ce69651097cbc383056a30d7";
+      sha256 = "84b436abd06806e27b0b495d092f333c27de323675d06f10485fafc504c030d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-US/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/en-US/firefox-139.0b9.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "8d61639f9b02659fa3486e2f17af815e028e87c373a1770c69e968af3c7c0b74";
+      sha256 = "3a54aff46064dade062cc5d6579b624afcff576083211ed45d7df7cce2fc0c64";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/eo/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/eo/firefox-139.0b9.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "dcd9df03ad825bd50f3b162ebd5bc6561d09688972d7c80af15b10d1801a3fd3";
+      sha256 = "27f4a91401cce0534f9ad5d188f56fd35ec7f429b14ee5b7abb1cdf695d86c68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-AR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/es-AR/firefox-139.0b9.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "cbe7dff319e0cf3d67126565366bf6063536188fb5b2c830e24b2b439d5410a2";
+      sha256 = "61d44589c8db02e6a9f095b9d795d03fae71f5fa30ca64db20d309fa0c91f2a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-CL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/es-CL/firefox-139.0b9.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "225c027d37ea0d6da7f9de2c784ee13db182bc76ea0398ae7dd3ec90b3146b7c";
+      sha256 = "ecb6140af738c32612e21f5e721d9d13a926bf9c11c29703f6dc90356caeb87b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-ES/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/es-ES/firefox-139.0b9.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "2b349436c1ce8d99138875f11af5d5210210eaeb39f0dbdea381dafb8c5d4404";
+      sha256 = "79dce27f9b882bb033837f22b9ae39288e98dcfbe68f01cdebf4e5ab238c41a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-MX/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/es-MX/firefox-139.0b9.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "016fada5c527dd9c4c95b6549e2cbb7b3616ec6256c9e30c527f995af1029ebb";
+      sha256 = "8a948142b243e5ef9f143934b73ca2ff314ab33003c717916cce7ebb3d299641";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/et/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/et/firefox-139.0b9.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "57eecae03d4cb2c2e86f2909e82a8e42113f86b7f30eb8711b3a6262e1157b4e";
+      sha256 = "191b1fca0f0456c334c8e220df563a9b5e6e1a3a7defb83c94b3a5e4b851cc62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/eu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/eu/firefox-139.0b9.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "af2405d4e1db8662e7cc6f212694ab80f607c854ddc707d5322d4a0565227f04";
+      sha256 = "822ce7c64a56652248c0f88ca5c13838aa5dcb5be327bf92c6c418a172cacc47";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fa/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/fa/firefox-139.0b9.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "1170f8ca54cc2eac1a2bdd9a63eee87b29a627d30cd2f06e91e519ac2be2b05c";
+      sha256 = "bf7e23ec39e69286a9d80213b84a2863bd834659a67d6404a979b0a92c1772eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ff/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ff/firefox-139.0b9.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "bdc3e84a777bba9e664f29cc3e109af18dc40253b0f9b4fba57765b604d4320f";
+      sha256 = "e081d3def5ef05f281cbcbc740477247a40b85d0a9ba84fa440765dbf68985fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/fi/firefox-139.0b9.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "db78665b7ea38f0f5f054949d3045239f6971b827e781bf740650596e7d91580";
+      sha256 = "ba5711cf7f1657ebf63eccbddec97387ac60c5392e189babc17386752d0a5e11";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/fr/firefox-139.0b9.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "9a41a156bf9c002d3f438c2895e3154ac483a67ebe6f80e0eee2b01b7fd7244e";
+      sha256 = "1886dae7883aa1cb197e0abfeffecd188e0286e1dcbf04b57b697e4ded399617";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/fur/firefox-139.0b9.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "56220f6634ea0e7e69a29f07736120b46f2c1911e82df13a842e4101ab0e7cf0";
+      sha256 = "e408738b7bf8dc5f2f0045a2823f4bc35ade65d0eec5b03487220e600aef2299";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fy-NL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/fy-NL/firefox-139.0b9.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "9334756030f7495ee55780665ba0f8587331364ef4221393106194b9ab938362";
+      sha256 = "eb4d129e6337546b8af87aff6ba8799a9ea5aad292e0f597b438d991c71d9ebb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ga-IE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ga-IE/firefox-139.0b9.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "96a68363e3a6593f3657da4d5add4af443b2db60d30efdcf23485244472e59eb";
+      sha256 = "1a99f6e9cad6ae5d0b4e6deeee76e6a65db5e473bf17750d9b9502f5c53b43b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gd/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/gd/firefox-139.0b9.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2a21ee5ca1acca96a81cbd1c0f6f0ce8c3a52ed88ba787d98d6059bbc097e22f";
+      sha256 = "86c18ec24f60a8343d1454f3c23d9bb9c76ebd4db8606f7eda1509ed339b1500";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/gl/firefox-139.0b9.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "bd8a9e005ba534d5ab7436f78b02cc84f380bd36a4044a797085f529b23466eb";
+      sha256 = "d59dd0e13067e998f5e56e5e28e5eccd9b63a51339e41a9e90b02b47d8972bb7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/gn/firefox-139.0b9.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "3d6aa78558ec05bfcab9872160c7ee06eda338aacdf78974022dab4fd047adaf";
+      sha256 = "9ce670a2ca0d4634a83a823dd3db8efb1f83b359c1e3aa561cbeb855dcde227e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gu-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/gu-IN/firefox-139.0b9.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "37a683ae33978ad481ef68f40b3c83f27a85b13aa1b55b905905c2d3ed1ceafb";
+      sha256 = "8687b810eae8661c8ecc8aca3c667430dd3d4c34f123b3eec5b81090d7b34918";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/he/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/he/firefox-139.0b9.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "1916e775b875911d87365bfdbbf549ae728ab674814ac222edb955853a224273";
+      sha256 = "94fa93221bae90ee68abab8f01122c61e1b54f3d0698bfcf460982482440dbb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hi-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/hi-IN/firefox-139.0b9.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "72a3b2387777f16e2b5f8232522d4080a276bf60b853a564f5e70c37d9fd2e3b";
+      sha256 = "bc5a7365ccd36c81e0a325b21bca6833dc10723335c2fea7bf60035fc9e63458";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/hr/firefox-139.0b9.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "4186afabb2595f717bda2555348fc082ea7167e6c83f03755d925ff2c084a31d";
+      sha256 = "c2e1ea1366cdf40918314d2d8fac0886b436484af5b2488a7b7c1c61324907e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/hsb/firefox-139.0b9.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6b12f273ce7cb98e913ebe1785e2271813c351fe85203a8e96558bee3d8b802b";
+      sha256 = "97bf266c310159262cfcb5ad58cc4b04f67f816f5f786cd5df3aaccff0bc5532";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/hu/firefox-139.0b9.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "f689294ca4226c898df2ebcbfcd60c4b9fb8bf529bc51df60b36896a77b3fb95";
+      sha256 = "093c46cddf7aee88b97b1f32b82829f05036eaceb666abf84997c98fc0cbf413";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hy-AM/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/hy-AM/firefox-139.0b9.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "c1483077c18d4527053c7d979f9d8abc10710580295056f6fc14ce0034dd0711";
+      sha256 = "b47682993d9ad738da2a8b30a8d1736fd293a96ad7f9474bec44b740866e0b59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ia/firefox-139.0b9.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "11829a72579c847b78622bedf1aa6e5af500bf2eebc04bd10cbf8c7ea7790b3f";
+      sha256 = "1eb3b5bd1311b7724c11ceb4844400f07724b0fba020997b01ec901aa110a216";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/id/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/id/firefox-139.0b9.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "2217188bd592ca5c4cc8e2749ea31015861287c59fc14780335e42275b559cae";
+      sha256 = "4a417c781558c9d3abaccdbcf16351a173544550fe696e67ca2b7c423b3d820d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/is/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/is/firefox-139.0b9.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1ffab05f776dc59104a34baa0164d6de764dc8882f4c7ab2748b59c492823c4d";
+      sha256 = "5dcbabddc5e7905260bb712acd4a705ea32f70da116580dde6f2d49972977b7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/it/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/it/firefox-139.0b9.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "3e9965d635107eaf2607463508d0da22906bcac4db645dd43708ad885c037ddb";
+      sha256 = "b6e4b4b41603ce26a68d9fcb6afa72b60687c851f223da1a9dee79c6094e4dc3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ja/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ja/firefox-139.0b9.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "1a971c6f7e1558b6a47ca204a398c5b1b9be44700726b8daf0c0298271b5562c";
+      sha256 = "7cad7418d44474f7ed83f1fe4891391b1231e4a5b78af6022c0de681dcb4c97b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ka/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ka/firefox-139.0b9.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "4b7c001d19b96b0254fc3d5760feb2f473014e5ba1602d320fe179d8c8e8e1f5";
+      sha256 = "16a65821abaddb4b88da76e179c02268197baec5061d6add9c58d19d9b0c4cbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kab/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/kab/firefox-139.0b9.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "4022280fc975d0fdccfe02ec6ee4159936a9de99ca2eed8d6c496f290a5a6d0a";
+      sha256 = "74528b6d2951857e25156aa4cf82f527d3c20d28af17110d75494bcdb4fb9f71";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/kk/firefox-139.0b9.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "06612dc7f831654df0ca60cf3c2ab4fd1e72b4cba16ec496f02528c0fd4fbfd8";
+      sha256 = "e9e94c4173ca58d650323a68307b91f5fe4cc22a3063a00dcc82ff100a54b501";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/km/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/km/firefox-139.0b9.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "91ed4c4b6b6f294b8d47b013393bfa48402a63c6f4d2f986947d51729c624f12";
+      sha256 = "5dfaaa836211e3788c65d93ceb1977ec5c046af627fb0044e23a3ead5b1c33eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/kn/firefox-139.0b9.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "a4a2e2c5759805640ae3080c563fd0e5ca127e8b5067351928b6dfd10e45a761";
+      sha256 = "eb873dd4bc0971c9993ec296974185fe9c8b762edcbb715dbbd7d2cef163ad4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ko/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ko/firefox-139.0b9.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "2e09752b2c02315d79185c86e546f66d314a5c158720e1163132c54934c06ebe";
+      sha256 = "c05860054e3c31ee558d3ed8189aa4178afc87f257badbd7d586110982a74645";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lij/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/lij/firefox-139.0b9.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ebf2dd79fc7c373feaf517f3030bddec4fb22879452cc3abd6192d5868333fc2";
+      sha256 = "1508c50b6c98aade2a660c3cd6171f6ae3b16bcf56a41ef6c3bc545c5bd5237c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lt/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/lt/firefox-139.0b9.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "71aa1ff3f47b4be838e06bdb791bfa70b638c09dbddae37128c90ff4b4974998";
+      sha256 = "6aeedbd45c1c1e96b4ac5328272c7b84ca4928467a4beb64b414f59292961882";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lv/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/lv/firefox-139.0b9.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "90b01be8cb7b2ebddbb2966a45f6ca29a86feb1285db233012ef85f301ca4fed";
+      sha256 = "90988cd5caf0556174ce9b01be183c83a676540f201e2ebb35f739251f286ebe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/mk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/mk/firefox-139.0b9.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "f6fa830344486666e46113e5515e1f24a0c32943db3c6bb7f02e5ad3db6de2d9";
+      sha256 = "5b195f70c78c31f12f4c1ab888f9d70a5c92c43a9cae14a8efbefa8d99c46a88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/mr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/mr/firefox-139.0b9.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "2c58107d0ab0cd7c5fa0a4030e047c892808c9d6de05123cd0337ce36e54360d";
+      sha256 = "a1a3972951fe5cfc1134008b1b909870f97c0f9800d6502c9be887bcea5ec093";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ms/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ms/firefox-139.0b9.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "8afefb023e6bd415c29f075e484bd0783f5f05f10616d4f191cff8839ce372ba";
+      sha256 = "bc1bed98182e82534d138f7040afbcbaea026d42898983da973109c13f99c603";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/my/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/my/firefox-139.0b9.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a713b3d904d5590488141f331d89560b0fe3c163287861b6c709133521aeda99";
+      sha256 = "0b8785c5c9b4aa387fc31fed5475a1c837585103f8a87f00042286cf44e9a609";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nb-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/nb-NO/firefox-139.0b9.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "40e037728d2697304965ff04db4e8d8206335a7e52866954241766182d9f150e";
+      sha256 = "085e3f364c5d420b82e7590166dae3ce2acfd0eda19d68945bd9feca5f8e337f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ne-NP/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ne-NP/firefox-139.0b9.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "32e752b56699102d5d0e65a5fbb2644b7d95059f12c737944a56c9807fcb5d4b";
+      sha256 = "6d64a2ce0dce31102d40abbb561960f692fc2922c0d8ed1b66935d37284777e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/nl/firefox-139.0b9.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "086f26eb82543f2f536b3546782d9531b2367c090244bb3dd7d7b3766f5e3bdb";
+      sha256 = "0c37da19802491f8c8216c9dc2a3f08d603af2843af176834e49fd39421ada04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nn-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/nn-NO/firefox-139.0b9.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "8f7faf5cf79fece9aa05dead8931cc51829399c1e77d865fc7a2e90586ffa68d";
+      sha256 = "9d60ac994be3233edf6e5bc367cee11ced1846bc47a49397a8aca2bea8d90612";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/oc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/oc/firefox-139.0b9.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "7a6743d63d6ebd2c8019e5e4431d0251eb1764e5cb4c2bcd2da43489c304e0a0";
+      sha256 = "47bbdea8db1ec74a2704dc8f0315be2ae2b2f03cb3112243da40d1a5f2248e22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pa-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/pa-IN/firefox-139.0b9.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "25c72f3a21ca5c1e09b4d6c97fe8ccda39c107ee4ac23c447cd7097d0fdd8eef";
+      sha256 = "6b92b77c2297264aa1369b92dff7462e6adf5c015e72f779d6b513d674f1192b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/pl/firefox-139.0b9.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "f1adf8d5eedd479cc763fefd80306a4f400a0b8838b356d223aab85f305c0b51";
+      sha256 = "340c82bc41b5b738b34e183a50c4d14e78d8d82c20e83b0ac3c364056de61507";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pt-BR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/pt-BR/firefox-139.0b9.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "ca70a854d9930a008fba706f839840408dfd37b7805b1fc686786c7804906c1b";
+      sha256 = "d82c61faee8990b0488beb128afac0508d23b8094007d809779e338f7167a000";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pt-PT/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/pt-PT/firefox-139.0b9.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b81b41f9aca42e313941fe69c2a884118144640f5faa53fb16b21e0d19ffc640";
+      sha256 = "023b25d0a2b391e86cd04a31c838ac5446593191c8c607f61a276f29457d4a1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/rm/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/rm/firefox-139.0b9.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "68b07bd5a6f6adf58851980157e1a04f6a0a069d4418fbf74108eb7101e39905";
+      sha256 = "6b6954c0e0c795a7d327a952c3629a946ceebc228a24e3431981e3efa1e782d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ro/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ro/firefox-139.0b9.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "34962c09e2f96ff552733d3e70363989122e58657d85488d215b12aba6a478de";
+      sha256 = "9c602bed55c78a1a742e659214a765a99aa3dedb3efdca9e47c5e1013e71cead";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ru/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ru/firefox-139.0b9.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "631f44ac7908c217df544986041576f22afa37ada0b550ceb4f143b68f6f044d";
+      sha256 = "eefee549c75661fb409e7c3ae4c0f8a38f01af88f78c917b0c62bd0629d98d9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sat/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/sat/firefox-139.0b9.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "f55ed94a407e02de8f519e0db3731c778ae27f53dba62a4d27dea12ee5c69d67";
+      sha256 = "25d074f6cefe84f1532245f87d4d70cd080b6fb96178d0e9c5851755e75c656c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/sc/firefox-139.0b9.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "ecdeba036f6d3c69377b282fc11b16137ddcc97c55d49f12a6497b3ddd857758";
+      sha256 = "f2ddd4ded46eebbecf607ea12edf2adebc060c764350db5b325ef2d94d1d1fe8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sco/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/sco/firefox-139.0b9.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "a9c5742f64b9018906b5fabd9373e5fe8805a447a001acbc3106818f081ff09b";
+      sha256 = "86dd8ce930c128edb3515dbe78ef60f7363584a9d75f3f9fd4286b4185afd4f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/si/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/si/firefox-139.0b9.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "3621682261e1243d64012ae5ef4508458ef088a20c097f22d0d3889b2c0fad00";
+      sha256 = "6b607387f76eb431211c795003575eba4dd9833dadf44ab1644aebb84bb6cdc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/sk/firefox-139.0b9.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "15ee029ae13f93060ceb44bc032e90062fbeb4e7f1cddd4acbdd8c03187441b2";
+      sha256 = "3d2a473c8aee5e63e2aea5e89f7c7b904dc668c0495f73db861378e24269beb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/skr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/skr/firefox-139.0b9.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "c61dbb39288239c7620c87d799fd745f02f1e2e4320ce8f44f92aeff38e35204";
+      sha256 = "9a633655f74c0a3a20502ecca81ede1f1d3a7edf9d2b93afff6f0d50a656373a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/sl/firefox-139.0b9.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "701b3105c92bf18dc0baa508008c6a9208ba69a67babe16f7404dc50e5b5c822";
+      sha256 = "27ee04c1840c2d915da0eb9a7e75cf1299aeb15e03e1696fcc52508625ba14da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/son/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/son/firefox-139.0b9.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "a7b5fb0c9cf055db86b411d5b4d8fe7b154dd79da1e0d23f050bb890e111584a";
+      sha256 = "1453a4bbe2344b7ae14cc4f8ea974732d74b905dc4d42195e1c73e43ec19fb70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sq/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/sq/firefox-139.0b9.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e88c917629b50cc933daed3134bf61bb9a7021db66d5840c00e179afd22af58b";
+      sha256 = "794de955d560fcee8d3dde0373ecfda97534526f2576bd0c2d17f546c89162f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/sr/firefox-139.0b9.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "c06aa97b94fee81c474784e005ea0b87fb108dbc023697caa036e0c8b394e825";
+      sha256 = "e347303b71619a4de64e9523fb67b3f45b0d74da2acebb5cd977b527a54f0f9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sv-SE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/sv-SE/firefox-139.0b9.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "972103e2717945e1c7f53e6606bbc6b8939f9030a4bcb2d4fc718e230669eaff";
+      sha256 = "8f71b2fe43f1fe939e5ccc2b25d5df5556b1227f849c1b76a1436cf1ca441da1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/szl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/szl/firefox-139.0b9.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "04adc5b6186a5af52d0e49dfb798bfd7da80553cd284763b5affc471dd1e8328";
+      sha256 = "93b5d03e42326e3415a6ecf822612525f837ccfa65fe329d83903db7e442c821";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ta/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ta/firefox-139.0b9.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "44934dc8cc75f9e0d96812ad7f60de98b1fc7f2008926afa61a3ac81d3c43977";
+      sha256 = "0c512af7e76cd71cfcf64593494f16680bbabf41d37cb69be95fd11f24d50f4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/te/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/te/firefox-139.0b9.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "a65484fff230858c4f0ce1c8554928e469fe06c5c0eb941217ba770a15cf3762";
+      sha256 = "7ede50b651323028d001d1df4ea1ce0f04e128fdeea1541b8e1cf838e0f19808";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/tg/firefox-139.0b9.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "78ea45f86204077dafa932bc892159ae11bf1bf8f32a86b9bb79742944115250";
+      sha256 = "2e7e33906f9eb6f80f484264db62469426c1ca4872f8bf8e8a0ea53a8c91f206";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/th/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/th/firefox-139.0b9.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "937d5f0858d4701a739557a54df30dc20ed3dfa0c92d9c08909b64c57ee34dc9";
+      sha256 = "0a4df8c123f1aeaf3043a575ad3a06de40a162f615b7cde3fcc7512f490270a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/tl/firefox-139.0b9.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "977abd61324f94d41a030ed8affb6d7c99a9f44cd89df35ae5e075ff746e3b45";
+      sha256 = "93b2deeb772d8a0d17041fa33c1c20dcd924fb8935482da799a139aa8d85b8ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/tr/firefox-139.0b9.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "a9de20042a68a2afa8726b31da47e950a5fb1578a9f1c3855fe04700dd3461a5";
+      sha256 = "3111dd5ab1d1ac0cda68d6ab138bd8f1d1fd5b420d6fc77a80f93c57a220a690";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/trs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/trs/firefox-139.0b9.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "7de7776812f6188e1b88aad5293f1472975356c989bb6dd61b53d634c1595d9e";
+      sha256 = "63cf34b83def5ec3179228abf11ed3ba9b50ede9f55bd2d0e7b39d53277e4422";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/uk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/uk/firefox-139.0b9.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "ccc2e770e91aed87bf1690dd82e52107ef49efe2062cb08ac4a4e372b097770b";
+      sha256 = "fe9bb88d6bfc9e07c4eb4834ad4102e810d3d9aa4fb8a87eedae905d33d366e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/ur/firefox-139.0b9.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "1e61bbf085a439b6a51add991499e582a58f50453c2018d15548f0ce50f95191";
+      sha256 = "b1edca3522b490b32cbd4af1f7838985b0919360150ee7b944bc1cbb13092450";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/uz/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/uz/firefox-139.0b9.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "7b4120e694d31a901d7e9224ca42034db85f27f9062463f1fbe7aa8dd7afcfd6";
+      sha256 = "ab6b7ff0ed6f4c057d08566d5240743ae2a6083462bc9b34ccdf873b73bc6b31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/vi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/vi/firefox-139.0b9.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "9798b0741ff2e5eb5eadf5234d54fc5c2e473ef3d093079b7b6ac23518e06404";
+      sha256 = "b8fa615b6ed8a8947f7b6eaa172a9fd2f417174784965e8fd835d73ba66c674b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/xh/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/xh/firefox-139.0b9.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "17e717b6a62c34d7f0e74b9c6b4af4e04e0bb9e6e0624b5691f1762c8ac734ab";
+      sha256 = "e7377d1765d3d55db0f5a08d19fccd520384f3b4e36a2d987c1ce564785e9f9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/zh-CN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/zh-CN/firefox-139.0b9.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "a32bd1b70bfb1c5fdcf33d0c4413fc1f3d4c7c1b355e06c1e7fa571657078682";
+      sha256 = "ff890a879620ec0cc975fad34a692b79fdac10f66d2fb6d16af0efeddbcb34e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/zh-TW/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-i686/zh-TW/firefox-139.0b9.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0ee631ecf8b7de2ffcb9a77aba4e4dd20cb62f2a1aab53650c1c12b39c5b48a2";
+      sha256 = "d14f0ef84ce6453ebb7677754748b0c65d2df48e4c634f726c0d146bbe34568b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ach/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ach/firefox-139.0b9.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "d754b7c77338934ad9c988af0ca76c20b9d0eeb9f63beb9423d48902cf39579c";
+      sha256 = "719379ae45df07f96c1f1b112473910ab2738850bb60ad04862ebd93db71f1ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/af/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/af/firefox-139.0b9.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "9e3893fe70cff031562b1f9b6d1a8651a591d050a02733126d00d24c8d676bf2";
+      sha256 = "1524fb5e290d22dd298ed9d7e8b37cb807530cc17a62315b5a2985b0538c8747";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/an/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/an/firefox-139.0b9.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "01055cd10e6bb1e963a7b7366233faf8d2951318576a02a9f1e81aa7a1c4c50b";
+      sha256 = "7a53dc420ff9cbfaae04b8e0adbfc3e8d480f112e182517792b3e36ef767b70a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ar/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ar/firefox-139.0b9.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "d1cd5710aee5418d9c903f195d96f2fff01bee31875877e737399c9f4479e056";
+      sha256 = "b6827405dc3a0fa60e31700a2a929b3c9025f99f8bfa88c72d6b72d2fbbbb0de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ast/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ast/firefox-139.0b9.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "55834b6c054928aa733035366c5b45ad19503f03730001d70a41ba6510d5bd72";
+      sha256 = "86a79d3c55f7bd11346fc3ac62ae54d307c8c9398bcb714dbab2348a105b9c65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/az/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/az/firefox-139.0b9.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "41c91dba441d06e022af5e90d2d8e77e2051e09e1cb4cec1a5fcb4bbc93dc97d";
+      sha256 = "ce2380e71a7fbbc30153111b129b2f4279c0f2f9e8b6cf72e2f6075624dbba74";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/be/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/be/firefox-139.0b9.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "be5610c2f38693dd6a1f8c4949bb8df06e201f4e769b986df4b3e404d9a0e494";
+      sha256 = "be027cd7739ab32bb53703729f7c594bd5262f5688dc8b3e889ed3607a2ab6e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/bg/firefox-139.0b9.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "8bd908287a0c2871839dfc027e0e6279218addfdf0de06a62b4018097375e2cd";
+      sha256 = "802ae94ad4ada3b023600546291881ae9bb40f519c825dc8d92a01bf00565c65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/bn/firefox-139.0b9.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "f74f9db667a9774b4c3eae709facd5a33b432cbf18fb72365c57ce0ce9e8c1da";
+      sha256 = "b68b25e86f2297a59ab759aa466046551e197e68fb9e49fc7b7485d9a25ecdd6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/br/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/br/firefox-139.0b9.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "a00ab0024862e999d7d739722f441b2b63368ba227346fee3e9bc80c31807771";
+      sha256 = "c78a40eef69e23973d279338914b8c0326f634d81e7d7718311c93665309ac9b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/bs/firefox-139.0b9.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "39b8da8c52d4fa01498d9684e0f80d2431ac029e72ca39ef431533333b4318a0";
+      sha256 = "fdc282d70030f38d2d88112e935fcfb937254813b0c1d34b5340a90a12ba4fdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ca-valencia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ca-valencia/firefox-139.0b9.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "de6ec7c3bfffbfb4f0783ab91c708449f0f90dc21d412220044715e56f209469";
+      sha256 = "a44a98bd4402241668d0be614483f7c252f7af2848f956bc216f9b0fe813e279";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ca/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ca/firefox-139.0b9.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "43a84887bc56e8e775a1fc77238a9a5b311a3922b342c0b8937a10864a58e1df";
+      sha256 = "e13f217998020a0aa432b4fe29a5c53f8edc4cc1b875eba371568d67869eda90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cak/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/cak/firefox-139.0b9.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "b781db306b99c87420a371d5504505613258001326341e12d53cad1c6d22eef9";
+      sha256 = "d784b27fb6132bae37d8a0ba4046958e4dc24eedeacce56ea0ddffbb391f804d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/cs/firefox-139.0b9.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "a0e7e2d60296d59eb438d67e9e6f7e7397cec1ced5b8eda1210e244fa10a0205";
+      sha256 = "27b728facc18b4a16a31f64c8c36526bde7c040a969913b0ed3718e6d7fbe88b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cy/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/cy/firefox-139.0b9.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "c985bf38fcb61a264e3e7cefe00ba90bdb935009546533bf018d4bd173b88c60";
+      sha256 = "c5051b70c047610421f6e86caca0abd1474d87ff75e47e738a254a559d35c126";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/da/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/da/firefox-139.0b9.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "31b86f8656a3c5a92439457714d2215481e175718dad2e71a0bd12cb9d8d53ab";
+      sha256 = "710e122577462dd9eed77f6273cd559d1ac62be4603c0d5ba424550cd69f1d39";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/de/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/de/firefox-139.0b9.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "2931c7cdfbb9113176130df3551731c1313c06168257a1e1a393a4d8c71fc648";
+      sha256 = "d489c6e6c9d48fa8dbd0039330b8e9a5478815bc2b949ec9054914034a75630a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/dsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/dsb/firefox-139.0b9.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "e4970af22566a2c423138dfc68a7d58b58e7d3284e88f4c7f3e9d00940739cf5";
+      sha256 = "a628592c0034702783b96c3e2b435fcaae8cedec391f709fc973fe44c7b26d66";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/el/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/el/firefox-139.0b9.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "b12bf7bbb352c7b34d9bfb11478a0ae7717325f4807c2baef04aa4f250400a90";
+      sha256 = "3d9b48d179bed76ea1d5b85ba2d997f9b6364ebe750d2ec75b1c1edb620d1c08";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-CA/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/en-CA/firefox-139.0b9.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "09e94e0803a321b313a740036171cb59e049a826e737a4151713f072c797953d";
+      sha256 = "b06d8f9db2e98013bca7e5034a80ef4d6555eba9e9529256067ce13b3f9a701c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-GB/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/en-GB/firefox-139.0b9.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "cf6922dd5832202593dab94022f82e91af46685f8c16cdf92ee6fd2665ac225c";
+      sha256 = "503cc70ee0fe2f505b3ac6b4c6e7cd4d5ad4306d0ed78213c448323bedc2d117";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-US/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/en-US/firefox-139.0b9.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "4edba8a869dfe9c906649b5e7989748490665e99599b44c653c2fbe896f268e5";
+      sha256 = "92b7f9581d5fbb822f602281c283078a141a4e318d85f65b6d0179b03174d28a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/eo/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/eo/firefox-139.0b9.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "8ce7a3c2d44ec47d0c76a896005cc485a5e325f5991a50833e244cf69b8a7645";
+      sha256 = "0dd7a31052314e4c0bf6f6968d7417959ca717c77241e62d7a2524b016b4778e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-AR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/es-AR/firefox-139.0b9.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "d1c49d9227b3d9e27e73f9788171c718c73829c077040520b05dc9b9a02cc839";
+      sha256 = "a7ae4dafc3fbbb851d22ec3bc0d178a754581427b6e63684f96a545b3a7ea2bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-CL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/es-CL/firefox-139.0b9.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "79c5b47dc1962faec8ef4db9860698a160b2e724145dbc3520a3b179073d2aaf";
+      sha256 = "ce91905fbce7fe97f9446a5f15bfdd33c10a9ceed5461bf4fc70f3f341e741fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-ES/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/es-ES/firefox-139.0b9.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "c3ea8d8ca383dc7271537b5fb888ea0c155c94b0f1a7988a69359d4930b1624c";
+      sha256 = "7564ac3919f41c91103b86f9bab4f776bfaf0b8a59b502d2cc225d7a01b6e779";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-MX/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/es-MX/firefox-139.0b9.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "fe673d9624ff97fafb5e41d4bbcb0142d24051201fcdd58ddf8863b0a169010c";
+      sha256 = "3b5be9006791f8e83c77361564338a094f9aa0922cd8e3e77521ad2c304cbdb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/et/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/et/firefox-139.0b9.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "721727d911c456833e9207f35b5fa574561789eb9d5aef2cf70c07a41996604f";
+      sha256 = "f59dc3304c057d5373f56af2bd9bdfbfde29ad1debc2958529925c1c16d3ef53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/eu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/eu/firefox-139.0b9.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "c1d51c11fe6eb6b74a1170e93ceb910aa01b227ff67181a436abd9a272f4006a";
+      sha256 = "25e106252507676605f3ccbac0bef911ca347c718e8fcbbe483146f529134356";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fa/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/fa/firefox-139.0b9.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "d48577e912bc8d9302164ce233c02bb0d1a802bbf6923d2f6e3e40466753e7ef";
+      sha256 = "44ac20982356c0008d9d402844301b8038adeae728b524c76753fc13dac13688";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ff/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ff/firefox-139.0b9.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "6397792fe1f9b6cf9e074f6dbdc620d2bb9e5a81cd9203a6b9e19d8ebe4af951";
+      sha256 = "6ad27b4b63dd3d5e1d5ec2bfa399cc56d75b3fe0493768884649d81765c35d1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/fi/firefox-139.0b9.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "8f5c2ca086de1cda97c4383b0032cbe134a4af7231def94e19abdcf794d3a858";
+      sha256 = "46a21ea8a6566d42d912281963f4da0c0ced0a70e5c9990143e6f140afb6f6ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/fr/firefox-139.0b9.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "cea552b5a870c9a0842dfc56bde4d91927fbc40cef6a1f0e36d0399b65ceac7a";
+      sha256 = "85729172a2892e57bced85ce70eb1aad3eef1c74819a3c6cad4ecfd71d9559a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/fur/firefox-139.0b9.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "baa9819189ba1ff16efeeb80052f6d0afc2306a09757630e978c4a92a74147d6";
+      sha256 = "5a6a7b1b63bd005925bd96b1dc9202cb20f1b61c287d88c512b13c4135040dcd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fy-NL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/fy-NL/firefox-139.0b9.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "c1b1b141ced5a635383e2e0066f36c56b852e0e44842e86b684d6ceb8209aa4a";
+      sha256 = "5f3000d88b8b697a9ac88ba9e20f905a4e193056a1566f9f1aad55a9ee389ec6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ga-IE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ga-IE/firefox-139.0b9.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "6a9348174c586c70f55d77ac9076c203287590eed6254b3d1eeed9cc8424b076";
+      sha256 = "c26c5f8aeef3992f859189b3de5e99460f1c28d9f9e4bc7224e5caa1abe3ed92";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gd/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/gd/firefox-139.0b9.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "c6f367eced3add25b7a51b8eb1d55b42d7cd5c674cc934c33fa9de86d6ef5c81";
+      sha256 = "129478b5a9cc1402bdf8471ece86f96f5ab70cff0693d7eae87e030b93ddf831";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/gl/firefox-139.0b9.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "30fcda0e983a655e8f0a87f40bf1f7e877569808b4b0e6710e58d446ec3913fe";
+      sha256 = "490d52542655458b2c87c2c61c203a618ed1f218adcb4aaaa75b23e8a9ba5cb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/gn/firefox-139.0b9.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "9c458bf9d63fec82a51b92391bc7d7b3030cce9e6228f14d5d5cde80c577349b";
+      sha256 = "1d651f3b15ce50db09d6adfdc6ebfa6b91933886facf25f2a6fac4c12ce5f39d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gu-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/gu-IN/firefox-139.0b9.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "92e5e135ac587dd6b7bea7a4df4803eaabf509a55b98ec2a127af3293a10c048";
+      sha256 = "beb312e51d5cc968060427898ad184ffa8c22d515846c22bf560e19fb52f518e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/he/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/he/firefox-139.0b9.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "ec64a5e068e2223c95ac1c90531ef9d857fa72f03a5b4b200242029b661344e3";
+      sha256 = "00e55f0158b605150587fd883e3038c37cf44016e9cf4a9806618657b99e3cf0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hi-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/hi-IN/firefox-139.0b9.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "434c8bfea7979d256f40f3f3766c1230b8a403678893ad988b54c19188ca82be";
+      sha256 = "b3ab07099b27ccfb4780a9d66a794ea01069cf59ed42788570024e4a09e4c837";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/hr/firefox-139.0b9.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "59d09b703c2ed3dc3e289310503e505507b345b1c5b2133da6ce59df9f952b06";
+      sha256 = "60ce5b0d2d1dbcaf9cb8e115fdd7d2920a4d6995ca66e71ec328179c4661a9dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/hsb/firefox-139.0b9.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "55ac7f1a2a6b00118aae7d3acab31a563cf05a23e4f35389795cdd7afd613b6c";
+      sha256 = "c5e1ffac71bb7bf160fed384c95fc8d43a839ce0e14189b9a0a5af837eb400e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/hu/firefox-139.0b9.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "75265bbd21c0c783c373f2ff57dfaebedb3baa8e8f635adb764d00ae340df15b";
+      sha256 = "42422fe36cac5c93a71a1dc98bd2960ddbc76682332df9ca49bfe1d45751a1af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hy-AM/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/hy-AM/firefox-139.0b9.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "825bb3ab555455af7204fc3081d4e881bfaad7272b97c7a52d574711ac6fce43";
+      sha256 = "16374424b4ec66cd40eb0ea68e9ef9e3e03d10b888fa1d1666c6637b80ec832d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ia/firefox-139.0b9.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "07b43f7d3dbf12f9d8a9a4b2d393b0cc9fe3ce0d333431b9d8c694abf2948607";
+      sha256 = "effad371a452a724917c4ec608e0d24dee18801555dadd9e8883db86e6fc4a5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/id/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/id/firefox-139.0b9.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "bf34449bee65bd3bf8ca7568683c111e19af99323970f6070bac75ae5d8df14e";
+      sha256 = "54c1367d5556ca2a35045d70cbaf2d0c0c3cb2433d3c6cce3c4748f886dfdac3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/is/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/is/firefox-139.0b9.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "4b825583d13bf6f4b75cba352d1bf0eba3ab97c92f62da2c16aae79174f6f185";
+      sha256 = "064116cc395c8af427dc533409f6064f3493dd910f2fd1c55e4c122e04ca7b7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/it/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/it/firefox-139.0b9.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "2dff0bac0c85f40cb21103c48e0489573cd12a21078b8edc5af5cfd6c1c5be9f";
+      sha256 = "0a018c7ea1a7922520d5de29b5d162418ec10fa8518f23480d8af33d67d3829a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ja/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ja/firefox-139.0b9.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "7012be903c3b748178a4bdd87849251f01bc341bb1d418e43c15adb8a5236697";
+      sha256 = "3e2801843052d7c6af8032eeff15e1a1da93d2180c16ac102d5b3d075c4dd99f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ka/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ka/firefox-139.0b9.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "bb7b562895a31c2985e5b57dcd697ea65e0627c3ca92a7a1031de12d88f2d112";
+      sha256 = "0ed1b75564e054a3213a42f41a19b073717fa34c8ef9afce1a364e8e5fd03d3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kab/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/kab/firefox-139.0b9.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "534d152fd21b7206fa1d781167d2d39114224e694cd6e0ce0df0c51f632be8d9";
+      sha256 = "7e887a3bf62d90d714462753446e595d5683bed7f744ac8abfe409f8c83e8dbe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/kk/firefox-139.0b9.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "c914ef270be6d93b244e77eae73f0b8dc81ccae98d1e5648c9f36df3534b5b83";
+      sha256 = "473bc0da20cd8e8b2959c3ad3f94fc94230383b488abff2f4c13db0b4017390c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/km/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/km/firefox-139.0b9.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "4c4b716afcad883b4c3d4ef98f256fd3a7383c6f6f9daf004ed57dc66c9cc1d3";
+      sha256 = "e468ae1eb9d2117ec2d820327dd2d63d2999cd1eb1206bba9af1b71106a11259";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/kn/firefox-139.0b9.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "bf36d322be0eb143d16b3266f468218e4db77edf5752d92d0527737d5699bead";
+      sha256 = "ec881ac15c2c8d278d9eb57dc706ac7bd418e8c736d00d6054e284a70f57c249";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ko/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ko/firefox-139.0b9.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "d306fe18f0afb856b5eca468cadf0661a0f296900aa213693f9dfce7ce01e693";
+      sha256 = "11298b330a43f7173b6d04882a553d346df96faf25d7e76a352647cf20772fe3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lij/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/lij/firefox-139.0b9.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "4134c5b66369b7e7baaf9ed18e686aec1f6fba8dabfcea557c8801e271099604";
+      sha256 = "042a6e79aaa8691ba462a5a7b02e0d000021e6ac7d4984e94cbe66f4fc65c826";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lt/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/lt/firefox-139.0b9.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "d02e63dc5244755d70d7c6adf8809e809ad5624b5b2cf7db5d549fe873c8e030";
+      sha256 = "21508347cd74c3d2ae77f8f1a870e522bd39c52e4f5eef1c792a9bca3ebdaf62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lv/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/lv/firefox-139.0b9.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "49906a5a4bf59e755de8002436a431adf3a26ae70865a5c14cf2b1148d67be46";
+      sha256 = "0cc27dab14bd3c8754cedd763ecf03dfea747ba3115d156f567724fbc02b0802";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/mk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/mk/firefox-139.0b9.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "d0baccadc36ae94f9038e2c22b0a90d2084c512b71471af4e8f744548c92a79d";
+      sha256 = "beb66bc899ed2119a6ce090a0e2df2b52090b2a88838e209b99b45909272af98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/mr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/mr/firefox-139.0b9.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "f8015e7594ec2b02914884f5be2d50f2cf0236bbe496fec731592ac81eeeb9a9";
+      sha256 = "0288a4336afa08ec36ea557f6b0bf3308c5e11b4d791b4f51b06cf4432b59177";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ms/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ms/firefox-139.0b9.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "fd820b03aebcfda8057f630f881c49d443f14661a6bf55ddd4b9a26b4cdb9308";
+      sha256 = "8656eef27fe54a422e8b40ee3c7c97b08fa64acbc96931e12d650b4ad6808a0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/my/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/my/firefox-139.0b9.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "f2286cf08af4be1daf434cfe972049f40ed68b1d59a0073c0f022c9f02dee1ca";
+      sha256 = "d7a9cd64e9a82009f64213d997ef9b846d7a06c804d9977c38eb81560e96a29e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nb-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/nb-NO/firefox-139.0b9.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "668569c1fccef37f1398b1ecd9e9974081e6c055edd0577bc464fde69e5e7ada";
+      sha256 = "28d81da895835670d6ea080a9a43c6f73fcd049417ae685aee49ec4455656fb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ne-NP/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ne-NP/firefox-139.0b9.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "6ce7d8b5d852ca4abd94fd8505e52a2482b5b1ba207d48fd02dce6f585ef0fd6";
+      sha256 = "b7cd7722872517aaafad8793babb4ccc067384a674d99cf451e617897f0702a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/nl/firefox-139.0b9.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "b57bac3e8a06c66f93f7c98a77accfe6a21661d6bdfc148cb2d8f3ce83bdbb80";
+      sha256 = "2da69ba4d98dd20d8fbcdff32fbb57e4f076b72cd427292b8cb2155463904a61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nn-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/nn-NO/firefox-139.0b9.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "01ee287813e78d073926bbeaab9cafae2a11e9239f8da1db3c45b5d6168a5f8b";
+      sha256 = "d410a100e8175d7f95b6ed2fd3eb0523150150693aaffe7d4c1ee008b7451f01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/oc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/oc/firefox-139.0b9.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "7af2c95d9d6c9241fb98dc21a4c542f6e038098eca89a72aad53d03d834cf8d7";
+      sha256 = "ac2275e1d3448e233985deb548f27dc92df8f7c820827f8f9d4c6cc3ca34c11d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pa-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/pa-IN/firefox-139.0b9.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "c109cbbfc292aa3ad04656c79ee5fcd0b839032fc156499dadb60aed37d93c13";
+      sha256 = "b28ca497e960c895e8eb5384fe858532d76d32bfab1bee634c8087231acb8253";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/pl/firefox-139.0b9.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "ad2ee57783e372d968b9a76b4b0c5f4cf039e53f6ab8ab5169d556bc9733b04e";
+      sha256 = "60f18f2547695985bd206b607bdb8e86588aa1af38e1b9a6ce6e82eb1820ebf8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pt-BR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/pt-BR/firefox-139.0b9.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "c4b649b39622a0cdd8afaffdf531681659ae6c092221786df71ada4f8e5dc81f";
+      sha256 = "66305bae1d14c5fb34d01854458459ea7932ca95ef1277feaf4686fdd97ec3df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pt-PT/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/pt-PT/firefox-139.0b9.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "d84337d337c87390e8ac98f43d8b1199d3b8bf640d55ddd2eda86f3c6c2f9084";
+      sha256 = "33edd1294da77332b94bc10dec8a7a7e4ace90e0eee2b1d6945b321d1db7a5f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/rm/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/rm/firefox-139.0b9.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "a8d422e2ebeb5c76a27e3df7dc8ca4052be628022d3d7df38255aae4b14089d7";
+      sha256 = "65e03fd57348fec51eb205718dc4279989fdeee37749bb420c5c34ede85ea6f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ro/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ro/firefox-139.0b9.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "4b222f477c9291a0ed28dd51f57588914e26efd69c0a249cd2f4a3251ef2b3cf";
+      sha256 = "cfe86f42624ef0bb3b3192d6fc9c25da749c6af62ced0f5db7fb204702be5f76";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ru/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ru/firefox-139.0b9.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "caa6d2698ce1e5508f5fad2bf90563b10a8f9961042c089f2f1a5e4d61822246";
+      sha256 = "df4a35db001517f197166feed6ac4c3f9a1419e4e4585c92247613786cc1d8da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sat/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/sat/firefox-139.0b9.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "3f17440f5a67e6ac0f7f0a67eea72a4beae7c20627ba97c786f4740563adb4ff";
+      sha256 = "7af4144c34202819a3a077ae6bc814ddbbdbad4d9ebee0966b983f87f463df02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/sc/firefox-139.0b9.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "3eb57781a60c295918d7f065edc1429bcd2685f01398c3176fbfd097bf88e059";
+      sha256 = "e3302f76619dc93e74a3308f88a74c7effca563952f677ee8703258fe7fe2cec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sco/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/sco/firefox-139.0b9.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "a6c32b5c1d63728429ada5211857a49c056ce93b23d428f26a8d00efbb143e91";
+      sha256 = "2fba0653a263c0fd8fad0c694edb3e2e5c3f538e5db9c9e104e47211c34f16b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/si/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/si/firefox-139.0b9.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "dc50c48c50cd0fa013b0754dfcecd15015392d23e0247f33b3ad15cd7aa309a6";
+      sha256 = "84379df4b151499d08f86ae7574102e17e06a7e68a15f9ef7c6fd8161f7cb080";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/sk/firefox-139.0b9.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "35906da5afd4bf8a52ddbd2ddeeb9ce01b40d5e93968e4e1f66541d0dcfb1b88";
+      sha256 = "54601b755ce4e14d57a9661ff10150894b1f4c33a51c6b2bf1565de1057f57a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/skr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/skr/firefox-139.0b9.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "0af03523f3a0987e32c36d182d51c318f62efba1f614d2864e571837ca8eab13";
+      sha256 = "0c90349083bf177a2ce715b1b160b040ac0b5c83096e49c06c4993c513643b2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/sl/firefox-139.0b9.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "d7b9c75397dddb544fc4287e43f255929f04ba3e5cbd9c8c737f1f47d4d8353f";
+      sha256 = "8f856b328e11337cb114ac98a22579e928004e2cad6bad64024a47fcb76adbca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/son/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/son/firefox-139.0b9.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "7ab390ad40c8c7db2029a5ff103e523f2dce8691926e4f3f140c911a862937c3";
+      sha256 = "df741c74fcb62a8c700b399080109d26d7e3b4779fbf366e89fdb51e8c76f511";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sq/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/sq/firefox-139.0b9.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "3fa9746d65d15ebed2d0bef82e16c26c25fe40671ea71651c3ea55f23769a5d1";
+      sha256 = "3e7508f29ed5e7bb8ec192ca5ac049ad839d8c1c40e79a3de42deda7e8cc320b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/sr/firefox-139.0b9.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "954194b63497a3c490f819188c7353139af87a0c6ab2a0b87ce5db1a942d8b68";
+      sha256 = "cdf99cb70bd578d6adb7cbad0d1920fcbbcfb22275d4b5886581c21b3b150f50";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sv-SE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/sv-SE/firefox-139.0b9.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "ef30b8f7ba31857b871c4e41d139eee7ac6bfc759a461c0addec73b1e1559695";
+      sha256 = "d0c3033edf7dd5911137228804151ed37be3a7e7ff3dd925323062b15074f290";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/szl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/szl/firefox-139.0b9.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "ba038643ce7af49c6e16e6eece4a56b4bbe85a9a14639d534b9cf64884046154";
+      sha256 = "8b70b8a282af6319853d042ca9322b831b7c4852bbad90ab74c7b056d31670d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ta/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ta/firefox-139.0b9.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "b12d92276744680c57aeabdbd714bf5d3f2ea09030858d6d38d4aae80099989c";
+      sha256 = "2b38b087fdaaa8a7daa72e34ca47d13d396081d7e145f26bd79d56173d51902c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/te/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/te/firefox-139.0b9.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "eb5b186241b7fde86cc0f57fbe3712ef1d3831700d741c1955fd89efe84aed96";
+      sha256 = "012bc501cd08bb0c1dd1e6fc7acadec73224775a97cf3d653120fa744f16fe46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/tg/firefox-139.0b9.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "b3f5feef512525cc09d11935cc1fb0b7086756158bd6cc6dffcd22cf3ec9497f";
+      sha256 = "8e1580e4e8eb1a657495759ad1201129f00d954d4a2e47792f6c7897477be1a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/th/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/th/firefox-139.0b9.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "2d187742b7e8a60f0a427b60f41f1d684d19360e562d2fc9d0f968cce4581b21";
+      sha256 = "98d992b718945a86dec2b4586caf00cd58c1179ca89bd7917004fffa3fb4031a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/tl/firefox-139.0b9.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "44c490eccdae6a1c0fd08d7c3b589de398498f4ff705292ff6f72366f27dd768";
+      sha256 = "64f1c2a70b36ad74e375a58f09b9a0ebf4e3c9e5230524354fbd4fc36c3f7f20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/tr/firefox-139.0b9.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "b784b58007959048c3067a041950813ec8be9ae30a73dc24bd0b5f1b3d702460";
+      sha256 = "09ce4bb9389d67633f6a1201e3bec43433622ca53da132d62bbe95f6fd71ca2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/trs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/trs/firefox-139.0b9.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "611991646e94273c6b142f2af670755fe18878f2a5c61a2e9f13a0fea99ce775";
+      sha256 = "5ea17137ec45da18832f76a07b68f5e0bfa890ce1adad46fb66ca2497a5bc6a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/uk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/uk/firefox-139.0b9.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "90c25ceb18b53030e881e0f44b7d3e23c5b6c9cd380babfdcad957783d0e0c4e";
+      sha256 = "91694083963797aac2be2d36c63f5120bca36c6454923a43f081786be42286e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/ur/firefox-139.0b9.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "9be466dcebfd73ff9b5a4b0982a9421034654310ccf077fb812d652b67d6d284";
+      sha256 = "0103a487bacc6aa45e28783efc197401bf8d737adbcd8bdbf8c4bd23ad197cfa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/uz/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/uz/firefox-139.0b9.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "9d58ea902acb5ad35b19cd87f5423b21fb7772512156198d2fd05f84c08a778f";
+      sha256 = "030c44732df6bf84f7f8869d3111bd043f7dd2f60fde0bbd8dc1ae6c2cc84ffa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/vi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/vi/firefox-139.0b9.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "2cfc4c3f5d129a3041096dde196f3e887498a886dac1ab6845fb54b7eeae16d2";
+      sha256 = "f47d68cb698eba8c43b896e778d4ffdd2e17988faafd401268bbec5b295512db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/xh/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/xh/firefox-139.0b9.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "4eab0c87e4bd3f54d1e77b83a8c82b084c23beb0d0882d542e04bb19e798c98a";
+      sha256 = "19d4737261b5911211c1d24ba3dd65cbede6f4097ee7edd034c28a7a6cf8c01c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/zh-CN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/zh-CN/firefox-139.0b9.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "e6094469887c77d367ca255d0b461d47f9a352b12602042caaf668846b5f295a";
+      sha256 = "16846f1c18b350b1356600b9e373338e5691c4a20c0d0088fa3d78bb10d185ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/zh-TW/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/linux-aarch64/zh-TW/firefox-139.0b9.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "4b5490a70185a206ad337404876cf943bd49681065d87e302a2856d2543b0329";
+      sha256 = "f9714bdf6f0b715ad188686216030d7767d7d8ae06f881fae80dd52ea16969e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ach/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ach/Firefox%20139.0b9.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "4a42735641e22b977ec4ac31451ac8e0a17faf7e409a33f0d35a33efe5e033c0";
+      sha256 = "7f572d1795dc9a4aa7413389627056b3a777120c31400a5719ff0048e1aa97f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/af/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/af/Firefox%20139.0b9.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "15754862b1b05ac166ae8f157655477aaf008fb7dff4ecb8847bda815dfb74fd";
+      sha256 = "ee513a8fae96deddae4cc1ad45e5778f9da05907d0b413bdeefd06e961483b5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/an/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/an/Firefox%20139.0b9.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "ae9f4fb8eeb5d868a89c2f602d036ce71c199489d704bfbb430ceea99d21ceb9";
+      sha256 = "c3bf0aedfb352a1ccc62b58863ab80fe1febf8ef64d381ec70c836aa96bfead1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ar/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ar/Firefox%20139.0b9.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "b5fa0c0e348e1aa81719979ed2348b36efb77e212e4806bb70131400ef3a3b1c";
+      sha256 = "0fb908308ce52137685c9ac0a0f2366eaa29aa5647017a7f7581a6463178efcb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ast/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ast/Firefox%20139.0b9.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "97c54f7224b0baf23d2f0c775de23aa3187f7f41de4e2d406634642967fbf797";
+      sha256 = "c16bb695936c0354fc944c2011ed8bff7893369ac35ce58b9e2454b3098da435";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/az/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/az/Firefox%20139.0b9.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "0166eb8d67ec5cef8efb3c0625e8a4d3b0dd23e1a697ad1b3193e3acf3515b82";
+      sha256 = "40211fd9a1f06b10bf7dcb67b5a2b46691c58ef2a8893ac1483e6c0904e4b5ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/be/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/be/Firefox%20139.0b9.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "995a25f2eb716ece9467a62673e1ad5938b3eca2bee1b8fc0392ecbf08d79c78";
+      sha256 = "4027839d085c513a6478b603e4e2f45502e81c3ea7ad394ab2cff366b1080943";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/bg/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/bg/Firefox%20139.0b9.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "58eebc470431b310c5012ee22e21051295742cb4cdcc991bfacec025f20f16a8";
+      sha256 = "8afcfc1570aba582aa93d1fef3776ac58e15cda64750818b91b5bf71e8b44cfe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/bn/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/bn/Firefox%20139.0b9.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "8c019e1b39c963a6c776bec5065440190afea8661a86e098d73a4139ede3438f";
+      sha256 = "d18e6c8994c25978eb2a3d6bbc7f80fb941e0e7abe218f34815a6c286b84febb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/br/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/br/Firefox%20139.0b9.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "c263c604507b44d9eceff1c6a4d88a5d03f6b72a437235902440811b5594fc4c";
+      sha256 = "1dcae52870b74b0daf2e62edb82718f1a5bca0df26722c55ac2fcd41c7f26b68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/bs/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/bs/Firefox%20139.0b9.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "709e3edf72a4927c929eb978611553f1c9c51f4d2b65ad8316ae08e7db5727da";
+      sha256 = "8b93d02a306e392882236f7e659693c6ac8026723174ca1e6f16bc86edc5401e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ca-valencia/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ca-valencia/Firefox%20139.0b9.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "fd21e0c49e8c89479e43a5e8e6eadcc565550ccedae11b48e534875c79858c40";
+      sha256 = "adb61366b7e1f87acc80ab9c3a0509b00551647fe487c1d55ed73241796913f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ca/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ca/Firefox%20139.0b9.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "49945e34d0031cd6d734904449c0cc45bb43a064674ae30d249a69202aa2ffc7";
+      sha256 = "ff921251160ac5e09df2e6382822c747a858b9dc5b39ef5ac310a4356a13e74c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/cak/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/cak/Firefox%20139.0b9.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "9716963c81d5bf84ccc5046a1cc61a3bc4e593f116b390e761f2dba1edf7d1f9";
+      sha256 = "83ddabfbfebd16281d8e638c6bc26e42d780aa393270237f1ea73bf2cf8e4de1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/cs/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/cs/Firefox%20139.0b9.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "239a8caba9b1a23b7c98ab9f507d8718594f353dd27c079efeb8b42bd77ae7ea";
+      sha256 = "c266900a458c01b545169363c3317a778db07eff3ed5133a4b06ca9b358f517a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/cy/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/cy/Firefox%20139.0b9.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "cecc8f11be8ccaa4b3d98120e86c347510b56a04c9812ba8e98852f331bfe6c5";
+      sha256 = "8f599ded7ca00bd6589148e73b01876b722a28ffbff01e93983c8c6787ec02ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/da/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/da/Firefox%20139.0b9.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "6edf58c11f2d4ab1ea575bc5b5fc32cf9cdafff197e17aa47450fc940a22ae15";
+      sha256 = "ca0e68654db6e3cb8629a785527c539b686ba520e2270a8009bd8c40351459c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/de/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/de/Firefox%20139.0b9.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "0e0d6110bb40aca8498523b49e48da8fc4e7ae198191aeab5b7f0e9e9baa11f2";
+      sha256 = "bc2587f6d88c710fb1351f58df82d75a1c52b1ce74f646941a0f755f98b93724";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/dsb/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/dsb/Firefox%20139.0b9.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "8713f01cea21be9d90e917809b963aacd05d8ca5fb8d311e46c06e693a40ded7";
+      sha256 = "ae76736b1ac1d8af9eb8aa3d26802f59a15fdf501ae15c4ab6c36e387ddfc7c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/el/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/el/Firefox%20139.0b9.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "75eb0726b6cbf7e2b5172a282b79069d1580cacfa0f9a1654853195d9976d84f";
+      sha256 = "3b5ee5816175227031cef15efcf884f38923f0e37ff57b45624695b1defeb96c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/en-CA/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/en-CA/Firefox%20139.0b9.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "1cf3f9e0bdd4941243f11a55c3fb4a24dac024a942ad2b89d568b784f174fb1b";
+      sha256 = "24f684f3d7d0d062a9f8686888e197f1782b70ed369a357ebb0603cfef229c54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/en-GB/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/en-GB/Firefox%20139.0b9.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "b29064c4277036ebca99ea3cbbebf7ef887247e97e34778180c3381da673aae2";
+      sha256 = "836e7ddfeb01b958c47b8b9bb88c3ac6d89473e675d60a7a2c9d8faea36a7efe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/en-US/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/en-US/Firefox%20139.0b9.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "c61d0fe161c6cb778a3e564f4cffa70cc7fb6bb5770586fa66c7db8ab9c31cf1";
+      sha256 = "599190ac643e7918219c3ed04cd1b191ec5492073794dabf22a73b29ae635807";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/eo/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/eo/Firefox%20139.0b9.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "fdf543162489d4165d8b39e01bad6d28addcad942d90c32aa2068e74558def80";
+      sha256 = "48188962b749c22c4868b65904454fbab6f075bc5b79d9b7a92019cbd63793fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/es-AR/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/es-AR/Firefox%20139.0b9.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "13641a204ea5fbce36d1c9661fc149081e90fcd03a2840300a288861bacd5925";
+      sha256 = "ee54e07579c27ec614751d4096365df237e2d225b221ed9be4b88bfe3e891d9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/es-CL/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/es-CL/Firefox%20139.0b9.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "1fb4f9f7f01c78188b038a1116b4e19607388947067dbcad3bde3daa115e5f68";
+      sha256 = "2495c64364082c13f0bd991ad62b64f64ab9d3f07b88c445a25e79b6f66c1d10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/es-ES/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/es-ES/Firefox%20139.0b9.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "13cc2d4179bc10b58253e8a88cabb8228f9fd14fb1e237f002c7220c29c790af";
+      sha256 = "7fb9a5f785766472417fa945f699ffa7553fcf7cf9d8ced8916c0479e02d7a93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/es-MX/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/es-MX/Firefox%20139.0b9.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "a78061c9a63720610f1a11990199299a66e6c3f805821df80fc994bcab01d2e1";
+      sha256 = "79c88a0ef6ab38671c5d25ae21e6977d3e4d1a2cb4380b85f1e2d8c4532526c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/et/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/et/Firefox%20139.0b9.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "3623ae5b628d82224b39e5506e5f1b604355e932d7a2e320795baeb72e892323";
+      sha256 = "3b57cf1fceb8b5fc4d48006b70cb2a0ca852105e01ca157bac1ea6b24e345d49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/eu/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/eu/Firefox%20139.0b9.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "ef038ab87151a9ec36b311ab73fab8d5444f8ac9317c94b8ade608a7387f83bb";
+      sha256 = "daa882f352232e32e6739129bc2e14c0ccaab0d87b50d2d098d3d8f456133bcd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fa/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/fa/Firefox%20139.0b9.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "84034c107634a08322974c899956ef02ec725970603d9f73d15833c508089984";
+      sha256 = "6661afb9044b11737a756dc1b274d25993d1113cd77c2e24b5b4cbd42a56a065";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ff/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ff/Firefox%20139.0b9.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "2874b586b9cc2f55fe12a1dda4de3f45f702966359f62276b6009c113193e87d";
+      sha256 = "092f1cfdb4f6ec164cec81d880d2074a304048648f4258c33449450ab67248d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fi/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/fi/Firefox%20139.0b9.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "dba286212463e1fcd3052dcaa8a66fa2d5a938052c74b655d634e700522041e3";
+      sha256 = "8e4b46300c0d2fc078ee4e810a04417439e3fe6796a0e1704cec285c9db5990a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/fr/Firefox%20139.0b9.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "d4ca7c3969f32f2af2f2ca4824d4439228a8e17386c9cf9fe849caba4c271280";
+      sha256 = "78daeb3bef7f4ee3d28e3fea0ad876c520e0fe5172cf8e1085f93b9d33198062";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fur/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/fur/Firefox%20139.0b9.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "4accfe0a3721b1ac5ffac33b586e778fe888210b92c4375c80aed95e3daa34db";
+      sha256 = "572d2766a810755fabee9bad9e69aabbee36c2aed0443399a537ac2500a290e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fy-NL/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/fy-NL/Firefox%20139.0b9.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "db6751ce87b9e801a1bb72a0f04c7f909fd6aab5c4cb5591b522e798355f9eba";
+      sha256 = "d2c79dc9949328156dfd902d43fd3e54fc198a0fea8ee0cfbe314ff31856cfbe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ga-IE/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ga-IE/Firefox%20139.0b9.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "257dc1d4b56b5e633bdba46ec71469b746f175ebab0463ca3792257e7c6efdf0";
+      sha256 = "90c2ed70b445d90309201a08b4802e71fed31731050ccf99a1083b4c4ed01a37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/gd/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/gd/Firefox%20139.0b9.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "e2f8d9c9c0a494239472b760687d1bdcaf018a9a3a87882541936ab3c628f974";
+      sha256 = "bd900e81aeae3342c588e9c5d94a02efa06338350df0085e2b3fc534ca67d6d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/gl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/gl/Firefox%20139.0b9.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "f735a8db8e58deb85c1b2455db1924f3375df450890bd1e0a94990e5744bc831";
+      sha256 = "df88ba75abac0c74d5b243630e408a64e03adfff05fd5abbee01ee7140c29b6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/gn/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/gn/Firefox%20139.0b9.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "4c859dcd1819e5c53a3adff48d958a8d301a37e72ed0de63abd71889aff02c0d";
+      sha256 = "dd813acf1d46ec403e23d19f5aad7bb930c9934510c710e841c169b614980b9b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/gu-IN/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/gu-IN/Firefox%20139.0b9.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "ba0941058959c7cfc06cbe6cab3245499850369f7f31d8428cc1cdb88f1ff673";
+      sha256 = "9d675fc02fdb217673b6781040a623af63c1eea46b29568f41f71c64d684fde5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/he/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/he/Firefox%20139.0b9.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "75e398253677225953a07d1e9e144adc4086968899554b7d57031cc8f5b1b638";
+      sha256 = "354a4e9696c37fd2fbed80d0f5734e6559775bd256643b8b10f594419763bc1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hi-IN/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/hi-IN/Firefox%20139.0b9.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "66872abb8f5eeacdbe8bd6f5c96c9566e72ebfa57b897dc64c46df2ab0fdfc84";
+      sha256 = "70d740bdec6ebff303691f8ebf992a9a1097c234da4a5d55fe033c53e44cd905";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/hr/Firefox%20139.0b9.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "d8d8e4aea4c86635ee536fa929e12eece775e2abab09956244776a9de308b4bc";
+      sha256 = "40b1951582877be963257de44cae0e1c2fae0d7cc27a561d434fe3bea4bc2f04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hsb/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/hsb/Firefox%20139.0b9.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "d5c31f2a62960141813d8f0d9120fd9af14a114e418b2f71c4b61760abb0addd";
+      sha256 = "4398de48ebcb52247c82fd9fc95ac3bde02dff0f81df93ad88dfeaf25b0349e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hu/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/hu/Firefox%20139.0b9.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "aec856b42ff661f07626fe6e7c49fbc09eb09b7e3732e5a4ffd7e2152ba18fdc";
+      sha256 = "4f406bb24677ea2e3720af53772e25a6bae46186935a42f701ac6e776c5e715a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hy-AM/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/hy-AM/Firefox%20139.0b9.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "3757bad209cde3d24c008756be1e1ba03bc86a6567c5f919221b75ca113c70c5";
+      sha256 = "466df9648f336c74bba3b288aa0608713b3e857611589d1cb185a358e402c5b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ia/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ia/Firefox%20139.0b9.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "669117617c58b1048772c519dd9796e25636703d6f1ce29ca4b41a25c9734140";
+      sha256 = "b7f827ffb60fc11e70e78191b108879143a6ca174fb3916a2c260d0e6417132b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/id/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/id/Firefox%20139.0b9.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "4e7a95a805b4a870201728c6fe267a69751b8d7135210133718b48771b1efd81";
+      sha256 = "35c6016a32b5f062afe34e96f514ba189a9f95c3bd55c68b157858dd89275381";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/is/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/is/Firefox%20139.0b9.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "1ab46c1a5858000683c0004dc3fdb59d2b2ded4e78b24b1d9ec0daf2945db6e3";
+      sha256 = "1ef506f5ba573832f5868b3d9cb7b37cdcc0e7bfa4ecb6df5c51c01f659583d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/it/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/it/Firefox%20139.0b9.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "e7cc58da37fa5dc49d32b85c226e25214546dab7798458f18db31c3a28420691";
+      sha256 = "388d6996b9c227ddf58f95da9781548652ddcaca2b217659288a20ed3b8da0d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ja-JP-mac/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ja-JP-mac/Firefox%20139.0b9.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "26ee160188fcb0d59bb88e0ae10856b556a01a16254f59b122490714ac3a8cef";
+      sha256 = "daf6132af9e1f18c05b8f8d16819b2bf131eac8938431ad91522c60f6eb10eac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ka/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ka/Firefox%20139.0b9.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "4ceb3e350415425f05ce77abdc582d4f5a8934dae7a987cfa9ab909543f25d1a";
+      sha256 = "84324204fb4ed94d71bd536a9f0c584fa783eda737d9a0dc2d3109d2323fdfef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/kab/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/kab/Firefox%20139.0b9.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "eb2cd412c94a67415664290b14a08f5bb870b3f25e7fa404dfd68272e33df4fd";
+      sha256 = "3a0bb016e4918430bd5761dc8535060a0fd576198197e1434d77e3afe114c9f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/kk/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/kk/Firefox%20139.0b9.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "c2bbf15bd5013388c090b9ba7631ccd6ca803c262b2e3f8ac8f07a8ff22d0bcf";
+      sha256 = "57ec15e34e9d13f1eff685971cb5c7c1da27a572385814bdb9740b618bb44b9b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/km/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/km/Firefox%20139.0b9.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "b75cfef561797c1b19f696234e6c5792f0835de469b71dc0736c47087ea43b02";
+      sha256 = "8ba4c1a804009ca9bfee1062281c052237e9663090bb665d9f70df48b3caa865";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/kn/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/kn/Firefox%20139.0b9.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "383e8dca3ee948a086e4a9bfb16149c443ecb5aab957564ec33e7f32b98f3c61";
+      sha256 = "531152592992ea35bceb6355ff60606047aa0fe97b35162c949596c36fa95c7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ko/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ko/Firefox%20139.0b9.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "e4fd810f240a24a9fa9d7d9a3e3d52d3eb8bcd59704da3777998c4288d8d5634";
+      sha256 = "151a1e93dbbed73836d73c1b36a2700b0df51352fe73ef385c7f9761539cbf19";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/lij/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/lij/Firefox%20139.0b9.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "d803bf21f5b2fbd058319b68b86ee3a1ceefa9473fc0ed85cf549065c4040a13";
+      sha256 = "f351f642cb6866f65b1974c371738eb77c7f8cb03ae5f3a5da62adfd8a0d4414";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/lt/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/lt/Firefox%20139.0b9.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "3e8a7440f91d017060f4045a2bf99eeaafbffeb114de3a3afde30b71dee77f54";
+      sha256 = "8eefa1a15d59304dbabfa971346f2e9875cde180d7e518bae4dcdf4dd09631d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/lv/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/lv/Firefox%20139.0b9.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "cc82e24338955ea73fc488cd2bd4408783e1006d8a4644036de09c2731cc1fa2";
+      sha256 = "d8e1c73aee2740c2b11c51787d4b24defe8b5c1ab34cbdfe0ae376bac0c7fa27";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/mk/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/mk/Firefox%20139.0b9.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "d12e758204660abeae700ad10b79effb2627486cda0a6123bed191e3d6ff9282";
+      sha256 = "f983abfffd17eb8ae08ac25429b89db1f969a26e93e17d7c1afc899edfd5c8e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/mr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/mr/Firefox%20139.0b9.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "8ad6085ae950d89ba4754dd9ea3f9154ecf12252ee47636fd6834ba8dc7ff71f";
+      sha256 = "3658847d7a3d231777efbf76fcd68160748d86ce85eb3ffdda00d3128aa2e2cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ms/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ms/Firefox%20139.0b9.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "c7f082195da9a650df72066d7f4e9004adb59fca30deaed4ecfd2e70514c02fd";
+      sha256 = "32cdb038500da359a998f9e5a9e0a313781a7811f84107287c38ec677091e8b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/my/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/my/Firefox%20139.0b9.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "639b38b8c6b9e42ae89fbaea360ddfed3be74e9eb3a55456a251d9d22ede241d";
+      sha256 = "efda419f60f07fc641beb6d30565993dc1087dc5a8aaecc5cf94578ebf9b11a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/nb-NO/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/nb-NO/Firefox%20139.0b9.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "87a676d880411221b19763c9263024507d41e0c89f6fd818f8efe8563952bd09";
+      sha256 = "707a060d5cf2d7f66ebd2a14eefe91cfdac42da3f386b021240527b37587d007";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ne-NP/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ne-NP/Firefox%20139.0b9.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "b8018da6989bdb66b02dc386b608ee439718b5ba2f377dc3302710ce7854aa8d";
+      sha256 = "2dbc03711b9107e1ab961a301abaf68d08967cd5516ef372cc780cf05b1ebbae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/nl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/nl/Firefox%20139.0b9.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "9037c896ea9aedd7275c8922f4a61d5ad9e4b41ecf43f808e9e996c7d702ed33";
+      sha256 = "f8c1e3245cfcaa4f37085c6894d3f09b736ff34d2309161991efd336e2316e31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/nn-NO/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/nn-NO/Firefox%20139.0b9.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "06368696dcedd347d62ceb7a1bf3ce6f0d92eab035310aa704b0a09a495448c9";
+      sha256 = "cbaf75dc6ca28500baf3a8b9555aa75cfda5eb0d2b7ed32b7146853d54be9e93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/oc/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/oc/Firefox%20139.0b9.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "9865f0cf11e8baf3b6930617597ba807b1e06d95abc9a8a68525119a0d591e48";
+      sha256 = "7b8388884a086f72d49cb7bbcf1b97411c64e6a92686b595e816bac88e2666c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/pa-IN/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/pa-IN/Firefox%20139.0b9.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "1bd442dfd70d0da87a4904f25a955323fa15d1551d529e710876c2c4e7cf257a";
+      sha256 = "3f3015a22de159e86ec812f8d43f3f26db652fdd97cecfbb07d0c6313529c484";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/pl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/pl/Firefox%20139.0b9.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "e261443f9dd5160e941378c9c8f0aaef9159ae21172babecd0154b7481081210";
+      sha256 = "07c424aa1f83a64cd5051b184c349a6b421b9f0631e08bb38038114642a72ac2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/pt-BR/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/pt-BR/Firefox%20139.0b9.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "4140fca76b890df5b79a7accc26bba64f43b31b3818bf5567930451666cfca43";
+      sha256 = "767514fb84497c93d46d550ce37c08630ab49447af9da1580134cb753473bdcc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/pt-PT/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/pt-PT/Firefox%20139.0b9.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "8d492cdcc1af5e98bf89039474b1af4e7e4f784e82ad2645351500a2dc22bf23";
+      sha256 = "d7ffc49f784722f4fe55713740027ff0ed1da75e0c3a8fbf0f887a16578ecba8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/rm/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/rm/Firefox%20139.0b9.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "c65018162dfec1f1f1a03be127fb27bbd25a604a4e5d2df53f5bbbd13f02e64c";
+      sha256 = "cdde6a37e773d297630d3fd8eefa27990477e0f364775c102f8577043cb8fc0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ro/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ro/Firefox%20139.0b9.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "396b5d2061bb0df1fa5af0b1b77e92c230e043a853cc0df7bad529c74eec6c1f";
+      sha256 = "23f9396ac0dd9da2b71a9b40f5a581538ad579d223996e2e701d624deca9b320";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ru/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ru/Firefox%20139.0b9.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "c90e4d1bf9440ab473eeeb6ebbf57051b30d13f5586abe7adb61487f43b15423";
+      sha256 = "e2beb748a54521798aa05ef6d4b0f6fef6cd7c20f2d3dc9c0c566dd55fee9363";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sat/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/sat/Firefox%20139.0b9.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "4a02f90828c7bcd302ed8e2689dad6b9186ae230210c0a56b2a8fcfc3001880f";
+      sha256 = "ca1856fe4a7d4b3cf1d6d4cc3dfa24316b3853cd86323d77917d0204a3166164";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sc/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/sc/Firefox%20139.0b9.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "1ce3f7cb4770771ab928006ccd0c2d855a5c69179efec9e62e8dafbdcffd54f5";
+      sha256 = "7061bbced129ccfb1ed8b03ba7399bd294f936e93807e12ebb1e5dc0a088b54b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sco/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/sco/Firefox%20139.0b9.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "5ac1424837f62ff290017a880b9b816bc7ab79e7a4401a2e8dbab8e3b05478c0";
+      sha256 = "c2fd882ee4dcdceb28f94c96bfb71c45175c2a8b16a09717d6f8de51c66dbb47";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/si/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/si/Firefox%20139.0b9.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "6f0f1b88034a03b3f1c31db951f23555b2e758338b92eb7e9486b38376b0540a";
+      sha256 = "544e5d8ca0a44498e3ab8383bb84cc785bc71164ab87ddd7ded2451911fcb18f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sk/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/sk/Firefox%20139.0b9.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "44d0e95057c74f1e6728ed14aeeb4846f789d5c7770a327a6530c21837bd230d";
+      sha256 = "e1cfe9fc9f9c635df43cd5a6b7f0caa92b3f27ac4aeb8303d6d63fbb6436f26b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/skr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/skr/Firefox%20139.0b9.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "e18e95beecb16f455ff78e9eab622e6df7e80b0461c6beec5e2b68534802653e";
+      sha256 = "68c939116c24457c6552faebb614a4609c3e0238c4cf67f5e524ed3a67a3635a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/sl/Firefox%20139.0b9.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "065a5250d0145b713685c045280cca1bf7a2559e10d1c812fc4e1a6108b0b114";
+      sha256 = "708bf09e3be017e6ccce44c622aee0f7e076e41ad00c1a69b98a6dec41751f6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/son/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/son/Firefox%20139.0b9.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "e7d1090386a485211cb358bb757a0fa54d0953eac79347eea36dce4808d443a8";
+      sha256 = "6b2325158126853761a7ba70b2225322f6090c75cfd1a1b679c39bea17787de4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sq/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/sq/Firefox%20139.0b9.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "cb5a4f74226b68fafe633f6e39af27948ffe9bfa3c866cb9f935018f0ab01fb4";
+      sha256 = "e146250fc5d78beac389e332b462400e27379ea0c29264255a8c1c9371a3e2f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/sr/Firefox%20139.0b9.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "676d0da9ee7951a46270b9f47bd33ac5135b4a439a93f61eb260c8f0af2c0d49";
+      sha256 = "d5fcb1328d86d36de1ff6b98566ad4d127095cc5b4aec5861499a4f1601bf9f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sv-SE/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/sv-SE/Firefox%20139.0b9.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "c4f9814dab5efee3a4a67cc9f8bd703d015b51f4e59947dac56636f0a9325048";
+      sha256 = "a7834c3ccf20c41bbe7769059a0d98ec7b85ff39185b8c5e36913e9af7d2b694";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/szl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/szl/Firefox%20139.0b9.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "1d92ef8edb7bb67be228771019f2f1fc9ae72ba3f005998f9f2db60287fc81e2";
+      sha256 = "985b691ef2f499e2db083fd8ad5577a340ec464501be9555a4178dcba2dc9743";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ta/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ta/Firefox%20139.0b9.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "f210471b4963521bce9aa29b4526e786cfd615a7dc3c57f6f16c92327ebaed86";
+      sha256 = "d9a001d899aff73338abe86dda5d31e3192574dbe32ae14ae3ae9e3ec5cd2903";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/te/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/te/Firefox%20139.0b9.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "0c22ca5d3109cd8ff222906afe4ac7023aad6e983e1c00cb21159e018a2ae52f";
+      sha256 = "0e9e76255ae6e750064445042cd72f4b67ab56891728df0d0520467d975ed4e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/tg/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/tg/Firefox%20139.0b9.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "1d9f2a44adec91d4120228640d6cf73290ca40333109b28f8c6f832e4cbd382b";
+      sha256 = "7fa0104ca0210c28376890884ccfd5389be09f01e5bea353fe8745a00e97566e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/th/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/th/Firefox%20139.0b9.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "315c2049ab3f0905cc8e3420cddf90e00e7e0a54b65b60625c1eab2f2e560ef4";
+      sha256 = "84af660a58275f474d517a2cac4977e4fddace2b8666660f72ab2ca625a68d14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/tl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/tl/Firefox%20139.0b9.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "b8ce0475f332fc463ab40763ef250ae4711591f81f60065a3d66fa39a1c06dfb";
+      sha256 = "c7394fb997aafa508ecfea9a598fd33331d2cceffcf063f791c0a9d6ce7827da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/tr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/tr/Firefox%20139.0b9.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "ba882caba5bec222b61c307d661caf1d2a3bbc8e58de21c6ecec9a0e48a10c64";
+      sha256 = "a93db7238698d30498c03062339330e4f55e093f8175016451f1d77128973124";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/trs/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/trs/Firefox%20139.0b9.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "fae309ad38fd0972148effa759d979a43c3233c424fcef036921371a5f5c4355";
+      sha256 = "09f4cee0683bcdca56f6f9edb84f39ff5231e02cab34651b5239f64c77e40475";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/uk/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/uk/Firefox%20139.0b9.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "54d8631cc02b44f286cc3716034fa854da91486ac78dae035a1206f1ac00685f";
+      sha256 = "f1ea38664e2bc92d02e8639c298cfd0e15a54fe9dc25f5ecef11999aec1150d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ur/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/ur/Firefox%20139.0b9.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "e401903f76ef26a3b968a605776428c8b55b54503587644706c2e991f4684932";
+      sha256 = "2bd3cddf89419988dff2be4527ce9f2da488e85630144af782e10c274313fbd2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/uz/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/uz/Firefox%20139.0b9.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "f12af8f8cd8d56742dd2a780842b88649d0914aae5151edd7071643bfd96337d";
+      sha256 = "77a24c4b020b31e579c606f15f51a197499343420eec138c0f89c9f294e23ab3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/vi/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/vi/Firefox%20139.0b9.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "5981392db9d826d35e2a23a0da72664883c57a2e30273912a35cc80dd5e8dba1";
+      sha256 = "3fe265d057317438d7870643b8f83adca529526ddc8125154f3b4bbbb93b289c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/xh/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/xh/Firefox%20139.0b9.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "4d86249d3b3cef3b87f2974199bdc49b5f4116b76595a8c33fc261b7ca6945a8";
+      sha256 = "9b348c4f99441449243fab1fe93ecfdb86f17f522438e05f3137a7d5773a312f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/zh-CN/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/zh-CN/Firefox%20139.0b9.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "1c1b40f50bc92af90419cf2851e707b815dca48ffd43a550a866c3c09e212f36";
+      sha256 = "08f8caf981b9ec654b063139ff1fe5a10fbb26718184e0ca9594801eaf4703ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/zh-TW/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b9/mac/zh-TW/Firefox%20139.0b9.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "7b41474db868d1ddf74bbf96486ea51ca8f187075bff0dabed74ef47db3114a5";
+      sha256 = "6bf040fcc8639206aa9bdceb534cee744600d801121aed49a7a60e4f157dbc38";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
@@ -1,2477 +1,2477 @@
 {
-  version = "139.0b3";
+  version = "139.0b8";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ach/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ach/firefox-139.0b8.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "fd57bc7e6844cedf2c85e685246c42d929d3156a77e1d0ded40b8bca1099d5a7";
+      sha256 = "ec5c620f8d009344852ccd22dd19199036a8823a5ab4e4b6a1adad9c4c1f179e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/af/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/af/firefox-139.0b8.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "5fdb91b4dee48d1ca0a4191b6d4be2ea44bc2b1513efa50434b763f1fcd9d69e";
+      sha256 = "5a70f51fdc0e69201179bcce8169fc99fb882a9914d37dd6519d2000d19f47aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/an/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/an/firefox-139.0b8.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "ddb7dea1828c4906c5a6126f1d325d4eafade0a247d0f22fcc9c4e212bb79010";
+      sha256 = "e77dcd294580886f2cae266639e49cb88d2a1f4338cff8c66f223fb3d3e1e77b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ar/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ar/firefox-139.0b8.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "cf581f622fb37c71e2886fd122bdc826600ab04cb8a2a5725905d29ea087157a";
+      sha256 = "ec68abb46feed1cb5def6da20abdcb319f8ec1e9485c3f3a8b6ed17403e0db80";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ast/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ast/firefox-139.0b8.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "436e4ab12e59de6b5cb5cba78d3e68db43e0408460ba46b25b81e03effd71eb0";
+      sha256 = "fb5fc4a70c749fde0d6017aeae0364f40332911ec1cb75ce1b009d4d31b0e6e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/az/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/az/firefox-139.0b8.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "1d62aa36c32b2dc2f4af25ba12679436bcf79e50c2b73db1624e4fd7bf46933b";
+      sha256 = "c7009a333d66d0aabe55112c55df45ad993aebe68b8030780b47e5e6984471da";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/be/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/be/firefox-139.0b8.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "f054bea6716d06ef8aecbbf147d3c81cb61f514e82ad57f515204aa176abc33d";
+      sha256 = "a52908948cb7cc52969e6ec43a7292ca1bc25ed703db5340938d082ce2506c54";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/bg/firefox-139.0b8.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "ffb4c108609792de752947becc51c2e2975e90ea0fe46d44601c186f804eab49";
+      sha256 = "86fbe46149b5724424caa8f05f2ef214340d4ec608899fc31b6001403e39838f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/bn/firefox-139.0b8.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "877a26a16590cde1bcd678b0d419bec76f09cf4be230d0fc93fddf751c08b13e";
+      sha256 = "2577cbba3d9c7614f297aec77204e6dbe468cbca4ca461575ce3055c367084c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/br/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/br/firefox-139.0b8.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "55bd564631ecc2614080ce653ad5312ec5d7de98df948b1bbe8dd9e613cc77a5";
+      sha256 = "8f03795a7fdc0fc207a0a260367b809454c953a32df8d89691ce6b9fce2eb1e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/bs/firefox-139.0b8.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "f33fbced526a89acab9fc34a860e4811cb83842a583f6d7871d11152ff1fee4c";
+      sha256 = "ea17537e363fcb0c59f41a8d04d87b03218d5c3ed5d3fe5cdfa77823949d890c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ca-valencia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ca-valencia/firefox-139.0b8.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "d9c250c770914d018f596cb15ff87c0d009ef0121a040f09c1c2e8c95e415570";
+      sha256 = "457b8fd25af6aff070da96f128394f9fa98ca913db7582e62f470f55e1261b30";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ca/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ca/firefox-139.0b8.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "1a675352282c3fb2966287a0e763defc6f259ea396ee17c9ba4d71e79ce263ad";
+      sha256 = "85f8dd113129b72c21c3b90cca6e4a245652b95ba36f99a96af26371ade51e8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cak/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/cak/firefox-139.0b8.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "3a672f2a6b1132d0cc37c9fac289c7029588d585e887a05943e01d2df0059562";
+      sha256 = "85699d18c165ccf4d02f43a9114b8475ae09d293d435d889342ee13d112c8e28";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/cs/firefox-139.0b8.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "f83bde54b11b0cb95c49a953d74f5d9dba8351e775ddb53238debeee26ab558b";
+      sha256 = "5fa9a98f73e295cb119c5575feaad31434b9b7768dfaafa528ccff7050f62692";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cy/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/cy/firefox-139.0b8.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "6876cb45e012664a3ddeeb8d833a28d97af191b3653a850393ba24c850c1c327";
+      sha256 = "5a39d9a2cdeafad8e67fcaee19f7fbf2a6c23e9457e8802a539950a21f1beb8f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/da/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/da/firefox-139.0b8.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "438f790a0a0c8648c9d265a4e3d487d87ffd6b41beb91bddc8b60e538e2a7d40";
+      sha256 = "2416da4c9e8584dba612a5cc38fddad7d573801a3a6afb192fd7f213684ef794";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/de/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/de/firefox-139.0b8.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "70d4882852da68a7e431de93377cb7b7a1f68b906c2b3332f6b65ec705f5256b";
+      sha256 = "6367e6d502e5cd41bb771c222c45dad1eafb7baaaade6717654edb69b28d1151";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/dsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/dsb/firefox-139.0b8.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "7e845675e5a334b6080505f62790e6dda22aca0f07af1e1599faa9b2478ac3f0";
+      sha256 = "088b9deddb8f9495294b192cb2e3248d0a068aca2ae338807a5a9595a45ef020";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/el/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/el/firefox-139.0b8.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "07675440e77b87a0b64a83b28e59be294fc559f7fe4d5d6506cd34fe4dfa69f7";
+      sha256 = "8fddf757884c172814eb0e739f33085e24ea0e48efeb4e9cb3f16c4df5b506ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-CA/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/en-CA/firefox-139.0b8.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "988e4e463a5e3684df5633e11e5e37dace06626bb20e04b1b69e9ef089d962cc";
+      sha256 = "78a686586a9b0238c5ddf4be3595721178dc71fdcb9befb2901e00ec9439f499";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-GB/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/en-GB/firefox-139.0b8.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "b1c268a2c350a065e37cf259c81b6e535c0597c15e046fbac6dbcc064625bcdf";
+      sha256 = "45889b27337d8af89996301212b0d24c7b63c7ff52a8c2bac440c2942eb6b3f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-US/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/en-US/firefox-139.0b8.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "7a5f6f3816f25442272606ed5e45a9db22c507f0ceaec5858e55d02e4dc10d54";
+      sha256 = "ab8deb35a1fdac2af1ed76ec87c7383804d943ef2b8d1043b64b7994a3054f7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/eo/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/eo/firefox-139.0b8.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "b36ab4a47cb20b07b1c1ac77c3cd24fb850feb40261d398bc0b1f16d7e1f0e1f";
+      sha256 = "847ab43da975790a78badcc04bc2819b31480efc7b2c2ffe842ce2cdf3897bec";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-AR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/es-AR/firefox-139.0b8.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "cd03f278e58beb350683174d9614b78e41f2f0ec1552d50882dc1c405bc37ee6";
+      sha256 = "6542901936f793dcb9f168dd9f3b8498ee9e1df074c7c56ecc0bf8f20028c2b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-CL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/es-CL/firefox-139.0b8.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "1ff43a0e99f0f540944209470ae660756cd41a1b9e5fa267a78cdfa1b6ddb287";
+      sha256 = "066b840068452ece09563c92ee97f8758d343689615b72da4f3bd3376932f696";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-ES/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/es-ES/firefox-139.0b8.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "9a8abef988292db0d3e2b7d728770d6e8b397f90493acba75b2910ff348114dc";
+      sha256 = "154499aa9ee0b52563459e8b817b329daf14f0a230080261cb454eb81989a850";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-MX/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/es-MX/firefox-139.0b8.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "f76653c3b4a3d7244eef6adb61ea79903f42133deb4ec5c93715cbe06dbaa1e9";
+      sha256 = "b8bbc80c5c47b7f7751028d5fb5289df73239f9d2aec18f217e5da57c386f594";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/et/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/et/firefox-139.0b8.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "3f725c9a2c84f3eb329d321ddd4b3a3ea6a21cf64fb3f18dd0fb681af378b007";
+      sha256 = "7e4876776174f492402d92485abf3267047f115eea6090053cf66c2ed20bd04a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/eu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/eu/firefox-139.0b8.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "bec67bfbfae8f1a0969c1bd083d200db25e9d7efadea0192955e2ca5be3a506d";
+      sha256 = "604fc36a93dfa8802f58d1592035045f41f051d82d1b4c3a76078556e910da71";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fa/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/fa/firefox-139.0b8.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "c37543777fc3c90368768c730398c1782400f94e05b26601cb6068f0b947284f";
+      sha256 = "58be6a272ad93a1980526ada948f90da50967bf59efd33f7d2410ebcac04f22b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ff/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ff/firefox-139.0b8.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "cd4af2a894a4a6f523aced106bad12f91ec41ae9409d0a5b32a1ee99f09c184a";
+      sha256 = "ffe1f2bb1dfa9578a554216096d94881008770d83fcb0222b2315707692fbcb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/fi/firefox-139.0b8.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "7e9e1692e2d870375e17d8f91be4808118409088160bc61df8d2ea99fc4879b6";
+      sha256 = "414c1c69563a4b1a76ac084a4b0529c3c47799068d4ce9709536ca1a4ceda94d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/fr/firefox-139.0b8.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2d1eb3ef8903cf00994a8b0b249cc806f0085b8ac4de11da66cc0611ec9ca62c";
+      sha256 = "5cc68b55345eff855d5df5a77b9d97684171349827b753612672ca4cd2c42188";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/fur/firefox-139.0b8.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "1b6a9f6592e3b2d35553c39b8bd59a1d0e7975c16d6e742fb748fc5071e61c8d";
+      sha256 = "c1d61189d11e684ae0fa834812a7bfcfabff359748a75558252f138a9ad87f95";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fy-NL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/fy-NL/firefox-139.0b8.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "9bea116bfd10e2687fd903fa533642f9380901196a4068a8d19d05176aa9b8df";
+      sha256 = "894d2e5aa087f731c1e5ad71c1d700616c16091e37c327e0d06406cee4c962b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ga-IE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ga-IE/firefox-139.0b8.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "fcc39ffaccfddff75c5b9dff184a7f67df03c24598910dd4d89380e29fc9fbdd";
+      sha256 = "c4e7abab47c661fc79bc5a675a670cceea2e7af21a170edbdd3cbcffff8b075c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gd/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/gd/firefox-139.0b8.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "3bfc75d90fd3c4cc7a271350e7b4474ac5dab71f742aee22bd994c775906fab9";
+      sha256 = "daa2e88453159ef7125eb8d11193a6f14cdf11e4496599fcc7dcbfd09fc4abfa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/gl/firefox-139.0b8.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "9a1008adc5c74857777bf8379bfcfd5592c987c36b9495534ae6c5cbd1be740d";
+      sha256 = "598a28a721a43e672dd1765d6d9702a82918db9d1ad46579324a8daf32368571";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/gn/firefox-139.0b8.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "46aa366e2df1df9365ff81214b637ab563689d53714f78c4950bca7e78334678";
+      sha256 = "02750d704805f44d660c90816aac81e19c562f39c8d6a06313f492594f19a596";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gu-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/gu-IN/firefox-139.0b8.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "c6a34a993efa290921958cc79bf4a59a9fe66548a7684710a8eaf07f1e62d9ec";
+      sha256 = "2fd93d1bba18eec6e3860dc88b6a8c34871b7075f60f759e4e4d70a5f6927476";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/he/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/he/firefox-139.0b8.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "86462bfc1e78034b69e106d1c3a728ccdd1f18ded37563fd9d7ee37d2b98fedb";
+      sha256 = "17fe145dceee88db833864259945d5b1528a4a273df760e5f5433cfa3858845d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hi-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/hi-IN/firefox-139.0b8.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "36235be9dc59e2c093a43ad0d7ec6ae8341f8afa9fc939c6d29590acbd384e72";
+      sha256 = "749aadcc0449a5687775a604aa64ec8655c2894380cc71dbff2d3ce81194ebfd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/hr/firefox-139.0b8.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "20eafa0b16a86da30b39dcda17e232d69b0df3e02f1301d7c52e192768ed52f6";
+      sha256 = "4e8d1792f6dcecf62dec56d8898fc05170979f98be2023badd0e6cb05b684f95";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/hsb/firefox-139.0b8.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "e99331dc0ecd3f9be2dfa63dfabb71c2b3d8d84b62fbdbe67faaa6e106cfe2b6";
+      sha256 = "b3f54fe1c820e39b6671c6aa2eb90177abe410d9ab558491ced4f96123e9f3c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/hu/firefox-139.0b8.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "1d14b5d69e230ef6ec21f2376b07230b64981e66f79c968c47ff109b34fe421a";
+      sha256 = "d415d5c96832b993d4a0cf6e356d881d0b36966d29a1c54cc8a0685ca88884dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hy-AM/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/hy-AM/firefox-139.0b8.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "cf226323063c8d2786031a888b9001b18f282708e858247f9180a1bea3451282";
+      sha256 = "a4392f853954d06623b244ea806a755f3cdeca3e65e55665bd1af5eaa4dd8d00";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ia/firefox-139.0b8.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "b4d61eab8372f1cc20f28c1a3e8c1f72b21d584c0dd45266a715ac116e4e0c04";
+      sha256 = "8cabe82da0246b3c0774fce7f50d1d3eb1741155c08da41019371766a73e5951";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/id/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/id/firefox-139.0b8.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "7086deb11a567fb9e15a2b301fe4234aff8ba5125cd6a9371700f10e6e89a06f";
+      sha256 = "9dd64561072b1513a9176c20978a43eb5e9547acef82e286b4d217e8e5f3df1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/is/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/is/firefox-139.0b8.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "f37387831ad3722a61a9bdf082e15cdcbdf6f9757be183bf2f4ff44b7e44d1e2";
+      sha256 = "efe26ce874881767c7e04930fdfa65689b7359173e90ed4a64630a1336a5c77a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/it/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/it/firefox-139.0b8.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "9957340442c44bbc4ce06897545bb977a290263377ee3eae5b64616e561b1a21";
+      sha256 = "d81f153667e47b55b532c9c3fe344f35f66cce5c7c93bf1f332588241365da03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ja/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ja/firefox-139.0b8.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "8eebb7e6d6351a8269b83fd8095b86bf8b2f4177565cd2fdd323717cef6971ef";
+      sha256 = "e6bd5a16459166dae3a8ccf6ec92ac3bc66415a300f4b47dc134c3d928a553ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ka/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ka/firefox-139.0b8.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "fafdbba964ad85b38565589118323d1551ac5021e041a00e29b8a629229e2085";
+      sha256 = "a8336192388a038c37a236ce067b779780e887cecbd2cda44905d76a489aae31";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kab/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/kab/firefox-139.0b8.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "ef2f0225bab971c7b6b6237cf2795e9281730b459812209f2d11656ad39e698d";
+      sha256 = "175380de8321c88094e9a46d97f035373c5d5830c20f06b1db0c99e1d00fbe1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/kk/firefox-139.0b8.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "cdfebcd9afe5c55c6ff84543580e08108f3e362751f09b99cb703c20dc1de3fe";
+      sha256 = "d5b574ab8312e2f4a2219ea684454db1164be8d20f1f85239100570bf881df47";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/km/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/km/firefox-139.0b8.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "ea997189f11e283f1d37e7e8a148f45ae0f7557fefc23501d2cf534a4f4d423f";
+      sha256 = "8cb11bb5efd1f13706c0486790ce74f8c7ef35ba70faee23978c9be10462b8d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/kn/firefox-139.0b8.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "005b89059b12d1369c338f9206e899c76c0d5a97ad94f28564778fc092694814";
+      sha256 = "c685be278c2d20b5569123f8ca80a45e084ed918b150d85f06d761bc3c099b75";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ko/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ko/firefox-139.0b8.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "56282aec275e94b3a556e3a9b95e107e68cf366f6d2a9dc8ce7fbcea9bc23ddd";
+      sha256 = "ef8c76e6c2e59e826910c5417658d47c37539e67ecff7e82580ee2ba5d476b37";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lij/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/lij/firefox-139.0b8.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "8ff69cc72d47d3e212280b8ae004abbb9a34b6e052cfb81f6fed4b1c0d85f8cd";
+      sha256 = "dcebfe0f93799cee6a0873df4a10db43a26f73b234917b077918a005c18eabe6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lt/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/lt/firefox-139.0b8.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "353a5ff5baa875628c32f6a0b7cbe5234209616684641032493394c986811cdc";
+      sha256 = "f4a92fb9cc816e197b0d43eea6a30f034fa91da6026de0e7c19febc74263863f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lv/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/lv/firefox-139.0b8.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "7eb1a0e3e0441da2df5082693588135b8e7069a29c82c1331d3defdf3e68b837";
+      sha256 = "60a2cacd485d668fbbc3d834b5594c186e0bfc99a5ebccaed9639345f32cda6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/mk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/mk/firefox-139.0b8.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "d7df7d215f440025117d472c7962f10b3db26536d424b633860bd0a2b8634e13";
+      sha256 = "717c4f09ce6cdb334e957dd0231665fc40e77c365393c1f1e036032d6fb42593";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/mr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/mr/firefox-139.0b8.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "9d6b1174365423cac77f4066e174ac0e24808cb8147cb0fc4a04f526883f3038";
+      sha256 = "3ec0bc4f3a1a7327d731f062ad296281b96c269c78bd99217ab9ab0fa334c12c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ms/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ms/firefox-139.0b8.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "1e3eb5e62665157538768e85c30728e1b0916e9637a4d7d5f3fb390c9bba31c1";
+      sha256 = "a9515d3764074429b48c153c42690d941306ca51eeef192dbd73de4b448177b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/my/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/my/firefox-139.0b8.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "76fed1cabb2e1ec137e939d6b0318c32e23e5fa9d5602c08f6a9e56f0a469734";
+      sha256 = "9ac6ac2e2a5dadd3717138b4de48404c0cad27698123a6bde13b4176264dae3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nb-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/nb-NO/firefox-139.0b8.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "afb07ebb11a8e3247b8689a7809bb33a83cbe88ded223e5967d4251541f3d55b";
+      sha256 = "21255ec43b6dbf99e01ef9370f0c8753018877c609f7df7558d512ae6fe088e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ne-NP/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ne-NP/firefox-139.0b8.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "a877b86d57e978bb020d9a4447a96ae85f0d8c9bad117373f81561e8379ac051";
+      sha256 = "69c57afd5a13dc81327f038af164e2b313774052c49db843a4af70af1489b43e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/nl/firefox-139.0b8.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "5aead7a62bbfa6f765be274d64d6d8a6402b2dd6ee68a571600e64433a871854";
+      sha256 = "6611444269dbad865b7a9a5af17574cc50f64689d8f62b267e2f100ba035fc2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nn-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/nn-NO/firefox-139.0b8.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "d35f50beb12afd6427c615f4faba025e2679289b7eed8772b9c2521c0f096130";
+      sha256 = "51da2a69466b99d5dc7949ec938dfd03b6f48faeb23158901f7026e8f24ec108";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/oc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/oc/firefox-139.0b8.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "a309df62f5d50210dab2d410ddf72cf8ce83124e49250d010a3098d45a519403";
+      sha256 = "acae7e11a475be3afb943aeb01ae1c2df68e7cf75bfb0063a13187b76a6d069f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pa-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/pa-IN/firefox-139.0b8.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "76fa9af171ca8ef48f2d40dd357dff2f4f434ec5972934d8d5660b975d9ff14e";
+      sha256 = "c616ec828a9cf6c0b93f432ec2d25acbfeb499fc40e17dee72fa8aa69a6480d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/pl/firefox-139.0b8.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "441c0d7aa570ab16c13da29e1eef27bd58277b0546481dd455af687eed1c3546";
+      sha256 = "1d121d5f6f8390ac0d50480a4340d626cb3e919dcd19f0a11b99915928ac9da3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pt-BR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/pt-BR/firefox-139.0b8.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "401cbd05af87d88f8351a6780a200f32d3e5521ddf8dea09f4caceb565eff554";
+      sha256 = "19b27f045ced6e7af049923acfe2434b19395183fde24accf81f6579f33e4a6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pt-PT/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/pt-PT/firefox-139.0b8.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "1a64160ff804281709b279c0671be0a378020c3e9cbbafc21c537212af67566d";
+      sha256 = "0dc32072a89ef5660c7b2335a3fa5ef6580a3e6e43500a2a89201ba42076d51d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/rm/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/rm/firefox-139.0b8.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d05161f9d5a54db76b46be34c13bd628645f57175e237d691b4607f8bb1ad13c";
+      sha256 = "93e5b13663645f1a5943bfa2dd521fa7a068267e3d2f8a8ed01bf7b4f1e97e67";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ro/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ro/firefox-139.0b8.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "01813e83959f3c51d841d5d5a134b903fdd6908c77f932219f7f2976be33d151";
+      sha256 = "c5b652cdea486fd1d300c7ed9c0bb3d75cf2a8ee5bbec0c037281b58397d9d33";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ru/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ru/firefox-139.0b8.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "60562e6b5bad99bd61b31790993b1af13d66b71888b75680ea2ff2a0a429a682";
+      sha256 = "b192c7529b91f5a433988bcf450ddb7c5f2786406116baa8342b6710cf7d0908";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sat/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/sat/firefox-139.0b8.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "363eedd05b26529651905995a75d4fa7cc4a4cb0eabd71223011df8819b2c9e2";
+      sha256 = "14bdfee20fc149aeba13e9fe4ab9eccaa10b4ec425968436eae18a8c8e8df096";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/sc/firefox-139.0b8.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "d4893587265913d0cdab363809038afd61a0c96f8add8605f8f709d7cf6df1c2";
+      sha256 = "7619c508d4f6c9b85ac576ecce3bb3ded068a7d1e1738e4996a92f1a8811666d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sco/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/sco/firefox-139.0b8.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "9c56abbb7208a26d8fbf1ebd3dccf42f23da60c73df628eaa44b9293e128f5d7";
+      sha256 = "5103207141607ba38a3bca962694bb50876cb376fe98bec521b1070a865bc5f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/si/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/si/firefox-139.0b8.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "f9d59c8e43c249293c844c8e46fe001aaea050fc32a9e06dac0544319b248872";
+      sha256 = "be85515e2512444e7755c3925d049c73b9f20e0e4ebeaf81c4820ea9e1703586";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/sk/firefox-139.0b8.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d7e396c453b86e7181a0af09f5a608b7b3120d0b2df93fbce472c4935ee1cb25";
+      sha256 = "c5f9923a0378b5982d476fcfb3fc06d851def6a566df3aa175083382d1ac17d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/skr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/skr/firefox-139.0b8.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "4b120fda51484bcc9e7251ffa267a42dea1328148476252dff33c22aa10da3c2";
+      sha256 = "3201e71ec7d1198ee5519c0d23055a144aac2f4619a53d06f10b94c12e8065d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/sl/firefox-139.0b8.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c145d10b2a5ed42b1e0ec7aac49caf51468f200f361b0d3b576430f14825e0ea";
+      sha256 = "bfab09c3510db9b5c3b45ebdc18c4969f41d9af65941c5e696e6a669d2101f8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/son/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/son/firefox-139.0b8.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "bb0a17d3089ea0fd8809fffc43258b2ea2d98e8a3ce96385ea80fd859f82ba2e";
+      sha256 = "76b7d7e5ed9dfbb95e7be631206d8b415df55979b5a02559b5de0c13fda97ca0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sq/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/sq/firefox-139.0b8.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a013d51f7dfd0ac9da4cb6159034027ef7bc3360de3421211f5ff453912d9065";
+      sha256 = "83de21693f00872758f66536c2dd97b1f09c173ece175689a74690fede3f9849";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/sr/firefox-139.0b8.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "5388d19db672524f2a4d5975070a4e5fe09d9bddba8b9a3a54c2cb3052b3c28f";
+      sha256 = "433205029c913221d206089559117c5999b4734e175d102f27697c3011e97403";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sv-SE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/sv-SE/firefox-139.0b8.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "49600c47143f89d34657577d1175db5c415d4a4a6766e1c410db58337371004b";
+      sha256 = "ae14971235e7ae87525d3d8fa9182bcc13cf158d97a5ec07ccdac215fd8f9f80";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/szl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/szl/firefox-139.0b8.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "25a6cce7c972c74bb8f8f881200417765ae7deab09405a947a4010002cb5fa82";
+      sha256 = "bbb79de883519793a9f2eefc2f321a6a415ee7c48537cee5fe0753631056c218";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ta/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ta/firefox-139.0b8.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "ca4eb3d2ffcbfdf0e70a42bc358854b99fb9d8b297959530b25db69fff8da6b1";
+      sha256 = "0ce84d9711e514710e5426a4d3e3df0a8cb428caf672b48fbae89ae7c090158f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/te/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/te/firefox-139.0b8.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "a642f8335f263b9fc58ec32128ac3467c1dd2879ab72b90e74411afa723685eb";
+      sha256 = "006538e0544c4fd2777db13231601305c36f05e87a4c52ea7a7d572e646955f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/tg/firefox-139.0b8.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "08636c243613e677caf9726e73e640165f90d0fb3b7f5d7a85535a9d20af06e2";
+      sha256 = "f4b1c39348a1d2c6fd7f53314fe1703115e1bfc88ce06aff0db341e7a1740232";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/th/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/th/firefox-139.0b8.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "4586b68f7a73cbaa86eab8a2a67b904a3300ae485b85ff878f442e58f2c25a86";
+      sha256 = "b3e499a884a51183786382820dcd149be463692e0de474ed9797b507cd23ff24";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/tl/firefox-139.0b8.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "29d943a1e465b089e4b4216bff1343a3b267bc2d0e6757429dfdefe1123c87be";
+      sha256 = "ffb54497143601306e37acb7959228ee3de094c49511346e0d9ee2061fbc2061";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/tr/firefox-139.0b8.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c0ebd1339d95eff201d85bf549f38ca93907021853a2841dbb48bb7587f84890";
+      sha256 = "1d545a843c1b127f67f577d403af164fa80b18fd0d32526fd522123376c416e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/trs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/trs/firefox-139.0b8.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "fbdd2bf864b5d2cbb0b633b733c70c71457c04cb405b0aa14c4dc83a5380f4e1";
+      sha256 = "e37edf6b09d12b75b615ae54fcd2537dba5df5aa9043c50ddbb44ea48138c0b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/uk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/uk/firefox-139.0b8.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "9f2af01f2187bc3dece162cd493ffa46bbb7b4af25aed176f81bc1bf99ab8f3e";
+      sha256 = "797d1352eb2182b4e1d89460d82989aeb560747fa1a4dd803275ac38385e8650";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/ur/firefox-139.0b8.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "4d3e57b37ea0d9f498701e768e6a1d3ebed495c83715df9b0623845b9ebf4464";
+      sha256 = "ce3d9c415808686a6d80d7d97fb40b9d75682ba7fc1c44c89fee7c5f25640822";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/uz/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/uz/firefox-139.0b8.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "c9419b604b2a6e91cdf9f3c7fcc1a7213eeba095a7ca4950138d4757326a5337";
+      sha256 = "e8fa45a6736b9eb7979fd288b00f4a1a188911865b23d0b2ae93d00d144991c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/vi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/vi/firefox-139.0b8.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "436b6789d5c91955affae937528b38532c09b96f80cca4ff893b593c10720138";
+      sha256 = "d016d3e3e93c6ba4eaf39eb659c5536e33ee6d0ab3dae663812af80cb8db42f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/xh/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/xh/firefox-139.0b8.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "ad35a67010effc02db685ab1b05a534e8454a3d7d8d9eac2abb20ea3494440bb";
+      sha256 = "3b37a0acb030248559d612ff86512c9a54703895f38a49dd26b1ed69c328a4e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/zh-CN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/zh-CN/firefox-139.0b8.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "25efcfc912e9e20d7479ec869afb471d4a4be279500e06f2609bfb5df9d65e21";
+      sha256 = "0358ad79a62a3a26d940cbf6a11bd055a6ed68b6dee7e6bedad9fad58a383338";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/zh-TW/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-x86_64/zh-TW/firefox-139.0b8.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "a694e1461292c471cbf263f1fca962b27e5bc1dcc655cd9c0f22b6ec868b0196";
+      sha256 = "b8b65e3dc97eef56d50a3e8544ae804c057d2be074d19b8200b659dcd5051267";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ach/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ach/firefox-139.0b8.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "8acea013f0230e45e5dfe7cb2d1495fc31fe8f62e3f0c71021faaeed56f88d90";
+      sha256 = "ecb77e23e66a76b8de3968981b1da008c0871b3b75e1295c5dba95e56f2d7a28";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/af/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/af/firefox-139.0b8.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "e9cd59e8ecb6f05aa3f71fbdc898e38f5fe16e7366283a899dc918639bbfabe2";
+      sha256 = "d7014a483355bce611cab3812b44d8025d92d34825710722c6c15f23e65b66f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/an/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/an/firefox-139.0b8.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "06f077e94b604c14d4b23b5c7ca90988a91fd77b4923762880a8ecf6d0d96549";
+      sha256 = "58cfea743bca6238791a13766799caed97c031d188b3b7928fcdc9c0b3f9a75a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ar/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ar/firefox-139.0b8.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d766a8ce6766609052f059d44b324cf67e872eea704095190a00099b472d1312";
+      sha256 = "b7915297d5873baa789224f672d081860f1e9598a85091005ef9fa6e67de42e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ast/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ast/firefox-139.0b8.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "2b4f5ea265d192b4ff27e24ccc60a1b2e70b5e19f5957ab482c6b0d36a4182eb";
+      sha256 = "bccee8d5dae3f5d17465daded12f4f4a7692853b61a3ec6ce67a7d7bd49e74af";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/az/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/az/firefox-139.0b8.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "1659ad578e6b9768e3a2bd2dd2ccffcf1b8d8060c08bb2dd9f45a5a8b35ce6fc";
+      sha256 = "f1394376e2f96ddf03a7846527ff40d8a36fbe6309d15b08fe40da40d9987f5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/be/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/be/firefox-139.0b8.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "7959c9e95a1858961a2322ea9ff572c53d08c5f1e855d5115cf68343f1dfce63";
+      sha256 = "7bae7aff5dbf59436bbe5622a39b2322a16d625e21fc57203826a7b37a124edd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/bg/firefox-139.0b8.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "74d7142554e8621b5662d322c5d1eb63a6bb4422365d037212813fc2b1ca17c4";
+      sha256 = "9623405177304c08112ef70e824f52e6c631c1baa1c6f51b8a66431a87fae8c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/bn/firefox-139.0b8.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "5d40f8cdadf7510337271c98350a14b002462dbb58fd89c7f5a5e898d4d96522";
+      sha256 = "cc3d879ea2fe3f025d719a66376b1cec73fae9b8202170d7f3c11781722a083c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/br/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/br/firefox-139.0b8.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "98606dd41a554c6642b07c7012c8fc0e831cae305c77b17018abd7cf1f835126";
+      sha256 = "f221608f792afae6d4335704632dfc47d5cfa06f1e069bb6c73cf4eac212cef5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/bs/firefox-139.0b8.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "319901c06f9ae63714f5e50def341f7af82446d657a4792f6aa0dacefa6c5aa5";
+      sha256 = "b9308825cf1be38fdac3f685f7d8f0bd4a258451e0795df6dc1889a1e6805fa0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ca-valencia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ca-valencia/firefox-139.0b8.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "bdbee33f7f53270a075e45854b42f5879eb081875310285ad4b99dfc2494c766";
+      sha256 = "501df4406e1770494916b9976fd1b2812ae6315b25c1ad88009eadc8a5f01df7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ca/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ca/firefox-139.0b8.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "9b8af77f7db2bd74065f7b56823ea68db58822db1d55e1a9c98d4654d5178e42";
+      sha256 = "992089e85f4a68233a46fdb327bd3c8c961ef50195f0b8a25a6974e162877d24";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cak/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/cak/firefox-139.0b8.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "649a2617e215d8f3610de863ddfc29dc0c2b27fb7d642c1e0c9f2c6aa365ecbc";
+      sha256 = "1af610ceb7030652f27a0418ffc93429b3d00c111ec4820e9b712fc8357fad4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/cs/firefox-139.0b8.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "8e8c2e892caa8bc5db5804f42332ad57d1264eda034feb467d6d75827c3a7cd7";
+      sha256 = "c6d937b24242f8c8c8c35bc21bac03bc88f8016eaaf9c73bbc5b80e303d7edba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cy/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/cy/firefox-139.0b8.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "394bb39242b8631d46d42586611e91b54028fea43d78248af3bb446e6c6834e6";
+      sha256 = "1f7f843f4aaba36100230ab554c3e447f8a17fa89b8bf22a6aa956fd1362b8a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/da/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/da/firefox-139.0b8.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b42f902cab834a1a177afec0812b118280f3733adba9433d31098df63d184d83";
+      sha256 = "410a863d20167be0eba22f3a180a466ab0f4e1cfd4a24b9713ca7afd522bd95d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/de/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/de/firefox-139.0b8.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "420f1853b37b823edbccdb02e19669d5caca76b2ba3f607a81d11b5654f04c1e";
+      sha256 = "58907baaf24a73804dcdd37562ecaac3fd64fb325163c8d791b4c7d40b2b8027";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/dsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/dsb/firefox-139.0b8.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "5987303e490b524c31619d18cdbcedff7f24d70a1652bb9bba15120d34befed6";
+      sha256 = "c94807cf4b1cbf09f755b04f6800e21285b2e568ddbe8059e93f1cee431b4fc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/el/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/el/firefox-139.0b8.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "4001d4bce1fff3dba641b7c38c2b26338e40ba28ddad8554c4f7dbbebf1536d6";
+      sha256 = "b7f3cda2f188d81041f95e42f684fb16cd23706cae115c824c30b2b4c68881c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-CA/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/en-CA/firefox-139.0b8.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "35707a5d0e7df572c341da8d4ccb76f560267feeb8df785eec304e6c920da3f8";
+      sha256 = "88fdf1e89775423a59543cb08e9d29b4e8f00c04b9a2cb48a371ca33600fbe46";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-GB/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/en-GB/firefox-139.0b8.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "02b5a1f051e02b949e7c8df2d4196e6e45cc02a0ae0178f8500c99b67737042d";
+      sha256 = "22b6e604d32896ed610fde0afae03422f2fc0e3109b52c2c3e493fb0171680eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-US/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/en-US/firefox-139.0b8.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "ddf19c5fd706f7d20060d009e26e5f98d15707d7ce1130a3e5209a80237c4d45";
+      sha256 = "179e91a8c310cecad82590bb11b760c0d77a0b777e6d3e9407ed4a7e13b5a6eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/eo/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/eo/firefox-139.0b8.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "75a9e8c3f3f1a11b22be4501fcc6743f6d7233591df6f1f3eee8243fea27e6a6";
+      sha256 = "8ecd0cd221f676a39426620dece0385c34ac356cf8dbe6ef6154d157f5976dfe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-AR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/es-AR/firefox-139.0b8.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "5a66e9d13ae53b0e163630f1b9a20c4b68f4e7cdbf88c2d2ca702fcf9846d064";
+      sha256 = "b443567907520bbed0d47921a8bb22417b2d13e5782603a7dcd6afa253245da5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-CL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/es-CL/firefox-139.0b8.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "79dd1dcc771346f0aadab81fdfcbc6fe1d532001ae17793447b423b1a85a4aae";
+      sha256 = "f5a625b04feba3042bb6e95a75a2c7fc377fdba7dbf379a95ccbf6b4274e538d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-ES/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/es-ES/firefox-139.0b8.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "90054b5ee7292a1df8f0e7688b35fedcb19f2a8945f0bfb440c44913bd123c4e";
+      sha256 = "c17634ec8c17606ac092851790c9348e37089c438d150cfe6514c216797270d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-MX/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/es-MX/firefox-139.0b8.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f18593686f6a02b0bfb66b364b93fbf1f868365eb96e8152ce1500d6c739b457";
+      sha256 = "779f17b2f1b253d628b3514bbd70e64ddb0613d93bdac668b95c1e6619b70417";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/et/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/et/firefox-139.0b8.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "b6f65d28916d962223af04027a1b5550ef7e6326924f83115a7b86791220bf2c";
+      sha256 = "c3cf1bffc91e1954952001b7391d55bccf275fcb80cb55d724579b53338daf63";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/eu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/eu/firefox-139.0b8.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "410f33a12c705d8ff753b4cbb11942df9aaca3777774e7cb2db5277b7791de1f";
+      sha256 = "1705f7e3d839f79f3ee55abf43954cf72a1ad66a82492f238b65851e5dbe6b2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fa/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/fa/firefox-139.0b8.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "67728e0982b672da05cf00b46a12e18539a0ce2c3cfbc3f91e0c5b62b6d01408";
+      sha256 = "c5e6930c1f8a01726cdf78671e4b74563ce03a2026e8e77b78c7cafc25439f5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ff/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ff/firefox-139.0b8.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "ea729dd3c19b979d00c25b6dfdd2f2d633055a9ca389ad5cde5b5154886d25d3";
+      sha256 = "f5064a06cfe8fc58b26b751a4fba855fcd9ca98f3ebfeecdca41eadddeba21dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/fi/firefox-139.0b8.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "40b78a9e4cea933865f06a41c8a32d276a59bae2488601afa6d6e936669eef4e";
+      sha256 = "2451f43d0e14392fd7cfbbff1bafb8d6fc7b5b07f0b13d3ba27c3a65f95b8628";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/fr/firefox-139.0b8.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "5828e6b8ebc7b7508f363f9309554b544205479c22b9632e230340774c46e442";
+      sha256 = "5d4d55edc7f98241f12ed8536f0afc8d8d5cfbf06f1e2e42d82cfdd79f91cb2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/fur/firefox-139.0b8.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "bae0801fdbab156db54f0562f246a59eb5f8c24c79ba17fe2b6c98fc9ed91c58";
+      sha256 = "e4bbc3948eaa3b6e6ad0e48ceae3d7477bf8dd3514cd0cf806d1bc3ae674dd02";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fy-NL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/fy-NL/firefox-139.0b8.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "0e21ed14bcfc78650f62cffa63d1d9f1a8f21b64b0d258b0e15e346b6f497f93";
+      sha256 = "5253538b9ec914feb61d2a7829eea57992e4104dc3cc1ef7e0adde155ef24fd4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ga-IE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ga-IE/firefox-139.0b8.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "a873d3ce455f8f8c82901d9e2b6795e59515263380443801b2e0c9fd050f03b9";
+      sha256 = "592f24ae4e4b74711732af64c01f1f69c9ee754cdbadbc8054da584b142524d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gd/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/gd/firefox-139.0b8.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "13d114359f5c30759febb7bfffe79286f3261477a160a35faa3d5d2e1e236271";
+      sha256 = "1589f362d76ef4444c982a0590acd8bf08496a721ea535c2903bab42b4663bde";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/gl/firefox-139.0b8.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "57c6b29e1b05a4e75224085c7a8f13a3948930e92204f882092cc71efc7d4071";
+      sha256 = "0b306b3951141c9e50327deaa69b90f3bbcf619020a1b30512eb39e417a2cbd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/gn/firefox-139.0b8.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "6a197a8c1b138f1eb95f85770e4734fcb400679fe18c0241352dc9d0d025dc5e";
+      sha256 = "c406230a7a33281d5fd4e76fba7dfe7a108073fb510d80decccb02d0e8ee5651";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gu-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/gu-IN/firefox-139.0b8.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "53bb01d3b87a5a463b993e69ea9472b9b7dce818ffd41a3efc74b0def2880c10";
+      sha256 = "dbbf861a2e7dbdbb4f562c054bb44d91324059d321f4a912324ab9556f686d26";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/he/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/he/firefox-139.0b8.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d2f51a83e9f625df054c75b6212c95a2ee98a6ac6912fb37f6dcce151f0d8cc5";
+      sha256 = "4df4cc85b6750906d8118b761810b2065d5e0aed58986d8639199a7e5255a098";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hi-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/hi-IN/firefox-139.0b8.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "72b1cb85cf3c3774befbafbec03aa95084356b955b6c86acdc2d12fad9a05d57";
+      sha256 = "ae083b7d86dceb43df246d1f062e068eb808fc8cc219d6028579a477b9efdbbf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/hr/firefox-139.0b8.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "9d0b4cfa3f23f962e2784f9a17e8998d2a6ee1a3e54740317473e32c790fb1b4";
+      sha256 = "e265e0ed005303dc8d12717e0a2bfbbbb276d7d5eb606bd3c16013118ed4356b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/hsb/firefox-139.0b8.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6ad41bdaeaa4bba9360ea98787f0c84760f849570452425508f3dbb0472e7349";
+      sha256 = "711a8e3062e299bd1df4db52e31ac5d6472ec7dc5cb30fa6d6a88b88b7776710";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/hu/firefox-139.0b8.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "583782cc9ee0da5f8ff488643ea6a1573979653130bb6120affc1a7ba57d10c4";
+      sha256 = "24971e696901ce2a163f60da471bea284cf9b1a48d9900491c9d211ec5372028";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hy-AM/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/hy-AM/firefox-139.0b8.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "bab8bcfd4374d076023b6e1fccf797fb3d83f26d0fa8df75a0d3c5f69879c5c3";
+      sha256 = "b28f91769b1e50c24d8b8484d2f3b99e105f1bc2f168e9728d7b0bdd01113f34";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ia/firefox-139.0b8.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "2bd01c27ac6e282be53d72b7993fe9b35847ef5639104924a5d45fc20a42e56e";
+      sha256 = "486598006895dede3d95a67abd140da488dcd9a3e4e91aef713da68117538947";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/id/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/id/firefox-139.0b8.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d110ba5a2d529cc020a476fcaa8781c35f1071224b33814983b83722fcad0078";
+      sha256 = "f49a915087101477c21c9146f014da7a086163b2903aa348623f479a9249d44e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/is/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/is/firefox-139.0b8.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1bb68a757bb2c9ec9c87522d91733fe55cf5aab0ccfec58cbee67c3a3764df85";
+      sha256 = "84d8fc09c7ae094dea0d07befc92f566859a46dbbe9842cdd62337ae1eb04d23";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/it/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/it/firefox-139.0b8.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "6eeaaa32990d457aaaf37804f54e39fee7fbcf90e024797461c76b7b1522bb84";
+      sha256 = "ba0ba37278ed980345fa8fe41371d59572c574a0a161a15812b17938695d528e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ja/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ja/firefox-139.0b8.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ad3d2dc245f06c540b7705e4c43b18477f3ef2b6cb21046f2c6aea5ec3343744";
+      sha256 = "c61347af8a7515baa43783271cb9360ebfb9b7aed5c46a24557dd57c11ef4237";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ka/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ka/firefox-139.0b8.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "5d1c0a0642967fcd4646e2a615c5033634913b4e55b53669de1a27f6de18d39d";
+      sha256 = "c21ba0b0798cda0e70757d91728d9150aa518e01f0b10eb604a3ad166051c210";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kab/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/kab/firefox-139.0b8.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "fb3636bc0836dc5754a86f40274e3cabb1d32ea1e493cb84bdd0f61b1ce526ae";
+      sha256 = "7dd7cefbffa339e083234ec994250ac16b3eec55d4c2cd1f739bbc3a2b13d88b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/kk/firefox-139.0b8.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "ff7faeccbc3977063bc69628c64320e0113a6cf0cf487fc0b6253debd7c1da04";
+      sha256 = "41675b79de922e5900353e0726a9981656099d09ec5c0f7b52b6fc7ea4d6df70";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/km/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/km/firefox-139.0b8.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "fad1f93e314bde16894eb472b2cc2ea41b5227f4d916d15c536b3892fead5587";
+      sha256 = "8778672d2b7c839a39aead336b68bd78513c9fd669355ec38dc9845a9bff72b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/kn/firefox-139.0b8.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "32891d6d78f97ce1eb3f72751252e8ac15474a67ff3b69e0fe78f21efbe50aea";
+      sha256 = "19c01d9173b0f9411db53183c70d672c9224aed15ec04f8337dca47df8d8d254";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ko/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ko/firefox-139.0b8.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "f4f7315ddffe3bd50d927cb29e6a29887f31601c6c062dd349e26920fa1faaa2";
+      sha256 = "5ca00232347574bbb87e8357ff3b2e396416a59f8beb5b6e815a42e1e1ea6a69";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lij/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/lij/firefox-139.0b8.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ffd066b6b01c2180e8d85ac3c91521b3c2d0a349184bd6c3a5daa220dde51942";
+      sha256 = "a0095b989cc31a07fb01feb54ff1a4dbf593a3718d15b6c6bfbebeedf4ef8ff9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lt/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/lt/firefox-139.0b8.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "6d14d17de1c256b6c2f44dc032a09b99244cf9dc81619c18cb750f9900857f94";
+      sha256 = "c0d73740a024ef05a451e7a4059c0cc6446ebadef6405b55510092e896c8207a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lv/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/lv/firefox-139.0b8.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "d9f0720f4d1b663406b14db66f739ff1d0e2dc5e849f88640d0899c3de528f4c";
+      sha256 = "f8d0864139b9e6cb14d25a7ff861146be0a9b53035f91754a41333f3b0a98cbf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/mk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/mk/firefox-139.0b8.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "e770c64d793af8d63bb33434f427ecc9cdffb49345ef966ee7b27232214a11ad";
+      sha256 = "f45108ce3499b979835691e6277f1e1184e1b394a13b8f34b7866cea73965624";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/mr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/mr/firefox-139.0b8.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "bf0a4fb9bec478a1fa1d48be903509b5f23c45dfa7754afb78aca3962e7fd21e";
+      sha256 = "73c82d61191684b55c88a8ad6d4f15c3bab36fea39c0f44edbedb49745d0c60d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ms/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ms/firefox-139.0b8.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "8d09acce703795b35bc04887cb26e4020af5c397fa396c2f2806548b5980b6da";
+      sha256 = "c2b7b25e75412a1716a2801a3f1a7698abacbeaa980b7f8e18c76835b4fc5ac1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/my/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/my/firefox-139.0b8.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "f0b894a6462f5a80c23cf83a1a011c491a0fcbf61fc04c2b0aad6a0ecf9b6a42";
+      sha256 = "b610b2df11a22696c5db2ef742fa6f2e6540249d9d76220f14408818b7e84f1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nb-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/nb-NO/firefox-139.0b8.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "2af8e1f308a6010c3b8523c1e9d12d0e1b5b9724ad1f444394ca58433a2298c0";
+      sha256 = "dbc7e9b0f4797e0f912641ab91184a89788e53bd76fcc91bcad2bbbf18a73f3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ne-NP/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ne-NP/firefox-139.0b8.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "004f3b52f367a1bbd35aa06d7040035bfaf5da5524370810c789746ed78af888";
+      sha256 = "4ad43ef6f4e6b3c09643e5c64f0d51e2a66368908f0593b2dffa30b4caa9c80a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/nl/firefox-139.0b8.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "eef545c2a3937500dd825e5e0ba94735246bb2e8750a3b3c2266026f5b1859b6";
+      sha256 = "fb3956cb059d9a11cc1e1d42676c2a8dace1f80c5fb3f447ddbd46c1477f5151";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nn-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/nn-NO/firefox-139.0b8.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "794b917cedc6dc92964665da249dd018ddf288f837ab2968794b63c2360a8cce";
+      sha256 = "0b100600c36e4951b65c814b44f5f1f88709f12b31663b19a23fad51a9bcf377";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/oc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/oc/firefox-139.0b8.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "3b83f2fbbf74b91e44a7f0043940d242b1b736d75394caecbb9401e328e23da6";
+      sha256 = "724ab7083f630c4b000faeef4e1f37e695178e370aea397ff0beab0a19a5a52e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pa-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/pa-IN/firefox-139.0b8.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "72e016689aa5823d0c1023afa000780e6e60bcf752eaa7f1fd68da107f22f6e3";
+      sha256 = "e002c76608ee3a40c72255b95a22fc3eed2f7a7ee1d53186257aa8196a0eb851";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/pl/firefox-139.0b8.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "263dbd2d79cbc7a2c0a0b21a3fbff69fa22383f39d7824ffdc31194f03a69327";
+      sha256 = "94f9c7c234a0066e7d119d76e72569364e79bf9065af22e0dca98a245ff56c9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pt-BR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/pt-BR/firefox-139.0b8.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2c9b08173760317cebebe8ab746b8a024db38bc7a7aaf4e9de034bfb50abe5be";
+      sha256 = "961bebddb5de9b1e7fc3415217d1c9a5f6fed345220c2026c88311d0842c6e45";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pt-PT/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/pt-PT/firefox-139.0b8.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "df8fdc9ca8a2a16decff55ac6b64775ae2dc7c64d6dbdd8fc15df014a8f8a656";
+      sha256 = "af2aaa922ba27b8bad38cefa8e5a27c816c8c19e26632e8a4f10fa4e5644925c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/rm/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/rm/firefox-139.0b8.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "2b6f3c308e293955fd8243fa724dc969d054b7c0d086bc1a243e2c19bef27bed";
+      sha256 = "78fbfc54e093887ea61074668879a62043ffdaae5b5ce6765001d41ff11224e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ro/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ro/firefox-139.0b8.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "81d6fb48b838aeb5e9fbbfaffac8936f376289b162958169a50e8a48bdb4bdbe";
+      sha256 = "b16b3c08f0c45393d8342ecdc326386c193f014db248fdb871543d9a5bb333dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ru/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ru/firefox-139.0b8.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "6fbcd6ea92f5e2c81c926dd407ff2523e551f388b56154a3324c1f04f66c80b7";
+      sha256 = "fdd9a227edf4c00cd6b0a2096cf04c1373b168cff856fe8a56e44373336744ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sat/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/sat/firefox-139.0b8.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "77b8647e8702ec7dd982ec622151de4eac6e1873fd632c57bc174d4ebcadb675";
+      sha256 = "845360d43d6af961a1b9dc45b5bd47bbbc331e5d3e2af1507f1a50accde6898e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/sc/firefox-139.0b8.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "cb23ce760425c17792dfb75fe52d39f4fd377b640f69ba8bb575df6fba3f80d1";
+      sha256 = "bd4de5952b51bfed6645fcb2eeedf70c93ecac121a802d78bdb80600d919ce07";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sco/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/sco/firefox-139.0b8.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "f1f71c42b2626d0dcfc3552a1224db422328f4f312512b3fce292b69b24b7560";
+      sha256 = "3e34f797a22461814039f3fd508995b923c18814cc9cd95a4789dcf6b9a6cb3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/si/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/si/firefox-139.0b8.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "7600e8c27c2e795f7cc4481badc279b461901aa516bbb0728128874791d6639b";
+      sha256 = "5a8649828590eec73372c93d93d10ab8343195d3e44acf1714b4573c00728d5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/sk/firefox-139.0b8.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "45d7b3b578ead0d40175954f9e65e124853e295a0c528dd6abde891622534e3e";
+      sha256 = "62e8c8950b98ffc2850334cca6b96f3a5181e077552b208ce1d26a20abeb93a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/skr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/skr/firefox-139.0b8.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "187fbb481c64cc981b20de374913b9d17c3b117a80ab1feec58c18c965ef3e4b";
+      sha256 = "318b8b98a39b3ac1f5af643cbe2fea530115af56fb0346e97d860b2e7eb59f2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/sl/firefox-139.0b8.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "17b5faa5a116cc9ab8fa1a322bf6555450f4bcee1a2abf09709645b17bd46ecc";
+      sha256 = "abfab9839ea1d938196a8ac83ebb90250323c65790369c3cf80b66b174802ee1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/son/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/son/firefox-139.0b8.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "4639c5d5d267896d07214291c468546ff26478c26c435ee4d10cb2e9dc307e65";
+      sha256 = "97deb6f16db9142a4cef0ba9754f2fe347a04bfbd4bd11f0ebca8adbe3f93817";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sq/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/sq/firefox-139.0b8.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "a0aa72766d7cee37f9d9a4c3a28ae8b954a2d28810bf553cbf442b30edd623d1";
+      sha256 = "22098a2953116e320d88962cf71934824166355c81a235e1dc3d32020ca566be";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/sr/firefox-139.0b8.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "607d5e9a73671eb99735e619a2ee701f31ed6dc55ba016a237618de6fe159933";
+      sha256 = "6ff73776cf82bd288ecaa45b89733c0da81428ccc75555e1658eb0301136fe28";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sv-SE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/sv-SE/firefox-139.0b8.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "dada2e913de21d7ecf323d302fe2b9263ef6820450622b3b06e73963a6d48f9a";
+      sha256 = "4a3dd72097c53da18669ee6a9263f08ef6efcc8d2107d4ab817d6834ed76889e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/szl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/szl/firefox-139.0b8.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "12526451c0f4c8a8446b0638be2e3c24a52cbd8277928a45e9dafb2c65eb2d03";
+      sha256 = "2fed784da3342671f533881090454d9fa3031d640ee1d66c08c27f1e66a3bc1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ta/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ta/firefox-139.0b8.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "d3153deeb5951fc6dbff2fac07a51e587d98559042cf1cfea70a55c4c8ad25c7";
+      sha256 = "e7b378eb26eef7e7d4faa5b5ec90f295f0659d0d6b032adab4127f90eb1d1c79";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/te/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/te/firefox-139.0b8.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "21377ea235bb38c01aa1a21516722e2a91ce679ef7d1b32487c8813f1cdd2aea";
+      sha256 = "9e3d481bc16b7f4a2756b8accaa8bed77349844d908d0213b31e1491809d0ad8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/tg/firefox-139.0b8.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "a428becb1a20753379791ae6538b0b1bf0ebad0d55f98d7d8c19af0a7294f7e0";
+      sha256 = "7cd6950994c0053774d4fbd37f05e5da1cae56d3c993f3f39b814432888218f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/th/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/th/firefox-139.0b8.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "28a30d8cda25aa1e63fbbcd1bbcdda5a3ae990e1d973f10d4744499a27f13ef8";
+      sha256 = "7cd602e8ade20a664257dc5cb98b9fa3e886b993a05db95360e4b1c56ce7b5bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/tl/firefox-139.0b8.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "80bd0de1021edfe3178abc43017669dbcfe1885c66b71729372bcdb27d381ab5";
+      sha256 = "81826764bc4861c13ad4596ec5e2586865b329f4cf36206675f72b1e83476e21";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/tr/firefox-139.0b8.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "f9bc32e243c091be454fc5b4356b986cbbd87bb76135e7cb9f9dd44115af2f5d";
+      sha256 = "6d31990f11d71b14a855d9643e8e25ff6b28bc9285d8200851e3e67041bc8202";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/trs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/trs/firefox-139.0b8.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "fc7e927f0ed152dea1940b6965c79c3f2a21d22c117d52d9f32568d5f80bd48f";
+      sha256 = "a108ca20893912c5e890d43b69004d538313faf3a03b183fcd2add9fcd518f45";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/uk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/uk/firefox-139.0b8.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "f529c85cd2f12c7b2fb66b1f79268af7ba889c8a6c4cc1accc5b19b74f77301f";
+      sha256 = "862f363a38425e818d0c0f2985804f16f01d2c5be71c965f3da324eb17c5305e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/ur/firefox-139.0b8.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "e677de49b31054981a22dfa36d9b29339cdc2dc230077b48a381edefa1a17271";
+      sha256 = "87fadd6dc821f636ad5b82423a956c5dd0c1c20bcf9b6d65a393e88d39368e4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/uz/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/uz/firefox-139.0b8.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "46d1fa8b789e3c4adb313883a438a8dc051b67b3f005541a31967921b4cf280f";
+      sha256 = "36997bfa496799263ed9840404d64b6af84ec31712ba80f9844f36cb8eaec438";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/vi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/vi/firefox-139.0b8.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "65e242430ce65fa104fbb0bdaff6cc53a5c0dc60b2094362f2dcebc9aecabb3a";
+      sha256 = "7409a08c3d28309497acdc5ead71f8e5630b6f40480f3287bec07dd97f8cb4c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/xh/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/xh/firefox-139.0b8.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "979438f443e8c0ab980af19e9bead77f3039c955c46a2c450db7265bbcf6259e";
+      sha256 = "679c5aa404049101b54faaa33e58b9c081363b86766c3e77ac6ae07a5350aeba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/zh-CN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/zh-CN/firefox-139.0b8.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "c79ad34593f9ef472d0231fe57082a1d4ec62bb4c7cc870c4e510cee5ba3ff44";
+      sha256 = "34c0240baff99364a1ec9a1dedeb82bb3385d26f1e5b7623723ccfac5ab85c07";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/zh-TW/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-i686/zh-TW/firefox-139.0b8.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0e169aa02e3102b396e0d721b15138fe39277e4d84935fe6c8931ef69117b4fe";
+      sha256 = "4fb339a8c078d918998eaec911af735814b47ae2d517c9ec48b30dd233ef20c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ach/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ach/firefox-139.0b8.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "bd3e5c69934115d423aa111c257520f9cc5219a29588843ee1c5b61b1a3e3da5";
+      sha256 = "3f44c1cdf49fd910984154257a5658a12112dd4b630eadb81f500ab94e99922b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/af/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/af/firefox-139.0b8.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "f3b63934c1632d71f49d9a401dc8bf6073936dcd656fb0462a3d34e352075352";
+      sha256 = "f8785351c3ec0ed4f415e7afb82cf162624c6c0810be2dd6daab4bb01de53789";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/an/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/an/firefox-139.0b8.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "313da7d73bf645cea5125e3909c310f3aa81b1713297fb7b66493b79f16d34cf";
+      sha256 = "7dc1aad2f4f54175c2538572ab96e49fe9162eb0a912b4f13020d4270edb7995";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ar/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ar/firefox-139.0b8.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "9bd0294aec83fb9bdb4164eb8eeeeda22fc3b2d26e8cb8b1a5e036251be3bcdd";
+      sha256 = "9ad46091231d0183b1e174aee0b4dac6d8931e7ad2d505b2c2f7c9707a9f8cb9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ast/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ast/firefox-139.0b8.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "2a3229c50482cd3b86ba9892985680b6cffe4259503d3efcee1ecd6fad4a6005";
+      sha256 = "57a63030eacf3371796f77dd8334649e6dc16dec92ede5521e38eb0b7c564ff8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/az/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/az/firefox-139.0b8.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "b64a348dab5618276f0102c23d7e74b4e1bc2af38b36e678b3db53fac08e3125";
+      sha256 = "352d9d676afd2eb311f926ba15165e0b8195762ed87e6cbba3ac40243b6f27ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/be/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/be/firefox-139.0b8.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "6e19e16df133ea7b7b796a92c470ddec4ad9db281361210dc249851dd9c05e3b";
+      sha256 = "02697c4472ab20e9730bc543e136629764d65e881e5d93a209648515a837ec5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/bg/firefox-139.0b8.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "c691fcf4ff5aa896b51e12c01b5faddf1ab8d3e990fcb5a37c89450511647335";
+      sha256 = "0551d66146af5361ce8dc6530b92167fa7c39c806e3e0931170746c8f2d4c467";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/bn/firefox-139.0b8.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "b88a34520fbc6cfa328e879478857b10a738dd5ed6c99d6db16d380e1b80b71a";
+      sha256 = "6be9475871b60891115f89f0ef38fc68ddecbe6bdf424a3489a4cc0893dd8e6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/br/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/br/firefox-139.0b8.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "d2a051c03154c151367d01d887dd22d9c029c948c7ff406e5ba975a981e3270d";
+      sha256 = "f6e7c2dc16917263505e323ca8fed66399f3222bbdfa38ca818e72154484596d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/bs/firefox-139.0b8.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "b7ba2f914aacea218596d2118c001961c1151b9df842b5afb498d7729f4c7efc";
+      sha256 = "259e7408dd18d5470d6ae543ecff16ec651a307034ccfe478c8ac984185318f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ca-valencia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ca-valencia/firefox-139.0b8.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "3d9cb24a0d049de007c4125efa869119aef50263f70bad64fb8ce328cce6abb0";
+      sha256 = "23865564d73e7e3bb1e1f9d2dd8426cd941779c75bc4ef1c8d582f14d944f975";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ca/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ca/firefox-139.0b8.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "40288f778e9706bb3c2bccd641b7f79a9b96f5129bfb282a88fe891f95d20e9d";
+      sha256 = "5ec71a760c0a97e789d3cadb60baa40e40154e1de90943b78674faa856f2dabb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cak/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/cak/firefox-139.0b8.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "79a734a1a83b350d123b7c76dd991e9139d14c84b795486587bac3e001e43fdf";
+      sha256 = "919bf2ff7723deee31f2fea17b98d29b1610614aaa508a3748707f26878be23e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/cs/firefox-139.0b8.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "3fbf932baa5ecb2c4ba06c6f8f29251d8c33c173df96ceef38250decdef6d73a";
+      sha256 = "b9097eb464d55dd0eeb11db6fc8206deb2701bff150e3b1daa50e2509d059b4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cy/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/cy/firefox-139.0b8.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "4bf4c523a593907dba5ef4ed211d721ce89ca13af52852b61a8a812f7da6473f";
+      sha256 = "2bfe13bd20bf09caf2e03ca4c9144548228afa52a4ccb33fe7147fea334ad0a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/da/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/da/firefox-139.0b8.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "f459937cbe98b49931130dc0ff35741600d919afc84226a0907f6b373496090d";
+      sha256 = "ff0542397dd195e8c53e22de0ac6f3a11c87a034f3888dba06f923150607cbc0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/de/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/de/firefox-139.0b8.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "c1cbb2e1a978612c0fa60ba060fcd00f45ab0610a49f42f3ea59a0032c1fdc5c";
+      sha256 = "5a2424f6166f9a02149f5a6b9b913d6769401163f753dd2fc5b853ddfdcf7274";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/dsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/dsb/firefox-139.0b8.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "94288aba032c65e197001b10641ae42ea05a9a6c87f8ca6d98b48f5924ccb314";
+      sha256 = "6cb12f419cb35da957e6b189c30427d6e1dd4793215e04175e02055dbce0d919";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/el/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/el/firefox-139.0b8.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "143f849d261a87f066952914b466e6737a337cbd412117add91e7731b088c89e";
+      sha256 = "80b8bbc596dde7a5af74e12818f0f2d0d9709423fe622552d299b3531cdd405f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-CA/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/en-CA/firefox-139.0b8.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "a08ab6a5968ebf60d9c4c082475e1c7cfd840d90e8dc1265d999eab45d0bb26f";
+      sha256 = "79bcc365b55823f8c01e63ed27630d964ee29f8e995162a631c390ea91476c9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-GB/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/en-GB/firefox-139.0b8.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "a14d387031ea588bddc104982f11480983a45f2d4e08c814ae91a6f9e8bdc4be";
+      sha256 = "2c87cdadd060ea7ffd4d7af0cf0c7d39fb262045c40a29113e35ca84ec577254";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-US/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/en-US/firefox-139.0b8.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "a8b95ece65cf5ebc5d5ae2144943c66135a2a32d64d7ca1c2424a621b8ffc152";
+      sha256 = "d8ac6e2bf9c69c61515861920d72e58bc815978cf286041b93894497e99afcba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/eo/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/eo/firefox-139.0b8.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "0bf932cdb5b2b672bad8875e4bd59da43fda2fc8293b14f5b6fa5cf58c11dee1";
+      sha256 = "02c9a073a1515ca3aeaeadafd52365327b0ec590e62c66224bfb26dd3c46b562";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-AR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/es-AR/firefox-139.0b8.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "991cd0e2894a4293fe8d8bb78dadc51b7c0527a1d64b1bbad6328e553b65ec7d";
+      sha256 = "c7ce5efbe65f3724700fd1f7e9ab33c51ad6c0565dcbcd709cadcc7f749bc054";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-CL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/es-CL/firefox-139.0b8.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "15f27bd91d2d9f1833a3dff0ebf957bff6ab740bd5de214482e348240968259c";
+      sha256 = "9bfee5ade11cdbf098115151323394bcd659d98c28117a8655aef9d3e1dca7a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-ES/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/es-ES/firefox-139.0b8.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "0abd7d09a96262f226564b01633ddf9912ab190e448b57422c965d7ab544bdaa";
+      sha256 = "51cbcdf4477abc4fd23871c59001fbc599994bfea08532b59d19d4f20e0a7e63";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-MX/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/es-MX/firefox-139.0b8.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "651f09eb5e0818805219e57f9e9567fde5ea538e62b0970270547349cdd6bf09";
+      sha256 = "7f29e98678f596cb3fddebf072cdc90eee87e047544f40ba2d7cbb56b0bf5914";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/et/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/et/firefox-139.0b8.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "3f970da97eba78efcb840aaa9e7812fc07340ead7b8939648fb8839c743298cd";
+      sha256 = "39fe503f7994b4c8a18bbfc599f238bb5c937ba6c3b0a366aa55980f3fdceb7b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/eu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/eu/firefox-139.0b8.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "eb5464b8618eeda6aa507d09e403528ac991f883e4ea6070c01ecf7ccb34a2f9";
+      sha256 = "d82aabf0160f4ddbc3639cb9224216d4451951edf208d63232db09872c8dbf34";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fa/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/fa/firefox-139.0b8.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "6f78eb8b602d2b349d564d08e1797f7dd381a818b4f5fc4916e5e2d80a6890d1";
+      sha256 = "c81a08d07f9ae1050dfbbc04f4723970f86e118ce0d84cb0844b03ce150c9558";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ff/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ff/firefox-139.0b8.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "dd74dfd1b55dc2005764ee2237f4bd0cd841a90dcca88f97f4d7ea1cda57be28";
+      sha256 = "280ad3965731ae60f913773454cda4d69339c99b78965758261f8c98c19b04d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/fi/firefox-139.0b8.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "108304dedc88ed30195dc443a62df7f1d579a8540fef911e7ebecc544aeebd2c";
+      sha256 = "d7daa58b95fdf644261709bd9631c54a1b9d6a7f592a04139c8e8b04250e32a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/fr/firefox-139.0b8.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "c02dfe50d5b405f8fb90868ad317f1020c85d6bd15c6167d4bb8af152af29f29";
+      sha256 = "f93456f169ab9f0f2190493c794eb8b0d7f88447bf597ba75f7ef531c5c5fed0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/fur/firefox-139.0b8.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "c110494b901de0d5cf4623bab3fb7aa523c2c8afe14ce1339207a07715c24e0c";
+      sha256 = "2b4ddcda7928720dbe5bf1bb6fb237e93ea8cd6ca6d3e1f5033769df441505ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fy-NL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/fy-NL/firefox-139.0b8.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "09fefbf594c1c840dc18611d303c8aeae70eb7126e17b5d0e41e96868601acbb";
+      sha256 = "aaffd3451e437667c0ed5e3203b963c9ec8e7a4dc8f1c239eca3bd3812378e9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ga-IE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ga-IE/firefox-139.0b8.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "51e4f9ad18f29f46875ce2e146a4300afb0f3b860f0bc9bbab2cd6be9c20a564";
+      sha256 = "63dc5bca8e416990de4e813df25e6bb2623a29c971270957948c61bc31132f37";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gd/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/gd/firefox-139.0b8.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "cab4cdd9d7b1af933f53863be982d427f59435522f24bdef27a302b9221dac7f";
+      sha256 = "fb0da907f078ffcbef661dcd24be0a89a413d5167c9f21a58a3547801b4bfefa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/gl/firefox-139.0b8.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "48b3771b813b62c8ade64e55ca5ea2e39671f2556e6057c49374b089adfbd2c7";
+      sha256 = "124a272957f2040c2818d56464cd86b120254c6287a9448abddb08cce4c97b30";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/gn/firefox-139.0b8.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "63e40c6ee16180e62fa6ef06f0bf1bf04fc9b368940013f2442e034229bbe586";
+      sha256 = "74660fe1ee2c6efa9e86f96fb6ae4eb7dce91bb22a21b9ea9f60ab33537b3edd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gu-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/gu-IN/firefox-139.0b8.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "3c3c3847fc36800336e000c7a5ca479edf4832f80b44ca7b4f79151a67119a16";
+      sha256 = "dc7abd2eae3faab4c9905d4f6dabfa75a561972555883d9c8a377dd91240e0f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/he/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/he/firefox-139.0b8.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "b77b031493a228f911f29ad93d55d9895005c31ba90a99a5b1b4e2d7d7034cbc";
+      sha256 = "c61804307f4831b201f2b4e2177d324ebd83b205554db38644fda6c535878425";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hi-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/hi-IN/firefox-139.0b8.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "a0ada0fe2c28f6e0bf6abdfcdf60ceb5cdab896ff1c86a58d33c9bfb4faedeec";
+      sha256 = "28c726593ab2fc021dcff625aa9da037c8e464a8e055ccb390944f9855c5defc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/hr/firefox-139.0b8.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "56fdf616a68d2701b4c505da83e70c14a6c08541ec826c7a187c23a30323c8a2";
+      sha256 = "0a190b5569a5f065a253763c0712f8016f44516325661e6084cfcef007119e50";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/hsb/firefox-139.0b8.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "dc133236dcd7500e46b2bb806212a41b11e906cf66a744dad2ab6aef663ab482";
+      sha256 = "fd743ea9ba723efc03595421b678b92e9803f04be27f24a2b55ce44aad2bbf03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/hu/firefox-139.0b8.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "d2c85ea926529b2caea6f3d5a07a954eac9fcb1feb1cd1780a7115fb38f7d03b";
+      sha256 = "ebe6fa08587ff086150fbba3a90e8268a8a5067775a3c60419301d4992e16d63";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hy-AM/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/hy-AM/firefox-139.0b8.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "b7e324693725687422ec9ffad3bec53e559fc755d9eb169783a0737edd9b173e";
+      sha256 = "45aeee4e0f82252c0a0ed89eecfc4c045bcbb344bb794bda55c28094be1641b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ia/firefox-139.0b8.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "1016c382f3add7c82860d4a7f980770ca8d2332e182b1b14a958012378f272f0";
+      sha256 = "f732ff486ceffe13f454cd36c046ae6dc3c1f3341ad5005dc64e726727db1541";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/id/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/id/firefox-139.0b8.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "331b1885e004f602ebc004460ad4780725dbb3829ed04714b21df919e4972661";
+      sha256 = "1e0c5d5d9cdde1d7e39e7b2d4d4f4a3e3014610ba4f92629304d6eef800e1f2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/is/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/is/firefox-139.0b8.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "4ec80ba6afb69479b2cbc942551cc129aa0d8887ee32a2803b07ae14de800744";
+      sha256 = "36e08908a97d209e3713d72f277c8c49b0cbfce023d389d207d75f89c04eec05";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/it/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/it/firefox-139.0b8.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "9d04dfe6d24db792b2091f6726f8ba5edf0ab2d9373f2e0957c951f1a055dce4";
+      sha256 = "f15064fccc035f775cb302d6729ed36546aeada3fdec0d1f4ee0821e9cc10a7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ja/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ja/firefox-139.0b8.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "7d2b0709f649b8a6b2edb124a2a501f2309b2570b1807efb038c5400cb0216b2";
+      sha256 = "0e405a971d651edfde03f17d0fd71875c78e919de2e5a82a4906426987c622f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ka/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ka/firefox-139.0b8.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "06eef2411c405e2a17267bddd6d958c7fb55497478b6213fe259e40fb273dcff";
+      sha256 = "a9fe2c7c7ebd7b4b92ce155adcdec39afe4b9ff4660fac6da2c3ece4dd7f1c9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kab/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/kab/firefox-139.0b8.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "eaafc34c8c596602091810cbc2af966e003d870c66a647c0cdd2a2a343f4a068";
+      sha256 = "f36b17d3371cc9b08c24ae3a1f339983f350e983e2b8050086cfe08380c5ef6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/kk/firefox-139.0b8.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "dfef47c7d3255b1a711b611afd9adbb53be80eebefdac763da04af2157faece1";
+      sha256 = "cd09ad63973b80836c99c8620749db08d1ce6e8760c24060ea89fa667409136c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/km/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/km/firefox-139.0b8.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "9074c6ee90c6582c1202582d35d81f97b43789ebc3f9019261130dabcb01fd46";
+      sha256 = "40308772ebc12fccff1ec8af954408a569579c9026c24b85545fa6ad3f96b0da";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/kn/firefox-139.0b8.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "f8badc895b36bdcb7666510faf5f775470ab90733ac31201f147f3b45dc4ad9e";
+      sha256 = "ece3b4a87cb845ec1dec9f30e83e15fd3f654b80efa28c369ed4ba10b8c01c2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ko/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ko/firefox-139.0b8.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "9d8739e1e382c5b96240a6564219c7b0ce161524386539141f4dcc020cbb5fee";
+      sha256 = "c2b19c37c5ecabfa08341c9cc36a5b1ddbf7646d9477fb8c8e2493efd1a46570";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lij/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/lij/firefox-139.0b8.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "c36fd45434f81e1c20c8793bd52cb85637999206b06ea9b094b2d1b0442f95cb";
+      sha256 = "e9e55ccb0af7157c9b9406792f5b9b2e9348f9e37ae013b4742c2e1f603cd634";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lt/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/lt/firefox-139.0b8.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "24d94d2ef16561bb3750d607fda39f4b39060efb83fd4d435cbef7383bf8f76d";
+      sha256 = "b517118c0a2a47488f0bab65da2ab1ec2a66dbc0805928598e0c0de41498ef9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lv/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/lv/firefox-139.0b8.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "6eb7553cd275cbf11b387088e52d9f508486d3f737b2482d1f53af1a2c1e0dbb";
+      sha256 = "12280dfd796c4fb858dbabdff79419189385c4e19ffec8d5d8ab982f3efa36d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/mk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/mk/firefox-139.0b8.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "8a1b20b6be53d68dd1effedc3522fec9b2d8c64a4d8e30c7a7113bf0fdb2317c";
+      sha256 = "305c2f2384b2f1223b81103ab04ccbe85c5a28a0ff9f3d98a653dd1bc8598f06";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/mr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/mr/firefox-139.0b8.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "4dc0347a86f3e4f784ae32e2324f3d134ce5b4fdec4eec34572f51c13763889b";
+      sha256 = "4f41992cbe27329ab0be827e8f5ee85264a1d7d9c3fe850bcc8219418222b68f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ms/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ms/firefox-139.0b8.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "7b3fbd663639fe8575eaadf01d3a9299f0c132a4b2fbbf25ddc2d18378102cf4";
+      sha256 = "c0d55c08ffad3c27e7dc21e46da544fe54925ef1b6bdfd5e5a6284d19856739c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/my/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/my/firefox-139.0b8.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "8a039ed198a5b338fd32dd632f05c4de8a9dd61cb09247d5f37a1ffbc640e0fa";
+      sha256 = "eab60777a12046f885d51de27055dd259d560cb79e0103c710d4ce037e1880cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nb-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/nb-NO/firefox-139.0b8.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "70404a9fe3361dff890f344eebb61001bdcb6a3d4356cc06386783d70a163857";
+      sha256 = "6679ec571008bd14b1b772a5d38fbbb1277712cb5f3e885b1ae290863b5ceec6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ne-NP/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ne-NP/firefox-139.0b8.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "e148000a58bd8b834985ad9dee1eb6724ed2550fc70279ab915c06fea148afe1";
+      sha256 = "b9caa521b999b3ac2aedb95abdeebb4a966af6a78c94a0bd74205663ce6fb3e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/nl/firefox-139.0b8.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "b15ebbf39c475a53fc5b01d1c5c6559f74c42e35c1d7b7bbd4cda37366359fee";
+      sha256 = "738a36102a2b2408621428b0ae7ac5ee95896233826342865338d7eff121f733";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nn-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/nn-NO/firefox-139.0b8.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "90221ff410eca0d1aed97186e45106b7ab826029965e2b4fb54d93c74f743ee0";
+      sha256 = "464a2243e42537b69aafb08e5ca561ed52620a0ea526691de0c54a34d05d59b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/oc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/oc/firefox-139.0b8.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "7cbad01d0adb697bcae6c072bb69cb151e83920f39b67df2a340f7c1dc4faaf2";
+      sha256 = "5623f111b8caa046beb5505bddadb271ff8a8048a78bf4b85a8893bd328370d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pa-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/pa-IN/firefox-139.0b8.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "1601a8192da0564af21b4cb7e63d87b6015d5533c08e96187a0d895e32bb03fd";
+      sha256 = "fcde32032e625a1173551080586840abd6f12be1d5c18ebdb88f930ff691ba94";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/pl/firefox-139.0b8.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "f62fa06e9e651e7db14cfdbd0af5acac3d6f282a2842e41bed7b6ea323342ff7";
+      sha256 = "a5f0a9ee1f112691e4fa3f3bd5a5d2443b7e1893fb76935830be6a406800376f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pt-BR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/pt-BR/firefox-139.0b8.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "493c505bc795451989d58049e0a16397eb32c6d26f3ff5c285b845b35cf63a53";
+      sha256 = "468e29808c54ab9319c32c534bd6aa60a0c168133e6f3fce39e67534717a6a7b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pt-PT/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/pt-PT/firefox-139.0b8.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "ce1caab07d4ca3f93e5be33580e09c1109f3a19176144d7cfa06e97ab04fe7fd";
+      sha256 = "6dbf94d0b840cad8ff3e68ee8478a1acf2774970f06199dc2b6da542713df9b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/rm/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/rm/firefox-139.0b8.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "d580649d6aa0f7fc519dbbc7c72943b36a437806020f6a56fb7659befb9dea7a";
+      sha256 = "7862db7ee3df1422f36386b2c2fd2f3c0ad099b6b210c3e977475f8cda7ad003";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ro/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ro/firefox-139.0b8.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "a78d357d761f72d5795608199701c429f2016ad618e2899c10d13b9f7ee8e3ef";
+      sha256 = "98585e37e4181db798448c5087b19182fd69f009378019cc3083d12c9fb8b5e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ru/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ru/firefox-139.0b8.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "8892c5688612eda284319c1df7c366d529be0d0c96a55d89958d7185a78ab30e";
+      sha256 = "bfab52d3520d834a21bcb27700b0b61408ac3310247bfdf0cadf2e83edc81a7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sat/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/sat/firefox-139.0b8.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "c6d9eec9c8ebe83c966c904611d6d865328b5a7f401b42b06d72dae32174fec3";
+      sha256 = "fce35a79404f34eccf8d10a54483f9996e88d21f064b772e70154149d8335c48";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/sc/firefox-139.0b8.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "d504d52b43598ec3fdcf02949868fa65d6e6a72f78f131c53fce804817de4ee2";
+      sha256 = "081552ad3612a4898bacd008c190275ec672f47536607954d4b1eed714390425";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sco/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/sco/firefox-139.0b8.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "89962ba5d9de002d3f03b4527eb9ef84235d59c19abb46165dfa9c52a085ad2a";
+      sha256 = "4415190f31ba416ad1b1df4979fd9a8ec129eaa713b788e698e3ca37b466e4ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/si/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/si/firefox-139.0b8.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "247261439dc9594b9ad95fa066431ce1629537b8cfc01df7716c491044a7c72a";
+      sha256 = "5e66c91eb313b0ce226018c07ce8fce694551a21732d5407b1b5ef7245389489";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/sk/firefox-139.0b8.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "29cb232a5339abc4890b306a12b0f55cd2700cfe2521fa745491903ee87a26ad";
+      sha256 = "ef7d6e36960bac349c1f1d547a1053ebc68caa9fed79f32f5b1ef5ba85e5cdbe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/skr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/skr/firefox-139.0b8.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "f606442e9a6f87616a77d2fd392412a8dd61e596ddc8c067e38846331cbfca0f";
+      sha256 = "de12f89202fddc9ca6e557fa47d60b6cd14165fb69a2a694b9e8c52aadb0f350";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/sl/firefox-139.0b8.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "43cc2db32879fce3424c1a3ff2f862cca4835b0a4c5df5c3e28def64812ce73c";
+      sha256 = "d6c1231b10c07a32f5fc5251b3b59393a763b09533af4df4cd6a90dec733ddcc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/son/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/son/firefox-139.0b8.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "cfec396b94bcc091927c0884ccddd3969f69acba8c09467609319c54c0bef55e";
+      sha256 = "37ec5bbdfda1377aacd08da67b5181348bdfd624aa7c16737e8352f2a50ced36";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sq/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/sq/firefox-139.0b8.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "ec827f911bb4553cd7caefbdf2aa3aa6b4521059beab32b23e65e80f9858181c";
+      sha256 = "e35b96bc620642340761d1998dd56ad8a06705e22bd6964dc64f88259234a322";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/sr/firefox-139.0b8.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "284b34324291ba29a1d1d7b36cff68fff0f00213a7e12fa7f48536fc5a80990a";
+      sha256 = "e7aa8819ebcd52e6f94dccc1bb2e4b3718d4cbcd97239dc437bc3153f5bcb7f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sv-SE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/sv-SE/firefox-139.0b8.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "07e48d548cfbc4c4ab3fb3b4ec630385a125d3c5cbe30526be95d0476b4d8f87";
+      sha256 = "735ad079a771e67c841eca74b411642aae2bdce087ddf2720c1ff2954ecc7cd6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/szl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/szl/firefox-139.0b8.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "84cfbf70da99b4f544193d6d167a2280142f8ae37d8de1e9b4093f7ca6671fea";
+      sha256 = "595aeec0ff51fad2bc85e891d99eb8d55dc09f81754325a176ff8d865b2af33d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ta/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ta/firefox-139.0b8.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "dca3f4fd1b468cae66bdb6ef3817860760a2527b94928359c302e789ca2c04c3";
+      sha256 = "918c7001fc63472f1f89e4cb624f760e2f0565ebec6b33b044a6b3316632552a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/te/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/te/firefox-139.0b8.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "bfa4f775d02a2b2cf0dfcfbf4ed3d2342f7db943256c2e73bddd7f9a8077484c";
+      sha256 = "2ea48cebd214860201944030b12f12fa9e39234575a9bee5fb30a468f85a9075";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/tg/firefox-139.0b8.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "1515a00b6d53e074bfb60b1bc7e37ac60fd977131a6ac6e772433b1daaaa4efa";
+      sha256 = "035fd8ec09cb99264e826741b1024b2c4fc3bef998528ac92b56c930d4060735";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/th/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/th/firefox-139.0b8.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "507d9c041c8874095a52f57e5a46adf8db6d4116d5ccdca0b100d831c41c0422";
+      sha256 = "bfbabe2eb3140fc7772c7ff4fff12c80c99edc28d78974b2d2d48e0d0428d159";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/tl/firefox-139.0b8.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "cba3d10cee0a09ed530f6e8ec71e1da36fc29c972136bcf6beacd7ccf91bd162";
+      sha256 = "fd20e0398081c02d9b506c708ea7b1e57eb29b09e7ba6ccb841c0a174073a0ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/tr/firefox-139.0b8.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "f5e68e280db29872b7570484dbc841756693b3d00eda2cc0840a77e5600628af";
+      sha256 = "247df0026e3bbdce9416e84b3e57940185aee4b82d026b9373cd95871bbeb543";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/trs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/trs/firefox-139.0b8.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "028e3728920e5978501773da88c2eb1d5d86927d83e5f51e910692fd4482d9f4";
+      sha256 = "973ac2e1d68fa69a0d0005494f6600bf9ffcc13256fca00db1242eb127029d0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/uk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/uk/firefox-139.0b8.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "9e63e86af01787ceec6b4776b78cd98db74230287f1c065eeda6b5e5f6133b42";
+      sha256 = "d7deb7aeebdd73f9777918b3592fb795078e0e3a4603fc907a1d50cc3976c933";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/ur/firefox-139.0b8.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "964b123de671b9f763861d626a444c86d48516cdefe9ab71f866dc564428d119";
+      sha256 = "af56128ffb1e463ddee90bea429abe958467ed07cf9a2cd151b80b86df5e35f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/uz/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/uz/firefox-139.0b8.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "e603da60f6be77a60584bd361f773a5e12612e8fad84f0aecaf33756fa13d9a5";
+      sha256 = "2bd73e91a9e377852efd01f224e2e800d9df7042afb7a4b4360819f7a295af30";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/vi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/vi/firefox-139.0b8.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "c8ce7aa8546ecaa76af778e29de3bfb12490c2e9e4f667888449939ac424f122";
+      sha256 = "cab618e3b1b105584baf8c05797a402016ff752d4990c3df81e529471ec32055";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/xh/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/xh/firefox-139.0b8.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "dc9071c3a8553cee661223eadaccb949944d11f4631cef76775e6b3d93f89eaa";
+      sha256 = "90d4c57b7d7d6818d4dc9eacf2b812e59d1e49c033104d2992b58154de4ddd79";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/zh-CN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/zh-CN/firefox-139.0b8.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "f8561851a5acce3ba9ea763855464592777d2371d1918d70cce0a01d833ee77c";
+      sha256 = "d35b4c7f4a3aaa6c6d95e52a0a78eea3ad93982a8b0119506cfb842bcabf8ee4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/zh-TW/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/linux-aarch64/zh-TW/firefox-139.0b8.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "180c46473119cdbe027f13a26a53234e63e1f2dfd291925b0af2edf68ff05650";
+      sha256 = "bdeba5394ca72538b950058b53297230088b30beb8ca1d5c4c5163b9eeff893b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ach/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ach/Firefox%20139.0b8.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "e0a518e46e2f11edca8e5e0ac47449947c3c2777505ef4da832cadcadd093a23";
+      sha256 = "d7b5a10d6098518a1e7ab0dc5fdf0ed01dfde92f383db9c2c0ea088a4ce0d7d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/af/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/af/Firefox%20139.0b8.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "680fd32905798aed50dd4a0bb0bb88817581ac246bf12ad7db49c90809619424";
+      sha256 = "7a79690afc6fccc61d27d3c647109a84833200e0317974c2d61069dcda993e03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/an/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/an/Firefox%20139.0b8.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "bff5ee309b3f73e65b5de3f40f1a7025a4137e806399c703d20c492ca925585c";
+      sha256 = "97506c8f55ba25e8bb2746356d87190459a4e1263730b9502c7b94b9685a3e37";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ar/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ar/Firefox%20139.0b8.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "71f47f400126a2729f37bf8947c8577cb012a787b9c37f8dda516f4e765e5b2f";
+      sha256 = "30c900dc267551967a760cc22210c2abaa5f4afa51fcfd199a3c47efaa296bc1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ast/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ast/Firefox%20139.0b8.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "a614feb3d06e2cf3430bcfc3daa02d53bbff1dca8a5433d43745efa03f0c7e73";
+      sha256 = "ac5369abf93d5d5fd95d6b174fec9c743d3aba498c56cc21c43bb04a3eecfbe6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/az/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/az/Firefox%20139.0b8.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "07482d9ffdbc3629e9c7c4fe419cbe2824b947cf93b4cc7fa371bf9c1083198a";
+      sha256 = "055b9d4908acd7b7b31b959f1d156f27b94cf580f0d91fde82819d8ecc27a987";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/be/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/be/Firefox%20139.0b8.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "6163ec17db5b8bbe2e897ee3820334928f18fae85055262561cedf1a1ee8918d";
+      sha256 = "124bbb75536356c687ac50d7b6b796b3d419282f1863e89c736f063475fea4a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/bg/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/bg/Firefox%20139.0b8.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "575f9b58298f0981566ba826294f80edc45dfd9de69d79e6c82d28d0c884c58c";
+      sha256 = "4f90434b4a5ab3bc025f918fde090208656140fd73463c9633289ad99d6437fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/bn/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/bn/Firefox%20139.0b8.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "076b89297184b520cce7ffc362b7bca90c4ebade5d64dccf0f7315bd2584f678";
+      sha256 = "18ec16ac4e0f67dfdfb45305def28b9ad6967d33370a209820aa59534ed7bb1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/br/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/br/Firefox%20139.0b8.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "1a29076fab57e50c45cd6fcc8f25cbfbd9d6a962705b88a607935c6184ebe2df";
+      sha256 = "b645d65fa53e7624fe5a1c397d10fe080565ada370d2ff027ed079a5f65d2218";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/bs/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/bs/Firefox%20139.0b8.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "267526f268fc1deec51cfd16fce9c24fbf7fa9789e1d3d82c42df7bef754787e";
+      sha256 = "eeb26363656a91864e61eb247e00aaaf065996a6aa4780eaf4f5951658737332";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ca-valencia/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ca-valencia/Firefox%20139.0b8.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "713b6a6a73f06e3a6f09bf1ec06fd9914bf0672b5569b51d4a8fce689fa02c67";
+      sha256 = "b185735633bb8dbb25f7121d5a0a383a9c06abcb9dc613b2f6f2a19edaa3c894";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ca/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ca/Firefox%20139.0b8.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "1537068f9e353f37f69d39acb852fd25bfee7c9bc6f83af2b2dab2da21737ca9";
+      sha256 = "db7efa41b08c2e65b7aa74a578da4214c3733addfbcfd12b66d5fa373ad6c0e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/cak/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/cak/Firefox%20139.0b8.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "726df556a936dbfd4cf756c7736abbe406c7c774986a745eba460a82f79a2f50";
+      sha256 = "8e0b5cb6ad38ec838435d98b82d9ff3348e60e1b58ac0636d6713e7e068d8e75";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/cs/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/cs/Firefox%20139.0b8.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "ef6701cb85dbc9af3f2e0013c2813e4cc140307b2c7ddf77ed18307b2a3583a9";
+      sha256 = "0b2e199806837330a6e8cc8352d07e139fdaed224b8365d82600fa7fccaa52db";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/cy/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/cy/Firefox%20139.0b8.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "911406e16a06a37be909b298d84fbca827b74a771e13ad7d1921f62c11e8b9dd";
+      sha256 = "fd4481ab8068de821c1f92a1c324dee06e90b563d77925e36ae0deed0f6efc2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/da/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/da/Firefox%20139.0b8.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "4080196890c2a15ef88a55a97e5f4ddbe03cfafb80f536894b3a9c25fb0ee8b1";
+      sha256 = "ce6ba82c844fc172c5c5577df6f6a339964a185e17fd609c07ef3a39590a202c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/de/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/de/Firefox%20139.0b8.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "40eae4dc5ab677b214dc13afd066444b892bd444f6ab09922a73ceb9ea00d4b3";
+      sha256 = "9ae6fa2b71f7bf0b3dfa932936373f96e8ddd7522203df2d185c5307ec4b8f25";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/dsb/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/dsb/Firefox%20139.0b8.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "3ee17df8b247301f376652f938f24464d0809b7fb6b402b9f5083ce2cee9bf34";
+      sha256 = "44ee0957444e3d288a695a77501445af0fe1ce8e959042e9ad02339116ea1ad6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/el/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/el/Firefox%20139.0b8.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "11fafe77ea6929eff1dcc1da0df306c0f8520d7f522c316518889ef6b4bdd273";
+      sha256 = "afa5b1e604d36151616d24f0d1d0f3ec0ab0c1ea76b74b557a13157028e55d3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/en-CA/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/en-CA/Firefox%20139.0b8.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "a15fcbf8b20e47ec62f8a0421d21f67ae091a3fb29aced137a52ba05247762d6";
+      sha256 = "f7119507248458449b78756881b2c9e2d11f14e29e1d4e8d28895a209c36ebf5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/en-GB/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/en-GB/Firefox%20139.0b8.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "cdf313854d38f48bc31f30fa4e546d2ea8867f49872b7398005b574d26362548";
+      sha256 = "ffb4cef711be0fc8bb4157dba8cd14ee776c37cbd4e6c7bd78a76371174a1755";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/en-US/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/en-US/Firefox%20139.0b8.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "bb516b07c4519ae946b79a6fc34e911221e5d83851aab2bafdff87c3e5b74b3c";
+      sha256 = "cde7537f542dddf61138ed6c815913e3dc308e8ab5d3d915f6ccfe60b1cfd24b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/eo/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/eo/Firefox%20139.0b8.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "00c505dc9fd5c7e10e424022ce7807a886567b9ef01817e0d86ebd7bcb51e38a";
+      sha256 = "83c10b01d85273aa95f3aaf49a20c8c4bef520d1c48c2f9dd335a2d345195ae3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/es-AR/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/es-AR/Firefox%20139.0b8.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "cb8cd92f3762979b88dfc445bf5d71d83fc7eccd138995b1f6f8662a00c06751";
+      sha256 = "8a79a908d95ec4f9a2052fd05bcd7f9b24472ceb60db6557a6e9481e0f10ae04";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/es-CL/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/es-CL/Firefox%20139.0b8.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "4d54031158a87e46f4dd79a2f3835fa2ecafe059160fece167a3eccb213d4ded";
+      sha256 = "204d2be81c8ba613fc25c8bc1cbff88f6eb6a77ef5a7c76975e190666f8ae373";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/es-ES/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/es-ES/Firefox%20139.0b8.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "2e150d79a2ba9e065128963097289a4ed340473de8a6b5f73a6435ca3bc8ae88";
+      sha256 = "ef42405c8b18d7cab819c6d4706f099637cf6720a20ca8864018e092c86cbc05";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/es-MX/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/es-MX/Firefox%20139.0b8.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "4e22a347506019c216f3d8f3b363677f9677a44816de1b1cb42a11fb3beb62b7";
+      sha256 = "a61d758cf8af02c2b9550a4b7bfddebdfc4367a940340e6606bff2be1ea9f3ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/et/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/et/Firefox%20139.0b8.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "f887cf78873cce42ec474a9bf7e2de793b39087b5d71a86a00ace6543d5f06ed";
+      sha256 = "d74732e10c63d5ea9801efae150dacd058e430446ec24a87eae3a1209d1693f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/eu/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/eu/Firefox%20139.0b8.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "832d8dc7d0d7d011967825e747ffca5697c6a8bbcd0592b60f77bcb602e64b3e";
+      sha256 = "a6280608b98b4a5ae9e11310f99568cb84333020d44d927c5f7c6d32b62894f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fa/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/fa/Firefox%20139.0b8.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "bd2fd21b2efddcbad65057b06059c93e4a3ed4535966f71f59b213b9dddcf110";
+      sha256 = "eab71c087d8121f19891b69c6b6b80e1cb562885e0e476bfc690d89eeade5aec";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ff/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ff/Firefox%20139.0b8.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "2268a7857090100091254d57e47d72826965e94d3d2922ae0713d8331c0c3fa7";
+      sha256 = "74494a858d4f6894b1625ddc47e860ed6e2c0112dd8b4f7fb4482ad293ce9628";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fi/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/fi/Firefox%20139.0b8.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "72c7f214ac536cddd3bdd12e14f8e18e82d91e2341622e340691dc119b44b459";
+      sha256 = "046f2eb12a2884cad9f89bf066d0fcb6fdfaebe5730d850c1a74e6ce55fe14a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/fr/Firefox%20139.0b8.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "1392ee9e9ece7c3c0a1034ea3460ce18d4dc09695a6c3872f75b44e2083dd6cf";
+      sha256 = "c58fede742e2b02d3c0a673ad1279fb9c42d82c15558183302deacf811b9d73f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fur/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/fur/Firefox%20139.0b8.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "6b37a09f9e0d05747bf71f6bf33bfee5405900a6486b0e327af7958c4848b889";
+      sha256 = "daac94acbebdc04803733f2f89ff37094febefd0195b68df41e89094f4d3b31e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fy-NL/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/fy-NL/Firefox%20139.0b8.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "c1ba5e0babab78374c0644917a985bd016fc84383e848c0c08e424ae229f33ee";
+      sha256 = "11048edc16fbbd847153ba12f9dab4f51c063a924c8e68e12fe794ad23dd67ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ga-IE/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ga-IE/Firefox%20139.0b8.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "ab89350cad0a76f3aa3b7958f5e41af7b3f0362ae5716ed764019d86cd55830a";
+      sha256 = "994461bc0a6604f22a31abdd3a08c19bfdb6c82ef9140d3175235d0984f6b311";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/gd/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/gd/Firefox%20139.0b8.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "4e36e3ca3e6f2336c10bb1c78db21449b0e893b56f8e0220ad783a0481676e2b";
+      sha256 = "a59193a1e2a4b25661310a4764a7c514cdabce93432cff2a73bebce260564449";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/gl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/gl/Firefox%20139.0b8.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "8834cb809f19bbe04bcb97fa0d231049fb0636d701ed04c2eb5c29cf2bb938cd";
+      sha256 = "9bc008dd35be32dc5041792cacb4526a2bfb6f36ac05038b3f4eac6360406c28";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/gn/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/gn/Firefox%20139.0b8.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "d14cd07d0fd5b9b0f805b327bcb76966ca52ea1790145e47ae770f6361245727";
+      sha256 = "9fce65099abeb9ef44a0fea47283ba1e0fe800cf4189a615eaf7b6ee598cb292";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/gu-IN/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/gu-IN/Firefox%20139.0b8.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "c2c14a42f72894d17751c324b5a372a2141c5f3228e8c2055e302ce5a619b795";
+      sha256 = "fdc762229b79ff4413e305c5b8d64faa314aa3dec6e3456b558a713c1722d3d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/he/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/he/Firefox%20139.0b8.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "36499814455eea5f4b625c332739530bcbe67b884fb3634086c51841043ab861";
+      sha256 = "85f5d0d3ffcc29caa8aa6f6ab5d925a1b1208b046f89cc27f7d203c441b58970";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hi-IN/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/hi-IN/Firefox%20139.0b8.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "6aaae4c73c81bbff984c8b94dbbc51c403161ce0658e713215167c62b9bd5a26";
+      sha256 = "c27e71ba7cb163a4dc53288ad69ba0208fff8d0bfc4312fadb1bf27b127712f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/hr/Firefox%20139.0b8.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "1d05037ef618476b485a1ee5f54fd379978caac33aed2601da1196b531ff9251";
+      sha256 = "428a3fbc8138e0f6df686dae72807c0e70bfb96d6e6c16b492fe373b3e13aebb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hsb/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/hsb/Firefox%20139.0b8.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "c5dc2bea7cc3035da37e6adbbb7ff5e4c9c8dadb18a0f284aa6480ba0523fa27";
+      sha256 = "1799c2c6a1781ada79e2feaa83839652b4cbd32eeaf4ec1a0fb2317d5098b3e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hu/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/hu/Firefox%20139.0b8.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "98747da364f017149e792d392c3799f5817960f84ef0fb291c2dc76bd2acff93";
+      sha256 = "f5178c3446d67a0ac00189c478e5467280563ae4f90b572321e6723b87d98118";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hy-AM/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/hy-AM/Firefox%20139.0b8.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "caf0feb89b4d2830699d9e6beb4f799269a291a8de1c7792b9ae7ea59cf33c4b";
+      sha256 = "0e37fe22c7ffdac01659f2989eb3219a528de0daf62aaa9f7d6acee4b632a241";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ia/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ia/Firefox%20139.0b8.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "e07aac3d382089f3b2739427a687f77ba1b4e366988c64dfca24fa7aa154ff41";
+      sha256 = "238f83d46632d7ee60eedb137995491b1a11b153df5a8c1b435092a2dffd3216";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/id/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/id/Firefox%20139.0b8.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "b080f0e359a540b588f44388fdeb340e73e00eca8183e75d3df34eb0c94e6adc";
+      sha256 = "15cb7274cea031f284808a9b93f33a25775b6e7f72bafe1c8a1501ea276f67f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/is/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/is/Firefox%20139.0b8.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "14ea2fdb726247ff132736ee16abf640a50e2c4626d4128cabf29c92868b9c64";
+      sha256 = "9a89aec519c8572bbf5b525a9a0ad93b6b0e6683877894d5560412c02f882aae";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/it/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/it/Firefox%20139.0b8.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "896c2b89b0e74550ffee1b2b64cbabba41a5e966f0a606b1cd1109c82fa7b839";
+      sha256 = "45cfad8617f887a0c78c3bfc1a6838abf7cf2910bb081cb2b52750965770e773";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ja-JP-mac/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ja-JP-mac/Firefox%20139.0b8.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "bce36ac2f32606f1ee92fd9bda765bb7a3956efb4b87827b94ea246779caff51";
+      sha256 = "3d61f05276c8dff69b6a4754a2c4c048118acaf1ef7b75e9962126b55198ab61";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ka/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ka/Firefox%20139.0b8.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "15c2a3a3f1b4d4b3602afd3e25774b1ea073b6cc1394c623ebde0d5cb2196d59";
+      sha256 = "272836020ba9cf068372ba8140368ab8a43df0030eaac125490f238b614ead20";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/kab/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/kab/Firefox%20139.0b8.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "3647fb09d5c77bb90788aab0329da3e7e562cb455483289d5152bd845162aaef";
+      sha256 = "26a4b06a38c425754fc7b0a21538c038becdf25703658c67957ce90634ac3201";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/kk/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/kk/Firefox%20139.0b8.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "bc253d2686952356ae7b6ee8429fc30b3b67b9c99ce1f8372b7a280172bc340a";
+      sha256 = "a1ed16f4b14283bdc7aa05119d504ea2640606ba2783fc0496f5202e9c4d2a05";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/km/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/km/Firefox%20139.0b8.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "62ffcffd64359b8cae0138819e4783678f2a50f9359a4d71a883731117cfc5c1";
+      sha256 = "b52e723d1f987d42b9326819721fcc5739c5e17e64735db44d8e533ed8532034";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/kn/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/kn/Firefox%20139.0b8.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "c213cbd3f6d7267f39be082f93dd5d46ead2df09878f31f2c2b472e3c795c718";
+      sha256 = "e6935fd375e6b1c7eaba95c5d8461fd5e2425b01f8b4dd069db0c7266829a939";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ko/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ko/Firefox%20139.0b8.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "257a6db2f9324b4f983ab0bd655096391dc193733ab0a4c3fcd8525f8e0d2e8b";
+      sha256 = "d8e9cafc2122541c40f0ec7f9c50218c65f9210a4c5b6bb9007bf6ce7435b64e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/lij/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/lij/Firefox%20139.0b8.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "13ab3253431ca8903376986973944f50930d81ba5265b20063819e425ccf03be";
+      sha256 = "c64e79058e646ca7f2e2df1ee40a0a9a660fcdf87829fb7e1cb1cd6f418ee19e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/lt/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/lt/Firefox%20139.0b8.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "eaf604655b8851623523e07adeb17d3c491a6446483f8ae08a0e3b26ac00537b";
+      sha256 = "2a269d37ab3708207470b6cc5e92a72ac998d760f2e42f303544b122772dbb80";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/lv/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/lv/Firefox%20139.0b8.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "68a8759f7b87d60a5888bc3e411ff1d96c8fbe2d777d955405c7175a26785947";
+      sha256 = "263093e125fbd7f7f7cb98956ee9e2005d6d20a1b1be2dbf0866aa2efd3d41d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/mk/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/mk/Firefox%20139.0b8.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "dfaf7648103b53050f8e6bfd9d15a16c91b5c8097ae66dbf29b4816c98585f8d";
+      sha256 = "89f2497fbc3833659809763b5e2f3a15916f5f542aab50e32798d434078c805e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/mr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/mr/Firefox%20139.0b8.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "98b55e60b28c26f2d4b64ccc6c2a168eb3778b3eb7f30338c7fe65b93c4947aa";
+      sha256 = "3a12a9db237b2fde119d32f26c10acbe22be4211ce8e7989cf8ce2fd73d05953";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ms/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ms/Firefox%20139.0b8.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "0f4dfebfe6a49408c9e6f86f08fbeeba1752e2338547414d3f951b54301a0190";
+      sha256 = "e68b6dc78c26768584b3f048614f5bafbc6f8f542dcd4770309f62020dfd8c55";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/my/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/my/Firefox%20139.0b8.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "69a6343204688fb6917ae3bc8246dbf05aa0d33ba1e3ab1dd63bff15517927eb";
+      sha256 = "a0031e9cc3f9bd1e646ae503330f5ca42cb1b632187d95664d437d01d17caaf7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/nb-NO/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/nb-NO/Firefox%20139.0b8.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "e53432862824641c579b83b0390c5266fd9acd775774e675b92c85dd0a1f283b";
+      sha256 = "f4542d317d4f4ec6c4b88eec5047b5fa421c5238dbb214ead4950a640e97df83";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ne-NP/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ne-NP/Firefox%20139.0b8.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "1ec4db3a6a73d9c89c1abac64c3f21f203a312d03239c634aab1b5fc1e1978f7";
+      sha256 = "d3b166d4a46e61bf712af63587fb78c0c1d37e9510ff0435e8433458adc2bf9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/nl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/nl/Firefox%20139.0b8.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "c4d22c9a149fc3b9fe1026e12463e95e96dd684dba1d6087d295d83b214ee419";
+      sha256 = "346155d47f565ea1ad10a7efd2211a2105c9f2f7ac2c0bdad0a43974af7df306";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/nn-NO/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/nn-NO/Firefox%20139.0b8.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "8ed77e09b7f21288f0afab5eeaa3f37d516d65c98937e6651362d1655be35b27";
+      sha256 = "364b781329855788389a1f7dbacd586c4967f40eb101731f893057c44e925950";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/oc/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/oc/Firefox%20139.0b8.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "228a5983879f3d71ed5c3f0e3147814889e647a495083a18b99ec0a352620138";
+      sha256 = "40e66e1a082e3c36d05d4dcb283d302f45bf4552028cf7227973d3baa68fa9f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/pa-IN/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/pa-IN/Firefox%20139.0b8.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "8b2c24e4396863b73b514035ef1bd950bbdce38a891bfd157e8dce2b47be0ce9";
+      sha256 = "bc1dbe8260c2e3aeac7b95de3efe6a3e94e7ceb511aff5072caee71b186c5042";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/pl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/pl/Firefox%20139.0b8.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "54dbd4a9a0ff77c603108afda46ad70d492795dfd1de37e0baa61fc1a1892839";
+      sha256 = "a45b845f7f2734cbaeb8a3e29aaefe5db35e14a63e153c92772b5838489151a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/pt-BR/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/pt-BR/Firefox%20139.0b8.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "67a1c150bf04edc8d4cc15fdb864828feeb3329cdd454be8b25bf455cd64b863";
+      sha256 = "033c6938aaf1972abfbae39b9136324ca53a7d19c99490c533fa5dbd49d9a099";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/pt-PT/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/pt-PT/Firefox%20139.0b8.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "8f64369b64b5bdecfd25eabd0efc4ddc1b2ca724e0532f1a79c4d1875217aba8";
+      sha256 = "ac37491c2f60bbc5cb3fee15ebcdbd0fff2255098f951a3c7f6deaed57ed603b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/rm/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/rm/Firefox%20139.0b8.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "2f2f00063d3bf05c486734567e26cbc9563d699208b180ee969bda9a3e990872";
+      sha256 = "39d1d590ee5de9433dfe78d6889a3c4ec9aede5bcf318deb1f93848a72d04171";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ro/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ro/Firefox%20139.0b8.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "8c4f64ff21c0fc81559d29958a9f3419680272a8fe3a309e07b2848b3a0756b2";
+      sha256 = "203bcc09ec8a5fa1e30230a83410920ef551003212bed45cf81fb0fadb433679";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ru/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ru/Firefox%20139.0b8.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "c0976a0c47d82613fbcbd3054cc92f1239ec8af017b79f9cc3c7e2a46058b085";
+      sha256 = "9fc35f530f6885e0f01cfb145f85810ae8b8149783b4e9e4f805a8bf8804d990";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sat/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/sat/Firefox%20139.0b8.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "ca292c59e2845540369343d79572523e1e4cf383ab27b079e5503ca9b336db40";
+      sha256 = "78597e454a4639425d954b7a3a19b5641d4759f908d04c3b6570baf2d665b072";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sc/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/sc/Firefox%20139.0b8.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "bef03d37448cd88fd7d455e263673ad057e51e5e375766c79dc96d10c807904c";
+      sha256 = "9c69fb3d4868f66446e67c4503db45f161467c2cad47bc755bfc8b5d9173f3ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sco/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/sco/Firefox%20139.0b8.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "6d303464a114597524152610c4e431a81fae3b9282764874f2a0548bc5d20974";
+      sha256 = "bfdd29249609b0426a436a5418b6d14b9d34888c06ebe320dd9075324aba6788";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/si/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/si/Firefox%20139.0b8.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "4f4c76296bc4f04ad97cbd35a02987d99ef9c05a3a02b06e8d48860087adbf8d";
+      sha256 = "a2855e7f3b815d9cdb122fbe36c7e126af54c0e120531b0cf8a50cea70b3b0fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sk/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/sk/Firefox%20139.0b8.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "07d0440034e2c92c183682ebc9778f32f7549e9e3668a9a012faebf64b66d1b3";
+      sha256 = "55e71bf0facbce03795a8219edfd88ff1ddb3dc50919caeb1eaa435327c35ca8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/skr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/skr/Firefox%20139.0b8.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "f8ceb672752e27a354ff54250a182465a718e1d83ccc6d7f3716c36d343b8ff7";
+      sha256 = "bf644b85d96b737901cc5f474a10a2ea58a0fb2206cef25ccaf91c6ced6d237f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/sl/Firefox%20139.0b8.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "76a258adaadc52b24f596495766cab8ce4344db2d06d291afcc20029627d9ea9";
+      sha256 = "8c189863e1a540ba6c0d9a6d48c89fa77d41e0a769f2613f06060c272c0a7bb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/son/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/son/Firefox%20139.0b8.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "6356d093eafd677b78e76fe1fa7247ec723df4432fe69024fc80de6ebd98a146";
+      sha256 = "f590ed966808e85f510ff002d6d571eb25f952ab88c156dd7b5d92589cb4109b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sq/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/sq/Firefox%20139.0b8.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "b57ecf837b0930f369a87bac330854dc952ea8fd664bc4d9367a1bc602884543";
+      sha256 = "ed60c7c8e924855d5589d7113793eb50a0fde5bfc48cf9abed859343c9d66b8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/sr/Firefox%20139.0b8.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "608a72824910e43dc62d6c6e856edf886e280fa1499eda3fb15df01aa58475ae";
+      sha256 = "c9e97810c6496d9fb6093a8e002b67e77f53d7764218317b4c575230977be55f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sv-SE/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/sv-SE/Firefox%20139.0b8.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "64c79d0c96810221692d65cf3830a4dc68c0123e93c15b4e6425825f2a485bc6";
+      sha256 = "804e0a66652d946257f981a755582f41308c91b9f9984c3d6f3983c19728a6c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/szl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/szl/Firefox%20139.0b8.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "598d0cedf0037f92e579917de539a72d2bf89963cc09e182dc298912724adc7b";
+      sha256 = "55432f3895f353d14efa3b71448360efc49b8f56081cd310220e4443dd4b5c84";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ta/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ta/Firefox%20139.0b8.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "5046f6a144780b890bd13599b5043b95989838ae021180c08479755411de60a3";
+      sha256 = "b8a71ea3c840c7a8ec2b1643756d584b47113e2cb41f9115641dffa806d0e860";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/te/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/te/Firefox%20139.0b8.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "e5dd35d5878bf0b397c6b55e4bf03405068e188c655f426160f00a2dee4eda87";
+      sha256 = "246531649d377ebe0ef05d6cd95f4d5d7015f56e8e7e258f7cb88a38c442432c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/tg/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/tg/Firefox%20139.0b8.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "245f224cb73ea1337c04d839cd10b5d5d67e9d1d278696cc408c7e7d71154124";
+      sha256 = "11f817fc523722332c5beda76e9ede6d0ef90238cbbaedc6ea1be3e2e89b193b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/th/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/th/Firefox%20139.0b8.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "056638b388bd20f14c6c41662aa0a495600a40ec9393e5d157fa9fcb0649ec78";
+      sha256 = "b8199350b45564cfd56cc26518b577947ae858badb46dd75ab3e6f604041e2bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/tl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/tl/Firefox%20139.0b8.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "32d4699b72e0e0adbca59d84fc63a3ce5a3780976545d1a3d150cabf0856b78b";
+      sha256 = "b915a1f0c343e233f5e17b1d5e4708688cefe834e68d8531f788d60392c9b78d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/tr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/tr/Firefox%20139.0b8.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "a8a3028435311d2c4124254372a5d6008ced3fae5cbcadbf25b02d74509c0c7d";
+      sha256 = "fedacd235c401bed72baa5d25b429bd3f6bd4c04fe86cc3a0b2557bbbd513b03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/trs/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/trs/Firefox%20139.0b8.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "f1d8039af76a04dca82979c42971d1096456e196f4a1124ec4beed727f2185d3";
+      sha256 = "00397033d4807cb61e6b78ca035a9b12d762651d09aca3c6d31e2587d4d17f65";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/uk/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/uk/Firefox%20139.0b8.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "838a1942ea4ca9e163b06df9bc72970e128af87e4a35376f912623ef73b5b52b";
+      sha256 = "c5812fe816665b66d8783ffed78c0ef5c0e6cbb00bffb77b93e7d46a4459c30f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ur/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/ur/Firefox%20139.0b8.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "306d04d7c9965e1c3c5ce1f45574b82437c32316dd5857c066c228d2a22606d2";
+      sha256 = "472c2ee122d961079c11c84267e40ca082774cb2b36ca65e38befacc7c548f19";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/uz/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/uz/Firefox%20139.0b8.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "93c61ed4ffb6875756b366f1ffe01682303bdb6ed20c6d2d7e44979305d31254";
+      sha256 = "90b40f64074f9491ad46b111e9fdf11f653a7181f2c832b6e2cd10854e6119b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/vi/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/vi/Firefox%20139.0b8.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "60fad61144cfdeeaad641b714e4e63ca184079d58091dc555975543657d54fcc";
+      sha256 = "a9a962c57eb85f229afb2311779cde8f7693db6f687154add781c366694d1529";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/xh/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/xh/Firefox%20139.0b8.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "00f599dfacd33bb98f67e05fab0d9588456de666f9bb78eb52e22d96a4f1e323";
+      sha256 = "b54e98bd3714ab6b594251c6cd298b0789d42dff5c32a1fea2e71f40b74522bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/zh-CN/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/zh-CN/Firefox%20139.0b8.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "0ab249304b86ca7ae055291353a4627e507d2699b6346b9ff3dbeba3766ba044";
+      sha256 = "4e4f898416b120f7b96c7b1e0efee08d2c861089147dc1cf1876335c69046ee0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/zh-TW/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b8/mac/zh-TW/Firefox%20139.0b8.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "b9c4765a5aed85cece38efa50fed10fa361ba9ba56d9c40925661885680d8165";
+      sha256 = "113dd1a1e9bed43dd054638f4ca548ab7773c8560f45ff9be3451282d60bcdcb";
     }
   ];
 }


### PR DESCRIPTION
Tested both on my existing devedition profile. Loaded everything like a charm, so should be fine.

Supersedes #408165 and #407615

Is this security-related? I am trying to figure out whether or not `139.0.b10` has the `138.0.4` fixes in it, though. See my attempt at that: https://discourse.nixos.org/t/firefox-138-0-4-128-10-1esr-pwn2own-releases/64442/4?u=dtomvan

I don't have the build oomph to do the regular build, so I guess I'll leave that one up someone else. I just use `firefox-devedition-bin` a lot because I need it to load unsigned xpi files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
