### PR TITLE
element-{web-unwrapped,desktop}: 1.11.100 -> 1.11.102

### DIFF
--- a/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
+++ b/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
@@ -1,7 +1,7 @@
 {
-  "version" = "1.11.100";
+  "version" = "1.11.102";
   "hashes" = {
-    "desktopSrcHash" = "sha256-qlKZkBPWcD1eyEetCrIKsSXmodg6DYCmENfY+UT7Khc=";
-    "desktopYarnHash" = "sha256-wuRAeb4IpA2Ihr3ohaMPvFsaMod4Bg8o9lm8yzStwmk=";
+    "desktopSrcHash" = "sha256-wefoN8Nk31lwJFYbBRoKfy+0n69yVg6jskqP6aTHApE=";
+    "desktopYarnHash" = "sha256-/Gy/sYk8EBWU07zXwPl0zsDW5ADRq1j5PH4lPFe8dxk=";
   };
 }

--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -4,15 +4,15 @@
   fetchFromGitHub,
   makeWrapper,
   makeDesktopItem,
-  yarnConfigHook,
+  yarn,
   nodejs,
-  fetchYarnDeps,
   jq,
-  electron_35,
+  electron_36,
   element-web,
   sqlcipher,
   callPackage,
   desktopToDarwinBundle,
+  typescript,
   useKeytar ? true,
   # command line arguments which are always set
   commandLineArgs ? "",
@@ -22,7 +22,7 @@ let
   pinData = import ./element-desktop-pin.nix;
   inherit (pinData.hashes) desktopSrcHash desktopYarnHash;
   executableName = "element-desktop";
-  electron = electron_35;
+  electron = electron_36;
   keytar = callPackage ./keytar {
     inherit electron;
   };
@@ -41,16 +41,22 @@ stdenv.mkDerivation (
       hash = desktopSrcHash;
     };
 
-    offlineCache = fetchYarnDeps {
-      yarnLock = finalAttrs.src + "/yarn.lock";
-      sha256 = desktopYarnHash;
+    # TODO: fetchYarnDeps currently does not deal properly with a dependency
+    # declared as a pin to a commit in a specific git repository.
+    # While it does download everything correctly, `yarn install --offline`
+    # always wants to `git ls-remote` to the repository, ignoring the local
+    # cached tarball.
+    offlineCache = callPackage ./yarn.nix {
+      inherit (finalAttrs) version src;
+      hash = desktopYarnHash;
     };
 
     nativeBuildInputs = [
-      yarnConfigHook
       nodejs
       makeWrapper
       jq
+      yarn
+      typescript
     ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ desktopToDarwinBundle ];
 
     inherit seshat;
@@ -60,13 +66,21 @@ stdenv.mkDerivation (
     # this shouldn't be in the closure just for unused scripts.
     dontPatchShebangs = true;
 
+    configurePhase = ''
+      mkdir -p node_modules/
+      cp -r $offlineCache/node_modules/* node_modules/
+      substituteInPlace package.json --replace-fail "tsx " "node node_modules/tsx/dist/cli.mjs "
+    '';
+
     buildPhase = ''
       runHook preBuild
 
       yarn --offline run build:ts
-      yarn --offline run i18n
+      node node_modules/matrix-web-i18n/scripts/gen-i18n.js
+      yarn --offline run i18n:sort
       yarn --offline run build:res
 
+      chmod -R a+w node_modules/keytar-forked
       rm -rf node_modules/matrix-seshat node_modules/keytar-forked
       ${lib.optionalString useKeytar "ln -s ${keytar} node_modules/keytar-forked"}
       ln -s $seshat node_modules/matrix-seshat
@@ -82,6 +96,7 @@ stdenv.mkDerivation (
       ln -s '${element-web}' "$out/share/element/webapp"
       cp -r '.' "$out/share/element/electron"
       cp -r './res/img' "$out/share/element"
+      chmod -R "a+w" "$out/share/element/electron/node_modules"
       rm -rf "$out/share/element/electron/node_modules"
       cp -r './node_modules' "$out/share/element/electron"
       cp $out/share/element/electron/lib/i18n/strings/en_EN.json $out/share/element/electron/lib/i18n/strings/en-us.json

--- a/pkgs/by-name/el/element-desktop/yarn.nix
+++ b/pkgs/by-name/el/element-desktop/yarn.nix
@@ -1,0 +1,38 @@
+{
+  stdenvNoCC,
+  yarn,
+  cacert,
+  git,
+  version,
+  src,
+  hash,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "element-desktop-yarn-deps";
+  inherit version src;
+
+  nativeBuildInputs = [
+    cacert
+    yarn
+    git
+  ];
+
+  dontInstall = true;
+
+  NODE_EXTRA_CA_CERTS = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  buildPhase = ''
+    export HOME=$(mktemp -d)
+    export YARN_ENABLE_TELEMETRY=0
+
+    yarn install --frozen-lockfile --ignore-platform --skip-integrity-check --ignore-scripts --no-progress --non-interactive
+
+    mkdir -p $out/node_modules
+    cp -r node_modules/* $out/node_modules/
+  '';
+
+  dontPatchShebangs = true;
+
+  outputHash = hash;
+  outputHashMode = "recursive";
+}

--- a/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
@@ -1,7 +1,7 @@
 {
-  "version" = "1.11.100";
+  "version" = "1.11.102";
   "hashes" = {
-    "webSrcHash" = "sha256-FiYjWOJ50Vhbs9vgEqK64HTVtwSuy4/BZAkPK4c6DXQ=";
-    "webYarnHash" = "sha256-C1yVJHU9ClTJHQfMLkdZEeRWVVu68eJp2kxnIlLinY8=";
+    "webSrcHash" = "sha256-B21fBRcksX8MoyWiqf1sa9yowJ/Z/wcM3vEqslunv7A=";
+    "webYarnHash" = "sha256-NXoGMEJM4uxFMCb5YX0ue9hgxe22hzG0MTeAOaBrJO4=";
   };
 }


### PR DESCRIPTION
#### `element-web`

Release notes: https://github.com/element-hq/element-web/releases/tag/v1.11.101
Changelog: https://github.com/element-hq/element-web/compare/v1.11.100...v1.11.101

#### `element-desktop`

Release notes: https://github.com/element-hq/element-desktop/releases/tag/v1.11.101
Changelog: https://github.com/element-hq/element-desktop/compare/v1.11.100...v1.11.101

Updates electron from 35 to 36.

Re-introduces the same mechanism for the yarnOfflineCache as #381196, as
the problem described in there is back again.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
