### PR TITLE
Revert "nixos-rebuild-ng: fix repl behaving differently on git flakes…

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -61,25 +61,6 @@ class BuildAttr:
         return cls(Path(file or "default.nix"), attr)
 
 
-def discover_git(location: Path) -> str | None:
-    current = location.resolve()
-    previous = None
-
-    while current.is_dir() and current != previous:
-        dotgit = current / ".git"
-        if dotgit.is_dir():
-            return str(current)
-        elif dotgit.is_file():  # this is a worktree
-            with dotgit.open() as f:
-                dotgit_content = f.read().strip()
-                if dotgit_content.startswith("gitdir: "):
-                    return dotgit_content.split("gitdir: ")[1]
-        previous = current
-        current = current.parent
-
-    return None
-
-
 @dataclass(frozen=True)
 class Flake:
     path: Path | str
@@ -103,15 +84,11 @@ class Flake:
         assert m is not None, f"got no matches for {flake_str}"
         attr = m.group("attr")
         nixos_attr = f"nixosConfigurations.{attr or hostname_fn() or 'default'}"
-        path_str = m.group("path")
-        if ":" in path_str:
-            return cls(path_str, nixos_attr)
-        else:
-            path = Path(path_str)
-            git_repo = discover_git(path)
-            if git_repo is not None:
-                return cls(f"git+file://{git_repo}", nixos_attr)
+        path = m.group("path")
+        if ":" in path:
             return cls(path, nixos_attr)
+        else:
+            return cls(Path(path), nixos_attr)
 
     @classmethod
     def from_arg(cls, flake_arg: Any, target_host: Remote | None) -> Self | None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -2,11 +2,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from pytest import MonkeyPatch
-
 import nixos_rebuild.models as m
-
-from .helpers import get_qualified_name
 
 
 def test_build_attr_from_arg() -> None:
@@ -30,7 +26,7 @@ def test_build_attr_to_attr() -> None:
     )
 
 
-def test_flake_parse(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
+def test_flake_parse() -> None:
     assert m.Flake.parse("/path/to/flake#attr") == m.Flake(
         Path("/path/to/flake"), "nixosConfigurations.attr"
     )
@@ -40,30 +36,14 @@ def test_flake_parse(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
     assert m.Flake.parse("/path/to/flake", lambda: "hostname") == m.Flake(
         Path("/path/to/flake"), "nixosConfigurations.hostname"
     )
-    # change directory to tmpdir
-    with monkeypatch.context() as patch_context:
-        patch_context.chdir(tmpdir)
-        assert m.Flake.parse(".#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
-        assert m.Flake.parse("#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
-        assert m.Flake.parse(".") == m.Flake(Path("."), "nixosConfigurations.default")
+    assert m.Flake.parse(".#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
+    assert m.Flake.parse("#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
+    assert m.Flake.parse(".") == m.Flake(Path("."), "nixosConfigurations.default")
     assert m.Flake.parse("path:/to/flake#attr") == m.Flake(
         "path:/to/flake", "nixosConfigurations.attr"
     )
     assert m.Flake.parse("github:user/repo/branch") == m.Flake(
         "github:user/repo/branch", "nixosConfigurations.default"
-    )
-    git_root = tmpdir / "git_root"
-    git_root.mkdir()
-    (git_root / ".git").mkdir()
-    assert m.Flake.parse(str(git_root)) == m.Flake(
-        f"git+file://{git_root}", "nixosConfigurations.default"
-    )
-
-    work_tree = tmpdir / "work_tree"
-    work_tree.mkdir()
-    (work_tree / ".git").write_text("gitdir: /path/to/git", "utf-8")
-    assert m.Flake.parse(str(work_tree)) == m.Flake(
-        "git+file:///path/to/git", "nixosConfigurations.default"
     )
 
 
@@ -77,9 +57,7 @@ def test_flake_to_attr() -> None:
 
 
 @patch("platform.node", autospec=True)
-def test_flake_from_arg(
-    mock_node: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
-) -> None:
+def test_flake_from_arg(mock_node: Mock) -> None:
     mock_node.return_value = "hostname"
 
     # Flake string
@@ -91,11 +69,9 @@ def test_flake_from_arg(
     assert m.Flake.from_arg(False, None) is None
 
     # True
-    with monkeypatch.context() as patch_context:
-        patch_context.chdir(tmpdir)
-        assert m.Flake.from_arg(True, None) == m.Flake(
-            Path("."), "nixosConfigurations.hostname"
-        )
+    assert m.Flake.from_arg(True, None) == m.Flake(
+        Path("."), "nixosConfigurations.hostname"
+    )
 
     # None when we do not have /etc/nixos/flake.nix
     with patch(
@@ -104,28 +80,6 @@ def test_flake_from_arg(
         return_value=False,
     ):
         assert m.Flake.from_arg(None, None) is None
-
-    # None when we have a file in /etc/nixos/flake.nix
-    with (
-        patch(
-            "pathlib.Path.exists",
-            autospec=True,
-            return_value=True,
-        ),
-        patch(
-            "pathlib.Path.is_symlink",
-            autospec=True,
-            return_value=False,
-        ),
-        patch(
-            get_qualified_name(m.discover_git),
-            autospec=True,
-            return_value="/etc/nixos",
-        ),
-    ):
-        assert m.Flake.from_arg(None, None) == m.Flake(
-            "git+file:///etc/nixos", "nixosConfigurations.hostname"
-        )
 
     with (
         patch(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -52,8 +52,7 @@ def test_build(mock_run: Mock) -> None:
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
-    monkeypatch.chdir(tmpdir)
+def test_build_flake(mock_run: Mock) -> None:
     flake = m.Flake.parse(".#hostname")
 
     assert n.build_flake(
@@ -169,10 +168,7 @@ def test_build_remote(
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build_remote_flake(
-    mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
-) -> None:
-    monkeypatch.chdir(tmpdir)
+def test_build_remote_flake(mock_run: Mock, monkeypatch: Mock) -> None:
     flake = m.Flake.parse(".#hostname")
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
@@ -294,7 +290,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     # Flake
-    flake = m.Flake.parse(f"{tmpdir}#attr")
+    flake = m.Flake.parse(".#attr")
     n.edit(flake, {"commit_lock_file": True})
     mock_run.assert_called_with(
         [
@@ -304,7 +300,7 @@ def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
             "edit",
             "--commit-lock-file",
             "--",
-            f"{tmpdir}#nixosConfigurations.attr",
+            ".#nixosConfigurations.attr",
         ],
         check=False,
     )


### PR DESCRIPTION
… than build commands"

This reverts commit 8e2bc8eed7fadaddc9960f2d117186420fe8067a.

Fix #410473.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
