### PR TITLE
python3Packages.ddddocr: init at 1.5.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22826,6 +22826,11 @@
     githubId = 10352679;
     name = "Simon Hammes";
   };
+  simonhollingshead = {
+    github = "simonhollingshead";
+    githubId = 3343403;
+    name = "Simon Hollingshead";
+  };
   simonkampe = {
     email = "simon.kampe+nix@gmail.com";
     github = "simonkampe";

--- a/pkgs/development/python-modules/ddddocr/default.nix
+++ b/pkgs/development/python-modules/ddddocr/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  numpy,
+  onnxruntime,
+  pillow,
+  opencv-python-headless,
+}:
+
+buildPythonPackage rec {
+  pname = "ddddocr";
+  version = "1.5.6";
+  pyproject = true;
+
+  # The maintainers do not track versions as tags or releases in GitHub, only
+  # in PyPI - so it's preferable to use fetchPypi.
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-KDmpQL+r4C4yhO8/nSoDcpKqn2QfNVtDqbcL7Onhtz0=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    onnxruntime
+    pillow
+    opencv-python-headless
+  ];
+
+  # https://github.com/microsoft/onnxruntime/issues/10038 - in the restricted
+  # build environment, ARM64 cannot import ddddocr (but it can normally).
+  pythonImportsCheck = lib.optionals (!stdenv.isAarch64) [ "ddddocr" ];
+
+  meta = {
+    description = "OCR library trained against simple CAPTCHAs for Latin and Chinese characters";
+    homepage = "https://github.com/sml2h3/ddddocr";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ simonhollingshead ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3307,6 +3307,8 @@ self: super: with self; {
 
   dctorch = callPackage ../development/python-modules/dctorch { };
 
+  ddddocr = callPackage ../development/python-modules/ddddocr { };
+
   ddt = callPackage ../development/python-modules/ddt { };
 
   deal = callPackage ../development/python-modules/deal { };


### PR DESCRIPTION
ddddocr is a python package capable of performing simple OCR on CAPTCHAs.  It has begun to be used by a discord bot that I run an instance of (for trivial screen scraping purposes), so I am contributing this back to nixpkgs.

https://github.com/sml2h3/ddddocr (11.7k stars)

https://pypi.org/project/ddddocr/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
