### PR TITLE
nixos/prowlarr: use DynamicUser again, configure bind mount

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1125,7 +1125,7 @@ in
   prosody = handleTest ./xmpp/prosody.nix { };
   prosody-mysql = handleTest ./xmpp/prosody-mysql.nix { };
   proxy = handleTest ./proxy.nix { };
-  prowlarr = handleTest ./prowlarr.nix { };
+  prowlarr = runTest ./prowlarr.nix;
   pt2-clone = handleTest ./pt2-clone.nix { };
   pykms = handleTest ./pykms.nix { };
   public-inbox = handleTest ./public-inbox.nix { };

--- a/nixos/tests/prowlarr.nix
+++ b/nixos/tests/prowlarr.nix
@@ -1,22 +1,40 @@
-import ./make-test-python.nix (
-  { lib, ... }:
+{ lib, config, ... }:
 
-  {
-    name = "prowlarr";
-    meta.maintainers = with lib.maintainers; [ ];
+{
+  name = "prowlarr";
+  meta.maintainers = with lib.maintainers; [ ];
 
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        services.prowlarr.enable = true;
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.prowlarr.enable = true;
+      specialisation.customDataDir = {
+        inheritParentConfig = true;
+        configuration.services.prowlarr.dataDir = "/srv/prowlarr";
       };
+    };
 
-    testScript = ''
+  testScript = ''
+    def verify_prowlarr_works():
       machine.wait_for_unit("prowlarr.service")
       machine.wait_for_open_port(9696)
       response = machine.succeed("curl --fail http://localhost:9696/")
       assert '<title>Prowlarr</title>' in response, "Login page didn't load successfully"
       machine.succeed("[ -d /var/lib/prowlarr ]")
-    '';
-  }
-)
+
+    with subtest("Prowlarr starts and responds to requests"):
+      verify_prowlarr_works()
+
+    with subtest("Prowlarr data directory migration works"):
+      machine.systemctl("stop prowlarr.service")
+      machine.succeed("mkdir -p /tmp/prowlarr-migration")
+      machine.succeed("mv /var/lib/prowlarr/* /tmp/prowlarr-migration")
+      machine.succeed("${config.nodes.machine.system.build.toplevel}/specialisation/customDataDir/bin/switch-to-configuration test")
+      machine.wait_for_unit("var-lib-private-prowlarr.mount")
+      machine.succeed("mv /tmp/prowlarr-migration/* /var/lib/prowlarr")
+      machine.systemctl("restart prowlarr.service")
+      # Check that we're using a bind mount when using a non-default dataDir
+      machine.succeed("findmnt /var/lib/private/prowlarr | grep /srv/prowlarr")
+      verify_prowlarr_works()
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I'm not sure if the module should create the custom dataDir or if that should be left to the user, open to hear opinions about this. 
Partially reverts https://github.com/NixOS/nixpkgs/pull/408902

Involved in the previous PR:
@K900 @mweinelt @alyraffauf 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
