### PR TITLE
Xfce updates 2025-05-22

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-3uW8wFZrotyVucO0yt1eizuyeYpUoqjYZScIkV/kXVA=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     gettext
     meson

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin/default.nix
@@ -1,20 +1,39 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
   glib,
   gtk3,
   libxfce4ui,
   libxfce4util,
   xfce4-panel,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "panel-plugins";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-netload-plugin";
-  version = "1.4.2";
-  rev-prefix = "xfce4-netload-plugin-";
-  odd-unstable = false;
-  sha256 = "sha256-g4pkNzggVjC0AuUnJeleR3RQCrneetjDyv8eCXmrYzI=";
+  version = "1.5.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "panel-plugins";
+    repo = "xfce4-netload-plugin";
+    tag = "xfce4-netload-plugin-${finalAttrs.version}";
+    hash = "sha256-iZnfPCOHg0+eo8ubfIsweH2T/DSLeL2Q+giWK/Vkpko=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
+  ];
 
   buildInputs = [
     glib
@@ -24,8 +43,13 @@ mkXfceDerivation {
     xfce4-panel
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "xfce4-netload-plugin-"; };
+
+  meta = {
     description = "Internet load speed plugin for Xfce4 panel";
-    teams = [ teams.xfce ];
+    homepage = "https://gitlab.xfce.org/panel-plugins/xfce4-netload-plugin";
+    license = lib.licenses.gpl2Plus;
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin/default.nix
@@ -1,7 +1,13 @@
 {
-  mkXfceDerivation,
+  stdenv,
   lib,
+  fetchFromGitLab,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
   vala,
+  wrapGAppsHook3,
   glib,
   gtk3,
   gtksourceview4,
@@ -9,17 +15,30 @@
   libxfce4util,
   xfce4-panel,
   xfconf,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "panel-plugins";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-notes-plugin";
-  version = "1.11.2";
-  sha256 = "sha256-qORKaqpLVPIB5t1JtClP3Ey8yBTKY46YsMIc/fGV688=";
-  odd-unstable = false;
+  version = "1.12.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "panel-plugins";
+    repo = "xfce4-notes-plugin";
+    tag = "xfce4-notes-plugin-${finalAttrs.version}";
+    hash = "sha256-q8XQSLhnD7rnRfmNEunc4rKpFSWg9Ja4W7fs5lrnhZ0=";
+  };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
     vala
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -32,11 +51,13 @@ mkXfceDerivation {
     xfconf
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "xfce4-notes-plugin-"; };
+
+  meta = {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-notes-plugin";
     description = "Sticky notes plugin for Xfce panel";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-    teams = [ teams.xfce ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin/default.nix
@@ -3,73 +3,70 @@
   lib,
   fetchurl,
   gettext,
+  meson,
+  ninja,
   pkg-config,
+  wrapGAppsHook3,
+  glib,
   gtk3,
+  libX11,
+  libXext,
   libxfce4ui,
   libxfce4util,
   xfce4-panel,
   libnotify,
   lm_sensors,
-  hddtemp,
-  netcat-gnu,
   libXNVCtrl,
   nvidiaSupport ? lib.meta.availableOn stdenv.hostPlatform libXNVCtrl,
   gitUpdater,
 }:
 
-let
-  category = "panel-plugins";
-in
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-sensors-plugin";
-  version = "1.4.5";
+  version = "1.5.0";
 
   src = fetchurl {
-    url = "mirror://xfce/src/${category}/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-9p/febf3bSqBckgoEkpvznaAOpEipMgt6PPfo++7F5o=";
+    url = "mirror://xfce/src/panel-plugins/xfce4-sensors-plugin/${lib.versions.majorMinor finalAttrs.version}/xfce4-sensors-plugin-${finalAttrs.version}.tar.xz";
+    hash = "sha256-hARCuH/d3NhZW9n4Pqi4H3cf4pa7nSq/Dhl54ghyeuk=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     gettext
+    meson
+    ninja
     pkg-config
+    wrapGAppsHook3
   ];
 
   buildInputs = [
+    glib
     gtk3
+    libX11
+    libXext
     libxfce4ui
     libxfce4util
     xfce4-panel
     libnotify
     lm_sensors
-    hddtemp
-    netcat-gnu
   ] ++ lib.optionals nvidiaSupport [ libXNVCtrl ];
 
-  enableParallelBuilding = true;
-
-  configureFlags =
-    [
-      "--with-pathhddtemp=${hddtemp}/bin/hddtemp"
-      "--with-pathnetcat=${netcat-gnu}/bin/netcat"
-    ]
-    ++ lib.optionals nvidiaSupport [
-      # Have to be explicitly enabled since this tries to figure out the default
-      # based on the existence of a hardcoded `/usr/include/NVCtrl` path.
-      "--enable-xnvctrl"
-    ];
+  mesonFlags = [
+    (lib.mesonEnable "xnvctrl" nvidiaSupport)
+  ];
 
   passthru.updateScript = gitUpdater {
-    url = "https://gitlab.xfce.org/panel-plugins/${pname}";
-    rev-prefix = "${pname}-";
+    url = "https://gitlab.xfce.org/panel-plugins/xfce4-sensors-plugin";
+    rev-prefix = "xfce4-sensors-plugin-";
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-sensors-plugin";
     description = "Panel plug-in for different sensors using acpi, lm_sensors and hddtemp";
     mainProgram = "xfce4-sensors";
-    license = licenses.gpl2Plus;
-    platforms = platforms.unix;
-    teams = [ teams.xfce ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin/default.nix
@@ -3,50 +3,59 @@
   stdenv,
   fetchurl,
   gettext,
+  meson,
+  ninja,
   pkg-config,
   xfce4-panel,
+  glib,
+  gtk3,
   libgtop,
   libxfce4ui,
+  libxfce4util,
   upower,
   xfconf,
   gitUpdater,
 }:
 
-let
-  category = "panel-plugins";
-in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-systemload-plugin";
-  version = "1.3.3";
+  version = "1.4.0";
 
   src = fetchurl {
-    url = "mirror://xfce/src/${category}/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-aFLV2cmnTQ4NtYLG9f5zkOvkii61aSF3rhLhxMzG78k=";
+    url = "mirror://xfce/src/panel-plugins/xfce4-systemload-plugin/${lib.versions.majorMinor finalAttrs.version}/xfce4-systemload-plugin-${finalAttrs.version}.tar.xz";
+    hash = "sha256-bjY7z4RbuIMptShY1loexuANtRIa6SRuRusDE12VacY=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     gettext
+    meson
+    ninja
     pkg-config
   ];
 
   buildInputs = [
+    glib
+    gtk3
     libgtop
     libxfce4ui
+    libxfce4util
     upower
     xfce4-panel
     xfconf
   ];
 
   passthru.updateScript = gitUpdater {
-    url = "https://gitlab.xfce.org/panel-plugins/${pname}";
-    rev-prefix = "${pname}-";
+    url = "https://gitlab.xfce.org/panel-plugins/xfce4-systemload-plugin";
+    rev-prefix = "xfce4-systemload-plugin-";
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-systemload-plugin";
     description = "System load plugin for Xfce panel";
-    license = licenses.bsd2;
-    platforms = platforms.linux;
-    teams = [ teams.xfce ];
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.xfce ];
   };
-}
+})

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-time-out-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-time-out-plugin/default.nix
@@ -1,34 +1,57 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
   glib,
   gtk3,
