### PR TITLE
cubeb: update, modernize, remove lazy loading

### DIFF
--- a/pkgs/by-name/ce/cemu/package.nix
+++ b/pkgs/by-name/ce/cemu/package.nix
@@ -150,7 +150,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup =
     let
-      libs = [ vulkan-loader ] ++ cubeb.passthru.backendLibs;
+      libs = [ vulkan-loader ];
     in
     ''
       gappsWrapperArgs+=(

--- a/pkgs/by-name/cu/cubeb/0001-cmake-add-pkg-config-file-generation.patch
+++ b/pkgs/by-name/cu/cubeb/0001-cmake-add-pkg-config-file-generation.patch
@@ -1,0 +1,208 @@
+From e0cbc1049b9a3a3322cd48d32af148f87d5007c2 Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Mon, 19 May 2025 22:36:53 +0200
+Subject: [PATCH] cmake: add pkg-config file generation
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ CMakeLists.txt | 50 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ libcubeb.pc.in | 12 ++++++++++++
+ 2 files changed, 62 insertions(+)
+ create mode 100644 libcubeb.pc.in
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 07618fa..6470837 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,6 +23,17 @@ if(NOT CMAKE_BUILD_TYPE)
+       "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+ endif()
+ 
++set(private_requires)
++set(private_libs)
++set(private_libs_flags)
++if(UNIX AND NOT APPLE)
++  if(BSD OR ANDROID)
++    list(APPEND private_libs c++)
++  else()
++    list(APPEND private_libs stdc++)
++  endif()
++endif()
++
+ set(CMAKE_C_STANDARD 99)
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+@@ -141,6 +152,7 @@ if(NOT BUNDLE_SPEEX)
+     pkg_check_modules(speexdsp IMPORTED_TARGET speexdsp)
+     if(speexdsp_FOUND)
+       add_library(speex ALIAS PkgConfig::speexdsp)
++      list(APPEND private_requires speexdsp)
+     endif()
+   endif()
+ endif()
+@@ -155,6 +167,7 @@ if(NOT TARGET speex)
+     EXPORT=
+     RANDOM_PREFIX=speex
+   )
++  list(APPEND private_libs speex)
+ endif()
+ 
+ # $<BUILD_INTERFACE:> required because of https://gitlab.kitware.com/cmake/cmake/-/issues/15415
+@@ -166,6 +179,7 @@ include(CheckIncludeFiles)
+ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ find_package(Threads)
+ target_link_libraries(cubeb PRIVATE Threads::Threads)
++list(APPEND private_libs ${CMAKE_THREAD_LIBS_INIT})
+ 
+ if(LAZY_LOAD_LIBS)
+   check_include_files(pulse/pulseaudio.h USE_PULSE)
+@@ -176,6 +190,7 @@ if(LAZY_LOAD_LIBS)
+ 
+   if(USE_PULSE OR USE_ALSA OR USE_JACK OR USE_SNDIO OR USE_AAUDIO)
+     target_link_libraries(cubeb PRIVATE ${CMAKE_DL_LIBS})
++    list(APPEND private_libs ${CMAKE_DL_LIBS})
+ 
+     if(ANDROID)
+       target_compile_definitions(cubeb PRIVATE __ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__)
+@@ -191,6 +206,7 @@ else()
+     set(USE_PULSE ON)
+     target_compile_definitions(cubeb PRIVATE DISABLE_LIBPULSE_DLOPEN)
+     target_link_libraries(cubeb PRIVATE PkgConfig::libpulse)
++    list(APPEND private_requires libpulse)
+   endif()
+ 
+   pkg_check_modules(alsa IMPORTED_TARGET alsa)
+@@ -198,6 +214,7 @@ else()
+     set(USE_ALSA ON)
+     target_compile_definitions(cubeb PRIVATE DISABLE_LIBASOUND_DLOPEN)
+     target_link_libraries(cubeb PRIVATE PkgConfig::alsa)
++    list(APPEND private_requires alsa)
+   endif()
+ 
+   pkg_check_modules(jack IMPORTED_TARGET jack)
+@@ -205,18 +222,21 @@ else()
+     set(USE_JACK ON)
+     target_compile_definitions(cubeb PRIVATE DISABLE_LIBJACK_DLOPEN)
+     target_link_libraries(cubeb PRIVATE PkgConfig::jack)
++    list(APPEND private_requires jack)
+   endif()
+ 
+   check_include_files(sndio.h USE_SNDIO)
+   if(USE_SNDIO)
+     target_compile_definitions(cubeb PRIVATE DISABLE_LIBSNDIO_DLOPEN)
+     target_link_libraries(cubeb PRIVATE sndio)
++    list(APPEND private_libs sndio)
+   endif()
+ 
+   check_include_files(aaudio/AAudio.h USE_AAUDIO)
+   if(USE_AAUDIO)
+     target_compile_definitions(cubeb PRIVATE DISABLE_LIBAAUDIO_DLOPEN)
+     target_link_libraries(cubeb PRIVATE aaudio)
++    list(APPEND private_libs aaudio)
+   endif()
+ endif()
+ 
+@@ -263,6 +283,7 @@ if(USE_AUDIOUNIT)
+     src/cubeb_osx_run_loop.cpp)
+   target_compile_definitions(cubeb PRIVATE USE_AUDIOUNIT)
+   target_link_libraries(cubeb PRIVATE "-framework AudioUnit" "-framework CoreAudio" "-framework CoreServices")
++  list(APPEND private_libs_flags "-framework AudioUnit" "-framework CoreAudio" "-framework CoreServices")
+ endif()
+ 
+ check_include_files(audioclient.h USE_WASAPI)
+@@ -271,6 +292,7 @@ if(USE_WASAPI)
+     src/cubeb_wasapi.cpp)
+   target_compile_definitions(cubeb PRIVATE USE_WASAPI)
+   target_link_libraries(cubeb PRIVATE avrt ole32 ksuser)
++  list(APPEND private_libs avrt ole32 ksuser)
+ endif()
+ 
+ check_include_files("windows.h;mmsystem.h" USE_WINMM)
+@@ -279,6 +301,7 @@ if(USE_WINMM)
+     src/cubeb_winmm.c)
+   target_compile_definitions(cubeb PRIVATE USE_WINMM)
+   target_link_libraries(cubeb PRIVATE winmm)
++  list(APPEND private_libs winmm)
+ endif()
+ 
+ check_include_files(SLES/OpenSLES.h USE_OPENSL)
+@@ -288,6 +311,7 @@ if(USE_OPENSL)
+     src/cubeb-jni.cpp)
+   target_compile_definitions(cubeb PRIVATE USE_OPENSL)
+   target_link_libraries(cubeb PRIVATE OpenSLES)
++  list(APPEND private_libs OpenSLES)
+ endif()
+ 
+ check_include_files(sys/soundcard.h HAVE_SYS_SOUNDCARD_H)
+@@ -303,6 +327,7 @@ if(HAVE_SYS_SOUNDCARD_H)
+       pkg_check_modules(libbsd-overlay IMPORTED_TARGET libbsd-overlay)
+       if(libbsd-overlay_FOUND)
+         target_link_libraries(cubeb PRIVATE PkgConfig::libbsd-overlay)
++        list(APPEND private_requires libbsd-overlay)
+         set(HAVE_STRLCPY true)
+       endif()
+     endif()
+@@ -320,6 +345,7 @@ if(USE_AUDIOTRACK)
+     src/cubeb_audiotrack.c)
+   target_compile_definitions(cubeb PRIVATE USE_AUDIOTRACK)
+   target_link_libraries(cubeb PRIVATE log)
++  list(APPEND private_libs log)
+ endif()
+ 
+ check_include_files(sys/audioio.h USE_SUN)
+@@ -335,6 +361,7 @@ if(USE_KAI)
+     src/cubeb_kai.c)
+   target_compile_definitions(cubeb PRIVATE USE_KAI)
+   target_link_libraries(cubeb PRIVATE kai)
++  list(APPEND private_libs kai)
+ endif()
+ 
+ if(USE_PULSE AND USE_PULSE_RUST)
+@@ -452,3 +479,26 @@ add_custom_target(clang-format-check
+   | xargs -0 ${CLANG_FORMAT_BINARY} -Werror -n
+   COMMENT "Check formatting with clang-format"
+   VERBATIM)
++
++
++list(TRANSFORM private_libs PREPEND "-l")
++string(JOIN " " CUBEB_PC_PRIVATE_LIBS ${private_libs} ${private_libs_flags})
++
++string(JOIN " " CUBEB_PC_PRIVATE_REQUIRES ${private_requires})
++
++if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
++  set(CUBEB_PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
++else()
++  set(CUBEB_PC_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
++endif()
++if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
++  set(CUBEB_PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
++else()
++  set(CUBEB_PC_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
++endif()
++
++configure_file(libcubeb.pc.in libcubeb.pc @ONLY)
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libcubeb.pc"
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
++)
++
+diff --git a/libcubeb.pc.in b/libcubeb.pc.in
+new file mode 100644
+index 0000000..2310ae6
+--- /dev/null
++++ b/libcubeb.pc.in
+@@ -0,0 +1,12 @@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=${prefix}
++libdir=@CUBEB_PC_LIBDIR@
++includedir=@CUBEB_PC_INCLUDEDIR@
++
++Name: libcubeb
++Description: Cross platform audio library
++Version: @PROJECT_VERSION@
++Requires.private: @CUBEB_PC_PRIVATE_REQUIRES@
++Libs: -L${libdir} -lcubeb
++Libs.private: @CUBEB_PC_PRIVATE_LIBS@
++Cflags: -I${includedir}
+-- 
+2.49.0
+

--- a/pkgs/by-name/cu/cubeb/0001-cmake-don-t-hardcode-include-as-the-includedir.patch
+++ b/pkgs/by-name/cu/cubeb/0001-cmake-don-t-hardcode-include-as-the-includedir.patch
@@ -1,0 +1,31 @@
+From 4f8dff52e99bdd70d07d7cb47d357bb91dc5f1a9 Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Sat, 24 May 2025 16:20:51 +0200
+Subject: [PATCH] cmake: don't hardcode "include" as the includedir
+
+When the default CMAKE_INSTALL_INCLUDEDIR is changed
+headers are installed to a different location, however, the
+INTERFACE_INCLUDE_DIRECTORIES in exported cmake configuration still
+point to <prefix>/include.
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 07618fa..bdf2212 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -91,7 +91,7 @@ add_library(cubeb
+   src/cubeb_utils.cpp
+ )
+ target_include_directories(cubeb
+-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
++  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+ )
+ set_target_properties(cubeb PROPERTIES
+   VERSION ${cubeb_VERSION}
+-- 
+2.49.0
+

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -70,13 +70,13 @@ stdenv.mkDerivation {
     updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cross platform audio library";
     mainProgram = "cubeb-test";
     homepage = "https://github.com/mozilla/cubeb";
-    license = licenses.isc;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [
+    license = lib.licenses.isc;
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [
       zhaofengli
       marcin-serwin
     ];

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -32,13 +32,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "cubeb";
-  version = "unstable-2022-10-18";
+  version = "0-unstable-2025-04-02";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "cubeb";
-    rev = "27d2a102b0b75d9e49d43bc1ea516233fb87d778";
-    hash = "sha256-q+uz1dGU4LdlPogL1nwCR/KuOX4Oy3HhMdA6aJylBRk=";
+    rev = "975a727e5e308a04cfb9ecdf7ddaf1150ea3f733";
+    hash = "sha256-3IP++tdiJUwXR6t5mf/MkPd524K/LYESNMkQ8vy10jo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -10,6 +10,8 @@
   libpulseaudio,
   sndio,
   speexdsp,
+  validatePkgConfig,
+  testers,
   alsaSupport ? !stdenv.hostPlatform.isDarwin,
   pulseSupport ? !stdenv.hostPlatform.isDarwin,
   jackSupport ? !stdenv.hostPlatform.isDarwin,
@@ -17,7 +19,7 @@
   buildSharedLibs ? true,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cubeb";
   version = "0-unstable-2025-04-02";
 
@@ -37,6 +39,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     pkg-config
+    validatePkgConfig
   ];
 
   buildInputs =
@@ -68,6 +71,7 @@ stdenv.mkDerivation {
 
   passthru = {
     updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
   };
 
   meta = {
@@ -80,5 +84,6 @@ stdenv.mkDerivation {
       zhaofengli
       marcin-serwin
     ];
+    pkgConfigModules = [ "libcubeb" ];
   };
-}
+})

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -48,6 +48,11 @@ stdenv.mkDerivation {
 
   buildInputs = [ speexdsp ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) backendLibs;
 
+  patches = [
+    # https://github.com/mozilla/cubeb/pull/813
+    ./0001-cmake-add-pkg-config-file-generation.patch
+  ];
+
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" buildSharedLibs)
     "-DBUILD_TESTS=OFF" # tests require an audio server
@@ -63,18 +68,6 @@ stdenv.mkDerivation {
     backendLibs = lib.optionals lazyLoad backendLibs;
     updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
   };
-
-  postInstall = ''
-    # TODO: remove after https://github.com/mozilla/cubeb/pull/813 is merged
-    mkdir -p $out/lib/pkgconfig/
-    echo > $out/lib/pkgconfig/libcubeb.pc \
-    "Name: libcubeb
-    Description: Cross platform audio library
-    Version: 0.0.0
-    Requires.private: libpulse
-    Libs: -L"$out/lib" -lcubeb
-    Libs.private: -lstdc++"
-  '';
 
   meta = with lib; {
     description = "Cross platform audio library";

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  unstableGitUpdater,
   cmake,
   pkg-config,
   alsa-lib,
@@ -60,6 +61,7 @@ stdenv.mkDerivation {
   passthru = {
     # For downstream users when lazyLoad is true
     backendLibs = lib.optionals lazyLoad backendLibs;
+    updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
   };
 
   postInstall = ''

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -67,8 +67,6 @@ stdenv.mkDerivation {
   ];
 
   passthru = {
-    # For downstream users when lazyLoad is true
-    backendLibs = [ ];
     updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
   };
 

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation {
     hash = "sha256-3IP++tdiJUwXR6t5mf/MkPd524K/LYESNMkQ8vy10jo=";
   };
 
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -51,6 +57,9 @@ stdenv.mkDerivation {
   patches = [
     # https://github.com/mozilla/cubeb/pull/813
     ./0001-cmake-add-pkg-config-file-generation.patch
+
+    # https://github.com/mozilla/cubeb/pull/814
+    ./0001-cmake-don-t-hardcode-include-as-the-includedir.patch
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -21,7 +21,7 @@
   pulseSupport ? !stdenv.hostPlatform.isDarwin,
   jackSupport ? !stdenv.hostPlatform.isDarwin,
   sndioSupport ? !stdenv.hostPlatform.isDarwin,
-  buildSharedLibs ? true,
+  enableShared ? !stdenv.hostPlatform.isStatic,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "BUILD_SHARED_LIBS" buildSharedLibs)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
     (lib.cmakeBool "BUILD_TESTS" false) # tests require an audio server
     (lib.cmakeBool "BUNDLE_SPEEX" false)
     (lib.cmakeBool "USE_SANITIZERS" false)

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -64,12 +64,12 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" buildSharedLibs)
-    "-DBUILD_TESTS=OFF" # tests require an audio server
-    "-DBUNDLE_SPEEX=OFF"
-    "-DUSE_SANITIZERS=OFF"
+    (lib.cmakeBool "BUILD_TESTS" false) # tests require an audio server
+    (lib.cmakeBool "BUNDLE_SPEEX" false)
+    (lib.cmakeBool "USE_SANITIZERS" false)
 
     # Whether to lazily load libraries with dlopen()
-    "-DLAZY_LOAD_LIBS=${if lazyLoad then "ON" else "OFF"}"
+    (lib.cmakeBool "LAZY_LOAD_LIBS" lazyLoad)
   ];
 
   passthru = {

--- a/pkgs/by-name/cu/cubeb/package.nix
+++ b/pkgs/by-name/cu/cubeb/package.nix
@@ -11,7 +11,12 @@
   sndio,
   speexdsp,
   validatePkgConfig,
+
+  # passthru.tests
   testers,
+  pcsx2,
+  duckstation,
+
   alsaSupport ? !stdenv.hostPlatform.isDarwin,
   pulseSupport ? !stdenv.hostPlatform.isDarwin,
   jackSupport ? !stdenv.hostPlatform.isDarwin,
@@ -71,7 +76,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+    tests = {
+      # These packages depend on a patched version of cubeb
+      inherit pcsx2 duckstation;
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    };
   };
 
   meta = {

--- a/pkgs/by-name/du/duckstation/package.nix
+++ b/pkgs/by-name/du/duckstation/package.nix
@@ -6,9 +6,7 @@
   callPackage,
   cmake,
   cpuinfo,
-  cubeb,
   curl,
-  discord-rpc,
   extra-cmake-modules,
   libXrandr,
   libbacktrace,
@@ -42,6 +40,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     ./002-hardcode-vars.diff
     # Fix NEON intrinsics usage
     ./003-fix-NEON-intrinsics.patch
+    ./remove-cubeb-vendor.patch
   ];
 
   nativeBuildInputs = [
@@ -57,6 +56,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     SDL2
     cpuinfo
+    sources.cubeb
     curl
     libXrandr
     libbacktrace
@@ -70,7 +70,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     sources.soundtouch-patched
     sources.spirv-cross-patched
     wayland
-  ] ++ cubeb.passthru.backendLibs;
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_TESTS" true)
@@ -115,14 +115,11 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   qtWrapperArgs =
     let
-      libPath = lib.makeLibraryPath (
-        [
-          sources.shaderc-patched
-          sources.spirv-cross-patched
-          vulkan-loader
-        ]
-        ++ cubeb.passthru.backendLibs
-      );
+      libPath = lib.makeLibraryPath ([
+        sources.shaderc-patched
+        sources.spirv-cross-patched
+        vulkan-loader
+      ]);
     in
     [
       "--prefix LD_LIBRARY_PATH : ${libPath}"

--- a/pkgs/by-name/du/duckstation/remove-cubeb-vendor.patch
+++ b/pkgs/by-name/du/duckstation/remove-cubeb-vendor.patch
@@ -1,0 +1,29 @@
+diff --git a/dep/CMakeLists.txt b/dep/CMakeLists.txt
+index af35687..8347825 100644
+--- a/dep/CMakeLists.txt
++++ b/dep/CMakeLists.txt
+@@ -22,9 +22,8 @@ add_subdirectory(rcheevos EXCLUDE_FROM_ALL)
+ disable_compiler_warnings_for_target(rcheevos)
+ add_subdirectory(rapidyaml EXCLUDE_FROM_ALL)
+ disable_compiler_warnings_for_target(rapidyaml)
+-add_subdirectory(cubeb EXCLUDE_FROM_ALL)
+-disable_compiler_warnings_for_target(cubeb)
+-disable_compiler_warnings_for_target(speex)
++find_package(cubeb REQUIRED GLOBAL)
++add_library(cubeb ALIAS cubeb::cubeb)
+ add_subdirectory(kissfft EXCLUDE_FROM_ALL)
+ disable_compiler_warnings_for_target(kissfft)
+ 
+diff --git a/src/util/cubeb_audio_stream.cpp b/src/util/cubeb_audio_stream.cpp
+index 85579c4..526d168 100644
+--- a/src/util/cubeb_audio_stream.cpp
++++ b/src/util/cubeb_audio_stream.cpp
+@@ -261,7 +261,7 @@ std::vector<std::pair<std::string, std::string>> AudioStream::GetCubebDriverName
+   std::vector<std::pair<std::string, std::string>> names;
+   names.emplace_back(std::string(), TRANSLATE_STR("AudioStream", "Default"));
+ 
+-  const char** cubeb_names = cubeb_get_backend_names();
++  const char*const * cubeb_names = cubeb_get_backend_names();
+   for (u32 i = 0; cubeb_names[i] != nullptr; i++)
+     names.emplace_back(cubeb_names[i], cubeb_names[i]);
+   return names;

--- a/pkgs/by-name/du/duckstation/sources.nix
+++ b/pkgs/by-name/du/duckstation/sources.nix
@@ -9,6 +9,7 @@
   stdenv,
   cmake,
   ninja,
+  cubeb,
 }:
 
 {
@@ -162,5 +163,16 @@
       license = lib.licenses.mit;
       platforms = lib.platforms.linux;
     };
+  });
+
+  cubeb = cubeb.overrideAttrs (old: {
+    pname = "cubeb-patched-for-duckstation";
+    patches = (old.patches or [ ]) ++ [
+      (fetchpatch {
+        url = "https://github.com/PCSX2/pcsx2/commit/430e31abe4a9e09567cb542f1416b011bb9b6ef9.patch";
+        stripLen = 2;
+        hash = "sha256-bbH0c1X3lMeX6hfNKObhcq5xraFpicFV3mODQGYudvQ=";
+      })
+    ];
   });
 }

--- a/pkgs/by-name/pc/pcsx2/package.nix
+++ b/pkgs/by-name/pc/pcsx2/package.nix
@@ -25,6 +25,7 @@
   wayland,
   zip,
   zstd,
+  fetchpatch,
 }:
 
 let
@@ -36,6 +37,16 @@ let
     qtwayland
     wrapQtAppsHook
     ;
+
+  cubeb' = cubeb.overrideAttrs (old: {
+    patches = (old.patches or [ ]) ++ [
+      (fetchpatch {
+        url = "https://github.com/PCSX2/pcsx2/commit/430e31abe4a9e09567cb542f1416b011bb9b6ef9.patch";
+        stripLen = 2;
+        hash = "sha256-bbH0c1X3lMeX6hfNKObhcq5xraFpicFV3mODQGYudvQ=";
+      })
+    ];
+  });
 in
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   inherit (sources.pcsx2) pname version src;
@@ -43,6 +54,8 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Remove PCSX2_GIT_REV
     ./0000-define-rev.patch
