### PR TITLE
tests.nixpkgs-check-by-name: remove throw; no need for this

### DIFF
--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -199,8 +199,6 @@ with pkgs;
 
   buildFHSEnv = recurseIntoAttrs (callPackages ./buildFHSEnv { });
 
-  nixpkgs-check-by-name = throw "tests.nixpkgs-check-by-name is now specified in a separate repository: https://github.com/NixOS/nixpkgs-check-by-name";
-
   auto-patchelf-hook = callPackage ./auto-patchelf-hook { };
 
   srcOnly = callPackage ../build-support/src-only/tests.nix { };


### PR DESCRIPTION
It's been long enough.

## Things done

- [x] Removed the thing.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).