### PR TITLE
spyglassmc-language-server: init at 0.4.40

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -5,14 +5,15 @@ npmInstallHook() {
 
     runHook preInstall
 
-    local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' package.json)"
+    local -r packageName="$(@jq@ --raw-output '.name' "${npmWorkspace-.}/package.json")"
+    local -r packageOut="$out/lib/node_modules/$packageName"
 
     # `npm pack` writes to cache so temporarily override it
     while IFS= read -r file; do
         local dest="$packageOut/$(dirname "$file")"
         mkdir -p "$dest"
         cp "${npmWorkspace-.}/$file" "$dest"
-    done < <(@jq@ --raw-output '.[0].files | map(.path | select(. | startswith("node_modules/") | not)) | join("\n")' <<< "$(npm_config_cache="$HOME/.npm" npm pack --json --dry-run --loglevel=warn --no-foreground-scripts ${npmWorkspace+--workspace=$npmWorkspace} $npmPackFlags "${npmPackFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}")")
+    done < <(@jq@ --raw-output '.[0].files | map(.path | select(. | startswith("node_modules/") | not)) | .[]' <<< "$(npm_config_cache="$HOME/.npm" npm pack --json --dry-run --loglevel=warn --no-foreground-scripts ${npmWorkspace+--workspace=$npmWorkspace} $npmPackFlags "${npmPackFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}")")
 
     nodejsInstallExecutables "${npmWorkspace-.}/package.json"
 
@@ -35,6 +36,25 @@ npmInstallHook() {
         fi
 
         find node_modules -maxdepth 1 -type d -empty -delete
+
+        # FIXME: after npm prune so the workspace package doesn't get turned back into a symlink
+        find node_modules -type l | while read -r link; do
+            target=$(readlink -f "$link")
+            if [ -e "$target" ]; then
+                if [[ "$link" == "node_modules/$packageName" ]]; then
+                    echo "❌ Removing symlink to self: $link"
+                    rm "$link"
+                elif [[ "$target" == *"/node_modules/"* ]]; then
+                    echo "✅ Keeping internal symlink: $link → $target"
+                else
+                    echo "📦 Dereferencing external symlink: $link → $target"
+                    rm "$link"
+                    cp -r "$target" "$link"
+                fi
+            else
+                echo "⚠️ Skipping broken symlink: $link"
+            fi
+        done
 
         cp -r node_modules "$nodeModulesPath"
     fi

--- a/pkgs/by-name/no/nodejsInstallExecutables/hook.sh
+++ b/pkgs/by-name/no/nodejsInstallExecutables/hook.sh
@@ -3,7 +3,7 @@
 nodejsInstallExecutables() {
     local -r packageJson="${1-./package.json}"
 
-    local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' package.json)"
+    local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' "$packageJson")"
 
     # Based on code from Python's buildPythonPackage wrap.sh script, for
     # supporting both the case when makeWrapperArgs is an array and a

--- a/pkgs/by-name/no/nodejsInstallManuals/hook.sh
+++ b/pkgs/by-name/no/nodejsInstallManuals/hook.sh
@@ -3,7 +3,7 @@
 nodejsInstallManuals() {
     local -r packageJson="${1-./package.json}"
 
-    local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' package.json)"
+    local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' "$packageJson")"
 
     while IFS= read -r man; do
         installManPage "$packageOut/$man"

--- a/pkgs/by-name/sp/spyglassmc-language-server/package.nix
+++ b/pkgs/by-name/sp/spyglassmc-language-server/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  python3,
+  npm-lockfile-fix,
+  pkg-config,
+  libsecret,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "spyglassmc-language-server";
+  version = "0.4.43"; # `jq -r '."language-server".released.version' .packages.json`
+
+  # TODO: is it an issue that result/lib/node_modules/@spyglassmc/language-server/package.json contains 0.1.0-PLACEHOLDER ?
+
+  src = fetchFromGitHub {
+    owner = "SpyglassMC";
+    repo = "Spyglass";
+
+    rev = "v2025.7.14+95eceb"; # the Git tags are atomically added with new versions of packages
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} -r $out/package-lock.json
+    '';
+    hash = "sha256-KK1Wzbq4yB5id2xUB7GvV/t7WT5AaGfWf1t1lRbybhw=";
+  };
+
+  npmDepsHash = "sha256-0xjjRqCjaLL6YAgNE5X5wDCL7C+E/ssZ4qFZ+Ey/Wmg=";
+
+  npmWorkspace = "packages/language-server";
+
+  # TODO: make this work!
+  # 408 MiB -> 1.7 MiB ???
+  # outside Nix 408 MiB -> 41 MiB after prune
+  #npmInstallFlags = [ "--workspace=${finalAttrs.npmWorkspace}" ];
+
+  nativeBuildInputs = [
+    (python3.withPackages (ps: [ ps.setuptools ])) # Used by node-gyp
+
+    pkg-config
+  ];
+  buildInputs = [
+    libsecret # Used by keytar
+  ];
+
+  meta = {
+    homepage = "https://github.com/SpyglassMC/Spyglass";
+    description = "Development tools for vanilla Minecraft: Java Edition data pack developers";
+    maintainers = with lib.maintainers; [ axka ];
+    license = lib.licenses.mit;
+    mainProgram = "spyglassmc-language-server";
+  };
+})


### PR DESCRIPTION
- Added spyglassmc-language-server
- Hacked buildNpmPackage hooks to get it to work:
  * `$out/lib/node_modules/${$npmWorkspace/package.json's name}` instead of `$out/lib/node_modules/${workspace root's name}`. mostly a style change but helps when multiple packages originating from the same monorepo have to be merged in a buildEnv, NixOS or similar.
  * Dereference links to workspace (links would have broken `node_modules` is copied to `$out`) in `node_modules`.
     Related: https://github.com/NixOS/nixpkgs/issues/380227 https://github.com/NixOS/nixpkgs/pull/378937 https://github.com/NixOS/nixpkgs/pull/371176 (see diffs for the PRs)
     Example of how a package in workspace is packaged in Arch Linux: [Package Contents](https://archlinux.org/packages/extra/any/vue-typescript-plugin/), [build script](https://gitlab.archlinux.org/archlinux/packaging/packages/vue-language-tools/-/blob/main/PKGBUILD?ref_type=heads)
     I'm guessing this is valid for non-workspace/monorepo packages as well.

"after npm prune so the workspace package doesn't get turned back into a symlink" in the code meaning that it's after npm prune and not before it.

Requesting comments @lilyinstarlight @winterqt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
