### PR TITLE
nixos-rebuild-ng: handle subflakes correctly

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -61,19 +61,39 @@ class BuildAttr:
         return cls(Path(file or "default.nix"), attr)
 
 
-def discover_git(location: Path) -> str | None:
+def discover_git(location: Path) -> Path | None:
+    """
+    Discover the current git repository in the given location.
+    """
     current = location.resolve()
     previous = None
 
     while current.is_dir() and current != previous:
         dotgit = current / ".git"
         if dotgit.is_dir():
-            return str(current)
+            return current
         elif dotgit.is_file():  # this is a worktree
             with dotgit.open() as f:
                 dotgit_content = f.read().strip()
                 if dotgit_content.startswith("gitdir: "):
-                    return dotgit_content.split("gitdir: ")[1]
+                    return Path(dotgit_content.split("gitdir: ")[1])
+        previous = current
+        current = current.parent
+
+    return None
+
+
+def discover_closest_flake(location: Path) -> Path | None:
+    """
+    Discover the closest flake.nix file starting from the given location upwards.
+    """
+    current = location.resolve()
+    previous = None
+
+    while current.is_dir() and current != previous:
+        flake_file = current / "flake.nix"
+        if flake_file.is_file():
+            return current
         previous = current
         current = current.parent
 
@@ -110,7 +130,15 @@ class Flake:
             path = Path(path_str)
             git_repo = discover_git(path)
             if git_repo is not None:
-                return cls(f"git+file://{git_repo}", nixos_attr)
+                url = f"git+file://{git_repo}"
+                flake_path = discover_closest_flake(path)
+                if (
+                    flake_path is not None
+                    and flake_path != git_repo
+                    and flake_path.is_relative_to(git_repo)
+                ):
+                    url += f"?dir={flake_path.relative_to(git_repo)}"
+                return cls(url, nixos_attr)
             return cls(path, nixos_attr)
 
     @classmethod


### PR DESCRIPTION
Tested with a simple flake setup:

```
/tmp/zen-mcnulty-jHbPy1 main*
% /nix/store/9a2w8pb4zxz084hmjbfcmgpswan1kz51-nixos-rebuild-ng-0.0.0/bin/nixos-rebuild-ng repl --flake .#nixos Nix 2.28.3
nix-repl> config.networking.hostName
"nixos"

/tmp/zen-mcnulty-jHbPy1 main*

% cd subflake
 configuration.nix   flake.nix   hardware-configuration.nix   tmp/

/tmp/zen-mcnulty-jHbPy1/subflake main*
% /nix/store/9a2w8pb4zxz084hmjbfcmgpswan1kz51-nixos-rebuild-ng-0.0.0/bin/nixos-rebuild-ng repl --flake .#nixos nix-repl> config.networking.hostName
"foo"
```

Fix: #410473.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
