### PR TITLE
nixos/frp: add setting

### DIFF
--- a/nixos/modules/services/networking/frp.nix
+++ b/nixos/modules/services/networking/frp.nix
@@ -43,6 +43,17 @@ in
                 '';
               };
 
+              environmentFiles = lib.mkOption {
+                type = lib.types.listOf lib.types.path;
+                description = ''
+                  List of paths files that follows systemd environmentfile structure.
+                  Can be used to pass secrets to settings attribute.
+
+                  Example content of a file: SECRET_TOKEN=1234
+                '';
+                default = [ ];
+              };
+
               settings = lib.mkOption {
                 type = settingsFormat.type;
                 default = { };
@@ -91,6 +102,7 @@ in
           RestartSec = 15;
           ExecStart = "${cfg.package}/bin/${executableFile} --strict_config -c ${configFile}";
           DynamicUser = true;
+          EnvironmentFile = options.environmentFiles;
           # Hardening
           CapabilityBoundingSet = serviceCapability;
           AmbientCapabilities = serviceCapability;

--- a/nixos/tests/frp.nix
+++ b/nixos/tests/frp.nix
@@ -1,4 +1,15 @@
 { pkgs, lib, ... }:
+let
+  token = "1234";
+  dummyFile = pkgs.writeTextFile {
+    name = "secrets";
+    text = "dummy=value";
+  };
+  secretFile = pkgs.writeTextFile {
+    name = "secrets";
+    text = "token=${token}";
+  };
+in
 {
   name = "frp";
   meta.maintainers = with lib.maintainers; [ zaldnoay ];
@@ -15,12 +26,18 @@
         networkConfig.Address = "10.0.0.1/24";
       };
 
-      services.frp = {
+      services.frp.instances.server = {
         enable = true;
         role = "server";
+        environmentFiles = [
+          (builtins.toPath dummyFile)
+          (builtins.toPath secretFile)
+        ];
         settings = {
           bindPort = 7000;
           vhostHTTPPort = 80;
+          auth.method = "token";
+          auth.token = "{{ .Envs.token }}";
         };
       };
     };
@@ -53,12 +70,14 @@
         enablePHP = true;
       };
 
-      services.frp = {
+      services.frp.instances.client = {
         enable = true;
         role = "client";
         settings = {
           serverAddr = "10.0.0.1";
           serverPort = 7000;
+          auth.method = "token";
+          auth.token = token;
           proxies = [
             {
               name = "web";
@@ -74,9 +93,9 @@
 
   testScript = ''
     start_all()
-    frps.wait_for_unit("frp.service")
+    frps.wait_for_unit("frp-server.service")
     frps.wait_for_open_port(80)
-    frpc.wait_for_unit("frp.service")
+    frpc.wait_for_unit("frp-client.service")
     response = frpc.succeed("curl -fvvv -s http://127.0.0.1/")
     assert "PHP Version ${pkgs.php84.version}" in response, "PHP version not detected"
     response = frpc.succeed("curl -fvvv -s http://10.0.0.1/")


### PR DESCRIPTION
For the nixos service.frp I have added the setting environmentFile to allow a convenient way to pass secrets.

Disclaimer: This is also my first time doing a pull request and contributing to nixpkgs

Closes #391108.

## Things done
I ran this command to test the change thats about it.
`nix build -f . nixosTests.frp`


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
