### PR TITLE
libadwaita: increase tests timeout to 300 seconds

### DIFF
--- a/pkgs/by-name/li/libadwaita/package.nix
+++ b/pkgs/by-name/li/libadwaita/package.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
       "HOME=$TMPDIR"
     )
     env "''${testEnvironment[@]}" ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "xvfb-run"} \
-      meson test --print-errorlogs
+      meson test --timeout-multiplier 10 --print-errorlogs
 
     runHook postCheck
   '';


### PR DESCRIPTION
The `libadwaita:doc / Validate docs` test fails on VF2 because of 30 seconds timeout.

```
libadwaita> buildPhase completed in 12 minutes 38 seconds
libadwaita> Running phase: checkPhase
libadwaita> ninja: Entering directory `/build/source/build'
libadwaita> ninja: no work to do.
libadwaita>  1/65 libadwaita:demo / Validate desktop file            OK              0.09s
libadwaita>  2/65 libadwaita:demo / Validate appstream file          OK              0.11s
libadwaita>  3/65 libadwaita / test-accent-color                     OK              1.26s
libadwaita>  4/65 libadwaita / test-action-row                       OK              1.37s
libadwaita>  5/65 libadwaita / test-about-dialog                     OK              1.80s
libadwaita>  6/65 libadwaita / test-about-window                     OK              1.84s
libadwaita>  7/65 libadwaita / test-alert-dialog                     OK              0.83s
libadwaita>  8/65 libadwaita / test-animation                        OK              0.79s
libadwaita>  9/65 libadwaita / test-application-window               OK              0.83s
libadwaita> 10/65 libadwaita / test-animation-target                 OK              1.11s
libadwaita> 11/65 libadwaita / test-back-button                      OK              0.88s
libadwaita> 12/65 libadwaita / test-avatar                           OK              1.05s
libadwaita> 13/65 libadwaita / test-banner                           OK              1.06s
libadwaita> 14/65 libadwaita / test-bin                              OK              0.91s
libadwaita> 15/65 libadwaita / test-breakpoint                       OK              0.76s
libadwaita> 16/65 libadwaita / test-bottom-sheet                     OK              0.96s
libadwaita> 17/65 libadwaita / test-button-content                   OK              0.84s
libadwaita> 18/65 libadwaita / test-breakpoint-bin                   OK              1.08s
libadwaita> 19/65 libadwaita / test-button-row                       OK              0.92s
libadwaita> 20/65 libadwaita / test-carousel                         OK              0.94s
libadwaita> 21/65 libadwaita / test-combo-row                        OK              0.81s
libadwaita> 22/65 libadwaita / test-carousel-indicator-dots          OK              1.09s
libadwaita> 23/65 libadwaita / test-carousel-indicator-lines         OK              0.98s
libadwaita> 24/65 libadwaita / test-dialog                           OK              0.90s
libadwaita> 25/65 libadwaita / test-easing                           OK              1.02s
libadwaita> 26/65 libadwaita / test-entry-row                        OK              0.99s
libadwaita> 27/65 libadwaita / test-expander-row                     OK              0.93s
libadwaita> 28/65 libadwaita / test-flap                             OK              0.97s
libadwaita> 29/65 libadwaita / test-leaflet                          OK              0.84s
libadwaita> 30/65 libadwaita / test-inline-view-switcher             OK              0.95s
libadwaita> 31/65 libadwaita / test-header-bar                       OK              1.03s
libadwaita> 32/65 libadwaita / test-message-dialog                   OK              1.05s
libadwaita> 33/65 libadwaita / test-multi-layout-view                OK              0.78s
libadwaita> 34/65 libadwaita / test-navigation-view                  OK              0.89s
libadwaita> 35/65 libadwaita / test-navigation-split-view            OK              0.99s
libadwaita> 36/65 libadwaita / test-overlay-split-view               OK              1.03s
libadwaita> 37/65 libadwaita / test-password-entry-row               OK              0.85s
libadwaita> 38/65 libadwaita / test-preferences-group                OK              0.78s
libadwaita> 39/65 libadwaita / test-preferences-dialog               OK              0.93s
libadwaita> 40/65 libadwaita / test-preferences-page                 OK              0.96s
libadwaita> 41/65 libadwaita / test-preferences-row                  OK              0.99s
libadwaita> 42/65 libadwaita / test-preferences-window               OK              0.91s
libadwaita> 43/65 libadwaita / test-spinner                          OK              0.97s
libadwaita> 44/65 libadwaita / test-spinner-paintable                OK              0.92s
libadwaita> 45/65 libadwaita / test-spin-row                         OK              0.80s
libadwaita> 46/65 libadwaita / test-split-button                     OK              1.07s
libadwaita> 47/65 libadwaita / test-squeezer                         OK              0.95s
libadwaita> 48/65 libadwaita / test-status-page                      OK              0.88s
libadwaita> 49/65 libadwaita / test-switch-row                       OK              0.98s
libadwaita> 50/65 libadwaita / test-tab-button                       OK              0.79s
libadwaita> 51/65 libadwaita / test-tab-bar                          OK              1.05s
libadwaita> 52/65 libadwaita / test-style-manager                    OK              1.56s
libadwaita> 53/65 libadwaita / test-timed-animation                  OK              0.91s
libadwaita> 54/65 libadwaita / test-tab-view                         OK              1.01s
libadwaita> 55/65 libadwaita / test-toast                            OK              0.97s
libadwaita> 56/65 libadwaita / test-tab-overview                     OK              1.24s
libadwaita> 57/65 libadwaita / test-toggle-group                     OK              0.95s
libadwaita> 58/65 libadwaita / test-toolbar-view                     OK              0.94s
libadwaita> 59/65 libadwaita / test-toast-overlay                    OK              1.05s
libadwaita> 60/65 libadwaita / test-view-switcher                    OK              0.91s
libadwaita> 61/65 libadwaita / test-window-title                     OK              0.86s
libadwaita> 62/65 libadwaita / test-view-switcher-bar                OK              0.99s
libadwaita> 63/65 libadwaita / test-wrap-layout                      OK              0.90s
libadwaita> 64/65 libadwaita / test-window                           OK              1.00s
libadwaita> libadwaita:doc / Validate docs time out (After 30 seconds)                29/30s
libadwaita> 65/65 libadwaita:doc / Validate docs                     TIMEOUT        30.12s   killed by signal 15 SIGTERM
libadwaita> >>> UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 MALLOC_PERTURB_=73 MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MESON_TEST_ITERATION=1 /nix/store/cr22cpwm6p2jcsd906wspdiz1z3gp0v2-gi-docgen-2025.3/bin/gi-docgen check --config /build/source/build/doc/libadwaita.toml --add-include-path=/build/source/build/doc/../src src/Adw-1.gir
libadwaita>  ✀
libadwaita> INFO: Loading config file: /build/source/build/doc/libadwaita.toml
libadwaita> INFO: Search paths: ['/build/source/build/doc/../src', '/build/source/build', '/build/.local/share/gir-1.0', '/nix/store/qzlpdmpyidpdllckpnc2ysrxgf9mwj93-pkg-config-wrapper-0.29.2/share/gir-1.0', '/nix/store/cr22cpwm6p2jcsd906wspdiz1z3gp0v2-gi-docgen-2025.3/share/gir-1.0', '/nix/store/x47i7a57agw3kb11j7hkhmgvrasdfrbb-meson-1.7.2/share/gir-1.0', '/nix/store/g337575c3ql1zsh46wrs2vbhc5y204g5-ninja-1.12.1/share/gir-1.0', '/nix/store/44vv5vmvkh4h38g45pa483nzq5fcyw5a-vala-0.56.18/share/gir-1.0', '/nix/store/4mpqrp7bca7wk81wj98f0slkmp39ylyk-gobject-introspection-wrapped-1.84.0-dev/share/gir-1.0', '/nix/store/hx2wsm4iri5b9a4snylaihqcyrfzr8kh-glib-2.84.1-dev/share/gir-1.0', '/nix/store/rvbmpv6790zr741w69x9nypqldv7lk5i-zlib-1.3.1/share/gir-1.0', '/nix/store/ciqvg8nkql3w3nqryi578f0f2hfiwn99-gettext-0.22.5/share/gir-1.0', '/nix/store/bn7xdqfx3vdi7sx2bxil1q2l93kymikq-glib-2.84.1-bin/share/gir-1.0', '/nix/store/wakjjq4xslrkqsyai0sraf70zgbxrg9r-glib-2.84.1/share/gir-1.0', '/nix/store/3qsnhpi9xfzknwb8m8djdc9400k1lmxk-desktop-file-utils-0.28/share/gir-1.0', '/nix/store/h4fz70mpr9n8cajqvqa7py75a5n6rbrh-adwaita-icon-theme-48.0/share/gir-1.0', '/nix/store/bsfmj3zghfl9yxsizzx636cxa2szgyac-hicolor-icon-theme-0.18/share/gir-1.0', '/nix/store/mpz8rvnp38n0amk1gmjzbymhz8783c7q-xvfb-run-1+g87f6705/share/gir-1.0', '/nix/store/8d70zc10vda1xyfi6z9x074yq6wk90pz-patchelf-0.15.0/share/gir-1.0', '/nix/store/44vv5vmvkh4h38g45pa483nzq5fcyw5a-vala-0.56.18/share/gir-1.0', '/nix/store/4mpqrp7bca7wk81wj98f0slkmp39ylyk-gobject-introspection-wrapped-1.84.0-dev/share/gir-1.0', '/nix/store/hx2wsm4iri5b9a4snylaihqcyrfzr8kh-glib-2.84.1-dev/share/gir-1.0', '/nix/store/lyxbjq9p3mp5q6r0avplg9l8sxca4bc3-gobject-introspection-1.84.0-dev/share/gir-1.0', '/nix/store/y1mbdrpplv14f80knp8d0dk25la74cp3-appstream-1.0.4-dev/share/gir-1.0', '/nix/store/wv9zgiq2gir8skz8r884gg0z7pah789d-gtk4-4.18.5-dev/share/gir-1.0', '/nix/store/paanwfzwg8sm6fg94l187cgzggn1zv4d-gdk-pixbuf-2.42.12-dev/share/gir-1.0', '/nix/store/s3f7rngd5v5hb8lj5b3vpi00bzzf1ami-graphene-1.10.8-dev/share/gir-1.0', '/nix/store/dcaz01wb84amsy0szfbh1s5nacl3yi9q-pango-1.56.3-dev/share/gir-1.0', '/nix/store/f59fhzn42nb4bjxi01izyf7bxh3fnbdq-harfbuzz-10.2.0-dev/share/gir-1.0', '/nix/store/gxc96cn4p14h88bn752wzwkya7c790v1-gsettings-desktop-schemas-48.0/share/gir-1.0', '/nix/store/gxc96cn4p14h88bn752wzwkya7c790v1-gsettings-desktop-schemas-48.0/share/gsettings-schemas/gsettings-desktop-schemas-48.0/gir-1.0', '/usr/share/gir-1.0']
libadwaita> INFO: Elapsed time 28.691 seconds
libadwaita>
libadwaita>
libadwaita>
libadwaita> Summary of Failures:
libadwaita>
libadwaita> 65/65 libadwaita:doc / Validate docs             TIMEOUT        30.12s   killed by signal 15 SIGTERM
libadwaita>
libadwaita> Ok:                 64
libadwaita> Expected Fail:      0
libadwaita> Fail:               0
libadwaita> Unexpected Pass:    0
libadwaita> Skipped:            0
libadwaita> Timeout:            1
libadwaita>
libadwaita> Full log written to /build/source/build/meson-logs/testlog.txt
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] riscv64-linux
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