+
+    ./remove-cubeb-vendor.patch
   ];
 
   cmakeFlags = [
@@ -80,7 +93,8 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     vulkan-headers
     wayland
     zstd
-  ] ++ cubeb.passthru.backendLibs;
+    cubeb'
+  ];
 
   strictDeps = true;
 
@@ -94,13 +108,10 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   qtWrapperArgs =
     let
-      libs = lib.makeLibraryPath (
-        [
-          vulkan-loader
-          shaderc
-        ]
-        ++ cubeb.passthru.backendLibs
-      );
+      libs = lib.makeLibraryPath ([
+        vulkan-loader
+        shaderc
+      ]);
     in
     [ "--prefix LD_LIBRARY_PATH : ${libs}" ];
 

--- a/pkgs/by-name/pc/pcsx2/remove-cubeb-vendor.patch
+++ b/pkgs/by-name/pc/pcsx2/remove-cubeb-vendor.patch
@@ -1,0 +1,29 @@
+diff --git a/cmake/SearchForStuff.cmake b/cmake/SearchForStuff.cmake
+index ff66f9c..e177c90 100644
+--- a/cmake/SearchForStuff.cmake
++++ b/cmake/SearchForStuff.cmake
+@@ -100,9 +100,8 @@ if(USE_VULKAN)
+ 	add_subdirectory(3rdparty/vulkan EXCLUDE_FROM_ALL)
+ endif()
+ 
+-add_subdirectory(3rdparty/cubeb EXCLUDE_FROM_ALL)
+-disable_compiler_warnings_for_target(cubeb)
+-disable_compiler_warnings_for_target(speex)
++find_package(cubeb REQUIRED GLOBAL)
++add_library(cubeb ALIAS cubeb::cubeb)
+ 
+ # Find the Qt components that we need.
+ find_package(Qt6 6.7.2 COMPONENTS CoreTools Core GuiTools Gui WidgetsTools Widgets LinguistTools REQUIRED)
+diff --git a/pcsx2/Host/CubebAudioStream.cpp b/pcsx2/Host/CubebAudioStream.cpp
+index 4cd9993..604635d 100644
+--- a/pcsx2/Host/CubebAudioStream.cpp
++++ b/pcsx2/Host/CubebAudioStream.cpp
+@@ -288,7 +288,7 @@ std::vector<std::pair<std::string, std::string>> AudioStream::GetCubebDriverName
+ 	std::vector<std::pair<std::string, std::string>> names;
+ 	names.emplace_back(std::string(), TRANSLATE_STR("AudioStream", "Default"));
+ 
+-	const char** cubeb_names = cubeb_get_backend_names();
++	const char* const* cubeb_names = cubeb_get_backend_names();
+ 	for (u32 i = 0; cubeb_names[i] != nullptr; i++)
+ 		names.emplace_back(cubeb_names[i], cubeb_names[i]);
+ 

