### PR TITLE
stdenv: Add CPE fields to meta

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -225,6 +225,12 @@
   "sec-language-cosmic": [
     "index.html#sec-language-cosmic"
   ],
+  "sec-meta-identifiers": [
+    "index.html#sec-meta-identifiers"
+  ],
+  "sec-meta-identifiers-cpe": [
+    "index.html#sec-meta-identifiers-cpe"
+  ],
   "sec-modify-via-packageOverrides": [
     "index.html#sec-modify-via-packageOverrides"
   ],
@@ -621,6 +627,15 @@
   ],
   "typst-package-scope-and-usage": [
     "index.html#typst-package-scope-and-usage"
+  ],
+  "var-meta-identifiers-cpe": [
+    "index.html#var-meta-identifiers-cpe"
+  ],
+  "var-meta-identifiers-cpeParts": [
+    "index.html#var-meta-identifiers-cpeParts"
+  ],
+  "var-meta-identifiers-possibleCPEs": [
+    "index.html#var-meta-identifiers-possibleCPEs"
   ],
   "var-meta-teams": [
     "index.html#var-meta-teams"

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -248,3 +248,74 @@ Code to be executed on a peripheral device or embedded controller, built by a th
 ### `lib.sourceTypes.binaryBytecode` {#lib.sourceTypes.binaryBytecode}
 
 Code to run on a VM interpreter or JIT compiled into bytecode by a third party. This includes packages which download Java `.jar` files from another source.
+
+## Software identifiers {#sec-meta-identifiers}
+
+Package's `meta.identifiers` attribute specifies information about software identifiers associated with this package. Software identifiers are used, for example:
+* to generate Software Bill of Materials (SBOM) that lists all components used to build the software, which can later be used to perform vulnerability or license analysis of the resulting software;
+* to lookup software in different vulnerability databases or report new vulnerabilities to them.
+
+Overriding the default `meta.identifiers` attribute is optional, but it is recommended to fill in pieces to help tools mentioned above get precise data.
+For example, we could get automatic notifications about potential vulnerabilities for users in the future.
+All identifiers specified in `meta.identifiers` are expected to be unambiguous and valid.
+
+`meta.identifiers` contains `v1` attribute which is an attribute set that guarantees backward compatibility of its constituents. Right now it contains copies of all other attributes in `meta.identifiers`.
+
+### CPE {#sec-meta-identifiers-cpe}
+
+Common Platform Enumeration (CPE) is a specification maintained by NIST as part of the Security Content Automation Protocol (SCAP). It is used to identify software in National Vulnerabilities Database (NVD, https://nvd.nist.gov) and other vulnerability databases.
+
+Current version of CPE 2.3 consists of 13 parts:
+
+```
+cpe:2.3:a:<vendor>:<product>:<version>:<update>:<edition>:<language>:<sw_edition>:<target_sw>:<target_hw>:<other>
+```
+
+Some of them are as follows:
+
+* *CPE version* - current version of CPE is `2.3`
+* *part* - usually in Nixpkgs `a` for "application", can also be `o` for "operating system" or `h` for "hardware"
+* *vendor* - can point to the source of the package, or to Nixpkgs itself
+* *product* - name of the package
+* *version* - version of the package
+* *update* - name of the latest update, can be a patch version for semantically versioned packages
+* *edition* - any additional specification about the version
+
+You can find information about all of these attributes in the [official specification](https://csrc.nist.gov/projects/security-content-automation-protocol/specifications/cpe/naming) (heading 5.3.3, pages 11-13).
+
+Any fields that don't have a value are set to either `-` if the value is not available or `*` when the field can match any value.
+
+For example, for glibc 2.40.1 CPE would be `cpe:2.3:a:gnu:glibc:2.40:1:*:*:*:*:*:*`.
+
+#### `meta.identifiers.cpeParts` {#var-meta-identifiers-cpeParts}
+
+This attribute contains an attribute set of all parts of the CPE for this package. Most of the parts default to `*` (match any value), with some exceptions:
+
+* `part` defaults to `a` (application), can also be set to `o` for operating systems, for example, Linux kernel, or to `h` for hardware
+* `vendor` cannot be deduced from other sources, so it must be specified by the package author
+* `product` defaults to provided derivation's `pname` attribute and must be provided explicitly if `pname` is missing
+* `version` and `update` have no defaults and should be specified explicitly or using helper functions, when missing, `cpe` attribute will be empty, and all possible guesses using helper functions will be in `possibleCPEs` attribute.
+
+It is up to the package author to make sure all parts are correct and match expected values in [NVD dictionary](https://nvd.nist.gov/products/cpe). Unknown values can be skipped, which would leave them with the default value of `*`.
+
+Following functions help with filling out `version` and `update` fields:
+
+* [`lib.meta.cpeFullVersionWithVendor`](#function-library-lib.meta.cpeFullVersionWithVendor)
+* [`lib.meta.cpePatchVersionInUpdateWithVendor`](#function-library-lib.meta.cpePatchVersionInUpdateWithVendor)
+
+For many packages to make CPE available it should be enough to specify only:
+
+```nix
+{
+  # ...
+  meta.identifiers.cpeParts = lib.meta.cpePatchVersionInUpdateWithVendor vendor version;
+}
+```
+
+#### `meta.identifiers.cpe` {#var-meta-identifiers-cpe}
+
+A readonly attribute that concatenates all CPE parts in one string.
+
+#### `meta.identifiers.possibleCPEs` {#var-meta-identifiers-possibleCPEs}
+
+A readonly attribute containing the list of guesses for what CPE for this package can look like. It includes all variants of version handling mentioned above. Each item is an attrset with attributes `cpeParts` and `cpe` for each guess.

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -15,7 +15,12 @@ let
     assertMsg
     ;
   inherit (lib.attrsets) mapAttrs' filterAttrs;
-  inherit (builtins) isString match typeOf;
+  inherit (builtins)
+    isString
+    match
+    typeOf
+    elemAt
+    ;
 
 in
 rec {
@@ -484,4 +489,186 @@ rec {
     assert assertMsg (match ".*/.*" y == null)
       "lib.meta.getExe': The second argument \"${y}\" is a nested path with a \"/\" character, but it should just be the name of the executable instead.";
     "${getBin x}/bin/${y}";
+
+  /**
+    Generate [CPE parts](#var-meta-identifiers-cpeParts) from inputs. Copies `vendor` and `version` to the output, and sets `update` to `*`.
+
+    # Inputs
+
+    `vendor`
+
+    : package's vendor
+
+    `version`
+
+    : package's version
+
+    # Type
+
+    ```
+    cpeFullVersionWithVendor :: string -> string -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.meta.cpeFullVersionWithVendor` usage example
+
+    ```nix
+    lib.meta.cpeFullVersionWithVendor "gnu" "1.2.3"
+    => {
+      vendor = "gnu";
+      version = "1.2.3";
+      update = "*";
+    }
+    ```
+
+    :::
+    :::{.example}
+    ## `lib.meta.cpeFullVersionWithVendor` usage in derivations
+
+    ```nix
+    mkDerivation rec {
+      version = "1.2.3";
+      # ...
+      meta = {
+        # ...
+        identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version;
+      };
+    }
+    ```
+    :::
+  */
+  cpeFullVersionWithVendor = vendor: version: {
+    inherit vendor version;
+    update = "*";
+  };
+
+  /**
+    Alternate version of [`lib.meta.cpePatchVersionInUpdateWithVendor`](#function-library-lib.meta.cpePatchVersionInUpdateWithVendor).
+    If `cpePatchVersionInUpdateWithVendor` succeeds, returns an attribute set with `success` set to `true` and `value` set to the result.
+    Otherwise, `success` is set to `false` and `error` is set to the string representation of the error.
+
+    # Inputs
+
+    `vendor`
+
+    : package's vendor
+
+    `version`
+
+    : package's version
+
+    # Type
+
+    ```
+    tryCPEPatchVersionInUpdateWithVendor :: string -> string -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.meta.tryCPEPatchVersionInUpdateWithVendor` usage example
+
+    ```nix
+    lib.meta.tryCPEPatchVersionInUpdateWithVendor "gnu" "1.2.3"
+    => {
+      success = true;
+      value = {
+        vendor = "gnu";
+        version = "1.2";
+        update = "3";
+      };
+    }
+    ```
+
+    :::
+    :::{.example}
+    ## `lib.meta.cpePatchVersionInUpdateWithVendor` error example
+
+    ```nix
+    lib.meta.tryCPEPatchVersionInUpdateWithVendor "gnu" "5.3p0"
+    => {
+      success = false;
+      error = "version 5.3p0 doesn't match regex `([0-9]+\\.[0-9]+)\\.([0-9]+)`";
+    }
+    ```
+
+    :::
+  */
+  tryCPEPatchVersionInUpdateWithVendor =
+    vendor: version:
+    let
+      regex = "([0-9]+\\.[0-9]+)\\.([0-9]+)";
+      # we have to call toString here in case version is an attrset with __toString attribute
+      versionMatch = builtins.match regex (toString version);
+    in
+    if versionMatch == null then
+      {
+        success = false;
+        error = "version ${version} doesn't match regex `${regex}`";
+      }
+    else
+      {
+        success = true;
+        value = {
+          inherit vendor;
+          version = elemAt versionMatch 0;
+          update = elemAt versionMatch 1;
+        };
+      };
+
+  /**
+    Generate [CPE parts](#var-meta-identifiers-cpeParts) from inputs. Copies `vendor` to the result. When `version` matches `X.Y.Z` where all parts are numerical, sets `version` and `update` fields to `X.Y` and `Z`. Throws an error if the version doesn't match the expected template.
+
+    # Inputs
+
+    `vendor`
+
+    : package's vendor
+
+    `version`
+
+    : package's version
+
+    # Type
+
+    ```
+    cpePatchVersionInUpdateWithVendor :: string -> string -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.meta.cpePatchVersionInUpdateWithVendor` usage example
+
+    ```nix
+    lib.meta.cpePatchVersionInUpdateWithVendor "gnu" "1.2.3"
+    => {
+      vendor = "gnu";
+      version = "1.2";
+      update = "3";
+    }
+    ```
+
+    :::
+    :::{.example}
+    ## `lib.meta.cpePatchVersionInUpdateWithVendor` usage in derivations
+
+    ```nix
+    mkDerivation rec {
+      version = "1.2.3";
+      # ...
+      meta = {
+        # ...
+        identifiers.cpeParts = lib.meta.cpePatchVersionInUpdateWithVendor "gnu" version;
+      };
+    }
+    ```
+
+    :::
+  */
+  cpePatchVersionInUpdateWithVendor =
+    vendor: version:
+    let
+      result = tryCPEPatchVersionInUpdateWithVendor vendor version;
+    in
+    if result.success then result.value else throw result.error;
 }

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -85,5 +85,10 @@ stdenv.mkDerivation rec {
       ivan
     ];
     platforms = platforms.unix;
+    identifiers.cpeParts = {
+      vendor = "samba";
+      inherit version;
+      update = "-";
+    };
   };
 }

--- a/pkgs/by-name/he/hello/package.nix
+++ b/pkgs/by-name/he/hello/package.nix
@@ -55,5 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ stv0g ];
     mainProgram = "hello";
     platforms = lib.platforms.all;
+    identifiers.cpeParts.vendor = "gnu";
   };
 })

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -30,4 +30,5 @@ in
   teams = [ teams.gcc ];
   mainProgram = "${targetPrefix}gcc";
 
+  identifiers.cpeParts.vendor = "gnu";
 }

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -419,6 +419,7 @@ pipe
           platforms
           teams
           mainProgram
