### PR TITLE
spotify: set `updateScript`, support macOS in `updateScript` and update

### DIFF
--- a/pkgs/by-name/sp/spotify/darwin.nix
+++ b/pkgs/by-name/sp/spotify/darwin.nix
@@ -4,6 +4,7 @@
   meta,
   fetchurl,
   undmg,
+  updateScript,
   lib,
 }:
 
@@ -37,7 +38,12 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru = { inherit updateScript; };
+
   meta = meta // {
-    maintainers = with lib.maintainers; [ matteopacini ];
+    maintainers = with lib.maintainers; [
+      matteopacini
+      Enzime
+    ];
   };
 }

--- a/pkgs/by-name/sp/spotify/darwin.nix
+++ b/pkgs/by-name/sp/spotify/darwin.nix
@@ -11,18 +11,18 @@
 stdenv.mkDerivation {
   inherit pname;
 
-  version = "1.2.40.599.g606b7f29";
+  version = "1.2.64.408";
 
   src =
     if stdenv.hostPlatform.isAarch64 then
       (fetchurl {
-        url = "https://web.archive.org/web/20240622065234/https://download.scdn.co/SpotifyARM64.dmg";
-        hash = "sha256-mmjxKYmsX0rFlIU19JOfPbNgOhlcZs5slLUhDhlON1c=";
+        url = "https://web.archive.org/web/20250522123639/https://download.scdn.co/SpotifyARM64.dmg";
+        hash = "sha256-28T+AxhnM1K6W50JUu9RdFRKsBRDTQulKK2+kk2RTMQ=";
       })
     else
       (fetchurl {
-        url = "https://web.archive.org/web/20240622065548/https://download.scdn.co/Spotify.dmg";
-        hash = "sha256-hvS0xnmJQoQfNJRFsLBQk8AJjDOzDy+OGwNOq5Ms/O0=";
+        url = "https://web.archive.org/web/20250522130546/https://download.scdn.co/Spotify.dmg";
+        hash = "sha256-P8itkT2w7xQl0WfMLcNHgi1zcoYMqOdGmNDXdwhZBUs=";
       });
 
   nativeBuildInputs = [ undmg ];

--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -44,6 +44,7 @@
   # High-DPI support: Spotify's --force-device-scale-factor argument
   # not added if `null`, otherwise, should be a number.
   deviceScaleFactor ? null,
+  updateScript,
 }:
 
 let
@@ -226,6 +227,8 @@ stdenv.mkDerivation {
 
     runHook postFixup
   '';
+
+  passthru = { inherit updateScript; };
 
   meta = meta // {
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
   # If an update breaks things, one of those might have valuable info:
   # https://aur.archlinux.org/packages/spotify/
   # https://community.spotify.com/t5/Desktop-Linux
-  version = "1.2.59.514.g834e17d4";
+  version = "1.2.60.564.gcc6305cb";
 
   # To get the latest stable revision:
   # curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/spotify?channel=stable' | jq '.download_url,.version,.last_updated'
@@ -113,7 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
   # curl -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/spotify' | jq '.'
   # More examples of api usage:
   # https://github.com/canonical-websites/snapcraft.io/blob/master/webapp/publisher/snaps/views.py
-  rev = "86";
+  rev = "87";
 
   # fetch from snapcraft instead of the debian repository most repos fetch from.
   # That is a bit more cumbersome. But the debian repository only keeps the last
@@ -126,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchurl {
     name = "spotify-${finalAttrs.version}-${finalAttrs.rev}.snap";
     url = "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_${finalAttrs.rev}.snap";
-    hash = "sha512-b9VlPwZ6JJ7Kt2p0ji1qtTJQHZE9d4KBO3iqQwsYh6k+ljtV/mSdinZi+B//Yb+KXhMErd0oaVzIpCCMqft6FQ==";
+    hash = "sha512-hdJOko/0EHkPiNgWO+WB3nP+0MO9D2fxgM/X/Ri6fM1ODJxz3XYY84Xf2Ru6iGqdA9XUNRcd/qi+Gfaj9Ez0Ug==";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -48,20 +48,6 @@
 }:
 
 let
-  # TO UPDATE: just execute the ./update.sh script (won't do anything if there is no update)
-  # "rev" decides what is actually being downloaded
-  # If an update breaks things, one of those might have valuable info:
-  # https://aur.archlinux.org/packages/spotify/
-  # https://community.spotify.com/t5/Desktop-Linux
-  version = "1.2.59.514.g834e17d4";
-  # To get the latest stable revision:
-  # curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/spotify?channel=stable' | jq '.download_url,.version,.last_updated'
-  # To get general information:
-  # curl -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/spotify' | jq '.'
-  # More examples of api usage:
-  # https://github.com/canonical-websites/snapcraft.io/blob/master/webapp/publisher/snaps/views.py
-  rev = "86";
-
   deps = [
     alsa-lib
     at-spi2-atk
@@ -110,11 +96,24 @@ let
     xorg.libXtst
     zlib
   ];
-
 in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname;
 
-stdenv.mkDerivation {
-  inherit pname version;
+  # TO UPDATE: just execute the ./update.sh script (won't do anything if there is no update)
+  # "rev" decides what is actually being downloaded
+  # If an update breaks things, one of those might have valuable info:
+  # https://aur.archlinux.org/packages/spotify/
+  # https://community.spotify.com/t5/Desktop-Linux
+  version = "1.2.59.514.g834e17d4";
+
+  # To get the latest stable revision:
+  # curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/spotify?channel=stable' | jq '.download_url,.version,.last_updated'
+  # To get general information:
+  # curl -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/spotify' | jq '.'
+  # More examples of api usage:
+  # https://github.com/canonical-websites/snapcraft.io/blob/master/webapp/publisher/snaps/views.py
+  rev = "86";
 
   # fetch from snapcraft instead of the debian repository most repos fetch from.
   # That is a bit more cumbersome. But the debian repository only keeps the last
@@ -125,8 +124,8 @@ stdenv.mkDerivation {
   # spotify ourselves:
   # https://community.spotify.com/t5/Desktop-Linux/Redistribute-Spotify-on-Linux-Distributions/td-p/1695334
   src = fetchurl {
-    name = "spotify-${version}-${rev}.snap";
-    url = "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_${rev}.snap";
+    name = "spotify-${finalAttrs.version}-${finalAttrs.rev}.snap";
+    url = "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_${finalAttrs.rev}.snap";
     hash = "sha512-b9VlPwZ6JJ7Kt2p0ji1qtTJQHZE9d4KBO3iqQwsYh6k+ljtV/mSdinZi+B//Yb+KXhMErd0oaVzIpCCMqft6FQ==";
   };
 
@@ -151,10 +150,10 @@ stdenv.mkDerivation {
       echo "You probably chose the wrong revision."
       exit 1
     fi
-    if ! grep -q '${version}' meta/snap.yaml; then
+    if ! grep -q '${finalAttrs.version}' meta/snap.yaml; then
       echo "Package version differs from version found in snap metadata:"
       grep 'version: ' meta/snap.yaml
-      echo "While the nix package specifies: ${version}."
+      echo "While the nix package specifies: ${finalAttrs.version}."
       echo "You probably chose the wrong revision or forgot to update the nix version."
       exit 1
     fi
@@ -238,4 +237,4 @@ stdenv.mkDerivation {
       ma27
     ];
   };
-}
+})

