### PR TITLE
nixos/sbctl: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -294,6 +294,7 @@
   ./programs/rush.nix
   ./programs/rust-motd.nix
   ./programs/ryzen-monitor-ng.nix
+  ./programs/sbctl.nix
   ./programs/schroot.nix
   ./programs/screen.nix
   ./programs/seahorse.nix

--- a/nixos/modules/programs/sbctl.nix
+++ b/nixos/modules/programs/sbctl.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.sbctl;
+
+  mkPathOption =
+    default: description:
+    lib.mkOption {
+      inherit default;
+      inherit description;
+      type = lib.types.oneOf [
+        lib.types.path
+        lib.types.str
+      ];
+    };
+
+  mkKeyOption = name: {
+    public = mkPathOption "/var/lib/sbctl/keys/${name}/${name}.pem" "Public key";
+    private = mkPathOption "/var/lib/sbctl/keys/${name}/${name}.key" "Private key";
+  };
+in
+{
+  options.programs.sbctl = {
+    enable = lib.mkEnableOption "sbctl";
+    package = lib.mkPackageOption pkgs "sbctl" { };
+    settings = {
+      landlock = lib.mkEnableOption "landlock" // {
+        default = true;
+      };
+      guid = mkPathOption "/var/lib/sbctl/GUID" "The file containing the GUID";
+      keys = {
+        platform = mkKeyOption "PK";
+        kek = mkKeyOption "KEK";
+        db = mkKeyOption "db";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    environment.etc."sbctl/sbctl.conf".text = ''
+      landlock: ${if cfg.settings.landlock then "true" else "false"}
+      guid: ${cfg.settings.guid}
+      keys:
+        pk:
+          privkey: ${cfg.settings.keys.platform.private}
+          pubkey: ${cfg.settings.keys.platform.public}
+          type: file
+        kek:
+          privkey: ${cfg.settings.keys.kek.private}
+          pubkey: ${cfg.settings.keys.kek.public}
+          type: file
+        db:
+          privkey: ${cfg.settings.keys.db.private}
+          pubkey: ${cfg.settings.keys.db.public}
+          type: file
+    '';
+  };
+}


### PR DESCRIPTION
This adds a (minimal) sbctl module to nixos to change where keys are stored or load custom keys.

Feedback is **very** appreciated.
Especially for things like:
- Should I move the module to a different section.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- There are no tests for this module as i don't know how i would i even write a test for this.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
