### PR TITLE
python3Packages.mlx-vlm: init at 0.3.3

### DIFF
--- a/pkgs/development/python-modules/mlx-vlm/default.nix
+++ b/pkgs/development/python-modules/mlx-vlm/default.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  datasets,
+  fastapi,
+  mlx,
+  mlx-lm,
+  numpy,
+  opencv-python,
+  pillow,
+  requests,
+  scipy,
+  soundfile,
+  tqdm,
+  transformers,
+  uvicorn,
+
+  # tests
+  psutil,
+  pytestCheckHook,
+  rich,
+}:
+
+buildPythonPackage rec {
+  pname = "mlx-vlm";
+  version = "0.3.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Blaizzy";
+    repo = "mlx-vlm";
+    tag = "v${version}";
+    hash = "sha256-KhppKqIJPmtjgSXSC3n5HTMm3fDUJaoYJEiGfQ5vGNQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "opencv-python"
+  ];
+  dependencies = [
+    datasets
+    fastapi
+    mlx
+    mlx-lm
+    numpy
+    opencv-python
+    pillow
+    requests
+    scipy
+    soundfile
+    tqdm
+    transformers
+    uvicorn
+  ];
+
+  pythonImportsCheck = [ "mlx_vlm" ];
+
+  nativeCheckInputs = [
+    psutil
+    pytestCheckHook
+    rich
+  ];
+
+  disabledTests = [
+    # Fatal Python error: Aborted
+    # mlx_vlm/models/multi_modality/vision.py", line 174 in __call__
+    "test_multi_modality"
+
+    # RuntimeError: [metal_kernel] No GPU back-end
+    "test_glm4v_moe"
+    "test_kimi_vl"
+  ];
+
+  disabledTestPaths = [
+    # ImportError: cannot import name 'get_class_predicate' from 'mlx_vlm.utils'
+    # This function is indeed not exposed by `mlx_vlm.utils`
+    "mlx_vlm/tests/test_utils.py"
+
+    # fixture 'model_path' not found
+    "mlx_vlm/tests/test_smoke.py"
+  ];
+
+  meta = {
+    description = "Inference and fine-tuning of Vision Language Models (VLMs) on your Mac using MLX";
+    homepage = "https://github.com/Blaizzy/mlx-vlm";
+    changelog = "https://github.com/Blaizzy/mlx-vlm/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9504,6 +9504,8 @@ self: super: with self; {
 
   mlx-lm = callPackage ../development/python-modules/mlx-lm { };
 
+  mlx-vlm = callPackage ../development/python-modules/mlx-vlm { };
+
   mlxtend = callPackage ../development/python-modules/mlxtend { };
 
   mmcif-pdbx = callPackage ../development/python-modules/mmcif-pdbx { };


### PR DESCRIPTION
## Things done

Add [mlx-vlm](https://github.com/Blaizzy/mlx-vlm), a package for inference and fine-tuning of Vision Language Models (VLMs) on MacOS using MLX.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
