### PR TITLE
wine: fix updateScript

### DIFF
--- a/pkgs/applications/emulators/wine/update-lib.sh
+++ b/pkgs/applications/emulators/wine/update-lib.sh
@@ -20,7 +20,7 @@ set_version_and_hash() {
 }
 
 get_latest_wine_version() {
-    list-directory-versions --pname=wine --url="$wine_url_base/source/$1" | grep -v 'diff\|rc\|tar' | sort --reverse --version-sort -u | head -n 1
+    list-directory-versions --pname=wine --url="$wine_url_base/source/$1/" | grep -v 'diff\|rc\|tar' | sort --reverse --version-sort -u | head -n 1
 }
 
 get_latest_lib_version() {


### PR DESCRIPTION
It looks like there was a recent change that breaks routing to download directories without a trailing slash.

For example:

```sh
> curl -s https://dl.winehq.org/wine/source/10.x
```
```xml
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>wine/source/10.x</Key><RequestId>AKNHP1J5C1T3RPE7</RequestId><HostId>aRh+/1HwSjshv35lm1saNkVC46nJtYFQmc6a2KxO5ZoKAuOVy4qgf6BE5aNz/UCZ/wa8UxIGlKmnRFFF6NSOQpXRoMttaaHhhsiczYeNfRc=</HostId></Error>
```

```sh
> curl -s https://dl.winehq.org/wine/source/10.x/
```
```html
<!doctype html>
<html lang="en">
<head>
    <title>WineHQ Downloads: /wine/source/10.x/</title>
    <meta charset="utf-8">
...
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
