### PR TITLE
nixos/limine: add test for specialisations

### DIFF
--- a/nixos/tests/limine/default.nix
+++ b/nixos/tests/limine/default.nix
@@ -5,5 +5,6 @@
 {
   checksum = runTest ./checksum.nix;
   secureBoot = runTest ./secure-boot.nix;
+  specialisations = runTest ./specialisations.nix;
   uefi = runTest ./uefi.nix;
 }

--- a/nixos/tests/limine/specialisations.nix
+++ b/nixos/tests/limine/specialisations.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+{
+  name = "specialisations";
+  meta.maintainers = with lib.maintainers; [
+    lzcunt
+    phip1611
+    programmerlexi
+  ];
+  nodes.machine =
+    { ... }:
+    {
+      virtualisation.useBootLoader = true;
+      virtualisation.useEFIBoot = true;
+
+      specialisation.test = { };
+
+      boot.loader.efi.canTouchEfiVariables = true;
+      boot.loader.limine.enable = true;
+      boot.loader.limine.efiSupport = true;
+      boot.loader.timeout = 0;
+    };
+
+  testScript = ''
+    machine.start()
+    with subtest('Machine boots correctly'):
+      machine.wait_for_unit('multi-user.target')
+  '';
+}


### PR DESCRIPTION
This patch adds a test to test unattended boot of a configuration that has specialisations.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
