### PR TITLE
matrix-appservice-discord: fix build by pinning nodejs_20

### DIFF
--- a/pkgs/by-name/ma/matrix-appservice-discord/package.nix
+++ b/pkgs/by-name/ma/matrix-appservice-discord/package.nix
@@ -7,11 +7,12 @@
   makeWrapper,
   removeReferencesTo,
   python3,
-  nodejs,
+  nodejs_20,
   matrix-sdk-crypto-nodejs,
 }:
 
 let
+  nodejs = nodejs_20; # only supports nodejs v18.X - v20.X
   pin = lib.importJSON ./pin.json;
   nodeSources = srcOnly nodejs;
 
@@ -19,6 +20,7 @@ in
 mkYarnPackage rec {
   pname = "matrix-appservice-discord";
   inherit (pin) version;
+  inherit nodejs;
 
   src = fetchFromGitHub {
     owner = "matrix-org";

--- a/pkgs/by-name/ma/matrix-appservice-discord/package.nix
+++ b/pkgs/by-name/ma/matrix-appservice-discord/package.nix
@@ -103,7 +103,7 @@ mkYarnPackage rec {
 
   meta = {
     description = "Bridge between Matrix and Discord";
-    homepage = "https://github.com/Half-Shot/matrix-appservice-discord";
+    homepage = "https://github.com/matrix-org/matrix-appservice-discord";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ euxane ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
- **matrix-appservice-discord: fix build by pinning nodejs_20**
- **matrix-appservice-discord: update meta.homepage**

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
