### PR TITLE
nerd-font-patcher: 3.3.0 -> 3.4.0

### DIFF
--- a/pkgs/by-name/ne/nerd-font-patcher/package.nix
+++ b/pkgs/by-name/ne/nerd-font-patcher/package.nix
@@ -6,11 +6,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "nerd-font-patcher";
-  version = "3.3.0";
+  version = "3.4.0";
 
   src = fetchzip {
     url = "https://github.com/ryanoasis/nerd-fonts/releases/download/v${version}/FontPatcher.zip";
-    sha256 = "sha256-/LbO8+ZPLFIUjtZHeyh6bQuplqRfR6SZRu9qPfVZ0Mw=";
+    sha256 = "sha256-qPEeUR7Xxp6WaAhYwGtQpkPqd1LibVzRPdXlzFOrF2A=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/ne/nerd-font-patcher/package.nix
+++ b/pkgs/by-name/ne/nerd-font-patcher/package.nix
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication rec {
 
   src = fetchzip {
     url = "https://github.com/ryanoasis/nerd-fonts/releases/download/v${version}/FontPatcher.zip";
-    sha256 = "sha256-qPEeUR7Xxp6WaAhYwGtQpkPqd1LibVzRPdXlzFOrF2A=";
+    sha256 = "sha256-koZj0Tn1HtvvSbQGTc3RbXQdUU4qJwgClOVq1RXW6aM=";
     stripRoot = false;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[`changelog.md`](https://github.com/ryanoasis/nerd-fonts/blob/v3.4.0/changelog.md):

> ## v3.4.0
> 
> Easter Release without Eggs
> 
> Mainly a font update release. No surprises here (we hope).
> 
> ### Breaking
>  - Remove patcher option `--use-single-width-glyphs` (use `-s` or `--mono` instead)
> 
> ### Icons
>  - Add new CSS icon @skoch13 ryanoasis/nerd-fonts#1762
>  - Manually optimize many Devicon icons ryanoasis/nerd-fonts#1779
> 
> ### Features
>  - Add possibility to create single width icons without touching existing glyphs ryanoasis/nerd-fonts#1773
>  - Add possibility to manually set target cell size (`--cell`) ryanoasis/nerd-fonts#1773
>  - The patched fonts in `otf` format are now much smaller (comparable to `ttf`) ryanoasis/nerd-fonts#1851
>  - Intermediate icon storage is not rounded anymore ryanoasis/nerd-fonts#1849
> 
> ### Bugs and improvements
>  - Fix few missing new Devicons @hasecilu ryanoasis/nerd-fonts#1768
>  - Fix glitches in Devicon icons ryanoasis/nerd-fonts#1779
>  - Fix self-patching on Windows ryanoasis/nerd-fonts#1761
>  - Fix handling of some glyphs in `Nerd Font Propo` and `SymbolsOnly` ryanoasis/nerd-fonts#1852

Closes #409578.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
