### PR TITLE
{k3s,nixos/kubernetes}: use util-linux.withPatches

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -336,7 +336,10 @@ in
           [
             gitMinimal
             openssh
-            util-linux
+            # TODO (#409339): remove this patch. We had to add it to avoid a mass rebuild
+            # for the 25.05 release. Once the staging cycle referenced in the above PR completes,
+            # switch back to plain util-linux.
+            util-linux.withPatches
             iproute2
             ethtool
             thin-provisioning-tools

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -333,16 +333,10 @@ let
     }).overrideAttrs
       overrideContainerdAttrs;
 
-  # TODO (#405952): remove this patch. We had to add it to avoid a mass rebuild
-  # for the 25.05 release. Once the above PR is merged, switch back to plain util-linuxMinimal.
-  k3sUtilLinux = util-linuxMinimal.overrideAttrs (prev: {
-    patches =
-      prev.patches or [ ]
-      ++ lib.singleton (fetchpatch {
-        url = "https://github.com/util-linux/util-linux/commit/7dbfe31a83f45d5aef2b508697e9511c569ffbc8.patch";
-        hash = "sha256-bJqpZiPli5Pm/XpDA445Ab5jesXrlcnaO6e4V0B3rSw=";
-      });
-  });
+  # TODO (#409339): remove this patch. We had to add it to avoid a mass rebuild
+  # for the 25.05 release. Once the staging cycle referenced in the above PR completes,
+  # switch back to plain util-linuxMinimal.
+  k3sUtilLinux = util-linuxMinimal.withPatches;
 in
 buildGoModule rec {
   pname = "k3s";

--- a/pkgs/by-name/ut/util-linux/fix-mount-regression.patch
+++ b/pkgs/by-name/ut/util-linux/fix-mount-regression.patch
@@ -1,0 +1,39 @@
+From 7dbfe31a83f45d5aef2b508697e9511c569ffbc8 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Mon, 24 Mar 2025 14:31:05 +0100
+Subject: [PATCH] libmount: fix --no-canonicalize regression
+
+Fixes: https://github.com/util-linux/util-linux/issues/3474
+Signed-off-by: Karel Zak <kzak@redhat.com>
+---
+ libmount/src/context.c | 3 ---
+ sys-utils/mount.8.adoc | 2 +-
+ 2 files changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/libmount/src/context.c b/libmount/src/context.c
+index 0323cb23d34..15a8ad3bbd0 100644
+--- a/libmount/src/context.c
++++ b/libmount/src/context.c
+@@ -530,9 +530,6 @@ int mnt_context_is_xnocanonicalize(
+ 	assert(cxt);
+ 	assert(type);
+ 
+-	if (mnt_context_is_nocanonicalize(cxt))
+-		return 1;
+-
+ 	ol = mnt_context_get_optlist(cxt);
+ 	if (!ol)
+ 		return 0;
+diff --git a/sys-utils/mount.8.adoc b/sys-utils/mount.8.adoc
+index 4f23f8d1f0e..5103b91c578 100644
+--- a/sys-utils/mount.8.adoc
++++ b/sys-utils/mount.8.adoc
+@@ -756,7 +756,7 @@ Allow to make a target directory (mountpoint) if it does not exist yet. The opti
+ *X-mount.nocanonicalize*[**=**_type_]::
+ Allows disabling of canonicalization for mount source and target paths. By default, the `mount` command resolves all paths to their absolute paths without symlinks. However, this behavior may not be desired in certain situations, such as when binding a mount over a symlink, or a symlink over a directory or another symlink. The optional argument _type_ can be either "source" or "target" (mountpoint). If no _type_ is specified, then canonicalization is disabled for both types. This mount option does not affect the conversion of source tags (e.g. LABEL= or UUID=) and fstab processing.
+ +
+-The command line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but it does not modify flags for open_tree syscalls.
++The command-line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but for backward compatibility, it does not modify open_tree syscall flags and does not allow the bind-mount over a symlink use case.
+ +
+ Note that *mount*(8) still sanitizes and canonicalizes the source and target paths specified on the command line by non-root users, regardless of the X-mount.nocanonicalize setting.
+ 

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -34,7 +34,7 @@
 let
   isMinimal = cryptsetupSupport == false && !nlsSupport && !ncursesSupport && !systemdSupport;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalPackage: rec {
   pname = "util-linux" + lib.optionalString isMinimal "-minimal";
   version = "2.41";
 
@@ -200,6 +200,18 @@ stdenv.mkDerivation rec {
     '';
 
   passthru = {
+    # TODO (#409339): Remove this hack. We had to add it to avoid a mass rebuild
+    # for the 25.05 release to fix Kubernetes. Once the staging cycle referenced
+    # in the above PR completes, this passthru and all consumers of it should go away.
+    withPatches = finalPackage.overrideAttrs (prev: {
+      patches = lib.unique (
+        prev.patches or [ ]
+        ++ [
+          ./fix-mount-regression.patch
+        ]
+      );
+    });
+
     updateScript = gitUpdater {
       # No nicer place to find latest release.
       url = "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git";
@@ -237,4 +249,4 @@ stdenv.mkDerivation rec {
     ];
     priority = 6; # lower priority than coreutils ("kill") and shadow ("login" etc.) packages
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As documented:

TODO (#409339): Remove this hack. We had to add it to avoid a mass rebuild for the 25.05 release to fix Kubernetes. Once the staging cycle referenced in the above PR completes, this passthru and all consumers of it should go away.

Should fix #408044 which affected both k3s and kubernetes, without a mass rebuild.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
