### PR TITLE
fetchpatch: add support for patches to files with apostrophes

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -67,7 +67,7 @@ lib.throwIfNot (excludes == [ ] || includes == [ ])
             ${lib.optionalString (relative != null) "-p1 -i ${lib.escapeShellArg relative}/'*'"} \
             "$out" \
           | sort -u | sed -e 's/[*?]/\\&/g' \
-          | xargs -I{} \
+          | xargs -I{} --delimiter='\n' \
             filterdiff \
             --include={} \
             --strip=${toString stripLen} \

--- a/pkgs/build-support/fetchpatch/tests.nix
+++ b/pkgs/build-support/fetchpatch/tests.nix
@@ -48,4 +48,22 @@ in
       else
         "sha256-SJHk8XrutqAyoIdORlhCpBCN626P+uzed7mjKz5eQYY=";
   };
+
+  fileWithSpace = testers.invalidateFetcherByDrvHash fetchpatch {
+    url = "https://github.com/jfly/annoying-filenames/commit/1e86a219f5fc9c4137b409bc9c38036f3922724b.patch";
+    sha256 =
+      if isFetchpatch2 then
+        "sha256-RB6pjigoXtzHILkGFXYd3Lz2aM9DvO0NRmLdey1N6gg="
+      else
+        "sha256-aptUvVojqIIIVNuHqkl+C+dZBGFfs+1MUd0FNV+4j4E=";
+  };
+
+  fileWithApostrophe = testers.invalidateFetcherByDrvHash fetchpatch {
+    url = "https://github.com/jfly/annoying-filenames/commit/8b6d8f8d7094ce646523b3369cfdf5030289c66c.patch";
+    sha256 =
+      if isFetchpatch2 then
+        "sha256-CrQFmVvLEvWpo2ucVrWyLb5qk2GVOxyUbFN3hp9sV68="
+      else
+        "sha256-CrQFmVvLEvWpo2ucVrWyLb5qk2GVOxyUbFN3hp9sV68=";
+  };
 }


### PR DESCRIPTION
We're feeding a list of files from `lsdiff` to `filterdiff` via `xargs`. That list is newline separated, and looks something like this:

```
$ lsdiff <(curl -s https://github.com/jfly/annoying-filenames/commit/1e86a219f5fc9c4137b409bc9c38036f3922724b.patch)
a/README.md
b/files/The Answer to the Ultimate Question of Life, The Universe, and Everything.txt
```

However, if the list contains files with apostrophes in it, xargs freaks out:

```
$ echo "there's an apostrophe here" | xargs -I{} python -c "import sys; print(sys.argv)" {}
xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option
```

The fix is simple, just explicitly specify a delimiter:

```
$ echo "there's an apostrophe here" | xargs -I{} --delimiter='\n' python -c "import sys; print(sys.argv)" {}
['-c', "there's an apostrophe here"]
```

I added 2 tests here:

- `nix-build -A pkgs.tests.fetchpatch.fileWithApostrophe` fails without the code change.
- `nix-build -A pkgs.tests.fetchpatch.fileWithSpace` passes both before and after this change, but I wanted to add it to prove that I didn't break anything.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
