### PR TITLE
arq: init at 7.35.1

### DIFF
--- a/pkgs/by-name/ar/arq/package.nix
+++ b/pkgs/by-name/ar/arq/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  cpio,
+  xar,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "arq";
+  version = "7.35.1";
+
+  src = fetchurl {
+    url = "https://www.arqbackup.com/download/arqbackup/Arq${finalAttrs.version}.pkg";
+    hash = "sha256-xkrWH2r3DaxsBBdyu0Wj/qzjJaa9DTZCzEaB/nb2WyY=";
+  };
+
+  nativeBuildInputs = [
+    cpio
+    xar
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    xar -xf $src
+    zcat client.pkg/Payload | cpio -i
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R Applications $out
+  '';
+
+  dontBuild = true;
+
+  # Arq is notarized
+  dontFixup = true;
+
+  meta = {
+    changelog = "https://www.arqbackup.com/download/arqbackup/arq7_release_notes.html";
+    description = "Multi-cloud backup software for your Macs";
+    homepage = "https://www.arqbackup.com/";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = [ lib.maintainers.Enzime ];
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Arq® is backup software for your Mac or Windows PC.

https://www.arqbackup.com/

To run this on your machine you'll need to use the nix-darwin module to set up the correct launch daemons and agents: https://github.com/nix-darwin/nix-darwin/pull/1474

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc