### PR TITLE
glitchtip: 4.2.10 -> 5.0.1

### DIFF
--- a/pkgs/by-name/gl/glitchtip/frontend.nix
+++ b/pkgs/by-name/gl/glitchtip/frontend.nix
@@ -9,18 +9,18 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "glitchtip-frontend";
-  version = "4.2.10";
+  version = "5.0.1";
 
   src = fetchFromGitLab {
     owner = "glitchtip";
     repo = "glitchtip-frontend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6ZOwAP6VB/uBrV6Yjc9jvzTNdfInekbLO/9PO57S9X8=";
+    hash = "sha256-mqwPCp7C5n2fOE8kgUnW3SYuuaY8ZkJtuhYXP4HevnM=";
   };
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
-    hash = "sha256-uEyET3y8LfjTasaJ+Hl206/Q7ov69mA7oNa0mhgcUEQ=";
+    hash = "sha256-Jzwarti+WwKecWn3fPcF9LV+mbU22rgiTP7mslyoqRk=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/gl/glitchtip/package.nix
+++ b/pkgs/by-name/gl/glitchtip/package.nix
@@ -3,6 +3,7 @@
   python313,
   fetchFromGitLab,
   fetchFromGitHub,
+  fetchPypi,
   rustPlatform,
   callPackage,
   stdenv,
@@ -14,7 +15,19 @@ let
   python = python313.override {
     self = python;
     packageOverrides = final: prev: {
-      django = final.django_5;
+      django = final.django_5_2;
+      django-csp = prev.django-csp.overridePythonAttrs rec {
+        version = "4.0";
+        src = fetchPypi {
+          inherit version;
+          pname = "django_csp";
+          hash = "sha256-snAQu3Ausgo9rTKReN8rYaK4LTOLcPvcE8OjvShxKDM=";
+        };
+      };
+      django-ninja-cursor-pagination = prev.django-ninja-cursor-pagination.overridePythonAttrs {
+        # checks are failing with django 5
+        doCheck = false;
+      };
       symbolic = prev.symbolic.overridePythonAttrs rec {
         version = "10.2.1";
         src = fetchFromGitHub {
@@ -55,7 +68,9 @@ let
       django-import-export
       django-ipware
       django-ninja
+      django-ninja-cursor-pagination
       django-organizations
+      django-postgres-partition
       django-prometheus
       django-redis
       django-storages
@@ -87,14 +102,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glitchtip";
-  version = "4.2.10";
+  version = "5.0.1";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "glitchtip";
     repo = "glitchtip-backend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EGk/mhDlqGrJm/j5rTKeKRkJ/fRTspwtPJ+5OHwplfM=";
+    hash = "sha256-vfsuJn6lpaesK40nqCdJMCDiaaqS1EdZdvgmy9jPuo8=";
   };
 
   propagatedBuildInputs = pythonPackages;

--- a/pkgs/development/python-modules/django-ninja-cursor-pagination/default.nix
+++ b/pkgs/development/python-modules/django-ninja-cursor-pagination/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+  django,
+  django-ninja,
+  pytestCheckHook,
+  pytest-django,
+}:
+
+buildPythonPackage {
+  pname = "django-ninja-cursor-pagination";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kitware-resonant";
+    repo = "django-ninja-cursor-pagination";
+    rev = "2cc22187885b9a12956530a00e554c7a6012de63";
+    hash = "sha256-uZ+l/s70A8UG/HlSLIXW4r2WFM0Jj1Ep7fGoNdH9P5M=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    django
+    django-ninja
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-django
+  ];
+
+  meta = {
+    description = "Django Ninja extension for cursor-based pagination";
+    homepage = "https://github.com/kitware-resonant/django-ninja-cursor-pagination";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ defelo ];
+  };
+}

--- a/pkgs/development/python-modules/django-postgres-partition/default.nix
+++ b/pkgs/development/python-modules/django-postgres-partition/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  django_5_2,
+  psycopg,
+  python-dateutil,
+}:
+
+buildPythonPackage rec {
+  pname = "django-postgres-partition";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "django_postgres_partition";
+    hash = "sha256-KUrgnfUXWyRerW4dqtVZO9bu5jHYnHcVOIg97w695RU=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django_5_2
+    psycopg
+    python-dateutil
+  ];
+
+  doCheck = false; # pypi version doesn't ship with tests
+
+  pythonImportsCheck = [ "psql_partition" ];
+
+  meta = {
+    description = "Partition support for django, based on django-postgres-extra";
+    homepage = "https://gitlab.com/burke-software/django-postgres-partition";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ defelo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3831,6 +3831,10 @@ self: super: with self; {
 
   django-ninja = callPackage ../development/python-modules/django-ninja { };
 
+  django-ninja-cursor-pagination =
+    callPackage ../development/python-modules/django-ninja-cursor-pagination
+      { };
+
   django-oauth-toolkit = callPackage ../development/python-modules/django-oauth-toolkit { };
 
   django-organizations = callPackage ../development/python-modules/django-organizations { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3863,6 +3863,8 @@ self: super: with self; {
 
   django-polymorphic = callPackage ../development/python-modules/django-polymorphic { };
 
+  django-postgres-partition = callPackage ../development/python-modules/django-postgres-partition { };
+
   django-postgresql-netfields =
     callPackage ../development/python-modules/django-postgresql-netfields
       { };


### PR DESCRIPTION
https://gitlab.com/glitchtip/glitchtip-backend/-/blob/v5.0.0/CHANGELOG

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
