### PR TITLE
[DO NOT MERGE]nixosTests.limine: change to secureboot (not camel case)

### DIFF
--- a/nixos/tests/limine/default.nix
+++ b/nixos/tests/limine/default.nix
@@ -4,7 +4,7 @@
 }:
 {
   checksum = runTest ./checksum.nix;
-  secureBoot = runTest ./secure-boot.nix;
+  secureboot = runTest ./secure-boot.nix;
   specialisations = runTest ./specialisations.nix;
   uefi = runTest ./uefi.nix;
 }

--- a/nixos/tests/limine/secure-boot.nix
+++ b/nixos/tests/limine/secure-boot.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 {
-  name = "secureBoot";
+  name = "secureboot";
   meta.maintainers = with lib.maintainers; [
     programmerlexi
   ];


### PR DESCRIPTION
just for testing, this test has been failing on Gihub action
with a qemu assertion failure, not sure why

https://github.com/JohnRTitor/nixpkgs-review-gha/actions/runs/15192229792

I am trying to figure out why