### PR TITLE
python313Packages.tracerite: add missing dep

### DIFF
--- a/pkgs/development/python-modules/tracerite/default.nix
+++ b/pkgs/development/python-modules/tracerite/default.nix
@@ -23,9 +23,9 @@ buildPythonPackage rec {
     hash = "sha256-rI1MNdYl/P64tUHyB3qV9gfLbGbCVOXnEFoqFTkaqgg=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     html5tagger
     setuptools
   ];

--- a/pkgs/development/python-modules/tracerite/default.nix
+++ b/pkgs/development/python-modules/tracerite/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   setuptools-scm,
   html5tagger,
+  setuptools,
   python,
   pythonOlder,
 }:
@@ -24,7 +25,10 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  propagatedBuildInputs = [ html5tagger ];
+  propagatedBuildInputs = [
+    html5tagger
+    setuptools
+  ];
 
   postInstall = ''
     cp tracerite/style.css $out/${python.sitePackages}/tracerite


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This package is currently broken; as I allude to in my other PR (https://github.com/NixOS/nixpkgs/pull/409599), Nixpkg Sanic is currently broken because `tracerite` fails to import:

```
$ ./result/bin/sanic
Traceback (most recent call last):
  File "/nix/store/mq2n407vs1hzpqyfdmvrgmb1nsj65k1y-python3.12-sanic-25.3.0/bin/.sanic-wrapped", line 6, in <module>
    from sanic.__main__ import main
  File "/nix/store/mq2n407vs1hzpqyfdmvrgmb1nsj65k1y-python3.12-sanic-25.3.0/lib/python3.12/site-packages/sanic/__init__.py", line 6, in <module>
    from sanic.app import Sanic
  File "/nix/store/mq2n407vs1hzpqyfdmvrgmb1nsj65k1y-python3.12-sanic-25.3.0/lib/python3.12/site-packages/sanic/app.py", line 50, in <module>
    from sanic.application.state import ApplicationState, ServerStage
  File "/nix/store/mq2n407vs1hzpqyfdmvrgmb1nsj65k1y-python3.12-sanic-25.3.0/lib/python3.12/site-packages/sanic/application/state.py", line 13, in <module>
    from sanic.server.async_server import AsyncioServer
  File "/nix/store/mq2n407vs1hzpqyfdmvrgmb1nsj65k1y-python3.12-sanic-25.3.0/lib/python3.12/site-packages/sanic/server/__init__.py", line 5, in <module>
    from sanic.server.runners import serve
  File "/nix/store/mq2n407vs1hzpqyfdmvrgmb1nsj65k1y-python3.12-sanic-25.3.0/lib/python3.12/site-packages/sanic/server/runners.py", line 6, in <module>
    from sanic.config import Config
  File "/nix/store/mq2n407vs1hzpqyfdmvrgmb1nsj65k1y-python3.12-sanic-25.3.0/lib/python3.12/site-packages/sanic/config.py", line 12, in <module>
    from sanic.errorpages import DEFAULT_FORMAT, check_error_format
  File "/nix/store/mq2n407vs1hzpqyfdmvrgmb1nsj65k1y-python3.12-sanic-25.3.0/lib/python3.12/site-packages/sanic/errorpages.py", line 27, in <module>
    from sanic.pages.error import ErrorPage
  File "/nix/store/mq2n407vs1hzpqyfdmvrgmb1nsj65k1y-python3.12-sanic-25.3.0/lib/python3.12/site-packages/sanic/pages/error.py", line 4, in <module>
    import tracerite.html
  File "/nix/store/iqaqkajlnl3v4k87y05q38d47k6g8z01-python3.12-tracerite-1.1.1/lib/python3.12/site-packages/tracerite/__init__.py", line 1, in <module>
    from .html import html_traceback
  File "/nix/store/iqaqkajlnl3v4k87y05q38d47k6g8z01-python3.12-tracerite-1.1.1/lib/python3.12/site-packages/tracerite/html.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Yes, there is a `pythonImportsCheck` to try to prevent this exact scenario. Unfortunately, it ended up not catching this because `setuptools-scm` nativeBuildInput present during the check phase, I think. Adding a `setuptools` dependency for that `import pkg_resources` line fixes things in my testing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
