### PR TITLE
ci/eval: cleanups, make slightly faster

### DIFF
--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -84,7 +84,6 @@ jobs:
 
       - name: Validate codeowners
         if: steps.app-token.outputs.token
-        run: result/bin/codeowners-validator
         env:
           OWNERS_FILE: pr/${{ env.OWNERS_FILE }}
           GITHUB_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -92,6 +91,7 @@ jobs:
           OWNER_CHECKER_REPOSITORY: ${{ github.repository }}
           # Set this to "notowned,avoid-shadowing" to check that all files are owned by somebody
           EXPERIMENTAL_CHECKS: "avoid-shadowing"
+        run: result/bin/codeowners-validator
 
   # Request reviews from code owners
   request:
@@ -120,6 +120,6 @@ jobs:
 
       - name: Request reviews
         if: steps.app-token.outputs.token
-        run: result/bin/request-code-owner-reviews.sh ${{ github.repository }} ${{ github.event.number }} "$OWNERS_FILE"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: result/bin/request-code-owner-reviews.sh ${{ github.repository }} ${{ github.event.number }} "$OWNERS_FILE"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -123,6 +123,10 @@ jobs:
       - name: Get target run id
         if: needs.prepare.outputs.targetSha
         id: targetRunId
+        env:
+          REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ needs.prepare.outputs.targetSha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Get the latest eval.yml workflow run for the PR's target commit
           if ! run=$(gh api --method GET /repos/"$REPOSITORY"/actions/workflows/eval.yml/runs \
@@ -148,10 +152,6 @@ jobs:
           fi
 
           echo "targetRunId=$runId" >> "$GITHUB_OUTPUT"
-        env:
-          REPOSITORY: ${{ github.repository }}
-          TARGET_SHA: ${{ needs.prepare.outputs.targetSha }}
-          GH_TOKEN: ${{ github.token }}
 
       - uses: actions/download-artifact@v4
         if: steps.targetRunId.outputs.targetRunId
@@ -163,6 +163,8 @@ jobs:
 
       - name: Compare against the target branch
         if: steps.targetRunId.outputs.targetRunId
+        env:
+          AUTHOR_ID: ${{ github.event.pull_request.user.id }}
         run: |
           git -C nixpkgs worktree add ../target ${{ needs.prepare.outputs.targetSha }}
           git -C nixpkgs diff --name-only ${{ needs.prepare.outputs.targetSha }} \
@@ -177,8 +179,6 @@ jobs:
             -o comparison
 
           cat comparison/step-summary.md >> "$GITHUB_STEP_SUMMARY"
-        env:
-          AUTHOR_ID: ${{ github.event.pull_request.user.id }}
 
       - name: Upload the combined results
         if: steps.targetRunId.outputs.targetRunId
@@ -232,6 +232,10 @@ jobs:
 
       - name: Labelling pull request
         if: ${{ github.event_name == 'pull_request_target' && github.repository_owner == 'NixOS' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
         run: |
           # Get all currently set labels that we manage
           gh api \
@@ -260,13 +264,12 @@ jobs:
               -f "labels[]=$toAdd"
           done < <(comm -13 before after)
 
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-          NUMBER: ${{ github.event.number }}
-
       - name: Add eval summary to commit statuses
         if: ${{ github.event_name == 'pull_request_target' && github.repository_owner == 'NixOS' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          NUMBER: ${{ github.event.number }}
         run: |
           description=$(jq -r '
           "Package: added " + (.attrdiff.added | length | tostring) +
@@ -280,20 +283,9 @@ jobs:
             -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/$GITHUB_REPOSITORY/statuses/$PR_HEAD_SHA" \
             -f "context=Eval / Summary" -f "state=success" -f "description=$description" -f "target_url=$target_url"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          NUMBER: ${{ github.event.number }}
 
       - name: Requesting maintainer reviews
         if: ${{ steps.app-token.outputs.token && github.repository_owner == 'NixOS' }}
-        run: |
-          # maintainers.json contains GitHub IDs. Look up handles to request reviews from.
-          # There appears to be no API to request reviews based on GitHub IDs
-          jq -r 'keys[]' comparison/maintainers.json \
-            | while read -r id; do gh api /user/"$id" --jq .login; done \
-            | GH_TOKEN=${{ steps.app-token.outputs.token }} result/bin/request-reviewers.sh "$REPOSITORY" "$NUMBER" "$AUTHOR"
-
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
@@ -301,3 +293,9 @@ jobs:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           # Don't request reviewers on draft PRs
           DRY_MODE: ${{ github.event.pull_request.draft && '1' || '' }}
+        run: |
+          # maintainers.json contains GitHub IDs. Look up handles to request reviews from.
+          # There appears to be no API to request reviews based on GitHub IDs
+          jq -r 'keys[]' comparison/maintainers.json \
+            | while read -r id; do gh api /user/"$id" --jq .login; done \
+            | GH_TOKEN=${{ steps.app-token.outputs.token }} result/bin/request-reviewers.sh "$REPOSITORY" "$NUMBER" "$AUTHOR"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           pattern: intermediate-*
           path: intermediate
+          merge-multiple: true
 
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -158,6 +159,7 @@ jobs:
         with:
           name: result
           path: targetResult
+          merge-multiple: true
           github-token: ${{ github.token }}
           run-id: ${{ steps.targetRunId.outputs.targetRunId }}
 

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -1,10 +1,10 @@
 {
+  callPackage,
   lib,
   jq,
   runCommand,
   writeText,
   python3,
-  ...
 }:
 {
   beforeResultDir,
@@ -127,7 +127,7 @@ let
       }
     );
 
-  maintainers = import ./maintainers.nix {
+  maintainers = callPackage ./maintainers.nix { } {
     changedattrs = lib.attrNames (lib.groupBy (a: a.name) rebuildsPackagePlatformAttrs);
     changedpathsjson = touchedFilesJson;
     inherit byName;

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -1,3 +1,6 @@
+{
+  lib,
+}:
 # Almost directly vendored from https://github.com/NixOS/ofborg/blob/5a4e743f192fb151915fcbe8789922fa401ecf48/ofborg/src/maintainers.nix
 {
   changedattrs,
@@ -10,7 +13,6 @@ let
     config = { };
     overlays = [ ];
   };
-  inherit (pkgs) lib;
 
   changedpaths = builtins.fromJSON (builtins.readFile changedpathsjson);
 

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -1,4 +1,5 @@
 {
+  callPackage,
   lib,
   runCommand,
   writeShellScript,
@@ -227,16 +228,7 @@ let
         done
       '';
 
-  compare = import ./compare {
-    inherit
-      lib
-      jq
-      runCommand
-      writeText
-      supportedSystems
-      python3
-      ;
-  };
+  compare = callPackage ./compare { };
 
   full =
     {


### PR DESCRIPTION
While working on some bigger changes for the eval workflow, I came across some possible small improvements that make the code better to maintain / extend and save 8s, which were spent for plain text parsing with jq.

The process job is expected to fail in this PR, because the storage layout of the `intermediate-*` artifacts has been changed. Thus, this will only start passing when it compares against an updated target branch.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
