### PR TITLE
zoom-us: 6.4.6.* -> 6.4.10.*

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -19,23 +19,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.4.6.53970";
-  versions.x86_64-darwin = "6.4.6.53970";
-  versions.x86_64-linux = "6.4.6.1370";
+  versions.aarch64-darwin = "6.4.10.56141";
+  versions.x86_64-darwin = "6.4.10.56141";
+  versions.x86_64-linux = "6.4.10.2027";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-yNsiFZNte4432d8DUyDhPUOVbLul7gUdvr+3qK/Y+tk=";
+      hash = "sha256-LIQl+s/2WfYFIEG/ZsvpWlsWRhToB+5+ymAXCMhDqWE=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-Ut93qQFFN0d58wXD5r8u0B17HbihFg3FgY3a1L8nsIA=";
+      hash = "sha256-jP9ajDCo8iImS8YGFLjNMOLLh9g8uSqYIRl3aqhJAaM=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-Y+8garSqDcKLCVv1cTiqGEfrGKpK3UoXIq8X4E8CF+8=";
+      hash = "sha256-BwYO8IlQJjZwwn/qokZ+gAgcgmAjG34uExHCajchVqs=";
     };
   };
 
@@ -200,7 +200,10 @@ let
     version = versions.${system} or throwSystem;
 
     targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
-    extraPreBwrapCmds = "unset QT_PLUGIN_PATH";
+    extraPreBwrapCmds = ''
+      unset QT_PLUGIN_PATH
+      unset LANG  # would break settings dialog on non-"en_XX" locales
+    '';
     extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
     runScript = "/opt/zoom/ZoomLauncher";
 


### PR DESCRIPTION
Mostly unspectacular update.

However, the release has one notable bug: The settings dialog is broken (mostly white instead of settings knobs visible) if a non-`en_XX` locale is defined in `LANG`.  To work around this problem, the update simply adds `unset LANG` to the initializing commands.  This shouldn't be a problem as Zoom has its own language setting and apparently doesn't use the `LANG` variable for anything else but breaking the settings dialog.

Notifying maintainers @danbst @tadfisher

Notifying known users @philiptaron @gvolpe , maybe you can test if dropping `LANG` does harm anything.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I also tested this branch in Plasma5/X11/Pulseaudio on a NixOS 24.11 machine (unchecked means "not tested"):

- [x] sidebar loads (albeit empty on my installation, cf. https://github.com/NixOS/nixpkgs/issues/344931 )
- [x] audio is "detected" by zoom: microphone VU-meter shows amplitude
- [x] audio is produced: "Test speaker" generates audible ting-a-ling
- [x] other participant's audio in video conference is audible
- [x] other participants can hear me
- [x] sending camera picture in video conference works
- [ ] participant's camera video is received in video conference
- [x] screen sharing sends screen to other participants
- [x] participant's shared screen is displayed
- [x] "Participants" dialog box is shown (cf. https://github.com/NixOS/nixpkgs/issues/116355 )
- [x] reading team chat messages works as expected
- [x] settings dialog is shown/useable  **fixed, see above**
- [x] SSO works: Zoom starts Firefox, then Firefox calls back to Zoom after login, as usual
- [ ] writing team chat messages
- [ ] sidebar shows content
- [ ] Pipewire
- [ ] Wayland
- [ ] xdg-desktop-portal (cf. https://github.com/NixOS/nixpkgs/issues/359533 )
- [ ] Darwin

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` tries to rebuild 7k packages and was therefore skipped.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
