### PR TITLE
nixos/tpm2: default pkcs#11 module based on abrmd config

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -232,6 +232,8 @@
 
 - `dwarf-fortress-packages` now only contains one minor version for each major version since version 0.44. Saves should still be compatible, but you may have to change which minor version you were using if it was one other than the newest.
 
+- `tpm2-pkcs11` now is compiled without abrmd (Access Broker and Resource Manager Daemon) support by default, preferring the kernel resource manager. Use `tpm2-pkcs11.abrmd` if you would like a version with abrmd support. Note that the NixOS module picks the correct one automatically based on `security.tpm2.abrmd`.
+
 - `zig_0_9` and `zig_0_10` have been removed, you should upgrade to `zig_0_13` (also available as just `zig`), `zig_0_12` or `zig_0_11` instead.
 
 - `webpack-cli` was updated to major version 6, which has breaking changes from the previous version 5.1.4. See the [upstream release notes](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%406.0.0) for details on these changes.

--- a/nixos/modules/security/tpm2.nix
+++ b/nixos/modules/security/tpm2.nix
@@ -75,8 +75,8 @@ in
       package = lib.mkOption {
         description = "tpm2-pkcs11 package to use";
         type = lib.types.package;
-        default = pkgs.tpm2-pkcs11;
-        defaultText = lib.literalExpression "pkgs.tpm2-pkcs11";
+        default = if cfg.abrmd.enable then pkgs.tpm2-pkcs11.abrmd else pkgs.tpm2-pkcs11;
+        defaultText = lib.literalExpression "if config.security.tpm2.abrmd.enable then pkgs.tpm2-pkcs11.abrmd else pkgs.tpm2-pkcs11";
       };
     };
 

--- a/pkgs/by-name/tp/tpm2-pkcs11/package.nix
+++ b/pkgs/by-name/tp/tpm2-pkcs11/package.nix
@@ -222,18 +222,26 @@ chosenStdenv.mkDerivation (finalAttrs: {
         $out/lib/libtpm2_pkcs11.so.0.0.0
     '';
 
-  passthru = {
+  passthru = rec {
+    esapi = tpm2-pkcs11-esapi;
+    fapi = tpm2-pkcs11-fapi;
+    abrmd = tpm2-pkcs11.override {
+      abrmdSupport = true;
+    };
+    esapi-abrmd = tpm2-pkcs11-esapi.override {
+      abrmdSupport = true;
+    };
+    fapi-abrmd = tpm2-pkcs11-fapi.override {
+      abrmdSupport = true;
+    };
     tests = {
-      inherit tpm2-pkcs11-esapi tpm2-pkcs11-fapi;
-      tpm2-pkcs11-abrmd = tpm2-pkcs11.override {
-        abrmdSupport = true;
-      };
-      tpm2-pkcs11-esapi-abrmd = tpm2-pkcs11-esapi.override {
-        abrmdSupport = true;
-      };
-      tpm2-pkcs11-fapi-abrmd = tpm2-pkcs11-fapi.override {
-        abrmdSupport = true;
-      };
+      inherit
+        esapi
+        fapi
+        abrmd
+        esapi-abrmd
+        fapi-abrmd
+        ;
     };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since there are now variants of tpm2-pkcs11 with and without ABRMD support (for the kernel resource manager), ensure we pick the correct default.

This was a breaking change that should be documented as such for the package, and shouldn't break the module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
