### PR TITLE
xdg-desktop-portal: 1.20.0 -> 1.20.3

### DIFF
--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -34,7 +34,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal";
-  version = "1.20.0";
+  version = "1.20.3";
 
   outputs = [
     "out"
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "flatpak";
     repo = "xdg-desktop-portal";
     tag = finalAttrs.version;
-    hash = "sha256-FHMa8fTr8qNEM5WptuMjMs/XOsvmFxi8pDaCrwJ3/ww=";
+    hash = "sha256-ntTGEsk8GlXkp3i9RtF+T7jqnNdL2GVbu05d68WVTYc=";
   };
 
   patches = [

--- a/pkgs/development/libraries/xdg-desktop-portal/fix-icon-validation.patch
+++ b/pkgs/development/libraries/xdg-desktop-portal/fix-icon-validation.patch
@@ -1,5 +1,3 @@
-diff --git a/src/validate-icon.c b/src/validate-icon.c
-index c42265b..320f028 100644
 --- a/src/validate-icon.c
 +++ b/src/validate-icon.c
 @@ -254,7 +254,7 @@ flatpak_get_bwrap (void)
@@ -12,9 +10,9 @@ index c42265b..320f028 100644
    g_autofree char* arg_input_fd = NULL;
    char validate_icon[PATH_MAX + 1];
 @@ -276,8 +276,7 @@ rerun_in_sandbox (int input_fd)
-             "--unshare-ipc",
-             "--unshare-net",
-             "--unshare-pid",
+             "--tmpfs", "/tmp",
+             "--proc", "/proc",
+             "--dev", "/dev",
 -            "--ro-bind", "/usr", "/usr",
 -            "--ro-bind-try", "/etc/ld.so.cache", "/etc/ld.so.cache",
 +            "--ro-bind", "@storeDir@", "@storeDir@",

--- a/pkgs/development/libraries/xdg-desktop-portal/fix-sound-validation.patch
+++ b/pkgs/development/libraries/xdg-desktop-portal/fix-sound-validation.patch
@@ -1,5 +1,3 @@
-diff --git a/src/validate-sound.c b/src/validate-sound.c
-index 7348d46..8b87c78 100644
 --- a/src/validate-sound.c
 +++ b/src/validate-sound.c
 @@ -234,7 +234,7 @@ flatpak_get_bwrap (void)
@@ -12,9 +10,9 @@ index 7348d46..8b87c78 100644
    g_autoptr(GPtrArray) args = g_ptr_array_new_with_free_func (g_free);
    char validate_sound[PATH_MAX + 1];
 @@ -255,8 +255,7 @@ rerun_in_sandbox (int input_fd)
-             "--unshare-ipc",
-             "--unshare-net",
-             "--unshare-pid",
+             "--tmpfs", "/tmp",
+             "--proc", "/proc",
+             "--dev", "/dev",
 -            "--ro-bind", "/usr", "/usr",
 -            "--ro-bind-try", "/etc/ld.so.cache", "/etc/ld.so.cache",
 +            "--ro-bind", "@storeDir@", "@storeDir@",

--- a/pkgs/development/libraries/xdg-desktop-portal/nix-pkgdatadir-env.patch
+++ b/pkgs/development/libraries/xdg-desktop-portal/nix-pkgdatadir-env.patch
@@ -1,5 +1,3 @@
-diff --git a/src/xdp-portal-impl.c b/src/xdp-portal-impl.c
-index 770c265..a34ca8e 100644
 --- a/src/xdp-portal-impl.c
 +++ b/src/xdp-portal-impl.c
 @@ -277,6 +277,8 @@ load_installed_portals (gboolean opt_verbose)
@@ -8,6 +6,6 @@ index 770c265..a34ca8e 100644
    portal_dir = g_getenv ("XDG_DESKTOP_PORTAL_DIR");
 +  if (portal_dir == NULL)
 +    portal_dir = g_getenv ("NIX_XDG_DESKTOP_PORTAL_DIR");
-   if (portal_dir == NULL)
-     portal_dir = DATADIR "/xdg-desktop-portal/portals";
+   if (portal_dir != NULL)
+     {
  


### PR DESCRIPTION
Changes:
- https://github.com/flatpak/xdg-desktop-portal/releases/tag/1.20.1
- https://github.com/flatpak/xdg-desktop-portal/releases/tag/1.20.2
- https://github.com/flatpak/xdg-desktop-portal/releases/tag/1.20.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
