### PR TITLE
dolt-workbench: init at 0.3.20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13696,6 +13696,12 @@
     githubId = 61395246;
     name = "Lampros Pitsillos";
   };
+  lapingvino = {
+    email = "ikojba@gmail.com";
+    github = "LaPingvino";
+    githubId = 10294;
+    name = "Joop Kiefte";
+  };
   larsr = {
     email = "Lars.Rasmusson@gmail.com";
     github = "larsr";

--- a/pkgs/by-name/do/dolt-workbench/package.nix
+++ b/pkgs/by-name/do/dolt-workbench/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+  autoPatchelfHook,
+}:
+let
+  pname = "dolt-workbench";
+  version = "0.3.20";
+
+  src = fetchurl {
+    url = "https://github.com/dolthub/dolt-workbench/releases/download/v${version}/Dolt-Workbench-linux-x86_64.AppImage";
+    hash = "sha256-Tgbg2wrfEwyZvdySj0/wlN4y4Pz/94boeCPk0OS34kA=";
+  };
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/dolt-workbench.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/dolt-workbench.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=dolt-workbench'
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  extraBwrapArgs = [
+    "--bind-try /etc/nixos/ /etc/nixos/"
+  ];
+
+  extraPkgs = pkgs: [
+    pkgs.unzip
+    pkgs.asar
+  ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  # vscode likes to kill the parent so that the
+  # gui application isn't attached to the terminal session
+  dieWithParent = false;
+
+  meta = {
+    description = "Web-based UI for Dolt databases";
+    homepage = "https://github.com/dolthub/dolt-workbench";
+    license = lib.licenses.asl20; # Apache License 2.0
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ lapingvino ];
+    mainProgram = "dolt-workbench";
+  };
+}


### PR DESCRIPTION
Adding a package for Dolt Workbench following the first experimental Linux release. It uses the officially provided Appimage for this. Dolt is already provided and is a git-style versioned database system with MySQL compatible interaction.

Previous attempt got abandoned after resetting my branch because of a failed sync.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
