### PR TITLE
plutosvg: init at 0.0.7

### DIFF
--- a/pkgs/by-name/pl/plutosvg/0001-Emit-correct-pkg-config-file-if-paths-are-absolute.patch
+++ b/pkgs/by-name/pl/plutosvg/0001-Emit-correct-pkg-config-file-if-paths-are-absolute.patch
@@ -1,0 +1,50 @@
+From 31e8aae418a1af681e389f27d3ad57b5fd7e1ba8 Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Sun, 25 May 2025 01:16:37 +0200
+Subject: [PATCH] Emit correct pkg-config file if paths are absolute
+
+CMAKE_INSTALL_INCLUDEDIR and CMAKE_INSTALL_LIBDIR may be defined to be
+absolute paths. In this situation they should not be appended to the
+prefix.
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ CMakeLists.txt | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2e84761..f2219e0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -107,6 +107,17 @@ file(RELATIVE_PATH plutosvg_pc_prefix_relative
+ set(plutosvg_pc_cflags "")
+ set(plutosvg_pc_libs_private "")
+ set(plutosvg_pc_requires "")
++set(plutosvg_pc_requires "")
++if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
++    set(plutosvg_pc_includedir "${CMAKE_INSTALL_INCLUDEDIR}")
++else()
++    set(plutosvg_pc_includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
++endif()
++if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
++    set(plutosvg_pc_libdir "${CMAKE_INSTALL_LIBDIR}")
++else()
++    set(plutosvg_pc_libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
++endif()
+ 
+ if(MATH_LIBRARY)
+     string(APPEND plutosvg_pc_libs_private " -lm")
+@@ -123,8 +134,8 @@ endif()
+ 
+ string(CONFIGURE [[
+ prefix=${pcfiledir}/@plutosvg_pc_prefix_relative@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=@plutosvg_pc_includedir@
++libdir=@plutosvg_pc_libdir@
+ 
+ Name: PlutoSVG
+ Description: Tiny SVG rendering library in C
+-- 
+2.49.0
+

--- a/pkgs/by-name/pl/plutosvg/package.nix
+++ b/pkgs/by-name/pl/plutosvg/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  validatePkgConfig,
+  testers,
+  cmake,
+  ninja,
+  plutovg,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "plutosvg";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "sammycage";
+    repo = "plutosvg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4JLk4+O9Tf8CGxMP0aDN70ak/8teZH3GWBWlrIkPQm4=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches = [
+    # https://github.com/sammycage/plutosvg/pull/29
+    ./0001-Emit-correct-pkg-config-file-if-paths-are-absolute.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    validatePkgConfig
+  ];
+  propagatedBuildInputs = [
+    plutovg
+  ];
+
+  cmakeFlags = [ (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic)) ];
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/sammycage/plutosvg";
+    changelog = "https://github.com/sammycage/plutosvg/releases/tag/${finalAttrs.src.tag}";
+    description = "Tiny SVG rendering library in C";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marcin-serwin ];
+    pkgConfigModules = [ "plutosvg" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
