### PR TITLE
[25.05] nixosTests.turbovnc-headless-server: Remove expected-failing test.

### DIFF
--- a/nixos/tests/turbovnc-headless-server.nix
+++ b/nixos/tests/turbovnc-headless-server.nix
@@ -120,24 +120,6 @@ import ./make-test-python.nix (
           )
 
 
-      # Checks that we detect glxgears failing when
-      # `LIBGL_DRIVERS_PATH=/nonexistent` is set
-      # (in which case software rendering should not work).
-      def test_glxgears_failing_with_bad_driver_path():
-          machine.execute(
-              # Note trailing & for backgrounding.
-              "(env DISPLAY=:0 LIBGL_DRIVERS_PATH=/nonexistent glxgears -info | tee /tmp/glxgears-should-fail.stdout) 3>&1 1>&2 2>&3 | tee /tmp/glxgears-should-fail.stderr >&2 &"
-          )
-          machine.wait_until_succeeds("test -f /tmp/glxgears-should-fail.stderr")
-          wait_until_terminated_or_succeeds(
-              termination_check_shell_command="pidof glxgears",
-              success_check_shell_command="grep 'MESA-LOADER: failed to open swrast' /tmp/glxgears-should-fail.stderr",
-              get_detail_message_fn=lambda: "Contents of /tmp/glxgears-should-fail.stderr:\n"
-              + machine.succeed("cat /tmp/glxgears-should-fail.stderr"),
-          )
-          machine.wait_until_fails("pidof glxgears")
-
-
       # Starts glxgears, backgrounding it. Waits until it prints the `GL_RENDERER`.
       # Does not quit glxgears.
       def test_glxgears_prints_renderer():
@@ -158,9 +140,6 @@ import ./make-test-python.nix (
           start_xvnc()
           wait_until_xvnc_glx_ready()
 
-      with subtest("Ensure bad driver path makes glxgears fail"):
-          test_glxgears_failing_with_bad_driver_path()
-
       with subtest("Run 3D application (glxgears)"):
           test_glxgears_prints_renderer()
 
@@ -170,8 +149,6 @@ import ./make-test-python.nix (
       # Copy files down.
       machine.copy_from_vm("/tmp/glxgears.png")
       machine.copy_from_vm("/tmp/glxgears.stdout")
-      machine.copy_from_vm("/tmp/glxgears-should-fail.stdout")
-      machine.copy_from_vm("/tmp/glxgears-should-fail.stderr")
       machine.copy_from_vm("/tmp/Xvnc.stdout")
       machine.copy_from_vm("/tmp/Xvnc.stderr")
     '';


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/403336

Backport of the test-fixing commit from #410000.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
