### PR TITLE
ndstrim: remove workaround

### DIFF
--- a/pkgs/by-name/nd/ndstrim/package.nix
+++ b/pkgs/by-name/nd/ndstrim/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   rustPlatform,
 }:
 
@@ -16,30 +15,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-KgtejBbFg6+klc8OpCs1CIb+7uVPCtP0/EM671vxauk=";
   };
 
-  patches = [
-    # https://github.com/Nemris/ndstrim/pull/1
-    (fetchpatch {
-      name = "update-cargo-lock.patch";
-      url = "https://github.com/Nemris/ndstrim/commit/8147bb31a8fb5765f33562957a61cb6ddbe65513.patch";
-      hash = "sha256-HsCc5un9dg0gRkRjwxtjms0cugqWhcTthGfcF50EgYA=";
-    })
-  ];
-
   useFetchCargoVendor = true;
   cargoHash = "sha256-wRMMWeZDk9Xt3263pq20Qioy1x8egiPhuoPxmpNTq8M=";
-
-  # TODO: remove this after upstream merge above patch.
-  # Without the workaround below the build results in the following error:
-  # Validating consistency between /build/source/Cargo.lock and /build/ndstrim-0.2.1-vendor.tar.gz/Cargo.lock
-  # <hash>
-  # < version = "0.2.1"
-  # ---
-  # > version = "0.1.0"
-  #
-  # ERROR: cargoHash or cargoSha256 is out of date
-  postPatch = ''
-    cargoSetupPostPatchHook() { true; }
-  '';
 
   meta = with lib; {
     description = "Trim the excess padding found in Nintendo DS(i) ROMs";


### PR DESCRIPTION
When this workaround was added, `cargoBuildHook` still passed `--frozen` as a build flag, meaning that outdated lockfiles were a no-go.
It has since been replaced with just the `--offline` flag, which is less strict.

If we wanted to keep the patch, and just get rid of the weird `cargoSetupPostPatchHook` workaround, we can just place patch inside `cargoPatches` instead of just the normal `patches`.

Since it doesn't really matter whether we keep the patch or not (since it acts the same), I opted to remove it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
