### PR TITLE
jetbrains.*: Don't remove shell scripts, they are invoked by JetBrains Gateway

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/linux.nix
+++ b/pkgs/applications/editors/jetbrains/bin/linux.nix
@@ -117,33 +117,43 @@ lib.makeOverridable mkDerivation (
       jdk=${jdk.home}
       item=${desktopItem}
 
-      launcher="$out/$pname/bin/${loName}"
-      if [ -e "$launcher" ]; then
-        rm "$launcher".sh # We do not wrap the old script-style launcher anymore.
-      else
-        launcher+=.sh
+      needsWrapping=()
+
+      if [ -f "$out/$pname/bin/${loName}" ]; then
+        needsWrapping+=("$out/$pname/bin/${loName}")
+      fi
+      if [ -f "$out/$pname/bin/${loName}.sh" ]; then
+        needsWrapping+=("$out/$pname/bin/${loName}.sh")
       fi
 
-      wrapProgram  "$launcher" \
-        --prefix PATH : "${
-          lib.makeBinPath [
-            jdk
-            coreutils
-            gnugrep
-            which
-            git
-          ]
-        }" \
-        --suffix PATH : "${lib.makeBinPath [ python3 ]}" \
-        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath extraLdPath}" \
-        ${lib.concatStringsSep " " extraWrapperArgs} \
-        --set-default JDK_HOME "$jdk" \
-        --set-default ANDROID_JAVA_HOME "$jdk" \
-        --set-default JAVA_HOME "$jdk" \
-        --set-default JETBRAINS_CLIENT_JDK "$jdk" \
-        --set-default ${hiName}_JDK "$jdk" \
-        --set-default LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive" \
-        --set-default ${vmoptsIDE}_VM_OPTIONS ${vmoptsFile}
+      for launcher in "''${needsWrapping[@]}"
+      do
+        wrapProgram  "$launcher" \
+          --prefix PATH : "${
+            lib.makeBinPath [
+              jdk
+              coreutils
+              gnugrep
+              which
+              git
+            ]
+          }" \
+          --suffix PATH : "${lib.makeBinPath [ python3 ]}" \
+          --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath extraLdPath}" \
+          ${lib.concatStringsSep " " extraWrapperArgs} \
+          --set-default JDK_HOME "$jdk" \
+          --set-default ANDROID_JAVA_HOME "$jdk" \
+          --set-default JAVA_HOME "$jdk" \
+          --set-default JETBRAINS_CLIENT_JDK "$jdk" \
+          --set-default ${hiName}_JDK "$jdk" \
+          --set-default LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive" \
+          --set-default ${vmoptsIDE}_VM_OPTIONS ${vmoptsFile}
+      done
+
+      launcher="$out/$pname/bin/${loName}"
+      if [ ! -e "$launcher" ]; then
+        launcher+=.sh
+      fi
 
       ln -s "$launcher" $out/bin/$pname
       rm -rf $out/$pname/plugins/remote-dev-server/selfcontained/


### PR DESCRIPTION
I encountered a problem where I was trying to start Rider on another service and then use remote development. This failed due to the rider.sh script missing, apparently because we delete it when installing. 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) - Tested that Rider and Webstorm opens and works
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

------ Report for 'x86_64-linux' ------
20 packages built:
jetbrains.aqua jetbrains.clion jetbrains.datagrip jetbrains.dataspell jetbrains.gateway jetbrains.goland jetbrains.idea-community jetbrains.idea-community-bin jetbrains.idea-ultimate jetbrains.mps jetbrains.phpstorm jetbrains.pycharm-community jetbrains.pycharm-community-bin jetbrains.pycharm-professional jetbrains.rider jetbrains.ruby-mine jetbrains.rust-rover jetbrains.webstorm jetbrains.writerside nixpkgs-manual

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