+  libX11,
   libxfce4ui,
   libxfce4util,
   xfce4-panel,
-  xfconf,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "panel-plugins";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-time-out-plugin";
-  version = "1.1.4";
-  rev-prefix = "xfce4-time-out-plugin-";
-  odd-unstable = false;
-  sha256 = "sha256-FYcmeOBSBxcPSm/4j294DSi8XZBTKHvAwTBdj0yCY7o=";
+  version = "1.2.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "panel-plugins";
+    repo = "xfce4-time-out-plugin";
+    tag = "xfce4-time-out-plugin-${finalAttrs.version}";
+    hash = "sha256-hyeqSnynsjAeD67oPjQs0ZeLKreXFMZXmvu38zweqrE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
+  ];
 
   buildInputs = [
     glib
     gtk3
+    libX11
     libxfce4ui
     libxfce4util
     xfce4-panel
-    xfconf
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "xfce4-time-out-plugin-"; };
+
+  meta = {
     description = "Panel plug-in to take periodical breaks from the computer";
-    license = licenses.gpl2Plus;
-    teams = [ teams.xfce ];
+    homepage = "https://gitlab.xfce.org/panel-plugins/xfce4-time-out-plugin";
+    license = lib.licenses.gpl2Plus;
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
It look me months to [port all panel-plugins to meson](https://github.com/search?q=org%3Axfce-mirror+Add+meson+build+author%3Abobby285271&type=commits) on upstream but everything are released within a day. Since I package stuff from scratch, I will likely do 5-6 packages per day due to my limited availability.

If you find a regression, when opening issues on upstream please also leave a comment here.

The 5 plugins today:

<img src="https://github.com/user-attachments/assets/a2196b4f-df2b-44c9-bbee-4fd6a5b4e49a" width=50%>


Previous:

- https://github.com/NixOS/nixpkgs/pull/409074
- https://github.com/NixOS/nixpkgs/pull/409413

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

