### PR TITLE
Revert "lib.meta.availableOn: Return false if pkg parameter is null"

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -289,8 +289,7 @@ rec {
   */
   availableOn =
     platform: pkg:
-    pkg != null
-    && ((!pkg ? meta.platforms) || any (platformMatch platform) pkg.meta.platforms)
+    ((!pkg ? meta.platforms) || any (platformMatch platform) pkg.meta.platforms)
     && all (elem: !platformMatch platform elem) (pkg.meta.badPlatforms or [ ]);
 
   /**


### PR DESCRIPTION
I believe this change is wrong both theoretically and practically.

Theoretically, `null` is available on every platform, because `buildInputs = [ null ];` always succeeds and never throws a platform availability error. `null` should be handled consistently with packages that have no explicit list of supported platforms, as it of course has no such list itself.

Practically, we use `null` to represent libraries that are always present on a platform and do not require a library (for instance, because they are part of `libc` or the macOS SDK). This has been used for a long time by `libintl` (on all non‐glibc platforms), and is also now used by `libGL` and friends on Darwin. This change broke the check SDL3 does for OpenGL availability on Darwin, causing <https://github.com/NixOS/nixpkgs/issues/407056>, which had to be worked around by <https://github.com/NixOS/nixpkgs/pull/409525>.

Both `libintl` and `libGL` should count as available on platforms where their functionality is part of the standard build environment, and a package that is completely unavailable and whose functionality cannot be expected should not use `null`, as it should result in errors if used in a dependency list on an unsupported platform.

I accept that overriding with `null` is often a useful way to disable dependencies that don’t have explicit feature flags, but I do not think that making it work better with feature flags conditioned on availability is worth the inconsistency and problems caused by this change. Packages can instead expose the relevant feature flags as arguments that default to the `lib.meta.availableOn` check or, if they want to keep an “override the dependency to `null`” interface, insert an explicit `pkg != null && …` check.

Additionally, the pull request was merged over a week after all breaking changes were restricted for the 25.05 release. I believe that the potential problems of dealing with the effects of this change for an entire release cycle – the first release cycle where `libGL` is `null` on Darwin, a change I made before the deadline and before this change to `lib.meta.availableOn` – offset the risks of backporting this revert at such a late stage.

It will cause overrides to backwards‐incompatibly revert to the behaviour they had before the change, but since such overrides were not possible until a few weeks ago, I hope that is an acceptable risk compared to the potential issues leaving this in the release can cause, given that it was merged after the deadline and has already broken an existing construction in Nixpkgs.

This reverts commit 9338d924dbe0c6b93daec3bf435322812fd176fe.

---

cc @adisbladis as author of the PR

cc @MatthewCroughan as merger of the PR

cc @leona-ya for very painful last‐minute freeze exemption for backport

cc @alyssais as Musl maintainer

cc @marcin-serwin as author of SDL3 fix

cc @K900 as merger of SDL3 fix

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
