### PR TITLE
workflows/backport: avoid retriggering workflows after adding "has: port to stable" label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,7 +9,9 @@ on:
   pull_request_target:
     types: [closed, labeled]
 
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   backport:
@@ -48,7 +50,8 @@ jobs:
       - name: "Add 'has: port to stable' label"
         if: steps.backport.outputs.created_pull_numbers != ''
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Not the app on purpose to avoid triggering another workflow run after adding this label
+          GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           NUMBER: ${{ github.event.number }}
         run: |


### PR DESCRIPTION
After creating the backport successfully, we previously created the "has: port to stable" label with the Nixpkgs CI App's token. This would trigger another labeled event for the backport workflow. This only appears as "skipped", so doesn't use any resources, but it clutters the GitHub Actions output with useless skipped workflows.

Using `github.token` does not trigger any other workflows so avoids that problem.

## Things done

Not explicitly tested, but:
- The permissions are taken 1:1 from the `labels` workflow, which also needs to add labels.
- The `gh` [docs](https://cli.github.com/manual/gh_auth_login) mention using `GH_TOKEN: ${{ github.token }}` in CI.
- We know that `github.token` doesn't trigger CI, that's why we're doing the whole dance with GitHub Apps in the first place.

So this should work.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