+          identifiers
           ;
       };
     }

--- a/pkgs/development/compilers/llvm/common/common-let.nix
+++ b/pkgs/development/compilers/llvm/common/common-let.nix
@@ -34,6 +34,8 @@ rec {
       ++ lib.optionals (lib.versionAtLeast release_version "7") lib.platforms.riscv
       ++ lib.optionals (lib.versionAtLeast release_version "14") lib.platforms.m68k
       ++ lib.optionals (lib.versionAtLeast release_version "16") lib.platforms.loongarch64;
+
+    identifiers.cpeParts.vendor = "llvm";
   };
 
   releaseInfo =

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -540,6 +540,13 @@ lib.makeOverridable (
             ]
             ++ lib.optional (lib.versionOlder version "5.19") "loongarch64-linux";
           timeout = 14400; # 4 hours
+          identifiers.cpeParts = {
+            part = "o";
+            vendor = "linux";
+            product = "linux_kernel";
+            inherit version;
+            update = "*";
+          };
         }
         // extraMeta;
       };

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -183,5 +183,15 @@ lib.warnIf (withDocs != null)
       badPlatforms = [ lib.systems.inspect.patterns.isMinGW ];
       maintainers = [ ];
       mainProgram = "bash";
+      identifiers.cpeParts =
+        let
+          versionSplit = lib.split "p" version;
+        in
+        {
+          vendor = "gnu";
+          product = "bash";
+          version = lib.elemAt versionSplit 0;
+          update = lib.elemAt versionSplit 2;
+        };
     };
   }

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -11,6 +11,7 @@ let
   inherit (lib)
     all
     attrNames
