### PR TITLE
python3Packages.cynthion: 0.1.8 -> 0.2.0

### DIFF
--- a/pkgs/by-name/cy/cynthion/package.nix
+++ b/pkgs/by-name/cy/cynthion/package.nix
@@ -1,26 +1,5 @@
 {
   python3,
-  fetchFromGitHub,
 }:
 
-let
-  python = python3.override {
-    self = python3;
-    packageOverrides = _: super: {
-      amaranth = super.amaranth.overridePythonAttrs rec {
-        version = "0.4.1";
-
-        src = fetchFromGitHub {
-          owner = "amaranth-lang";
-          repo = "amaranth";
-          rev = "refs/tags/v${version}";
-          sha256 = "sha256-VMgycvxkphdpWIib7aZwh588En145RgYlG2Zfi6nnDo=";
-        };
-
-        postPatch = null;
-      };
-    };
-  };
-in
-
-python.pkgs.toPythonApplication python.pkgs.cynthion
+python3.pkgs.toPythonApplication python3.pkgs.cynthion

--- a/pkgs/development/python-modules/cynthion/default.nix
+++ b/pkgs/development/python-modules/cynthion/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  pythonOlder,
 
   # build-system
   setuptools,
@@ -28,15 +27,14 @@
 }:
 buildPythonPackage rec {
   pname = "cynthion";
-  version = "0.1.8";
+  version = "0.2.0";
   pyproject = true;
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
     repo = "cynthion";
     tag = version;
-    hash = "sha256-twkCv47Goob2cO7FeHegvab3asf8fqbY9qg97Vw4ZCo=";
+    hash = "sha256-rbvw2eieZwTxStwCRuvIx/f4vdPsOFnV/U80Ga+fNPA=";
   };
 
   sourceRoot = "${src.name}/cynthion/python";
@@ -75,11 +73,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "cynthion" ];
 
   meta = {
-    changelog = "https://github.com/greatscottgadgets/cynthion/releases/tag/${version}";
+    changelog = "https://github.com/greatscottgadgets/cynthion/releases/tag/${src.tag}";
     description = "Python package and utilities for the Great Scott Gadgets Cynthion USB Test Instrument";
     homepage = "https://github.com/greatscottgadgets/cynthion";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ carlossless ];
-    broken = lib.versionAtLeast amaranth.version "0.5";
   };
 }

--- a/pkgs/development/python-modules/luna-soc/default.nix
+++ b/pkgs/development/python-modules/luna-soc/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  pythonOlder,
 
   # build-system
   setuptools,
@@ -13,15 +12,14 @@
 
 buildPythonPackage rec {
   pname = "luna-soc";
-  version = "0.2.2";
+  version = "0.3.2";
   pyproject = true;
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
     repo = "luna-soc";
     tag = version;
-    hash = "sha256-fP2Pg0H/Aj3nFP0WG1yZjfZMqLutLwmibTohWUbgG34=";
+    hash = "sha256-Rks1wC0CR5FSu4TrE1thzolT3QBd0yh7q+SxZ1U+pB4=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/luna-usb/default.nix
+++ b/pkgs/development/python-modules/luna-usb/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  pythonOlder,
 
   # build-system
   setuptools,
@@ -21,15 +20,14 @@
 }:
 buildPythonPackage rec {
   pname = "luna-usb";
-  version = "0.1.3";
+  version = "0.2.0";
   pyproject = true;
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
     repo = "luna";
     tag = version;
-    hash = "sha256-BKFfEkhgOH0lYfkAE94h27pb+T/uJxKFmMeVJI9I3qg=";
+    hash = "sha256-SVpAPq77IH2/2WZrc25j7q6qTMW2ToPY5lYQcYUlJfs=";
   };
 
   postPatch = ''
@@ -70,6 +68,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/greatscottgadgets/luna";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ carlossless ];
-    broken = lib.versionAtLeast amaranth.version "0.5";
   };
 }


### PR DESCRIPTION
This update removes the necessity to override amaranth to `0.4.x` as the latest version of `cynthion`, `luna-soc` and `luna-usb` support amaranth `0.5.x`

Changelogs:
* python3Packages.cynthion: https://github.com/greatscottgadgets/cynthion/releases/tag/0.2.0
* python3Packages.luna-soc: https://github.com/greatscottgadgets/luna-soc/releases/tag/0.3.2
* python3Packages.luna-usb: https://github.com/greatscottgadgets/luna/releases/tag/0.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
