### PR TITLE
libdiscid: 0.6.4 -> 0.6.5

### DIFF
--- a/pkgs/by-name/li/libdiscid/package.nix
+++ b/pkgs/by-name/li/libdiscid/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libdiscid";
-  version = "0.6.4";
+  version = "0.6.5";
 
   nativeBuildInputs = [
     cmake
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "metabrainz";
     repo = "libdiscid";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oN/qpzdTa5+rD7kwDOW6UCg7bbDOy/AYmP8sv9Q8+Kk=";
+    hash = "sha256-lGq2iGt7c4h8HntEPeQcd7X+IykRLm0kvjrLswRWSSs=";
   };
 
   NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework CoreFoundation -framework IOKit";

--- a/pkgs/by-name/li/libdiscid/package.nix
+++ b/pkgs/by-name/li/libdiscid/package.nix
@@ -1,12 +1,13 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   cmake,
   pkg-config,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libdiscid";
   version = "0.6.4";
 
@@ -15,18 +16,22 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  src = fetchurl {
-    url = "http://ftp.musicbrainz.org/pub/musicbrainz/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-3V6PHJrq1ELiO3SanMkzY3LmLoitcHmitiiVsDkMsoI=";
+  src = fetchFromGitHub {
+    owner = "metabrainz";
+    repo = "libdiscid";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oN/qpzdTa5+rD7kwDOW6UCg7bbDOy/AYmP8sv9Q8+Kk=";
   };
 
   NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework CoreFoundation -framework IOKit";
 
+  passthru.updateScript = nix-update-script { };
+
   meta = with lib; {
     description = "C library for creating MusicBrainz DiscIDs from audio CDs";
-    homepage = "http://musicbrainz.org/doc/libdiscid";
+    homepage = "https://musicbrainz.org/doc/libdiscid";
     maintainers = with maintainers; [ ehmry ];
     license = licenses.lgpl21;
     platforms = platforms.all;
   };
-}
+})


### PR DESCRIPTION
The change to fetchFromGitHub necessitates a hash change, as the
tarballs being distributed are not equal to the content of the git
repository at the tag[1].

[1]: https://github.com/metabrainz/libdiscid/blob/v0.6.5/CMakeLists.txt#L172-L178

Changelog: https://raw.githubusercontent.com/metabrainz/libdiscid/refs/tags/v0.6.5/ChangeLog

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package up    Changelog: https://raw.githubusercontent.com/metabrainz/libdiscid/refs/tags/v0.6.5/ChangeLog
dates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