+    attrValues
     concatMapStrings
     concatMapStringsSep
     concatStrings
@@ -37,6 +38,8 @@ let
 
   inherit (lib.meta)
     availableOn
+    cpeFullVersionWithVendor
+    tryCPEPatchVersionInUpdateWithVendor
     ;
 
   inherit (lib.generators)
@@ -437,6 +440,8 @@ let
       # Used for the original location of the maintainer and team attributes to assist with pings.
       maintainersPosition = any;
       teamsPosition = any;
+
+      identifiers = attrs;
     };
 
   checkMetaAttr =
@@ -570,6 +575,19 @@ let
     else
       validYes;
 
+  # Helper functions and declarations to handle identifiers, extracted to reduce allocations
+  hasAllCPEParts = cpeParts: !any isNull (attrValues cpeParts);
+  makeCPE =
+    cpeParts:
+    "cpe:2.3:${cpeParts.part}:${cpeParts.vendor}:${cpeParts.product}:${cpeParts.version}:${cpeParts.update}:${cpeParts.edition}:${cpeParts.sw_edition}:${cpeParts.target_sw}:${cpeParts.target_hw}:${cpeParts.language}:${cpeParts.other}";
+  possibleCPEPartsFuns = [
+    (vendor: version: {
+      success = true;
+      value = cpeFullVersionWithVendor vendor version;
+    })
+    tryCPEPatchVersionInUpdateWithVendor
+  ];
+
   # The meta attribute is passed in the resulting attribute set,
   # but it's not part of the actual derivation, i.e., it's not
   # passed to the builder and is not a dependency.  But since we
