### PR TITLE
doc: Improve lazyAttrsOf, attrsWith/lazy

### DIFF
--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -405,7 +405,7 @@ Composed types are types that take a type as parameter. `listOf
     An attribute set of where all the values are of *`t`* type.
 
     This type is *strict* in its values, which in turn means attributes cannot depend on other attributes.
-    See `lazy` in `attrsWith`.
+    See [`lazy` in `attrsWith`](#sec-option-types-composed-attrsWith-lazy).
 
 `types.lazyAttrsOf` *`t`*
 
@@ -414,25 +414,25 @@ Composed types are types that take a type as parameter. `listOf
     An attribute set of where all the values are of *`t`* type.
 
     This is the lazy version of `types.attrsOf`, allowing attributes to depend on each other, at the cost of potentially containing more attributes than desirable.
-    See `lazy` in `attrsWith`.
+    See [`lazy` in `attrsWith`](#sec-option-types-composed-attrsWith-lazy).
 
 `types.attrsWith` { *`elemType`*, *`lazy`* ? false, *`placeholder`* ? "name" }
 
 :   An attribute set of where all the values are of *`elemType`* type.
 
-    Multiple definitions result in the joined attribute set.
+    Multiple definitions will be merged in the resulting attribute set.
 
     **Parameters**
 
     `elemType` (Required)
     : Specifies the type of the values contained in the attribute set.
 
-    `lazy`
+    [`lazy`]{#sec-option-types-composed-attrsWith-lazy}
     : Determines whether the set of attribute names is evaluated before or after evaluating any attribute values.
 
       `lazy = true` is a preferable choice in principle, but requires extra effort if the option value is used in aggregate (e.g. `attrNames` or `toJSON`).
 
-      When `lazy`, the attribute names are determined by looking at the definitions without evaluating them.
+      When `lazy` is `true`, the attribute names are determined by looking at the definitions without evaluating them.
       If only a `mkIf false` occurs in an attribute, this may result in an error when the attribute value is accessed.
 
       When `lazy` is `false`, the attribute names are determined by evaluating the definitions to see if they are `mkIf` false, but this also causes the evaluation of regular non-`mkIf` definitions.
@@ -443,10 +443,10 @@ Composed types are types that take a type as parameter. `listOf
 
       **Recommendation**
 
-      If the attribute set is used _in aggregate_ (e.g. `attrNames`, `toJSON`), use the default `lazy = false;` option, so that `mkIf` conditions are evaluated *before* the attribute names are returned.
+      If the attribute set is used _in aggregate_ (e.g. `attrNames`, `toJSON`), use the default `lazy = false;`, so that `mkIf` conditions are evaluated *before* the attribute names are returned.
 
       If the attribute set is used _individually_ (e.g. `config.foo`), use `lazy = true;` so that `mkIf` conditions are evaluated *after* the attribute names are returned.
-      This will result in a more robust and efficient evaluation, as the attribute values are not evaluated until it is needed.
+      This will be more robust and efficient, as the attribute values are not computed until it is needed.
 
       It possible to combine both behaviors `submodule` with `freeformType = attrsWith { lazy = false; ... }` instead of `attrsWith`, in which case the declared options are allowed to refer to each other, but *only* through the submodule's module arguments.
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -430,10 +430,10 @@ Composed types are types that take a type as parameter. `listOf
     [`lazy`]{#sec-option-types-composed-attrsWith-lazy}
     : Determines whether the set of attribute names is evaluated before or after evaluating any attribute values.
 
-      `lazy = true` is a preferable choice in principle, but requires extra effort if the option value is used in aggregate (e.g. `attrNames` or `toJSON`).
+      `lazy = true` is a preferable choice in principle, but requires extra effort if the option value is used as a whole (e.g. `attrNames` or `toJSON`).
 
       When `lazy` is `true`, the attribute names are determined by looking at the definitions without evaluating them.
-      If only a `mkIf false` occurs in an attribute, this may result in an error when the attribute value is accessed.
+      If all definitions in the attribute are `mkIf false ...`, this may result in an error when the attribute value is accessed.
 
       When `lazy` is `false`, the attribute names are determined by evaluating the definitions to see if they are `mkIf` false, but this also causes the evaluation of regular non-`mkIf` definitions.
       Evaluating too much causes multiple problems:
@@ -441,12 +441,10 @@ Composed types are types that take a type as parameter. `listOf
         - irrelevant errors are triggered, despite an attribute not really being used
         - performance is worse, if any of the values are expensive to evaluate
 
-      **Recommendation**
-
-      If the attribute set is used _in aggregate_ (e.g. `attrNames`, `toJSON`), use the default `lazy = false;`, so that `mkIf` conditions are evaluated *before* the attribute names are returned.
-
-      If the attribute set is used _individually_ (e.g. `config.foo`), use `lazy = true;` so that `mkIf` conditions are evaluated *after* the attribute names are returned.
-      This will be more robust and efficient, as the attribute values are not computed until it is needed.
+      Maintainers of this code recommend:
+      - If the attribute set is used _in aggregate_ (e.g. `attrNames`, `toJSON`), use the default `lazy = false;`, so that `mkIf` conditions are evaluated *before* the attribute names are returned.
+      - If attributes are accessed _in isolation_ (e.g. `config.foo`), use `lazy = true;` so that `mkIf` conditions are evaluated *after* the attribute names are returned.
+        This will be more robust and efficient, as the attribute values are not computed until it is needed.
 
       It possible to combine both behaviors using `submodule` with `freeformType = attrsWith { lazy = false; ... }` instead of `attrsWith`, in which case the declared options are allowed to refer to each other, but *only* through the submodule's module arguments. See the following example.
 

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1,4 +1,7 @@
 {
+  "ex-freeform-attrsWith-recursive": [
+    "index.html#ex-freeform-attrsWith-recursive"
+  ],
   "sec-option-types-composed-attrsWith-lazy": [
     "index.html#sec-option-types-composed-attrsWith-lazy"
   ],

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1,4 +1,7 @@
 {
+  "sec-option-types-composed-attrsWith-lazy": [
+    "index.html#sec-option-types-composed-attrsWith-lazy"
+  ],
   "sec-override-nixos-test": [
     "index.html#sec-override-nixos-test"
   ],


### PR DESCRIPTION
From the commit message:

- Elaborate the laziness trade-off and add recommendations.

- Improve the flow of the text by not interrupting with warning boxes. It's just a trade-off. (If we add them back, they'd be in three places!)

- Use sentence-per-line as recommended by the docs team

### Context

- https://github.com/nix-darwin/nix-darwin/pull/1468
- all other usages of `lazyAttrsOf` that I can't possibly list

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
