### PR TITLE
ci/eval: don't evaluate packages marked as broken

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -73,7 +73,9 @@ let
       # The number of attributes per chunk, see ./README.md for more info.
       chunkSize,
       checkMeta ? true,
-      includeBroken ? true,
+
+      # Don't try to eval packages marked as broken.
+      includeBroken ? false,
       # Whether to just evaluate a single chunk for quick testing
       quickTest ? false,
     }:

--- a/pkgs/top-level/release-outpaths.nix
+++ b/pkgs/top-level/release-outpaths.nix
@@ -27,7 +27,7 @@ let
           config = {
             allowAliases = false;
             allowBroken = includeBroken;
-            allowUnfree = false;
+            allowUnfree = true;
             allowInsecurePredicate = x: true;
             checkMeta = checkMeta;
 


### PR DESCRIPTION
I took this out of #406825, which we realized needs more work. Still, the change to evaluation of broken packages is good to fix cases like https://github.com/NixOS/nixpkgs/issues/355847#issuecomment-2878873137.

Since the first two commits of that PR kind of belong together for me, I squashed them. I also adjusted the commit message slightly, so that it doesn't refer to the "next commit" anymore, which would be the release-checks. Instead the reasoning is now more along the lines of fixing the above mentioned issue without causing regressions for unfree packages.

## Things done

- [x] Let's look at the eval results / "rebuilds" this produces.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
