### PR TITLE
blockbook: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/bl/blockbook/package.nix
+++ b/pkgs/by-name/bl/blockbook/package.nix
@@ -6,7 +6,7 @@
   lz4,
   nixosTests,
   pkg-config,
-  rocksdb_7_10,
+  rocksdb_9_10,
   snappy,
   stdenv,
   zeromq,
@@ -14,23 +14,23 @@
 }:
 
 let
-  rocksdb = rocksdb_7_10;
+  rocksdb = rocksdb_9_10;
 in
 buildGoModule rec {
   pname = "blockbook";
-  version = "0.4.0";
-  commit = "b227dfe";
+  version = "0.5.0";
+  commit = "657cbcf";
 
   src = fetchFromGitHub {
     owner = "trezor";
     repo = "blockbook";
     rev = "v${version}";
-    hash = "sha256-98tp3QYaHfhVIiJ4xkA3bUanXwK1q05t+YNroFtBUxE=";
+    hash = "sha256-8/tyqmZE9NJWGg7zYcdei0f1lpXfehy6LM6k5VHW33g=";
   };
 
   proxyVendor = true;
 
-  vendorHash = "sha256-n03eWWy+58KAbYnKxI3/ulWIpmR+ivtImQSqbe2kpYU=";
+  vendorHash = "sha256-W29AvzfleCYC2pgHj2OB00PWBTcD2UUDbDH/z5A3bQ4=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -48,8 +48,6 @@ buildGoModule rec {
     "-X github.com/trezor/blockbook/common.gitcommit=${commit}"
     "-X github.com/trezor/blockbook/common.buildDate=unknown"
   ];
-
-  tags = [ "rocksdb_7_10" ];
 
   CGO_LDFLAGS = [
     "-L${lib.getLib stdenv.cc.cc}/lib"

--- a/pkgs/by-name/bl/blockbook/package.nix
+++ b/pkgs/by-name/bl/blockbook/package.nix
@@ -82,7 +82,6 @@ buildGoModule rec {
     license = licenses.agpl3Only;
     maintainers = with maintainers; [
       mmahut
-      _1000101
     ];
     platforms = platforms.unix;
     mainProgram = "blockbook";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9505,6 +9505,17 @@ with pkgs;
     jvm = jre8;
   };
 
+  rocksdb_9_10 = rocksdb.overrideAttrs rec {
+    pname = "rocksdb";
+    version = "9.10.0";
+    src = fetchFromGitHub {
+      owner = "facebook";
+      repo = pname;
+      rev = "v${version}";
+      hash = "sha256-G+DlQwEUyd7JOCjS1Hg1cKWmA/qAiK8UpUIKcP+riGQ=";
+    };
+  };
+
   rocksdb_8_11 = rocksdb.overrideAttrs rec {
     pname = "rocksdb";
     version = "8.11.4";


### PR DESCRIPTION
In collaboration with @stapelberg @LorenzBischof ♥️

We also added `rocksdb_9_10` because it wouldn't build without it. This was necessary because the latest `rocksdb` on nixpkgs is now version 10 which broke blockbook 0.5.0. This PR therefore superseeds https://github.com/NixOS/nixpkgs/pull/409089 which broke since it was created due to the rocksdb version.

@mmahut

#ZurichZHF

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
