### PR TITLE
python3Packages.nltk: add data(Dir) passthru, run tests

### DIFF
--- a/pkgs/by-name/un/unstructured-api/package.nix
+++ b/pkgs/by-name/un/unstructured-api/package.nix
@@ -5,8 +5,6 @@
   python3,
   makeWrapper,
   nix-update-script,
-  symlinkJoin,
-  nltk-data,
 }:
 let
   pythonEnv = python3.withPackages (
@@ -147,14 +145,10 @@ let
     ++ unstructured.optional-dependencies.all-docs
   );
   version = "0.0.82";
-  unstructured_api_nltk_data = symlinkJoin {
-    name = "unstructured_api_nltk_data";
-
-    paths = [
-      nltk-data.punkt
-      nltk-data.averaged-perceptron-tagger
-    ];
-  };
+  unstructured_api_nltk_data = python3.pkgs.nltk.dataDir (d: [
+    d.punkt
+    d.averaged-perceptron-tagger
+  ]);
 in
 stdenvNoCC.mkDerivation {
   pname = "unstructured-api";

--- a/pkgs/development/python-modules/aider-chat/default.nix
+++ b/pkgs/development/python-modules/aider-chat/default.nix
@@ -6,8 +6,6 @@
   gitMinimal,
   portaudio,
   playwright-driver,
-  symlinkJoin,
-  nltk-data,
   pythonOlder,
   pythonAtLeast,
   setuptools-scm,
@@ -122,13 +120,10 @@
 }:
 
 let
-  aider-nltk-data = symlinkJoin {
-    name = "aider-nltk-data";
-    paths = [
-      nltk-data.punkt-tab
-      nltk-data.stopwords
-    ];
-  };
+  aider-nltk-data = nltk.dataDir (d: [
+    d.punkt-tab
+    d.stopwords
+  ]);
 
   version = "0.83.1";
   aider-chat = buildPythonPackage {

--- a/pkgs/development/python-modules/nltk/data-dir.nix
+++ b/pkgs/development/python-modules/nltk/data-dir.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  pkgs,
+  python3Packages,
+}:
+lib.makeOverridable (
+  { ... }@nltkDataPkgs:
+  f:
+  pkgs.symlinkJoin {
+    inherit (python3Packages.nltk) meta;
+    name = "nltk-data-dir";
+
+    paths = f nltkDataPkgs;
+  }
+) python3Packages.nltk.data

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -8,6 +8,16 @@
   joblib,
   regex,
   tqdm,
+
+  # preInstallCheck
+  nltk,
+
+  # nativeCheckInputs
+  matplotlib,
+  numpy,
+  pyparsing,
+  pytestCheckHook,
+  pytest-mock,
 }:
 
 buildPythonPackage rec {
@@ -29,13 +39,58 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  # Tests require some data, the downloading of which is impure. It would
-  # probably make sense to make the data another derivation, but then feeding
-  # that into the tests (given that we need nltk itself to download the data,
-  # unless there's an easy way to download it without nltk's downloader) might
-  # be complicated. For now let's just disable the tests and hope for the
-  # best.
-  doCheck = false;
+  # Use new passthru function to pass dependencies required for testing
+  preInstallCheck = ''
+    export NLTK_DATA=${
+      nltk.dataDir (
+        d: with d; [
+          averaged-perceptron-tagger-eng
+          averaged-perceptron-tagger-rus
+          brown
+          cess-cat
+          cess-esp
+          conll2007
+          floresta
+          gutenberg
+          inaugural
+          indian
+          large-grammars
+          nombank-1-0
+          omw-1-4
+          pl196x
+          porter-test
+          ptb
+          punkt-tab
+          rte
+          sinica-treebank
+          stopwords
+          tagsets-json
+          treebank
+          twitter-samples
+          udhr
+          universal-tagset
+          wmt15-eval
+          wordnet
+          wordnet-ic
+          words
+        ]
+      )
+    }
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    matplotlib
+    numpy
+    pyparsing
+    pytest-mock
+
+    pkgs.which
+  ];
+
+  disabledTestPaths = [
+    "nltk/test/unit/test_downloader.py" # Touches network
+  ];
 
   pythonImportsCheck = [ "nltk" ];
 

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     hash = "sha256-h9EnvT3kvYmk+BJl5fpZyxsZmydEAXU3D3QX0rx66Gg=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     click
     joblib
     regex

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   fetchPypi,
   buildPythonPackage,
   pythonOlder,
@@ -37,6 +38,10 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonImportsCheck = [ "nltk" ];
+
+  passthru = {
+    data = pkgs.nltk-data;
+  };
 
   meta = with lib; {
     description = "Natural Language Processing ToolKit";

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -41,6 +41,7 @@ buildPythonPackage rec {
 
   passthru = {
     data = pkgs.nltk-data;
+    dataDir = pkgs.callPackage ./data-dir.nix { };
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     mainProgram = "nltk";
     homepage = "http://nltk.org/";
     license = licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.bengsparks ];
   };
 }

--- a/pkgs/development/python-modules/type-infer/default.nix
+++ b/pkgs/development/python-modules/type-infer/default.nix
@@ -16,18 +16,13 @@
   python-dateutil,
   scipy,
   toml,
-  nltk-data,
-  symlinkJoin,
 }:
 let
-  testNltkData = symlinkJoin {
-    name = "nltk-test-data";
-    paths = [
-      nltk-data.punkt
-      nltk-data.punkt-tab
-      nltk-data.stopwords
-    ];
-  };
+  testNltkData = nltk.dataDir (d: [
+    d.punkt
+    d.punkt-tab
+    d.stopwords
+  ]);
 
   version = "0.0.21";
   tag = "v${version}";


### PR DESCRIPTION
~~Reviewers: Please take a look at e4284ec008b546911e3a3afc7ac236050b94f9de; Somehow I couldn't reference `nltk-data` in the `passthru` due to the aliases, but I don't see why that would have broken something.
I've removed them so that the CI completes, was there something wrong here?
They were added <24h ago, so I doubt anyone depends on them.~~
Reverted in https://github.com/NixOS/nixpkgs/pull/409843.

~~Depends on #409952, WIP until then~~

Now `{ python3Packages, python3.pkgs }.nltk.dataDir(d: [ d.wordnet ])` can be used to create a directory to point to with `NLTK_DATA=`, allowing packages to make use of corpora, taggers etc.

We can make use of this very function to run the tests from the NLTK package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
