### PR TITLE
nltk-data: make searchable, add all downloadables

### DIFF
--- a/nixos/modules/services/web-apps/mealie.nix
+++ b/nixos/modules/services/web-apps/mealie.nix
@@ -76,7 +76,7 @@ in
         API_PORT = toString cfg.port;
         BASE_URL = "http://localhost:${toString cfg.port}";
         DATA_DIR = "/var/lib/mealie";
-        NLTK_DATA = pkgs.nltk-data.averaged_perceptron_tagger_eng;
+        NLTK_DATA = pkgs.nltk-data.averaged-perceptron-tagger-eng;
       } // (builtins.mapAttrs (_: val: toString val) cfg.settings);
 
       serviceConfig = {

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -109,7 +109,7 @@ pythonpkgs.buildPythonApplication rec {
 
   # Needed for tests
   preCheck = ''
-    export NLTK_DATA=${nltk-data.averaged_perceptron_tagger_eng}
+    export NLTK_DATA=${nltk-data.averaged-perceptron-tagger-eng}
   '';
 
   disabledTestPaths = [

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -314,7 +314,7 @@ python.pkgs.buildPythonApplication rec {
       ;
     nltkData = with nltk-data; [
       punkt-tab
-      snowball_data
+      snowball-data
       stopwords
     ];
     tests = { inherit (nixosTests) paperless; };

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -313,7 +313,7 @@ python.pkgs.buildPythonApplication rec {
       tesseract5
       ;
     nltkData = with nltk-data; [
-      punkt_tab
+      punkt-tab
       snowball_data
       stopwords
     ];

--- a/pkgs/by-name/un/unstructured-api/package.nix
+++ b/pkgs/by-name/un/unstructured-api/package.nix
@@ -152,7 +152,7 @@ let
 
     paths = [
       nltk-data.punkt
-      nltk-data.averaged_perceptron_tagger
+      nltk-data.averaged-perceptron-tagger
     ];
   };
 in

--- a/pkgs/development/python-modules/aider-chat/default.nix
+++ b/pkgs/development/python-modules/aider-chat/default.nix
@@ -125,7 +125,7 @@ let
   aider-nltk-data = symlinkJoin {
     name = "aider-nltk-data";
     paths = [
-      nltk-data.punkt_tab
+      nltk-data.punkt-tab
       nltk-data.stopwords
     ];
   };

--- a/pkgs/development/python-modules/ingredient-parser-nlp/default.nix
+++ b/pkgs/development/python-modules/ingredient-parser-nlp/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   # Needed for tests
   preCheck = ''
-    export NLTK_DATA=${nltk-data.averaged_perceptron_tagger_eng}
+    export NLTK_DATA=${nltk-data.averaged-perceptron-tagger-eng}
   '';
 
   meta = {

--- a/pkgs/development/python-modules/type-infer/default.nix
+++ b/pkgs/development/python-modules/type-infer/default.nix
@@ -24,7 +24,7 @@ let
     name = "nltk-test-data";
     paths = [
       nltk-data.punkt
-      nltk-data.punkt_tab
+      nltk-data.punkt-tab
       nltk-data.stopwords
     ];
   };

--- a/pkgs/tools/text/nltk-data/default.nix
+++ b/pkgs/tools/text/nltk-data/default.nix
@@ -76,7 +76,7 @@ lib.makeScope newScope (self: {
     location = "taggers";
     hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";
   };
-  snowball_data = makeNltkDataPackage {
+  snowball-data = makeNltkDataPackage {
     pname = "snowball_data";
     location = "stemmers";
     hash = "sha256-mNefwOPVJGz9kXV3LV4DuV7FJpNir/Nwg4ujd0CogEk=";

--- a/pkgs/tools/text/nltk-data/default.nix
+++ b/pkgs/tools/text/nltk-data/default.nix
@@ -71,7 +71,7 @@ lib.makeScope newScope (self: {
     location = "taggers";
     hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";
   };
-  averaged_perceptron_tagger_eng = makeNltkDataPackage {
+  averaged-perceptron-tagger-eng = makeNltkDataPackage {
     pname = "averaged_perceptron_tagger_eng";
     location = "taggers";
     hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";

--- a/pkgs/tools/text/nltk-data/default.nix
+++ b/pkgs/tools/text/nltk-data/default.nix
@@ -54,41 +54,212 @@ let
         '';
       }
     );
+
+  makeChunker =
+    pname:
+    makeNltkDataPackage {
+      inherit pname;
+      location = "chunkers";
+      hash = "sha256-kemjqaCM9hlKAdMw8oVJnp62EAC9rMQ50dKg7wlAwEc=";
+    };
+
+  makeCorpus =
+    pname:
+    makeNltkDataPackage {
+      inherit pname;
+      location = "corpora";
+      hash = "sha256-8lMjW5YI8h6dHJ/83HVY2OYGDyKPpgkUAKPISiAKqqk=";
+    };
+
+  makeGrammar =
+    pname:
+    makeNltkDataPackage {
+      inherit pname;
+      location = "grammars";
+      hash = "sha256-pyLEcX3Azv8j1kCGvVYonuiNgVJxtWt7veU0S/yNbIM=";
+    };
+
+  makeHelp =
+    pname:
+    makeNltkDataPackage {
+      inherit pname;
+      location = "help";
+      hash = "sha256-97mYLNES5WujLF5gD8Ul4cJ6LqSzz+jDzclUsdBeHNE=";
+    };
+
+  makeMisc =
+    pname:
+    makeNltkDataPackage {
+      inherit pname;
+      location = "misc";
+      hash = "sha256-XtizfEsc8TYWqvvC/eSFdha2ClC5/ZiJM8nue0vXLb4=";
+    };
+
+  makeModel =
+    pname:
+    makeNltkDataPackage {
+      inherit pname;
+      location = "models";
+      hash = "sha256-iq3weEgCci6rgLW2j28F2eRLprJtInGXKe/awJPSVG4=";
+    };
+
+  makeTagger =
+    pname:
+    makeNltkDataPackage {
+      inherit pname;
+      location = "taggers";
+      hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";
+    };
+
+  makeTokenizer =
+    pname:
+    makeNltkDataPackage {
+      inherit pname;
+      location = "tokenizers";
+      hash = "sha256-OzMkruoYbFKqzuimOXIpE5lhHz8tmSqOFoLT+fjdTVg=";
+    };
+
+  makeStemmer =
+    pname:
+    makeNltkDataPackage {
+      inherit pname;
+      location = "stemmers";
+      hash = "sha256-mNefwOPVJGz9kXV3LV4DuV7FJpNir/Nwg4ujd0CogEk=";
+    };
 in
 lib.makeScope newScope (self: {
-  punkt = makeNltkDataPackage {
-    pname = "punkt";
-    location = "tokenizers";
-    hash = "sha256-OzMkruoYbFKqzuimOXIpE5lhHz8tmSqOFoLT+fjdTVg=";
-  };
-  punkt-tab = makeNltkDataPackage {
-    pname = "punkt_tab";
-    location = "tokenizers";
-    hash = "sha256-OzMkruoYbFKqzuimOXIpE5lhHz8tmSqOFoLT+fjdTVg=";
-  };
-  averaged-perceptron-tagger = makeNltkDataPackage {
-    pname = "averaged_perceptron_tagger";
-    location = "taggers";
-    hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";
-  };
-  averaged-perceptron-tagger-eng = makeNltkDataPackage {
-    pname = "averaged_perceptron_tagger_eng";
-    location = "taggers";
-    hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";
-  };
-  snowball-data = makeNltkDataPackage {
-    pname = "snowball_data";
-    location = "stemmers";
-    hash = "sha256-mNefwOPVJGz9kXV3LV4DuV7FJpNir/Nwg4ujd0CogEk=";
-  };
-  stopwords = makeNltkDataPackage {
-    pname = "stopwords";
-    location = "corpora";
-    hash = "sha256-8lMjW5YI8h6dHJ/83HVY2OYGDyKPpgkUAKPISiAKqqk=";
-  };
-  wordnet = makeNltkDataPackage {
-    pname = "wordnet";
-    location = "corpora";
-    hash = "sha256-8lMjW5YI8h6dHJ/83HVY2OYGDyKPpgkUAKPISiAKqqk=";
-  };
+  ## Chunkers
+  maxent-ne-chunker = makeChunker "maxent_ne_chunker";
+  maxent-ne-chunker-tab = makeChunker "maxent_ne_chunker_tab";
+
+  ## Corpora
+  abc = makeCorpus "abc";
+  alpino = makeCorpus "alpino";
+  bcp47 = makeCorpus "bcp47";
+  biocreative-ppi = makeCorpus "biocreative_ppi";
+  brown = makeCorpus "brown";
+  brown-tei = makeCorpus "brown_tei";
+  cess-cat = makeCorpus "cess_cat";
+  cess-esp = makeCorpus "cess_esp";
+  chat80 = makeCorpus "chat80";
+  city-database = makeCorpus "city_database";
+  cmudict = makeCorpus "cmudict";
+  comparative-sentences = makeCorpus "comparative_sentences";
+  comtrans = makeCorpus "comtrans";
+  conll2000 = makeCorpus "conll2000";
+  conll2002 = makeCorpus "conll2002";
+  conll2007 = makeCorpus "conll2007";
+  crubadan = makeCorpus "crubadan";
+  dependency-treebank = makeCorpus "dependency_treebank";
+  dolch = makeCorpus "dolch";
+  europarl-raw = makeCorpus "europarl_raw";
+  extended-omw = makeCorpus "extended_omw";
+  floresta = makeCorpus "floresta";
+  framenet-v15 = makeCorpus "framenet_v15";
+  framenet-v17 = makeCorpus "framenet_v17";
+  gazetteers = makeCorpus "gazetteers";
+  genesis = makeCorpus "genesis";
+  gutenberg = makeCorpus "gutenberg";
+  ieer = makeCorpus "ieer";
+  inaugural = makeCorpus "inaugural";
+  indian = makeCorpus "indian";
+  jeita = makeCorpus "jeita";
+  kimmo = makeCorpus "kimmo";
+  knbc = makeCorpus "knbc";
+  lin-thesaurus = makeCorpus "lin_thesaurus";
+  mac-morpho = makeCorpus "mac_morpho";
+  machado = makeCorpus "machado";
+  masc-tagged = makeCorpus "masc_tagged";
+  movie-reviews = makeCorpus "movie_reviews";
+  mte-teip5 = makeCorpus "mte_teip5";
+  names = makeCorpus "names";
+  nombank-1-0 = makeCorpus "nombank.1.0";
+  nonbreaking-prefixes = makeCorpus "nonbreaking_prefixes";
+  nps-chat = makeCorpus "nps_chat";
+  omw = makeCorpus "omw";
+  omw-1-4 = makeCorpus "omw-1.4";
+  opinion-lexicon = makeCorpus "opinion_lexicon";
+  panlex-swadesh = makeCorpus "panlex_swadesh";
+  paradigms = makeCorpus "paradigms";
+  pe08 = makeCorpus "pe08";
+  pil = makeCorpus "pil";
+  pl196x = makeCorpus "pl196x";
+  ppattach = makeCorpus "ppattach";
+  problem-reports = makeCorpus "problem_reports";
+  product-reviews-1 = makeCorpus "product_reviews_1";
+  product-reviews-2 = makeCorpus "product_reviews_2";
+  propbank = makeCorpus "propbank";
+  pros-cons = makeCorpus "pros_cons";
+  ptb = makeCorpus "ptb";
+  qc = makeCorpus "qc";
+  reuters = makeCorpus "reuters";
+  rte = makeCorpus "rte";
+  semcor = makeCorpus "semcor";
+  senseval = makeCorpus "senseval";
+  sentence-polarity = makeCorpus "sentence_polarity";
+  sentiwordnet = makeCorpus "sentiwordnet";
+  shakespeare = makeCorpus "shakespeare";
+  sinica-treebank = makeCorpus "sinica_treebank";
+  smultron = makeCorpus "smultron";
+  state-union = makeCorpus "state_union";
+  stopwords = makeCorpus "stopwords";
+  subjectivity = makeCorpus "subjectivity";
+  swadesh = makeCorpus "swadesh";
+  switchboard = makeCorpus "switchboard";
+  timit = makeCorpus "timit";
+  toolbox = makeCorpus "toolbox";
+  treebank = makeCorpus "treebank";
+  twitter-samples = makeCorpus "twitter_samples";
+  udhr = makeCorpus "udhr";
+  udhr2 = makeCorpus "udhr2";
+  unicode-samples = makeCorpus "unicode_samples";
+  universal-treebanks-v20 = makeCorpus "universal_treebanks_v20";
+  verbnet = makeCorpus "verbnet";
+  verbnet3 = makeCorpus "verbnet3";
+  webtext = makeCorpus "webtext";
+  wordnet = makeCorpus "wordnet";
+  wordnet-ic = makeCorpus "wordnet_ic";
+  wordnet2021 = makeCorpus "wordnet2021";
+  wordnet2022 = makeCorpus "wordnet2022";
+  wordnet31 = makeCorpus "wordnet31";
+  words = makeCorpus "words";
+  ycoe = makeCorpus "ycoe";
+
+  ## Grammars
+  basque-grammars = makeGrammar "basque_grammars";
+  book-grammars = makeGrammar "book_grammars";
+  large-grammars = makeGrammar "large_grammars";
+  sample-grammars = makeGrammar "sample_grammars";
+  spanish-grammars = makeGrammar "spanish_grammars";
+
+  ## Help
+  tagsets-json = makeHelp "tagsets_json";
+
+  ## Misc
+  mwa-ppdb = makeMisc "mwa_ppdb";
+  perluniprops = makeMisc "perluniprops";
+
+  ## Models
+  bllip-wsj-no-aux = makeModel "bllip_wsj_no_aux";
+  moses-sample = makeModel "moses_sample";
+  wmt15-eval = makeModel "wmt15_eval";
+  word2vec-sample = makeModel "word2vec_sample";
+
+  ## Taggers
+  averaged-perceptron-tagger = makeTagger "averaged_perceptron_tagger";
+  averaged-perceptron-tagger-eng = makeTagger "averaged_perceptron_tagger_eng";
+  averaged-perceptron-tagger-ru = makeTagger "averaged_perceptron_tagger_ru";
+  averaged-perceptron-tagger-rus = makeTagger "averaged_perceptron_tagger_rus";
+  maxent-treebank-pos-tagger = makeTagger "maxent_treebank_pos_tagger";
+  maxent-treebank-pos-tagger-tab = makeTagger "maxent_treebank_pos_tagger_tab";
+  universal-tagset = makeTagger "universal_tagset";
+
+  ## Tokenizers
+  punkt = makeTokenizer "punkt";
+  punkt-tab = makeTokenizer "punkt_tab";
+
+  ## Stemmers
+  porter-test = makeStemmer "porter_test";
+  rslp = makeStemmer "rslp";
+  snowball-data = makeStemmer "snowball_data";
 })

--- a/pkgs/tools/text/nltk-data/default.nix
+++ b/pkgs/tools/text/nltk-data/default.nix
@@ -61,7 +61,7 @@ lib.makeScope newScope (self: {
     location = "tokenizers";
     hash = "sha256-OzMkruoYbFKqzuimOXIpE5lhHz8tmSqOFoLT+fjdTVg=";
   };
-  punkt_tab = makeNltkDataPackage {
+  punkt-tab = makeNltkDataPackage {
     pname = "punkt_tab";
     location = "tokenizers";
     hash = "sha256-OzMkruoYbFKqzuimOXIpE5lhHz8tmSqOFoLT+fjdTVg=";

--- a/pkgs/tools/text/nltk-data/default.nix
+++ b/pkgs/tools/text/nltk-data/default.nix
@@ -15,7 +15,10 @@ let
       homepage = "https://github.com/nltk/nltk_data";
       license = licenses.asl20;
       platforms = platforms.all;
-      maintainers = with maintainers; [ happysalada ];
+      maintainers = with maintainers; [
+        bengsparks
+        happysalada
+      ];
     };
   };
   makeNltkDataPackage =

--- a/pkgs/tools/text/nltk-data/default.nix
+++ b/pkgs/tools/text/nltk-data/default.nix
@@ -66,7 +66,7 @@ lib.makeScope newScope (self: {
     location = "tokenizers";
     hash = "sha256-OzMkruoYbFKqzuimOXIpE5lhHz8tmSqOFoLT+fjdTVg=";
   };
-  averaged_perceptron_tagger = makeNltkDataPackage {
+  averaged-perceptron-tagger = makeNltkDataPackage {
     pname = "averaged_perceptron_tagger";
     location = "taggers";
     hash = "sha256-tl3Cn2okhBkUtTXvAmFRx72Brez6iTGRdmFTwFmpk3M=";

--- a/pkgs/tools/text/nltk-data/default.nix
+++ b/pkgs/tools/text/nltk-data/default.nix
@@ -10,6 +10,7 @@ let
     version = "0-unstable-2024-07-29";
     nativeBuildInputs = [ unzip ];
     dontBuild = true;
+    dontFixup = true;
     meta = with lib; {
       description = "NLTK Data";
       homepage = "https://github.com/nltk/nltk_data";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1352,6 +1352,7 @@ mapAliases {
   nltk-data.averaged_perceptron_tagger = nltk-data.averaged-perceptron-tagger; # Added 2025-05-21
   nltk-data.averaged_perceptron_tagger_eng = nltk-data.averaged-perceptron-tagger-eng; # Added 2025-05-21
   nltk-data.punkt_tab = nltk-data.punkt-tab; # Added 2025-05-21
+  nltk-data.snowball_data = nltk-data.snowball-data; # Added 2025-05-21
   nmap-unfree = throw "'nmap-unfree' has been renamed to/replaced by 'nmap'"; # Converted to throw 2024-10-17
   noah = throw "'noah' has been removed because it was broken and its upstream archived"; # Added 2025-05-10
   nodejs_18 = throw "Node.js 18.x has reached End-Of-Life and has been removed"; # Added 2025-04-23

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1350,6 +1350,7 @@ mapAliases {
 
   nixosTest = testers.nixosTest; # Added 2022-05-05
   nltk-data.averaged_perceptron_tagger = nltk-data.averaged-perceptron-tagger; # Added 2025-05-21
+  nltk-data.averaged_perceptron_tagger_eng = nltk-data.averaged-perceptron-tagger-eng; # Added 2025-05-21
   nltk-data.punkt_tab = nltk-data.punkt-tab; # Added 2025-05-21
   nmap-unfree = throw "'nmap-unfree' has been renamed to/replaced by 'nmap'"; # Converted to throw 2024-10-17
   noah = throw "'noah' has been removed because it was broken and its upstream archived"; # Added 2025-05-10

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1349,6 +1349,7 @@ mapAliases {
   # When the nixops_unstable alias is removed, nixops_unstable_minimal can be renamed to nixops_unstable.
 
   nixosTest = testers.nixosTest; # Added 2022-05-05
+  nltk-data.punkt_tab = nltk-data.punkt-tab; # Added 2025-05-21
   nmap-unfree = throw "'nmap-unfree' has been renamed to/replaced by 'nmap'"; # Converted to throw 2024-10-17
   noah = throw "'noah' has been removed because it was broken and its upstream archived"; # Added 2025-05-10
   nodejs_18 = throw "Node.js 18.x has reached End-Of-Life and has been removed"; # Added 2025-04-23

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1349,6 +1349,7 @@ mapAliases {
   # When the nixops_unstable alias is removed, nixops_unstable_minimal can be renamed to nixops_unstable.
 
   nixosTest = testers.nixosTest; # Added 2022-05-05
+  nltk-data.averaged_perceptron_tagger = nltk-data.averaged-perceptron-tagger; # Added 2025-05-21
   nltk-data.punkt_tab = nltk-data.punkt-tab; # Added 2025-05-21
   nmap-unfree = throw "'nmap-unfree' has been renamed to/replaced by 'nmap'"; # Converted to throw 2024-10-17
   noah = throw "'noah' has been removed because it was broken and its upstream archived"; # Added 2025-05-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2344,7 +2344,7 @@ with pkgs;
 
   mpd-sima = python3Packages.callPackage ../tools/audio/mpd-sima { };
 
-  nltk-data = callPackage ../tools/text/nltk-data { };
+  nltk-data = lib.recurseIntoAttrs (callPackage ../tools/text/nltk-data { });
 
   seabios-coreboot = seabios.override { ___build-type = "coreboot"; };
   seabios-csm = seabios.override { ___build-type = "csm"; };


### PR DESCRIPTION
Searching for [nltk-data](https://search.nixos.org/packages?channel=24.11&from=0&size=50&sort=relevance&type=packages&query=nltk-data) returns no results.
Applying a similar fix as done in https://github.com/NixOS/nixpkgs/pull/402602 will hopefully fix this.

Additional QoL fixes include not attempting to patch files where there is nothing to patch and adding all downloadables that are in the `nltk_data` repository to the attribute set.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
