### PR TITLE
g-golf: init at 0.8.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18133,6 +18133,12 @@
     githubId = 7831184;
     name = "John Mercier";
   };
+  mobid = {
+    email = "matija.obid@posteo.net";
+    github = "mobid";
+    githubId = 10497126;
+    name = "Matija Obid";
+  };
   mochienya = {
     name = "mochienya";
     github = "mochienya";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18310,6 +18310,12 @@
     githubId = 7831184;
     name = "John Mercier";
   };
+  mobid = {
+    email = "matija.obid@posteo.net";
+    github = "mobid";
+    githubId = 10497126;
+    name = "Matija Obid";
+  };
   mochienya = {
     name = "mochienya";
     github = "mochienya";

--- a/pkgs/by-name/g-/g-golf-gtk-4-examples/package.nix
+++ b/pkgs/by-name/g-/g-golf-gtk-4-examples/package.nix
@@ -1,0 +1,92 @@
+{
+  stdenv,
+  lib,
+  makeWrapper,
+  wrapGAppsHook4,
+  pkg-config,
+  guile,
+  guile-cairo-unstable,
+  glib,
+  gobject-introspection,
+  gtk4,
+  which,
+  adwaita-icon-theme,
+  libadwaita,
+  g-golf,
+  texinfo,
+  g-golf-adw-1-examples,
+  useLibadwaita ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+
+  inherit (g-golf) version src;
+
+  pname = "g-golf-${finalAttrs.variant}-examples";
+
+  variant = if useLibadwaita then "adw-1" else "gtk-4";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    which
+    texinfo
+    makeWrapper
+    wrapGAppsHook4
+    glib
+  ]
+  ++ lib.optionals useLibadwaita [ libadwaita ];
+
+  buildInputs = [
+    guile
+    g-golf
+    guile-cairo-unstable
+    gobject-introspection
+    gtk4
+    adwaita-icon-theme
+  ];
+
+  propagatedBuildInputs = [
+    gobject-introspection
+    gtk4
+  ]
+  ++ lib.optionals useLibadwaita [ libadwaita ];
+
+  sourceRoot = "g-golf-${finalAttrs.version}/examples/${finalAttrs.variant}/${
+    if useLibadwaita then "demo" else "demos"
+  }";
+
+  postBuild =
+    if useLibadwaita then "glib-compile-resources --target g-resources g-resources.xml" else "";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/doc/g-golf/examples
+    cp -rf .. $out/share/doc/g-golf/examples/
+
+    find $out/share -type f -executable | while read file; do
+      name=g-golf-${finalAttrs.variant}-$(basename $file)
+      makeWrapper $file $out/bin/$name \
+        --chdir $(dirname $file) \
+        --prefix PATH : "${guile}/bin" \
+        --prefix GUILE_LOAD_PATH : "$GUILE_LOAD_PATH" \
+        --prefix GUILE_LOAD_COMPILED_PATH : "$GUILE_LOAD_COMPILED_PATH" \
+        --prefix LD_LIBRARY_PATH : "${g-golf}/lib:${guile-cairo-unstable}/lib" \
+        --set GUILE_AUTO_COMPILE 0
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.tests = { inherit g-golf-adw-1-examples; };
+
+  meta = {
+    description = "G-Golf ${finalAttrs.variant} examples";
+    homepage = "https://www.gnu.org/software/g-golf/";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ mobid ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/g-/g-golf-gtk-4-examples/package.nix
+++ b/pkgs/by-name/g-/g-golf-gtk-4-examples/package.nix
@@ -1,0 +1,93 @@
+{
+  stdenv,
+  lib,
+  makeWrapper,
+  wrapGAppsHook4,
+  pkg-config,
+  guile,
+  guile-cairo-unstable,
+  glib,
+  gobject-introspection,
+  gtk4,
+  which,
+  adwaita-icon-theme,
+  libadwaita,
+  g-golf,
+  texinfo,
+  g-golf-adw-1-examples,
+  useLibadwaita ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+
+  inherit (g-golf) version src;
+
+  pname = "g-golf-${finalAttrs.variant}-examples";
+
+  variant = if useLibadwaita then "adw-1" else "gtk-4";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    which
+    texinfo
+    makeWrapper
+    wrapGAppsHook4
+    glib
+    gobject-introspection
+  ]
+  ++ lib.optionals useLibadwaita [ libadwaita ];
+
+  buildInputs = [
+    guile
+    g-golf
+    guile-cairo-unstable
+    gobject-introspection
+    gtk4
+    adwaita-icon-theme
+  ];
+
+  propagatedBuildInputs = [
+    gobject-introspection
+    gtk4
+  ]
+  ++ lib.optionals useLibadwaita [ libadwaita ];
+
+  sourceRoot = "g-golf-${finalAttrs.version}/examples/${finalAttrs.variant}/${
+    if useLibadwaita then "demo" else "demos"
+  }";
+
+  postBuild =
+    if useLibadwaita then "glib-compile-resources --target g-resources g-resources.xml" else "";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/doc/g-golf/examples
+    cp -rf .. $out/share/doc/g-golf/examples/
+
+    find $out/share -type f -executable | while read file; do
+      name=g-golf-${finalAttrs.variant}-$(basename $file)
+      makeWrapper $file $out/bin/$name \
+        --chdir $(dirname $file) \
+        --prefix PATH : "${guile}/bin" \
+        --prefix GUILE_LOAD_PATH : "$GUILE_LOAD_PATH" \
+        --prefix GUILE_LOAD_COMPILED_PATH : "$GUILE_LOAD_COMPILED_PATH" \
+        --prefix LD_LIBRARY_PATH : "${g-golf}/lib:${guile-cairo-unstable}/lib" \
+        --set GUILE_AUTO_COMPILE 0
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.tests = { inherit g-golf-adw-1-examples; };
+
+  meta = {
+    description = "G-Golf ${finalAttrs.variant} examples";
+    homepage = "https://www.gnu.org/software/g-golf/";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ mobid ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/g-/g-golf/package.nix
+++ b/pkgs/by-name/g-/g-golf/package.nix
@@ -1,0 +1,77 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  pkg-config,
+  texinfo,
+  guile,
+  guile-lib,
+  gobject-introspection,
+  glib,
+  xvfb-run,
+  gtk3,
+  gtk4,
+}:
+stdenv.mkDerivation (finalAttrs: {
+
+  pname = "g-golf";
+  version = "0.8.5";
+
+  src = fetchurl {
+    url = "mirror://gnu/g-golf/g-golf-${finalAttrs.version}.tar.gz";
+    hash = "sha256-XINWFdSlKiBY2R5iCB9A4uPay2k6ZwSsh7q7OFU5cjM=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  doCheck = true;
+  makeFlags = [ "GUILE_AUTO_COMPILE=0" ];
+
+  nativeBuildInputs = [
+    pkg-config
+    texinfo
+    guile
+    guile-lib
+  ];
+
+  buildInputs = [
+    guile
+    gtk3
+    glib
+  ];
+
+  nativeCheckInputs = [
+    gobject-introspection
+    xvfb-run
+  ];
+
+  postPatch = ''
+    sed -i 's|libgirepository-1.0|${gobject-introspection}/lib/libgirepository-1.0.so|' g-golf/init.scm
+    sed -i "s|libglib-2.0|${glib.out}/lib/libglib-2.0.so|" g-golf/init.scm
+    sed -i "s|libgobject-2.0|${glib.out}/lib/libgobject-2.0.so|" g-golf/init.scm
+
+    # In build environment, There is no /dev/tty
+    sed -i "s|/dev/tty|/dev/null|g" test-suite/tests/gobject.scm
+
+    sed -i "s|SITEDIR=.*$|SITEDIR="$out/${guile.siteDir}"|" configure
+    sed -i "s|SITECCACHEDIR=.*$|SITECCACHEDIR="$out/${guile.siteCcacheDir}"|" configure
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    xvfb-run make check
+    runHook postCheck
+  '';
+
+  postFixup = ''
+    sed -i "s|(dynamic-link \"libg-golf\")|(dynamic-link \"$out/lib/libg-golf\")|" $out/${guile.siteDir}/g-golf/init.scm
+  '';
+
+  meta = {
+    description = "Guile Object Library for GNOME";
+    homepage = "https://www.gnu.org/software/g-golf/";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ mobid ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/g-/g-golf/package.nix
+++ b/pkgs/by-name/g-/g-golf/package.nix
@@ -1,0 +1,77 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  pkg-config,
+  texinfo,
+  guile,
+  guile-lib,
+  gobject-introspection,
+  glib,
+  xvfb-run,
+  gtk3,
+  gtk4,
+}:
+stdenv.mkDerivation (finalAttrs: {
+
+  pname = "g-golf";
+  version = "0.8.7";
+
+  src = fetchurl {
+    url = "mirror://gnu/g-golf/g-golf-${finalAttrs.version}.tar.gz";
+    hash = "sha256-shv8mSLGQdclu4KZoACiOo41U3sc7kN+dKQF3HZJNII=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  doCheck = true;
+  makeFlags = [ "GUILE_AUTO_COMPILE=0" ];
+
+  nativeBuildInputs = [
+    pkg-config
+    texinfo
+    guile
+    guile-lib
+  ];
+
+  buildInputs = [
+    guile
+    gtk3
+    glib
+  ];
+
+  nativeCheckInputs = [
+    gobject-introspection
+    xvfb-run
+  ];
+
+  postPatch = ''
+    sed -i 's|libgirepository-1.0|${gobject-introspection}/lib/libgirepository-1.0.so|' g-golf/init.scm
+    sed -i "s|libglib-2.0|${glib.out}/lib/libglib-2.0.so|" g-golf/init.scm
+    sed -i "s|libgobject-2.0|${glib.out}/lib/libgobject-2.0.so|" g-golf/init.scm
+
+    # In build environment, There is no /dev/tty
+    sed -i "s|/dev/tty|/dev/null|g" test-suite/tests/gobject.scm
+
+    sed -i "s|SITEDIR=.*$|SITEDIR="$out/${guile.siteDir}"|" configure
+    sed -i "s|SITECCACHEDIR=.*$|SITECCACHEDIR="$out/${guile.siteCcacheDir}"|" configure
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    xvfb-run make check
+    runHook postCheck
+  '';
+
+  postFixup = ''
+    sed -i "s|(dynamic-link \"libg-golf\")|(dynamic-link \"$out/lib/libg-golf\")|" $out/${guile.siteDir}/g-golf/init.scm
+  '';
+
+  meta = {
+    description = "Guile Object Library for GNOME";
+    homepage = "https://www.gnu.org/software/g-golf/";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ mobid ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/gu/guile-cairo-unstable/package.nix
+++ b/pkgs/by-name/gu/guile-cairo-unstable/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  cairo,
+  expat,
+  guile,
+  guile-lib,
+  pkg-config,
+  autoconf,
+  automake,
+  libtool,
+  texinfo,
+  gettext,
+}:
+
+stdenv.mkDerivation {
+  pname = "guile-cairo";
+  version = "1.11.2-unstable-2026-01-05";
+
+  src = fetchgit {
+    url = "https://git.savannah.gnu.org/git/guile-cairo.git";
+    hash = "sha256-MdXqMl0seOoL8muKOOrR5h4arpCeTunNnrHCEAD+nI4=";
+    rev = "399fbb3f9cb80dca2fefd2fceaedde4c8e75deee";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    texinfo
+    pkg-config
+    gettext
+    libtool
+    guile
+  ];
+
+  buildInputs = [
+    cairo
+    expat
+    guile
+  ];
+
+  preConfigure = ''
+    cp ${gettext}/share/gettext/m4/lib-{ld,link,prefix}.m4 m4
+    autoreconf -fvi
+  '';
+
+  enableParallelBuilding = true;
+
+  doCheck = false; # Cannot find unit-test module from guile-lib
+  nativeCheckInputs = [ guile-lib ];
+
+  meta = {
+    homepage = "https://www.nongnu.org/guile-cairo/";
+    description = "Cairo bindings for GNU Guile";
+    longDescription = ''
+      Guile-Cairo wraps the Cairo graphics library for Guile Scheme.
+
+      Guile-Cairo is complete, wrapping almost all of the Cairo API.  It is API
+      stable, providing a firm base on which to do graphics work.  Finally, and
+      importantly, it is pleasant to use.  You get a powerful and well
+      maintained graphics library with all of the benefits of Scheme: memory
+      management, exceptions, macros, and a dynamic programming environment.
+    '';
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ mobid ];
+    platforms = guile.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2360,6 +2360,10 @@ with pkgs;
 
   uniscribe = callPackage ../tools/text/uniscribe { };
 
+  g-golf-adw-1-examples = callPackage ../by-name/g-/g-golf-gtk-4-examples/package.nix {
+    useLibadwaita = true;
+  };
+
   inherit (callPackages ../tools/filesystems/garage { })
     garage
     garage_1

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2305,6 +2305,10 @@ with pkgs;
 
   uniscribe = callPackage ../tools/text/uniscribe { };
 
+  g-golf-adw-1-examples = callPackage ../by-name/g-/g-golf-gtk-4-examples/package.nix {
+    useLibadwaita = true;
+  };
+
   inherit (callPackages ../tools/filesystems/garage { })
     garage
     garage_1


### PR DESCRIPTION
Guile library for GTK.
- https://www.gnu.org/software/g-golf/
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
