### PR TITLE
wrangler: 3.80.1 -> 4.16.0

### DIFF
--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -113,6 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
       seanrmurphy
       dezren39
       ryand56
+      ezrizhu
     ];
     mainProgram = "wrangler";
     # Tunneling and other parts of wrangler, which require workerd won't run on

--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -10,23 +10,35 @@
   llvmPackages,
   musl,
   xorg,
+  jq,
+  moreutils,
   gitUpdater,
+  versionCheckHook,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wrangler";
-  version = "3.80.1";
+  version = "4.16.0";
 
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = "workers-sdk";
     rev = "wrangler@${finalAttrs.version}";
-    hash = "sha256-9ClosoDIT+yP2dvNenHW2RSxLimOT3znXD+Pq+N6cQA=";
+    hash = "sha256-H/ds5NfOjyTZ4AcsCAP0wbalgOljOUtLSjkjEn+atVk=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
-    inherit (finalAttrs) pname version src;
-    hash = "sha256-8EItfBV2n2rnXPCTYjDZlr/tdlEn8YOdIzOsj35w5gQ=";
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      postPatch
+      ;
+    hash = "sha256-msIXeN8t8Dm3RUkw4woZIMn7wXxw/0jVl8oFmkPJbrA=";
   };
+  # pnpm packageManager version in workers-sdk root package.json may not match nixpkgs
+  postPatch = ''
+    jq 'del(.packageManager)' package.json | sponge package.json
+  '';
 
   passthru.updateScript = gitUpdater { rev-prefix = "wrangler@"; };
 
@@ -45,6 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
       makeWrapper
       nodejs
       pnpm_9.configHook
+      jq
+      moreutils
     ]
     ++ lib.optionals (stdenv.hostPlatform.isLinux) [
       autoPatchelfHook
@@ -53,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
   # @cloudflare/vitest-pool-workers wanted to run a server as part of the build process
   # so I simply removed it
   postBuild = ''
-    rm -fr packages/vitest-pool-workers
+    mv packages/vitest-pool-workers packages/~vitest-pool-workers
     NODE_ENV="production" pnpm --filter workers-shared run build
     NODE_ENV="production" pnpm --filter miniflare run build
     NODE_ENV="production" pnpm --filter wrangler run build
@@ -65,19 +79,17 @@ stdenv.mkDerivation (finalAttrs: {
   # - the build process builds a version of miniflare which is used by wrangler; for this reason, the miniflare package is copied also
   # - pnpm stores all content in the top-level node_modules directory, but it is linked to from a node_modules directory inside wrangler
   # - as they are linked via symlinks, the relative location of them on the filesystem should be maintained
+  # - Update: Now we're copying everything over due to broken symlink errors
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin $out/lib $out/lib/packages/wrangler
-    rm -rf node_modules/typescript node_modules/eslint node_modules/prettier node_modules/bin node_modules/.bin node_modules/**/bin node_modules/**/.bin
+    mv packages/~vitest-pool-workers packages/vitest-pool-workers
+    cp -r fixtures $out/lib
+    cp -r packages $out/lib
     cp -r node_modules $out/lib
-    cp -r packages/miniflare $out/lib/packages
-    cp -r packages/workers-tsconfig $out/lib/packages
-    cp -r packages/workers-shared $out/lib/packages
-    cp -r packages/wrangler/node_modules $out/lib/packages/wrangler
-    cp -r packages/wrangler/templates $out/lib/packages/wrangler
-    cp -r packages/wrangler/wrangler-dist $out/lib/packages/wrangler
+    cp -r tools $out/lib/tools
+    rm -rf node_modules/typescript node_modules/eslint node_modules/prettier node_modules/bin node_modules/.bin node_modules/**/bin node_modules/**/.bin
     rm -rf $out/lib/**/bin $out/lib/**/.bin
-    cp -r packages/wrangler/bin $out/lib/packages/wrangler
     NODE_PATH_ARRAY=( "$out/lib/node_modules" "$out/lib/packages/wrangler/node_modules" )
     makeWrapper ${lib.getExe nodejs} $out/bin/wrangler \
       --inherit-argv0 \
@@ -86,7 +98,10 @@ stdenv.mkDerivation (finalAttrs: {
       --set-default SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" # https://github.com/cloudflare/workers-sdk/issues/3264
     runHook postInstall
   '';
-
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
   meta = {
     description = "Command-line interface for all things Cloudflare Workers";
     homepage = "https://github.com/cloudflare/workers-sdk#readme";


### PR DESCRIPTION
Fixes #409155
Fixes #381980
Fixes #376947

Relates to #352287 but I think we should have a closer look to address the comments in a future commit.

Closes #377334 

Upstream Changelog: https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.16.0

Besides the version update, I also resolved two issues that prevented us from updating wrangler (context in the update request issue).

* Broken symlinks: nixpkgs build now checks for broken symlinks, this PR adds all the relevant directories back to the out dir so all symlinks are intact.
* Missing npm: wrangler specifies an older version of pnpm than the one in pnpm_9 as used in the build process, this PR patches the package.json to remove the pnpm version so pnpm_9 doesn't attempt to change it's version resulting in a pnpm binary not found error. (with help from @cameronraysmith)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