--- a/pkgs/by-name/sp/spotify/package.nix
+++ b/pkgs/by-name/sp/spotify/package.nix
@@ -10,6 +10,8 @@ let
 
   pname = "spotify";
 
+  updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://www.spotify.com/";
     description = "Play music from the Spotify music service";
@@ -25,6 +27,6 @@ let
 
 in
 if stdenv.hostPlatform.isDarwin then
-  callPackage ./darwin.nix (extraArgs // { inherit pname meta; })
+  callPackage ./darwin.nix (extraArgs // { inherit pname updateScript meta; })
 else
-  callPackage ./linux.nix (extraArgs // { inherit pname meta; })
+  callPackage ./linux.nix (extraArgs // { inherit pname updateScript meta; })

--- a/pkgs/by-name/sp/spotify/update.sh
+++ b/pkgs/by-name/sp/spotify/update.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash -p curl jq git gnused gnugrep
+#! nix-shell -i bash -p common-updater-scripts curl jq git gnused gnugrep libplist undmg
+set -euo pipefail
 
 
 # executing this script without arguments will
@@ -20,69 +21,96 @@
 
 channel="${1:-stable}" # stable/candidate/edge
 nixpkgs="$(git rev-parse --show-toplevel)"
-spotify_nix="$nixpkgs/pkgs/by-name/sp/spotify/linux.nix"
 
+update_linux() {
+  nix_file="$nixpkgs/pkgs/by-name/sp/spotify/linux.nix"
+  #
+  # find the newest stable spotify version available on snapcraft
+  #
 
-#
-# find the newest stable spotify version avaiable on snapcraft
-#
+  # create bash array from snap info
+  snap_info=($(
+    curl -s -H 'X-Ubuntu-Series: 16' \
+      "https://api.snapcraft.io/api/v1/snaps/details/spotify?channel=$channel" \
+    | jq --raw-output \
+      '.revision,.download_sha512,.version,.last_updated'
+  ))
 
-# create bash array from snap info
-snap_info=($(
-  curl -s -H 'X-Ubuntu-Series: 16' \
-    "https://api.snapcraft.io/api/v1/snaps/details/spotify?channel=$channel" \
-  | jq --raw-output \
-    '.revision,.download_sha512,.version,.last_updated'
-))
+  # "revision" is the actual version identifier on snapcraft, the "version" is
+  # just for human consumption. Revision is just an integer that gets increased
+  # by one every (stable or unstable) release.
+  revision="${snap_info[0]}"
+  # We need to escape the slashes
+  hash="$(nix-hash --to-sri --type sha512 ${snap_info[1]} | sed 's|/|\\/|g')"
+  upstream_version="${snap_info[2]}"
+  last_updated="${snap_info[3]}"
+  echo "Latest $channel release for Spotify on Linux is $upstream_version from $last_updated."
+  #
+  # read the current spotify version from the currently *committed* nix expression
+  #
 
-# "revision" is the actual version identifier on snapcraft, the "version" is
-# just for human consumption. Revision is just an integer that gets increased
-# by one every (stable or unstable) release.
-revision="${snap_info[0]}"
-# We need to escape the slashes
-hash="$(nix-hash --to-sri --type sha512 ${snap_info[1]} | sed 's|/|\\/|g')"
-upstream_version="${snap_info[2]}"
-last_updated="${snap_info[3]}"
-echo "Latest $channel release is $upstream_version from $last_updated."
-#
-# read the current spotify version from the currently *committed* nix expression
-#
+  current_nix_version=$(
+    grep 'version\s*=' "$nix_file" \
+    | sed -Ene 's/.*"(.*)".*/\1/p'
+  )
 
-current_nix_version=$(
-  grep 'version\s*=' "$spotify_nix" \
-  | sed -Ene 's/.*"(.*)".*/\1/p'
-)
+  echo "Current Spotify for Linux version in Nixpkgs: $current_nix_version"
 
-echo "Current nix version: $current_nix_version"
+  #
+  # update the nix expression if the versions differ
+  #
 
-#
-# update the nix expression if the versions differ
-#
+  if [[ "$current_nix_version" = "$upstream_version" ]]; then
+    echo "Spotify on Linux is already up-to-date"
+    return
+  fi
 
-if [[ "$current_nix_version" = "$upstream_version" ]]; then
-  echo "Spotify is already up-to-date"
-  exit 0
-fi
+  echo "Updating Spotify on Linux from ${current_nix_version} to ${upstream_version}, released on ${last_updated}"
 
-echo "Updating from ${current_nix_version} to ${upstream_version}, released on ${last_updated}"
+  # search-and-replace revision, hash and version
+  sed --regexp-extended \
+    -e 's/rev\s*=\s*"[0-9]+"\s*;/rev = "'"${revision}"'";/' \
+    -e 's/hash\s*=\s*"[^"]*"\s*;/hash = "'"${hash}"'";/' \
+    -e 's/version\s*=\s*".*"\s*;/version = "'"${upstream_version}"'";/' \
+    -i "$nix_file"
+}
 
-# search-and-replace revision, hash and version
-sed --regexp-extended \
-  -e 's/rev\s*=\s*"[0-9]+"\s*;/rev = "'"${revision}"'";/' \
-  -e 's/hash\s*=\s*"[^"]*"\s*;/hash = "'"${hash}"'";/' \
-  -e 's/version\s*=\s*".*"\s*;/version = "'"${upstream_version}"'";/' \
-  -i "$spotify_nix"
+update_macos() {
+  nix_file="$nixpkgs/pkgs/by-name/sp/spotify/darwin.nix"
 
-#
-# try to build the updated version
-#
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "$tmp_dir"' EXIT
 
-export NIXPKGS_ALLOW_UNFREE=1
-if ! nix-build -A spotify "$nixpkgs"; then
-  echo "The updated spotify failed to build."
-  exit 1
-fi
+  pushd $tmp_dir
 
-# Commit changes
-git add "$spotify_nix"
-git commit -m "spotify: ${current_nix_version} -> ${upstream_version}"
+  x86_64_url="https://download.scdn.co/Spotify.dmg"
+  aarch64_url="https://download.scdn.co/SpotifyARM64.dmg"
+
+  curl -OL $aarch64_url
+  undmg SpotifyARM64.dmg
+  upstream_version=$(plistutil -i Spotify.app/Contents/Info.plist -f json -o - | jq -r '.CFBundleVersion')
+
+  popd
+
+  current_nix_version=$(
+    grep 'version\s*=' "$nix_file" \
+    | sed -Ene 's/.*"(.*)".*/\1/p'
+  )
+
+  if [[ "$current_nix_version" != "$upstream_version" ]]; then
+    archive_url="https://web.archive.org/save"
+    archived_x86_64_url=$(curl -s -I -L -o /dev/null "$archive_url/$x86_64_url" -w '%{url_effective}')
+    archived_aarch64_url=$(curl -s -I -L -o /dev/null "$archive_url/$aarch64_url" -w '%{url_effective}')
+
+    update-source-version "pkgsCross.x86_64-darwin.spotify" "$upstream_version" "" "$archived_x86_64_url" \
+      --file=$nix_file \
+      --ignore-same-version
+
+    update-source-version "pkgsCross.aarch64-darwin.spotify" "$upstream_version" "" "$archived_aarch64_url" \
+      --file=$nix_file \
+      --ignore-same-version
+  fi
+}
+
+update_linux
+update_macos


### PR DESCRIPTION
- spotify: set `passthru.updateScript`
- spotify: add macOS support to update script
- spotify/linux: allow overriding `version` and `rev`
- spotify/linux: 1.2.59.514.g834e17d4 -> 1.2.60.564.gcc6305cb
- spotify/darwin: 1.2.40.599.g606b7f29 -> 1.2.64.408

The current version of Spotify on macOS in Nixpkgs is so old that the search no longer works

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
