### PR TITLE
nixos/librenms: Add documentation and an option for syslog

### DIFF
--- a/nixos/modules/services/monitoring/librenms.md
+++ b/nixos/modules/services/monitoring/librenms.md
@@ -1,0 +1,76 @@
+# LibreNMS {#module-services-librenms}
+
+[LibreNMS](https://www.librenms.org/) is a fully featured network monitoring system that provides a wealth of features and device support.
+The server setup can be automated using [services.librenms](#opt-services.librenms.enable).
+
+## Initial setup {#module-services-librenms-initial-setup}
+
+A basic configuration could look like this:
+
+```nix
+{
+  networking.firewall.allowedTCPPorts = [
+    80 # Required for the web interface.
+  ];
+  services.librenms = {
+    enable = true;
+    database = {
+      createLocally = true;
+      socket = "/run/mysqld/mysqld.sock";
+    };
+  };
+}
+```
+
+Create an admin user:
+
+```bash
+librenms-artisan user:add --role=admin admin
+```
+
+## Configuring LibreNMS
+
+If you want to configure LibreNMS you can use the [services.librenms.settings](#opt-services.librenms.settings) option.
+See https://docs.librenms.org/Support/Configuration/ for reference, all possible options are listed there.
+Be aware, that in case you want to extend a setting that is of type list, you will overwrite the defaults and not extend them.
+Therefore you have to include the defaults as well, if you want to use them.
+
+## Ignore certain mount points
+
+By default LibreNMS monitors every mount point including virtual devices.
+This can be hard to get an overview over the actual state of the system.
+
+To counter this you can configure LibreNMS to ignore specified mount points.
+LibreNMS upstream ignores these mount points by default: [Default Ignored mount points](https://github.com/librenms/librenms/blob/master/resources/definitions/config_definitions.json#L4596-L4602)
+When we want to extend that list we need to include the defaults as well, otherwise they get overwritten by our new list.
+
+```nix
+{
+  services.librenms = {
+    settings = {
+      ignore_mount = [
+        "/example/mount/point"
+        # defaults: https://github.com/librenms/librenms/blob/master/resources/definitions/config_definitions.json#L4596-L4602
+        "/compat/linux/proc"
+        "/compat/linux/sys"
+        "/dev"
+        "/kern"
+        "/mnt/cdrom"
+        "/proc"
+        "/sys/fs/cgroup"
+      ];
+      ignore_mount_string = [
+        "example_string"
+        # defaults: https://github.com/librenms/librenms/blob/master/resources/definitions/config_definitions.json#L4646-L4652
+        "packages"
+        "devfs"
+        "procfs"
+        "linprocfs"
+        "linsysfs"
+        "UMA"
+        "MALLOC"
+      ];
+    };
+  };
+}
+```

--- a/nixos/modules/services/monitoring/librenms.md
+++ b/nixos/modules/services/monitoring/librenms.md
@@ -74,3 +74,21 @@ When we want to extend that list we need to include the defaults as well, otherw
   };
 }
 ```
+
+## Ingest Syslog traffic
+
+It is a good security practice to ship logs to a remote system in case the system gets breaches so one can try to reconstruct the events even when the attacker deletes the logs on the compromised system.
+
+LibreNMS has support for Syslog built in but it isn't configured by default on NixOS.
+
+```nix
+{
+  networking.firewall.allowedTCPPorts = [
+    514 # Required for Syslog
+  ];
+  networking.firewall.allowedUDPPorts = [
+    514 # Required for Syslog
+  ];
+  services.librenms.ingest-syslog.enable = true;
+}
+```

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -354,7 +354,11 @@ in
       description = ''
         Attrset of the LibreNMS configuration.
         See <https://docs.librenms.org/Support/Configuration/> for reference.
-        All possible options are listed [here](https://github.com/librenms/librenms/blob/master/resources/definitions/config_definitions.json).
+
+        All possible options and their defaults are listed [here](https://github.com/librenms/librenms/blob/master/misc/config_definitions.json).
+        Be aware, that in case you want to extend a setting that is of type list, you will overwrite the defaults and not extend them.
+        Therefore you have to include the defaults as well, if you want to use them.
+
         See <https://docs.librenms.org/Extensions/Authentication/> for setting other authentication methods.
       '';
       default = { };

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -377,7 +377,7 @@ in
         Attrset of the LibreNMS configuration.
         See <https://docs.librenms.org/Support/Configuration/> for reference.
 
-        All possible options and their defaults are listed [here](https://github.com/librenms/librenms/blob/master/misc/config_definitions.json).
+        All possible options and their defaults are listed [here](https://github.com/librenms/librenms/blob/master/resources/definitions/config_definitions.json).
         Be aware, that in case you want to extend a setting that is of type list, you will overwrite the defaults and not extend them.
         Therefore you have to include the defaults as well, if you want to use them.
 
@@ -396,7 +396,7 @@ in
       default = null;
       description = ''
         Additional config for LibreNMS that will be appended to the `config.php`. See
-        <https://github.com/librenms/librenms/blob/master/misc/config_definitions.json>
+        <https://github.com/librenms/librenms/blob/master/resources/definitions/config_definitions.json>
         for possible options. Useful if you want to use PHP-Functions in your config.
       '';
     };

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -43,6 +43,11 @@ let
     $sudo ${package}/artisan "$@"
   '';
 
+  libreNMSSyslogWrapper = pkgs.writeShellScriptBin "librenms-syslog" ''
+    cd ${package}
+    exec ${package.phpPackage}/bin/php ${package}/syslog.php "$@"
+  '';
+
   lnmsWrapper = pkgs.writeShellScriptBin "lnms" ''
     cd ${package}
     sudo=exec
@@ -337,6 +342,23 @@ in
       };
     };
 
+    ingestSyslog = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable a syslog-ng service on this LibreNMS instance in order to ingest and display Syslog traffic.
+        '';
+      };
+      syslogPort = mkOption {
+        type = types.port;
+        default = 514;
+        description = ''
+          Port accepting syslog traffic.
+        '';
+      };
+    };
+
     environmentFile = mkOption {
       type = types.nullOr types.str;
       default = null;
@@ -522,6 +544,26 @@ in
         "listen.group" = config.services.nginx.group;
       }
       // cfg.poolConfig;
+    };
+
+    services.syslog-ng = lib.mkIf cfg.ingestSyslog.enable {
+      enable = true;
+      # Taken from here: https://docs.librenms.org/Extensions/Syslog/
+      extraConfig = ''
+        source s_net {
+          tcp(port(${toString cfg.ingestSyslog.syslogPort}) flags(syslog-protocol));
+          udp(port(${toString cfg.ingestSyslog.syslogPort}) flags(syslog-protocol));
+        };
+
+        destination d_librenms {
+          program("${libreNMSSyslogWrapper}/bin/librenms-syslog" template ("''$HOST||''$FACILITY||''$PRIORITY||''$LEVEL||''$TAG||''$R_YEAR-''$R_MONTH-''$R_DAY ''$R_HOUR:''$R_MIN:''$R_SEC||''$MSG||''$PROGRAM\n") template-escape(yes));
+        };
+
+        log {
+          source(s_net);
+          destination(d_librenms);
+        };
+      '';
     };
 
     systemd.services.librenms-scheduler = {


### PR DESCRIPTION
Add some basic documentation for LibreNMS.
Extend the module to add support for Syslog.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

#ZurichZHF