### PR TITLE
niimprint: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17544,7 +17544,7 @@
     github = "nicodemus26";
     githubId = 58434;
     name = "Nicodemus Paradiso";
-    keys = [ { fingerprint = "5F59 D92C 686F 3812 5510 1040 285E 8D1B D1B5 FC10" ; } ];
+    keys = [ { fingerprint = "5F59 D92C 686F 3812 5510 1040 285E 8D1B D1B5 FC10"; } ];
   };
   nicolas-goudry = {
     email = "goudry.nicolas@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17540,10 +17540,11 @@
     name = "Nicolò Balzarotti";
   };
   nicodemus26 = {
-    email = "nicodemus26@gmail.com";
+    email = "hi@nicodemus.dev";
     github = "nicodemus26";
     githubId = 58434;
     name = "Nicodemus Paradiso";
+    keys = [ { fingerprint = "5F59 D92C 686F 3812 5510 1040 285E 8D1B D1B5 FC10" ; } ];
   };
   nicolas-goudry = {
     email = "goudry.nicolas@gmail.com";
@@ -17564,13 +17565,6 @@
     githubId = 1155801;
     name = "nicoo";
     keys = [ { fingerprint = "E44E 9EA5 4B8E 256A FB73 49D3 EC9D 3708 72BC 7A8C"; } ];
-  };
-  nicodemus26 = {
-    email = "hi@nicodemus.dev";
-    github = "nicodemus26";
-    githubId = 58434;
-    name = "Nicodemus Paradiso";
-    keys = [ { fingerprint = "5F59 D92C 686F 3812 5510 1040 285E 8D1B D1B5 FC10" ; } ];
   };
   nidabdella = {
     name = "Mohamed Nidabdella";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17539,6 +17539,12 @@
     githubId = 8214542;
     name = "Nicolò Balzarotti";
   };
