### PR TITLE
haskell.compiler.ghc94: don't roundtrip C compilation via assembly

### DIFF
--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -364,7 +364,44 @@ stdenv.mkDerivation (
           else
             ./Cabal-3.2-3.4-paths-fix-cycle-aarch64-darwin.patch
         )
-      ];
+      ]
+      # Before GHC 9.6, GHC, when used to compile C sources (i.e. to drive the CC), would first
+      # invoke the C compiler to generate assembly and later call the assembler on the result of
+      # that operation. Unfortunately, that is brittle in a lot of cases, e.g. when using mismatched
+      # CC / assembler (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/12005). This issue
+      # does not affect us. However, LLVM 18 introduced a check in clang that makes sure no
+      # non private labels occur between .cfi_startproc and .cfi_endproc which causes the
+      # assembly that the same version (!) of clang generates from rts/StgCRun.c to be rejected.
+      # This causes GHC to fail compilation on mach-o platforms ever since we upgraded to
+      # LLVM 19.
+      #
+      # clang compiles the same file without issues whithout the roundtrip via assembly. Thus,
+      # the solution is to backport those changes from GHC 9.6 that skip the intermediate
+      # assembly step.
+      #
+      # https://gitlab.haskell.org/ghc/ghc/-/issues/25608#note_622589
+      # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6877
+      ++ (
+        if lib.versionAtLeast version "9.4" then
+          [
+            # Need to use this patch so the next one applies, passes file location info to the cc phase
+            (fetchpatch {
+              name = "ghc-add-location-to-cc-phase.patch";
+              url = "https://gitlab.haskell.org/ghc/ghc/-/commit/4a7256a75af2fc0318bef771a06949ffb3939d5a.patch";
+              hash = "sha256-DnTI+i1zMebeWvw75D59vMaEEBb2Nr9HusxTyhmdy2M=";
+            })
+            # Makes Cc phase directly generate object files instead of assembly
+            (fetchpatch {
+              name = "ghc-cc-directly-emit-object.patch";
+              url = "https://gitlab.haskell.org/ghc/ghc/-/commit/96811ba491495b601ec7d6a32bef8563b0292109.patch";
+              hash = "sha256-G8u7/MK/tGOEN8Wxccxj/YIOP7mL2G9Co1WKdHXOo6I=";
+            })
+          ]
+        else
+          [
+            # TODO(@sternenseemann): backport changes to GHC < 9.4 if possible
+          ]
+      );
 
     postPatch = "patchShebangs .";
 


### PR DESCRIPTION
GHC can be used to compile C sources which causes it to drive the configured C compiler. This is particularly relevant during GHC's own compilation, e.g. when building the rts. GHC takes a peculiar approach, always generating intermediate assembly instead of letting the C compiler emit object files directly. This causes an assembler check in clang >= 18 to fail on rts/StgCRun.c, failing the GHC build on darwin completely.

Later GHC versions don't exhibit this issue since object code is emitted directly since 9.6. The easiest way to resolve the compilation failure seems to backport this change. However, the patch only applies on GHC 9.4 which is done here. The patch may be difficult to backport further, as the changed code was extensively refactored in GHC 9.4.

Reference #367686.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
