### PR TITLE
Don't trigger the evaluation of apple-sdk in Linux stdenv

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -492,7 +492,7 @@ stdenvNoCC.mkDerivation {
         darwinMinVersionVariable
         ;
     }
-    // lib.optionalAttrs (apple-sdk != null && stdenvNoCC.targetPlatform.isDarwin) {
+    // lib.optionalAttrs (stdenvNoCC.targetPlatform.isDarwin && apple-sdk != null) {
       # Wrapped compilers should do something useful even when no SDK is provided at `DEVELOPER_DIR`.
       fallback_sdk = apple-sdk.__spliced.buildTarget or apple-sdk;
     };

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -889,7 +889,7 @@ stdenvNoCC.mkDerivation {
       # These will become empty strings when not targeting Darwin.
       inherit (targetPlatform) darwinMinVersion darwinMinVersionVariable;
     }
-    // lib.optionalAttrs (apple-sdk != null && stdenvNoCC.targetPlatform.isDarwin) {
+    // lib.optionalAttrs (stdenvNoCC.targetPlatform.isDarwin && apple-sdk != null) {
       # Wrapped compilers should do something useful even when no SDK is provided at `DEVELOPER_DIR`.
       fallback_sdk = apple-sdk.__spliced.buildTarget or apple-sdk;
     };


### PR DESCRIPTION
During the Apple SDK revamp of #346043, `cc-wrapper` and `bintools-wrapper` were [modified](https://github.com/NixOS/nixpkgs/commit/51755b0c00881bfe1602db0eb689efd2c66bcc20) to automatically add a fallback SDK if `$DEVELOPER_DIR` is not set. However, because of the order of the `&&` operands, `apple-sdk` is always evaluated even when it's not needed.

Let's flip the `&&` operands so we only trigger the evaluation when targeting Darwin. This should speed things up too.

## Example

Apply this simple patch:

```patch
diff --git a/pkgs/by-name/ap/apple-sdk/package.nix b/pkgs/by-name/ap/apple-sdk/package.nix
index 04b32f07a642..67e76d634d1c 100644
--- a/pkgs/by-name/ap/apple-sdk/package.nix
+++ b/pkgs/by-name/ap/apple-sdk/package.nix
@@ -46,6 +46,7 @@ let
     # This has to happen last.
     ++ [
       (callPackage ./common/run-build-phase-hooks.nix { })
+      (self: super: builtins.trace "SDK hash: ${super.src.outputHash}" super)
     ]
   );
 in
```

And watch everything explode on Linux while it tries to call `fetchSDK` with the bootstrap `fetchurl`:

```console
$ nix-instantiate --system x86_64-linux -A hello
error:
       … while evaluating r
         at /home/zhaofeng/Git/nixpkgs/pkgs/top-level/default.nix:91:11:
           90|       (x: throwIfNot (lib.isFunction x) "All crossOverlays passed to nixpkgs must be functions.")
           91|       (r: r)
             |           ^
           92|       crossOverlays;

       … while evaluating cur
         at /home/zhaofeng/Git/nixpkgs/pkgs/stdenv/booter.nix:80:5:
           79|     in
           80|     cur;
             |     ^
           81|

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: function 'anonymous lambda' called with unexpected arguments 'version', 'pname', 'nativeBuildInputs', 'recursiveHash' and 'postFetch'
       at /home/zhaofeng/Git/nixpkgs/pkgs/build-support/fetchurl/boot.nix:7:1:
            6|
            7| {
             | ^
            8|   url ? builtins.head urls,
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
