### PR TITLE
testers.hasCmakeConfigModules: init

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -40,6 +40,26 @@ If the `moduleNames` argument is omitted, `hasPkgConfigModules` will use `meta.p
 
 :::
 
+## `hasCmakeConfigModules` {#tester-hasCmakeConfigModules}
+
+Checks whether a package exposes a given list of `*config.cmake` modules.
+Note the moduleNames used in cmake find_package are case sensitive.
+
+:::{.example #ex-hascmakeconfigmodules}
+
+# Check that `*config.cmake` modules are exposed using explicit module names
+
+```nix
+{
+  passthru.tests.cmake-config = testers.hasCmakeConfigModules {
+    package = finalAttrs.finalPackage;
+    moduleNames = [ "Foo" ];
+  };
+}
+```
+
+:::
+
 ## `lycheeLinkCheck` {#tester-lycheeLinkCheck}
 
 Check a packaged static site's links with the [`lychee` package](https://search.nixos.org/packages?show=lychee&type=packages&query=lychee).

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1694,6 +1694,12 @@
   "ex-haspkgconfigmodules-explicitmodules": [
     "index.html#ex-haspkgconfigmodules-explicitmodules"
   ],
+  "tester-hasCmakeConfigModules": [
+    "index.html#tester-hasCmakeConfigModules"
+  ],
+  "ex-hascmakeconfigmodules": [
+    "index.html#ex-hascmakeconfigmodules"
+  ],
   "tester-lycheeLinkCheck": [
     "index.html#tester-lycheeLinkCheck"
   ],

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -225,6 +225,8 @@
       );
   hasPkgConfigModules = callPackage ./hasPkgConfigModules/tester.nix { };
 
+  hasCmakeConfigModules = callPackage ./hasCmakeConfigModules/tester.nix { };
+
   testMetaPkgConfig = callPackage ./testMetaPkgConfig/tester.nix { };
 
   shellcheck = callPackage ./shellcheck/tester.nix { };

--- a/pkgs/build-support/testers/hasCmakeConfigModules/tester.nix
+++ b/pkgs/build-support/testers/hasCmakeConfigModules/tester.nix
@@ -1,0 +1,86 @@
+# Static arguments
+{
+  lib,
+  runCommandCC,
+  cmake,
+}:
+
+# Tester arguments
+{
+  package,
+  moduleNames,
+  # Extra nativeBuildInputs needed to pass the cmake find_package test, e.g. pkg-config.
+  nativeBuildInputs ? [ ],
+  # buildInputs is used to help pass the cmake find_package test.
+  # The purpose of buildInputs here is to allow us to iteratively add
+  # any missing dependencies required by the *Config.cmake module
+  # during testing. This allows us to test and fix the CMake setup
+  # without rebuilding the finalPackage each time. Once all required
+  # packages are properly added to the finalPackage's propagateBuildInputs,
+  # this buildInputs should be set to an empty list [].
+  buildInputs ? [ ],
+  # Extra cmakeFlags needed to pass the cmake find_package test.
+  # Can be used to set verbose/debug flags.
+  cmakeFlags ? [ ],
+  testName ? "check-cmake-config-${package.pname or package.name}",
+  version ? package.version or null,
+  versionCheck ? false,
+}:
+
+runCommandCC testName
+  {
+    inherit moduleNames versionCheck cmakeFlags;
+    version = if versionCheck then version else null;
+    nativeBuildInputs = [
+      cmake
+    ] ++ nativeBuildInputs;
+    buildInputs = [ package ] ++ buildInputs;
+    meta =
+      {
+        description = "Test whether ${package.name} exposes cmake-config modules ${lib.concatStringsSep ", " moduleNames}";
+      }
+      # Make sure licensing info etc is preserved, as this is a concern for e.g. cache.nixos.org,
+      # as hydra can't check this meta info in dependencies.
+      # The test itself is just Nixpkgs, with MIT license.
+      // builtins.intersectAttrs {
+        available = throw "unused";
+        broken = throw "unused";
+        insecure = throw "unused";
+        license = throw "unused";
+        maintainers = throw "unused";
+        teams = throw "unused";
+        platforms = throw "unused";
+        unfree = throw "unused";
+        unsupported = throw "unused";
+      } package.meta;
+  }
+  ''
+    touch "$out"
+    notFound=0
+    for moduleName in $moduleNames; do
+      echo "checking cmake-config module $moduleName"
+
+      cat <<EOF > CMakeLists.txt
+    cmake_minimum_required(VERSION 3.14)
+    project(CheckCmakeModule)
+
+    find_package($moduleName $version EXACT NO_MODULE REQUIRED)
+    EOF
+
+      echoCmd 'cmake flags' $cmakeFlags
+      set +e
+      cmake . $cmakeFlags
+      r=$?
+      set -e
+      if [[ $r = 0 ]]; then
+        echo "✅ cmake-config module $moduleName exists"
+      else
+        echo "❌ cmake-config module $moduleName was not found"
+        ((notFound+=1))
+      fi
+    done
+
+    if [[ $notFound -ne 0 ]]; then
+      exit 1
+    fi
+  ''

--- a/pkgs/build-support/testers/hasCmakeConfigModules/tests.nix
+++ b/pkgs/build-support/testers/hasCmakeConfigModules/tests.nix
@@ -1,0 +1,73 @@
+# cd nixpkgs
+# nix-build -A tests.testers.hasCmakeConfigModules
+{
+  lib,
+  testers,
+  boost,
+  mpi,
+  eigen,
+  runCommand,
+}:
+
+lib.recurseIntoAttrs {
+
+  boost-versions-match = testers.hasCmakeConfigModules {
+    package = boost;
+    moduleNames = [
+      "Boost"
+      "boost_math"
+    ];
+    versionCheck = true;
+  };
+
+  boost-versions-mismatch = testers.testBuildFailure (
+    testers.hasCmakeConfigModules {
+      package = boost;
+      moduleNames = [
+        "Boost"
+        "boost_math"
+      ];
+      version = "1.2.3"; # Deliberately-incorrect version number
+      versionCheck = true;
+    }
+  );
+
+  boost-no-versionCheck = testers.hasCmakeConfigModules {
+    package = boost;
+    moduleNames = [
+      "Boost"
+      "boost_math"
+    ];
+    version = "1.2.3"; # Deliberately-incorrect version number
+    versionCheck = false;
+  };
+
+  boost-has-boost_mpi = testers.hasCmakeConfigModules {
+    package = boost.override { useMpi = true; };
+    moduleNames = [
+      "boost_mpi"
+    ];
+    buildInputs = [ mpi ];
+  };
+
+  boost_mpi-does-not-have-mpi = testers.testBuildFailure (
+    testers.hasCmakeConfigModules {
+      package = boost.override { useMpi = true; };
+      moduleNames = [
+        "boost_mpi"
+      ];
+    }
+  );
+
+  eigen-has-Eigen = testers.hasCmakeConfigModules {
+    package = eigen;
+    moduleNames = [ "Eigen3" ];
+  };
+
+  eigen-does-not-have-eigen = testers.testBuildFailure (
+    testers.hasCmakeConfigModules {
+      package = eigen;
+      moduleNames = [ "eigen3" ];
+    }
+  );
+}

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -37,6 +37,8 @@ lib.recurseIntoAttrs {
 
   hasPkgConfigModules = pkgs.callPackage ../hasPkgConfigModules/tests.nix { };
 
+  hasCmakeConfigModules = pkgs.callPackage ../hasCmakeConfigModules/tests.nix { };
+
   shellcheck = pkgs.callPackage ../shellcheck/tests.nix { };
 
   shfmt = pkgs.callPackages ../shfmt/tests.nix { };

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -11,7 +11,6 @@
   python3Packages,
   mpi,
   bzip2,
-  lz4,
   c-blosc2,
   hdf5-mpi,
   libfabric,
@@ -22,8 +21,6 @@
   zeromq,
   zfp,
   zlib,
-  zlib-ng,
-  zstd,
   ucx,
   yaml-cpp,
   nlohmann_json,
@@ -69,7 +66,6 @@ stdenv.mkDerivation (finalAttrs: {
     [
       mpi
       bzip2
-      lz4
       c-blosc2
       (hdf5-mpi.override { inherit mpi; })
       libfabric
@@ -80,8 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
       zeromq
       zfp
       zlib
-      zlib-ng # required by c-blocs2
-      zstd # required by c-blocs2
       yaml-cpp
       nlohmann_json
 

--- a/pkgs/development/libraries/c-blosc/1.nix
+++ b/pkgs/development/libraries/c-blosc/1.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     lz4
     zlib
     zstd
@@ -54,15 +54,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = !static;
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    cmake-config = testers.hasCmakeConfigModules {
+      moduleNames = [ "Blosc2" ];
+      package = finalAttrs.finalPackage;
+    };
+  };
 
   meta = with lib; {
     description = "Blocking, shuffling and loss-less compression library";
     homepage = "https://www.blosc.org";
     changelog = "https://github.com/Blosc/c-blosc/releases/tag/v${finalAttrs.version}";
-    pkgConfigModules = [
-      "blosc"
-    ];
+    pkgConfigModules = [ "blosc2" ];
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = with maintainers; [ ris ];

--- a/pkgs/development/libraries/c-blosc/2.nix
+++ b/pkgs/development/libraries/c-blosc/2.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     lz4
     zlib-ng
     zstd
@@ -56,15 +56,19 @@ stdenv.mkDerivation (finalAttrs: {
   # possibly https://github.com/Blosc/c-blosc2/issues/432
   enableParallelChecking = false;
 
-  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  passthru.tests = {
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    cmake-config = testers.hasCmakeConfigModules {
+      moduleNames = [ "Blosc2" ];
+      package = finalAttrs.finalPackage;
+    };
+  };
 
   meta = with lib; {
     description = "Fast, compressed, persistent binary data store library for C";
     homepage = "https://www.blosc.org";
     changelog = "https://github.com/Blosc/c-blosc2/releases/tag/v${finalAttrs.version}";
-    pkgConfigModules = [
-      "blosc2"
-    ];
+    pkgConfigModules = [ "blosc2" ];
     license = licenses.bsd3;
     platforms = platforms.all;
     maintainers = with maintainers; [ ris ];


### PR DESCRIPTION
This tester write a mininal CmakeLists.txt to test if the finalPackages and all its dependencies can be imported via
`find_package($modulename NO_MODULE REQUIRED)`

It is used to check if the finalPackage does correctly propagate all the needed packages required in *config.cmake module.

As a example, we check the library c-blosc2 with hasCmakeConfigModules.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
