### PR TITLE
catnap: init at 0-unstable-2024-11-19, nixos/tests: catnap

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -291,11 +291,12 @@ in
   calibre-web = runTest ./calibre-web.nix;
   calibre-server = import ./calibre-server.nix { inherit pkgs runTest; };
   canaille = runTest ./canaille.nix;
-  castopod = runTest ./castopod.nix;
   cassandra = runTest {
     imports = [ ./cassandra.nix ];
     _module.args.getPackage = pkgs: pkgs.cassandra;
   };
+  castopod = runTest ./castopod.nix;
+  catnap = runTest ./catnap.nix;
   centrifugo = runTest ./centrifugo.nix;
   ceph-multi-node = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./ceph-multi-node.nix;
   ceph-single-node = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./ceph-single-node.nix;

--- a/nixos/tests/catnap.nix
+++ b/nixos/tests/catnap.nix
@@ -1,0 +1,14 @@
+{ lib, pkgs, ... }:
+{
+  name = "catnap";
+  meta.maintainers = with lib.maintainers; [ phanirithvij ];
+  nodes.machine = {
+    virtualisation.memorySize = 512;
+    environment.systemPackages = with pkgs; [ catnap ];
+  };
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("catnap")
+    machine.succeed("${pkgs.catnap.testsout}/scripts/test-commandline-args.sh")
+  '';
+}

--- a/pkgs/by-name/ca/catnap/fallback-config.patch
+++ b/pkgs/by-name/ca/catnap/fallback-config.patch
@@ -1,0 +1,59 @@
+diff --git a/scripts/test_config.toml b/scripts/test_config.toml
+index 08d189c..b074663 100644
+--- a/scripts/test_config.toml
++++ b/scripts/test_config.toml
+@@ -11,8 +11,8 @@ kernel    = {icon = ">", name = "kernel", color = "(MA)"}
+ desktop   = {icon = ">", name = "desktp", color = "(CN)"}
+ terminal  = {icon = ">", name = "term", color = "(RD)"}
+ shell     = {icon = ">", name = "shell", color = "(MA)"}
+-packages  = {icon = ">", name = "packages", color = "(GN)"}
+-weather   = {icon = ">", name = "weather", color = "(BE)"}
++# packages  = {icon = ">", name = "packages", color = "(GN)"}
++# weather   = {icon = ">", name = "weather", color = "(BE)"}
+ gpu       = {icon = ">", name = "gpu", color = "(MA)"}
+ cpu       = {icon = ">", name = "cpu", color = "(RD)"}
+ disk_0    = {icon = ">", name = "disk", color = "(GN)"}
+diff --git a/src/catnaplib/global/config.nim b/src/catnaplib/global/config.nim
+index 0b929fb..e883d5e 100644
+--- a/src/catnaplib/global/config.nim
++++ b/src/catnaplib/global/config.nim
+@@ -18,16 +18,18 @@ proc isImageTerm(): bool =
+         term = getEnv("TERM")
+     return (term in VALID_TERMS or "iTerm" in term or "WezTerm" in term or "mintty" in term or "kitty" in term)
+
+-proc LoadConfig*(cfgPath: string, dstPath: string): Config =
++proc LoadConfig*(cfgArg: string, dstArg: string): Config =
++    var cfgPath = cfgArg
++    var dstPath = dstArg
+     # Lads a config file and validates it
+
+     # Validate the config file
+     if not fileExists(cfgPath):
+-        logError(&"{cfgPath} - file not found!")
+-    
++        cfgPath = "@out@/share/config/config.toml"
++
+     # Validate the art file
+     if not fileExists(dstPath):
+-        logError(&"{dstPath} - file not found!")
++        dstPath = "@out@/share/config/distros.toml"
+
+     let tcfg = parsetoml.parseFile(cfgPath)
+     let tdistros = parsetoml.parseFile(dstPath)
+diff --git a/src/catnaplib/global/definitions.nim b/src/catnaplib/global/definitions.nim
+index 6b30857..a88fb71 100644
+--- a/src/catnaplib/global/definitions.nim
++++ b/src/catnaplib/global/definitions.nim
+@@ -140,9 +140,10 @@ const
+         "homebrew": "brew list | wc -l",
+     }.toOrderedTable
+
++var
+     # Files / Dirs
+-    CONFIGPATH*   = static: joinPath(getConfigDir(), "catnap/config.toml")
+-    DISTROSPATH*  = static: joinPath(getConfigDir(), "catnap/distros.toml")
++    CONFIGPATH*   = joinPath(getConfigDir(), "catnap/config.toml")
++    DISTROSPATH*  = joinPath(getConfigDir(), "catnap/distros.toml")
+
+
+ proc getCachePath*(): string =

