### PR TITLE
nvi: Fix build by applying Debian patches and enabling wide chars

### DIFF
--- a/pkgs/by-name/nv/nvi/package.nix
+++ b/pkgs/by-name/nv/nvi/package.nix
@@ -2,48 +2,75 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
+  fetchzip,
   ncurses,
   db,
 }:
 
-stdenv.mkDerivation rec {
+let
   pname = "nvi";
   version = "1.81.6";
+  deb_version = "23";
+
+  base_url = "mirror://debian/pool/main/n/${pname}/${pname}_${version}";
+
+  debian-extras = fetchzip {
+    url = "${base_url}-${deb_version}.debian.tar.xz";
+    hash = "sha256-dR7vZtCV5PjUDlNTWxubxH7eucizkPRaMlyNdziud84=";
+  };
+in
+stdenv.mkDerivation rec {
+  inherit pname;
+  inherit version;
 
   src = fetchurl {
-    url = "https://deb.debian.org/debian/pool/main/n/nvi/nvi_${version}.orig.tar.gz";
+    url = "${base_url}.orig.tar.gz";
     sha256 = "13cp9iz017bk6ryi05jn7drbv7a5dyr201zqd3r4r8srj644ihwb";
   };
-
-  patches = [
-    # Fix runtime error with modern versions of db.
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/nvi/raw/f33/f/nvi-03-db4.patch";
-      sha256 = "1vpnly3dcldwl8gwl0jrh5yh0vhgbdhsh6xn7lnwhrawlvk6d55y";
-    })
-
-    # Fix build with Glibc.
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/nvi/raw/f33/f/nvi-20-glibc_has_grantpt.patch";
-      sha256 = "1ypqj263wh53m5rgiag5c4gy1rksj2waginny1lcj34n72p2dsml";
-    })
-  ];
 
   buildInputs = [
     ncurses
     db
   ];
 
+  # Debian maintains lots of patches for nvi. Let's include all of them.
+  prePatch = ''
+    patches="$patches $(cat ${debian-extras}/patches/series | sed 's|^|${debian-extras}/patches/|')"
+  '';
+
   preConfigure = ''
     cd build.unix
+    # mkdir -p /var/tmp/vi.recover
   '';
   configureScript = "../dist/configure";
-  configureFlags = [ "vi_cv_path_preserve=/tmp" ];
+  configureFlags = [
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Commented out entries without other comments are commented out due to
+    # request by @tnias in PR #410629 due to no difference when examined with
+    # diffoscope.
+    #
+    # Keeping as comments to make tracking Debian easier.
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # "--disable-curses"
+    # "--disable-shared"
+    # "--enable-static"
+    "--enable-widechar"
+    # "--disable-threads"
+    # "--without-x"
+    # "--with-gnu-ld=yes"
+    # XXX: TODO: Integrate with a sendmail facility for recover file notifications
+    # "ac_cv_path_vi_cv_path_sendmail=sendmail"
+    # XXX: TODO: This should auto-detect /var/tmp/vi.recover instead
+    "vi_cv_path_preserve=/var/tmp"
+    # Let autoconf select shell from stdenv
+    # "vi_cv_path_shell=/bin/sh"
+    # "vi_cv_revoke=no"
+  ];
 
   meta = with lib; {
     description = "Berkeley Vi Editor";
     license = licenses.free;
+    maintainers = with maintainers; [ suominen ];
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/nvi.x86_64-darwin
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Instead of fetching a couple of patches from Fedora, apply all the Debian patches.  Also use the same `configure` options as Debian, most importantly enabling wide chars.  This makes it build again.

Resolves #382978.

Side notes:

- nvi is my daily editor and I want to make sure it is usable in NixOS.
- I will need to learn the backport part to get this into 25.05 so I can continue editing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
