### PR TITLE
jasp-desktop: 0.19.1 -> 0.19.3

### DIFF
--- a/pkgs/by-name/ja/jasp-desktop/cmake.patch
+++ b/pkgs/by-name/ja/jasp-desktop/cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/Tools/CMake/Libraries.cmake b/Tools/CMake/Libraries.cmake
-index cc4681a..f484013 100644
+index a95ef78..6ee84cd 100644
 --- a/Tools/CMake/Libraries.cmake
 +++ b/Tools/CMake/Libraries.cmake
 @@ -67,7 +67,7 @@ if((NOT LibArchive_FOUND) AND (NOT WIN32))
@@ -11,36 +11,67 @@ index cc4681a..f484013 100644
  find_package(
    Boost 1.78 REQUIRED
    COMPONENTS filesystem
-@@ -178,10 +178,10 @@ if(LINUX)
-     set(LIBREADSTAT_INCLUDE_DIRS /app/include)
-     set(LIBREADSTAT_LIBRARY_DIRS /app/lib)
-   else()
--    set(LIBREADSTAT_INCLUDE_DIRS /usr/local/include /usr/include)
-+    set(LIBREADSTAT_INCLUDE_DIRS @readstat@/include /usr/include)
-     # The last two library paths handle the two most common multiarch cases.
-     # Other multiarch-compliant paths may come up but should be rare.
--    set(LIBREADSTAT_LIBRARY_DIRS /usr/local/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu)
-+    set(LIBREADSTAT_LIBRARY_DIRS @readstat@/lib /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu)
+@@ -185,7 +185,7 @@ if(LINUX)
    endif()
  
    message(CHECK_START "Looking for libreadstat.so")
+-  find_file(LIBREADSTAT_LIBRARIES libreadstat.so
++  find_library(LIBREADSTAT_LIBRARIES libreadstat.so
+             HINTS ${LIBREADSTAT_LIBRARY_DIRS} REQUIRED)
+ 
+   if(EXISTS ${LIBREADSTAT_LIBRARIES})
 diff --git a/Tools/CMake/Programs.cmake b/Tools/CMake/Programs.cmake
-index dbd089d..ef6857a 100644
+index bfdc8dc..af5ac03 100644
 --- a/Tools/CMake/Programs.cmake
 +++ b/Tools/CMake/Programs.cmake
-@@ -39,6 +39,7 @@ endif()
+@@ -38,8 +38,9 @@ if(NOT WIN32)
+ endif()
  
  # ------ Linux Tools/Programs
- 
-+#[[
- if(LINUX)
+-
+-if(LINUX)
++# We don't need to check for any dependencies that are used to build R packages
++# since we build them separately
++if(false)
  
    message(CHECK_START "Looking for 'gfortran'")
-@@ -81,6 +82,7 @@ if(LINUX)
-   endif()
+   find_program(
+diff --git a/Tools/CMake/R.cmake b/Tools/CMake/R.cmake
+index 9ae27d4..64fd96a 100644
+--- a/Tools/CMake/R.cmake
++++ b/Tools/CMake/R.cmake
+@@ -841,11 +841,6 @@ message(STATUS "R_CPP_INCLUDES_LIBRARY = ${R_CPP_INCLUDES_LIBRARY}")
+ configure_file(${PROJECT_SOURCE_DIR}/Modules/setup_renv.R.in
+                 ${SCRIPT_DIRECTORY}/setup_renv.R @ONLY)
  
- endif()
-+]]#
+-execute_process(
+-  COMMAND_ECHO STDOUT
+-  #ERROR_QUIET OUTPUT_QUIET
+-  WORKING_DIRECTORY ${R_HOME_PATH}
+-  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save --file=${SCRIPT_DIRECTORY}/setup_renv.R)
  
- # ----------------------
+ if(APPLE)
+   # Patch renv
+@@ -867,11 +862,6 @@ endif()
+ configure_file(${PROJECT_SOURCE_DIR}/Modules/setup_rcpp_rinside.R.in
+                 ${SCRIPT_DIRECTORY}/setup_rcpp_rinside.R @ONLY)
+ 
+-execute_process(
+-  COMMAND_ECHO STDOUT
+-  #ERROR_QUIET OUTPUT_QUIET
+-  WORKING_DIRECTORY ${R_HOME_PATH}
+-  COMMAND ${R_EXECUTABLE} --slave --no-restore --no-save --file=${SCRIPT_DIRECTORY}/setup_rcpp_rinside.R)
+ 
+ if(APPLE)
+   # Patch RInside and RCpp
+@@ -892,8 +882,8 @@ endif()
+ 
+ include(FindRPackagePath)
+ 
+-find_package_path(RCPP_PATH       ${R_CPP_INCLUDES_LIBRARY} "Rcpp")
+-find_package_path(RINSIDE_PATH    ${R_CPP_INCLUDES_LIBRARY} "RInside")
++find_package_path(RCPP_PATH       ${R_LIBRARY_PATH} "Rcpp")
++find_package_path(RINSIDE_PATH    ${R_LIBRARY_PATH} "RInside")
+ 
+ set(RENV_PATH "${RENV_LIBRARY}/renv")
  

--- a/pkgs/by-name/ja/jasp-desktop/modules.nix
+++ b/pkgs/by-name/ja/jasp-desktop/modules.nix
@@ -165,6 +165,12 @@ let
       src = jasp-src;
       sourceRoot = "${jasp-src.name}/Modules/${name}";
       propagatedBuildInputs = deps;
+
+      # some packages have a .Rprofile that tries to activate renv
+      # we disable this by removing .Rprofile
+      postPatch = ''
+        rm -f .Rprofile
+      '';
     };
 in
 {
@@ -228,6 +234,20 @@ in
       jaspBase
       jaspGraphs
       jaspSem
+    ];
+    jaspBFF = buildJaspModule "jaspBFF" [
+      BFF
+      jaspBase
+      jaspGraphs
+    ];
+    jaspBfpack = buildJaspModule "jaspBfpack" [
+      BFpack
+      bain
+      ggplot2
+      stringr
+      coda
+      jaspBase
+      jaspGraphs
     ];
     jaspBsts = buildJaspModule "jaspBsts" [
       Boom
@@ -305,6 +325,7 @@ in
       conting'
       multibridge
       ggplot2
+      interp
       jaspBase
       jaspGraphs
       plyr
@@ -353,6 +374,8 @@ in
       ggforce
       tidyr
       igraph
+      HDInterval
+      metafor
     ];
     jaspMachineLearning = buildJaspModule "jaspMachineLearning" [
       kknn
@@ -375,6 +398,7 @@ in
       jaspBase
       jaspGraphs
       MASS
+      mclust
       mvnormalTest
       neuralnet
       network
@@ -385,6 +409,7 @@ in
       ROCR
       Rtsne
       signal
+      VGAM
     ];
     jaspMetaAnalysis = buildJaspModule "jaspMetaAnalysis" [
       dplyr
@@ -406,6 +431,12 @@ in
       metamisc
       ggmcmc
       pema
+      clubSandwich
+      CompQuadForm
+      sp
+      dfoptim
+      nleqslv
+      patchwork
     ];
     jaspMixedModels = buildJaspModule "jaspMixedModels" [
       afex
@@ -459,6 +490,8 @@ in
       BART
       EBMAforecast
       imputeTS
+      scoringRules
+      scoringutils
     ];
     jaspProcess = buildJaspModule "jaspProcess" [
       blavaan
@@ -543,6 +576,7 @@ in
       lme4
       MASS
       psych
+      mirt
     ];
     jaspRobustTTests = buildJaspModule "jaspRobustTTests" [
       RoBTT
@@ -553,16 +587,17 @@ in
     jaspSem = buildJaspModule "jaspSem" [
       forcats
       ggplot2
-      jaspBase
-      jaspGraphs
       lavaan
       cSEM
       reshape2
+      jaspBase
+      jaspGraphs
       semPlot
       semTools
       stringr
       tibble
       tidyr
+      SEMsens
     ];
     jaspSummaryStatistics = buildJaspModule "jaspSummaryStatistics" [
       BayesFactor
@@ -579,7 +614,7 @@ in
     ];
     jaspSurvival = buildJaspModule "jaspSurvival" [
       survival
-      survminer
+      ggsurvfit
       jaspBase
       jaspGraphs
     ];
@@ -592,6 +627,12 @@ in
       logspline
       plotrix
       plyr
+    ];
+    jaspTestModule = buildJaspModule "jaspTestModule" [
+      jaspBase
+      jaspGraphs
+      svglite
+      stringi
     ];
     jaspTimeSeries = buildJaspModule "jaspTimeSeries" [
       jaspBase


### PR DESCRIPTION
https://github.com/jasp-stats/jasp-desktop/releases/tag/v0.19.3
https://github.com/jasp-stats/jasp-desktop/releases/tag/v0.19.2

Some new modules were added in 0.19.2, those are also included.
I was able to find a cleaner way to patch `readstat`, so `replaceVars` is no longer needed.
I migrated over to using `lib.cmake*` for `cmakeFlags`
Note: I no longer specify `INSTALL_R_FRAMEWORK`, since that is darwin only, and we don't support darwin currently.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
