### PR TITLE
treewide: add udevCheckHook

### DIFF
--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -20,6 +20,7 @@
   gnupg,
   libusb1,
   pcsclite,
+  udevCheckHook,
 }:
 
 let
@@ -221,6 +222,7 @@ stdenvNoCC.mkDerivation rec {
   nativeBuildInputs = [
     makeWrapper
     copyDesktopItems
+    udevCheckHook
   ];
 
   desktopItems = [
@@ -276,6 +278,8 @@ stdenvNoCC.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Modern desktop Bitcoin wallet application supporting most hardware wallets and built on common standards such as PSBT, with an emphasis on transparency and usability";

--- a/pkgs/applications/emulators/zsnes/2.x.nix
+++ b/pkgs/applications/emulators/zsnes/2.x.nix
@@ -10,6 +10,7 @@
   nasm,
   pkg-config,
   zlib,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nasm
     pkg-config
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -55,6 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 icons/48x48x32.png $out/share/icons/hicolor/48x48/apps/zsnes.png
     install -Dm644 icons/64x64x32.png $out/share/icons/hicolor/64x64/apps/zsnes.png
   '';
+
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://github.com/xyproto/zsnes";

--- a/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
@@ -2,8 +2,8 @@
   fetchFromGitHub,
   lib,
   gettext,
-  pkgs,
   python3,
+  udevCheckHook,
   umockdev,
   writeScript,
 }:
@@ -54,6 +54,7 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = [
     python3.pkgs.pytestCheckHook
+    udevCheckHook
     umockdev
   ];
 
@@ -62,6 +63,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   doCheck = true;
+  doInstallCheck = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -175,6 +175,8 @@ stdenv.mkDerivation rec {
   # https://github.com/NixOS/nixpkgs/issues/224569
   enableParallelInstalling = false;
 
+  doInstallCheck = true;
+
   passthru.tests = {
     inherit (nixosTests) sane;
   };

--- a/pkgs/applications/misc/digitalbitbox/default.nix
+++ b/pkgs/applications/misc/digitalbitbox/default.nix
@@ -17,11 +17,12 @@
   qtwebsockets,
   qtmultimedia,
   udevRule51 ? ''
-    ,   SUBSYSTEM=="usb", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbb%n", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402"
-    , '',
+    SUBSYSTEM=="usb", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbb%n", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402"
+  '',
   udevRule52 ? ''
-    ,   KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbbf%n"
-    , '',
+    KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="dbbf%n"
+  '',
+  udevCheckHook,
   writeText,
 }:
 
@@ -66,6 +67,7 @@ mkDerivation rec {
     makeWrapper
     pkg-config
     qttools
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -120,6 +122,8 @@ mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "QT based application for the Digital Bitbox hardware wallet";

--- a/pkgs/applications/misc/moolticute/default.nix
+++ b/pkgs/applications/misc/moolticute/default.nix
@@ -37,6 +37,8 @@ mkDerivation rec {
     qtwebsockets
   ];
 
+  doInstallCheck = true;
+
   preConfigure = "mkdir -p build && cd build";
   qmakeFlags = [ "../Moolticute.pro" ];
 

--- a/pkgs/applications/misc/openambit/default.nix
+++ b/pkgs/applications/misc/openambit/default.nix
@@ -49,7 +49,11 @@ mkDerivation rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
+    runHook preInstallCheck
+
     $out/bin/openambit --version
+
+    runHook postInstallCheck
   '';
 
   postInstall = ''

--- a/pkgs/applications/misc/opentx/default.nix
+++ b/pkgs/applications/misc/opentx/default.nix
@@ -12,6 +12,7 @@
   gtest,
   dfu-util,
   avrdude,
+  udevCheckHook,
 }:
 
 mkDerivation rec {
@@ -30,6 +31,7 @@ mkDerivation rec {
     gcc-arm-embedded
     python3Packages.pillow
     qttools
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -53,6 +55,8 @@ mkDerivation rec {
     # file RPATH_CHANGE could not write new RPATH
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "OpenTX Companion transmitter support software";

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -38,6 +38,7 @@
   ctestCheckHook,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   systemd,
+  udevCheckHook,
   wxGTK-override ? null,
   opencascade-override ? null,
 }:
@@ -96,6 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     wrapGAppsHook3
     wxGTK-override'
+    udevCheckHook
   ];
 
   buildInputs =
@@ -137,6 +139,8 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   separateDebugInfo = true;
+
+  doInstallCheck = true;
 
   # The build system uses custom logic - defined in
   # cmake/modules/FindNLopt.cmake in the package source - for finding the nlopt

--- a/pkgs/applications/misc/qlcplus/default.nix
+++ b/pkgs/applications/misc/qlcplus/default.nix
@@ -14,6 +14,7 @@
   libusb-compat-0_1,
   libsndfile,
   libmad,
+  udevCheckHook,
 }:
 
 mkDerivation rec {
@@ -30,6 +31,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     pkg-config
+    udevCheckHook
   ];
   buildInputs = [
     udev
@@ -59,6 +61,8 @@ mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
 
   postInstall = ''
     ln -sf $out/lib/*/libqlcplus* $out/lib

--- a/pkgs/applications/radio/direwolf/default.nix
+++ b/pkgs/applications/radio/direwolf/default.nix
@@ -13,6 +13,7 @@
   python3,
   espeak,
   udev,
+  udevCheckHook,
   extraScripts ? false,
 }:
 
@@ -27,7 +28,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-Vbxc6a6CK+wrBfs15dtjfRa1LJDKKyHMrg8tqsF7EX4=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    udevCheckHook
+  ];
 
   strictDeps = true;
 
@@ -70,6 +74,8 @@ stdenv.mkDerivation rec {
       substituteInPlace scripts/dwespeak.sh \
         --replace espeak ${espeak}/bin/espeak
     '';
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Soundcard Packet TNC, APRS Digipeater, IGate, APRStt gateway";

--- a/pkgs/applications/radio/limesuite/default.nix
+++ b/pkgs/applications/radio/limesuite/default.nix
@@ -46,6 +46,8 @@ stdenv.mkDerivation rec {
       wxGTK32
     ];
 
+  doInstallCheck = true;
+
   postInstall = ''
     install -Dm444 -t $out/lib/udev/rules.d ../udev-rules/64-limesuite.rules
     install -Dm444 -t $out/share/limesuite bin/Release/lms7suite_mcu/*

--- a/pkgs/applications/radio/qdmr/default.nix
+++ b/pkgs/applications/radio/qdmr/default.nix
@@ -62,6 +62,8 @@ stdenv.mkDerivation rec {
     cp ${src}/dist/99-qdmr.rules $out/etc/udev/rules.d/
   '';
 
+  doInstallCheck = true;
+
   meta = {
     description = "GUI application and command line tool for programming DMR radios";
     homepage = "https://dm3mat.darc.de/qdmr/";

--- a/pkgs/applications/radio/rtl-sdr/default.nix
+++ b/pkgs/applications/radio/rtl-sdr/default.nix
@@ -28,6 +28,8 @@ let
         "-DWITH_RPC=ON"
       ];
 
+      doInstallCheck = true;
+
       postPatch = ''
         substituteInPlace CMakeLists.txt \
           --replace '/etc/udev/rules.d' "$out/etc/udev/rules.d" \

--- a/pkgs/applications/science/electronics/dsview/default.nix
+++ b/pkgs/applications/science/electronics/dsview/default.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ] ++ lib.optional stdenv.hostPlatform.isLinux qtwayland;
 
+  doInstallCheck = true;
+
   meta = {
     description = "GUI program for supporting various instruments from DreamSourceLab, including logic analyzer, oscilloscope, etc";
     mainProgram = "DSView";

--- a/pkgs/applications/science/electronics/linux-gpib/user.nix
+++ b/pkgs/applications/science/electronics/linux-gpib/user.nix
@@ -7,6 +7,7 @@
   bison,
   flex,
   automake,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (
@@ -22,11 +23,14 @@ stdenv.mkDerivation (
       bison
       flex
       automake
+      udevCheckHook
     ];
 
     configureFlags = [
       "--sysconfdir=$(out)/etc"
       "--prefix=$(out)"
     ];
+
+    doInstallCheck = true;
   }
 )

--- a/pkgs/applications/science/electronics/openhantek6022/default.nix
+++ b/pkgs/applications/science/electronics/openhantek6022/default.nix
@@ -41,6 +41,8 @@ mkDerivation rec {
     sed -i 's#/usr/share#share#g' CMakeLists.txt
   '';
 
+  doInstallCheck = true;
+
   meta = with lib; {
     description = "Free software for Hantek and compatible (Voltcraft/Darkwire/Protek/Acetech) USB digital signal oscilloscopes";
     mainProgram = "OpenHantek";

--- a/pkgs/by-name/ac/acpilight/package.nix
+++ b/pkgs/by-name/ac/acpilight/package.nix
@@ -4,6 +4,7 @@
   fetchgit,
   python3,
   coreutils,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,6 +31,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ pyenv ];
 
   makeFlags = [ "DESTDIR=$(out) prefix=" ];
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = with lib; {
     homepage = "https://gitlab.com/wavexx/acpilight";

--- a/pkgs/by-name/ai/airspy/package.nix
+++ b/pkgs/by-name/ai/airspy/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
   ];
+
+  doInstallCheck = true;
   buildInputs = [ libusb1 ];
 
   cmakeFlags = lib.optionals stdenv.hostPlatform.isLinux [ "-DINSTALL_UDEV_RULES=ON" ];

--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -67,6 +67,12 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/aplay --set-default ALSA_PLUGIN_DIR ${plugin-dir}
   '';
 
+  postInstall = ''
+    # udev rules are super broken, violating `udevadm verify` in various creative ways.
+    # NixOS has its own set of alsa udev rules, we can just delete the udev rules for this package
+    rm -rf $out/lib/udev
+  '';
+
   passthru.updateScript = directoryListingUpdater {
     url = "https://www.alsa-project.org/files/pub/utils/";
   };

--- a/pkgs/by-name/am/amazon-ec2-net-utils/package.nix
+++ b/pkgs/by-name/am/amazon-ec2-net-utils/package.nix
@@ -12,6 +12,7 @@
   makeWrapper,
   nix-update-script,
   systemd,
+  udevCheckHook,
   util-linux,
 }:
 
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     installShellFiles
     makeWrapper
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -100,6 +102,8 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  doInstallCheck = true;
 
   outputs = [
     "out"

--- a/pkgs/by-name/am/amazon-ec2-utils/package.nix
+++ b/pkgs/by-name/am/amazon-ec2-utils/package.nix
@@ -12,6 +12,7 @@
   nix-update-script,
   python3,
   stdenv,
+  udevCheckHook,
   util-linux,
 }:
 
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     installShellFiles
     makeWrapper
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -92,7 +94,11 @@ stdenv.mkDerivation rec {
 
   # We can't run `ec2-metadata` since it calls IMDS even with `--help`.
   installCheckPhase = ''
+    runHook preInstallCheck
+
     $out/bin/ebsnvme-id --help
+
+    runHook postInstallCheck
   '';
 
   passthru = {

--- a/pkgs/by-name/an/android-udev-rules/package.nix
+++ b/pkgs/by-name/an/android-udev-rules/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  udevCheckHook,
 }:
 
 ## Usage
@@ -24,6 +25,11 @@ stdenv.mkDerivation rec {
     install -D 51-android.rules $out/lib/udev/rules.d/51-android.rules
     runHook postInstall
   '';
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/M0Rf30/android-udev-rules";

--- a/pkgs/by-name/ap/apio-udev-rules/package.nix
+++ b/pkgs/by-name/ap/apio-udev-rules/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  udevCheckHook,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -16,6 +17,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   dontBuild = true;
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   # 80-* renamed to 70-* for uaccess TAG
   installPhase = ''

--- a/pkgs/by-name/ar/argyllcms/package.nix
+++ b/pkgs/by-name/ar/argyllcms/package.nix
@@ -20,6 +20,7 @@
   openssl,
   buildPackages,
   replaceVars,
+  udevCheckHook,
   writeScript,
 }:
 
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     jam
+    udevCheckHook
     unzip
   ];
 
@@ -163,6 +165,8 @@ stdenv.mkDerivation rec {
     sed -i -e 's/^CREATED .*/CREATED "'"$(date -d @$SOURCE_DATE_EPOCH)"'"/g' $out/share/argyllcms/RefMediumGamut.gam
 
   '';
+
+  doInstallCheck = true;
 
   passthru = {
     updateScript = writeScript "update-argyllcms" ''

--- a/pkgs/by-name/as/asdbctl/package.nix
+++ b/pkgs/by-name/as/asdbctl/package.nix
@@ -5,6 +5,7 @@
   rustPlatform,
   pkg-config,
   udev,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -23,6 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+    udevCheckHook
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
@@ -34,6 +36,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       rules.d/20-asd-backlight.rules \
       $out/lib/udev/rules.d/20-asd-backlight.rules
   '';
+
+  doInstallCheck = true;
 
   meta = {
     description = "Apple Studio Display brightness controll";

--- a/pkgs/by-name/as/asusctl/package.nix
+++ b/pkgs/by-name/as/asusctl/package.nix
@@ -14,6 +14,7 @@
   seatd,
   wayland,
   glibc,
+  udevCheckHook,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "asusctl";
@@ -61,6 +62,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     pkg-config
     rustPlatform.bindgenHook
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -85,6 +87,7 @@ rustPlatform.buildRustPackage rec {
 
   # upstream has minimal tests, so don't rebuild twice
   doCheck = false;
+  doInstallCheck = true;
 
   postInstall = ''
     make prefix=$out install-data

--- a/pkgs/by-name/au/autorandr/package.nix
+++ b/pkgs/by-name/au/autorandr/package.nix
@@ -6,6 +6,7 @@
   xrandr,
   installShellFiles,
   desktop-file-utils,
+  udevCheckHook,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -23,6 +24,7 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = [
     installShellFiles
     desktop-file-utils
+    udevCheckHook
   ];
   propagatedBuildInputs = with python3.pkgs; [ packaging ];
 

--- a/pkgs/by-name/bc/bcache-tools/package.nix
+++ b/pkgs/by-name/bc/bcache-tools/package.nix
@@ -6,6 +6,7 @@
   util-linux,
   bash,
   replaceVars,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -19,8 +20,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-6gy0ymecMgEHXbwp/nXHlrUEeDFnmFXWZZPlzP292g4=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [ util-linux ];
+
+  doInstallCheck = true;
 
   # * Remove broken install rules (they ignore $PREFIX) for stuff we don't need
   #   anyway (it's distro specific stuff).

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -24,6 +24,7 @@
   nixosTests,
   installShellFiles,
   fuseSupport ? false,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -45,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     rustPlatform.bindgenHook
     makeWrapper
     installShellFiles
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -83,6 +85,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   # FIXME: Try enabling this once the default linux kernel is at least 6.7
   doCheck = false; # needs bcachefs module loaded on builder
+
+  doInstallCheck = true;
 
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/by-name/bi/bitbox-bridge/package.nix
+++ b/pkgs/by-name/bi/bitbox-bridge/package.nix
@@ -7,6 +7,7 @@
   libudev-zero,
   nixosTests,
   nix-update-script,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -30,6 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+    udevCheckHook
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
@@ -42,6 +44,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail /opt/bitbox-bridge/bin/bitbox-bridge $out/bin/bitbox-bridge
     install -Dm644 bitbox-bridge/release/linux/hid-digitalbitbox.rules $out/etc/udev/rules.d/50-hid-digitalbitbox.rules
   '';
+
+  doInstallCheck = true;
 
   passthru = {
     tests.basic = nixosTests.bitbox-bridge;

--- a/pkgs/by-name/bi/bitbox/package.nix
+++ b/pkgs/by-name/bi/bitbox/package.nix
@@ -6,6 +6,7 @@
   clang,
   go,
   libsForQt5,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -76,7 +77,10 @@ stdenv.mkDerivation rec {
     clang
     go
     libsForQt5.wrapQtAppsHook
+    udevCheckHook
   ];
+
+  doInstallCheck = true;
 
   meta = {
     description = "Companion app for the BitBox02 hardware wallet";

--- a/pkgs/by-name/bl/bluez/package.nix
+++ b/pkgs/by-name/bl/bluez/package.nix
@@ -23,6 +23,7 @@
     lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
   gitUpdater,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -51,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3Packages.pygments
     python3Packages.wrapPython
+    udevCheckHook
   ];
 
   outputs = [
@@ -121,6 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = stdenv.hostPlatform.isx86_64;
+  doInstallCheck = true;
 
   postInstall =
     let

--- a/pkgs/by-name/bm/bmputil/package.nix
+++ b/pkgs/by-name/bm/bmputil/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   rustPlatform,
   versionCheckHook,
+  udevCheckHook,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "bmputil";
@@ -24,6 +25,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
+  nativeBuildInputs = [ udevCheckHook ];
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 

--- a/pkgs/by-name/bo/bolt/package.nix
+++ b/pkgs/by-name/bo/bolt/package.nix
@@ -18,6 +18,7 @@
   glib,
   systemd,
   polkit,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -56,6 +57,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     glib
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -85,6 +87,8 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dlocalstatedir=/var"
   ];
+
+  doInstallCheck = true;
 
   PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
   PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";

--- a/pkgs/by-name/bo/boxflat/package.nix
+++ b/pkgs/by-name/bo/boxflat/package.nix
@@ -9,6 +9,7 @@
   copyDesktopItems,
   makeDesktopItem,
   nix-update-script,
+  udevCheckHook,
 }:
 
 python3Packages.buildPythonPackage rec {
@@ -41,6 +42,7 @@ python3Packages.buildPythonPackage rec {
     copyDesktopItems
     wrapGAppsHook4
     gobject-introspection
+    udevCheckHook
   ];
 
   postPatch = ''

--- a/pkgs/by-name/br/brightnessctl/package.nix
+++ b/pkgs/by-name/br/brightnessctl/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   systemd,
   coreutils,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -37,8 +38,13 @@ stdenv.mkDerivation rec {
     "install_udev_rules"
   ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [ systemd ];
+
+  doInstallCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/Hummer12007/brightnessctl";

--- a/pkgs/by-name/br/brillo/package.nix
+++ b/pkgs/by-name/br/brillo/package.nix
@@ -5,6 +5,7 @@
   go-md2man,
   coreutils,
   replaceVars,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -26,12 +27,17 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ go-md2man ];
+  nativeBuildInputs = [
+    go-md2man
+    udevCheckHook
+  ];
 
   makeFlags = [
     "PREFIX=$(out)"
     "AADIR=$(out)/etc/apparmor.d"
   ];
+
+  doInstallCheck = true;
 
   installTargets = [ "install-dist" ];
 

--- a/pkgs/by-name/br/brltty/package.nix
+++ b/pkgs/by-name/br/brltty/package.nix
@@ -16,6 +16,7 @@
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
   systemd,
   ncurses,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
     python3.pkgs.cython
     python3.pkgs.setuptools
     tcl
+    udevCheckHook
   ];
   buildInputs =
     [
@@ -40,6 +42,8 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional alsaSupport alsa-lib
     ++ lib.optional systemdSupport systemd;
+
+  doInstallCheck = true;
 
   meta = {
     description = "Access software for a blind person using a braille display";

--- a/pkgs/by-name/bt/btrfs-progs/package.nix
+++ b/pkgs/by-name/bt/btrfs-progs/package.nix
@@ -16,6 +16,7 @@
   btrfs-progs,
   gitUpdater,
   udevSupport ? true,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,6 +31,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs =
     [
       pkg-config
+    ]
+    ++ lib.optionals udevSupport [
+      udevCheckHook
     ]
     ++ [
       (buildPackages.python3.withPackages (
@@ -74,6 +78,8 @@ stdenv.mkDerivation rec {
   makeFlags = [ "udevruledir=$(out)/lib/udev/rules.d" ];
 
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
 
   passthru.tests = {
     simple-filesystem = runCommand "btrfs-progs-create-fs" { } ''

--- a/pkgs/by-name/ca/casync/package.nix
+++ b/pkgs/by-name/ca/casync/package.nix
@@ -19,6 +19,7 @@
   udevSupport ? true,
   glibcLocales,
   rsync,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation {
@@ -49,10 +50,14 @@ stdenv.mkDerivation {
     python3
     sphinx
   ];
-  nativeCheckInputs = [
-    glibcLocales
-    rsync
-  ];
+  nativeCheckInputs =
+    [
+      glibcLocales
+      rsync
+    ]
+    ++ lib.optionals udevSupport [
+      udevCheckHook
+    ];
 
   postPatch = ''
     for f in test/test-*.sh.in; do
@@ -71,6 +76,8 @@ stdenv.mkDerivation {
   preCheck = ''
     export LC_ALL="en_US.utf-8"
   '';
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Content-Addressable Data Synchronizer";

--- a/pkgs/by-name/cc/cc-tool/package.nix
+++ b/pkgs/by-name/cc/cc-tool/package.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation {
       --replace 'MODE="0666"' 'MODE="0660", GROUP="plugdev", TAG+="uaccess"'
   '';
 
+  doInstallCheck = true;
+
   postInstall = ''
     install -D udev/90-cc-debugger.rules $out/lib/udev/rules.d/90-cc-debugger.rules
   '';

--- a/pkgs/by-name/cc/ccid/package.nix
+++ b/pkgs/by-name/cc/ccid/package.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
+  doInstallCheck = true;
+
   postInstall = ''
     install -Dm 0444 -t $out/lib/udev/rules.d ../src/92_pcscd_ccid.rules
     substituteInPlace $out/lib/udev/rules.d/92_pcscd_ccid.rules \
@@ -68,11 +70,15 @@ stdenv.mkDerivation rec {
   };
 
   installCheckPhase = ''
+    runHook preInstallCheck
+
     [ -f $out/etc/reader.conf.d/libccidtwin ]
     [ -f $out/lib/udev/rules.d/92_pcscd_ccid.rules ]
     [ -f $out/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist ]
     [ -f $out/pcsc/drivers/ifd-ccid.bundle/Contents/Linux/libccid.so ]
     [ -f $out/pcsc/drivers/serial/libccidtwin.so ]
+
+    runHook preInstallCheck
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/co/colord/package.nix
+++ b/pkgs/by-name/co/colord/package.nix
@@ -31,6 +31,7 @@
   gtk-doc,
   libxslt,
   enableDaemon ? true,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -91,6 +92,7 @@ stdenv.mkDerivation rec {
       shared-mime-info
       vala
       wrapGAppsNoGuiHook
+      udevCheckHook
     ]
     ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
       mesonEmulatorHook
@@ -115,6 +117,8 @@ stdenv.mkDerivation rec {
     ++ lib.optionals enableDaemon [
       polkit
     ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     glib-compile-schemas $out/share/glib-2.0/schemas

--- a/pkgs/by-name/co/comedilib/package.nix
+++ b/pkgs/by-name/co/comedilib/package.nix
@@ -11,6 +11,7 @@
   swig,
   perl,
   python3,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     docbook_xsl
     python3
     perl
+    udevCheckHook
   ];
 
   preConfigure = ''
@@ -44,6 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-udev-hotplug=${placeholder "out"}/lib"
     "--sysconfdir=${placeholder "out"}/etc"
   ];
+
+  doInstallCheck = true;
 
   outputs = [
     "out"

--- a/pkgs/by-name/cp/cpu-energy-meter/package.nix
+++ b/pkgs/by-name/cp/cpu-energy-meter/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   libcap,
+  udevCheckHook,
 }:
 stdenv.mkDerivation rec {
   pname = "cpu-energy-meter";
@@ -22,6 +23,11 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ libcap ];
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   env.NIX_CFLAGS_COMPILE = "-fcommon";
 

--- a/pkgs/by-name/cu/cutecapture/package.nix
+++ b/pkgs/by-name/cu/cutecapture/package.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
     EOF
   '';
 
+  doInstallCheck = true;
+
   postInstall = ''
     install -Dm644 -t $out/lib/udev/rules.d 95-{3,}dscapture.rules
     install -Dm444 -t $out/share/applications Cute{3,}DSCapture.desktop

--- a/pkgs/by-name/da/dataexplorer/package.nix
+++ b/pkgs/by-name/da/dataexplorer/package.nix
@@ -8,6 +8,7 @@
   swt,
   makeWrapper,
   strip-nondeterminism,
+  udevCheckHook,
 }:
 let
   swt-jdk17 = swt.override { jdk = jdk17; };
@@ -26,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     jdk17
     makeWrapper
     strip-nondeterminism
+    udevCheckHook
   ];
 
   buildPhase = ''
@@ -39,6 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
   #checkPhase = ''
   #  ant -f build/build.xml check
   #'';
+
+  doInstallCheck = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/dd/ddcutil/package.nix
+++ b/pkgs/by-name/dd/ddcutil/package.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   ];
 
   enableParallelBuilding = true;
+  doInstallCheck = true;
 
   meta = with lib; {
     homepage = "http://www.ddcutil.com/";

--- a/pkgs/by-name/dd/dduper/package.nix
+++ b/pkgs/by-name/dd/dduper/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   btrfs-progs,
   python3,
+  udevCheckHook,
 }:
 
 let
@@ -38,6 +39,12 @@ stdenv.mkDerivation rec {
     btrfsProgsPatched
     py3
   ];
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   patchPhase = ''
     substituteInPlace ./dduper --replace "/usr/sbin/btrfs.static" "${btrfsProgsPatched}/bin/btrfs"

--- a/pkgs/by-name/de/dediprog-sf100/package.nix
+++ b/pkgs/by-name/de/dediprog-sf100/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ libusb1 ];
   nativeBuildInputs = [ pkg-config ];
 
+  doInstallCheck = true;
   udevRules = pkgs.writeText "dediprog.rules" ''
     ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="dada", MODE="660", GROUP="plugdev"
   '';

--- a/pkgs/by-name/dm/dmrconfig/package.nix
+++ b/pkgs/by-name/dm/dmrconfig/package.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     systemd
   ];
 
+  doInstallCheck = true;
   preConfigure = ''
     substituteInPlace Makefile \
       --replace /usr/local/bin/dmrconfig $out/bin/dmrconfig

--- a/pkgs/by-name/do/dolphin-emu-primehack/package.nix
+++ b/pkgs/by-name/do/dolphin-emu-primehack/package.nix
@@ -142,6 +142,8 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail 'if(LIBUSB_FOUND AND NOT APPLE)' 'if(LIBUSB_FOUND)'
     '';
 
+  doInstallCheck = true;
+
   postInstall =
     ''
       mv $out/bin/dolphin-emu $out/bin/dolphin-emu-primehack

--- a/pkgs/by-name/do/dolphin-emu/package.nix
+++ b/pkgs/by-name/do/dolphin-emu/package.nix
@@ -156,6 +156,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--set QT_QPA_PLATFORM xcb"
   ];
 
+  doInstallCheck = true;
+
   postInstall =
     lib.optionalString stdenv.hostPlatform.isLinux ''
       install -D $src/Data/51-usb-device.rules $out/etc/udev/rules.d/51-usb-device.rules

--- a/pkgs/by-name/ea/easypdkprog/package.nix
+++ b/pkgs/by-name/ea/easypdkprog/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +15,12 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0hc3gdmn6l01z63hzzwdhbdyy288gh5v219bsfm8fb1498vpnd6f";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   installPhase =
     ''

--- a/pkgs/by-name/ec/ecpdap/package.nix
+++ b/pkgs/by-name/ec/ecpdap/package.nix
@@ -24,6 +24,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ libusb1 ];
 
+  doInstallCheck = true;
+
   postInstall = ''
     mkdir -p $out/etc/udev/rules.d
     cp drivers/*.rules $out/etc/udev/rules.d

--- a/pkgs/by-name/ed/edgetx/package.nix
+++ b/pkgs/by-name/ed/edgetx/package.nix
@@ -14,6 +14,7 @@
   gtest,
   miniz,
   yaml-cpp,
+  udevCheckHook,
   # List of targets to build simulators for
   targetsToBuild ? import ./targets.nix,
 }:
@@ -55,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     pythonEnv
     libsForQt5.qttools
     libsForQt5.wrapQtAppsHook
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -84,6 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
       -e 's|/usr/.*bin/dfu-util|${dfu-util}/bin/dfu-util|'
     patchShebangs companion/util radio/util
   '';
+
+  doInstallCheck = true;
 
   cmakeFlags = [
     # Unvendoring these libraries is infeasible. At least lets reuse the same sources.

--- a/pkgs/by-name/eg/eg25-manager/package.nix
+++ b/pkgs/by-name/eg/eg25-manager/package.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
+  doInstallCheck = true;
 
   meta = {
     description = "Manager daemon for the Quectel EG25 mobile broadband modem found on the Pine64 PinePhone and PinePhone Pro";

--- a/pkgs/by-name/el/elogind/package.nix
+++ b/pkgs/by-name/el/elogind/package.nix
@@ -27,6 +27,7 @@
   docbook_xsl_ns,
   docbook_xml_dtd_42,
   docbook_xml_dtd_45,
+  udevCheckHook,
 
   # Defaulting to false because usually the rationale for using elogind is to
   # use it in situation where a systemd dependency does not work (especially
@@ -45,25 +46,30 @@ stdenv.mkDerivation rec {
     hash = "sha256-4KZr/NiiGVwzdDROhiX3GEQTUyIGva6ezb+xC2U3bkg=";
   };
 
-  nativeBuildInputs = [
-    meson
-    ninja
-    m4
-    pkg-config
-    gperf
-    getent
-    libcap
-    gettext
-    libxslt.bin # xsltproc
-    docbook5
-    docbook_xsl
-    docbook_xsl_ns
-    docbook_xml_dtd_42
-    docbook_xml_dtd_45 # needed for docbook without Internet
+  nativeBuildInputs =
+    [
+      meson
+      ninja
+      m4
+      pkg-config
+      gperf
+      getent
+      libcap
+      gettext
+      libxslt.bin # xsltproc
+      docbook5
+      docbook_xsl
+      docbook_xsl_ns
+      docbook_xml_dtd_42
+      docbook_xml_dtd_45 # needed for docbook without Internet
 
-    python3Packages.python
-    python3Packages.jinja2
-  ];
+      python3Packages.python
+      python3Packages.jinja2
+    ]
+    ++ lib.optionals enableSystemd [
+      # udevCheckHook introduces a dependency on systemdMinimal
+      udevCheckHook
+    ];
 
   buildInputs = [
     acl

--- a/pkgs/by-name/em/em100/package.nix
+++ b/pkgs/by-name/em/em100/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation {
     "makedpfw"
   ];
 
+  doInstallCheck = true;
+
   installPhase = ''
     runHook preInstall
     install -Dm755 em100 $out/bin/em100

--- a/pkgs/by-name/ep/epsonscan2/package.nix
+++ b/pkgs/by-name/ep/epsonscan2/package.nix
@@ -114,6 +114,8 @@ stdenv.mkDerivation {
       "-DNO_GUI=ON"
     ];
 
+  doInstallCheck = true;
+
   postInstall =
     ''
       # But when we put all the libraries in lib/${system}-gnu, then SANE can't find the

--- a/pkgs/by-name/fe/feedbackd/package.nix
+++ b/pkgs/by-name/fe/feedbackd/package.nix
@@ -21,6 +21,7 @@
   gmobile,
   umockdev,
   feedbackd-device-themes,
+  udevCheckHook,
   nix-update-script,
 }:
 
@@ -58,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     vala
     wrapGAppsHook3
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -97,6 +99,8 @@ stdenv.mkDerivation (finalAttrs: {
         done
     fi
   '';
+
+  doInstallCheck = true;
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/fl/flashprog/package.nix
+++ b/pkgs/by-name/fl/flashprog/package.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 ../util/50-flashprog.rules "$out/lib/udev/rules.d/50-flashprog.rules"
   '';
 
+  doInstallCheck = true;
+
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";
     allowedVersions = "^[0-9\\.]+$";

--- a/pkgs/by-name/fl/flashrom/package.nix
+++ b/pkgs/by-name/fl/flashrom/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = !stdenv.hostPlatform.isDarwin;
+  doInstallCheck = true;
 
   postInstall = ''
     install -Dm644 $NIX_BUILD_TOP/$sourceRoot/util/flashrom_udev.rules $out/lib/udev/rules.d/flashrom.rules

--- a/pkgs/by-name/fo/foo2zjs/package.nix
+++ b/pkgs/by-name/fo/foo2zjs/package.nix
@@ -6,6 +6,7 @@
   bc,
   ghostscript,
   systemd,
+  udevCheckHook,
   vim,
   time,
 }:
@@ -24,6 +25,7 @@ stdenv.mkDerivation rec {
     foomatic-filters
     ghostscript
     vim
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -72,6 +74,7 @@ stdenv.mkDerivation rec {
 
   nativeCheckInputs = [ time ];
   doCheck = false; # fails to find its own binary. Also says "Tests will pass only if you are using ghostscript-8.71-16.fc14".
+  doInstallCheck = true;
 
   preInstall = ''
     mkdir -pv $out/{etc/udev/rules.d,lib/udev/rules.d,etc/hotplug/usb}

--- a/pkgs/by-name/fo/footswitch/package.nix
+++ b/pkgs/by-name/fo/footswitch/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   hidapi,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation {
@@ -17,7 +18,10 @@ stdenv.mkDerivation {
     hash = "sha256-vwjeWjIXQiFJ0o/wgEBrKP3hQi8Xa/azVS1IE/Q/MyY=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [ hidapi ];
 
   postPatch = ''
@@ -30,6 +34,8 @@ stdenv.mkDerivation {
   preInstall = ''
     mkdir -p $out/bin $out/lib/udev/rules.d
   '';
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Command line utlities for programming PCsensor and Scythe foot switches";

--- a/pkgs/by-name/g8/g810-led/package.nix
+++ b/pkgs/by-name/g8/g810-led/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   hidapi,
+  udevCheckHook,
   profile ? "/etc/g810-led/profile",
 }:
 
@@ -29,6 +30,12 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     hidapi
   ];
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ga/game-devices-udev-rules/package.nix
+++ b/pkgs/by-name/ga/game-devices-udev-rules/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitea,
   bash,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -16,6 +17,12 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-dWWo3qXnxdLP68NuFKM4/Cw5yE6uAsWzj0vZa9UTT0U=";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     install -Dm444 -t "$out/lib/udev/rules.d" *.rules

--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -31,6 +31,7 @@
   dbus,
   nixos-icons,
   runCommand,
+  udevCheckHook,
 }:
 
 let
@@ -74,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     gobject-introspection
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -143,6 +145,8 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace meson.build \
       --replace-fail "dconf_prefix = dconf_dep.get_variable(pkgconfig: 'prefix')" "dconf_prefix = gdm_prefix"
   '';
+
+  doInstallCheck = true;
 
   preInstall = ''
     install -D ${override} "$DESTDIR/$out/share/glib-2.0/schemas/org.gnome.login-screen.gschema.override"

--- a/pkgs/by-name/gf/gfs2-utils/package.nix
+++ b/pkgs/by-name/gf/gfs2-utils/package.nix
@@ -9,6 +9,7 @@
   bzip2,
   check,
   ncurses,
+  udevCheckHook,
   util-linux,
   zlib,
 }:
@@ -34,6 +35,7 @@ stdenv.mkDerivation rec {
     bison
     flex
     pkg-config
+    udevCheckHook
   ];
   buildInputs = [
     bzip2
@@ -44,6 +46,7 @@ stdenv.mkDerivation rec {
 
   nativeCheckInputs = [ check ];
   doCheck = true;
+  doInstallCheck = true;
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/gm/gmobile/package.nix
+++ b/pkgs/by-name/gm/gmobile/package.nix
@@ -10,6 +10,7 @@
   json-glib,
   libuev,
   gobject-introspection,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     gobject-introspection
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -38,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
     json-glib
     libuev
   ];
+
+  doInstallCheck = true;
 
   meta = {
     description = "Functions useful in mobile related, glib based projects";

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -38,6 +38,7 @@
   tzdata,
   gcr_4,
   gnome-session-ctl,
+  udevCheckHook,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
 
@@ -76,6 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     docbook_xsl
     wrapGAppsHook3
     python3
+    udevCheckHook
   ];
 
   buildInputs =
@@ -124,6 +126,8 @@ stdenv.mkDerivation (finalAttrs: {
       patchShebangs $f
     done
   '';
+
+  doInstallCheck = true;
 
   passthru = {
     updateScript = gnome.updateScript {

--- a/pkgs/by-name/go/gobi_loader/package.nix
+++ b/pkgs/by-name/go/gobi_loader/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,6 +18,12 @@ stdenv.mkDerivation rec {
     substituteInPlace 60-gobi.rules --replace "gobi_loader" "${placeholder "out"}/lib/udev/gobi_loader"
     substituteInPlace 60-gobi.rules --replace "/lib/firmware" "/run/current-system/firmware"
   '';
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   makeFlags = [ "prefix=${placeholder "out"}" ];
 

--- a/pkgs/by-name/go/google-guest-configs/package.nix
+++ b/pkgs/by-name/go/google-guest-configs/package.nix
@@ -11,6 +11,7 @@
   gnugrep,
   gnused,
   nvme-cli,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -34,7 +35,10 @@ stdenv.mkDerivation rec {
     iproute2
   ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    udevCheckHook
+  ];
 
   dontConfigure = true;
   dontBuild = true;
@@ -48,6 +52,8 @@ stdenv.mkDerivation rec {
       --subst-var-by logger "${util-linux}/bin/logger"
     patch -p1 < ./fix-paths.patch
   '';
+
+  doInstallCheck = true;
 
   installPhase = ''
     mkdir -p $out/{bin,etc,lib}

--- a/pkgs/by-name/go/goxlr-utility/package.nix
+++ b/pkgs/by-name/go/goxlr-utility/package.nix
@@ -8,6 +8,7 @@
   dbus,
   openssl,
   speechd-minimal,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -35,9 +36,12 @@ rustPlatform.buildRustPackage rec {
     pkg-config
     installShellFiles
     rustPlatform.bindgenHook
+    udevCheckHook
   ];
 
   buildFeatures = [ "tts" ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     install -Dm644 "50-goxlr.rules" "$out/etc/udev/rules.d/50-goxlr.rules"

--- a/pkgs/by-name/gp/gpsd/package.nix
+++ b/pkgs/by-name/gp/gpsd/package.nix
@@ -121,6 +121,8 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/lib/udev/rules.d"
   '';
 
+  doInstallCheck = true;
+
   installTargets = [
     "install"
     "udev-install"

--- a/pkgs/by-name/gr/gradm/package.nix
+++ b/pkgs/by-name/gr/gradm/package.nix
@@ -5,6 +5,7 @@
   bison,
   flex,
   pam,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,6 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     bison
     flex
+    udevCheckHook
   ];
 
   buildInputs = [ pam ];
@@ -46,6 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p "$out/etc/udev/rules.d"
   '';
+
+  doInstallCheck = true;
 
   postInstall = "rmdir $out/dev";
 

--- a/pkgs/by-name/gu/gummy/package.nix
+++ b/pkgs/by-name/gu/gummy/package.nix
@@ -15,6 +15,7 @@
   fmt,
   nlohmann_json,
   spdlog,
+  udevCheckHook,
   nix-update-script,
 }:
 
@@ -32,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -67,6 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     ln -s $out/libexec/gummyd $out/bin/gummyd
   '';
+
+  doInstallCheck = true;
 
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ha/hackrf/package.nix
+++ b/pkgs/by-name/ha/hackrf/package.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation rec {
     cd host
   '';
 
+  doInstallCheck = true;
+
   postPatch = ''
     substituteInPlace host/cmake/modules/FindFFTW.cmake \
       --replace "find_library (FFTW_LIBRARIES NAMES fftw3)" "find_library (FFTW_LIBRARIES NAMES fftw3f)"

--- a/pkgs/by-name/hd/hdapsd/package.nix
+++ b/pkgs/by-name/hd/hdapsd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -12,6 +13,12 @@ stdenv.mkDerivation rec {
     url = "https://github.com/evgeni/hdapsd/releases/download/${version}/hdapsd-${version}.tar.gz";
     sha256 = "0ppgrfabd0ivx9hyny3c3rv4rphjyxcdsd5svx5pgfai49mxnl36";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   postInstall = builtins.readFile ./postInstall.sh;
 

--- a/pkgs/by-name/he/headsetcontrol/package.nix
+++ b/pkgs/by-name/he/headsetcontrol/package.nix
@@ -5,6 +5,7 @@
   fetchpatch,
   cmake,
   hidapi,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -27,11 +28,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    udevCheckHook
   ];
 
   buildInputs = [
     hidapi
   ];
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Sidetone and Battery status for Logitech G930, G533, G633, G933 SteelSeries Arctis 7/PRO 2019 and Corsair VOID (Pro)";

--- a/pkgs/by-name/hu/huion-switcher/package.nix
+++ b/pkgs/by-name/hu/huion-switcher/package.nix
@@ -6,6 +6,7 @@
   udev,
   pkg-config,
   installShellFiles,
+  udevCheckHook,
   versionCheckHook,
 }:
 
@@ -24,6 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     installShellFiles
+    udevCheckHook
   ];
 
   useFetchCargoVendor = true;

--- a/pkgs/by-name/ii/iio-sensor-proxy/package.nix
+++ b/pkgs/by-name/ii/iio-sensor-proxy/package.nix
@@ -11,6 +11,7 @@
   libgudev,
   systemd,
   polkit,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -44,12 +45,15 @@ stdenv.mkDerivation rec {
     libxml2
     ninja
     pkg-config
+    udevCheckHook
   ];
 
   mesonFlags = [
     (lib.mesonOption "udevrulesdir" "${placeholder "out"}/lib/udev/rules.d")
     (lib.mesonOption "systemdsystemunitdir" "${placeholder "out"}/lib/systemd/system")
   ];
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Proxy for sending IIO sensor data to D-Bus";

--- a/pkgs/by-name/im/imsprog/package.nix
+++ b/pkgs/by-name/im/imsprog/package.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
       }"
   '';
 
+  doInstallCheck = true;
+
   meta = {
     changelog = "https://github.com/bigbigmdm/IMSProg/releases/tag/v${finalAttrs.version}";
     description = "A free I2C EEPROM programmer tool for CH341A device";

--- a/pkgs/by-name/in/incus/generic.nix
+++ b/pkgs/by-name/in/incus/generic.nix
@@ -21,6 +21,7 @@
   pkg-config,
   sqlite,
   udev,
+  udevCheckHook,
   installShellFiles,
   nix-update-script,
   nixosTests,
@@ -85,6 +86,7 @@ buildGoModule (finalAttrs: {
     installShellFiles
     pkg-config
     docsPython
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -128,6 +130,8 @@ buildGoModule (finalAttrs: {
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     installShellCompletion --cmd incus \

--- a/pkgs/by-name/in/infnoise/package.nix
+++ b/pkgs/by-name/in/infnoise/package.nix
@@ -5,6 +5,7 @@
   fetchpatch,
   libftdi,
   testers,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,6 +32,12 @@ stdenv.mkDerivation (finalAttrs: {
   GIT_DATE = "2023-02-14";
 
   buildInputs = [ libftdi ];
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   makefile = "Makefile.linux";
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/by-name/in/inputmodule-control/package.nix
+++ b/pkgs/by-name/in/inputmodule-control/package.nix
@@ -7,6 +7,7 @@
   inputmodule-control,
   pkg-config,
   libudev-zero,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -25,8 +26,13 @@ rustPlatform.buildRustPackage rec {
 
   buildAndTestSubdir = "inputmodule-control";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [ libudev-zero ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     install -Dm644 release/50-framework-inputmodule.rules $out/etc/udev/rules.d/50-framework-inputmodule.rules

--- a/pkgs/by-name/ip/ipad_charge/package.nix
+++ b/pkgs/by-name/ip/ipad_charge/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libusb1 ];
 
+  doInstallCheck = true;
+
   postPatch = ''
     substituteInPlace Makefile \
       --replace " -o root -g root" "" \

--- a/pkgs/by-name/ip/ipp-usb/package.nix
+++ b/pkgs/by-name/ip/ipp-usb/package.nix
@@ -40,6 +40,8 @@ buildGoModule rec {
 
   vendorHash = null;
 
+  doInstallCheck = true;
+
   postInstall = ''
     # to accomodate the makefile
     cp $out/bin/ipp-usb .

--- a/pkgs/by-name/ip/iptsd/package.nix
+++ b/pkgs/by-name/ip/iptsd/package.nix
@@ -13,6 +13,7 @@
   microsoft-gsl,
   spdlog,
   systemd,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
+    udevCheckHook
   ];
 
   dontUseCmakeConfigure = true;
@@ -44,6 +46,8 @@ stdenv.mkDerivation rec {
     spdlog
     systemd
   ];
+
+  doInstallCheck = true;
 
   # Original installs udev rules and service config into global paths
   postPatch = ''

--- a/pkgs/by-name/jo/joycond/package.nix
+++ b/pkgs/by-name/jo/joycond/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   libevdev,
   udev,
+  udevCheckHook,
   acl,
 }:
 
@@ -23,11 +24,14 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     pkg-config
+    udevCheckHook
   ];
   buildInputs = [
     libevdev
     udev
   ];
+
+  doInstallCheck = true;
 
   # CMake has hardcoded install paths
   installPhase = ''

--- a/pkgs/by-name/k4/k40-whisperer/package.nix
+++ b/pkgs/by-name/k4/k40-whisperer/package.nix
@@ -6,6 +6,7 @@
   fetchzip,
   inkscape,
   lib,
+  udevCheckHook,
   udevGroup ? "k40",
 }:
 
@@ -35,7 +36,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Pc6iqBQUoI0dsrf+2dA1ZbxX+4Eks/lVgMGC4SR+oFI=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    udevCheckHook
+  ];
 
   patchPhase = ''
     substituteInPlace svg_reader.py \
@@ -43,6 +47,8 @@ stdenv.mkDerivation rec {
   '';
 
   buildPhase = "";
+
+  doInstallCheck = true;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/by-name/le/ledger-udev-rules/package.nix
+++ b/pkgs/by-name/le/ledger-udev-rules/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation {
@@ -14,6 +15,12 @@ stdenv.mkDerivation {
     rev = "f474382e370c9fa2a2207e6e675b9b364441aed7";
     sha256 = "sha256-5jN9xy3+kk540PAyfsxIqck9hdI3t2CNpgqKxLbAsDg=";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   dontBuild = true;
   dontConfigure = true;

--- a/pkgs/by-name/li/libbladeRF/package.nix
+++ b/pkgs/by-name/li/libbladeRF/package.nix
@@ -54,6 +54,8 @@ stdenv.mkDerivation rec {
     sed -i 's/$(hostname)/hostname/' host/utilities/bladeRF-cli/src/cmd/doc/generate.bash
   '';
 
+  doInstallCheck = true;
+
   cmakeFlags =
     [
       "-DBUILD_DOCUMENTATION=ON"

--- a/pkgs/by-name/li/libedgetpu/package.nix
+++ b/pkgs/by-name/li/libedgetpu/package.nix
@@ -61,6 +61,8 @@ stdenv.mkDerivation {
     flatbuffers_23_5_26
   ];
 
+  doInstallCheck = true;
+
   nativeBuildInputs = [ xxd ];
 
   NIX_CXXSTDLIB_COMPILE = "-std=c++17";

--- a/pkgs/by-name/li/libfido2/package.nix
+++ b/pkgs/by-name/li/libfido2/package.nix
@@ -8,6 +8,7 @@
   libcbor,
   openssl,
   udev,
+  udevCheckHook,
   zlib,
   withPcsclite ? true,
   pcsclite,
@@ -26,6 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    udevCheckHook
   ];
 
   buildInputs =
@@ -44,6 +46,8 @@ stdenv.mkDerivation rec {
     "dev"
     "man"
   ];
+
+  doInstallCheck = true;
 
   cmakeFlags =
     [

--- a/pkgs/by-name/li/libfprint/package.nix
+++ b/pkgs/by-name/li/libfprint/package.nix
@@ -12,6 +12,7 @@
   gobject-introspection,
   cairo,
   libgudev,
+  udevCheckHook,
   gtk-doc,
   docbook-xsl-nons,
   docbook_xml_dtd_43,
@@ -51,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     docbook-xsl-nons
     docbook_xml_dtd_43
     gobject-introspection
+    udevCheckHook
   ];
 
   buildInputs = [

--- a/pkgs/by-name/li/libftdi1/package.nix
+++ b/pkgs/by-name/li/libftdi1/package.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation {
 
   strictDeps = true;
 
+  doInstallCheck = true;
+
   nativeBuildInputs =
     [
       cmake

--- a/pkgs/by-name/li/libgphoto2/package.nix
+++ b/pkgs/by-name/li/libgphoto2/package.nix
@@ -45,6 +45,8 @@ stdenv.mkDerivation rec {
     gd
   ];
 
+  doInstallCheck = true;
+
   # These are mentioned in the Requires line of libgphoto's pkg-config file.
   propagatedBuildInputs = [ libexif ];
 

--- a/pkgs/by-name/li/libirecovery/package.nix
+++ b/pkgs/by-name/li/libirecovery/package.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation rec {
     libimobiledevice-glue
   ];
 
+  doInstallCheck = true;
+
   preAutoreconf = ''
     export RELEASE_VERSION=${version}
   '';

--- a/pkgs/by-name/li/libjaylink/package.nix
+++ b/pkgs/by-name/li/libjaylink/package.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ libusb1 ];
 
+  doInstallCheck = true;
+
   postPatch = ''
     substituteInPlace contrib/60-libjaylink.rules \
       --replace-fail 'GROUP="plugdev"' 'GROUP="jlink"'

--- a/pkgs/by-name/li/libmtp/package.nix
+++ b/pkgs/by-name/li/libmtp/package.nix
@@ -58,6 +58,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doInstallCheck = true;
+
   meta = with lib; {
     homepage = "https://github.com/libmtp/libmtp";
     description = "Implementation of Microsoft's Media Transfer Protocol";

--- a/pkgs/by-name/li/libnitrokey/package.nix
+++ b/pkgs/by-name/li/libnitrokey/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [ hidapi ];
 
+  doInstallCheck = true;
+
   meta = with lib; {
     description = "Communicate with Nitrokey devices in a clean and easy manner";
     homepage = "https://github.com/Nitrokey/libnitrokey";

--- a/pkgs/by-name/li/libpsm2/package.nix
+++ b/pkgs/by-name/li/libpsm2/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   numactl,
   pkg-config,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +18,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [ numactl ];
 
   makeFlags = [
@@ -25,6 +29,8 @@ stdenv.mkDerivation rec {
     # on fresh toolchains like gcc-11.
     "WERROR="
   ];
+
+  doInstallCheck = true;
 
   installFlags = [
     "DESTDIR=$(out)"

--- a/pkgs/by-name/li/libticables2/package.nix
+++ b/pkgs/by-name/li/libticables2/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
     "--enable-libusb10"
   ];
 
+  doInstallCheck = true;
+
   postInstall = ''
     mkdir -p $out/etc/udev/rules.d
     cat > $out/etc/udev/rules.d/69-libsane.rules << EOF

--- a/pkgs/by-name/li/libuldaq/package.nix
+++ b/pkgs/by-name/li/libuldaq/package.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libusb1 ];
 
+  doInstallCheck = true;
+
   meta = with lib; {
     description = "Library to talk to uldaq devices";
     longDescription = ''

--- a/pkgs/by-name/li/libusb1/package.nix
+++ b/pkgs/by-name/li/libusb1/package.nix
@@ -8,6 +8,7 @@
   enableUdev ?
     stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic && !stdenv.hostPlatform.isAndroid,
   udev,
+  udevCheckHook,
   withExamples ? false,
   withStatic ? false,
   withDocs ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
@@ -34,6 +35,10 @@ stdenv.mkDerivation rec {
     autoreconfHook
   ] ++ lib.optionals withDocs [ doxygen ];
   propagatedBuildInputs = lib.optional enableUdev udev;
+
+  # Many dependents are dealing with hardware devices, exposing udev rules for them.
+  # Checking these by propagated hook might improve discoverability
+  propagatedNativeBuildInputs = lib.optional enableUdev udevCheckHook;
 
   dontDisableStatic = withStatic;
 

--- a/pkgs/by-name/li/libwacom/package.nix
+++ b/pkgs/by-name/li/libwacom/package.nix
@@ -7,6 +7,7 @@
   glib,
   pkg-config,
   udev,
+  udevCheckHook,
   libevdev,
   libgudev,
   python3,
@@ -38,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     python3
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -61,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Tests are in the `tests` pass-through derivation because one of them is flaky, frequently causing build failures.
   # See https://github.com/NixOS/nixpkgs/issues/328140
   doCheck = false;
+  doInstallCheck = true;
 
   nativeCheckInputs = [
     valgrind

--- a/pkgs/by-name/li/libwebcam/package.nix
+++ b/pkgs/by-name/li/libwebcam/package.nix
@@ -5,6 +5,7 @@
   cmake,
   pkg-config,
   libxml2,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,6 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    udevCheckHook
   ];
   buildInputs = [ libxml2 ];
 
@@ -44,6 +46,8 @@ stdenv.mkDerivation rec {
       "-DCMAKE_INSTALL_PREFIX=$out"
     )
   '';
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Webcam-tools package";

--- a/pkgs/by-name/li/light/package.nix
+++ b/pkgs/by-name/li/light/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   autoreconfHook,
   coreutils,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation {
@@ -19,7 +20,10 @@ stdenv.mkDerivation {
 
   configureFlags = [ "--with-udev" ];
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    udevCheckHook
+  ];
 
   patches = [
     ./0001-define-light-loglevel-as-extern.patch
@@ -31,6 +35,8 @@ stdenv.mkDerivation {
       --replace-fail '/bin/chgrp' '${coreutils}/bin/chgrp' \
       --replace-fail '/bin/chmod' '${coreutils}/bin/chmod'
   '';
+
+  doInstallCheck = true;
 
   meta = {
     description = "GNU/Linux application to control backlights";

--- a/pkgs/by-name/li/linuxConsoleTools/package.nix
+++ b/pkgs/by-name/li/linuxConsoleTools/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   SDL,
   SDL2,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +17,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-TaKXRceCt9sY9fN8Sed78WMSHdN2Hi/HY2+gy/NcJFY=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [
     SDL
     SDL2
@@ -25,6 +29,8 @@ stdenv.mkDerivation rec {
   makeFlags = [ "DESTDIR=$(out)" ];
 
   installFlags = [ "PREFIX=\"\"" ];
+
+  doInstallCheck = true;
 
   meta = with lib; {
     homepage = "https://sourceforge.net/projects/linuxconsole/";

--- a/pkgs/by-name/lm/lm4flash/package.nix
+++ b/pkgs/by-name/lm/lm4flash/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "PREFIX=$(out)" ];
 
+  doInstallCheck = true;
+
   postInstall = ''
     install -Dm644 "${stellaris-udev-rules}" "$out/etc/udev/rules.d/61.stellpad.rules"
   '';

--- a/pkgs/by-name/lt/ltunify/package.nix
+++ b/pkgs/by-name/lt/ltunify/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  udevCheckHook,
 }:
 
 # Although we copy in the udev rules here, you probably just want to use
@@ -17,6 +18,12 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-9avri/2H0zv65tkBsIi9yVxx3eVS9oCkVCCFdjXqSgI=";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   makeFlags = [
     "DESTDIR=$(out)"

--- a/pkgs/by-name/m3/m33-linux/package.nix
+++ b/pkgs/by-name/m3/m33-linux/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation {
@@ -25,6 +26,12 @@ stdenv.mkDerivation {
       hash = "sha256-ubdCwXFVljvOCzYrWVJgU6PY1j6Ei6aaclhXaGwZT2w=";
     })
   ];
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   installPhase = ''
     install -Dm755 m33-linux $out/bin/m33-linux

--- a/pkgs/by-name/md/mdadm4/package.nix
+++ b/pkgs/by-name/md/mdadm4/package.nix
@@ -7,6 +7,7 @@
   groff,
   system-sendmail,
   udev,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -57,7 +58,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ udev ];
 
-  nativeBuildInputs = [ groff ];
+  nativeBuildInputs = [
+    groff
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   postPatch = ''
     sed -e 's@/lib/udev@''${out}/lib/udev@' \

--- a/pkgs/by-name/md/mdevctl/package.nix
+++ b/pkgs/by-name/md/mdevctl/package.nix
@@ -4,6 +4,7 @@
   fetchCrate,
   docutils,
   installShellFiles,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -26,7 +27,10 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     docutils
     installShellFiles
+    udevCheckHook
   ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     ln -s mdevctl $out/bin/lsmdev

--- a/pkgs/by-name/me/media-player-info/package.nix
+++ b/pkgs/by-name/me/media-player-info/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   python3,
   udev,
+  udevCheckHook,
   systemd,
 }:
 
@@ -29,7 +30,10 @@ stdenv.mkDerivation rec {
     autoreconfHook
     pkg-config
     python3
+    udevCheckHook
   ];
+
+  doInstallCheck = true;
 
   postPatch = ''
     patchShebangs ./tools

--- a/pkgs/by-name/me/meletrix-udev-rules/package.nix
+++ b/pkgs/by-name/me/meletrix-udev-rules/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenvNoCC,
+  udevCheckHook,
 }:
 stdenvNoCC.mkDerivation {
   pname = "meletrix-udev-rules";
@@ -10,6 +11,12 @@ stdenvNoCC.mkDerivation {
 
   dontUnpack = true;
   dontBuild = true;
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   installPhase = ''
     install -Dpm644 $src $out/lib/udev/rules.d/70-meletrix.rules

--- a/pkgs/by-name/mi/minipro/package.nix
+++ b/pkgs/by-name/mi/minipro/package.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     "CFLAGS=-O2"
   ];
 
+  doInstallCheck = true;
+
   meta = with lib; {
     homepage = "https://gitlab.com/DavidGriffith/minipro";
     description = "Open source program for controlling the MiniPRO TL866xx series of chip programmers";

--- a/pkgs/by-name/mo/modemmanager/package.nix
+++ b/pkgs/by-name/mo/modemmanager/package.nix
@@ -19,6 +19,7 @@
   dbus,
   bash,
   gobject-introspection,
+  udevCheckHook,
   buildPackages,
   withIntrospection ?
     lib.meta.availableOn stdenv.hostPlatform gobject-introspection
@@ -64,6 +65,7 @@ stdenv.mkDerivation rec {
       pkg-config
       libxslt
       python3
+      udevCheckHook
     ]
     ++ lib.optionals withIntrospection [
       gobject-introspection

--- a/pkgs/by-name/mo/mouse-actions-gui/package.nix
+++ b/pkgs/by-name/mo/mouse-actions-gui/package.nix
@@ -13,6 +13,7 @@
   wrapGAppsHook3,
   libXtst,
   libevdev,
+  udevCheckHook,
   gtk3,
   libsoup_2_4,
   webkitgtk_4_0,
@@ -37,6 +38,7 @@ rustPlatform.buildRustPackage rec {
     cargo-tauri_1.hook
     pkg-config
     wrapGAppsHook3
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -60,6 +62,8 @@ rustPlatform.buildRustPackage rec {
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-G5PQWPcPOVhq11BQIplbB3mLAGFCVm+vQ4eM4/5MFwI=";
+
+  doInstallCheck = true;
 
   postInstall = ''
     install -Dm644 ${./80-mouse-actions.rules} $out/etc/udev/rules.d/80-mouse-actions.rules

--- a/pkgs/by-name/mo/mouse-actions/package.nix
+++ b/pkgs/by-name/mo/mouse-actions/package.nix
@@ -7,6 +7,7 @@
   libXi,
   libXtst,
   libevdev,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -23,6 +24,8 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-3ylJSb6ItIkOl5Unhnm5aL83mQvWIM0PUg+1lMtUbPY=";
 
+  doInstallCheck = true;
+
   buildInputs = [
     libX11
     libXi
@@ -32,6 +35,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
+    udevCheckHook
   ];
 
   postInstall = ''

--- a/pkgs/by-name/mo/mouse_m908/package.nix
+++ b/pkgs/by-name/mo/mouse_m908/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ libusb1 ];
 
+  doInstallCheck = true;
+
   # Uses proper nix directories rather than the ones specified in the makefile
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/mu/multipath-tools/package.nix
+++ b/pkgs/by-name/mu/multipath-tools/package.nix
@@ -15,6 +15,7 @@
   lvm2,
   readline,
   systemd,
+  udevCheckHook,
   util-linuxMinimal,
 
   cmocka,
@@ -51,6 +52,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     perl
     pkg-config
+    udevCheckHook
   ];
   buildInputs = [
     json_c
@@ -80,6 +82,8 @@ stdenv.mkDerivation rec {
     substituteInPlace tests/Makefile --replace-fail ' devt ' ' '
   '';
   checkInputs = [ cmocka ];
+
+  doInstallCheck = true;
 
   passthru.tests = { inherit (nixosTests) iscsi-multipath-root; };
 

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -65,6 +65,7 @@
   desktop-file-utils,
   egl-wayland,
   graphene,
+  udevCheckHook,
   wayland,
   wayland-protocols,
 }:
@@ -123,6 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
     gi-docgen
     xorgserver
     gobject-introspection
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -200,6 +202,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   separateDebugInfo = true;
   strictDeps = true;
+
+  doInstallCheck = true;
 
   passthru = {
     libmutter_api_version = "16"; # bumped each dev cycle

--- a/pkgs/by-name/mu/mutter46/package.nix
+++ b/pkgs/by-name/mu/mutter46/package.nix
@@ -62,6 +62,7 @@
   desktop-file-utils,
   egl-wayland,
   graphene,
+  udevCheckHook,
   wayland,
   wayland-protocols,
 }:
@@ -115,6 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
     gi-docgen
     xorgserver
     gobject-introspection
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -185,6 +187,8 @@ stdenv.mkDerivation (finalAttrs: {
   PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
 
   separateDebugInfo = true;
+
+  doInstallCheck = true;
 
   passthru = {
     libdir = "${finalAttrs.finalPackage}/lib/mutter-14";

--- a/pkgs/by-name/nf/nfs-utils/package.nix
+++ b/pkgs/by-name/nf/nfs-utils/package.nix
@@ -24,6 +24,7 @@
   openldap,
   cyrus_sasl,
   libxml2,
+  udevCheckHook,
   enablePython ? true,
   enableLdap ? true,
 }:
@@ -58,6 +59,7 @@ stdenv.mkDerivation rec {
     pkg-config
     buildPackages.stdenv.cc
     rpcsvc-proto
+    udevCheckHook
   ];
 
   buildInputs =
@@ -141,6 +143,8 @@ stdenv.mkDerivation rec {
     "sbindir=$(out)/bin"
     "generator_dir=$(out)/etc/systemd/system-generators"
   ];
+
+  doInstallCheck = true;
 
   installFlags = [
     "statedir=$(TMPDIR)"

--- a/pkgs/by-name/ni/nitrokey-udev-rules/package.nix
+++ b/pkgs/by-name/ni/nitrokey-udev-rules/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchFromGitHub,
   python3,
+  udevCheckHook,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -16,7 +17,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-LKpd6O9suAc2+FFgpuyTClEgL/JiZiokH3DV8P3C7Aw=";
   };
 
-  nativeBuildInputs = [ python3 ];
+  nativeBuildInputs = [
+    python3
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ns/ns-usbloader/package.nix
+++ b/pkgs/by-name/ns/ns-usbloader/package.nix
@@ -9,6 +9,7 @@
   gvfs,
   maven,
   jre,
+  udevCheckHook,
 }:
 let
   pkgDescription = "All-in-one tool for managing Nintendo Switch homebrew";
@@ -47,9 +48,12 @@ maven.buildMavenPackage rec {
     makeWrapper
     wrapGAppsHook3
     gvfs
+    udevCheckHook
   ];
 
   doCheck = false;
+
+  doInstallCheck = true;
 
   # Don't wrap binaries twice.
   dontWrapGApps = true;

--- a/pkgs/by-name/nu/numworks-udev-rules/package.nix
+++ b/pkgs/by-name/nu/numworks-udev-rules/package.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv }:
+{
+  lib,
+  stdenv,
+  udevCheckHook,
+}:
 
 stdenv.mkDerivation rec {
   pname = "numworks-udev-rules";
@@ -6,6 +10,12 @@ stdenv.mkDerivation rec {
 
   udevRules = ./50-numworks-calculator.rules;
   dontUnpack = true;
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   installPhase = ''
     install -Dm 644 "${udevRules}" "$out/lib/udev/rules.d/50-numworks-calculator.rules"

--- a/pkgs/by-name/nu/nut/package.nix
+++ b/pkgs/by-name/nu/nut/package.nix
@@ -72,6 +72,8 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
+  doInstallCheck = true;
+
   configureFlags = [
     "--with-all"
     "--with-ssl"

--- a/pkgs/by-name/nv/nvme-cli/package.nix
+++ b/pkgs/by-name/nv/nvme-cli/package.nix
@@ -9,6 +9,7 @@
   json_c,
   zlib,
   python3Packages,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -31,12 +32,15 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3Packages.nose2
+    udevCheckHook
   ];
   buildInputs = [
     libnvme
     json_c
     zlib
   ];
+
+  doInstallCheck = true;
 
   meta = with lib; {
     inherit (src.meta) homepage; # https://nvmexpress.org/

--- a/pkgs/by-name/nx/nxpmicro-mfgtools/package.nix
+++ b/pkgs/by-name/nx/nxpmicro-mfgtools/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
     zstd
   ];
 
+  doInstallCheck = true;
+
   preConfigure = "echo ${version} > .tarball-version";
 
   postInstall = ''

--- a/pkgs/by-name/op/open-vm-tools/package.nix
+++ b/pkgs/by-name/op/open-vm-tools/package.nix
@@ -37,6 +37,7 @@
   udev,
   util-linux,
   xmlsec,
+  udevCheckHook,
   withX ? true,
 }:
 let
@@ -71,6 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     makeWrapper
     pkg-config
+    udevCheckHook
   ];
 
   buildInputs =
@@ -139,6 +141,8 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ optional (!withX) "--without-x";
 
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
 
   preConfigure = ''
     mkdir -p ${placeholder "out"}/lib/udev/rules.d

--- a/pkgs/by-name/op/opencbm/package.nix
+++ b/pkgs/by-name/op/opencbm/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
     ncurses
   ];
 
+  doInstallCheck = true;
+
   meta = with lib; {
     description = "Kernel driver and development library to control serial CBM devices";
     longDescription = ''

--- a/pkgs/by-name/op/openiscsi/package.nix
+++ b/pkgs/by-name/op/openiscsi/package.nix
@@ -13,6 +13,7 @@
   systemd,
   runtimeShell,
   nixosTests,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
     pkg-config
     ninja
     perl
+    udevCheckHook
   ];
   buildInputs = [
     kmod
@@ -56,6 +58,8 @@ stdenv.mkDerivation rec {
     "-Dsystemddir=${placeholder "out"}/lib/systemd"
     "-Ddbroot=/etc/iscsi"
   ];
+
+  doInstallCheck = true;
 
   passthru.tests = { inherit (nixosTests) iscsi-root; };
 

--- a/pkgs/by-name/op/openobex/package.nix
+++ b/pkgs/by-name/op/openobex/package.nix
@@ -6,6 +6,7 @@
   bluez,
   libusb-compat-0_1,
   cmake,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -20,11 +21,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     cmake
+    udevCheckHook
   ];
   buildInputs = [
     bluez
     libusb-compat-0_1
   ];
+
+  doInstallCheck = true;
 
   configureFlags = [ "--enable-apps" ];
 

--- a/pkgs/by-name/op/openocd/package.nix
+++ b/pkgs/by-name/op/openocd/package.nix
@@ -61,6 +61,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  doInstallCheck = true;
+
   env.NIX_CFLAGS_COMPILE = toString (
     lib.optionals stdenv.cc.isGNU [
       "-Wno-error=cpp"

--- a/pkgs/by-name/op/openrgb/package.nix
+++ b/pkgs/by-name/op/openrgb/package.nix
@@ -52,7 +52,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
   installCheckPhase = ''
+    runHook preInstallCheck
+
     HOME=$TMPDIR $out/bin/openrgb --help > /dev/null
+
+    runHook postInstallCheck
   '';
 
   passthru.withPlugins =

--- a/pkgs/by-name/op/openswitcher/package.nix
+++ b/pkgs/by-name/op/openswitcher/package.nix
@@ -11,6 +11,7 @@
   pkg-config,
   scdoc,
   wrapGAppsHook3,
+  udevCheckHook,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -43,6 +44,7 @@ python3Packages.buildPythonApplication rec {
     pkg-config
     scdoc
     wrapGAppsHook3
+    udevCheckHook
   ];
 
   dontWrapGApps = true;

--- a/pkgs/by-name/op/opentabletdriver/package.nix
+++ b/pkgs/by-name/op/opentabletdriver/package.nix
@@ -18,6 +18,7 @@
   wrapGAppsHook3,
   versionCheckHook,
   nix-update-script,
+  udevCheckHook,
 }:
 
 buildDotnetModule (finalAttrs: {
@@ -49,6 +50,7 @@ buildDotnetModule (finalAttrs: {
   nativeBuildInputs = [
     copyDesktopItems
     wrapGAppsHook3
+    udevCheckHook
     # Dependency of generate-rules.sh
     jq
   ];

--- a/pkgs/by-name/op/openterface-qt/package.nix
+++ b/pkgs/by-name/op/openterface-qt/package.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation (final: {
     runHook postInstall
   '';
 
+  doInstallCheck = true;
+
   desktopItems = [
     (makeDesktopItem {
       name = "openterfaceQT";

--- a/pkgs/by-name/or/orbuculum/package.nix
+++ b/pkgs/by-name/or/orbuculum/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
     SDL2
   ];
 
+  doInstallCheck = true;
+
   installFlags = [
     "INSTALL_ROOT=$(out)/"
   ];

--- a/pkgs/by-name/ov/oversteer/package.nix
+++ b/pkgs/by-name/ov/oversteer/package.nix
@@ -17,6 +17,7 @@
   gobject-introspection,
   bash,
   linuxConsoleTools,
+  udevCheckHook,
 }:
 
 let
@@ -60,6 +61,7 @@ stdenv.mkDerivation {
     gobject-introspection
     meson
     udev
+    udevCheckHook
     ninja
     appstream
     appstream-glib
@@ -92,6 +94,8 @@ stdenv.mkDerivation {
     substituteInPlace $out/lib/udev/rules.d/99-fanatec-wheel-perms.rules \
       --replace-fail /usr/bin/evdev-joystick ${linuxConsoleTools}/bin/evdev-joystick
   '';
+
+  doInstallCheck = true;
 
   patches = [ ];
 

--- a/pkgs/by-name/pc/pcmciaUtils/package.nix
+++ b/pkgs/by-name/pc/pcmciaUtils/package.nix
@@ -8,6 +8,7 @@
   sysfsutils,
   kmod,
   udev,
+  udevCheckHook,
   firmware ? config.pcmciaUtils.firmware or [ ], # Special pcmcia cards.
   configOpts ? config.pcmciaUtils.config or null, # Special hardware (map memory & port & irq)
 }: # used to generate postInstall script.
@@ -29,6 +30,12 @@ stdenv.mkDerivation rec {
     kmod
     flex
   ];
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   patchPhase =
     ''

--- a/pkgs/by-name/ph/phodav/package.nix
+++ b/pkgs/by-name/ph/phodav/package.nix
@@ -8,6 +8,7 @@
   meson,
   ninja,
   gnome,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -29,6 +30,7 @@ stdenv.mkDerivation rec {
     pkg-config
     meson
     ninja
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -44,6 +46,8 @@ stdenv.mkDerivation rec {
   ];
 
   NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-lintl";
+
+  doInstallCheck = true;
 
   passthru = {
     updateScript = gnome.updateScript {

--- a/pkgs/by-name/pi/picoprobe-udev-rules/package.nix
+++ b/pkgs/by-name/pi/picoprobe-udev-rules/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  udevCheckHook,
 }:
 
 ## Usage
@@ -16,6 +17,12 @@ stdenv.mkDerivation {
     url = "https://raw.githubusercontent.com/probe-rs/webpage/1cba61acc6ecb5ff96f74641269844ad88ad8ad5/static/files/69-probe-rs.rules";
     sha256 = "sha256-vQMPX3Amttja0u03KWGnPDAVTGM9ekJ+IBTjW+xlJS0=";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   dontUnpack = true;
   dontBuild = true;

--- a/pkgs/by-name/qm/qmk-udev-rules/package.nix
+++ b/pkgs/by-name/qm/qmk-udev-rules/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  udevCheckHook,
 }:
 
 ## Usage
@@ -19,6 +20,12 @@ stdenv.mkDerivation rec {
   };
 
   dontBuild = true;
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/qu/quark-goldleaf/package.nix
+++ b/pkgs/by-name/qu/quark-goldleaf/package.nix
@@ -9,6 +9,7 @@
   imagemagick,
   wrapGAppsHook3,
   gtk3,
+  udevCheckHook,
 }:
 
 let
@@ -48,12 +49,15 @@ maven.buildMavenPackage rec {
     imagemagick # for icon conversion
     copyDesktopItems
     wrapGAppsHook3
+    udevCheckHook
   ];
 
   buildInputs = [ gtk3 ];
 
   # don't double-wrap
   dontWrapGApps = true;
+
+  doInstallCheck = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/rd/rdma-core/package.nix
+++ b/pkgs/by-name/rd/rdma-core/package.nix
@@ -10,6 +10,7 @@
   iproute2,
   libnl,
   udev,
+  udevCheckHook,
   python3,
   perl,
 }:
@@ -39,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     pandoc
     pkg-config
     python3
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -72,6 +74,8 @@ stdenv.mkDerivation (finalAttrs: {
         "${perl}/bin/perl" "${perl}/bin/perl -I $out/${perl.libPrefix}"
     done
   '';
+
+  doInstallCheck = true;
 
   meta = {
     description = "RDMA Core Userspace Libraries and Daemons";

--- a/pkgs/by-name/rk/rkdeveloptool-pine64/package.nix
+++ b/pkgs/by-name/rk/rkdeveloptool-pine64/package.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ libusb1 ];
 
+  doInstallCheck = true;
+
   meta = {
     homepage = "https://gitlab.com/pine64-org/quartz-bsp/rkdeveloptool/";
     description = "Tool from Rockchip to communicate with Rockusb devices (pine64 fork)";

--- a/pkgs/by-name/ro/roccat-tools/package.nix
+++ b/pkgs/by-name/ro/roccat-tools/package.nix
@@ -14,6 +14,7 @@
   runtimeShell,
   coreutils,
   kmod,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -43,6 +44,7 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
     gettext
+    udevCheckHook
   ];
   buildInputs = [
     dbus
@@ -67,6 +69,8 @@ stdenv.mkDerivation rec {
     #     ryos_custom_lights.c.o:(.bss+0x0): first defined here
     "-fcommon"
   ];
+
+  doInstallCheck = true;
 
   meta = {
     description = "Tools to configure ROCCAT devices";

--- a/pkgs/by-name/rp/rpcs3/package.nix
+++ b/pkgs/by-name/rp/rpcs3/package.nix
@@ -142,6 +142,8 @@ stdenv.mkDerivation {
       qtwayland
     ];
 
+  doInstallCheck = true;
+
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';

--- a/pkgs/by-name/rt/rtl_fm_streamer/package.nix
+++ b/pkgs/by-name/rt/rtl_fm_streamer/package.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "INSTALL_UDEV_RULES" stdenv.hostPlatform.isLinux)
   ];
 
+  doInstallCheck = true;
+
   meta = {
     description = "Turns your Realtek RTL2832 based DVB dongle into a FM radio stereo receiver";
     homepage = "https://github.com/AlbrechtL/rtl_fm_streamer";

--- a/pkgs/by-name/ru/rust-streamdeck/package.nix
+++ b/pkgs/by-name/ru/rust-streamdeck/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   lib,
   udev,
+  udevCheckHook,
   nix-update-script,
   versionCheckHook,
 }:
@@ -29,7 +30,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-OiXpG45jwWydbpRHnbIlECOaa75CzUOmdWxZ3WE5+hY=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [ udev ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/rw/rwedid/package.nix
+++ b/pkgs/by-name/rw/rwedid/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitea,
   pkg-config,
+  udevCheckHook,
   xz,
 }:
 
@@ -23,11 +24,14 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
+    udevCheckHook
   ];
 
   buildInputs = [
     xz
   ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     mkdir -p $out/etc/udev/rules.d

--- a/pkgs/by-name/sc/sc-controller/package.nix
+++ b/pkgs/by-name/sc/sc-controller/package.nix
@@ -14,6 +14,7 @@
   libXfixes,
   libusb1,
   udev,
+  udevCheckHook,
   gtk-layer-shell,
 }:
 
@@ -31,6 +32,7 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [
     wrapGAppsHook3
     gobject-introspection
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -88,6 +90,8 @@ python3Packages.buildPythonApplication rec {
       patchPythonScript scc-osd-daemon.py
     )
   '';
+
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://github.com/C0rn3j/sc-controller";

--- a/pkgs/by-name/sn/snagboot/package.nix
+++ b/pkgs/by-name/sn/snagboot/package.nix
@@ -6,6 +6,7 @@
   snagboot,
   testers,
   gitUpdater,
+  udevCheckHook,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -27,6 +28,10 @@ python3Packages.buildPythonApplication rec {
   pythonRemoveDeps = [
     "pylibfdt"
     "swig"
+  ];
+
+  nativeBuildInputs = [
+    udevCheckHook
   ];
 
   dependencies = with python3Packages; [
@@ -54,9 +59,6 @@ python3Packages.buildPythonApplication rec {
     mkdir -p "$out/lib/udev/rules.d"
     cp "$rules" "$out/lib/udev/rules.d/50-snagboot.rules"
   '';
-
-  # There are no tests
-  doCheck = false;
 
   passthru = {
     updateScript = gitUpdater {

--- a/pkgs/by-name/so/solaar/package.nix
+++ b/pkgs/by-name/so/solaar/package.nix
@@ -8,6 +8,7 @@
   gdk-pixbuf,
   libappindicator,
   librsvg,
+  udevCheckHook,
 }:
 
 # Although we copy in the udev rules here, you probably just want to use
@@ -33,6 +34,7 @@ python3Packages.buildPythonApplication rec {
     gdk-pixbuf
     gobject-introspection
     wrapGAppsHook3
+    udevCheckHook
   ];
 
   buildInputs = [

--- a/pkgs/by-name/so/solo2-cli/package.nix
+++ b/pkgs/by-name/so/solo2-cli/package.nix
@@ -7,6 +7,7 @@
   pkg-config,
   pcsclite,
   udev,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -26,6 +27,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     installShellFiles
     pkg-config
+    udevCheckHook
   ];
 
   buildInputs =
@@ -42,6 +44,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   doCheck = true;
+  doInstallCheck = true;
 
   buildFeatures = [ "cli" ];
 

--- a/pkgs/by-name/sp/speakersafetyd/package.nix
+++ b/pkgs/by-name/sp/speakersafetyd/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   alsa-lib,
   rust,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -19,7 +20,10 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-DnOnqi60JsRX8yqEM/5zZ3yX/rk85/ruwL3aW1FRXKg=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [ alsa-lib ];
 
   postPatch = ''
@@ -38,6 +42,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   dontCargoInstall = true;
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Userspace daemon written in Rust that implements an analogue of the Texas Instruments Smart Amp speaker protection model";

--- a/pkgs/by-name/st/steam-devices-udev-rules/package.nix
+++ b/pkgs/by-name/st/steam-devices-udev-rules/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchFromGitHub,
   bash,
+  udevCheckHook,
   nix-update-script,
 }:
 
@@ -16,6 +17,12 @@ stdenvNoCC.mkDerivation {
     rev = "e2971e45063f6b327ccedbf18e168bda6749155c";
     hash = "sha256-kBqWw3TlCSWS7gJXgza2ghemypQ0AEg7NhWqAFnal04=";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/st/stlink/package.nix
+++ b/pkgs/by-name/st/stlink/package.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation rec {
       wrapGAppsHook3
     ];
 
+  doInstallCheck = true;
+
   cmakeFlags = [
     "-DSTLINK_MODPROBED_DIR=${placeholder "out"}/etc/modprobe.d"
     "-DSTLINK_UDEV_RULES_DIR=${placeholder "out"}/lib/udev/rules.d"

--- a/pkgs/by-name/st/stratisd/package.nix
+++ b/pkgs/by-name/st/stratisd/package.nix
@@ -23,6 +23,7 @@
   curl,
   tpm2-tools,
   coreutils,
+  udevCheckHook,
   clevisSupport ? false,
   nixosTests,
 }:
@@ -65,6 +66,7 @@ stdenv.mkDerivation rec {
     pkg-config
     asciidoc
     ncurses # tput
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -107,6 +109,8 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkTarget = "test";
+
+  doInstallCheck = true;
 
   # remove files for supporting dracut
   postInstall = ''

--- a/pkgs/by-name/st/streamcontroller/package.nix
+++ b/pkgs/by-name/st/streamcontroller/package.nix
@@ -14,6 +14,7 @@
   xdg-desktop-portal,
   xdg-desktop-portal-gtk,
   kdotool,
+  udevCheckHook,
 }:
 let
   # We have to hardcode revision because upstream often create multiple releases for the same version number.
@@ -88,6 +89,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     copyDesktopItems
     wrapGAppsHook4
+    udevCheckHook
     gobject-introspection
   ];
 
@@ -194,6 +196,8 @@ stdenv.mkDerivation {
       webencodings
       websocket-client
     ]);
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Elegant Linux app for the Elgato Stream Deck with support for plugins";

--- a/pkgs/by-name/st/streamdeck-ui/package.nix
+++ b/pkgs/by-name/st/streamdeck-ui/package.nix
@@ -8,6 +8,7 @@
   wrapGAppsHook3,
   writeText,
   xvfb-run,
+  udevCheckHook,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -35,6 +36,7 @@ python3Packages.buildPythonApplication rec {
     copyDesktopItems
     qt6.wrapQtAppsHook
     wrapGAppsHook3
+    udevCheckHook
   ];
 
   propagatedBuildInputs =
@@ -68,7 +70,7 @@ python3Packages.buildPythonApplication rec {
     export STREAMDECK_UI_LOG_FILE=$(pwd)/.streamdeck_ui.log
     xvfb-run pytest tests
 
-    runHook preCheck
+    runHook postCheck
   '';
 
   postInstall =

--- a/pkgs/by-name/su/sunshine/package.nix
+++ b/pkgs/by-name/su/sunshine/package.nix
@@ -48,6 +48,7 @@
   nlohmann_json,
   config,
   coreutils,
+  udevCheckHook,
   cudaSupport ? config.cudaSupport,
   cudaPackages ? { },
 }:
@@ -92,6 +93,7 @@ stdenv'.mkDerivation rec {
       wayland-scanner
       # Avoid fighting upstream's usage of vendored ffmpeg libraries
       autoPatchelfHook
+      udevCheckHook
     ]
     ++ lib.optionals cudaSupport [
       autoAddDriverRunpath
@@ -230,6 +232,8 @@ stdenv'.mkDerivation rec {
   postInstall = ''
     install -Dm644 ../packaging/linux/${pname}.desktop $out/share/applications/${pname}.desktop
   '';
+
+  doInstallCheck = true;
 
   passthru = {
     tests.sunshine = nixosTests.sunshine;

--- a/pkgs/by-name/su/supergfxctl/package.nix
+++ b/pkgs/by-name/su/supergfxctl/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   pkg-config,
   systemd,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -25,11 +26,16 @@ rustPlatform.buildRustPackage rec {
     substituteInPlace data/99-nvidia-ac.rules --replace /usr/bin/systemctl ${systemd}/bin/systemctl
   '';
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [ systemd ];
 
   # upstream doesn't have tests, don't build twice just to find that out
   doCheck = false;
+
+  doInstallCheck = true;
 
   postInstall = ''
     install -Dm444 -t $out/lib/udev/rules.d/ data/*.rules

--- a/pkgs/by-name/sw/swayosd/package.nix
+++ b/pkgs/by-name/sw/swayosd/package.nix
@@ -18,6 +18,7 @@
   sassc,
   stdenv,
   udev,
+  udevCheckHook,
 }:
 stdenv.mkDerivation rec {
   pname = "swayosd";
@@ -43,6 +44,7 @@ stdenv.mkDerivation rec {
     cargo
     ninja
     rustPlatform.cargoSetupHook
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -70,6 +72,8 @@ stdenv.mkDerivation rec {
       --replace /bin/chgrp ${coreutils}/bin/chgrp \
       --replace /bin/chmod ${coreutils}/bin/chmod
   '';
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "GTK based on screen display for keyboard shortcuts";

--- a/pkgs/by-name/th/thunderbolt/package.nix
+++ b/pkgs/by-name/th/thunderbolt/package.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   pkg-config,
   txt2tags,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -22,6 +23,7 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
     txt2tags
+    udevCheckHook
   ];
   buildInputs = [ boost ];
 
@@ -29,6 +31,8 @@ stdenv.mkDerivation rec {
     "-DUDEV_BIN_DIR=${placeholder "out"}/bin"
     "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d"
   ];
+
+  doInstallCheck = true;
 
   meta = {
     description = "Thunderbolt(TM) user-space components";

--- a/pkgs/by-name/ti/tiny-dfr/package.nix
+++ b/pkgs/by-name/ti/tiny-dfr/package.nix
@@ -10,6 +10,7 @@
   libxml2,
   pango,
   udev,
+  udevCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -26,7 +27,10 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-9UlH2W8wNzdZJxIgOafGylliS2RjaBlpirxSWHJ/SIQ=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    udevCheckHook
+  ];
   buildInputs = [
     cairo
     gdk-pixbuf
@@ -47,6 +51,8 @@ rustPlatform.buildRustPackage rec {
     cp -R etc $out/lib
     cp -R share $out
   '';
+
+  doInstallCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/WhatAmISupposedToPutHere/tiny-dfr";

--- a/pkgs/by-name/ti/tiscamera/package.nix
+++ b/pkgs/by-name/ti/tiscamera/package.nix
@@ -129,6 +129,8 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = true;
 
+  doInstallCheck = true;
+
   preFixup = ''
     gappsWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';

--- a/pkgs/by-name/tr/trezor-udev-rules/package.nix
+++ b/pkgs/by-name/tr/trezor-udev-rules/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   nixosTests,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +15,12 @@ stdenv.mkDerivation rec {
     url = "https://raw.githubusercontent.com/trezor/trezor-firmware/68a3094b0a8e36b588b1bcb58c34a2c9eafc0dca/common/udev/51-trezor.rules";
     sha256 = "0vlxif89nsqpbnbz1vwfgpl1zayzmq87gw1snskn0qns6x2rpczk";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   dontUnpack = true;
 

--- a/pkgs/by-name/ts/tsduck/package.nix
+++ b/pkgs/by-name/ts/tsduck/package.nix
@@ -9,6 +9,7 @@
   python3,
   ruby,
   qpdf,
+  udevCheckHook,
   # build deps
   curl,
   glibcLocales,
@@ -37,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     ruby
     qpdf
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -71,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [ ./tests.patch ];
   checkTarget = "test";
   doCheck = true;
+  doInstallCheck = true;
 
   installTargets = [
     "install-tools"

--- a/pkgs/by-name/ub/ubertooth/package.nix
+++ b/pkgs/by-name/ub/ubertooth/package.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
     "-DUDEV_RULES_GROUP=${udevGroup}"
   ];
 
+  doInstallCheck = true;
+
   meta = with lib; {
     description = "Open source wireless development platform suitable for Bluetooth experimentation";
     homepage = "https://github.com/greatscottgadgets/ubertooth";

--- a/pkgs/by-name/uh/uhd/package.nix
+++ b/pkgs/by-name/uh/uhd/package.nix
@@ -178,6 +178,8 @@ stdenv.mkDerivation (finalAttrs: {
   # many tests fails on darwin, according to ofborg
   doCheck = !stdenv.hostPlatform.isDarwin;
 
+  doInstallCheck = true;
+
   # Build only the host software
   preConfigure = "cd host";
   patches = [

--- a/pkgs/by-name/uh/uhk-udev-rules/package.nix
+++ b/pkgs/by-name/uh/uhk-udev-rules/package.nix
@@ -2,11 +2,18 @@
   lib,
   stdenv,
   uhk-agent,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation {
   pname = "uhk-udev-rules";
   inherit (uhk-agent) version;
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   dontUnpack = true;
   dontBuild = true;

--- a/pkgs/by-name/up/upower/package.nix
+++ b/pkgs/by-name/up/upower/package.nix
@@ -162,6 +162,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
+  doInstallCheck = true;
 
   postPatch = ''
     patchShebangs src/linux/integration-test.py

--- a/pkgs/by-name/us/usb-blaster-udev-rules/package.nix
+++ b/pkgs/by-name/us/usb-blaster-udev-rules/package.nix
@@ -1,10 +1,20 @@
-{ lib, stdenvNoCC }:
+{
+  lib,
+  stdenvNoCC,
+  udevCheckHook,
+}:
 
 stdenvNoCC.mkDerivation rec {
   name = "usb-blaster-udev-rules";
 
   udevRules = ./usb-blaster.rules;
   dontUnpack = true;
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   installPhase = ''
     install -Dm 644 "${udevRules}" "$out/lib/udev/rules.d/51-usbblaster.rules"

--- a/pkgs/by-name/us/usb-modeswitch/data.nix
+++ b/pkgs/by-name/us/usb-modeswitch/data.nix
@@ -4,6 +4,7 @@
   fetchurl,
   tcl,
   usb-modeswitch,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +15,8 @@ stdenv.mkDerivation rec {
     url = "http://www.draisberghof.de/usb_modeswitch/${pname}-${version}.tar.bz2";
     sha256 = "1ygahl3r26r38ai8yyblq9nhf3v5i6n6r6672p5wf88wg5h9n0rz";
   };
+
+  doInstallCheck = true;
 
   makeFlags = [
     "PREFIX=$(out)"
@@ -32,7 +35,10 @@ stdenv.mkDerivation rec {
 
   # we add tcl here so we can patch in support for new devices by dropping config into
   # the usb_modeswitch.d directory
-  nativeBuildInputs = [ tcl ];
+  nativeBuildInputs = [
+    tcl
+    udevCheckHook
+  ];
 
   meta = with lib; {
     description = "Device database and the rules file for 'multi-mode' USB devices";

--- a/pkgs/by-name/us/usbkvm/package.nix
+++ b/pkgs/by-name/us/usbkvm/package.nix
@@ -12,6 +12,7 @@
   python3,
   stdenv,
   udev,
+  udevCheckHook,
   wrapGAppsHook3,
 }:
 
@@ -53,6 +54,7 @@ stdenv.mkDerivation {
     makeWrapper
     wrapGAppsHook3
     udev
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -89,6 +91,8 @@ stdenv.mkDerivation {
       wrapProgram $out/bin/usbkvm \
         --prefix GST_PLUGIN_PATH : "${GST_PLUGIN_PATH}"
     '';
+
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://github.com/carrotIndustries/usbkvm";

--- a/pkgs/by-name/us/usbmuxd/package.nix
+++ b/pkgs/by-name/us/usbmuxd/package.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation rec {
     "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
   ];
 
+  doInstallCheck = true;
+
   meta = with lib; {
     homepage = "https://github.com/libimobiledevice/usbmuxd";
     description = "Socket daemon to multiplex connections from and to iOS devices";

--- a/pkgs/by-name/us/usbmuxd2/package.nix
+++ b/pkgs/by-name/us/usbmuxd2/package.nix
@@ -72,6 +72,8 @@ clangStdenv.mkDerivation rec {
     libusb1
   ];
 
+  doInstallCheck = true;
+
   configureFlags = [
     "--with-udevrulesdir=${placeholder "out"}/lib/udev/rules.d"
     "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"

--- a/pkgs/by-name/us/usbsdmux/package.nix
+++ b/pkgs/by-name/us/usbsdmux/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchPypi,
+  udevCheckHook,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -20,8 +21,11 @@ python3Packages.buildPythonApplication rec {
       --replace-fail 'TAG+="uaccess", GROUP="plugdev"' 'TAG+="uaccess"'
   '';
 
-  # usbsdmux is not meant to be used as an importable module and has no tests
-  doCheck = false;
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     install -Dm0444 -t $out/lib/udev/rules.d/ contrib/udev/99-usbsdmux.rules

--- a/pkgs/by-name/uu/uuu/package.nix
+++ b/pkgs/by-name/uu/uuu/package.nix
@@ -61,6 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
     cat <($out/bin/uuu -udev) > $out/lib/udev/rules.d/70-uuu.rules
   '';
 
+  doInstallCheck = true;
+
   meta = with lib; {
     description = "Freescale/NXP I.MX Chip image deploy tools";
     homepage = "https://github.com/nxp-imx/mfgtools";

--- a/pkgs/by-name/uv/uvcdynctrl/package.nix
+++ b/pkgs/by-name/uv/uvcdynctrl/package.nix
@@ -5,6 +5,7 @@
   cmake,
   pkg-config,
   libxml2,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation {
@@ -21,6 +22,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     pkg-config
+    udevCheckHook
   ];
   buildInputs = [ libxml2 ];
 
@@ -36,6 +38,8 @@ stdenv.mkDerivation {
         --replace "/lib/udev" "$out/lib/udev"
     done
   '';
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Simple interface for devices supported by the linux UVC driver";

--- a/pkgs/by-name/wa/waagent/package.nix
+++ b/pkgs/by-name/wa/waagent/package.nix
@@ -6,6 +6,7 @@
   bash,
   openssl,
   nixosTests,
+  udevCheckHook,
 }:
 
 let
@@ -26,7 +27,12 @@ python.pkgs.buildPythonApplication rec {
     # Read-only file system: '/etc/ssh/sshd_config'
     ./dont-configure-sshd.patch
   ];
-  doCheck = false;
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   # Replace tools used in udev rules with their full path and ensure they are present.
   postPatch = ''

--- a/pkgs/by-name/wc/wch-isp/package.nix
+++ b/pkgs/by-name/wc/wch-isp/package.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     "install-rules"
   ];
 
+  doInstallCheck = true;
+
   meta = {
     description = "Firmware programmer for WCH microcontrollers over USB";
     mainProgram = "wch-isp";

--- a/pkgs/by-name/wo/wooting-udev-rules/package.nix
+++ b/pkgs/by-name/wo/wooting-udev-rules/package.nix
@@ -1,4 +1,8 @@
-{ lib, stdenv }:
+{
+  lib,
+  stdenv,
+  udevCheckHook,
+}:
 
 stdenv.mkDerivation {
   pname = "wooting-udev-rules";
@@ -6,6 +10,12 @@ stdenv.mkDerivation {
 
   # Source: https://help.wooting.io/article/147-configuring-device-access-for-wootility-under-linux-udev-rules
   src = [ ./wooting.rules ];
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   dontUnpack = true;
 

--- a/pkgs/by-name/xe/xe-guest-utilities/package.nix
+++ b/pkgs/by-name/xe/xe-guest-utilities/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   runtimeShell,
+  udevCheckHook,
 }:
 
 buildGoModule rec {
@@ -15,6 +16,12 @@ buildGoModule rec {
     rev = "v${version}";
     hash = "sha256-LpZx+Km2qRywYK/eFLP3aCDku6K6HC4+MzEODH+8Gvs=";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   deleteVendor = true;
   vendorHash = "sha256-X/BI+ZhoqCGCmJfccyEBVgZc70aRTp3rL5j+rBWG5fE=";

--- a/pkgs/by-name/xf/xf86_input_wacom/package.nix
+++ b/pkgs/by-name/xf/xf86_input_wacom/package.nix
@@ -14,6 +14,7 @@
   pixman,
   pkg-config,
   udev,
+  udevCheckHook,
   utilmacros,
   xorgserver,
 }:
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -48,6 +50,8 @@ stdenv.mkDerivation rec {
     xorgproto
     xorgserver
   ];
+
+  doInstallCheck = true;
 
   configureFlags = [
     "--with-xorg-module-dir=${placeholder "out"}/lib/xorg/modules"

--- a/pkgs/by-name/xf/xfel/package.nix
+++ b/pkgs/by-name/xf/xfel/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     "PREFIX=/"
   ];
 
+  doInstallCheck = true;
+
   meta = {
     description = "Tooling for working with the FEL mode on Allwinner SoCs";
     homepage = "https://github.com/xboot/xfel";

--- a/pkgs/by-name/xp/xpra/package.nix
+++ b/pkgs/by-name/xp/xpra/package.nix
@@ -48,6 +48,7 @@
   clang,
   withHtml ? true,
   xpra-html5,
+  udevCheckHook,
 }@args:
 
 let
@@ -120,6 +121,7 @@ buildPythonApplication rec {
     pkg-config
     wrapGAppsHook3
     pandoc
+    udevCheckHook
   ] ++ lib.optional withNvenc cudatoolkit;
 
   buildInputs =
@@ -273,7 +275,7 @@ buildPythonApplication rec {
       ln -s ${xpra-html5}/share/xpra/www $out/share/xpra/www;
     '';
 
-  doCheck = false;
+  # doCheck = false;
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/xr/xr-hardware/package.nix
+++ b/pkgs/by-name/xr/xr-hardware/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchFromGitLab,
   nix-update-script,
+  udevCheckHook,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "xr-hardware";
@@ -15,6 +16,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     rev = "refs/tags/${finalAttrs.version}";
     hash = "sha256-w35/LoozCJz0ytHEHWsEdCaYYwyGU6sE13iMckVdOzY=";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/by-name/yu/yubikey-personalization/package.nix
+++ b/pkgs/by-name/yu/yubikey-personalization/package.nix
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  doInstallCheck = true;
+
   postInstall = ''
     # Don't use 70-yubikey.rules because it depends on ConsoleKit
     install -D -t $out/lib/udev/rules.d 69-yubikey.rules

--- a/pkgs/by-name/zs/zsa-udev-rules/package.nix
+++ b/pkgs/by-name/zs/zsa-udev-rules/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation {
@@ -14,6 +15,12 @@ stdenv.mkDerivation {
     rev = "a6648f6b543b703e3902faf5c08e997e0d58c909";
     hash = "sha256-j9n3VoX+UngX12DF28rtNh+oy80Th1BINPQqk053lvE=";
   };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   # Only copies udevs rules
   dontConfigure = true;

--- a/pkgs/desktops/deepin/go-package/dde-daemon/default.nix
+++ b/pkgs/desktops/deepin/go-package/dde-daemon/default.nix
@@ -31,6 +31,7 @@
   lshw,
   dmidecode,
   systemd,
+  udevCheckHook,
 }:
 
 buildGoModule rec {
@@ -93,6 +94,7 @@ buildGoModule rec {
     gettext
     python3
     wrapGAppsHook3
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -126,6 +128,8 @@ buildGoModule rec {
   '';
 
   doCheck = false;
+
+  doInstallCheck = true;
 
   preFixup = ''
     gappsWrapperArgs+=(

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -19,6 +19,7 @@
   libpulseaudio,
   wrapGAppsHook3,
   mateUpdateScript,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -34,6 +35,7 @@ stdenv.mkDerivation rec {
     gettext
     pkg-config
     wrapGAppsHook3
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -54,6 +56,8 @@ stdenv.mkDerivation rec {
   env.NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
 
   passthru.updateScript = mateUpdateScript { inherit pname; };
 

--- a/pkgs/desktops/plasma-5/plasma-remotecontrollers.nix
+++ b/pkgs/desktops/plasma-5/plasma-remotecontrollers.nix
@@ -11,6 +11,7 @@
   kpackage,
   kscreenlocker,
   kwindowsystem,
+  udevCheckHook,
   wayland,
   wayland-scanner,
   pkg-config,
@@ -25,6 +26,7 @@ mkDerivation {
   nativeBuildInputs = [
     extra-cmake-modules
     pkg-config
+    udevCheckHook
     wayland-scanner
   ];
   buildInputs = [
@@ -45,4 +47,5 @@ mkDerivation {
     plasma-workspace
     plasma-wayland-protocols
   ];
+  doInstallCheck = true;
 }

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -8,6 +8,7 @@
   spdx-license-list-data,
   replaceVars,
   writableTmpDirAsHomeHook,
+  udevCheckHook,
 }:
 
 with python3Packages;
@@ -57,6 +58,7 @@ buildPythonApplication rec {
   nativeBuildInputs = [
     installShellFiles
     setuptools
+    udevCheckHook
   ];
 
   pythonRelaxDeps = true;

--- a/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
@@ -4,16 +4,21 @@
   extra-cmake-modules,
   qtbase,
   qtdeclarative,
+  udevCheckHook,
 }:
 
 mkDerivation {
   pname = "bluez-qt";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [
+    extra-cmake-modules
+    udevCheckHook
+  ];
   buildInputs = [ qtdeclarative ];
   propagatedBuildInputs = [ qtbase ];
   preConfigure = ''
     substituteInPlace CMakeLists.txt \
       --replace /lib/udev/rules.d "$bin/lib/udev/rules.d"
   '';
+  doInstallCheck = true;
   meta.platforms = lib.platforms.linux;
 }

--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -16,6 +16,7 @@
   libimobiledevice,
   monoSupport ? false,
   mono,
+  udevCheckHook,
   gtk-sharp-2_0,
 }:
 
@@ -59,6 +60,7 @@ stdenv.mkDerivation rec {
       autoreconfHook
       intltool
       pkg-config
+      udevCheckHook
     ]
     ++ (with perlPackages; [
       perl
@@ -78,6 +80,8 @@ stdenv.mkDerivation rec {
     glib
     libimobiledevice
   ];
+
+  doInstallCheck = true;
 
   env = lib.optionalAttrs stdenv.cc.isGNU {
     NIX_CFLAGS_COMPILE = toString [

--- a/pkgs/development/libraries/libiio/default.nix
+++ b/pkgs/development/libraries/libiio/default.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional avahiSupport avahi
     ++ lib.optional stdenv.hostPlatform.isLinux libaio;
 
+  doInstallCheck = true;
+
   cmakeFlags =
     [
       "-DUDEV_RULES_INSTALL_DIR=${placeholder "out"}/lib/udev/rules.d"

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -24,6 +24,7 @@
   python3,
   nixosTests,
   wayland-scanner,
+  udevCheckHook,
 }:
 
 let
@@ -74,6 +75,7 @@ stdenv.mkDerivation rec {
       pkg-config
       meson
       ninja
+      udevCheckHook
     ]
     ++ lib.optionals documentationSupport [
       doxygen
@@ -121,6 +123,8 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = testsSupport && stdenv.hostPlatform == stdenv.buildPlatform;
+
+  doInstallCheck = true;
 
   postPatch = ''
     patchShebangs \

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -244,6 +244,7 @@ stdenv.mkDerivation (finalAttrs: {
   FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
 
   doCheck = true;
+  doInstallCheck = true;
 
   postUnpack = ''
     patchShebangs ${finalAttrs.src.name}/doc/*.py

--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -16,6 +16,7 @@
   gsl,
   fftw,
   gtest,
+  udevCheckHook,
   indi-full,
 }:
 
@@ -32,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -60,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
   checkInputs = [ gtest ];
 
   doCheck = true;
+  doInstallCheck = true;
 
   # Socket address collisions between tests
   enableParallelChecking = false;

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -37,6 +37,7 @@
   limesuite,
   pkg-config,
   zeromq,
+  udevCheckHook,
 }:
 
 let
@@ -86,6 +87,7 @@ let
           cmake
           ninja
           pkg-config
+          udevCheckHook
         ] ++ nativeBuildInputs;
 
         checkInputs = [ gtest ];
@@ -102,6 +104,8 @@ let
           done
           ${postInstall}
         '';
+
+        doInstallCheck = true;
 
         meta =
           with lib;

--- a/pkgs/development/python-modules/busylight-for-humans/default.nix
+++ b/pkgs/development/python-modules/busylight-for-humans/default.nix
@@ -12,6 +12,7 @@
   pythonOlder,
   typer,
   webcolors,
+  udevCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -42,6 +43,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-mock
+    udevCheckHook
   ];
 
   disabledTestPaths = [ "tests/test_pydantic_models.py" ];

--- a/pkgs/development/python-modules/liquidctl/default.nix
+++ b/pkgs/development/python-modules/liquidctl/default.nix
@@ -16,6 +16,7 @@
   colorlog,
   crcmod,
   pillow,
+  udevCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -37,6 +38,7 @@ buildPythonPackage rec {
     setuptools
     setuptools-scm
     wheel
+    udevCheckHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/openant/default.nix
+++ b/pkgs/development/python-modules/openant/default.nix
@@ -8,6 +8,7 @@
   influxdb-client,
   pyserial,
   pytestCheckHook,
+  udevCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -24,7 +25,10 @@ buildPythonPackage rec {
     hash = "sha256-wDtHlkVyD7mMDXZ4LGMgatr9sSlQKVbgkYsKvHGr9Pc=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  nativeBuildInputs = [
+    setuptools
+    udevCheckHook
+  ];
 
   postInstall = ''
     install -dm755 "$out/etc/udev/rules.d"

--- a/pkgs/development/python-modules/py3buddy/default.nix
+++ b/pkgs/development/python-modules/py3buddy/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   python,
   pyusb,
+  udevCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -19,6 +20,8 @@ buildPythonPackage rec {
   };
 
   dependencies = [ pyusb ];
+
+  nativeBuildInputs = [ udevCheckHook ];
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/development/python-modules/rfcat/default.nix
+++ b/pkgs/development/python-modules/rfcat/default.nix
@@ -10,6 +10,7 @@
   pyusb,
   pytestCheckHook,
   pythonOlder,
+  udevCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -32,6 +33,10 @@ buildPythonPackage rec {
     numpy
     pyserial
     pyusb
+  ];
+
+  nativeBuildInputs = [
+    udevCheckHook
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/pkgs/development/python-modules/seabreeze/default.nix
+++ b/pkgs/development/python-modules/seabreeze/default.nix
@@ -9,6 +9,7 @@
   pkgconfig,
   setuptools,
   setuptools-scm,
+  udevCheckHook,
 
   # dependneices
   numpy,
@@ -56,6 +57,7 @@ buildPythonPackage rec {
     pkgconfig
     setuptools
     setuptools-scm
+    udevCheckHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -65,10 +65,14 @@ stdenv.mkDerivation {
 
   doInstallCheck = true;
   installCheckPhase = ''
+    runHook preInstallCheck
+
     # assert that c++ bindings are included
     # note that this is only true for modern (>0.5) versions; the 0.3 series does not have these
     [[ -f $out/include/libsigrokcxx/libsigrokcxx.hpp ]] \
       || { echo 'C++ bindings were not generated; check configure output'; false; }
+
+    runHook postInstallCheck
   '';
 
   meta = with lib; {

--- a/pkgs/misc/drivers/utsushi/default.nix
+++ b/pkgs/misc/drivers/utsushi/default.nix
@@ -112,7 +112,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doInstallCheck = false;
+  doInstallCheck = true;
 
   postInstall = lib.optionalString withNetworkScan ''
     ln -s ${utsushi-networkscan}/libexec/utsushi/networkscan $out/libexec/utsushi

--- a/pkgs/os-specific/linux/drbd/utils.nix
+++ b/pkgs/os-specific/linux/drbd/utils.nix
@@ -14,6 +14,7 @@
   perlPackages,
   systemd,
   keyutils,
+  udevCheckHook,
 
   # drbd-utils are compiled twice, once with forOCF = true to extract
   # its OCF definitions for use in the ocf-resource-agents derivation,
@@ -38,6 +39,7 @@ stdenv.mkDerivation rec {
     docbook_xsl
     asciidoctor
     keyutils
+    udevCheckHook
   ];
 
   buildInputs = [
@@ -119,6 +121,8 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
 
   passthru.tests.drbd = nixosTests.drbd;
 

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -17,6 +17,7 @@
   which,
   withMixer ? false,
   qt5,
+  udevCheckHook,
 }:
 
 let
@@ -73,6 +74,7 @@ stdenv.mkDerivation rec {
       scons
       pkg-config
       which
+      udevCheckHook
     ]
     ++ lib.optionals withMixer [
       python
@@ -116,6 +118,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   dontWrapQtApps = true;
   strictDeps = true;
+  doInstallCheck = true;
 
   preFixup = lib.optionalString withMixer ''
     wrapQtApp "$bin/bin/ffado-mixer"

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -14,6 +14,7 @@
   pkg-config,
   autoreconfHook,
   runtimeShell,
+  udevCheckHook,
 }:
 
 let
@@ -60,6 +61,7 @@ stdenv.mkDerivation rec {
         meson
         ninja
         pkg-config
+        udevCheckHook
       ]
     else
       [
@@ -111,6 +113,7 @@ stdenv.mkDerivation rec {
 
   # v2: no tests, v3: all tests get skipped in a sandbox
   doCheck = false;
+  doInstallCheck = true;
 
   # Drop `/etc/fuse.conf` because it is a no-op config and
   # would conflict with our fuse module.

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -13,6 +13,7 @@
   enableDmeventd ? false,
   udevSupport ? !stdenv.hostPlatform.isStatic,
   udev,
+  udevCheckHook,
   onlyLib ? stdenv.hostPlatform.isStatic,
   # Otherwise we have a infinity recursion during static compilation
   enableUtilLinux ? !stdenv.hostPlatform.isStatic,
@@ -46,7 +47,7 @@ stdenv.mkDerivation rec {
     inherit hash;
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals udevSupport [ udevCheckHook ];
   buildInputs =
     [
       libaio
@@ -132,6 +133,7 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = false; # requires root
+  doInstallCheck = true;
 
   makeFlags =
     lib.optionals udevSupport [

--- a/pkgs/os-specific/linux/nxp-pn5xx/default.nix
+++ b/pkgs/os-specific/linux/nxp-pn5xx/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   kernel,
   kernelModuleMakeFlags,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -17,13 +18,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-jVkcvURFlihKW2vFvAaqzKdtexPXywRa2LkPkIhmdeU=";
   };
 
-  nativeBuildInputs = kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ udevCheckHook ] ++ kernel.moduleBuildDependencies;
 
   makeFlags = kernelModuleMakeFlags ++ [
     "KERNELRELEASE=${kernel.modDirVersion}"
     "BUILD_KERNEL_PATH=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)/lib/modules/${kernel.modDirVersion}"
   ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     mkdir -p $out/etc/udev/rules.d

--- a/pkgs/os-specific/linux/openrazer/driver.nix
+++ b/pkgs/os-specific/linux/openrazer/driver.nix
@@ -5,6 +5,7 @@
   kernelModuleMakeFlags,
   stdenv,
   lib,
+  udevCheckHook,
   util-linux,
 }:
 
@@ -19,11 +20,13 @@ stdenv.mkDerivation (
     pname = "openrazer";
     version = "${common.version}-${kernel.version}";
 
-    nativeBuildInputs = kernel.moduleBuildDependencies;
+    nativeBuildInputs = [ udevCheckHook ] ++ kernel.moduleBuildDependencies;
 
     makeFlags = kernelModuleMakeFlags ++ [
       "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     ];
+
+    doInstallCheck = true;
 
     installPhase = ''
       runHook preInstall

--- a/pkgs/os-specific/linux/projecteur/default.nix
+++ b/pkgs/os-specific/linux/projecteur/default.nix
@@ -7,6 +7,7 @@
   qtbase,
   qtgraphicaleffects,
   wrapQtAppsHook,
+  udevCheckHook,
 }:
 
 mkDerivation rec {
@@ -34,7 +35,10 @@ mkDerivation rec {
     cmake
     pkg-config
     wrapQtAppsHook
+    udevCheckHook
   ];
+
+  doInstallCheck = true;
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_PREFIX:PATH=${placeholder "out"}"

--- a/pkgs/os-specific/linux/rfkill/udev.nix
+++ b/pkgs/os-specific/linux/rfkill/udev.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   replaceVarsWith,
+  udevCheckHook,
 }:
 
 # Provides a facility to hook into rfkill changes.
@@ -37,6 +38,12 @@ let
 in
 stdenv.mkDerivation {
   name = "rfkill-udev";
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   dontUnpack = true;
   dontBuild = true;

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -35,6 +35,7 @@
   nilfs-utils,
   ntfs3g,
   nixosTests,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -93,6 +94,7 @@ stdenv.mkDerivation rec {
     docbook_xml_dtd_412
     docbook_xml_dtd_43
     docbook_xsl
+    udevCheckHook
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isMusl ''
@@ -136,6 +138,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   doCheck = true;
+  doInstallCheck = true;
 
   passthru = {
     inherit libblockdev;

--- a/pkgs/os-specific/linux/usbrelay/daemon.nix
+++ b/pkgs/os-specific/linux/usbrelay/daemon.nix
@@ -3,6 +3,7 @@
   usbrelay,
   python3,
   installShellFiles,
+  udevCheckHook,
 }:
 let
   python = python3.withPackages (
@@ -26,11 +27,16 @@ stdenv.mkDerivation {
       --replace '/usr/sbin/usbrelayd' "$out/bin/usbrelayd"
   '';
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    udevCheckHook
+  ];
 
   buildInputs = [ python ];
 
   dontBuild = true;
+
+  doInstallCheck = true;
 
   installPhase = ''
     runHook preInstall;

--- a/pkgs/os-specific/linux/v4l-utils/default.nix
+++ b/pkgs/os-specific/linux/v4l-utils/default.nix
@@ -7,6 +7,7 @@
   argp-standalone,
   libjpeg,
   udev,
+  udevCheckHook,
   withUtils ? true,
   withGUI ? true,
   alsa-lib,
@@ -54,6 +55,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     perl
+    udevCheckHook
   ] ++ lib.optional withQt wrapQtAppsHook;
 
   buildInputs =
@@ -73,6 +75,8 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "V4L utils and libv4l, provide common image formats regardless of the v4l device";

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -10,6 +10,7 @@ let
       coreutils,
       linuxPackages,
       perl,
+      udevCheckHook,
       configFile ? "all",
 
       # Userspace dependencies
@@ -145,7 +146,10 @@ let
           nukeReferences
         ]
         ++ optionals buildKernel (kernel.moduleBuildDependencies ++ [ perl ])
-        ++ optional buildUser pkg-config;
+        ++ optionals buildUser [
+          pkg-config
+          udevCheckHook
+        ];
       buildInputs =
         optionals buildUser [
           zlib
@@ -197,6 +201,8 @@ let
       makeFlags = optionals buildKernel kernelModuleMakeFlags;
 
       enableParallelBuilding = true;
+
+      doInstallCheck = true;
 
       installFlags = [
         "sysconfdir=\${out}/etc"

--- a/pkgs/servers/persistent-evdev/default.nix
+++ b/pkgs/servers/persistent-evdev/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   evdev,
   pyudev,
+  udevCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -23,6 +24,12 @@ buildPythonPackage rec {
     pyudev
   ];
 
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
+
   postPatch = ''
     patchShebangs bin/persistent-evdev.py
   '';
@@ -30,15 +37,16 @@ buildPythonPackage rec {
   dontBuild = true;
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     cp bin/persistent-evdev.py $out/bin
 
     mkdir -p $out/etc/udev/rules.d
     cp udev/60-persistent-input-uinput.rules $out/etc/udev/rules.d
-  '';
 
-  # has no tests
-  doCheck = false;
+    runHook postInstall
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/aiberia/persistent-evdev";

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -20,6 +20,7 @@
   sbc,
   bluez5,
   udev,
+  udevCheckHook,
   openssl,
   fftwFloat,
   soxr,
@@ -110,6 +111,7 @@ stdenv.mkDerivation rec {
       perlPackages.perl
       perlPackages.XMLParser
       m4
+      udevCheckHook
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ glib ]
     # gstreamer plugin discovery requires wrapping
@@ -228,6 +230,9 @@ stdenv.mkDerivation rec {
 
   # tests fail on Darwin because of timeouts
   doCheck = !stdenv.hostPlatform.isDarwin;
+
+  doInstallCheck = true;
+
   preCheck = ''
     export HOME=$(mktemp -d)
   '';

--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -19,6 +19,7 @@
   procps,
   gtksourceview4,
   bash,
+  udevCheckHook,
   nixosTests,
   # Change the default log level to debug for easier debugging of package issues
   withDebugLogLevel ? false,
@@ -65,6 +66,7 @@ in
     glib
     gobject-introspection
     pygobject3
+    udevCheckHook
   ] ++ maybeXmodmap;
 
   dependencies = [

--- a/pkgs/tools/misc/antimicrox/default.nix
+++ b/pkgs/tools/misc/antimicrox/default.nix
@@ -9,6 +9,7 @@
   xorg,
   fetchFromGitHub,
   itstool,
+  udevCheckHook,
 }:
 
 mkDerivation rec {
@@ -27,6 +28,7 @@ mkDerivation rec {
     extra-cmake-modules
     pkg-config
     itstool
+    udevCheckHook
   ];
   buildInputs = [
     SDL2
@@ -38,6 +40,8 @@ mkDerivation rec {
     substituteInPlace CMakeLists.txt \
         --replace "/usr/lib/udev/rules.d/" "$out/lib/udev/rules.d/"
   '';
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "GUI for mapping keyboard and mouse controls to a gamepad";

--- a/pkgs/tools/misc/ckb-next/default.nix
+++ b/pkgs/tools/misc/ckb-next/default.nix
@@ -18,6 +18,7 @@
   withPulseaudio ? stdenv.hostPlatform.isLinux,
   libpulseaudio,
   quazip,
+  udevCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -46,6 +47,7 @@ stdenv.mkDerivation rec {
     wrapQtAppsHook
     pkg-config
     cmake
+    udevCheckHook
   ];
 
   cmakeFlags = [
@@ -61,6 +63,8 @@ stdenv.mkDerivation rec {
       inherit kmod;
     })
   ];
+
+  doInstallCheck = true;
 
   postInstall = ''
     substituteInPlace "$out/lib/udev/rules.d/99-ckb-next-daemon.rules" \

--- a/pkgs/tools/misc/heimdall/default.nix
+++ b/pkgs/tools/misc/heimdall/default.nix
@@ -41,6 +41,8 @@ mkDerivation rec {
       substituteInPlace libpit/CMakeLists.txt --replace "-std=gnu++11" ""
     '';
 
+  doInstallCheck = true;
+
   installPhase =
     lib.optionalString (stdenv.hostPlatform.isDarwin && enableGUI) ''
       mkdir -p $out/Applications

--- a/pkgs/tools/misc/polar/default.nix
+++ b/pkgs/tools/misc/polar/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   ruby,
   bundlerEnv,
+  udevCheckHook,
 }:
 let
 
@@ -41,6 +42,12 @@ stdenv.mkDerivation rec {
     gems
     ruby
   ];
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  doInstallCheck = true;
 
   # See: https://wiki.nixos.org/wiki/Packaging/Ruby
   #

--- a/pkgs/tools/misc/qflipper/default.nix
+++ b/pkgs/tools/misc/qflipper/default.nix
@@ -95,6 +95,8 @@ mkDerivation {
     cp installer-assets/udev/42-flipperzero.rules $out/etc/udev/rules.d/
   '';
 
+  doInstallCheck = true;
+
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {

--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -119,6 +119,7 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
+  doInstallCheck = true;
 
   postInstall = ''
     buildPythonPath "$out $pythonPath"

--- a/pkgs/tools/misc/tlp/default.nix
+++ b/pkgs/tools/misc/tlp/default.nix
@@ -18,6 +18,7 @@
   shellcheck,
   smartmontools,
   systemd,
+  udevCheckHook,
   util-linux,
   x86_energy_perf_policy,
   # RDW only works with NetworkManager, and thus is optional with default off
@@ -46,7 +47,10 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ perl ];
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    udevCheckHook
+  ];
 
   # XXX: While [1] states that DESTDIR should not be used, and that the correct
   # variable to set is, in fact, PREFIX, tlp thinks otherwise. The Makefile for
@@ -80,6 +84,8 @@ stdenv.mkDerivation rec {
     shellcheck
   ];
   checkTarget = [ "checkall" ];
+
+  doInstallCheck = true;
 
   # TODO: Consider using resholve here
   postInstall =

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -52,6 +52,7 @@
   nixosTests,
   systemd,
   udev,
+  udevCheckHook,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
 
@@ -184,6 +185,7 @@ stdenv.mkDerivation (finalAttrs: {
       docbook_xml_dtd_42
       docbook_xml_dtd_43
       pythonForDocs
+      udevCheckHook
     ]
     ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
       mesonEmulatorHook
@@ -218,6 +220,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r ${buildPackages.networkmanager.devdoc} $devdoc
     cp -r ${buildPackages.networkmanager.man} $man
   '';
+
+  doInstallCheck = true;
 
   passthru = {
     updateScript = gitUpdater {

--- a/pkgs/tools/security/proxmark3/default.nix
+++ b/pkgs/tools/security/proxmark3/default.nix
@@ -12,6 +12,7 @@
   whereami,
   lua,
   lz4,
+  udevCheckHook,
   withGui ? true,
   wrapQtAppsHook,
   qtbase,
@@ -57,6 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     gcc-arm-embedded
+    udevCheckHook
   ] ++ lib.optional withGui wrapQtAppsHook;
   buildInputs =
     [
@@ -85,6 +87,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withSmall "PLATFORM_SIZE=256"
     ++ map (x: "SKIP_${x}=1") withoutFunctions;
   enableParallelBuilding = true;
+
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Client for proxmark3, powerful general purpose RFID tool";

--- a/pkgs/tools/system/cm-rgb/default.nix
+++ b/pkgs/tools/system/cm-rgb/default.nix
@@ -9,6 +9,8 @@
   hidapi,
   psutil,
   pygobject3,
+  udevCheckHook,
+  stdenv,
 }:
 
 buildPythonApplication rec {
@@ -28,6 +30,7 @@ buildPythonApplication rec {
     # Populate GI_TYPELIB_PATH
     gobject-introspection
     wrapGAppsHook3
+    udevCheckHook
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -7,6 +7,7 @@
   util-linux,
   setuptools,
   distro,
+  udevCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -24,6 +25,10 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     setuptools
     distro
+  ];
+
+  nativeBuildInputs = [
+    udevCheckHook
   ];
 
   postPatch = ''
@@ -53,7 +58,6 @@ buildPythonPackage rec {
     patchShebangs $out/bin/*
   '';
 
-  doCheck = false;
   pythonImportsCheck = [ "google_compute_engine" ];
 
   meta = with lib; {

--- a/pkgs/tools/virtualization/mkosi/default.nix
+++ b/pkgs/tools/virtualization/mkosi/default.nix
@@ -14,6 +14,7 @@
   btrfs-progs,
   libseccomp,
   replaceVars,
+  udevCheckHook,
 
   # Python packages
   setuptools,
@@ -110,6 +111,7 @@ buildPythonApplication rec {
     setuptools
     setuptools-scm
     wheel
+    udevCheckHook
   ];
 
   dependencies = deps;


### PR DESCRIPTION
treewide: add udevCheckHook to packages with udev rules output

- [x] `{ doInstallCheck = false; name = "acpilight-1.2"; }`
    - Configuration file /nix/store/sckm27vsrh58glp3acw07z8jdmpj72q7-acpilight-1.2/etc/udev/rules.d/90-backlight.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "airspy-1.0.10"; }`
    - propagated via libusb1
- [ ] `{ doInstallCheck = false; name = "alsa-utils-1.2.13"; }`
    - /nix/store/pj5lqap32lsaipnmr1pjp8zi6zmc1ng2-alsa-utils-1.2.13/lib/udev/rules.d/90-alsa-restore.rules:16 GOTO="alsa_restore_std" has no matching label, ignoring.
    - /nix/store/pj5lqap32lsaipnmr1pjp8zi6zmc1ng2-alsa-utils-1.2.13/lib/udev/rules.d/90-alsa-restore.rules:16 The line has no effect any more, dropping.
    - /nix/store/pj5lqap32lsaipnmr1pjp8zi6zmc1ng2-alsa-utils-1.2.13/lib/udev/rules.d/90-alsa-restore.rules:20 GOTO="alsa_restore_std" has no matching label, ignoring.
    - /nix/store/pj5lqap32lsaipnmr1pjp8zi6zmc1ng2-alsa-utils-1.2.13/lib/udev/rules.d/90-alsa-restore.rules:20 The line has no effect any more, dropping.
    - /nix/store/pj5lqap32lsaipnmr1pjp8zi6zmc1ng2-alsa-utils-1.2.13/lib/udev/rules.d/90-alsa-restore.rules: udev rules check failed.
- [x] `{ doInstallCheck = false; name = "amazon-ec2-net-utils-2.5.5"; }`
- [x] `{ doInstallCheck = true; name = "amazon-ec2-utils-2.2.0"; }`
    - has butchered pre/post phases, needs some proper cleaning up
- [x] `{ doInstallCheck = false; name = "android-udev-rules-20250314"; }`
    - Configuration file /nix/store/30028n5xqh5lr1lxvm1vsmgxrpyk65fj-android-udev-rules-20250314/lib/udev/rules.d/51-android.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "antimicrox-3.5.1"; }`
- [x] `{ doInstallCheck = false; name = "apio-udev-rules-0.9.5"; }`
    - Configuration file /nix/store/hh4k648cymsa3dq966f6ivf2l0i528vx-apio-udev-rules-0.9.5/lib/udev/rules.d/70-fpga-ftdi.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
    - Configuration file /nix/store/hh4k648cymsa3dq966f6ivf2l0i528vx-apio-udev-rules-0.9.5/lib/udev/rules.d/70-fpga-serial.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "argyllcms-3.3.0"; }`
- [ ] `{ doInstallCheck = false; name = "artisan-3.1.4"; }`
    - ???? No udev rules
- [x] `{ doInstallCheck = false; name = "asdbctl-1.0.0"; }`
- [x] `{ doInstallCheck = false; name = "asusctl-6.1.12"; }`
- [x] `{ doInstallCheck = true; name = "autorandr-1.15"; }`
- [ ] `{ doInstallCheck = false; name = "bazecor-1.7.0"; }`
    - wrapAppImage does not support postInstallCheck: https://github.com/NixOS/nixpkgs/blob/a094b5d8cce756083b19c6931d2ba52a1b1e45f1/pkgs/build-support/appimage/default.nix#L60-L79
- [x] `{ doInstallCheck = false; name = "bcachefs-tools-1.25.2"; }`
- [x] `{ doInstallCheck = false; name = "bcache-tools-1.0.8"; }`
- [x] `{ doInstallCheck = false; name = "bitbox-bridge-1.6.1"; }`
- [x] `{ doInstallCheck = false; name = "bitbox-4.46.3"; }`
    - Configuration file /nix/store/jxcdrn03zwv4npdif9r0zhz68f06w911-bitbox-4.46.3/lib/udev/rules.d/51-hid-digitalbitbox.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
    - Configuration file /nix/store/jxcdrn03zwv4npdif9r0zhz68f06w911-bitbox-4.46.3/lib/udev/rules.d/52-hid-digitalbitbox.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
    - Configuration file /nix/store/jxcdrn03zwv4npdif9r0zhz68f06w911-bitbox-4.46.3/lib/udev/rules.d/53-hid-bitbox02.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
    - Configuration file /nix/store/jxcdrn03zwv4npdif9r0zhz68f06w911-bitbox-4.46.3/lib/udev/rules.d/54-hid-bitbox02.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "bluez-5.80"; }`
- [x] `{ doInstallCheck = false; name = "bluez-5.80"; }`
    - ***staged***
- [x] `{ doInstallCheck = true; name = "bmputil-0.1.3"; }`
- [x] `{ doInstallCheck = false; name = "bolt-0.9.8"; }`
- [ ] `{ doInstallCheck = false; name = "bottles"; }`
    - ??? no udev
- [x] `{ doInstallCheck = true; name = "python3.12-boxflat-1.30.1"; }`
- [x] `{ doInstallCheck = false; name = "brightnessctl-0.5.1"; }`
- [x] `{ doInstallCheck = false; name = "brillo-1.4.13"; }`
- [x] `{ doInstallCheck = false; name = "brltty-6.7"; }`
- [x] `{ doInstallCheck = false; name = "btrfs-progs-6.14"; }`
- [x] `{ doInstallCheck = false; name = "casync-2-unstable-2023-10-16"; }`
- [x] `{ doInstallCheck = false; name = "ccid-1.6.2"; }`
    - propagated via libusb1
    - `meta.platforms` is `unix`, but installs udev rules unconditionally. This seems silly.
    - has butchered pre/post phases
- [x] `{ doInstallCheck = false; name = "cc-tool-unstable-2020-05-19"; }`
    - Configuration file /nix/store/0nv753w4k0vpv7k032gdj3mfadlxvy81-cc-tool-unstable-2020-05-19/lib/udev/rules.d/90-cc-debugger.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [ ] `{ doInstallCheck = false; name = "chrysalis-0.13.3"; }`
    - wrapAppImage does not support postInstallCheck
- [x] `{ doInstallCheck = false; name = "ckb-next-0.6.2"; }`
- [x] `{ doInstallCheck = true; name = "cm-rgb-0.3.6"; }`
- [x] `{ doInstallCheck = false; name = "colord-1.4.6"; }`
- [x] `{ doInstallCheck = false; name = "comedilib-0.12.0"; }`
- [x] `{ doInstallCheck = false; name = "cpu-energy-meter-1.2"; }`
- [ ] `{ doInstallCheck = false; name = "cura-appimage-5.10.0"; }`
    - ??? no udev rules
- [x] `{ doInstallCheck = false; name = "cutecapture-1.4.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "dataexplorer-3.9.3"; }`
- [x] `{ doInstallCheck = false; name = "ddcutil-2.2.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "dduper-0.04"; }`
- [x] `{ doInstallCheck = false; name = "dediprog-sf100-linux-1.14.21-x"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "dde-daemon-6.0.43"; }`
- [x] `{ doInstallCheck = false; name = "digitalbitbox-3.0.0"; }`
    - /nix/store/m78h8jh8sqxqycw4y4h4pmhj8q7blmjf-digitalbitbox-3.0.0/etc/udev/rules.d/51-hid-digitalbox.rules:1 style: stray leading comma.
    - /nix/store/m78h8jh8sqxqycw4y4h4pmhj8q7blmjf-digitalbitbox-3.0.0/etc/udev/rules.d/51-hid-digitalbox.rules:2 style: stray leading comma.
    - /nix/store/m78h8jh8sqxqycw4y4h4pmhj8q7blmjf-digitalbitbox-3.0.0/etc/udev/rules.d/51-hid-digitalbox.rules:2 The line has no effect, ignoring.
    - /nix/store/m78h8jh8sqxqycw4y4h4pmhj8q7blmjf-digitalbitbox-3.0.0/etc/udev/rules.d/51-hid-digitalbox.rules: udev rules check failed.
    - /nix/store/m78h8jh8sqxqycw4y4h4pmhj8q7blmjf-digitalbitbox-3.0.0/etc/udev/rules.d/52-hid-digitalbox.rules:1 style: stray leading comma.
    - /nix/store/m78h8jh8sqxqycw4y4h4pmhj8q7blmjf-digitalbitbox-3.0.0/etc/udev/rules.d/52-hid-digitalbox.rules:2 style: stray leading comma.
    - /nix/store/m78h8jh8sqxqycw4y4h4pmhj8q7blmjf-digitalbitbox-3.0.0/etc/udev/rules.d/52-hid-digitalbox.rules:2 The line has no effect, ignoring.
    - /nix/store/m78h8jh8sqxqycw4y4h4pmhj8q7blmjf-digitalbitbox-3.0.0/etc/udev/rules.d/52-hid-digitalbox.rules: udev rules check failed.
    - fixed
- [x] `{ doInstallCheck = false; name = "direwolf-1.7"; }`
- [x] `{ doInstallCheck = false; name = "dmrconfig-1.1"; }`
    - propagated via libusb1
    - Configuration file /nix/store/bymjc5sh1jpk7lk7j1whwd63wl3sagic-dmrconfig-1.1/lib/udev/rules.d/99-dmr.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "dolphin-emu-2503a"; }`
    - Configuration file /nix/store/z22spasql9rrkgn4lrxpsv6zhm1jhg10-dolphin-emu-2503a/etc/udev/rules.d/51-usb-device.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "dolphin-emu-primehack-1.0.7a"; }`
    - Configuration file /nix/store/2kjvxh1m2b7aiw240sj76gd7fp8kd96i-dolphin-emu-primehack-1.0.7a/etc/udev/rules.d/51-usb-device.rules is marked executable. Please remove executable permission bits. Proceeding anyway
- [x] `{ doInstallCheck = false; name = "drbd-9.27.0"; }`
- [x] `{ doInstallCheck = false; name = "dsview-1.3.2"; }`
- [x] `{ doInstallCheck = false; name = "easypdkprog-1.3"; }`
- [x] `{ doInstallCheck = false; name = "ecpdap-0.2.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "edgetx-2.11.0-rc3"; }`
- [x] `{ doInstallCheck = false; name = "eg25-manager-0.5.2"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "elogind-255.5"; }`
    - can be built without systemd
- [x] `{ doInstallCheck = false; name = "em100-0-unstable-2024-11-14"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "epsonscan2-6.7.70.0-01-2025"; }`
    - propagated via libusb1
- [ ] `{ doInstallCheck = false; name = "eudev-3.2.14"; }`
    - not viable, skipped
- [x] `{ doInstallCheck = false; name = "feedbackd-0.8.1"; }`
- [x] `{ doInstallCheck = false; name = "ffado-2.4.9"; }`
- [x] `{ doInstallCheck = false; name = "ffado-2.4.9"; }`
- [x] `{ doInstallCheck = false; name = "flashprog-1.4"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "flashrom-1.5.1"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "foo2zjs-20210116"; }`
- [x] `{ doInstallCheck = false; name = "footswitch-unstable-2023-10-10"; }`
- [x] `{ doInstallCheck = false; name = "fuse-3.16.2"; }`
    - ***staged***
- [x] `{ doInstallCheck = false; name = "g810-led-0.4.3"; }`
    - Configuration file /nix/store/klh2fxrrkcj9zy6r2pd4x3csldinnnj9-g810-led-0.4.3/etc/udev/rules.d/90-g810-led.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "game-devices-udev-rules-0.23"; }`
- [x] `{ doInstallCheck = false; name = "gdm-48.0"; }`
- [x] `{ doInstallCheck = false; name = "gfs2-utils-3.6.1"; }`
- [x] `{ doInstallCheck = true; name = "glasgow-0-unstable-2025-01-26"; }`
- [x] `{ doInstallCheck = false; name = "gmobile"; }`
- [x] `{ doInstallCheck = false; name = "gnome-settings-daemon-46.0"; }`
- [x] `{ doInstallCheck = false; name = "gnome-settings-daemon-48.1"; }`
- [x] `{ doInstallCheck = false; name = "gobi_loader-0.7"; }`
    - Configuration file /nix/store/nr89b2svcjgsxl5jla8w77y33dcm5nwj-gobi_loader-0.7/lib/udev/rules.d/60-gobi.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "google-compute-engine-20190124"; }`
    - needed `doCheck = true`, but nothing exploded
- [x] `{ doInstallCheck = false; name = "google-guest-configs-20211116.00"; }`
- [x] `{ doInstallCheck = false; name = "goxlr-utility-1.2.2"; }`
- [x] `{ doInstallCheck = false; name = "gpsd-3.25"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "gradm-3.1-202111052217"; }`
- [x] `{ doInstallCheck = false; name = "gummy-0.6.1"; }`
- [x] `{ doInstallCheck = false; name = "hackrf-2024.02.1"; }`
    - propagated via libusb1
- [ ] `{ doInstallCheck = false; name = "handheld-daemon-3.15.3"; }`
    - wrapAppImage does not support postInstallCheck
- [x] `{ doInstallCheck = false; name = "hdapsd-20141203"; }`
- [x] `{ doInstallCheck = false; name = "headsetcontrol-3.0.0"; }`
- [x] `{ doInstallCheck = false; name = "heimdall-gui-1.4.2"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "heimdall-1.4.2"; }`
    - propagated via libusb1
- [ ] `{ doInstallCheck = false; name = "heroic-2.16.1"; }`
    - ??? no udev
- [x] `{ doInstallCheck = true; name = "hplip-3.24.4"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = true; name = "huion-switcher-0.5.0"; }`
- [x] `{ doInstallCheck = false; name = "iio-sensor-proxy-3.7"; }`
- [x] `{ doInstallCheck = false; name = "imsprog-1.5.3"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "incus-6.12.0"; }`
- [x] `{ doInstallCheck = false; name = "incus-lts-6.0.4"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-aagcloudwatcher-ng-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-aok-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-apogee-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-armadillo-platypus-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-astarbox-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-avalon-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-avalonud-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-beefocus-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-bresserexos2-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-celestronaux-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-dsi-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-duino-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-eqmod-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-ffmv-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-fishcamp-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-fli-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-gige-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-gphoto-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-gpio-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-gpsd-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-gpsnmea-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-limesdr-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-maxdomeii-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-mgen-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-nexdome-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-nightscape-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-nut-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-ocs-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-orion-ssg3-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-rolloffino-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-rtklib-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-shelyak-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-starbook-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-starbook-ten-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-sx-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-talon6-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-webcam-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-3rdparty-indi-weewx-json-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indi-full-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "indilib-2.1.3"; }`
- [x] `{ doInstallCheck = false; name = "infnoise-0.3.3"; }`
- [x] `{ doInstallCheck = true; name = "inkscape-silhouette-1.29"; }`
- [x] `{ doInstallCheck = false; name = "inputmodule-control-0.2.0"; }`
- [x] `{ doInstallCheck = false; name = "input-remapper-2.1.1"; }`
    - doCheck defaults to false
- [x] `{ doInstallCheck = false; name = "ipad_charge-2015-02-03"; }`
- [x] `{ doInstallCheck = false; name = "ipp-usb-0.9.30"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "iptsd-3"; }`
- [x] `{ doInstallCheck = false; name = "joycond-unstable-2021-07-30"; }`
- [x] `{ doInstallCheck = false; name = "k40-whisperer-0.68"; }`
    - has butchered pre/post phases
- [x] `{ doInstallCheck = false; name = "ledger-udev-rules-0-unstable-2024-02-12"; }`
- [x] `{ doInstallCheck = false; name = "libbladeRF-2.5.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "libedgetpu-0-unstable-2024-03-14"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "libfido2-1.15.0"; }`
- [x] `{ doInstallCheck = true; name = "libfprint-1.94.9"; }`
- [x] `{ doInstallCheck = true; name = "libfprint-tod-1.94.9+tod1"; }`
- [ ] `{ doInstallCheck = false; name = "libftdi-1.5-unstable-2023-12-21"; }`
    - propagated via libusb1
    - seems to ignore phase???
- [x] `{ doInstallCheck = false; name = "libgphoto2-2.5.31"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "libgpod-0.8.3"; }`
- [x] `{ doInstallCheck = false; name = "libiio-0.24"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "libinput-1.27.1"; }`
- [ ] `{ doInstallCheck = false; name = "libirecovery-1.2.1"; }`
    - propagated via libusb1
    - /nix/store/srmj1r8hp8ipwc0s5gz8wdv8gpcy8f25-libirecovery-1.2.1/lib/udev/rules.d/39-libirecovery.rules:4 Invalid key/value pair, ignoring.
    - /nix/store/srmj1r8hp8ipwc0s5gz8wdv8gpcy8f25-libirecovery-1.2.1/lib/udev/rules.d/39-libirecovery.rules:7 Invalid key/value pair, ignoring.
    - /nix/store/srmj1r8hp8ipwc0s5gz8wdv8gpcy8f25-libirecovery-1.2.1/lib/udev/rules.d/39-libirecovery.rules: udev rules check failed.
- [x] `{ doInstallCheck = false; name = "libjaylink-0.4.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "libmtp-1.1.22"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "libnitrokey-3.8"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "libpsm2-12.0.1"; }`
- [x] `{ doInstallCheck = false; name = "bluez-qt-5.116.0"; }`
- [x] `{ doInstallCheck = false; name = "plasma-remotecontrollers-5.27.11"; }`
- [x] `{ doInstallCheck = true; name = "libsigrok-0.5.2-unstable-2024-10-20"; }`
    - propagated via libusb1
    - has butchered pre/post phases
- [x] `{ doInstallCheck = false; name = "libticables2-1.3.5"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "libuldaq-1.2.1"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "libwacom-2.15.0"; }`
- [x] `{ doInstallCheck = false; name = "libwacom-surface-2.15.0"; }`
- [x] `{ doInstallCheck = false; name = "libwebcam-0.2.5"; }`
- [x] `{ doInstallCheck = false; name = "light-1.2.2"; }`
- [x] `{ doInstallCheck = false; name = "limesuite-23.11.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "limesuite-23.11.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "linuxconsoletools-1.8.1"; }`
- [x] `{ doInstallCheck = false; name = "linux-gpib-user-4.3.6"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-5.10.235"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-5.10.235"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-5.15.179"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-5.15.179"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-5.15.183"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-5.15.183"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-5.4.293"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-5.4.293"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.12.29"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.12.29"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.13.7"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.13.7"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.13.12"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.13.12"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.14.7"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.14.7"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.1.131"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.1.131"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.1.139"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.1.139"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.6.83"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.6.83"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.6.91"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.6.91"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.13.12"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.13.12"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.12.19"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.12.19"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.12.29"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.12.29"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.14.7"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.14.7"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.12.28"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.12.28"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.14.6"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.14.6"; }`
- [x] `{ doInstallCheck = false; name = "nxp-pn5xx-0.4-unstable-2025-02-08-6.14.7"; }`
- [x] `{ doInstallCheck = false; name = "openrazer-3.10.1-6.14.7"; }`
- [x] `{ doInstallCheck = true; name = "liquidctl-1.15.0"; }`
- [x] `{ doInstallCheck = false; name = "lm4flash-0.1.3"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "ltunify-0.3"; }`
- [ ] `{ doInstallCheck = false; name = "luminance-1.1.0"; }`
    - hackage, skipped
- [ ] `{ doInstallCheck = false; name = "lutris-0.5.19"; }`
    - fhsenv, skipped
- [x] `{ doInstallCheck = false; name = "lvm2-with-dmeventd-2.03.31"; }`
    - has butchered pre/post phases
    - ***staged locally***
- [x] `{ doInstallCheck = false; name = "lvm2-2.03.31"; }`
    - has butchered pre/post phases
    - ***staged locally***
- [x] `{ doInstallCheck = false; name = "lvm2-with-dmeventd-with-vdo-2.03.31"; }`
    - has butchered pre/post phases
    - ***staged locally***
- [x] `{ doInstallCheck = false; name = "M33-Linux-unstable-2016-06-23"; }`
    - has butchered pre/post phases
    - Configuration file /nix/store/m4mixbgrz9b0l6qy9q4nsmqdq772jfyq-M33-Linux-unstable-2016-06-23/lib/udev/rules.d/90-micro-3d-local.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "mate-settings-daemon-1.28.0"; }`
- [x] `{ doInstallCheck = false; name = "mdadm-4.3"; }`
- [x] `{ doInstallCheck = false; name = "mdevctl-1.4.0"; }`
- [x] `{ doInstallCheck = false; name = "media-player-info-26"; }`
- [x] `{ doInstallCheck = false; name = "meletrix-udev-rules-0-unstable-2023-10-20"; }`
- [x] `{ doInstallCheck = false; name = "minipro-0.7.2"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = true; name = "mkosi-25.3-unstable-2025-04-01"; }`
    - uses udev rules, but does not output them
- [x] `{ doInstallCheck = true; name = "modemmanager-1.22.0"; }`
- [x] `{ doInstallCheck = false; name = "moolticute-1.03.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "mouse-actions-gui-0.4.5"; }`
- [x] `{ doInstallCheck = false; name = "mouse-actions-0.4.5"; }`
- [x] `{ doInstallCheck = false; name = "mouse_m908-3.4"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "multipath-tools-0.9.8"; }`
- [x] `{ doInstallCheck = false; name = "mutter-46.8"; }`
- [x] `{ doInstallCheck = false; name = "mutter-48.2"; }`
- [x] `{ doInstallCheck = false; name = "networkmanager-1.52.0"; }`
- [x] `{ doInstallCheck = false; name = "nfs-utils-2.7.1"; }`
- [x] `{ doInstallCheck = false; name = "nitrokey-udev-rules-1.1.0"; }`
    - Configuration file /nix/store/dni4l2ikb7qrj6j78arkj09h4f6i3qx1-nitrokey-udev-rules-1.1.0/etc/udev/rules.d/41-nitrokey.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [ ] `{ doInstallCheck = false; name = "ns-usbloader-7.1"; }`
- [x] `{ doInstallCheck = false; name = "numworks-udev-rules-unstable-2020-08-31"; }`
- [x] `{ doInstallCheck = false; name = "nut-2.8.2"; }`
- [x] `{ doInstallCheck = false; name = "nvme-cli-2.11"; }`
- [x] `{ doInstallCheck = false; name = "nxpmicro-mfgtools-1.5.139"; }`
    - propagated via libusb1
    - Configuration file /nix/store/rara91k0ck7658px2296inp4v7av8hhj-nxpmicro-mfgtools-1.5.139/lib/udev/rules.d/70-uuu.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [ ] `{ doInstallCheck = false; name = "ocf-resource-agents"; }`
    - runCommand, no install check
- [x] `{ doInstallCheck = true; name = "openambit-0.5"; }`
    - propagated via libusb1
    - has butchered pre/post phases
- [x] `{ doInstallCheck = false; name = "opencbm-0.4.99.104"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "openhantek6022-3.4.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "open-iscsi-2.1.11"; }`
- [x] `{ doInstallCheck = false; name = "openobex-1.7.2"; }`
- [x] `{ doInstallCheck = false; name = "openocd-0.12.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "openocd-rp2040-0.12.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = true; name = "openrgb-0.9"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = true; name = "openrgb-0.9"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = true; name = "openswitcher-0.11.0"; }`
- [x] `{ doInstallCheck = true; name = "OpenTabletDriver-0.6.5.1"; }`
- [x] `{ doInstallCheck = false; name = "openterface-qt-0.3.12"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "opentx-2.3.15"; }`
- [x] `{ doInstallCheck = false; name = "open-vm-tools-12.5.0"; }`
- [x] `{ doInstallCheck = false; name = "open-vm-tools-12.5.0"; }`
- [x] `{ doInstallCheck = false; name = "orbuculum-2.1.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "oversteer-0.8.3"; }`
- [x] `{ doInstallCheck = false; name = "pcmciautils-018"; }`
- [x] `{ doInstallCheck = false; name = "python3.12-persistent-evdev-unstable-2022-05-07"; }`
- [x] `{ doInstallCheck = false; name = "phodav-3.0"; }`
- [x] `{ doInstallCheck = false; name = "picoprobe-udev-rules-unstable-2023-01-31"; }`
    - Configuration file /nix/store/7yf9s8l8zjs49ccxyqq5bn6m6i1nsr1f-picoprobe-udev-rules-unstable-2023-01-31/lib/udev/rules.d/69-probe-rs.rules is marked executable. Please remove executable permission bits. Proceeding anyway
- [x] `{ doInstallCheck = true; name = "picotool-2.1.1"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "pipewire-1.4.2"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = true; name = "platformio-6.1.18"; }`
- [x] `{ doInstallCheck = false; name = "polar-unstable-2021-01-12"; }`
- [x] `{ doInstallCheck = false; name = "projecteur-0.10"; }`
- [x] `{ doInstallCheck = false; name = "proxmark3-4.20142"; }`
- [x] `{ doInstallCheck = false; name = "prusa-slicer-2.9.0"; }`
- [x] `{ doInstallCheck = false; name = "pulseaudio-17.0"; }`
- [x] `{ doInstallCheck = false; name = "pulseaudio-17.0"; }`
- [x] `{ doInstallCheck = true; name = "python3.12-busylight-for-humans-0.33.3"; }`
- [x] `{ doInstallCheck = true; name = "python3.12-openant-unstable-1.3.1"; }`
- [x] `{ doInstallCheck = true; name = "python3.12-py3buddy-1.0"; }`
    - Configuration file /nix/store/242snzks6b64a0jwwdk1xcwz16z8inmq-python3.12-py3buddy-1.0/lib/udev/rules.d/99-ibuddy.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = true; name = "python3.12-rfcat-2.0.1"; }`
- [x] `{ doInstallCheck = true; name = "python3.12-seabreeze-2.10.1"; }`
- [x] `{ doInstallCheck = true; name = "python3.12-sigrok-0.5.2-unstable-2024-10-20"; }`
- [ ] `{ doInstallCheck = false; name = "soapysdr-0.8.1-unstable-2025-03-30-03"; }`
    - ??? no udev rules
- [x] `{ doInstallCheck = true; name = "python3.13-busylight-for-humans-0.33.3"; }`
- [x] `{ doInstallCheck = false; name = "python3.13-google-compute-engine-20190124"; }`
- [x] `{ doInstallCheck = false; name = "libiio-0.24"; }`
- [x] `{ doInstallCheck = true; name = "python3.13-liquidctl-1.15.0"; }`
- [x] `{ doInstallCheck = true; name = "python3.13-openant-unstable-1.3.1"; }`
- [x] `{ doInstallCheck = true; name = "python3.13-py3buddy-1.0"; }`
- [x] `{ doInstallCheck = true; name = "python3.13-seabreeze-2.10.1"; }`
- [x] `{ doInstallCheck = true; name = "python3.13-sigrok-0.5.2-unstable-2024-10-20"; }`
- [ ] `{ doInstallCheck = false; name = "soapysdr-0.8.1-unstable-2025-03-30-03"; }`
    - ??? no udev rules
- [x] `{ doInstallCheck = false; name = "qdmr-0.12.1"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "qFlipper-1.3.3"; }`
- [x] `{ doInstallCheck = false; name = "qlcplus-4.13.1"; }`
- [x] `{ doInstallCheck = false; name = "qmk-udev-rules-0.27.13"; }`
    - Configuration file /nix/store/kzj3frkxnk0nggywz29mmdb8bv4yfgg7-qmk-udev-rules-0.27.13/lib/udev/rules.d/50-qmk.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "quark-goldleaf-1.0.0"; }`
- [x] `{ doInstallCheck = false; name = "rdma-core-57.0"; }`
- [x] `{ doInstallCheck = false; name = "rfkill-udev"; }`
- [ ] `{ doInstallCheck = false; name = "python3.12-rivalcfg-4.14.0"; }`
    - skipped, broken tests
- [x] `{ doInstallCheck = false; name = "rkdeveloptool-unstable-2021-09-04"; }`
    - propagated via libusb1
- [ ] `{ doInstallCheck = false; name = "roccat-tools-5.9.0"; }`
    - /nix/store/bh790j6va11b5zagkhy4429j2dvng3jq-roccat-tools-5.9.0/lib/udev/rules.d/90-roccat-kone.rules:17 Invalid value "/nix/store/xy4jjgw87sbgwylm5kn047d9gkbhsr9x-bash-5.2p37/bin/bash -c 'ROCCAT_PATH=$(roccatkonecontrol -p); if test $? -eq 0; then chgrp roccat $ROCCAT_PATH/*; fi'" for RUN (char 82: invalid substitution type), ignoring.
    - /nix/store/bh790j6va11b5zagkhy4429j2dvng3jq-roccat-tools-5.9.0/lib/udev/rules.d/90-roccat-kone.rules:18 Invalid value "/nix/store/xy4jjgw87sbgwylm5kn047d9gkbhsr9x-bash-5.2p37/bin/bash -c 'ROCCAT_PATH=$(roccatkonecontrol -p); if test $? -eq 0; then chgrp roccat $ROCCAT_PATH/*; fi'" for RUN (char 82: invalid substitution type), ignoring.
    - /nix/store/bh790j6va11b5zagkhy4429j2dvng3jq-roccat-tools-5.9.0/lib/udev/rules.d/90-roccat-kone.rules: udev rules check failed.
- [ ] `{ doInstallCheck = false; name = "rpcs3-0.0.36-17736-c86a25079"; }`
    - propagated via libusb1
    - Configuration file /nix/store/wvspxipk6bzc042cfh5mjcw7j038hsjk-rpcs3-0.0.36-17736-c86a25079/etc/udev/rules.d/99-ds3-controllers.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
    - Configuration file /nix/store/wvspxipk6bzc042cfh5mjcw7j038hsjk-rpcs3-0.0.36-17736-c86a25079/etc/udev/rules.d/99-ds4-controllers.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
    - Configuration file /nix/store/wvspxipk6bzc042cfh5mjcw7j038hsjk-rpcs3-0.0.36-17736-c86a25079/etc/udev/rules.d/99-dualsense-controllers.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "rtl_fm_streamer-unstable-2021-06-08"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "rtl-sdr-librtlsdr-0.9.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "rtl-sdr-osmocom-2.0.1"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "rtl-sdr-blog-1.3.5"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = true; name = "rust-streamdeck-0.9.0"; }`
- [x] `{ doInstallCheck = false; name = "rwedid-0.3.2"; }`
- [x] `{ doInstallCheck = false; name = "sane-backends-1.3.1"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = true; name = "sc-controller-0.5.2"; }`
    - NOT propagated via libusb1: not in buildInputs
- [x] `{ doInstallCheck = false; name = "snagboot-2.2"; }`
- [ ] `{ doInstallCheck = false; name = "soapysdr-0.8.1-unstable-2025-03-30-03"; }`
    - ??? no udev rules
- [x] `{ doInstallCheck = true; name = "solaar-1.1.14"; }`
- [x] `{ doInstallCheck = true; name = "solaar-1.1.14"; }`
- [x] `{ doInstallCheck = false; name = "solo2-cli-0.2.2"; }`
    - Configuration file /nix/store/djjqw8ii7fbszmay3hzq139mg78r2gqi-solo2-cli-0.2.2/lib/udev/rules.d/70-solo2.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [ ] `{ doInstallCheck = false; name = "sparrow-desktop-2.0.0"; }`
    - untested (BIIG build, valkey in the closure was annoyingly flaky)
- [ ] `{ doInstallCheck = false; name = "sparrow-unwrapped-2.0.0"; }`
    - untested (BIIG build, valkey in the closure was annoyingly flaky)
- [x] `{ doInstallCheck = false; name = "speakersafetyd-1.0.2"; }`
- [x] `{ doInstallCheck = false; name = "steam-devices-udev-rules-1.0.0.61-unstable-2024-05-22"; }`
- [ ] `{ doInstallCheck = false; name = "steam"; }`
    - skipped: wrapper, no installCheck
- [ ] `{ doInstallCheck = false; name = "steam-run"; }`
    - skipped: fhs environment
- [x] `{ doInstallCheck = false; name = "stlink-1.8.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "stlink-1.8.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "stratisd-3.7.3"; }`
- [x] `{ doInstallCheck = false; name = "stratisd-3.7.3"; }`
- [x] `{ doInstallCheck = false; name = "streamcontroller-1.5.0-beta.8"; }`
- [ ] `{ doInstallCheck = true; name = "streamdeck-ui-4.1.3"; }`
    - had butchered post phase
    - seems to ignore hook
- [x] `{ doInstallCheck = false; name = "sunshine-2025.122.141614"; }`
- [x] `{ doInstallCheck = false; name = "supergfxctl-5.2.7"; }`
- [x] `{ doInstallCheck = false; name = "super-slicer-2.5.60.0"; }`
- [x] `{ doInstallCheck = false; name = "super-slicer-2.5.59.13"; }`
- [x] `{ doInstallCheck = false; name = "swayosd-0.2.0"; }`
- [x] `{ doInstallCheck = false; name = "system-config-printer-1.5.18"; }`
- [ ] `{ doInstallCheck = false; name = "systemd-minimal-257.5"; }`
    - skipped: inf rec
- [ ] `{ doInstallCheck = false; name = "systemd-257.5"; }`
    - skipped: inf rec
- [ ] `{ doInstallCheck = false; name = "systemd-257.5"; }`
    - skipped: inf rec
- [x] `{ doInstallCheck = false; name = "thunderbolt-0.9.3"; }`
- [x] `{ doInstallCheck = false; name = "tiny-dfr-0.3.2"; }`
- [x] `{ doInstallCheck = false; name = "tiscamera-1.1.1"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "tlp-1.8.0"; }`
- [x] `{ doInstallCheck = false; name = "trezor-udev-rules-unstable-2019-07-17"; }`
    - has butchered pre/post phases
- [x] `{ doInstallCheck = false; name = "tsduck-3.40-4165"; }`
- [x] `{ doInstallCheck = false; name = "ubertooth-2020-12-R1"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "udisks-2.10.1"; }`
- [x] `{ doInstallCheck = false; name = "uhd-4.7.0.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "upower-1.90.6"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "usb-blaster-udev-rules"; }`
- [x] `{ doInstallCheck = false; name = "usbkvm-0.2.0"; }`
- [x] `{ doInstallCheck = false; name = "usb-modeswitch-data-20191128"; }`
- [x] `{ doInstallCheck = false; name = "usbmuxd2-unstable-2023-12-12"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "usbmuxd-1.1.1+date=2023-05-05"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "usbrelayd-1.2.1"; }`
- [x] `{ doInstallCheck = false; name = "usbsdmux-24.1.1"; }`
- [ ] `{ doInstallCheck = false; name = "imagescan-3.65.0"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "uuu-1.5.201"; }`
    - propagated via libusb1
- [x] `{ doInstallCheck = false; name = "uvcdynctrl-0.3.0"; }`
- [x] `{ doInstallCheck = false; name = "v4l-utils-1.24.1"; }`
- [ ] `{ doInstallCheck = false; name = "Vial-0.7.3"; }`
    - appimage, no install checks
- [ ] `{ doInstallCheck = false; name = "via-3.0.0"; }`
    - appimage, no install checks
- [x] `{ doInstallCheck = false; name = "waagent-2.13.1.1"; }`
- [x] `{ doInstallCheck = false; name = "wch-isp-0.4.1"; }`
    - propagated via libusb1
- [ ] `{ doInstallCheck = false; name = "wine-wow-10.0"; }`
    - skipped
- [x] `{ doInstallCheck = false; name = "wooting-udev-rules-0-unstable-2024-11-20"; }`
- [x] `{ doInstallCheck = false; name = "xe-guest-utilities-8.4.0"; }`
    - Configuration file /nix/store/4ainz0zf0577288qjkvfslf8kl0zhp0b-xe-guest-utilities-8.4.0/etc/udev/rules.d/z10_xen-vcpu-hotplug.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "xf86-input-wacom-1.2.3"; }`
- [x] `{ doInstallCheck = false; name = "xfel-1.3.2"; }`
    - propagated via libusb1
- [ ] `{ doInstallCheck = false; name = "xf86-input-vmmouse-13.2.0"; }`
    - skipped: `# THIS IS A GENERATED FILE.  DO NOT EDIT!`
- [x] `{ doInstallCheck = false; name = "xpra-6.3"; }`
- [x] `{ doInstallCheck = false; name = "xr-hardware-1.1.1"; }`
- [x] `{ doInstallCheck = false; name = "yubikey-personalization-1.20.0"; }`
    - propagated via libusb1
    - Configuration file /nix/store/y6bp1cqla1xhs23a9zsddrf1mqxg2amq-yubikey-personalization-1.20.0/lib/udev/rules.d/69-yubikey.rules is marked executable. Please remove executable permission bits. Proceeding anyway.
- [x] `{ doInstallCheck = false; name = "zfs-user-2.2.7"; }`
- [x] `{ doInstallCheck = false; name = "zfs-user-2.3.2"; }`
- [x] `{ doInstallCheck = false; name = "zsa-udev-rules-unstable-2023-11-30"; }`
- [x] `{ doInstallCheck = false; name = "zsnes2-2.0.12"; }`



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
