### PR TITLE
nixos-rebuild-ng: fixes for Python 3.13

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import textwrap
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from importlib.resources import files
@@ -9,7 +10,6 @@ from pathlib import Path
 from string import Template
 from subprocess import PIPE, CalledProcessError
 from typing import Final, Literal
-from uuid import uuid4
 
 from . import tmpdir
 from .constants import WITH_NIX_2_18
@@ -107,7 +107,7 @@ def build_remote(
             "--attr",
             build_attr.to_attr(attr),
             "--add-root",
-            tmpdir.TMPDIR_PATH / uuid4().hex,
+            tmpdir.TMPDIR_PATH / uuid.uuid4().hex,
             *dict_to_flags(instantiate_flags),
         ],
         stdout=PIPE,
@@ -127,7 +127,7 @@ def build_remote(
                 "--realise",
                 drv,
                 "--add-root",
-                remote_tmpdir / uuid4().hex,
+                remote_tmpdir / uuid.uuid4().hex,
                 *dict_to_flags(realise_flags),
             ],
             remote=build_host,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -1,4 +1,5 @@
 import atexit
+import getpass
 import logging
 import os
 import re
@@ -6,7 +7,6 @@ import shlex
 import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass
-from getpass import getpass
 from typing import Final, Self, TypedDict, Unpack
 
 from . import tmpdir
@@ -46,7 +46,7 @@ class Remote:
             cls._validate_opts(opts, ask_sudo_password)
         sudo_password = None
         if ask_sudo_password:
-            sudo_password = getpass(f"[sudo] password for {host}: ")
+            sudo_password = getpass.getpass(f"[sudo] password for {host}: ")
         return cls(host, opts, sudo_password)
 
     @staticmethod

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/helpers.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/helpers.py
@@ -8,4 +8,8 @@ def get_qualified_name(
 ) -> str:
     module_name = getattr(module, "__name__", method.__module__)
     method_name = getattr(method, "__qualname__", method.__name__)
-    return f"{module_name}.{method_name}"
+    name = f"{module_name}.{method_name}"
+    assert name.startswith("nixos_rebuild"), (
+        f"Non-internal module '{name}' called with 'get_qualified_name'"
+    )
+    return name

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -1083,8 +1083,8 @@ def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
 
 
 @patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-@patch(get_qualified_name(nr.nix.Path.exists, nr.nix), autospec=True, return_value=True)
-@patch(get_qualified_name(nr.nix.Path.mkdir, nr.nix), autospec=True)
+@patch("pathlib.Path.exists", autospec=True, return_value=True)
+@patch("pathlib.Path.mkdir", autospec=True)
 def test_execute_test_rollback(
     mock_path_mkdir: Mock,
     mock_path_exists: Mock,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import textwrap
 import uuid
 from pathlib import Path
@@ -126,8 +127,8 @@ def test_parse_args() -> None:
     ]
 
 
-@patch.dict(nr.os.environ, {}, clear=True)
-@patch(get_qualified_name(nr.os.execve, nr.os), autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+@patch("os.execve", autospec=True)
 @patch(get_qualified_name(nr.nix.build), autospec=True)
 def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(nr, "EXECUTABLE", "nixos-rebuild-ng")
@@ -170,8 +171,8 @@ def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -
     )
 
 
-@patch.dict(nr.os.environ, {}, clear=True)
-@patch(get_qualified_name(nr.os.execve, nr.os), autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+@patch("os.execve", autospec=True)
 @patch(get_qualified_name(nr.nix.build_flake), autospec=True)
 def test_reexec_flake(
     mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch
@@ -212,8 +213,8 @@ def test_reexec_flake(
     )
 
 
-@patch.dict(nr.process.os.environ, {}, clear=True)
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+@patch("subprocess.run", autospec=True)
 def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.mkdir()
@@ -296,8 +297,8 @@ def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
     )
 
 
-@patch.dict(nr.process.os.environ, {}, clear=True)
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+@patch("subprocess.run", autospec=True)
 def test_execute_nix_build_vm(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
@@ -345,8 +346,8 @@ def test_execute_nix_build_vm(mock_run: Mock, tmp_path: Path) -> None:
     )
 
 
-@patch.dict(nr.process.os.environ, {}, clear=True)
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+@patch("subprocess.run", autospec=True)
 def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
@@ -420,8 +421,8 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
     )
 
 
