### PR TITLE
stockfish: 17 -> 17.1 by adding updateScript

### DIFF
--- a/pkgs/by-name/st/stockfish/package.nix
+++ b/pkgs/by-name/st/stockfish/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   fetchFromGitHub,
+  versionCheckHook,
   _experimental-update-script-combinators,
   nix-update-script,
   writeShellApplication,
@@ -69,6 +70,13 @@ stdenv.mkDerivation rec {
   buildFlags = [ "build" ];
 
   enableParallelBuilding = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/stockfish";
+  versionCheckProgramArg = "--help";
 
   passthru = {
     updateScript = _experimental-update-script-combinators.sequence [

--- a/pkgs/by-name/st/stockfish/package.nix
+++ b/pkgs/by-name/st/stockfish/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchurl,
   fetchFromGitHub,
-  apple-sdk,
 }:
 
 let

--- a/pkgs/by-name/st/stockfish/package.nix
+++ b/pkgs/by-name/st/stockfish/package.nix
@@ -29,8 +29,8 @@ let
       "unknown";
 
   # These files can be found in src/evaluate.h
-  nnueBigFile = "nn-1111cefa1111.nnue";
-  nnueBigHash = "sha256-ERHO+hERa3cWG9SxTatMUPJuWSDHVvSGFZK+Pc1t4XQ=";
+  nnueBigFile = "nn-1c0000000000.nnue";
+  nnueBigHash = "sha256-HAAAAAAApn1imZnZMtDDc/dFDOQ80S0FYoaPTq+a4q0=";
   nnueBig = fetchurl {
     name = nnueBigFile;
     url = "https://tests.stockfishchess.org/api/nn/${nnueBigFile}";
@@ -47,13 +47,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "stockfish";
-  version = "17";
+  version = "17.1";
 
   src = fetchFromGitHub {
     owner = "official-stockfish";
     repo = "Stockfish";
     tag = "sf_${version}";
-    hash = "sha256-oXvLaC5TEUPlHjhm7tOxpNPY88QxYHFw+Cev3Q8NEeQ=";
+    hash = "sha256-c8o1d7/yPnF3Eo7M/MSzYuYQr2qt2tIwyu7WfuKMAzg=";
   };
 
   postUnpack = ''

--- a/pkgs/by-name/st/stockfish/update.bash
+++ b/pkgs/by-name/st/stockfish/update.bash
@@ -1,0 +1,20 @@
+new_src="$(nix-build --attr "pkgs.$PNAME.src" --no-out-link)"
+new_nnue_big_file="$(grep --perl-regexp --only-matching 'EvalFileDefaultNameBig "\Knn-(\w+).nnue' "$new_src/src/evaluate.h")"
+new_nnue_small_file="$(grep --perl-regexp --only-matching 'EvalFileDefaultNameSmall "\Knn-(\w+).nnue' "$new_src/src/evaluate.h")"
+new_nnue_big_hash="$(
+    nix hash convert --hash-algo sha256 "$(
+        nix-prefetch-url --type sha256 "https://tests.stockfishchess.org/api/nn/$new_nnue_big_file"
+    )"
+)"
+new_nnue_small_hash="$(
+    nix hash convert --hash-algo sha256 "$(
+        nix-prefetch-url --type sha256 "https://tests.stockfishchess.org/api/nn/$new_nnue_small_file"
+    )"
+)"
+
+pkg_body="$(<"$PKG_FILE")"
+pkg_body="${pkg_body//"$NNUE_BIG_FILE"/"$new_nnue_big_file"}"
+pkg_body="${pkg_body//"$NNUE_BIG_HASH"/"$new_nnue_big_hash"}"
+pkg_body="${pkg_body//"$NNUE_SMALL_FILE"/"$new_nnue_small_file"}"
+pkg_body="${pkg_body//"$NNUE_SMALL_HASH"/"$new_nnue_small_hash"}"
+echo "$pkg_body" >"$PKG_FILE"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR aims to fix failing(skipping) updater: https://nixpkgs-update-logs.nix-community.org/stockfish/2025-05-13.log

Release Note: https://github.com/official-stockfish/Stockfish/releases/tag/sf_17.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
