### PR TITLE
ocamlPackages.decoders: init at 1.0.0 with dependencies

### DIFF
--- a/pkgs/development/ocaml-modules/bencode/default.nix
+++ b/pkgs/development/ocaml-modules/bencode/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  ounit,
+  qcheck,
+}:
+
+buildDunePackage rec {
+  pname = "bencode";
+  version = "2.0";
+  minimalOCamlVersion = "4.02.0";
+
+  src = fetchFromGitHub {
+    owner = "rgrinberg";
+    repo = "bencode";
+    tag = version;
+    hash = "sha256-sEMS9oBOPeFX1x7cHjbQhCD2QI5yqC+550pPqqMsVws=";
+  };
+
+  doCheck = true;
+  checkInputs = [
+    ounit
+    qcheck
+  ];
+
+  meta = {
+    description = "Bencode (.torrent file format) reader/writer in OCaml ";
+    homepage = "https://github.com/rgrinberg/bencode";
+    changelog = "https://github.com/rgrinberg/bencode/blob/${version}/Changelog.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/cbor/default.nix
+++ b/pkgs/development/ocaml-modules/cbor/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildDunePackage,
+  fetchurl,
+  ocplib-endian,
+  yojson,
+}:
+
+buildDunePackage rec {
+  pname = "cbor";
+  version = "0.5";
+
+  minimalOCamlVersion = "4.07.0";
+
+  src = fetchurl {
+    url = "https://github.com/ygrek/ocaml-cbor/releases/download/${version}/ocaml-cbor-${version}.tar.gz";
+    hash = "sha256-4mpm/fv9X5uFRQO8XqBhOpxYwZreEtJ3exIwN6YulKM=";
+  };
+
+  propagatedBuildInputs = [
+    ocplib-endian
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    yojson
+  ];
+
+  meta = {
+    description = "CBOR encoder/decoder (RFC 7049) - native OCaml implementation";
+    homepage = "https://github.com/ygrek/ocaml-cbor";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders-bencode/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-bencode/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildDunePackage,
+  decoders,
+  bencode,
+  containers,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "decoders-bencode";
+
+  # sub-package built separately from the same source
+  inherit (decoders) src version;
+
+  minimalOCamlVersion = "4.03.0";
+
+  propagatedBuildInputs = [
+    decoders
+    bencode
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    containers
+    ounit2
+  ];
+
+  meta = {
+    description = "Bencode backend for decoders";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders-cbor/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-cbor/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildDunePackage,
+  decoders,
+  cbor,
+  containers,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "decoders-cbor";
+
+  # sub-package built separately from the same source
+  inherit (decoders) src version;
+
+  minimalOCamlVersion = "4.03.0";
+
+  propagatedBuildInputs = [
+    decoders
+    cbor
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    containers
+    ounit2
+  ];
+
+  meta = {
+    description = "CBOR backend for decoders";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders-ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-ezjsonm/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildDunePackage,
+  decoders,
+  ezjsonm,
+  containers,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "decoders-ezjsonm";
+
+  # sub-package built separately from the same source
+  inherit (decoders) src version;
+
+  minimalOCamlVersion = "4.03.0";
+
+  propagatedBuildInputs = [
+    decoders
+    ezjsonm
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    containers
+    ounit2
+  ];
+
+  meta = {
+    description = "Ezjsonm backend for decoders";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders-ezxmlm/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-ezxmlm/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildDunePackage,
+  decoders,
+  ezxmlm,
+  containers,
+}:
+
+buildDunePackage rec {
+  pname = "decoders-ezxmlm";
+
+  # sub-package built separately from the same source
+  inherit (decoders) src version;
+
+  minimalOCamlVersion = "4.03.0";
+
+  propagatedBuildInputs = [
+    decoders
+    ezxmlm
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    containers
+  ];
+
+  meta = {
+    description = "Ezxmlm backend for decoders";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders-jsonaf/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-jsonaf/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildDunePackage,
+  decoders,
+  jsonaf ? null,
+  containers,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "decoders-jsonaf";
+
+  # sub-package built separately from the same source
+  inherit (decoders) src version;
+
+  minimalOCamlVersion = "4.11.0";
+
+  propagatedBuildInputs = [
+    decoders
+    jsonaf
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    containers
+    ounit2
+  ];
+
+  meta = {
+    description = "Jsonaf backend for decoders";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders-jsonm/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-jsonm/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildDunePackage,
+  decoders,
+  jsonm,
+  containers,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "decoders-jsonm";
+
+  # sub-package built separately from the same source
+  inherit (decoders) src version;
+
+  minimalOCamlVersion = "4.03.0";
+
+  propagatedBuildInputs = [
+    decoders
+    jsonm
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    containers
+    ounit2
+  ];
+
+  meta = {
+    description = "Jsonm backend for decoders";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders-msgpck/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-msgpck/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildDunePackage,
+  decoders,
+  msgpck,
+  containers,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "decoders-msgpck";
+
+  # sub-package built separately from the same source
+  inherit (decoders) src version;
+
+  minimalOCamlVersion = "4.03.0";
+
+  propagatedBuildInputs = [
+    decoders
+    msgpck
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    containers
+    ounit2
+  ];
+
+  meta = {
+    description = "Msgpck backend for decoders";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders-sexplib/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-sexplib/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildDunePackage,
+  decoders,
+  sexplib,
+  sexplib0,
+  containers,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "decoders-sexplib";
+
+  # sub-package built separately from the same source
+  inherit (decoders) src version;
+
+  minimalOCamlVersion = "4.03.0";
+
+  propagatedBuildInputs = [
+    decoders
+    sexplib
+    sexplib0
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    containers
+    ounit2
+  ];
+
+  meta = {
+    description = "sexplib backend for decoders";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders-yojson/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-yojson/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildDunePackage,
+  decoders,
+  yojson,
+  containers,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "decoders-yojson";
+
+  # sub-package built separately from the same source
+  inherit (decoders) src version;
+
+  minimalOCamlVersion = "4.03.0";
+
+  propagatedBuildInputs = [
+    decoders
+    yojson
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    containers
+    ounit2
+  ];
+
+  meta = {
+    description = "Yojson backend for decoders";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/development/ocaml-modules/decoders/default.nix
+++ b/pkgs/development/ocaml-modules/decoders/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildDunePackage,
+  fetchurl,
+  containers,
+}:
+
+buildDunePackage rec {
+  pname = "decoders";
+  version = "1.0.0";
+
+  minimalOCamlVersion = "4.03.0";
+
+  src = fetchurl {
+    url = "https://github.com/mattjbray/ocaml-decoders/releases/download/v${version}/${pname}-${version}.tbz";
+    hash = "sha256-R/55xBAtD3EO/zzq7zExANnfPHlFg00884o5dCpXNZc=";
+  };
+
+  doCheck = true;
+  checkInputs = [
+    containers
+  ];
+
+  meta = {
+    description = "Elm-inspired decoders for Ocaml";
+    homepage = "https://github.com/mattjbray/ocaml-decoders";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ infinidoge ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -330,6 +330,26 @@ let
 
         dbf = callPackage ../development/ocaml-modules/dbf { };
 
+        decoders = callPackage ../development/ocaml-modules/decoders { };
+
+        decoders-bencode = callPackage ../development/ocaml-modules/decoders-bencode { };
+
+        decoders-cbor = callPackage ../development/ocaml-modules/decoders-cbor { };
+
+        decoders-ezjsonm = callPackage ../development/ocaml-modules/decoders-ezjsonm { };
+
+        decoders-ezxmlm = callPackage ../development/ocaml-modules/decoders-ezxmlm { };
+
+        decoders-jsonaf = callPackage ../development/ocaml-modules/decoders-jsonaf { };
+
+        decoders-jsonm = callPackage ../development/ocaml-modules/decoders-jsonm { };
+
+        decoders-msgpck = callPackage ../development/ocaml-modules/decoders-msgpck { };
+
+        decoders-sexplib = callPackage ../development/ocaml-modules/decoders-sexplib { };
+
+        decoders-yojson = callPackage ../development/ocaml-modules/decoders-yojson { };
+
         decompress = callPackage ../development/ocaml-modules/decompress { };
 
         dedukti = callPackage ../development/ocaml-modules/dedukti { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -88,6 +88,8 @@ let
 
         benchmark = callPackage ../development/ocaml-modules/benchmark { };
 
+        bencode = callPackage ../development/ocaml-modules/bencode { };
+
         bheap = callPackage ../development/ocaml-modules/bheap { };
 
         bigarray-compat = callPackage ../development/ocaml-modules/bigarray-compat { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -202,6 +202,8 @@ let
           git-binary = pkgs.git;
         };
 
+        cbor = callPackage ../development/ocaml-modules/cbor { };
+
         cfstream = callPackage ../development/ocaml-modules/cfstream { };
 
         chacha = callPackage ../development/ocaml-modules/chacha { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds `ocaml-decoders` with all of its backends (separate packages in 1 commit, as they are intrinsically linked), as well as missing dependencies for 2 of the backends, `cbor` and `bencode`.

Part of my work for https://github.com/ngi-nix/projects/issues/31, decoders-ezjsonm is a dependency of #Seppo

Same as my other recent PR, I don't have much experience with OCaml, so please let me know if I've missed anything.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
