### PR TITLE
nixos/restic: Add SFTP repository to tests

### DIFF
--- a/nixos/tests/restic.nix
+++ b/nixos/tests/restic.nix
@@ -1,11 +1,17 @@
 { pkgs, ... }:
 
 let
+  inherit (import ./ssh-keys.nix pkgs)
+    snakeOilEd25519PrivateKey
+    snakeOilEd25519PublicKey
+    ;
+
   remoteRepository = "/root/restic-backup";
   remoteFromFileRepository = "/root/restic-backup-from-file";
   remoteInhibitTestRepository = "/root/restic-backup-inhibit-test";
   remoteNoInitRepository = "/root/restic-backup-no-init";
   rcloneRepository = "rclone:local:/root/restic-rclone-backup";
+  sftpRepository = "sftp:alice@sftp:backups/test";
 
   backupPrepareCommand = ''
     touch /root/backupPrepareCommand
@@ -51,7 +57,34 @@ in
   };
 
   nodes = {
-    server =
+    sftp =
+      # Copied from openssh.nix
+      { pkgs, ... }:
+      {
+        services.openssh = {
+          enable = true;
+          extraConfig = ''
+            Match Group sftponly
+              ChrootDirectory /srv/sftp
+              ForceCommand internal-sftp
+          '';
+        };
+
+        users.groups = {
+          sftponly = { };
+        };
+        users.users = {
+          alice = {
+            isNormalUser = true;
+            createHome = false;
+            group = "sftponly";
+            shell = "/run/current-system/sw/bin/nologin";
+            openssh.authorizedKeys.keys = [ snakeOilEd25519PublicKey ];
+          };
+        };
+      };
+
+    restic =
       { pkgs, ... }:
       {
         services.restic.backups = {
@@ -67,6 +100,20 @@ in
             repository = remoteRepository;
             initialize = true;
             timerConfig = null; # has no effect here, just checking that it doesn't break the service
+          };
+          remote-sftp = {
+            inherit
+              passwordFile
+              paths
+              exclude
+              pruneOpts
+              ;
+            repository = sftpRepository;
+            initialize = true;
+            timerConfig = null; # has no effect here, just checking that it doesn't break the service
+            extraOptions = [
+              "sftp.command='ssh alice@sftp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -s sftp'"
+            ];
           };
           remote-from-file-backup = {
             inherit passwordFile exclude pruneOpts;
@@ -143,28 +190,55 @@ in
   };
 
   testScript = ''
-    server.start()
-    server.wait_for_unit("dbus.socket")
-    server.fail(
+    restic.start()
+    sftp.start()
+    restic.wait_for_unit("dbus.socket")
+    sftp.wait_for_unit("sshd.service")
+
+    restic.systemctl("start network-online.target")
+    restic.wait_for_unit("network-online.target")
+
+    sftp.succeed(
+      "mkdir -p /srv/sftp/backups",
+      "chown alice:sftponly /srv/sftp/backups",
+      "chmod 0755 /srv/sftp/backups",
+    )
+
+    restic.succeed(
+      "mkdir -p /root/.ssh/",
+      "cat ${snakeOilEd25519PrivateKey} > /root/.ssh/id_ed25519",
+      "chmod 0600 /root/.ssh/id_ed25519",
+    )
+
+    restic.fail(
         "restic-remotebackup snapshots",
+        "restic-remote-sftp snapshots",
         'restic-remote-from-file-backup snapshots"',
         "restic-rclonebackup snapshots",
         "grep 'backup.* /opt' /root/fake-restic.log",
     )
-    server.succeed(
+    restic.succeed(
         # set up
         "cp -rT ${testDir} /opt",
         "touch /opt/excluded_file_1 /opt/excluded_file_2",
         "mkdir -p /root/restic-rclone-backup",
     )
 
-    server.fail(
+    restic.fail(
         # test that noinit backup in fact does not initialize the repository
         # and thus fails without a pre-initialized repository
         "systemctl start restic-backups-remote-noinit-backup.service",
     )
 
-    server.succeed(
+    restic.succeed(
+        # test that remotebackup runs custom commands and produces a snapshot
+        "timedatectl set-time '2016-12-13 13:45'",
+        "systemctl start restic-backups-remotebackup.service",
+        "rm /root/backupCleanupCommand",
+        'restic-remotebackup snapshots --json | ${pkgs.jq}/bin/jq "length | . == 1"',
+    )
+
+    restic.succeed(
         # test that remotebackup runs custom commands and produces a snapshot
         "timedatectl set-time '2016-12-13 13:45'",
         "systemctl start restic-backups-remotebackup.service",
@@ -231,15 +305,29 @@ in
         'restic-remotebackup snapshots --json | ${pkgs.jq}/bin/jq "length | . == 4"',
         'restic-rclonebackup snapshots --json | ${pkgs.jq}/bin/jq "length | . == 4"',
 
+        # test that SFTP backup works by copying from the remotebackup
+        'restic-remote-sftp init --from-repo ${remoteRepository} --from-password-file ${passwordFile} --copy-chunker-params',
+        'restic-remote-sftp copy --from-repo ${remoteRepository} --from-password-file ${passwordFile}',
+        'restic-remote-sftp snapshots --json | ${pkgs.jq}/bin/jq "length | . == 4"',
+
         # test that remoteprune brings us back to 1 snapshot in remotebackup
         "systemctl start restic-backups-remoteprune.service",
         'restic-remotebackup snapshots --json | ${pkgs.jq}/bin/jq "length | . == 1"',
 
+        # test that remoteprune brings us back to 1 snapshot in remotebackup
+        "systemctl start restic-backups-remoteprune.service",
+        'restic-remotebackup snapshots --json | ${pkgs.jq}/bin/jq "length | . == 1"',
     )
 
     # test that the inhibit option is working
-    server.systemctl("start --no-block restic-backups-inhibit-test.service")
-    server.wait_until_succeeds(
+    restic.systemctl("start --no-block restic-backups-inhibit-test.service")
+    restic.wait_until_succeeds(
+        "systemd-inhibit --no-legend --no-pager | grep -q restic",
+        5
+    )
+    # test that the inhibit option is working
+    restic.systemctl("start --no-block restic-backups-inhibit-test.service")
+    restic.wait_until_succeeds(
         "systemd-inhibit --no-legend --no-pager | grep -q restic",
         5
     )


### PR DESCRIPTION
Adds a SFTP server and repo to the restic tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