--- a/pkgs/by-name/ca/catnap/package.nix
+++ b/pkgs/by-name/ca/catnap/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  makeWrapper,
+  nixosTests,
+  installShellFiles,
+  writableTmpDirAsHomeHook,
+
+  nim,
+  curl,
+  gzip,
+  gitMinimal,
+  viu,
+  figlet,
+  pcre2,
+  usbutils,
+  pciutils,
+}:
+# buildNimPackage doesn't work because there is no .nimble file
+stdenv.mkDerivation (finalAttrs: {
+  pname = "catnap";
+  version = "0-unstable-2024-11-19";
+
+  src = fetchFromGitHub {
+    owner = "iinsertNameHere";
+    repo = "catnap";
+    rev = "268e207ab39d217b6768229e371c9520688a3e68";
+    hash = "sha256-Q3Mjo3v9u6Y+CZA/08iTBBq5DmorfiDw1KEHQXvGaJE=";
+    leaveDotGit = true;
+    postFetch = ''
+      pushd $out
+      git rev-parse HEAD | tr -d '\n' > .commit-hash
+      rm -rf .git
+      popd
+    '';
+  };
+
+  postPatch = ''
+    substituteInPlace scripts/git-commit-id.sh \
+    --replace-fail '$(git rev-parse HEAD)' "$(cat .commit-hash)"
+    source ./scripts/git-commit-id.sh
+
+    # As we need the $out reference, we can't use `replaceVars` here.
+    cp ${./fallback-config.patch} fallback-config.patch
+    substituteInPlace fallback-config.patch \
+      --replace-fail '@out@' "$out"
+    patch -p1 < ./fallback-config.patch
+  '';
+
+  nativeBuildInputs = [
+    gzip
+    nim
+    gitMinimal
+    makeWrapper
+    installShellFiles
+    writableTmpDirAsHomeHook
+  ];
+
+  runtimeDependencies = [
+    pcre2
+    usbutils
+    figlet
+    viu
+    curl
+    pciutils
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    mkdir -p $out/bin $out/share $testsout
+    nim release
+    cp bin/catnap $out/bin
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    installManPage docs/catnap.1 docs/catnap.5
+    wrapProgram $out/bin/catnap \
+      --set PATH ${lib.makeBinPath finalAttrs.runtimeDependencies}
+    cp -r config $out/share
+    sed -i "s|./../bin/catnap|$out/bin/catnap|g" scripts/test-commandline-args.sh
+    sed -i "s|../config|$out/share/config|g" scripts/test-commandline-args.sh
+    sed -i "s|./test_config.toml|$testsout/scripts/test_config.toml|g" scripts/test-commandline-args.sh
+    cp -R scripts $testsout
+    runHook postInstall
+  '';
+
+  outputs = [
+    "out"
+    "testsout"
+  ];
+
+  # Tests don't run inside the sandbox they need a nixos system
+  doCheck = false; # false is the default
+  passthru.tests.nixosTest = nixosTests.catnap;
+
+  meta = {
+    description = "A highly customizable systemfetch written in nim";
+    homepage = "https://github.com/iinsertNameHere/catnap";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "catnap";
+    maintainers = with lib.maintainers; [ phanirithvij ];
+  };
+})


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/issues/354603

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
