### PR TITLE
[Backport release-25.05]: playwright-driver: use upstream chromium build

### DIFF
--- a/pkgs/development/web/playwright/chromium.nix
+++ b/pkgs/development/web/playwright/chromium.nix
@@ -8,27 +8,102 @@
   suffix,
   system,
   throwSystem,
+  lib,
+  alsa-lib,
+  at-spi2-atk,
+  atk,
+  autoPatchelfHook,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  glib,
+  gobject-introspection,
+  libGL,
+  libgbm,
+  libgcc,
+  libxkbcommon,
+  nspr,
+  nss,
+  pango,
+  patchelf,
+  pciutils,
+  stdenv,
+  systemd,
+  vulkan-loader,
+  xorg,
   ...
 }:
 let
-  chromium-linux =
-    runCommand "playwright-chromium"
-      {
-        nativeBuildInputs = [
-          makeWrapper
-        ];
-      }
-      ''
-        mkdir -p $out/chrome-linux
+  chromium-linux = stdenv.mkDerivation {
+    name = "playwright-chromium";
+    src = fetchzip {
+      url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-${suffix}.zip";
+      hash =
+        {
+          x86_64-linux = "sha256-9bK8HOGoQY5kYYfJypYHeuAoVlXIh/1tv1IsXPpUTpA=";
+          aarch64-linux = "sha256-KL6tYnPDszXjCHiSNOPHLtz839JPljSOoP7biQfTTAI=";
+        }
+        .${system} or throwSystem;
+    };
 
-        # See here for the Chrome options:
-        # https://github.com/NixOS/nixpkgs/issues/136207#issuecomment-908637738
-        # We add --disable-gpu to be able to run in gpu-less environments such
-        # as headless nixos test vms.
-        makeWrapper ${chromium}/bin/chromium $out/chrome-linux/chrome \
-          --set-default SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
-          --set-default FONTCONFIG_FILE ${fontconfig_file}
-      '';
+    nativeBuildInputs = [
+      autoPatchelfHook
+      patchelf
+      makeWrapper
+    ];
+    buildInputs = [
+      alsa-lib
+      at-spi2-atk
+      atk
+      cairo
+      cups
+      dbus
+      expat
+      glib
+      gobject-introspection
+      libgbm
+      libgcc
+      libxkbcommon
+      nspr
+      nss
+      pango
+      stdenv.cc.cc.lib
+      systemd
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXrandr
+      xorg.libxcb
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/chrome-linux
+      cp -R . $out/chrome-linux
+
+      wrapProgram $out/chrome-linux/chrome \
+        --set-default SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
+        --set-default FONTCONFIG_FILE ${fontconfig_file}
+
+      runHook postInstall
+    '';
+
+    appendRunpaths = lib.makeLibraryPath [
+      libGL
+      vulkan-loader
+      pciutils
+    ];
+
+    postFixup = ''
+      # replace bundled vulkan-loader since we are also already adding our own to RPATH
+      rm "$out/chrome-linux/libvulkan.so.1"
+      ln -s -t "$out/chrome-linux" "${lib.getLib vulkan-loader}/lib/libvulkan.so.1"
+    '';
+  };
   chromium-darwin = fetchzip {
     url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-${suffix}.zip";
     stripRoot = false;

--- a/pkgs/development/web/playwright/chromium.nix
+++ b/pkgs/development/web/playwright/chromium.nix
@@ -41,8 +41,8 @@ let
       url = "https://playwright.azureedge.net/builds/chromium/${revision}/chromium-${suffix}.zip";
       hash =
         {
-          x86_64-linux = "sha256-9bK8HOGoQY5kYYfJypYHeuAoVlXIh/1tv1IsXPpUTpA=";
-          aarch64-linux = "sha256-KL6tYnPDszXjCHiSNOPHLtz839JPljSOoP7biQfTTAI=";
+          x86_64-linux = "sha256-7oQQCAIt1VJiMNFEJO40K8oENK/L0BICXm2D/3fZ8bA=";
+          aarch64-linux = "sha256-1OmByLX2jNHXAzWdXF8Od7S7pj/jl4wwvOQcsZc5R7o=";
         }
         .${system} or throwSystem;
     };

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -149,7 +149,10 @@ let
       description = "Framework for Web Testing and Automation";
       homepage = "https://playwright.dev";
       license = lib.licenses.asl20;
-      maintainers = with lib.maintainers; [ kalekseev ];
+      maintainers = with lib.maintainers; [
+        kalekseev
+        marie
+      ];
       inherit (nodejs.meta) platforms;
     };
   };

--- a/pkgs/development/web/playwright/driver.nix
+++ b/pkgs/development/web/playwright/driver.nix
@@ -174,6 +174,7 @@ let
         withWebkit = false;
         withChromiumHeadlessShell = false;
       };
+      inherit components;
     };
   });
 
@@ -201,6 +202,32 @@ let
       mainProgram = "playwright";
     };
   });
+
+  components = {
+    chromium = callPackage ./chromium.nix {
+      inherit suffix system throwSystem;
+      inherit (playwright-core.passthru.browsersJSON.chromium) revision;
+      fontconfig_file = makeFontsConf {
+        fontDirectories = [ ];
+      };
+    };
+    chromium-headless-shell = callPackage ./chromium-headless-shell.nix {
+      inherit suffix system throwSystem;
+      inherit (playwright-core.passthru.browsersJSON.chromium) revision;
+    };
+    firefox = callPackage ./firefox.nix {
+      inherit suffix system throwSystem;
+      inherit (playwright-core.passthru.browsersJSON.firefox) revision;
+    };
+    webkit = callPackage ./webkit.nix {
+      inherit suffix system throwSystem;
+      inherit (playwright-core.passthru.browsersJSON.webkit) revision;
+    };
+    ffmpeg = callPackage ./ffmpeg.nix {
+      inherit suffix system throwSystem;
+      inherit (playwright-core.passthru.browsersJSON.ffmpeg) revision;
+    };
+  };
 
   browsers = lib.makeOverridable (
     {
@@ -232,17 +259,7 @@ let
           lib.nameValuePair
             # TODO check platform for revisionOverrides
             "${lib.replaceStrings [ "-" ] [ "_" ] name}-${value.revision}"
-            (
-              callPackage (./. + "/${name}.nix") (
-                {
-                  inherit suffix system throwSystem;
-                  inherit (value) revision;
-                }
-                // lib.optionalAttrs (name == "chromium") {
-                  inherit fontconfig_file;
-                }
-              )
-            )
+            components.${name}
         ) browsers
       )
     )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Backport of #383876 and #409116

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
