### PR TITLE
udevCheckHook: guard platform

### DIFF
--- a/pkgs/by-name/ud/udevCheckHook/hook.sh
+++ b/pkgs/by-name/ud/udevCheckHook/hook.sh
@@ -21,7 +21,7 @@ udevCheckHook() {
     echo Finished udevCheckPhase
 }
 
-if [[ -z "${dontUdevCheck-}" ]]; then
+if [[ -z "${dontUdevCheck-}" && -n "@udevadm@" ]]; then
     echo "Using udevCheckHook"
     preInstallCheckHooks+=(udevCheckHook)
 fi

--- a/pkgs/by-name/ud/udevCheckHook/package.nix
+++ b/pkgs/by-name/ud/udevCheckHook/package.nix
@@ -2,12 +2,20 @@
   lib,
   makeSetupHook,
   systemdMinimal,
+  udev,
+  stdenv,
 }:
-
+let
+  # udev rules can only be checked if systemd (specifically, 'udevadm') can be executed on build platform
+  # if udev is not available on hostPlatform, there is no point in checking rules
+  applyHook =
+    lib.meta.availableOn stdenv.hostPlatform udev
+    && lib.meta.availableOn stdenv.buildPlatform systemdMinimal;
+in
 makeSetupHook {
   name = "udev-check-hook";
   substitutions = {
-    udevadm = lib.getExe' systemdMinimal "udevadm";
+    udevadm = if applyHook then lib.getExe' systemdMinimal "udevadm" else "";
   };
   meta = {
     description = "check validity of udev rules in outputs";


### PR DESCRIPTION
It is technically possible to guard all udevCheckHook usages behind `lib.optionals (stdenv.hostPlatform.isLinux && lib.meta.availableOn stdenv.buildPlatform systemdMinimal)`.

However, doing this is hard to read, clunky, and hard to discover. *Not* doing such a guard would mean cross-compilation darwin -> linux breaks (or darwin itself breaks, without cross). The workaround here is to just accept any udev rules if they can't be properly checked.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
