### PR TITLE
Warpgate: init at 0.17.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1106,6 +1106,12 @@
     githubId = 83360;
     name = "Aleksey Sidorov";
   };
+  alemonmk = {
+    email = "almk@rmntn.net";
+    github = "alemonmk";
+    githubId = 3955369;
+    name = "Lemon Lam";
+  };
   alerque = {
     email = "caleb@alerque.com";
     github = "alerque";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -80,6 +80,8 @@
 
 - [Corteza](https://cortezaproject.org/), a low-code platform. Available as [services.corteza](#opt-services.corteza.enable).
 
+- [Warpgate](https://warpgate.null.page), a SSH, HTTPS, MySQL and Postgres bastion. Available as [services.warpgate](#opt-services.warpgate.enable). Note that you need to run `warpgate recover-access` to recover builtin admin account, as the initialisation script uses a throwaway value to initialise its database.
+
 - [TuneD](https://tuned-project.org/), a system tuning service for Linux. Available as [services.tuned](#opt-services.tuned.enable).
 
 - [yubikey-manager](https://github.com/Yubico/yubikey-manager), a tool for configuring YubiKey devices. Available as [programs.yubikey-manager](#opt-programs.yubikey-manager.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1497,6 +1497,7 @@
   ./services/security/vault-agent.nix
   ./services/security/vault.nix
   ./services/security/vaultwarden/default.nix
+  ./services/security/warpgate.nix
   ./services/security/yubikey-agent.nix
   ./services/system/automatic-timezoned.nix
   ./services/system/bpftune.nix

--- a/nixos/modules/services/security/warpgate.nix
+++ b/nixos/modules/services/security/warpgate.nix
@@ -1,0 +1,444 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.warpgate;
+  yaml = pkgs.formats.yaml { };
+in
+{
+  options.services.warpgate =
+    let
+      inherit (lib.types)
+        nullOr
+        enum
+        str
+        bool
+        port
+        listOf
+        attrsOf
+        submodule
+        ;
+      inherit (lib.options) mkOption mkPackageOption literalExpression;
+    in
+    {
+      enable = mkOption {
+        description = ''
+          Whether to enable Warpgate.
+          This module will initialize Warpgate base on your config automatically. Please run `warpgate recover-access` to gain access.
+        '';
+        type = bool;
+        default = false;
+      };
+
+      package = mkPackageOption pkgs "warpgate" { };
+
+      databaseUrlFile = mkOption {
+        description = ''
+          Path to file containing database connection string with credentials.
+          Should be a one line file with: `database_url: <protocol>://<username>:<password>@<host>/<database>`.
+          See [SeaORM documentation](https://www.sea-ql.org/SeaORM/docs/install-and-config/connection/).
+        '';
+        type = nullOr str;
+        default = null;
+      };
+
+      settings = mkOption {
+        description = "Warpgate configuration.";
+        type = submodule {
+          freeformType = yaml.type;
+          options = {
+            sso_providers = mkOption {
+              description = "Configure OIDC single sign-on providers.";
+              default = [ ];
+              type = listOf (submodule {
+                freeformType = yaml.type;
+                options = {
+                  name = mkOption {
+                    description = "Internal identifier of SSO provider.";
+                    type = str;
+                  };
+                  label = mkOption {
+                    description = "SSO provider name displayed on login page.";
+                    type = str;
+                  };
+                  provider = mkOption {
+                    description = "SSO provider configurations.";
+                    type = attrsOf yaml.type;
+                  };
+                };
+              });
+              example = literalExpression ''
+                [
+                  {
+                    name = "3rd party SSO";
+                    label = "ACME SSO";
+                    provider = {
+                      type = "custom";
+                      client_id = "123...";
+                      client_secret = "BC...";
+                      issuer_url = "https://sso.acme.inc";
+                      scopes = ["email"];
+                    };
+                  }
+                  {
+                    ...
+                  }
+                ]
+              '';
+            };
+            recordings = {
+              enable = mkOption {
+                description = "Whether to enable session recording.";
+                default = true;
+                type = bool;
+              };
+              path = mkOption {
+                description = "Path to store session recordings.";
+                default = "/var/lib/warpgate/recordings";
+                type = str;
+              };
+            };
+            external_host = mkOption {
+              description = ''
+                Configure the domain name of this Warpgate instance.
+                See [HTTP domain binding](https://warpgate.null.page/http-domain-binding/).
+              '';
+              default = null;
+              type = nullOr str;
+            };
+            database_url = mkOption {
+              description = ''
+                Database connection string.
+                See [SeaORM documentation](https://www.sea-ql.org/SeaORM/docs/install-and-config/connection/).
+              '';
+              default = "sqlite:/var/lib/warpgate/db";
+              type = nullOr str;
+            };
+            ssh = {
+              enable = mkOption {
+                description = "Whether to enable SSH listener.";
+                default = false;
+                type = bool;
+              };
+              listen = mkOption {
+                description = "Listen endpoint of SSH listener.";
+                default = "[::]:2222";
+                type = str;
+              };
+              external_port = mkOption {
+                description = "The SSH listener is reachable via this port externally.";
+                default = null;
+                type = nullOr port;
+              };
+              keys = mkOption {
+                description = "Path to store SSH host & client keys.";
+                default = "/var/lib/warpgate/ssh-keys";
+                type = str;
+              };
+              host_key_verification = mkOption {
+                description = "Specify host key verification action when connecting to a SSH target with unknown/differing host key.";
+                default = "prompt";
+                type = enum [
+                  "prompt"
+                  "auto_accept"
+                  "auto_reject"
+                ];
+              };
+              inactivity_timeout = mkOption {
+                description = "How long can user be inactive until Warpgate terminates the connection.";
+                default = "5m";
+                type = str;
+              };
+              keepalive_interval = mkOption {
+                description = "If nothing is received from the client for this amount of time, server will send a keepalive message.";
+                default = null;
+                type = nullOr str;
+              };
+            };
+            http = {
+              listen = mkOption {
+                description = "Listen endpoint of HTTP listener.";
+                default = "[::]:8888";
+                type = str;
+              };
+              external_port = mkOption {
+                description = "The HTTP listener is reachable via this port externally.";
+                default = null;
+                type = nullOr port;
+              };
+              certificate = mkOption {
+                description = "Path to HTTPS listener certificate.";
+                default = "/var/lib/warpgate/tls.certificate.pem";
+                type = str;
+              };
+              key = mkOption {
+                description = "Path to HTTPS listener private key.";
+                default = "/var/lib/warpgate/tls.key.pem";
+                type = str;
+              };
+              sni_certificates = mkOption {
+                description = "Certificates for additional domains.";
+                default = [ ];
+                type = listOf (submodule {
+                  freeformType = yaml.type;
+                  options = {
+                    certificate = mkOption {
+                      description = "Path to certificate.";
+                      default = "";
+                      type = str;
+                    };
+                    key = mkOption {
+                      description = "Path to private key.";
+                      default = "";
+                      type = str;
+                    };
+                  };
+                });
+                example = literalExpression ''
+                  [
+                    {
+                      certificate = "/var/lib/warpgate/example.tld.pem";
+                      key = "/var/lib/warpgate/example.tld.key.pem";
+                    }
+                    {
+                      ...
+                    }
+                  ]
+                '';
+              };
+              trust_x_forwarded_headers = mkOption {
+                description = ''
+                  Trust X-Forwarded-* headers. Required when being reverse proxied.
+                  See [Running behind a reverse proxy](https://warpgate.null.page/reverse-proxy/).
+                '';
+                default = false;
+                type = bool;
+              };
+              session_max_age = mkOption {
+                description = "How long until a logged in session expires.";
+                default = "30m";
+                type = str;
+              };
+              cookie_max_age = mkOption {
+                description = "How long until logged in cookie expires.";
+                default = "1day";
+                type = str;
+              };
+            };
+            mysql = {
+              enable = mkOption {
+                description = "Whether to enable MySQL listener.";
+                default = false;
+                type = bool;
+              };
+              listen = mkOption {
+                description = "Listen endpoint of MySQL listener.";
+                default = "[::]:33306";
+                type = str;
+              };
+              external_port = mkOption {
+                description = "The MySQL listener is reachable via this port externally.";
+                default = null;
+                type = nullOr port;
+              };
+              certificate = mkOption {
+                description = "Path to MySQL listener certificate.";
+                default = "/var/lib/warpgate/tls.certificate.pem";
+                type = str;
+              };
+              key = mkOption {
+                description = "Path to MySQL listener private key.";
+                default = "/var/lib/warpgate/tls.key.pem";
+                type = str;
+              };
+            };
+            postgres = {
+              enable = mkOption {
+                description = "Whether to enable PostgreSQL listener.";
+                default = false;
+                type = bool;
+              };
+              listen = mkOption {
+                description = "Listen endpoint of PostgreSQL listener.";
+                default = "[::]:55432";
+                type = str;
+              };
+              external_port = mkOption {
+                description = "The PostgreSQL listener is reachable via this port externally.";
+                default = null;
+                type = nullOr str;
+              };
+              certificate = mkOption {
+                description = "Path to PostgreSQL listener certificate.";
+                default = "/var/lib/warpgate/tls.certificate.pem";
+                type = str;
+              };
+              key = mkOption {
+                description = "Path to PostgreSQL listener private key.";
+                default = "/var/lib/warpgate/tls.key.pem";
+                type = str;
+              };
+            };
+            log = {
+              retention = mkOption {
+                description = "How long Warpgate keep its logs.";
+                default = "7days";
+                type = str;
+              };
+              send_to = mkOption {
+                description = ''
+                  Path of UNIX socket of log forwarder.
+                  See [Log forwarding](https://warpgate.null.page/log-forwarding/);
+                '';
+                default = null;
+                type = nullOr str;
+              };
+            };
+            config_provider = mkOption {
+              description = ''
+                Source of truth of users.
+                DO NOT change this, Warpgate only implemented database provider.
+              '';
+              default = "database";
+              type = enum [
+                "file"
+                "database"
+              ];
+            };
+          };
+        };
+        default = { };
+        example = {
+          ssh = {
+            enable = true;
+            listen = "[::]:2211";
+          };
+          http = {
+            listen = "[::]:8011";
+          };
+        };
+      };
+    };
+
+  config =
+    let
+      inherit (lib.lists)
+        any
+        map
+        head
+        reverseList
+        ;
+      inherit (lib.strings) splitString toIntBase10;
+
+      preStartScript = pkgs.writers.writeBash "warpgate-init" ''
+        CFGFILE=/var/lib/warpgate/config.yaml
+        if [ ! -O $CFGFILE ] || [ ! -s $CFGFILE ]; then
+          INITPWD=$(tr -dc 'A-Za-z0-9!?%=' </dev/urandom 2>/dev/null | head -c 16)
+          ${lib.getExe cfg.package} \
+            --config $CFGFILE unattended-setup \
+            --data-path /var/lib/warpgate \
+            --http-port 8888 \
+            --admin-password $INITPWD
+        fi
+        ${
+          if cfg.databaseUrlFile != null then
+            ''
+              sed -e '/^database_url: null/d' ${yaml.generate "warpgate-config" cfg.settings} > $CFGFILE
+              cat /run/credentials/warpgate.service/databaseUrl >> $CFGFILE
+            ''
+          else
+            "cp --no-preserve=ownership ${yaml.generate "warpgate-config" cfg.settings} $CFGFILE"
+        }
+      '';
+      bindOnPrivilegedPorts = any (x: toIntBase10 x < 1025) (
+        map (x: head (reverseList (splitString ":" x))) (
+          [ cfg.settings.http.listen ]
+          ++ lib.optional cfg.settings.ssh.enable cfg.settings.ssh.listen
+          ++ lib.optional cfg.settings.mysql.enable cfg.settings.mysql.listen
+          ++ lib.optional cfg.settings.postgres.enable cfg.settings.postgres.listen
+        )
+      );
+    in
+    lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = !((cfg.databaseUrlFile != null) && (cfg.settings.database_url != null));
+          message = "You cannot configure databaseUrlFile and settings.database_url at the same time.";
+        }
+        {
+          assertion = !((cfg.databaseUrlFile == null) && (cfg.settings.database_url == null));
+          message = "Either databaseUrlFile or settings.database_url must be set; Set the other to null.";
+        }
+      ];
+
+      environment.systemPackages = [ cfg.package ];
+
+      systemd.services.warpgate = {
+        description = "Warpgate smart bastion";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        startLimitBurst = 5;
+        serviceConfig = {
+          LoadCredential = "${
+            if cfg.databaseUrlFile != null then "databaseUrl:${cfg.databaseUrlFile}" else ""
+          }";
+          ExecStartPre = preStartScript;
+          ExecStart = "${lib.getExe cfg.package} --config /var/lib/warpgate/config.yaml run";
+          DynamicUser = true;
+          RestartSec = 3;
+          Restart = "on-failure";
+          StateDirectory = "warpgate";
+          StateDirectoryMode = "0700";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          ProtectHome = true;
+          PrivateDevices = true;
+          DeviceAllow = [
+            "/dev/null rw"
+            "/dev/urandom r"
+          ];
+          DevicePolicy = "strict";
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          RestrictNamespaces = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "full";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+          ];
+        }
+        // (
+          if bindOnPrivilegedPorts then
+            {
+              AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+              CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+            }
+          else
+            {
+              PrivateUsers = true;
+            }
+        );
+      };
+    };
+
+  meta.maintainers = with lib.maintainers; [ alemonmk ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1609,6 +1609,7 @@ in
   vsftpd = runTest ./vsftpd.nix;
   waagent = runTest ./waagent.nix;
   wakapi = runTest ./wakapi.nix;
+  warpgate = runTest ./warpgate.nix;
   warzone2100 = runTest ./warzone2100.nix;
   wasabibackend = runTest ./wasabibackend.nix;
   wastebin = runTest ./wastebin.nix;

--- a/nixos/tests/warpgate.nix
+++ b/nixos/tests/warpgate.nix
@@ -1,0 +1,49 @@
+{
+  name = "warpgate";
+
+  nodes = {
+    machine = {
+      services.warpgate = {
+        enable = true;
+      };
+    };
+
+    machine2 = {
+      environment.etc."warpgate-db-url".text = "database: sqlite:/var/lib/warpgate/db/";
+      services.warpgate = {
+        enable = true;
+        databaseUrlFile = "/etc/warpgate-db-url";
+        settings = {
+          database_url = null;
+        };
+      };
+    };
+
+    machine3 = {
+      services.warpgate = {
+        enable = true;
+        settings = {
+          http.listen = "[::]:443";
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("warpgate.service")
+    machine.wait_for_open_port(8888)
+    machine.succeed("stat /var/lib/warpgate/db/db.sqlite3")
+    machine.succeed("curl -k --fail https://localhost:8888/@warpgate")
+    machine.shutdown()
+
+    machine2.wait_for_unit("warpgate.service")
+    machine2.wait_for_open_port(8888)
+    machine2.succeed("curl -k --fail https://localhost:8888/@warpgate")
+    machine2.shutdown()
+
+    machine3.wait_for_unit("warpgate.service")
+    machine3.wait_for_open_port(443)
+    machine3.succeed("curl -k --fail https://localhost/@warpgate")
+    machine3.shutdown()
+  '';
+}

--- a/pkgs/by-name/wa/warpgate/disable-rust-reproducible-build.patch
+++ b/pkgs/by-name/wa/warpgate/disable-rust-reproducible-build.patch
@@ -1,0 +1,14 @@
+diff --git a/.cargo/config.toml b/.cargo/config.toml
+index 8ab4225..8e0c812 100644
+--- a/.cargo/config.toml
++++ b/.cargo/config.toml
+@@ -1,8 +1,5 @@
+ # https://github.com/rust-lang/cargo/issues/5376#issuecomment-2163350032
+ [target.'cfg(all())']
+ rustflags = [
+-    "--cfg", "tokio_unstable",
+-    "-Zremap-cwd-prefix=/reproducible-cwd",
+-    "--remap-path-prefix=$HOME=/reproducible-home",
+-    "--remap-path-prefix=$PWD=/reproducible-pwd",
++    "--cfg", "tokio_unstable"
+ ]

--- a/pkgs/by-name/wa/warpgate/hardcode-version.patch
+++ b/pkgs/by-name/wa/warpgate/hardcode-version.patch
@@ -1,0 +1,14 @@
+diff --git a/warpgate-common/src/version.rs b/warpgate-common/src/version.rs
+index 07db547..2a7967f 100644
+--- a/warpgate-common/src/version.rs
++++ b/warpgate-common/src/version.rs
+@@ -1,8 +1,3 @@
+-use git_version::git_version;
+-
+ pub fn warpgate_version() -> &'static str {
+-    git_version!(
+-        args = ["--tags", "--always", "--dirty=-modified"],
+-        fallback = "unknown"
+-    )
++    "v@version@"
+ }

--- a/pkgs/by-name/wa/warpgate/package.nix
+++ b/pkgs/by-name/wa/warpgate/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  replaceVars,
+  fetchurl,
+  fetchFromGitHub,
+  rustPlatform,
+  buildNpmPackage,
+  openapi-generator-cli,
+  nixosTests,
+}:
+rustPlatform.buildRustPackage (
+  finalAttrs:
+  let
+    warpgate-web = buildNpmPackage {
+      pname = "${finalAttrs.pname}-web";
+      version = finalAttrs.version;
+
+      src = finalAttrs.src;
+      sourceRoot = "${finalAttrs.src.name}/warpgate-web";
+
+      patches = [ ./web-ui-package-json.patch ];
+
+      npmDepsHash = "sha256-1zCxKAH2IAKSFdL8Pyd8dJi0i8Y5mgYcWNKVpiQszc0=";
+
+      nativeBuildInputs = [ openapi-generator-cli ];
+
+      preBuild = "rm node_modules/.bin/openapi-generator-cli";
+
+      installPhase = ''
+        runHook preInstall
+        cp -R dist $out
+        runHook postInstall
+      '';
+    };
+  in
+  {
+    pname = "warpgate";
+    version = "0.17.0";
+
+    src = fetchFromGitHub {
+      owner = "warp-tech";
+      repo = "warpgate";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-nr0z8c0o5u4Rqs9pFUaxnasRHUhwT3qQe5+JNV+LObg=";
+    };
+
+    cargoHash = "sha256-pIr5Z7rp+dYOuKYnlsBdya6MqAdL0U2gUhwXvLfmM34=";
+
+    patches = [
+      (replaceVars ./hardcode-version.patch { inherit (finalAttrs) version; })
+      ./disable-rust-reproducible-build.patch
+    ];
+
+    buildFeatures = [
+      "postgres"
+      "mysql"
+      "sqlite"
+    ];
+
+    preBuild = ''ln -rs "${warpgate-web}" warpgate-web/dist'';
+
+    # skip check, project included tests require python stuff and docker
+    doCheck = false;
+
+    passthru.tests = {
+      inherit (nixosTests) warpgate;
+    };
+
+    meta = {
+      description = "Smart SSH, HTTPS, MySQL and Postgres bastion that requires no additional client-side software";
+      homepage = "https://warpgate.null.page";
+      license = lib.licenses.asl20;
+      platforms = lib.platforms.linux;
+      mainProgram = "warpgate";
+      maintainers = with lib.maintainers; [ alemonmk ];
+    };
+  }
+)

--- a/pkgs/by-name/wa/warpgate/web-ui-package-json.patch
+++ b/pkgs/by-name/wa/warpgate/web-ui-package-json.patch
@@ -1,0 +1,15 @@
+diff --git a/package.json b/package.json
+index 54125c3..6942dfb 100644
+--- a/package.json
++++ b/package.json
+@@ -12,8 +12,8 @@
+     "postinstall": "npm run openapi:client:gateway && npm run openapi:client:admin",
+     "openapi:schema:gateway": "cargo run -p warpgate-protocol-http > src/gateway/lib/openapi-schema.json",
+     "openapi:schema:admin": "cargo run -p warpgate-admin > src/admin/lib/openapi-schema.json",
+-    "openapi:client:gateway": "openapi-generator-cli generate -g typescript-fetch -i src/gateway/lib/openapi-schema.json -o src/gateway/lib/api-client -p npmName=warpgate-gateway-api-client -p useSingleRequestParameter=true && cd src/gateway/lib/api-client && npm i typescript@5 && npm i && npx tsc --target esnext --module esnext && rm -rf src tsconfig.json",
+-    "openapi:client:admin": "openapi-generator-cli generate -g typescript-fetch -i src/admin/lib/openapi-schema.json -o src/admin/lib/api-client -p npmName=warpgate-admin-api-client -p useSingleRequestParameter=true && cd src/admin/lib/api-client && npm i typescript@5 && npm i && npx tsc --target esnext --module esnext && rm -rf src tsconfig.json",
++    "openapi:client:gateway": "openapi-generator-cli generate -g typescript-fetch -i src/gateway/lib/openapi-schema.json -o src/gateway/lib/api-client -p npmName=warpgate-gateway-api-client -p useSingleRequestParameter=true && ln -sr node_modules src/gateway/lib/api-client/node_modules && cd src/gateway/lib/api-client && npx tsc --target esnext --module esnext && rm -rf src tsconfig.json",
++    "openapi:client:admin": "openapi-generator-cli generate -g typescript-fetch -i src/admin/lib/openapi-schema.json -o src/admin/lib/api-client -p npmName=warpgate-admin-api-client -p useSingleRequestParameter=true && ln -sr node_modules src/admin/lib/api-client/node_modules && cd src/admin/lib/api-client && npx tsc --target esnext --module esnext && rm -rf src tsconfig.json",
+     "openapi:tests-sdk": "openapi-generator-cli generate -g python -i src/admin/lib/openapi-schema.json -o ../tests/api_sdk",
+     "openapi": "npm run openapi:schema:admin && npm run openapi:schema:gateway && npm run openapi:client:admin && npm run openapi:client:gateway"
+   },


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Warpgate](https://warpgate.null.page/) is a bastion that support SSH, HTTP(S), MySQL and PostgreSQL target.

Packaged the application and provided a module for systemd service.

Closes #217963.

This is my first pull request to nixpkgs, hope I have done everything I should do here. :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