@@ -633,6 +651,51 @@ let
       # if you add a new maintainer or team attribute please ensure that this expectation is still met.
       maintainers =
         attrs.meta.maintainers or [ ] ++ concatMap (team: team.members or [ ]) attrs.meta.teams or [ ];
+
+      identifiers =
+        let
+          defaultCPEParts = {
+            part = "a";
+            vendor = null;
+            product = attrs.pname or null;
+            version = null;
+            update = null;
+            edition = "*";
+            sw_edition = "*";
+            target_sw = "*";
+            target_hw = "*";
+            language = "*";
+            other = "*";
+          };
+
+          cpeParts = defaultCPEParts // attrs.meta.identifiers.cpeParts or { };
+          cpe = if hasAllCPEParts cpeParts then makeCPE cpeParts else null;
+
+          possibleCPEs =
+            if cpe != null then
+              [ { inherit cpeParts cpe; } ]
+            else if attrs.meta.identifiers.cpeParts.vendor or null == null || attrs.version or null == null then
+              [ ]
+            else
+              concatMap (
+                f:
+                let
+                  result = f attrs.meta.identifiers.cpeParts.vendor attrs.version;
+                  # Note that attrs.meta.identifiers.cpeParts at this point can include defaults with user overrides.
+                  # Since we can't split them apart, user overrides don't apply to possibleCPEs.
+                  guessedParts = cpeParts // result.value;
+                in
+                optional (result.success && (hasAllCPEParts guessedParts)) {
+                  cpeParts = guessedParts;
+                  cpe = (makeCPE guessedParts);
+                }
+              ) possibleCPEPartsFuns;
+          v1 = { inherit cpeParts cpe possibleCPEs; };
+        in
+        v1
+        // {
+          inherit v1;
+        };
 
       # Expose the result of the checks for everyone to see.
       unfree = hasUnfreeLicense attrs;


### PR DESCRIPTION
Add `identifiers` attr to `meta` attribute with following attrs:

* `cpe` with the full CPE string when available
* `cpeParts` with the destructured CPE string, allowing to override it whenever needed
* `v1` attribute set with `cpe` and `cpeParts` from above and a guarantee of a backwards-compatible interface

Also add `vendor` part as an example to packages: `hello`, `gcc`, `clang`.

Related issue: https://github.com/NixOS/nixpkgs/issues/354012

