### PR TITLE
limine, nixos/limine, nixosTests.limine: inherit pkgs.limine maintainers, add johnrtitor

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -130,7 +130,8 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @NixOS/nix-team @raitobeza
 /nixos/modules/system/boot/loader/systemd-boot      @JulienMalka
 
 # Limine
-/nixos/modules/system/boot/loader/limine        @lzcunt @phip1611 @programmerlexi
+/nixos/modules/system/boot/loader/limine        @lzcunt @phip1611 @programmerlexi @johnrtitor
+/nixos/tests/limine                             @johnrtitor
 
 # Images and installer media
 /nixos/modules/profiles/installation-device.nix @ElvishJerricco

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -39,11 +39,9 @@ let
   defaultWallpaper = pkgs.nixos-artwork.wallpapers.simple-dark-gray-bootloader.gnomeFilePath;
 in
 {
-  meta.maintainers = with lib.maintainers; [
-    lzcunt
-    phip1611
-    programmerlexi
-  ];
+  meta = {
+    inherit (pkgs.limine.meta) maintainers;
+  };
 
   options.boot.loader.limine = {
     enable = lib.mkEnableOption "the Limine Bootloader";

--- a/nixos/tests/limine/checksum.nix
+++ b/nixos/tests/limine/checksum.nix
@@ -1,11 +1,10 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "checksum";
-  meta.maintainers = with lib.maintainers; [
-    lzcunt
-    phip1611
-    programmerlexi
-  ];
+  meta = {
+    inherit (pkgs.limine.meta) maintainers;
+  };
+
   nodes.machine =
     { ... }:
     {

--- a/nixos/tests/limine/secure-boot.nix
+++ b/nixos/tests/limine/secure-boot.nix
@@ -1,9 +1,10 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "secureBoot";
-  meta.maintainers = with lib.maintainers; [
-    programmerlexi
-  ];
+  meta = {
+    inherit (pkgs.limine.meta) maintainers;
+  };
+
   meta.platforms = [
     "aarch64-linux"
     "i686-linux"

--- a/nixos/tests/limine/specialisations.nix
+++ b/nixos/tests/limine/specialisations.nix
@@ -1,11 +1,10 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "specialisations";
-  meta.maintainers = with lib.maintainers; [
-    lzcunt
-    phip1611
-    programmerlexi
-  ];
+  meta = {
+    inherit (pkgs.limine.meta) maintainers;
+  };
+
   nodes.machine =
     { ... }:
     {

--- a/nixos/tests/limine/uefi.nix
+++ b/nixos/tests/limine/uefi.nix
@@ -1,11 +1,10 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "uefi";
-  meta.maintainers = with lib.maintainers; [
-    lzcunt
-    phip1611
-    programmerlexi
-  ];
+  meta = {
+    inherit (pkgs.limine.meta) maintainers;
+  };
+
   nodes.machine =
     { ... }:
     {

--- a/pkgs/by-name/li/limine/package.nix
+++ b/pkgs/by-name/li/limine/package.nix
@@ -111,6 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
       zlib # tinf
     ];
     maintainers = with lib.maintainers; [
+      johnrtitor
       lzcunt
       phip1611
       prince213

--- a/pkgs/by-name/li/limine/package.nix
+++ b/pkgs/by-name/li/limine/package.nix
@@ -114,6 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
       lzcunt
       phip1611
       prince213
+      programmerlexi
       surfaceflinger
     ];
   };


### PR DESCRIPTION
It makes sense that limine maintainers would also maintain its modules and tests. So instead of fragmenting maintainer entries, just reuse.

In addition, add myself to limine maintainers list. I have recently taken an interest to limine after secureBoot support (it just seems superior to systemd-boot). I am willing to review and merge Limine PRs.