### PR TITLE
devmode: refactor, modernize

### DIFF
--- a/pkgs/by-name/de/devmode/package.nix
+++ b/pkgs/by-name/de/devmode/package.nix
@@ -1,93 +1,111 @@
 {
-  lib,
   live-server,
   parallel,
   watchexec,
-  writeShellScriptBin,
+  writeShellApplication,
   # arguments to `nix-build`, e.g. `"foo.nix -A bar"`
   buildArgs ? "",
   # what path to open a browser at
   open ? "/index.html",
 }:
 let
-  error-page = writeShellScriptBin "error-page" ''
-    rm -rf $serve
-    mkdir -p "$(dirname $error_page_absolute)"
+  error-page = writeShellApplication {
+    name = "error-page";
+    text = ''
+      rm -rf "''${serve:?}"
+      mkdir -p "$(dirname "''${error_page_absolute:?}")"
 
-    cat > $error_page_absolute << EOF
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <style>
-        @media (prefers-color-scheme: dark) {
-          :root { filter: invert(100%); }
-        }
-      </style>
-    </head>
-    <body><pre>$1</pre></body>
-    </html>
-    EOF
-  '';
+      cat > "''${error_page_absolute:?}" << EOF
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <style>
+          @media (prefers-color-scheme: dark) {
+            :root { filter: invert(100%); }
+          }
+        </style>
+      </head>
+      <body><pre>$1</pre></body>
+      </html>
+      EOF
+    '';
+  };
 
-  build-and-link = writeShellScriptBin "build-and-link" ''
-    set -euxo pipefail
+  build-and-link = writeShellApplication {
+    name = "build-and-link";
+    runtimeInputs = [ error-page ];
+    text = ''
+      set +e
+      stderr=$(2>&1 nix-build --out-link "''${staging:?}" ${buildArgs})
+      exit_status=$?
+      set -e
 
-    set +e
-    stderr=$(2>&1 nix-build --out-link $staging ${buildArgs})
-    exit_status=$?
-    set -e
+      rm -rf "''${serve:?}"
 
-    rm -rf $serve
-
-    if [ $exit_status -eq 0 ]; then
-      mv $staging $serve
-    else
-      ${lib.getExe error-page} "$stderr"
-    fi
-  '';
+      if [ $exit_status -eq 0 ]; then
+        mv "''${staging:?}" "''${serve:?}"
+      else
+        error-page "$stderr"
+      fi
+    '';
+  };
 
   # https://watchexec.github.io/
-  watcher = writeShellScriptBin "watcher" ''
-    set -euxo pipefail
-
-    ${lib.getExe watchexec} \
-      --shell=none \
-      --restart \
-      --print-events \
-      ${lib.getExe build-and-link}
-  '';
+  watcher = writeShellApplication {
+    name = "watcher";
+    runtimeInputs = [
+      watchexec
+      build-and-link
+    ];
+    text = ''
+      watchexec \
+        --shell=none \
+        --restart \
+        --print-events \
+        build-and-link
+    '';
+  };
 
   # https://crates.io/crates/live-server
-  server = writeShellScriptBin "server" ''
-    set -euxo pipefail
-
-    ${lib.getExe live-server} \
-      --host=127.0.0.1 \
-      --open=${open} \
-      $serve
-  '';
+  server = writeShellApplication {
+    name = "server";
+    runtimeInputs = [ live-server ];
+    text = ''
+      live-server \
+        --host=127.0.0.1 \
+        --open=${open} \
+        "''${serve:?}"
+    '';
+  };
 in
-writeShellScriptBin "devmode" ''
-  set -euxo pipefail
+writeShellApplication {
+  name = "devmode";
+  runtimeInputs = [
+    parallel
+    watcher
+    server
+    error-page
+  ];
+  text = ''
+    function handle_exit {
+      rm -rf "$tmpdir"
+    }
 
-  function handle_exit {
-    rm -rf "$tmpdir"
-  }
+    tmpdir="$(mktemp -d)"
+    trap handle_exit EXIT
 
-  tmpdir=$(mktemp -d)
-  trap handle_exit EXIT
+    export serve="$tmpdir/serve"
+    export staging="$tmpdir/staging"
 
-  export serve="$tmpdir/serve"
-  export staging="$tmpdir/staging"
-  export error_page_absolute="$serve/${open}"
+    export error_page_absolute="$serve/${open}"
+    error-page "building …"
 
-  ${lib.getExe error-page} "building …"
-
-  ${lib.getExe parallel} \
-    --will-cite \
-    --line-buffer \
-    --tagstr '{/}' \
-    ::: \
-    "${lib.getExe watcher}" \
-    "${lib.getExe server}"
-''
+    parallel \
+      --will-cite \
+      --line-buffer \
+      --tagstr '{/}' \
+      ::: \
+      watcher \
+      server
+  '';
+}

