### PR TITLE
pkgs/top-level/all-packages.nix: add cc & ccChooser

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -9,6 +9,9 @@
   and newer series. However, embedded chips without LSX (Loongson SIMD eXtension), such as 2K0300 SoC, are not
   supported. `pkgsCross.loongarch64-linux-embedded` can be used to build software and systems for these platforms.
 
+- Added `cc` as a path towards providing a C compiler without inheriting it inside the standard environment.
+  Packages which wish to pick a compiler can explicitly do it or utilize the new `ccChooser`.
+
 ## Backward Incompatibilities {#sec-nixpkgs-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/by-name/ma/makeBinaryWrapper/package.nix
+++ b/pkgs/by-name/ma/makeBinaryWrapper/package.nix
@@ -5,7 +5,7 @@
   dieHook,
   writeShellScript,
   tests,
-  cc ? targetPackages.stdenv.cc,
+  cc,
   sanitizers ? [ ],
 }:
 

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -103,30 +103,7 @@ lib.init bootStages
 
             hasCC = !stdenvNoCC.targetPlatform.isGhcjs;
 
-            cc =
-              if crossSystem.useiOSPrebuilt or false then
-                buildPackages.darwin.iosSdkPkgs.clang
-              else if crossSystem.useAndroidPrebuilt or false then
-                buildPackages."androidndkPkgs_${crossSystem.androidNdkVersion}".clang
-              else if
-                targetPlatform.isGhcjs
-              # Need to use `throw` so tryEval for splicing works, ugh.  Using
-              # `null` or skipping the attribute would cause an eval failure
-              # `tryEval` wouldn't catch, wrecking accessing previous stages
-              # when there is a C compiler and everything should be fine.
-              then
-                throw "no C compiler provided for this platform"
-              else if crossSystem.isDarwin then
-                buildPackages.llvmPackages.libcxxClang
-              else if crossSystem.useLLVM or false then
-                buildPackages.llvmPackages.clang
-              else if crossSystem.useZig or false then
-                buildPackages.zig.cc
-              else if crossSystem.useArocc or false then
-                buildPackages.arocc
-              else
-                buildPackages.gcc;
-
+            cc = buildPackages.ccChooser crossSystem buildPackages null;
           };
         in
         if config ? replaceCrossStdenv then

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -594,6 +594,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
       overrides = self: super: {
         inherit (prevStage) ccWrapperStdenv cctools ld64;
 
+        # TODO: change this when CC is no longer provided by the stdenv
+        inherit (self.stdenv) cc;
+
         binutils-unwrapped = builtins.throw "nothing in the Darwin bootstrap should depend on GNU binutils";
         curl = builtins.throw "nothing in the Darwin bootstrap can depend on curl";
 
@@ -735,6 +738,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           {
             inherit (prevStage) ccWrapperStdenv;
 
+            # TODO: change this when CC is no longer provided by the stdenv
+            inherit (self.stdenv) cc;
+
             # Disable ld64’s install check phase because the required LTO libraries are not built yet.
             ld64 = super.ld64.overrideAttrs { doInstallCheck = false; };
 
@@ -799,6 +805,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           (llvmToolsDeps prevStage)
           {
             inherit (prevStage) ccWrapperStdenv;
+
+            # TODO: change this when CC is no longer provided by the stdenv
+            inherit (self.stdenv) cc;
 
             # Avoid an infinite recursion due to the SDK’s including ncurses, which depends on bash in its `dev` output.
             bashNonInteractive = super.bashNonInteractive.override { stdenv = self.darwin.bootstrapStdenv; };
@@ -884,6 +893,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           {
             inherit (prevStage) ccWrapperStdenv;
 
+            # TODO: change this when CC is no longer provided by the stdenv
+            inherit (self.stdenv) cc;
+
             # Disable tests because they use dejagnu, which fails to run.
             libffi = super.libffi.override { doCheck = false; };
 
@@ -964,6 +976,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           (sdkPackagesNoCC prevStage)
           {
             inherit (prevStage) ccWrapperStdenv;
+
+            # TODO: change this when CC is no longer provided by the stdenv
+            inherit (self.stdenv) cc;
 
             # Rebuild locales and sigtool with the new clang.
             darwin = super.darwin.overrideScope (
@@ -1203,6 +1218,8 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
                 gzip
                 patch
                 ;
+
+              inherit cc;
 
               "apple-sdk_${sdkMajorVersion}" = self.apple-sdk;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8197,6 +8197,44 @@ with pkgs;
       null;
 
   # We can choose:
+  ccChooser =
+    platform: pkgs: fallback:
+    let
+      # TODO: use cc when https://github.com/NixOS/nixpkgs/pull/365057 is merged
+      inherit (platform) useLLVM isDarwin isGhcjs;
+      useArocc = platform.useArocc or false;
+      useZig = platform.useZig or false;
+      useiOSPrebuilt = platform.useiOSPrebuilt or false;
+      useAndroidPrebuilt = platform.useAndroidPrebuilt or false;
+    in
+    if useiOSPrebuilt then
+      pkgs.darwin.iosSdkPkgs.clang or fallback
+    else if useAndroidPrebuilt then
+      pkgs."androidndkPkgs_${platform.androidNdkVersion}".clang or fallback
+    else if isGhcjs then
+      # Need to use `throw` so tryEval for splicing works, ugh.  Using
+      # `null` or skipping the attribute would cause an eval failure
+      # `tryEval` wouldn't catch, wrecking accessing previous stages
+      # when there is a C compiler and everything should be fine.
+      # NOTE: maybe we remove this and return null instead?
+      throw "no C compiler provided for this platform"
+    else if isDarwin then
+      pkgs.llvmPackages.libcxxClang or fallback
+    else if useArocc then
+      pkgs.arocc or fallback
+    else if useZig then
+      pkgs.zig.cc or fallback
+    else if useLLVM then
+      pkgs.llvmPackages.clang or fallback
+    else
+      # NOTE: we shouldn't imply GCC, ideally we should either fallback, null, or error.
+      pkgs.gcc or fallback;
+
+  # The default C compiler to use, this has been provided by the stdenv for a long time.
+  # However, we're working to move it out of the stdenv. It is recommended to switch to
+  # this attribute and using an "stdenvNoCC" as soon as possible.
+  cc = ccChooser stdenv.targetPlatform pkgs null;
+
   libc =
     let
       inherit (stdenv.hostPlatform) libc;

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -72,12 +72,14 @@ let
     buildPackages.binutils = nativePlatforms;
     buildPackages.gcc = nativePlatforms;
     libc = nativePlatforms;
+    cc = nativePlatforms;
   };
 
   common = {
     buildPackages.binutils = nativePlatforms;
     gmp = nativePlatforms;
     libc = nativePlatforms;
+    cc = nativePlatforms;
     nix = nativePlatforms;
     nixVersions.git = nativePlatforms;
     mesa = nativePlatforms;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Introduce `ccCross` and `ccCrossChooser` since #365057 will make it easier to switch elements of the toolchain out. By localizing it to a specific mechanism similar to `libcCross` and `libcCrossChooser`, it simplifies the addition of new CC's.

This is necessary for working on the new `crossStdenv`s which will be added in to replace nixpkgs internally calling variants/sub nixpkgs instances.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
