### PR TITLE
openldap: 2.6.9 -> 2.6.13

### DIFF
--- a/pkgs/by-name/op/openldap/package.nix
+++ b/pkgs/by-name/op/openldap/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openldap";
-  version = "2.6.9";
+  version = "2.6.13";
 
   src = fetchurl {
     url = "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${finalAttrs.version}.tgz";
-    hash = "sha256-LLfcc+nINA3/DZk1f7qleKvzDMZhnwUhlyxVVoHmsv8=";
+    hash = "sha256-1pO0lRekLvuFoaNkoxCu0WpT1CjRtGwNMe8/unj8tlY=";
   };
 
   patches = [
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtool
     openssl
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux) [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     libxcrypt # causes linking issues on *-darwin
   ]
   ++ lib.optionals withModules [


### PR DESCRIPTION
```
OpenLDAP 2.6.10 Release (2025/05/22)
	Added slapd microsecond timestamp format for local logging (ITS#10140)
	Fixed libldap ldap_result behavior with LDAP_MSG_RECEIVED (ITS#10229)
	Fixed lloadd handling of starttls critical (ITS#10323)
	Fixed slapd syncrepl when used with slapo-rwm (ITS#10290)
	Fixed slapd regression with certain searches (ITS#10307)
	Fixed slapo-autoca olcAutoCAserverClass object (ITS#10288)
	Fixed slapo-pcache caching behaviors (ITS#10270)
OpenLDAP 2.6.11 Release (2026/01/28)
	Fixed slapd to use fresh timestamp for lastbind (ITS#10379)
	Fixed slapd delta-syncrepl to always use logDB rootdn (ITS#10360)
	Fixed slapd reverse lookup of proxied IPv6 addresses (ITS#10387)
	Fixed slapd logging buffer overflow (ITS#10410)
	Fixed slapd-ldap response when invalid secprops is configured (ITS#10392)
	Fixed slapd-mdb error when deleting last child of a branch (ITS#10304)
	Fixed slapd-mdb check for pool pause in search (ITS#10191)
	Fixed slapo-memberof clash with refint on subtree rename (ITS#10398)
	Fixed slapo-syncprov use correct rootDN for accesslog replay (ITS#10385)
OpenLDAP 2.6.12 Release (2026/01/29)
	Fixed libldap to reject empty types in LDIF (ITS#10429)
	Fixed libldap to not scroll past nul bytes (ITS#10430)
	Fixed libldap to enforce stop when encountering nul-leading line (ITS#10431)
OpenLDAP 2.6.13 Release (2026/03/09)
	Fixed liblber ber_bvreplace_x potential NULL dereference (ITS#10438)
	Fixed libldap heap buffer overflow in parse_whsp (ITS#10430)
	Fixed slap(add|modify) to not recreate config frontend (ITS#10414)
	Fixed slapd authzPrettyNormal function memory leak (ITS#10446)
	Fixed slapd memory leak in get_mra function (ITS#10445)
	Fixed slapd memory leak in parseAssert and parseReturnFilter functions (ITS#10450)
	Fixed slapd memory leak in parseReadAttrs function (ITS#10449)
	Fixed slapd slapd_sasl_mechs race condition (ITS#10443)
	Fixed slapd syncrepl to be more efficient with refresh task (ITS#10413)
	Fixed slapd unbind/close race condition (ITS#10258)
	Fixed slapd-ldap memory leak in ldap_chain_parse_ctrl function (ITS#10447)
	Fixed slapd-mdb always initialize pausepoll (ITS#10191)
	Fixed slapo-constraint to not propagate request controls to internal ops (ITS#10440)
	Fixed slapo-dds minttl incorrectly set in certain scenarios (ITS#10442)
	Fixed slapo-memberof to not propagate request controls to internal ops (ITS#10440)
	Fixed slapo-nestgroup to not propagate request controls to internal ops (ITS#10440)
	Fixed slapo-retcode to not propagate request controls to internal ops (ITS#10440)
	Fixed slapo-syncprov to not propagate request controls to internal ops (ITS#10440)
	Fixed slapo-syncprov memory leak in syncprov_parseCtrl (ITS#10448)
	Fixed slapo-translucent to not propagate request controls to internal ops (ITS#10440)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
