### PR TITLE
maintainer.jwiegley: add key fingerprint

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12542,6 +12542,7 @@
     github = "jwiegley";
     githubId = 8460;
     name = "John Wiegley";
+    keys = [ { fingerprint = "4710 CF98 AF9B 327B B80F  60E1 46C4 BD1A 7AC1 4BA2"; } ];
   };
   jwijenbergh = {
     email = "jeroenwijenbergh@protonmail.com";


### PR DESCRIPTION
Just adding a GnuPG fingerprint, since I use GnuPG a lot but noticed that my fingerprint was not in the maintainer list.