### PR TITLE
honey-home: init at 0-unstable-2022-10-25

### DIFF
--- a/pkgs/by-name/ho/honey-home/package.nix
+++ b/pkgs/by-name/ho/honey-home/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  zip,
+  love,
+  imagemagick,
+  strip-nondeterminism,
+  copyDesktopItems,
+  fetchFromGitHub,
+  fetchpatch2,
+  makeDesktopItem,
+  makeBinaryWrapper,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "honey-home";
+  version = "0-unstable-2022-10-25";
+
+  # submodules have git@github.com which doesn't work
+  # error: cannot run ssh: No such file or directory
+  # this override is required to fetch them via https
+  src =
+    (fetchFromGitHub {
+      owner = "dvdfu";
+      repo = "ld38";
+      rev = "45bb4bde8a667ee8cfb5034345bec90f70eb3b91";
+      hash = "sha256-m8dyCoudTJDfP0KGcoA0Xj5LmRwN/8YOfEwiwCa8sOE=";
+      fetchSubmodules = true;
+    }).overrideAttrs
+      (_: {
+        GIT_CONFIG_COUNT = 1;
+        GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+        GIT_CONFIG_VALUE_0 = "git@github.com:";
+      });
+
+  patches = [
+    # follow https://github.com/dvdfu/ld38/pull/58 and remove if ever merged
+    (fetchpatch2 {
+      url = "https://github.com/dvdfu/ld38/commit/808537065a8dacc903e3d704b381f61b11f91d47.patch?full_index=1";
+      hash = "sha256-iXFQWRU2hbKjVGjkwZKgxckRpr3/DUXczNNuMz48ktA=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeBinaryWrapper
+    imagemagick
+    strip-nondeterminism
+    zip
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Honey Home";
+      exec = "honey-home";
+      icon = "honey-home";
+      comment = "Save the bees in this tiny world";
+      desktopName = "Honey Home";
+      genericName = "Honey Home";
+      categories = [ "Game" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/pixmaps
+    # generate a logo as the title logo in the readme is too wide for an app icon
+    magick \
+      res/tree_hive.png \
+      res/hud_bee.png -gravity Center -geometry -8+15 -composite \
+      res/hud_bee.png -gravity Center -geometry -24+8 -composite \
+      honey-home-logo.png
+    install -Dm644 honey-home-logo.png $out/share/pixmaps/honey-home.png
+    rm honey-home-logo.png
+    zip -9 -r honey-home.love ./*
+    strip-nondeterminism --type zip honey-home.love
+    install -Dm444 -t $out/share/games/lovegames/ honey-home.love
+    makeWrapper ${love}/bin/love $out/bin/honey-home \
+      --add-flags $out/share/games/lovegames/honey-home.love
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/dvdfu/ld38";
+    downloadPage = "https://dvdfu.itch.io/honey-home";
+    description = "A game where you save the bees, Ludum Dare 38 Game Jam winner";
+    license = lib.licenses.unfreeRedistributable; # best guess as it is source available
+    platforms = love.meta.platforms;
+    mainProgram = "honey-home";
+    maintainers = with lib.maintainers; [ phanirithvij ];
+  };
+})


### PR DESCRIPTION
ld38 winner, honey home

- https://dvdfu.itch.io/honey-home
- https://ldjam.com/events/ludum-dare/38/results
- https://ldjam.com/events/ludum-dare/38/$16179
- https://github.com/dvdfu/ld38

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