This is the first step towards adding software identifiers to Nixpkgs. See [issue](https://github.com/NixOS/nixpkgs/issues/354012) for the discussion.

Here's my summary of the discussion and decisions made here:

<details>

<summary>Proposal</summary>

## Interested actors

* Nixpkgs authors
  * want to provide necessary details with as little effort as possible
* Nixpkgs consumers
  * want to be able to use external tools to find known vulnerabilities
* Tools
  * SBOM generators (bombon, sbomnix)
    * want to use less heuristic, more precision for identifiers in generated SBOMs
  * Security tracker
    * wants to match identifiers against external vulnerability databases, avoid heuristics
    * wants to provide tools to enrich Nixpkgs with more data and more precision (detect inconsistencies, generate PRs)
    * wants to become a point of contact with external vulnerability databases, providing them with more data

## Options

### Identifier types

It seems that the most common identifier formats are CPE and PURL.

#### CPE

CPE comes from NIST, with the official list of CPE names maintained in NVD.

CPE looks like `cpe:2.3:a:gnu:glibc:2.40:1::::::` with parts meaning:

* *CPE version* - current version of CPE is `2.3`
* *part* - `a` for "application"
* *vendor* - can point to the source of the package, or to Nixpkgs itself
* *product* - name of the package
* *version* - version of the package
* *update* - name of the latest update, can be a patch version as in the example
* *edition* - any additional specification about the version
* many more fields that seem to be generally unused for software

CPE allows to be very specific, but requires knowledge about vendor and the versioning process of the software to match NVD data.

NVD attaches CPE identifiers to CVE entries, but this mapping is by no means full. Some CVE entries have no CPE, some have strangely formatted ones.

If we maintain a good list of CPE identifiers of our own, we could influence NVD to make CVE database better in this regard.

#### PURL

PURL stand for "package URL" (not "persistent URL" from 1990s). They are [adopted](https://github.com/package-url/purl-spec/blob/main/ADOPTERS.rst) by many SBOM replated tools and [OSV database](https://osv.dev/).

PURLs look like `pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie`, with mandatory parts:

* `pkg:` is the URL schema
* *type* - comes from the [list of known PURL types](https://github.com/package-url/purl-spec/blob/main/PURL-TYPES.rst) and defines what namespace and qualifiers mean.
* *namespace* - whatever the type requires, for example, it can be empty or point to a specific repository
* *name* - name of the package
* *version* - version of the package, in type specific format
* *qualifiers* - depend on the type

While PURLs are less specific, they can be derived completely from the information about package sources.

### Structuring

We can write and present identifiers either just as a whole string (e.g. in `hello.meta.cpe` or `hello.meta.purl`), providing authors with functions to generate appropriate values, for example:

```
drv = stdenv.mkDerivation (finalAttrs: {
  pname = "foo";
  version = "1.2.3";
  ...
  meta.cpe = lib.mkCPE finalAttrs {vendor = "foo_upstream";};
})

drv.meta.cpe => "cpe:2.3:a:foo_upstream:foo:1.2:3::::::"
```

The other option is to destructure these values both on input and on output and make all generation logic implicit in `mkDerivation`, for example:

```
drv = stdenv.mkDerivation (finalAttrs: {
  pname = "foo";
  version = "1.2.3";
  ...
  meta.cpeParts.vendor = "foo_upstream";
})

drv.meta.cpe => "cpe:2.3:a:foo_upstream:foo:1.2:3::::::"
drv.meta.cpeParts => {
  vendor = "foo_upstream";
  product = "foo";
  version = "1.2";
  update = "3";
}
```

In both cases Nixpkgs authors would be able to provide just the information that cannot be correctly derived from other arguments.

Consumers that want to match these identifiers against upstream databases would only need the final identifier available. However, in cases when direct matching doesn't yield gooed enough results, they might rely on heuristics that require identifier's consituent parts. Both formats are easy to parse, but it can be benefitial to not have to do this additional step.

Tools like Security Tracker want to be able to update these identifiers in Nixpkgs. Finding the place to edit necessary part seems to be easier in the second example.

### Versioning

Consumers that have to support multiple versions of Nixpkgs, want to distinguish which set of fields they can expect to read and write in Nixpkgs. Currently this is not supported anywhere, but we could start with namespacing package identifiers with their own version. For example:

```
drv = stdenv.mkDerivation (finalAttrs: {
  pname = "foo";
  version = "1.2.3";
  ...
  meta.tracking-information.v1.cpeParts.vendor = "foo_upstream";
})

drv.meta.tracking-information.v1.cpe => "cpe:2.3:a:foo_upstream:foo:1.2:3::::::"
```

Note that this forces versioning on Nixpkgs authors as well as consumers, which increases cognitive load while writing package definitions (which version do I need to write? are there other versions? what do I need to do to support them?). Neither Nixpkgs authors nor "single-version" Nixpkgs consumers (ones that don't collect data over multiple Nixpkgs versions) benefit from such versioning.

We could provide a stable versioned output for this information while keeping input simple:

```
drv = stdenv.mkDerivation (finalAttrs: {
  pname = "foo";
  version = "1.2.3";
  ...
  meta.tracking-information.cpeParts.vendor = "foo_upstream";
})

drv.meta.tracking-information.cpe => "cpe:2.3:a:foo_upstream:foo:1.2:3::::::"
drv.meta.tracking-information.v1.cpe => "cpe:2.3:a:foo_upstream:foo:1.2:3::::::"
```

In this example `tracking-information.v1` would be always backwards-compatible, providing fields like `cpe`, `cpeParts`, `purl`, `purlParts` and possible some new ones in the future.

</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