--- a/pkgs/by-name/de/devmode/package.nix
+++ b/pkgs/by-name/de/devmode/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   findutils,
-  nodejs_latest,
+  live-server,
   parallel,
   rsync,
   watchexec,
@@ -12,8 +12,6 @@
   open ? "/index.html",
 }:
 let
-  inherit (nodejs_latest.pkgs) live-server;
-
   error-page = writeShellScriptBin "error-page" ''
     cat << EOF
     <!DOCTYPE html>
@@ -81,17 +79,12 @@ let
       ${lib.getExe build-and-copy}
   '';
 
-  # A Rust alternative to live-server exists, but it fails to open the temporary directory.
-  # `--no-css-inject`: without this it seems that only CSS is auto-reloaded.
-  # https://www.npmjs.com/package/live-server
+  # https://crates.io/crates/live-server
   server = writeShellScriptBin "server" ''
     set -euxo pipefail
 
-    ${lib.getExe' live-server "live-server"} \
+    ${lib.getExe live-server} \
       --host=127.0.0.1 \
-      --verbose \
-      --no-css-inject \
-      --entry-file=$error_page_relative \
       --open=${open} \
       $serve
   '';

--- a/pkgs/by-name/de/devmode/package.nix
+++ b/pkgs/by-name/de/devmode/package.nix
@@ -29,7 +29,7 @@ let
     EOF
   '';
 
-  build-and-copy = writeShellScriptBin "build-and-copy" ''
+  build-and-link = writeShellScriptBin "build-and-link" ''
     set -euxo pipefail
 
     set +e
@@ -54,7 +54,7 @@ let
       --shell=none \
       --restart \
       --print-events \
-      ${lib.getExe build-and-copy}
+      ${lib.getExe build-and-link}
   '';
 
   # https://crates.io/crates/live-server

--- a/pkgs/by-name/de/devmode/package.nix
+++ b/pkgs/by-name/de/devmode/package.nix
@@ -61,7 +61,6 @@ let
       watchexec \
         --shell=none \
         --restart \
-        --print-events \
         build-and-link
     '';
   };

--- a/pkgs/by-name/de/devmode/package.nix
+++ b/pkgs/by-name/de/devmode/package.nix
@@ -25,8 +25,7 @@ let
           }
         </style>
       </head>
-      <body><pre>$1</pre></body>
-      </html>
+      <body/><pre/>building...
       EOF
     '';
   };
@@ -35,17 +34,17 @@ let
     name = "build-and-link";
     runtimeInputs = [ error-page ];
     text = ''
+      error-page
+
       set +e
-      stderr=$(2>&1 nix-build --out-link "''${staging:?}" ${buildArgs})
+      2>&1 nix-build --out-link "''${staging:?}" ${buildArgs} \
+        | tee -a "''${error_page_absolute:?}"
       exit_status=$?
       set -e
 
-      rm -rf "''${serve:?}"
-
       if [ $exit_status -eq 0 ]; then
+        rm -rf "''${serve:?}"
         mv "''${staging:?}" "''${serve:?}"
-      else
-        error-page "$stderr"
       fi
     '';
   };
@@ -95,9 +94,9 @@ writeShellApplication {
 
     export serve="$tmpdir/serve"
     export staging="$tmpdir/staging"
-
     export error_page_absolute="$serve/${open}"
-    error-page "building …"
+
+    error-page
 
     parallel \
       --will-cite \


### PR DESCRIPTION
Edit: as discovered in https://github.com/NixOS/nixpkgs/pull/409083#issuecomment-2901205490

- Switched to the rust `live-server` alternative
- Use `shellcheck` through `writeShellApplication`
- Swap outlinks around after each rebuild, don't `rsync`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
