### PR TITLE
python3Packages.lizard: Update Lizard to fix test failures

### DIFF
--- a/pkgs/development/python-modules/lizard/default.nix
+++ b/pkgs/development/python-modules/lizard/default.nix
@@ -6,6 +6,8 @@
   pytestCheckHook,
   mock,
   jinja2,
+  pygments, # for Erlang support
+  pathspec, # for .gitignore support
 }:
 
 buildPythonPackage rec {
@@ -21,7 +23,11 @@ buildPythonPackage rec {
     hash = "sha256-yXiRbC85IeeNR8rWSqLTQD9qy2CzAhlDD7YeTm5Vj9c=";
   };
 
-  propagatedBuildInputs = [ jinja2 ];
+  propagatedBuildInputs = [
+    jinja2
+    pygments
+    pathspec
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/lizard/default.nix
+++ b/pkgs/development/python-modules/lizard/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "lizard";
-  version = "1.17.10";
+  version = "1.17.30";
   format = "setuptools";
   disabled = pythonOlder "3.7";
 
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "terryyin";
     repo = "lizard";
     rev = version;
-    hash = "sha256-4jq6gXpI1hFtX7ka2c/qQ+S6vZCThKOGhQwJ2FOYItY=";
+    hash = "sha256-yXiRbC85IeeNR8rWSqLTQD9qy2CzAhlDD7YeTm5Vj9c=";
   };
 
   propagatedBuildInputs = [ jinja2 ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I have updated lizard to fix test failures when installing it in NixOS. The initial test failure was because assertRegexpMatches had been renamed to assertRegex in unittest in Python 3.2. This problem was fixed by [lizard commit f44f796](https://github.com/terryyin/lizard/commit/f44f796), but 1.17.10 does not include this fix. After updating lizard, there was an import error because `pygments` was missing, which is required for Erlang support. The third test failure, involving gitignore, was because lizard needs `pathspec` package to follow .gitignore rules.

After applying these two commits, the Lizard test suite passes with Python 3.12.8 and NixOS 24.11 on x86_64 in WSL2 on Windows 10.

The reason I was trying to install Lizard was because C++ Advanced Lint extension for VSCode can use it to check code quality.

[Test failures before applying or partially applying this PR](https://gist.github.com/Quipyowert2/c7fed24da512bebf2bd272b2c902f2fb)

<details>

<summary> NixOS configuration /etc/nixos/configuration.nix </summary>

```
# Edit this configuration file to define what should be installed on
# your system. Help is available in the configuration.nix(5) man page, on
# https://search.nixos.org/options and in the NixOS manual (`nixos-help`).

# NixOS-WSL specific options are documented on the NixOS-WSL repository:
# https://github.com/nix-community/NixOS-WSL

{ config, lib, pkgs, ... }:

{
  imports = [
    # include NixOS-WSL modules
    <nixos-wsl/modules>
  ];

  wsl.enable = true;
  wsl.defaultUser = "nixos";

  wsl.docker-desktop.enable = true;
  users.users.nixos.extraGroups = [ "docker" ];
#  virtualisation.docker.enable = true;

  programs.nix-ld.enable = true;

  programs.nix-ld.libraries = with pkgs; [
    #trying to get VSCode working...
    # Add any missing dynamic libraries for unpackaged programs

    # here, NOT in environment.systemPackages

  ];

  environment.systemPackages = [
  # Install the manuals
     pkgs.man-pages pkgs.man-pages-posix
     #Fuzzing
     pkgs.aflplusplus
     #Compiling
     pkgs.cmake
     pkgs.gcc14
     pkgs.clang
     pkgs.gdb
     pkgs.rr
     pkgs.gnumake
     pkgs.git
     #possibly required for building perl?
     pkgs.libxcrypt
     # to get Lua to run faster
     pkgs.luajit
     pkgs.meld
     pkgs.neovim
     pkgs.neovim-qt
     pkgs.ninja # Development
     pkgs.nix-index

     # Programming languages
     pkgs.python312 #3.14 does not have a distutils Nix package yet.
     pkgs.ruby
     pkgs.rustup

     pkgs.SDL2
     pkgs.SDL2_image
     pkgs.SDL2_mixer
     pkgs.SDL2_net
     pkgs.SDL2_ttf
     pkgs.silver-searcher #Quick string searcher
     pkgs.valgrind # Memory leaks
     pkgs.wget

     #Static analysis
     #lizard package currently does not pass unit tests, so it is commented out
     #pkgs.python312Packages.lizard
     pkgs.flawfinder
  ];
  documentation.dev.enable = true;

  fonts = {
    enableDefaultPackages = true;
  };

  # This value determines the NixOS release from which the default
  # settings for stateful data, like file locations and database versions
  # on your system were taken. It's perfectly fine and recommended to leave
  # this value at the release version of the first install of this system.
  # Before changing this value read the documentation for this option
  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
  system.stateVersion = "24.11"; # Did you read the comment?
}
```

</details>

TODO:
- [ ] Should Erlang support be an optional dependency?
- [ ] Somehow get nixpkgs-review to work, it ate all the RAM available to WSL2, which then became unresponsive.

Note: I had to write the PR description again because pasting in the entire test failure log exceeded 65k characters, so I have put it in a gist.

nixos-version: `24.11.717837.a39ed32a651f (Vicuna)`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
