### PR TITLE
bitsnpicas: init at 2.1

### DIFF
--- a/pkgs/by-name/bi/bitsnpicas/package.nix
+++ b/pkgs/by-name/bi/bitsnpicas/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  jdk,
+  jre,
+  zip,
+  makeWrapper,
+  desktop-file-utils,
+  spleen,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "bitsnpicas";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "kreativekorp";
+    repo = "bitsnpicas";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hw7UuzesqpmnTjgpfikAIYyY70ni7BxjaUtHAPEdkXI=";
+  };
+
+  nativeBuildInputs =
+    [
+      jdk
+      zip
+      makeWrapper
+    ]
+    ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [
+      desktop-file-utils
+    ];
+
+  sourceRoot = "${finalAttrs.src.name}/main/java/BitsNPicas";
+
+  installPhase =
+    ''
+      runHook preInstall
+
+      install -Dm444 BitsNPicas.jar "$out/share/java/bitsnpicas.jar"
+      install -Dm444 MapEdit.jar "$out/share/java/mapedit.jar"
+      install -Dm444 KeyEdit.jar "$out/share/java/keyedit.jar"
+
+      makeWrapper "${jre}/bin/java" "$out/bin/bitsnpicas" \
+        --add-flags "-jar $out/share/java/bitsnpicas.jar"
+      makeWrapper "${jre}/bin/java" "$out/bin/mapedit" \
+        --add-flags "-jar $out/share/java/mapedit.jar"
+      makeWrapper "${jre}/bin/java" "$out/bin/keyedit" \
+        --add-flags "-jar $out/share/java/keyedit.jar"
+
+      install -Dm444 dep/bitsnpicas.png "$out/share/icons/hicolor/128x128/apps/bitsnpicas.png"
+      install -Dm444 dep/kbnp-icon.png "$out/share/icons/hicolor/512x512/apps/bitsnpicas.png"
+      install -Dm444 dep/mapedit-icon.png "$out/share/icons/hicolor/512x512/apps/mapedit.png"
+      install -Dm444 dep/keyedit-icon.png "$out/share/icons/hicolor/256x256/apps/keyedit.png"
+    ''
+    + lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
+      mkdir -p "$out/share/applications/"
+      cp dep/*.desktop "$out/share/applications/"
+    ''
+    + ''
+      runHook postInstall
+    '';
+
+  postFixup = lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
+    desktop-file-edit "$out/share/applications/bitsnpicas.desktop" \
+      --set-key='Exec' --set-value='bitsnpicas edit %F' \
+      --set-key='Icon' --set-value='bitsnpicas' \
+      --set-key='StartupWMClass' --set-value='com-kreative-bitsnpicas-main-Main'
+    desktop-file-edit "$out/share/applications/mapedit.desktop" \
+      --set-key='Exec' --set-value='mapedit %F' \
+      --set-key='Icon' --set-value='mapedit' \
+      --set-key='StartupWMClass' --set-value='com-kreative-mapedit-Main'
+    desktop-file-edit "$out/share/applications/keyedit.desktop" \
+      --set-key='Exec' --set-value='keyedit %F' \
+      --set-key='Icon' --set-value='keyedit' \
+      --set-key='StartupWMClass' --set-value='com-kreative-keyedit-Main'
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    "$out/bin/bitsnpicas" convertbitmap -f psf "${spleen}/share/fonts/misc/spleen-8x16.bdf"
+    [[ -f Spleen.psf ]]
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Bitmap and emoji font creation and conversion tools";
+    homepage = "https://github.com/kreativekorp/bitsnpicas";
+    # Written in https://github.com/kreativekorp/bitsnpicas/blob/v2.1/main/java/BitsNPicas/LICENSE
+    license = lib.licenses.mpl11;
+    mainProgram = "bitsnpicas";
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    platforms = lib.lists.unique (jdk.meta.platforms ++ lib.platforms.windows);
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces [Bits'N'Picas](https://github.com/kreativekorp/bitsnpicas), a set of bitmap and emoji font creation and conversion tools.

The main application, bitsnpicas, offers font viewing and conversion functionalities. It also includes auxiliary tools like KeyEdit and MapEdit, which are similarly packaged as seen in [AUR](https://aur.archlinux.org/packages/bitsnpicas-git).

The build successfully passes on both Linux and macOS. However, desktop items have only been configured for Linux at this time.

<details>

<summary>Screenshots on my GNOME</summary>

![image](https://github.com/user-attachments/assets/3493c00a-487b-42d9-964c-f14060f0b54d)

![image](https://github.com/user-attachments/assets/8984659c-e812-4c98-b7f8-e1f4cfeafec2)

![image](https://github.com/user-attachments/assets/35b4acd5-81b5-4034-98fe-9a28ad315a35)

![image](https://github.com/user-attachments/assets/0cbf98d1-13d4-44fe-98e9-fb45e1310e2d)

![image](https://github.com/user-attachments/assets/f6745af1-571f-4e93-8301-bfff07c474df)

![image](https://github.com/user-attachments/assets/8285b8c4-b289-4ca4-b859-b395604bcddc)

icons on dash: ![image](https://github.com/user-attachments/assets/81e4d2ba-7962-447f-a7cc-ec42720d7e06)

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
