### PR TITLE
[Backport staging-24.11] qrencode: fix build failure

### DIFF
--- a/pkgs/development/libraries/qrencode/default.nix
+++ b/pkgs/development/libraries/qrencode/default.nix
@@ -1,12 +1,13 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   pkg-config,
   SDL2,
   libpng,
   libiconv,
   libobjc,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: rec {
@@ -20,12 +21,17 @@ stdenv.mkDerivation (finalAttrs: rec {
     "dev"
   ];
 
-  src = fetchurl {
-    url = "https://fukuchi.org/works/qrencode/qrencode-${version}.tar.gz";
-    sha256 = "sha256-2kSO1PUqumvLDNSMrA3VG4aSvMxM0SdDFAL8pvgXHo4=";
+  src = fetchFromGitHub {
+    owner = "fukuchi";
+    repo = "libqrencode";
+    rev = "v${version}";
+    hash = "sha256-nbrmg9SqCqMrLE7WCfNEzMV/eS9UVCKCrjBrGMzAsLk";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
 
   buildInputs = [
     libiconv

--- a/pkgs/development/libraries/qrencode/default.nix
+++ b/pkgs/development/libraries/qrencode/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   pkg-config,
-  SDL2,
   libpng,
   libiconv,
   libobjc,
@@ -37,8 +36,6 @@ stdenv.mkDerivation (finalAttrs: rec {
     libiconv
     libpng
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libobjc ];
-
-  nativeCheckInputs = [ SDL2 ];
 
   doCheck = false;
 


### PR DESCRIPTION
This is a manual backport of #407835

Ref: https://github.com/NixOS/nixpkgs/pull/407835#issuecomment-2902181410

Cc @philiptaron 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
