### PR TITLE
json-schema-catalog-rs: init at 0.1.1

### DIFF
--- a/pkgs/by-name/js/json-schema-catalog-rs/package.nix
+++ b/pkgs/by-name/js/json-schema-catalog-rs/package.nix
@@ -4,6 +4,7 @@
   lib,
   nix-update-script,
   rustPlatform,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -18,6 +19,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-YI2LN2DBzC1B5wCZOrGAZi/hkKHoAm6xLkdJ+8DDFo8=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/json-schema-catalog";
+  versionCheckProgramArg = "--version";
 
   passthru = {
     tests = {

--- a/pkgs/by-name/js/json-schema-catalog-rs/package.nix
+++ b/pkgs/by-name/js/json-schema-catalog-rs/package.nix
@@ -1,0 +1,42 @@
+{
+  callPackage,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "json-schema-catalog-rs";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "roberth";
+    repo = "json-schema-catalog-rs";
+    tag = finalAttrs.version;
+    hash = "sha256-BbEPpolv2aoKFlfZ6A+CmUlr5sySGIqRlv3rLgf1VkA=";
+  };
+
+  cargoHash = "sha256-YI2LN2DBzC1B5wCZOrGAZi/hkKHoAm6xLkdJ+8DDFo8=";
+
+  passthru = {
+    tests = {
+      run = callPackage ./test-run.nix { json-schema-catalog-rs = finalAttrs.finalPackage; };
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "CLI for working with JSON Schema Catalogs";
+    longDescription = ''
+      A JSON Schema Catalog file provides a mapping from schema URIs to schema locations.
+      By constructing and using a catalog, you can avoid the need to download and parse schemas from the internet.
+      This is particularly useful when working with large schemas or when you need to work, test or build offline.
+    '';
+    homepage = "https://github.com/roberth/json-schema-catalog-rs";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.roberth ];
+    mainProgram = "json-schema-catalog";
+  };
+})

--- a/pkgs/by-name/js/json-schema-catalog-rs/test-run.nix
+++ b/pkgs/by-name/js/json-schema-catalog-rs/test-run.nix
@@ -1,0 +1,54 @@
+{
+  json-schema-catalog-rs,
+  runCommand,
+}:
+let
+
+  sample = builtins.toFile "example-schema.json" (
+    builtins.toJSON {
+      "$schema" = "http://json-schema.org/draft-07/schema#";
+      "$id" = "https://example.com/example-2.9.json";
+      "title" = "Example Schema";
+    }
+  );
+
+in
+runCommand "json-schema-catalog-rs-test-run"
+  {
+    nativeBuildInputs = [
+      json-schema-catalog-rs
+    ];
+    inherit sample;
+    expectedOutput = ''
+      {
+        "groups": [
+          {
+            "baseLocation": "/nix/store",
+            "name": "Example Schema",
+            "schemas": [
+              {
+                "id": "https://example.com/example-2.9.json",
+                "location": "${baseNameOf sample}"
+              }
+            ]
+          }
+        ],
+        "name": "Catalog"
+      }
+    '';
+    passAsFile = [
+      "expectedOutput"
+    ];
+  }
+  ''
+    set -u
+
+    # Test version
+    json-schema-catalog --version | grep ${json-schema-catalog-rs.version}
+
+    # Test a simple command
+    json-schema-catalog new "$sample" > out.json
+    diff -U3 "$expectedOutputPath" out.json
+
+    touch $out
+  ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


This adds a new package that's useful for working with JSON Schema Catalog, which is not an independently specified standard yet, but common at least common with [cp-framework-libraries](https://github.com/hmcts/cp-framework-libraries/tree/main?tab=readme-ov-file#json-schema-catalog).

JSON Schema Catalog is useful for defining mappings that make schemas available offline.

I have written some Nix code upstream that I'd like to contribute to Nixpkgs after this:
- add a setup hook to bring catalogs into `XDG_DATA_DIRS` scope
- package some schemas into a new package set



## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