--- a/pkgs/by-name/qc/qcm/package.nix
+++ b/pkgs/by-name/qc/qcm/package.nix
@@ -40,16 +40,12 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     ffmpeg
     cubeb
-  ] ++ cubeb.passthru.backendLibs;
+  ];
 
   # Correct qml import path
   postInstall = ''
     mv $out/lib/qt6 $out/lib/qt-6
   '';
-
-  qtWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath cubeb.passthru.backendLibs}"
-  ];
 
   meta = {
     description = "Unofficial Qt client for netease cloud music";

--- a/pkgs/by-name/rp/rpcs3/0001-cmake-add-option-to-use-system-cubeb.patch
+++ b/pkgs/by-name/rp/rpcs3/0001-cmake-add-option-to-use-system-cubeb.patch
@@ -1,0 +1,46 @@
+From 5af2b630da7a6a450ec6bc4f07fc7ad9a825361d Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Sat, 24 May 2025 18:51:09 +0200
+Subject: [PATCH] cmake: add option to use system cubeb
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ 3rdparty/CMakeLists.txt | 9 ++++++++-
+ CMakeLists.txt          | 1 +
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/3rdparty/CMakeLists.txt b/3rdparty/CMakeLists.txt
+index 044fd464e..6c49a889b 100644
+--- a/3rdparty/CMakeLists.txt
++++ b/3rdparty/CMakeLists.txt
+@@ -131,7 +131,14 @@ add_subdirectory(stblib)
+ add_subdirectory(discord-rpc)
+ 
+ # Cubeb
+-add_subdirectory(cubeb EXCLUDE_FROM_ALL)
++if(USE_SYSTEM_CUBEB)
++	find_package(cubeb REQUIRED GLOBAL)
++	message(STATUS "Using system cubeb version '${cubeb_VERSION}'")
++	add_library(3rdparty::cubeb ALIAS cubeb::cubeb)
++else()
++	message(STATUS "Using static cubeb from 3rdparty")
++	add_subdirectory(cubeb EXCLUDE_FROM_ALL)
++endif()
+ 
+ # SoundTouch
+ add_subdirectory(SoundTouch EXCLUDE_FROM_ALL)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d2edd836..39aa150c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,6 +31,7 @@ option(USE_SYSTEM_FFMPEG "Prefer system ffmpeg instead of the prebuild one" OFF)
+ option(USE_SYSTEM_OPENAL "Prefer system OpenAL instead of the prebuild one" ON)
+ option(USE_SYSTEM_CURL "Prefer system Curl instead of the prebuild one" ON)
+ option(USE_SYSTEM_OPENCV "Prefer system OpenCV instead of the builtin one" ON)
++option(USE_SYSTEM_CUBEB "Prefer system cubeb instead of the builtin one" OFF)
+ option(HAS_MEMORY_BREAKPOINTS "Add support for memory breakpoints to the interpreter" OFF)
+ option(USE_LTO "Use LTO for building" ON)
+ option(BUILD_RPCS3_TESTS "Build RPCS3 unit tests." OFF)
+-- 
+2.49.0
+

--- a/pkgs/by-name/rp/rpcs3/package.nix
+++ b/pkgs/by-name/rp/rpcs3/package.nix
@@ -63,6 +63,9 @@ stdenv.mkDerivation {
   patches = [
     # Modified from https://github.com/RPCS3/rpcs3/pull/17009; doesn't apply cleanly due to intermediate commits
     ./fix-qt6.9-compilation.patch
+
+    # https://github.com/RPCS3/rpcs3/pull/17246
+    ./0001-cmake-add-option-to-use-system-cubeb.patch
   ];
 
   passthru.updateScript = ./update.sh;
@@ -89,6 +92,7 @@ stdenv.mkDerivation {
     (lib.cmakeBool "USE_SYSTEM_FLATBUFFERS" true)
     (lib.cmakeBool "USE_SYSTEM_SDL" true)
     (lib.cmakeBool "USE_SYSTEM_OPENCV" true)
+    (lib.cmakeBool "USE_SYSTEM_CUBEB" true)
     (lib.cmakeBool "USE_SDL" true)
     (lib.cmakeBool "WITH_LLVM" true)
     (lib.cmakeBool "BUILD_LLVM" false)
@@ -130,8 +134,8 @@ stdenv.mkDerivation {
       llvm_18
       libSM
       opencv
+      cubeb
     ]
-    ++ cubeb.passthru.backendLibs
     ++ lib.optional faudioSupport faudio
     ++ lib.optionals waylandSupport [
       wayland

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -7,7 +7,6 @@
   webrtc,
   pkg-config,
   cubeb,
-  libpulseaudio,
 }:
 let
   cubeb' = cubeb.override {
@@ -49,11 +48,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     cmake
     pkg-config
   ];
-  buildInputs = [
-    webrtc
-    cubeb'
-    libpulseaudio
-  ];
+  buildInputs =
+    [
+      webrtc
+      cubeb'
+    ]
+    # Workaround for https://github.com/NixOS/nixpkgs/pull/394607
+    ++ cubeb'.buildInputs;
 
   meta = {
     homepage = "https://github.com/signalapp/ringrtc";

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -14,7 +14,7 @@ let
     pulseSupport = true;
     jackSupport = false;
     sndioSupport = false;
-    buildSharedLibs = false;
+    enableShared = false;
   };
 in
 rustPlatform.buildRustPackage (finalAttrs: {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Tested that sound still works in `cemu`, `pcsx2`, `dolphin-emu`, and `signal-desktop`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
