### PR TITLE
clipgrab: 3.9.7 -> 3.9.10

### DIFF
--- a/pkgs/applications/video/clipgrab/default.nix
+++ b/pkgs/applications/video/clipgrab/default.nix
@@ -17,10 +17,10 @@
 
 mkDerivation rec {
   pname = "clipgrab";
-  version = "3.9.7";
+  version = "3.9.10";
 
   src = fetchurl {
-    sha256 = "sha256-9H8raJd6MyyFICY8WUZQGLJ4teKPJUiQfqbu1HWAVIw=";
+    sha256 = "sha256-5shHv3hPccFgEPOE8J3YIi0Qxz+jcmSW14E49uczBJI=";
     # The .tar.bz2 "Download" link is a binary blob, the source is the .tar.gz!
     url = "https://download.clipgrab.org/${pname}-${version}.tar.gz";
   };

--- a/pkgs/applications/video/clipgrab/yt-dlp-path.patch
+++ b/pkgs/applications/video/clipgrab/yt-dlp-path.patch
@@ -17,8 +17,8 @@
  }
 --- a/youtube_dl.cpp
 +++ b/youtube_dl.cpp
-@@ -8,52 +8,16 @@ YoutubeDl::YoutubeDl()
- QString YoutubeDl::path = QString();
+@@ -9,81 +9,17 @@ QString YoutubeDl::path = QString();
+ QString YoutubeDl::pythonCaFile = QString();
  
  QString YoutubeDl::find(bool force) {
 -    if (!force && !path.isEmpty()) return path;
@@ -63,24 +63,55 @@
  
 -    QString execPath = QCoreApplication::applicationDirPath();
 -    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
--    env.insert("PATH", execPath + ":" + env.value("PATH"));
--    process->setEnvironment(env.toStringList());
--
--    #if defined Q_OS_WIN
--        process->setProgram(execPath + "/python/python.exe");
--    #else
--        process->setProgram(QStandardPaths::findExecutable("python3"));
--    #endif
 +    process->setProgram(path);
  
+-    #if defined Q_OS_WIN
+-        env.insert("PATH", QDir::toNativeSeparators(execPath) + ";" + env.value("PATH"));
+-        process->setProgram(execPath + "/python/python.exe");
+-    #elif defined Q_OS_MAC
+-        QDir pythonDir(execPath + "/../Frameworks/Python.framework/Versions/Current/bin");
+-        QString pythonPath = pythonDir.canonicalPath() + "/python3";
+-        if (QFile::exists(pythonPath)) {
+-            if (pythonCaFile.isEmpty()) {
+-                QProcess* caFileProcess = new QProcess();
+-                caFileProcess->setProgram(pythonPath);
+-                caFileProcess->setProcessEnvironment(env);
+-                caFileProcess->setArguments(QStringList() << "-m" << "pip._vendor.certifi");
+-                caFileProcess->start();
+-                caFileProcess->waitForFinished(10000);
+-                pythonCaFile = caFileProcess->readLine().trimmed();
+-                QString error = caFileProcess->readAllStandardError();
+-                if (!error.isEmpty()) {
+-                    qDebug() << "Error finding Python certificates" << error;
+-                }
+-                qDebug() << "Using SSL_CERT_FILE" << pythonCaFile;
+-            }
+-        } else {
+-            pythonPath = QStandardPaths::findExecutable("python3");
+-        }
+-
+-        if (!pythonCaFile.isEmpty()) {
+-            env.insert("SSL_CERT_FILE", pythonCaFile);
+-        }
+-
+-        env.insert("PATH", execPath + ":" + env.value("PATH"));
+-        process->setProgram(pythonPath);
+-    #else
+-        env.insert("PATH", execPath + ":" + env.value("PATH"));
+-        process->setProgram(QStandardPaths::findExecutable("python3"));
+-    #endif
+-    
      QSettings settings;
      QStringList proxyArguments;
-@@ -81,7 +45,7 @@ QProcess* YoutubeDl::instance(QString path, QStringList arguments) {
+     if (settings.value("UseProxy", false).toBool()) {
+@@ -110,9 +46,8 @@ QProcess* YoutubeDl::instance(QString path, QStringList arguments) {
          networkArguments << "--force-ipv4";
      }
  
 -    process->setArguments(QStringList() << path << arguments << proxyArguments << networkArguments);
 +    process->setArguments(QStringList() << arguments << proxyArguments << networkArguments);
+     process->setWorkingDirectory(QDir::tempPath());
+-    process->setProcessEnvironment(env);
+     
      return process;
  }
- 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Fixes #410391.

#ZurichZHF


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc