### PR TITLE
openssh: fix Darwin and musl tests

### DIFF
--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -137,69 +137,76 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = false;
   enableParallelChecking = false;
-  nativeCheckInputs = [
-    openssl
-    softhsm
-  ] ++ lib.optional (!stdenv.hostPlatform.isDarwin) hostname;
-  preCheck = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
-    # construct a dummy HOME
-    export HOME=$(realpath ../dummy-home)
-    mkdir -p ~/.ssh
+  nativeCheckInputs =
+    [
+      openssl
+    ]
+    ++ lib.optional (!stdenv.hostPlatform.isDarwin) hostname
+    ++ lib.optional (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isMusl) softhsm;
 
-    # construct a dummy /etc/passwd file for the sshd under test
-    # to use to look up the connecting user
-    DUMMY_PASSWD=$(realpath ../dummy-passwd)
-    cat > $DUMMY_PASSWD <<EOF
-    $(whoami)::$(id -u):$(id -g)::$HOME:$SHELL
-    EOF
+  preCheck =
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      # construct a dummy HOME
+      export HOME=$(realpath ../dummy-home)
+      mkdir -p ~/.ssh
 
-    # we need to NIX_REDIRECTS /etc/passwd both for processes
-    # invoked directly and those invoked by the "remote" session
-    cat > ~/.ssh/environment.base <<EOF
-    NIX_REDIRECTS=/etc/passwd=$DUMMY_PASSWD
-    LD_PRELOAD=${libredirect}/lib/libredirect.so
-    EOF
+      # construct a dummy /etc/passwd file for the sshd under test
+      # to use to look up the connecting user
+      DUMMY_PASSWD=$(realpath ../dummy-passwd)
+      cat > $DUMMY_PASSWD <<EOF
+      $(whoami)::$(id -u):$(id -g)::$HOME:$SHELL
+      EOF
 
-    # use an ssh environment file to ensure environment is set
-    # up appropriately for build environment even when no shell
-    # is invoked by the ssh session. otherwise the PATH will
-    # only contain default unix paths like /bin which we don't
-    # have in our build environment
-    cat - regress/test-exec.sh > regress/test-exec.sh.new <<EOF
-    cp $HOME/.ssh/environment.base $HOME/.ssh/environment
-    echo "PATH=\$PATH" >> $HOME/.ssh/environment
-    EOF
-    mv regress/test-exec.sh.new regress/test-exec.sh
+      # we need to NIX_REDIRECTS /etc/passwd both for processes
+      # invoked directly and those invoked by the "remote" session
+      cat > ~/.ssh/environment.base <<EOF
+      NIX_REDIRECTS=/etc/passwd=$DUMMY_PASSWD
+      LD_PRELOAD=${libredirect}/lib/libredirect.so
+      EOF
 
-    # explicitly enable the PermitUserEnvironment feature
-    substituteInPlace regress/test-exec.sh \
-      --replace \
-        'cat << EOF > $OBJ/sshd_config' \
-        $'cat << EOF > $OBJ/sshd_config\n\tPermitUserEnvironment yes'
+      # use an ssh environment file to ensure environment is set
+      # up appropriately for build environment even when no shell
+      # is invoked by the ssh session. otherwise the PATH will
+      # only contain default unix paths like /bin which we don't
+      # have in our build environment
+      cat - regress/test-exec.sh > regress/test-exec.sh.new <<EOF
+      cp $HOME/.ssh/environment.base $HOME/.ssh/environment
+      echo "PATH=\$PATH" >> $HOME/.ssh/environment
+      EOF
+      mv regress/test-exec.sh.new regress/test-exec.sh
 
-    # some tests want to use files under /bin as example files
-    for f in regress/sftp-cmds.sh regress/forwarding.sh; do
-      substituteInPlace $f --replace '/bin' "$(dirname $(type -p ls))"
-    done
+      # explicitly enable the PermitUserEnvironment feature
+      substituteInPlace regress/test-exec.sh \
+        --replace \
+          'cat << EOF > $OBJ/sshd_config' \
+          $'cat << EOF > $OBJ/sshd_config\n\tPermitUserEnvironment yes'
 
-    # set up NIX_REDIRECTS for direct invocations
-    set -a; source ~/.ssh/environment.base; set +a
+      # some tests want to use files under /bin as example files
+      for f in regress/sftp-cmds.sh regress/forwarding.sh; do
+        substituteInPlace $f --replace '/bin' "$(dirname $(type -p ls))"
+      done
 
-    # The extra tests check PKCS#11 interactions, which softhsm emulates with software only
-    substituteInPlace regress/test-exec.sh \
-      --replace /usr/local/lib/softhsm/libsofthsm2.so ${lib.getLib softhsm}/lib/softhsm/libsofthsm2.so
-  '';
+      # set up NIX_REDIRECTS for direct invocations
+      set -a; source ~/.ssh/environment.base; set +a
+    ''
+    + lib.optionalString (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isMusl) ''
+      # The extra tests check PKCS#11 interactions, which softhsm emulates with software only
+      substituteInPlace regress/test-exec.sh \
+        --replace /usr/local/lib/softhsm/libsofthsm2.so ${lib.getLib softhsm}/lib/softhsm/libsofthsm2.so
+    '';
   # integration tests hard to get working on darwin with its shaky
   # sandbox
   # t-exec tests fail on musl
   checkTarget =
-    lib.optional (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isMusl) "t-exec"
+    lib.optionals (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isMusl) [
+      "t-exec"
+      "extra-tests"
+    ]
     # other tests are less demanding of the environment
     ++ [
       "unit"
       "file-tests"
       "interop-tests"
-      "extra-tests"
     ];
 
   postInstall = ''

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -40,7 +40,10 @@ in
       ./ssh-keysign-8.5.patch
     ];
     extraMeta = {
-      maintainers = [ lib.maintainers.philiptaron ];
+      maintainers = with lib.maintainers; [
+        philiptaron
+        numinit
+      ];
       teams = [ lib.teams.helsinki-systems ];
     };
   };


### PR DESCRIPTION
Followup to #407077, disabling new tests that don't work on Darwin and musl.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
