### PR TITLE
rsshub: 0-unstable-2025-02-03 -> 0-unstable-2025-05-31

### DIFF
--- a/pkgs/by-name/rs/rsshub/0002-fix-network-call.patch
+++ b/pkgs/by-name/rs/rsshub/0002-fix-network-call.patch
@@ -1,0 +1,18 @@
+diff --git a/scripts/workflow/build-routes.ts b/scripts/workflow/build-routes.ts
+index 9807cfc..b9dcfb9 100644
+--- a/scripts/workflow/build-routes.ts
++++ b/scripts/workflow/build-routes.ts
+@@ -4,6 +4,7 @@ import { parse } from 'tldts';
+ import fs from 'node:fs';
+ import path from 'node:path';
+ import toSource from 'tosource';
++import { exit } from 'node:process';
+
+ import { getCurrentPath } from '../../lib/utils/helpers';
+ const __dirname = getCurrentPath(import.meta.url);
+@@ -73,3 +74,5 @@ fs.writeFileSync(path.join(__dirname, '../../assets/build/radar-rules.js'), `(${
+ fs.writeFileSync(path.join(__dirname, '../../assets/build/maintainers.json'), JSON.stringify(maintainers, null, 2));
+ fs.writeFileSync(path.join(__dirname, '../../assets/build/routes.json'), JSON.stringify(namespaces, null, 2));
+ fs.writeFileSync(path.join(__dirname, '../../assets/build/routes.js'), `export default ${JSON.stringify(namespaces, null, 2)}`.replaceAll(/"module": "(.*)"\n/g, `"module": $1\n`));
++
++exit(0);

--- a/pkgs/by-name/rs/rsshub/package.nix
+++ b/pkgs/by-name/rs/rsshub/package.nix
@@ -9,24 +9,25 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "rsshub";
-  version = "0-unstable-2025-02-03";
+  version = "0-unstable-2025-05-31";
 
   src = fetchFromGitHub {
     owner = "DIYgod";
     repo = "RSSHub";
-    rev = "72f78e2bfbcf000a6f374a92894430cf845fd1fd";
-    hash = "sha256-okavLIYJZ+0iCsYtBc2r3FS18MVE/ap2OwRae7rWTrw=";
+    rev = "2dce2e32dd5f4dade2fc915ac8384c953e11cc83";
+    hash = "sha256-gS/t6O3MishJgi2K9hV22hT95oYHfm44cJqrUo2GPlM=";
   };
 
   patches = [
     (replaceVars ./0001-fix-git-hash.patch {
       "GIT_HASH" = finalAttrs.src.rev;
     })
+    ./0002-fix-network-call.patch
   ];
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-c16Ue5YiRWlF7ldt/8WLi1/xYhGqqr6XqvUieQbvbWg=";
+    hash = "sha256-7qh6YZbIH/kHVssDZxHY7X8bytrnMcUq0MiJzWZYItc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/rs/rsshub/package.nix
+++ b/pkgs/by-name/rs/rsshub/package.nix
@@ -7,6 +7,9 @@
   replaceVars,
   stdenv,
 }:
+let
+  pnpm = pnpm_9;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rsshub";
   version = "0-unstable-2025-05-31";
@@ -25,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0002-fix-network-call.patch
   ];
 
-  pnpmDeps = pnpm_9.fetchDeps {
+  pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-7qh6YZbIH/kHVssDZxHY7X8bytrnMcUq0MiJzWZYItc=";
   };
@@ -33,23 +36,19 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeBinaryWrapper
     nodejs
-    pnpm_9.configHook
+    pnpm.configHook
   ];
 
   buildPhase = ''
     runHook preBuild
-
     pnpm build
-
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-
     mkdir -p $out/bin $out/lib/rsshub
     cp -r lib node_modules assets api package.json tsconfig.json $out/lib/rsshub
-
     runHook postInstall
   '';
 


### PR DESCRIPTION
I tried to find where the error is coming from, to patch that, but wasn't able to.
Added a weird hack to fix it.

<details open>
<summary>Expand/Collapse error</summary>

```js
Running phase: buildPhase

> rsshub@1.0.0 build /build/source
> tsx scripts/workflow/build-routes.ts && tsdown

/build/source/node_modules/.pnpm/undici@5.29.0/node_modules/undici/index.js:112
        Error.captureStackTrace(err, this)
              ^

TypeError: fetch failed
    at fetch (/build/source/node_modules/.pnpm/undici@5.29.0/node_modules/undici/index.js:112:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Function.create (/build/source/node_modules/.pnpm/youtubei.js@13.4.0/node_modules/youtubei.js/src/core/Player.ts:37:19)
    at async Function.create (/build/source/node_modules/.pnpm/youtubei.js@13.4.0/node_modules/youtubei.js/src/core/Session.ts:312:55)
    at async Function.create (/build/source/node_modules/.pnpm/youtubei.js@13.4.0/node_modules/youtubei.js/src/Innertube.ts:70:26) {
  cause: Error: getaddrinfo EAI_AGAIN www.youtube.com
      at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26) {
    errno: -3001,
    code: 'EAI_AGAIN',
    syscall: 'getaddrinfo',
    hostname: 'www.youtube.com'
  }
}

Node.js v22.14.0
 ELIFECYCLE  Command failed with exit code 1.
```
</details>


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
