### PR TITLE
python3Packages.cx-freeze: 8.2.0 -> 8.3.0

### DIFF
--- a/pkgs/development/python-modules/cx-freeze/default.nix
+++ b/pkgs/development/python-modules/cx-freeze/default.nix
@@ -11,7 +11,6 @@
   filelock,
   packaging,
   tomli,
-  typing-extensions,
 
   distutils,
   pythonOlder,
@@ -29,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "cx-freeze";
-  version = "8.2.0";
+  version = "8.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "marcelotduarte";
     repo = "cx_Freeze";
     tag = version;
-    hash = "sha256-xrSMW7z3XblwAuaC18Rju/XuBZvU+5+xAW+MO6u32EE=";
+    hash = "sha256-PhUzHSn9IqUcb11D0kRT8zhmZ/KusTBDpAempiDN4Rc=";
   };
 
   patches = [
@@ -44,6 +43,11 @@ buildPythonPackage rec {
     # is not in the subpath of '/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9'
     ./fix-tests-relative-path.patch
   ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=77.0.3,<=80.4.0" "setuptools>=77.0.3"
+  '';
 
   build-system = [
     setuptools
@@ -62,9 +66,6 @@ buildPythonPackage rec {
     ]
     ++ lib.optionals (pythonOlder "3.11") [
       tomli
-    ]
-    ++ lib.optionals (pythonOlder "3.10") [
-      typing-extensions
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       dmgbuild
@@ -97,6 +98,7 @@ buildPythonPackage rec {
   disabledTests =
     [
       # Require internet access
+      "test_bdist_appimage_download_appimagetool"
       "test_bdist_appimage_target_name"
       "test_bdist_appimage_target_name_and_version"
       "test_bdist_appimage_target_name_and_version_none"
@@ -150,7 +152,7 @@ buildPythonPackage rec {
   meta = {
     description = "Set of scripts and modules for freezing Python scripts into executables";
     homepage = "https://marcelotduarte.github.io/cx_Freeze";
-    changelog = "https://github.com/marcelotduarte/cx_Freeze/releases/tag/${version}";
+    changelog = "https://github.com/marcelotduarte/cx_Freeze/releases/tag/${src.tag}";
     license = lib.licenses.psfl;
     maintainers = [ ];
     mainProgram = "cxfreeze";


### PR DESCRIPTION
Diff: https://github.com/marcelotduarte/cx_Freeze/compare/refs/tags/8.2.0...refs/tags/8.3.0

Changelog: https://github.com/marcelotduarte/cx_Freeze/releases/tag/8.3.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
