### PR TITLE
smatch: fix build by applying custom fix

### DIFF
--- a/pkgs/by-name/sm/smatch/package.nix
+++ b/pkgs/by-name/sm/smatch/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [ pkg-config ];
+  patches = [ ./remove_const.patch ];
 
   buildInputs =
     [

--- a/pkgs/by-name/sm/smatch/remove_const.patch
+++ b/pkgs/by-name/sm/smatch/remove_const.patch
@@ -1,0 +1,32 @@
+diff --git a/smatch.h b/smatch.h
+index 36ae3497..ceb1907c 100644
+--- a/smatch.h
++++ b/smatch.h
+@@ -1375,7 +1375,7 @@ bool buf_comp_has_bytes(struct expression *buf, struct expression *var);
+ bool buf_comp2_has_bytes(struct expression *buf_expr, struct expression *var);
+ 
+ /* smatch_untracked_param.c */
+-void mark_untracked(struct expression *expr, int param, const char *key, const char *value);
++void mark_untracked(struct expression *expr, int param, char *key, char *value);
+ void add_untracked_param_hook(void (func)(struct expression *call, int param));
+ void add_lost_param_hook(void (func)(struct expression *call, int param));
+ void mark_all_params_untracked(int return_id, char *return_ranges, struct expression *expr);
+diff --git a/smatch_untracked_param.c b/smatch_untracked_param.c
+index 4bb3c244..d24958e7 100644
+--- a/smatch_untracked_param.c
++++ b/smatch_untracked_param.c
+@@ -120,12 +120,12 @@ free:
+ 
+ }
+ 
+-void mark_untracked(struct expression *expr, int param, const char *key, const char *value)
++void mark_untracked(struct expression *expr, int param, char *key, char *value)
+ {
+ 	mark_untracked_lost(expr, param, key, UNTRACKED_PARAM);
+ }
+ 
+-void mark_lost(struct expression *expr, int param, const char *key, const char *value)
++void mark_lost(struct expression *expr, int param, char *key, char *value)
+ {
+ 	mark_untracked_lost(expr, param, key, LOST_PARAM);
+ }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Applied a custom patch that removes const from methods, that caused an invalid function being passed as an argument.

#ZurichZHF

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
