### PR TITLE
xcircuit: fix build with gcc 14

### DIFF
--- a/pkgs/by-name/xc/xcircuit/declare-missing-prototype.patch
+++ b/pkgs/by-name/xc/xcircuit/declare-missing-prototype.patch
@@ -1,0 +1,24 @@
+From 323c4c437b0eb027ac5acbd2d0c5b6d62a38befb Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Tue, 11 Apr 2023 09:03:09 +0200
+Subject: [PATCH] Declare UDrawXAt in prototypes.h
+
+This avoids an implicit function declaration in functions.c for
+HAVE_CAIRO.  Future compilers will not accept such implicit function
+declarations by default, leading to a build failure.
+---
+ prototypes.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/prototypes.h b/prototypes.h
+index d577c854c48eddf1b9d086294930c714d69b7af5..5ec4b272722fd658253b70a3fe211c65881075a5 100644
+--- a/prototypes.h
++++ b/prototypes.h
+@@ -431,6 +431,7 @@ extern void UDrawSimpleLine(XPoint *, XPoint *);
+ extern void UDrawLine(XPoint *, XPoint *);
+ extern void UDrawCircle(XPoint *, u_char);
+ extern void UDrawX(labelptr);
++extern void UDrawXAt(XPoint *);
+ extern void UDrawXDown(labelptr);
+ extern int  toplevelwidth(objinstptr, short *);
+ extern int  toplevelheight(objinstptr, short *);

--- a/pkgs/by-name/xc/xcircuit/package.nix
+++ b/pkgs/by-name/xc/xcircuit/package.nix
@@ -38,6 +38,11 @@ stdenv.mkDerivation {
     "--with-ngspice=${lib.getBin ngspice}/bin/ngspice"
   ];
 
+  patches = [
+    # fix compilation with GCC 14
+    ./declare-missing-prototype.patch
+  ];
+
   buildInputs = with xorg; [
     cairo
     ghostscript


### PR DESCRIPTION
- #403336
- #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
