### PR TITLE
astal: fix update script

### DIFF
--- a/pkgs/development/libraries/astal/source.nix
+++ b/pkgs/development/libraries/astal/source.nix
@@ -7,15 +7,15 @@ let
   originalDrv = fetchFromGitHub {
     owner = "Aylur";
     repo = "astal";
-    rev = "dc0e5d37abe9424c53dcbd2506a4886ffee6296e";
-    hash = "sha256-5WgfJAeBpxiKbTR/gJvxrGYfqQRge5aUDcGKmU1YZ1Q=";
+    rev = "4820a3e37cc8eb81db6ed991528fb23472a8e4de";
+    hash = "sha256-SaHAtzUyfm4urAcUEZlBFn7dWhoDqA6kaeFZ11CCTf8=";
   };
 in
 originalDrv.overrideAttrs (
   final: prev: {
     name = "${final.pname}-${final.version}"; # fetchFromGitHub already defines name
     pname = "astal-source";
-    version = "0-unstable-2025-03-21";
+    version = "0-unstable-2025-05-12";
 
     meta = prev.meta // {
       description = "Building blocks for creating custom desktop shells (source)";

--- a/pkgs/development/libraries/astal/source.nix
+++ b/pkgs/development/libraries/astal/source.nix
@@ -3,31 +3,34 @@
   nix-update-script,
   fetchFromGitHub,
 }:
-(fetchFromGitHub {
-  owner = "Aylur";
-  repo = "astal";
-  rev = "dc0e5d37abe9424c53dcbd2506a4886ffee6296e";
-  hash = "sha256-5WgfJAeBpxiKbTR/gJvxrGYfqQRge5aUDcGKmU1YZ1Q=";
-}).overrideAttrs
-  (
-    final: prev: {
-      name = "${final.pname}-${final.version}"; # fetchFromGitHub already defines name
-      pname = "astal-source";
-      version = "0-unstable-2025-03-21";
+let
+  originalDrv = fetchFromGitHub {
+    owner = "Aylur";
+    repo = "astal";
+    rev = "dc0e5d37abe9424c53dcbd2506a4886ffee6296e";
+    hash = "sha256-5WgfJAeBpxiKbTR/gJvxrGYfqQRge5aUDcGKmU1YZ1Q=";
+  };
+in
+originalDrv.overrideAttrs (
+  final: prev: {
+    name = "${final.pname}-${final.version}"; # fetchFromGitHub already defines name
+    pname = "astal-source";
+    version = "0-unstable-2025-03-21";
 
-      meta = prev.meta // {
-        description = "Building blocks for creating custom desktop shells (source)";
-        longDescription = ''
-          Please don't use this package directly, use one of subpackages in
-          `astal` namespace. This package is just a `fetchFromGitHub`, which is
-          reused between all subpackages.
-        '';
-        maintainers = with lib.maintainers; [ perchun ];
-        platforms = lib.platforms.linux;
-      };
+    meta = prev.meta // {
+      description = "Building blocks for creating custom desktop shells (source)";
+      longDescription = ''
+        Please don't use this package directly, use one of subpackages in
+        `astal` namespace. This package is just a `fetchFromGitHub`, which is
+        reused between all subpackages.
+      '';
+      maintainers = with lib.maintainers; [ perchun ];
+      platforms = lib.platforms.linux;
+    };
 
-      passthru = prev.passthru // {
-        updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
-      };
-    }
-  )
+    passthru = prev.passthru // {
+      updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+      src = originalDrv;
+    };
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tested
Error log: https://nixpkgs-update-logs.nix-community.org/astal.source/2025-05-23.log
Commit diff: https://github.com/Aylur/astal/compare/dc0e5d37abe9424c53dcbd2506a4886ffee6296e...4820a3e37cc8eb81db6ed991528fb23472a8e4de

Reasoning: `nix-update` couldn't find `astal.source.src`, so it crashed. Someone suggested putting `passthru.src = final` in Matrix, but after overriding `fetchFromGitHub`, the `rev` attribute disappears and `nix-update` silently crashes. I tried to do `passthru.src = prev` but it didn't have `rev` as well for some reason. Now I just moved the `fetchFromGitHub` to a `let` block and put it to `passthru.src`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
