### PR TITLE
python312Packages.ax-platform: 0.5.0 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/ax-platform/default.nix
+++ b/pkgs/development/python-modules/ax-platform/default.nix
@@ -1,41 +1,42 @@
 {
   lib,
-  botorch,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  hypothesis,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  botorch,
   ipywidgets,
   jinja2,
-  jupyter,
-  mercurial,
+  markdown,
   pandas,
   plotly,
-  pyfakefs,
   pyre-extensions,
+  scikit-learn,
+  scipy,
+  sympy,
+
+  # tests
+  pyfakefs,
   pytestCheckHook,
-  pythonAtLeast,
-  pythonOlder,
-  setuptools-scm,
-  setuptools,
   sqlalchemy,
-  stdenvNoCC,
   tabulate,
-  typeguard,
-  yappi,
 }:
 
 buildPythonPackage rec {
   pname = "ax-platform";
-  version = "0.5.0";
+  version = "1.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "ax";
     tag = version;
-    hash = "sha256-CMKdnPvzQ9tvU9/01mRaWi/Beuyo19CtaXNJCoiwLOw=";
+    hash = "sha256-DFsV1w6J7bTZNUq9OYExDvfc7IfTcthGKAnRMNujRKI=";
   };
 
   env.ALLOW_BOTORCH_LATEST = "1";
@@ -49,39 +50,47 @@ buildPythonPackage rec {
     botorch
     ipywidgets
     jinja2
+    markdown
     pandas
     plotly
-    typeguard
     pyre-extensions
+    scikit-learn
+    scipy
+    sympy
   ];
 
-  optional-dependencies = {
-    mysql = [ sqlalchemy ];
-    notebook = [ jupyter ];
-  };
-
   nativeCheckInputs = [
-    hypothesis
-    mercurial
     pyfakefs
+    # pytest-xdist
     pytestCheckHook
+    sqlalchemy
     tabulate
-    yappi
-  ] ++ lib.flatten (lib.attrValues optional-dependencies);
+  ];
+  pytestFlagsArray = [
+    # Hangs forever
+    "--deselect=ax/analysis/plotly/tests/test_top_surfaces.py::TestTopSurfacesAnalysis::test_online"
+  ];
 
   disabledTestPaths = [
     "ax/benchmark"
     "ax/runners/tests/test_torchx.py"
+
     # broken with sqlalchemy 2
     "ax/core/tests/test_experiment.py"
     "ax/service/tests/test_ax_client.py"
     "ax/service/tests/test_scheduler.py"
     "ax/service/tests/test_with_db_settings_base.py"
-    "ax/storage"
   ];
 
   disabledTests =
     [
+      # sqlalchemy.exc.ArgumentError: Strings are not accepted for attribute names in loader options; please use class-bound attributes directly.
+      "SQAStoreUtilsTest"
+      "SQAStoreTest"
+
+      # ValueError: `db_settings` argument should be of type ax.storage.sqa_store
+      "test_get_next_trials_with_db"
+
       # exact comparison of floating points
       "test_optimize_l0_homotopy"
       # AssertionError: 5 != 2
@@ -93,18 +102,7 @@ buildPythonPackage rec {
       # broken with sqlalchemy 2
       "test_sql_storage"
     ]
-    ++ lib.optionals (pythonAtLeast "3.13") [
-      #  Both `metric_aggregation` and `criterion` must be `ReductionCriterion`
-      "test_SingleDiagnosticBestModelSelector_max_mean"
-      "test_SingleDiagnosticBestModelSelector_min_mean"
-      "test_SingleDiagnosticBestModelSelector_min_min"
-      "test_SingleDiagnosticBestModelSelector_model_cv_kwargs"
-      "test_init"
-      "test_gen"
-      # "use MIN or MAX" does not match "Both `metric_aggregation` and `criterion` must be `ReductionCriterion`
-      "test_user_input_error"
-    ]
-    ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # flaky on x86
       "test_gen_with_expanded_parameter_space"
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Diff: https://github.com/facebook/ax/compare/refs/tags/0.5.0...refs/tags/1.0.0
Changelog: https://github.com/facebook/Ax/releases/tag/1.0.0

cc @veprbl

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
