### PR TITLE
couchdb-dump: init at 0-unstable-2021-07-24

### DIFF
--- a/pkgs/by-name/co/couchdb-dump/gsed.patch
+++ b/pkgs/by-name/co/couchdb-dump/gsed.patch
@@ -1,0 +1,19 @@
+--- a/couchdb-dump.sh	1970-01-01 01:00:01.000000000 +0100
++++ b/couchdb-dump.sh	2025-05-21 10:08:22.092922719 +0200
+@@ -182,15 +182,8 @@
+ fi
+ file_name_orig=$file_name
+ 
+-# Get OS TYPE (Linux for Linux, Darwin for MacOSX)
+-os_type=`uname -s`
++sed_cmd="@sed_cmd@";
+ 
+-# Pick sed or gsed
+-if [ "$os_type" = "FreeBSD" ]||[ "$os_type" = "Darwin" ]; then
+-    sed_cmd="gsed";
+-else
+-    sed_cmd="sed";
+-fi
+ ## Make sure it's installed
+ echo | $sed_cmd 's/a//' >/dev/null 2>&1 
+ if [ ! $? = 0 ]; then

--- a/pkgs/by-name/co/couchdb-dump/package.nix
+++ b/pkgs/by-name/co/couchdb-dump/package.nix
@@ -1,0 +1,64 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  coreutils,
+  curl,
+  gawk,
+  gnugrep,
+  gnused,
+  gzip,
+  sysctl,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "couchdb-dump";
+  version = "0-unstable-2021-07-24";
+
+  src = fetchFromGitHub {
+    owner = "danielebailo";
+    repo = "couchdb-dump";
+    rev = "f59fa242d34e505cb22ecb2ad1ffba0f6402978c";
+    hash = "sha256-fBvbt/1ukpvcu8Aa/uAmVzw0ms8Sp35WLJPvHs9E9Bc=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  patches = [ ./gsed.patch ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D couchdb-dump.sh $out/bin/couchdb-dump
+
+    substituteInPlace $out/bin/couchdb-dump \
+      --subst-var-by sed_cmd ${lib.getExe gnused}
+
+    wrapProgram $out/bin/couchdb-dump --prefix PATH : ${
+      lib.makeBinPath (
+        [
+          coreutils
+          curl
+          gawk
+          gnugrep
+          gnused
+          gzip
+        ]
+        ++ lib.optionals (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isFreeBSD) [
+          sysctl
+        ]
+      )
+    }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    inherit (finalAttrs.src.meta) homepage;
+
+    description = "Bash command line scripts to dump & restore a couchdb database";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ DamienCassou ];
+    mainProgram = "couchdb-dump";
+  };
+})


### PR DESCRIPTION
The goal of this package is to give a simple way to Dump & Restore
a CouchDB database.

https://github.com/danielebailo/couchdb-dump

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc