### PR TITLE
luminance-hdr: Fix build with current boost

### DIFF
--- a/pkgs/applications/graphics/luminance-hdr/default.nix
+++ b/pkgs/applications/graphics/luminance-hdr/default.nix
@@ -35,6 +35,25 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.archlinux.org/archlinux/packaging/packages/luminancehdr/-/raw/2e4a7321c7d20a52da104f4aa4dc76ac7224d94b/exiv2-0.28.patch";
       hash = "sha256-Hj+lqAd5VuTjmip8Po7YiGOWWDxnu4IMXOiEFBukXpk=";
     })
+    (fetchpatch {
+      name = "luminance-hdr-Fix-building-with-Boost-1.85.0.patch";
+      url = "https://github.com/LuminanceHDR/LuminanceHDR/commit/33b364f76b0edca4352cf701c1557d0c0e796c4f.patch";
+      hash = "sha256-jzyfKFmmzo6WUOUn33gr1g4MbSVpRfKLUIi49PSF5cg=";
+    })
+    # Fix lots of errors of form:
+    #     include/boost/math/tools/type_traits.hpp:208:12: error: 'is_final' has not been declared in 'std'
+    (fetchpatch {
+      name = "luminancehdr-fix-boost-1.87.0-compilation.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/luminancehdr/-/raw/d5fdbad3c11b6d414d842a7751e858f51292f544/luminancehdr-fix-boost-1.87.0-compilation.patch";
+      hash = "sha256-bKJhENnOWNwKUUSrSUF9fS1Por1A7exYAeiuCa2fRJY=";
+    })
+    # Fix error:
+    #     /build/source/src/Libpfs/manip/gamma_levels.cpp:136:25: error: call of overloaded 'clamp(float, float, float)' is ambiguous
+    (fetchpatch {
+      name = "luminancehdr-clamp.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/luminancehdr/-/raw/d5fdbad3c11b6d414d842a7751e858f51292f544/clamp.patch";
+      hash = "sha256-iAcZV1lFREPzjA9J3feSdhyTougvQA11I0IQRRYOmxY=";
+    })
   ];
 
   env.NIX_CFLAGS_COMPILE = "-I${ilmbase.dev}/include/OpenEXR";


### PR DESCRIPTION
Adopting minimal patches from Arch Linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
