### PR TITLE
aqualung: init at 2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1602,6 +1602,12 @@
     githubId = 5149377;
     name = "Amine Chikhaoui";
   };
+  amiryal = {
+    email = "nixpkgs-maintainer@please.nospammail.net";
+    github = "amiryal";
+    githubId = 105565;
+    name = "Amir Yalon";
+  };
   amozeo = {
     email = "wroclaw223@outlook.com";
     github = "amozeo";

--- a/pkgs/by-name/aq/aqualung/package.nix
+++ b/pkgs/by-name/aq/aqualung/package.nix
@@ -1,0 +1,136 @@
+{
+  lib,
+  stdenv,
+  autoreconfHook,
+  pkg-config,
+  fetchFromGitHub,
+  fetchpatch,
+  nix-update-script,
+
+  # Mandatory
+  gtk3,
+  libxml2,
+
+  # Optional
+  enableLadspa ? true,
+  lrdf,
+  enableCdda ? true,
+  libcdio,
+  libcdio-paranoia,
+  enableCddb ? true,
+  libcddb,
+  enableSrc ? true,
+  libsamplerate,
+  # enableIfp ? true, # FIXME: find the right dependency to support the iRiver iFP driver if it exists in nixpkgs
+  enableLua ? true,
+  lua,
+
+  # File I/O
+  enableSndfile ? true,
+  libsndfile,
+  enableFlac ? true,
+  flac,
+  enableVorbis ? true,
+  libvorbis,
+  enableSpeex ? true,
+  liboggz,
+  speex,
+  enableMpeg ? true,
+  libmad,
+  enableLame ? true,
+  lame,
+  enableMod ? true,
+  libmodplug,
+  enableMpc ? true,
+  libmpcdec,
+  enableMac ? true,
+  monkeys-audio,
+  enableWavpack ? true,
+  wavpack,
+  enableLavc ? true,
+  ffmpeg,
+
+  # Output
+  enableSndio ? true,
+  sndio,
+  enableAlsa ? true,
+  alsa-lib,
+  enableJack ? true,
+  libjack2,
+  enablePulse ? true,
+  pulseaudio,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "aqualung";
+  version = "2.0";
+  strictDeps = true;
+  __structuredAttrs = true;
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs = [
+    gtk3
+    libxml2
+  ]
+  ++ lib.optional enableLadspa lrdf
+  ++ lib.optionals enableCdda [
+    libcdio
+    libcdio-paranoia
+  ]
+  ++ lib.optional enableCddb libcddb
+  ++ lib.optional enableSrc libsamplerate
+  ++ lib.optional enableLua lua
+
+  ++ lib.optional enableSndfile libsndfile
+  ++ lib.optional enableFlac flac
+  ++ lib.optional enableVorbis libvorbis
+  ++ lib.optionals enableSpeex [
+    liboggz
+    speex
+  ]
+  ++ lib.optional enableMpeg libmad
+  ++ lib.optional enableLame lame
+  ++ lib.optional enableMod libmodplug
+  ++ lib.optional enableMpc libmpcdec
+  ++ lib.optional enableMac monkeys-audio
+  ++ lib.optional enableWavpack wavpack
+  ++ lib.optional enableLavc ffmpeg
+
+  ++ lib.optional enableSndio sndio
+  ++ lib.optional enableAlsa alsa-lib
+  ++ lib.optional enableJack libjack2
+  ++ lib.optional enablePulse pulseaudio;
+  src = fetchFromGitHub {
+    owner = "jeremyevans";
+    repo = "aqualung";
+    tag = finalAttrs.version;
+    hash = "sha256-jUz5iOvXJTxsF4EA35RyxBawcen+flULlpZs9p67YsA=";
+  };
+  patches =
+    [ ]
+    # use avcodec_free_context in place of avcodec_close in supported versions of ffmpeg
+    ++ lib.optional (lib.versionAtLeast ffmpeg.version "3.3") (fetchpatch {
+      url = "https://github.com/jeremyevans/aqualung/commit/d830ac5898412280ea02faebe82509a8129dac59.patch";
+      hash = "sha256-YMWlfK4242q3DoCcmfIeP3xQk2Ot05ifs2AN5CCDcco=";
+    });
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    homepage = "https://aqualung.jeremyevans.net/";
+    description = "Gapless music player";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "aqualung";
+    maintainers = with lib.maintainers; [ amiryal ];
+    platforms = lib.platforms.all;
+
+    # Source for longDescription: https://github.com/jeremyevans/aqualung/blob/5e0226f7ddd871be4fc4f0854a5e125bde3d7918/index.md
+    # (Converted with html2markdown from nixpkgs#html2text.)
+    longDescription = ''
+      Aqualung is an advanced music player originally targeted at the GNU/Linux
+      operating system, today also running on FreeBSD and OpenBSD, with native ports
+      to Mac OS X and even Microsoft Windows. It plays audio CDs, internet radio
+      streams and podcasts as well as soundfiles in just about any audio format and
+      has the feature of _**inserting no gaps**_ between adjacent tracks.
+    '';
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Homepage: https://aqualung.jeremyevans.net/

I saw the [announcement on LWN](https://lwn.net/Articles/1011671/) and decided to [try it out](https://github.com/amiryal/mypkgs/blob/main/aqualung.nix):
> [Version 2.0](https://github.com/jeremyevans/aqualung/releases/tag/2.0) of the [Aqualung](http://aqualung.jeremyevans.net/) gapless music player has been released. Aqualung supports playback of a wide range of audio formats, ripping CDs to WAV, FLAC, Ogg Vorbis, or MP3, and subscribing to podcasts via RSS or Atom feeds. The primary change in this release is the [migration](https://github.com/jeremyevans/aqualung/issues/38) from GTK2 to GTK3, and dropping support for custom skins as a result.

The selling point for me was its being gapless playback-oriented.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
