### PR TITLE
[25.05] plasma5Packages.kinfocenter: fix with `--inherit-argv0`

### DIFF
--- a/pkgs/desktops/plasma-5/kinfocenter/default.nix
+++ b/pkgs/desktops/plasma-5/kinfocenter/default.nix
@@ -98,6 +98,8 @@ mkDerivation {
     done
   '';
 
+  qtWrapperArgs = [ "--inherit-argv0" ];
+
   # fix wrong symlink of infocenter pointing to a 'systemsettings5' binary in
   # the same directory, while it is actually located in a completely different
   # store path


### PR DESCRIPTION
KDE's `kinfocenter` program is simply a symlink to `systemsettings`, which then looks at `argv[0]` in order to decide whether the info center or system settings should be shown.  https://github.com/NixOS/nixpkgs/pull/383082 changed symlink handling in `wrapQtAppsHook` and thereby broke that mechanism.  https://github.com/NixOS/nixpkgs/pull/390557 fixed `kinfocenter` for plasma6 by adding `--inherit-argv0` to `qtWrapperArgs`.  The pull request at hand does the same for plasma5.

Notifying author of breaking pull request @jian-lin

Notifying author of plasma6 fix @devusb

Notifying plasma5 maintainers @ttuegel @nyanloutre

Note: Please add the backport label to backport this to NixOS 25.05, as `kinfocenter` got broken before branch-off and should be fixed there as well.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

All `nixosTests.plasma5` still build/pass, but I doubt that they probe `kinfocenter` in any way.

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` tries to rebuild 7k packages and was therefore skipped.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
