### PR TITLE
gamdl: init at 2.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25785,6 +25785,19 @@
     githubId = 10956211;
     name = "Valerio Besozzi";
   };
+  valentinegb = {
+    name = "Valentine Briese";
+
+    email = "valentinegb@icloud.com";
+    github = "valentinegb";
+    githubId = 35977727;
+
+    keys = [
+      {
+        fingerprint = "5F94 504D C611 FC4E 40AB  E6DE 9538 CFC6 8507 210B";
+      }
+    ];
+  };
   valeriangalliat = {
     email = "val@codejam.info";
     github = "valeriangalliat";

--- a/pkgs/by-name/ga/gamdl/package.nix
+++ b/pkgs/by-name/ga/gamdl/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+
+  # buildInputs
+  ffmpeg,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "gamdl";
+  version = "2.4.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-hxrhU5eUnz5xh6UL0D9R1YlPJFf/buoIBkIzBiqCC2Y=";
+  };
+
+  build-system = with python3Packages; [ flit ];
+
+  buildInputs = [ ffmpeg ];
+
+  dependencies = with python3Packages; [
+    click
+    colorama
+    inquirerpy
+    m3u8
+    mutagen
+    pillow
+    pywidevine
+    yt-dlp
+  ];
+
+  meta = {
+    description = "CLI for downloading songs and videos from Apple Music";
+    homepage = "https://github.com/glomatico/gamdl";
+    changelog = "https://github.com/glomatico/gamdl/releases/tag/v${version}";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ valentinegb ];
+    mainProgram = "gamdl";
+  };
+}

--- a/pkgs/development/python-modules/pymp4/default.nix
+++ b/pkgs/development/python-modules/pymp4/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchPypi,
+
+  # build-system
+  poetry-core,
+
+  # nativeCheckInputs
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "pymp4";
+  version = "1.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "beardypig";
+    repo = "pymp4";
+    rev = "v${version}";
+    hash = "sha256-gX9ovkA5+siYXmZ+StyQHRKrqS0NkKw0c/0SeUFcOqU=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    # pymp4 (as of v1.4.0) requires exactly v2.8.8 of construct
+    (buildPythonPackage rec {
+      pname = "construct";
+      version = "2.8.8";
+
+      src = fetchPypi {
+        inherit pname version;
+        hash = "sha256-G4S4FH9v0VvPZLc3w+isUQCBGtgMgwy0slRRQFEcQVc=";
+      };
+    })
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "MP4 parser and toolkit";
+    homepage = "https://github.com/beardypig/pymp4";
+    changelog = "https://github.com/beardypig/pymp4/releases/tag/v${version}";
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ valentinegb ];
+  };
+}

--- a/pkgs/development/python-modules/pywidevine/default.nix
+++ b/pkgs/development/python-modules/pywidevine/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  pyyaml,
+  unidecode,
+  click,
+  protobuf4,
+  pycryptodome,
+  pymp4,
+  requests,
+}:
+buildPythonPackage rec {
+  pname = "pywidevine";
+  version = "1.8.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-wU8/4oZEc0FrnKpz2aISUaAtchOObVTYwaP0S3prBck=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pyyaml
+    unidecode
+    click
+    protobuf4
+    pycryptodome
+    pymp4
+    requests
+  ];
+
+  meta = {
+    description = "Python implementation of Google's Widevine DRM CDM";
+    homepage = "https://github.com/devine-dl/pywidevine";
+    changelog = "https://github.com/devine-dl/pywidevine/releases/tag/v${version}";
+    license = with lib.licenses; [ gpl3Only ];
+    maintainers = with lib.maintainers; [ valentinegb ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12864,6 +12864,8 @@ self: super: with self; {
 
   pymorphy3-dicts-uk = callPackage ../development/python-modules/pymorphy3/dicts-uk.nix { };
 
+  pymp4 = callPackage ../development/python-modules/pymp4 { };
+
   pympler = callPackage ../development/python-modules/pympler { };
 
   pymsgbox = callPackage ../development/python-modules/pymsgbox { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14636,6 +14636,8 @@ self: super: with self; {
 
   pywfa = callPackage ../development/python-modules/pywfa { };
 
+  pywidevine = callPackage ../development/python-modules/pywidevine { };
+
   pywikibot = callPackage ../development/python-modules/pywikibot { };
 
   pywilight = callPackage ../development/python-modules/pywilight { };


### PR DESCRIPTION
Adds [gamdl](https://github.com/glomatico/gamdl) as a package, a CLI tool which downloads songs and videos from Apple Music. Also adds [pywidevine](https://github.com/devine-dl/pywidevine) (Python implementation of Google's Widevine DRM CDM), a dependency of gamdl, and [pymp4](https://github.com/beardypig/pymp4) (MP4 parser), a dependency of pywidevine.

This is my first contribution to nixpkgs, so please be forgiving if I make any mistakes. ^^'

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