+  nicodemus26 = {
+    email = "nicodemus26@gmail.com";
+    github = "nicodemus26";
+    githubId = 58434;
+    name = "Nicodemus Paradiso";
+  };
   nicolas-goudry = {
     email = "goudry.nicolas@gmail.com";
     github = "nicolas-goudry";
@@ -17558,6 +17564,13 @@
     githubId = 1155801;
     name = "nicoo";
     keys = [ { fingerprint = "E44E 9EA5 4B8E 256A FB73 49D3 EC9D 3708 72BC 7A8C"; } ];
+  };
+  nicodemus26 = {
+    email = "hi@nicodemus.dev";
+    github = "nicodemus26";
+    githubId = 58434;
+    name = "Nicodemus Paradiso";
+    keys = [ { fingerprint = "5F59 D92C 686F 3812 5510 1040 285E 8D1B D1B5 FC10" ; } ];
   };
   nidabdella = {
     name = "Mohamed Nidabdella";

--- a/pkgs/by-name/ni/niimprint/package.nix
+++ b/pkgs/by-name/ni/niimprint/package.nix
@@ -1,6 +1,7 @@
-{ lib
-, python3
-, fetchFromGitHub
+{
+  lib,
+  python3,
+  fetchFromGitHub,
 }:
 
 python3.pkgs.buildPythonPackage rec {

--- a/pkgs/by-name/ni/niimprint/package.nix
+++ b/pkgs/by-name/ni/niimprint/package.nix
@@ -15,7 +15,7 @@ python3.pkgs.buildPythonPackage rec {
     hash = "sha256-+YISYchdqeVKrQ0h2cj5Jy2ezMjnQcWCCYm5f95H9dI="; # Needs to be updated
   };
 
-  format = "pyproject";
+  pyproject = true;
 
   # Relax Pillow version constraint to work with newer versions
   postPatch = ''

--- a/pkgs/by-name/ni/niimprint/package.nix
+++ b/pkgs/by-name/ni/niimprint/package.nix
@@ -10,8 +10,8 @@ python3.pkgs.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "AndBondStyle";
     repo = "niimprint";
-    rev = "be39f68c16a5a7dc1b09bb173700d0ee1ec9cb66"; # Or a specific commit hash
-    sha256 = "sha256-+YISYchdqeVKrQ0h2cj5Jy2ezMjnQcWCCYm5f95H9dI="; # Needs to be updated
+    rev = "be39f68c16a5a7dc1b09bb173700d0ee1ec9cb66";
+    hash = "sha256-+YISYchdqeVKrQ0h2cj5Jy2ezMjnQcWCCYm5f95H9dI=";
   };
 
   format = "pyproject";

--- a/pkgs/by-name/ni/niimprint/package.nix
+++ b/pkgs/by-name/ni/niimprint/package.nix
@@ -22,11 +22,11 @@ python3.pkgs.buildPythonPackage rec {
       --replace 'pillow = "^10.1.0"' 'pillow = ">=10.1.0"'
   '';
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [
     poetry-core
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     pillow
     pyserial
     click
@@ -38,7 +38,7 @@ python3.pkgs.buildPythonPackage rec {
   postInstall = ''
     mkdir -p $out/bin
     makeWrapper ${python3.interpreter} $out/bin/niimprint \
-      --prefix PYTHONPATH : ${python3.pkgs.makePythonPath propagatedBuildInputs}:$out/${python3.sitePackages} \
+      --prefix PYTHONPATH : ${python3.pkgs.makePythonPath dependencies}:$out/${python3.sitePackages} \
       --add-flags "-m niimprint"
   '';
 

--- a/pkgs/by-name/ni/niimprint/package.nix
+++ b/pkgs/by-name/ni/niimprint/package.nix
@@ -40,7 +40,7 @@ python3.pkgs.buildPythonPackage rec {
     description = "A command line tool to print to Niimbot label printers";
     homepage = "https://github.com/AndBondStyle/niimprint";
     license = licenses.mit; # Repository appears to use MIT license
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ nicodemus26 ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/ni/niimprint/package.nix
+++ b/pkgs/by-name/ni/niimprint/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "niimprint";
+  version = "0.1.0"; # Keep in sync with pyproject.toml
+
+  src = fetchFromGitHub {
+    owner = "AndBondStyle";
+    repo = "niimprint";
+    rev = "be39f68c16a5a7dc1b09bb173700d0ee1ec9cb66"; # Or a specific commit hash
+    sha256 = "sha256-+YISYchdqeVKrQ0h2cj5Jy2ezMjnQcWCCYm5f95H9dI="; # Needs to be updated
+  };
+
+  format = "pyproject";
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pillow
+    pyserial
+    click
+  ];
+  
+  # Disable tests as the package doesn't have any
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/bin
+    makeWrapper ${python3.interpreter} $out/bin/niimprint \
+      --prefix PYTHONPATH : ${python3.pkgs.makePythonPath propagatedBuildInputs}:$out/${python3.sitePackages} \
+      --add-flags "-m niimprint"
+  '';
+
+  meta = with lib; {
+    description = "A command line tool to print to Niimbot label printers";
+    homepage = "https://github.com/AndBondStyle/niimprint";
+    license = licenses.mit; # Repository appears to use MIT license
+    maintainers = with maintainers; [ ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/ni/niimprint/package.nix
+++ b/pkgs/by-name/ni/niimprint/package.nix
@@ -10,11 +10,17 @@ python3.pkgs.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "AndBondStyle";
     repo = "niimprint";
-    rev = "be39f68c16a5a7dc1b09bb173700d0ee1ec9cb66";
-    hash = "sha256-+YISYchdqeVKrQ0h2cj5Jy2ezMjnQcWCCYm5f95H9dI=";
+    rev = "be39f68c16a5a7dc1b09bb173700d0ee1ec9cb66"; # Or a specific commit hash
+    hash = "sha256-+YISYchdqeVKrQ0h2cj5Jy2ezMjnQcWCCYm5f95H9dI="; # Needs to be updated
   };
 
   format = "pyproject";
+
+  # Relax Pillow version constraint to work with newer versions
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'pillow = "^10.1.0"' 'pillow = ">=10.1.0"'
+  '';
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
@@ -25,7 +31,7 @@ python3.pkgs.buildPythonPackage rec {
     pyserial
     click
   ];
-  
+
   # Disable tests as the package doesn't have any
   doCheck = false;
 
@@ -37,10 +43,9 @@ python3.pkgs.buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    description = "A command line tool to print to Niimbot label printers";
+    description = "Command line tool to print to Niimbot label printers";
     homepage = "https://github.com/AndBondStyle/niimprint";
-    license = licenses.mit; # Repository appears to use MIT license
-    maintainers = with maintainers; [ nicodemus26 ];
-    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
Adds a new package `niimprint`, https://github.com/AndBondStyle/niimprint, which is used for printing on small heat transfer label makers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Tested on my D110 printer successfully (though the v0.1 package is a bit rough).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
