### PR TITLE
amp-cli: 0.0.1747483284-g8cf01d -> 0.0.1747886591-g90f24f

### DIFF
--- a/pkgs/by-name/am/amp-cli/package-lock.json
+++ b/pkgs/by-name/am/amp-cli/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@sourcegraph/amp": "^0.0.1747483284-g8cf01d"
+        "@sourcegraph/amp": "^0.0.1747886591-g90f24f"
       }
     },
     "node_modules/@colors/colors": {
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@sourcegraph/amp": {
-      "version": "0.0.1747483284-g8cf01d",
-      "resolved": "https://registry.npmjs.org/@sourcegraph/amp/-/amp-0.0.1747483284-g8cf01d.tgz",
-      "integrity": "sha512-LTlMR3cs5ax9EGIuyu92g85SJdsXV7fvADsEnYmBOd/no7r1CIxeEtOzLFY1FPDCxLHjN74BivwHs0piMiLktg==",
+      "version": "0.0.1747886591-g90f24f",
+      "resolved": "https://registry.npmjs.org/@sourcegraph/amp/-/amp-0.0.1747886591-g90f24f.tgz",
+      "integrity": "sha512-therl4OchUfqcVPhG3YNJKjcZUvXadnfowKzJeZtVNZAcJMWz2+u0gZoWE+V8FPgrMaX/crYcYwPmiBl5NM6lg==",
       "dependencies": {
         "@types/runes": "^0.4.3",
         "@vscode/ripgrep": "1.15.11",

--- a/pkgs/by-name/am/amp-cli/package.nix
+++ b/pkgs/by-name/am/amp-cli/package.nix
@@ -72,7 +72,7 @@ buildNpmPackage rec {
 
   meta = {
     description = "Amp is an AI coding agent, in research preview from Sourcegraph. This is the CLI for Amp.";
-    homepage = "https://github.com/sourcegraph/amp";
+    homepage = "https://ampcode.com/";
     downloadPage = "https://www.npmjs.com/package/@sourcegraph/amp";
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/am/amp-cli/package.nix
+++ b/pkgs/by-name/am/amp-cli/package.nix
@@ -8,11 +8,11 @@
 
 buildNpmPackage rec {
   pname = "amp-cli";
-  version = "0.0.1747483284-g8cf01d";
+  version = "0.0.1747886591-g90f24f";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@sourcegraph/amp/-/amp-${version}.tgz";
-    hash = "sha256-8mPYdr0t/5kEGK/0nG0GyxviAU9EhjA1bAQXggvuF6k=";
+    hash = "sha256-knNzJYGXmLuerlw6j+lbIf45uv0tYtMOfsIQVfpJ0Kc=";
   };
 
   postPatch = ''
@@ -44,7 +44,7 @@ buildNpmPackage rec {
     chmod +x bin/amp-wrapper.js
   '';
 
-  npmDepsHash = "sha256-aFB9EuWp7skmY5uzNRBBs8/UcFgtrQpBqciO2UK1fwY=";
+  npmDepsHash = "sha256-ir13FuVQtxEcryqmSh5BOdrCUWeXAUUX72BYZweUNBU=";
 
   propagatedBuildInputs = [
     ripgrep


### PR DESCRIPTION
Additionally fixed the homepage to point to a publically available link.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