-@patch.dict(nr.process.os.environ, {}, clear=True)
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+@patch("subprocess.run", autospec=True)
 def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
@@ -503,13 +504,13 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
     )
 
 
-@patch.dict(nr.process.os.environ, {}, clear=True)
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-@patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
-@patch(get_qualified_name(nr.nix.uuid4, nr.nix), autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+@patch("subprocess.run", autospec=True)
+@patch("uuid.uuid4", autospec=True)
+@patch(get_qualified_name(nr.cleanup_ssh), autospec=True)
 def test_execute_nix_switch_build_target_host(
-    mock_uuid4: Mock,
     mock_cleanup_ssh: Mock,
+    mock_uuid4: Mock,
     mock_run: Mock,
     tmp_path: Path,
 ) -> None:
@@ -713,9 +714,9 @@ def test_execute_nix_switch_build_target_host(
     )
 
 
-@patch.dict(nr.process.os.environ, {}, clear=True)
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-@patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+@patch("subprocess.run", autospec=True)
+@patch(get_qualified_name(nr.cleanup_ssh), autospec=True)
 def test_execute_nix_switch_flake_target_host(
     mock_cleanup_ssh: Mock,
     mock_run: Mock,
@@ -816,9 +817,9 @@ def test_execute_nix_switch_flake_target_host(
     )
 
 
-@patch.dict(nr.process.os.environ, {}, clear=True)
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
-@patch(get_qualified_name(nr.cleanup_ssh, nr), autospec=True)
+@patch.dict(os.environ, {}, clear=True)
+@patch("subprocess.run", autospec=True)
+@patch(get_qualified_name(nr.cleanup_ssh), autospec=True)
 def test_execute_nix_switch_flake_build_host(
     mock_cleanup_ssh: Mock,
     mock_run: Mock,
@@ -927,7 +928,7 @@ def test_execute_nix_switch_flake_build_host(
     )
 
 
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
+@patch("subprocess.run", autospec=True)
 def test_execute_switch_rollback(mock_run: Mock, tmp_path: Path) -> None:
     nixpkgs_path = tmp_path / "nixpkgs"
     nixpkgs_path.touch()
@@ -1004,7 +1005,7 @@ def test_execute_switch_rollback(mock_run: Mock, tmp_path: Path) -> None:
     )
 
 
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
+@patch("subprocess.run", autospec=True)
 def test_execute_build(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
@@ -1033,7 +1034,7 @@ def test_execute_build(mock_run: Mock, tmp_path: Path) -> None:
     )
 
 
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
+@patch("subprocess.run", autospec=True)
 def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
     config_path = tmp_path / "test"
     config_path.touch()
@@ -1082,7 +1083,7 @@ def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
     )
 
 
-@patch(get_qualified_name(nr.process.subprocess.run), autospec=True)
+@patch("subprocess.run", autospec=True)
 @patch("pathlib.Path.exists", autospec=True, return_value=True)
 @patch("pathlib.Path.mkdir", autospec=True)
 def test_execute_test_rollback(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -100,7 +100,7 @@ def test_flake_from_arg(
 
     # None when we do not have /etc/nixos/flake.nix
     with patch(
-        get_qualified_name(m.Path.exists, m),
+        "pathlib.Path.exists",
         autospec=True,
         return_value=False,
     ):
@@ -109,12 +109,12 @@ def test_flake_from_arg(
     # None when we have a file in /etc/nixos/flake.nix
     with (
         patch(
-            get_qualified_name(m.Path.exists, m),
+            "pathlib.Path.exists",
             autospec=True,
             return_value=True,
         ),
         patch(
-            get_qualified_name(m.Path.is_symlink, m),
+            "pathlib.Path.is_symlink",
             autospec=True,
             return_value=False,
         ),
@@ -130,17 +130,17 @@ def test_flake_from_arg(
 
     with (
         patch(
-            get_qualified_name(m.Path.exists, m),
+            "pathlib.Path.exists",
             autospec=True,
             return_value=True,
         ),
         patch(
-            get_qualified_name(m.Path.is_symlink, m),
+            "pathlib.Path.is_symlink",
             autospec=True,
             return_value=True,
         ),
         patch(
-            get_qualified_name(m.Path.resolve, m),
+            "pathlib.Path.resolve",
             autospec=True,
             return_value=Path("/path/to/flake.nix"),
         ),
@@ -161,7 +161,7 @@ def test_flake_from_arg(
         )
 
 
-@patch(get_qualified_name(m.Path.mkdir, m), autospec=True)
+@patch("pathlib.Path.mkdir", autospec=True)
 def test_profile_from_arg(mock_mkdir: Mock) -> None:
     assert m.Profile.from_arg("system") == m.Profile(
         "system",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -1,4 +1,3 @@
-import platform
 import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -77,7 +76,7 @@ def test_flake_to_attr() -> None:
     )
 
 
-@patch(get_qualified_name(platform.node), autospec=True)
+@patch("platform.node", autospec=True)
 def test_flake_from_arg(
     mock_node: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
 ) -> None:
@@ -119,7 +118,7 @@ def test_flake_from_arg(
             return_value=False,
         ),
         patch(
-            get_qualified_name(m.discover_git, m),
+            get_qualified_name(m.discover_git),
             autospec=True,
             return_value="/etc/nixos",
         ),
@@ -151,7 +150,7 @@ def test_flake_from_arg(
 
     with (
         patch(
-            get_qualified_name(m.subprocess.run),
+            "subprocess.run",
             autospec=True,
             return_value=subprocess.CompletedProcess([], 0, "remote-hostname\n"),
         ),

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -78,7 +78,7 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-@patch(get_qualified_name(n.uuid4, n), autospec=True)
+@patch("uuid.uuid4", autospec=True)
 def test_build_remote(
     mock_uuid4: Mock, mock_run: Mock, monkeypatch: MonkeyPatch
 ) -> None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -809,7 +809,7 @@ def test_switch_to_configuration_with_systemd_run(
 
 
 @patch(
-    get_qualified_name(n.Path.glob, n),
+    "pathlib.Path.glob",
     autospec=True,
     return_value=[
         Path("/nix/var/nix/profiles/per-user/root/channels/nixos"),
@@ -817,7 +817,7 @@ def test_switch_to_configuration_with_systemd_run(
         Path("/nix/var/nix/profiles/per-user/root/channels/home-manager"),
     ],
 )
-@patch(get_qualified_name(n.Path.is_dir, n), autospec=True, return_value=True)
+@patch("pathlib.Path.is_dir", autospec=True, return_value=True)
 def test_upgrade_channels(mock_is_dir: Mock, mock_glob: Mock) -> None:
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.upgrade_channels(False)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -6,10 +6,8 @@ from pytest import MonkeyPatch
 import nixos_rebuild.models as m
 import nixos_rebuild.process as p
 
-from .helpers import get_qualified_name
 
-
-@patch(get_qualified_name(p.subprocess.run), autospec=True)
+@patch("subprocess.run", autospec=True)
 def test_run(mock_run: Any) -> None:
     p.run_wrapper(["test", "--with", "flags"], check=True)
     mock_run.assert_called_with(
@@ -96,7 +94,7 @@ def test_run(mock_run: Any) -> None:
     )
 
 
-@patch(get_qualified_name(p.subprocess.run), autospec=True)
+@patch("subprocess.run", autospec=True)
 def test__kill_long_running_ssh_process(mock_run: Any) -> None:
     p._kill_long_running_ssh_process(
         [
@@ -135,9 +133,7 @@ def test_remote_from_name(monkeypatch: MonkeyPatch) -> None:
         sudo_password=None,
     )
 
-    # get_qualified_name doesn't work because getpass is aliased to another
-    # function
-    with patch(f"{p.__name__}.getpass", autospec=True, return_value="password"):
+    with patch("getpass.getpass", autospec=True, return_value="password"):
         monkeypatch.setenv("NIX_SSHOPTS", "-f foo -b bar -t")
         assert m.Remote.from_arg("user@localhost", True, True) == m.Remote(
             "user@localhost",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Change the way we do mocking in `nixos-rebuild-ng` for `pathlib.Path` to fix breakage caused by changes in Python 3.13, as seen in Hydra:
https://hydra.lossy.network/log/fhvxw88568wlz786k4qh4ri7805q6mwn-nixos-rebuild-ng-0.0.0.drv

To avoid breakage in future this also avoid using `get_qualified_name()` for any non-internal mock. This is fine because the idea to `get_qualified_name()` is to make it easier to refactor since you can rename the method name and this is also automatically rename the mocks, but non-internal mocks are unlikely to change names anyway.

Keep in mind that this derivation right now is still building with Python 3.12, but I manually changed the derivation to build with Python 3.13 and tested and now it is working fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
