### PR TITLE
linuxPackages.rtl8852au: fix build

### DIFF
--- a/pkgs/os-specific/linux/rtl8852au/default.nix
+++ b/pkgs/os-specific/linux/rtl8852au/default.nix
@@ -60,13 +60,18 @@ stdenv.mkDerivation (finalAttrs: {
     nuke-refs $out/lib/modules/*/kernel/net/wireless/*.ko
   '';
 
+  # GCC 14 makes this an error by default
+  env.NIX_CFLAGS_COMPILE = "-Wno-designated-init";
+
   enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Driver for Realtek 802.11ac, rtl8852au, provides the 8852au mod";
     homepage = "https://github.com/lwfinger/rtl8852au";
     license = licenses.gpl2Only;
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ];
+    # FIX: error: invalid initializer
+    broken = kernel.kernelOlder "6" && kernel.isHardened;
     maintainers = with maintainers; [ lonyelon ];
   };
 })

--- a/pkgs/os-specific/linux/rtl8852au/default.nix
+++ b/pkgs/os-specific/linux/rtl8852au/default.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation (finalAttrs: {
     "format"
   ];
 
+  patches = [
+    # https://github.com/lwfinger/rtl8852au/pull/115
+    ./fix-build-for-kernels-6.13-6.14.patch
+  ];
+
   postPatch = ''
     substituteInPlace ./Makefile \
       --replace-fail /sbin/depmod \# \

--- a/pkgs/os-specific/linux/rtl8852au/fix-build-for-kernels-6.13-6.14.patch
+++ b/pkgs/os-specific/linux/rtl8852au/fix-build-for-kernels-6.13-6.14.patch
@@ -1,0 +1,77 @@
+From c65ed43f42656aecf43e7ea80c58d204c3c67aca Mon Sep 17 00:00:00 2001
+From: Soham Nandy <soham.nandy2006@gmail.com>
+Date: Fri, 28 Mar 2025 17:24:55 +0530
+Subject: [PATCH 1/2] rtl8852au(fix): remove MODULE_IMPORT and net_device for
+ kernel versions over 6.13
+
+---
+ os_dep/linux/ioctl_cfg80211.c | 3 +++
+ os_dep/osdep_service_linux.c  | 4 ++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
+index 2b79c97..277dffb 100755
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -6350,6 +6350,9 @@ static void rtw_get_chbwoff_from_cfg80211_chan_def(
+ 
+ static int cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
++	, struct net_device *dev
++#endif
+ 	, struct cfg80211_chan_def *chandef
+ #else
+ 	, struct ieee80211_channel *chan
+diff --git a/os_dep/osdep_service_linux.c b/os_dep/osdep_service_linux.c
+index fe47c3b..8fdbcfc 100644
+--- a/os_dep/osdep_service_linux.c
++++ b/os_dep/osdep_service_linux.c
+@@ -390,7 +390,9 @@ static int openFile(struct file **fpp, const char *path, int flag, int mode)
+ 	struct file *fp;
+ 
+ #if defined(MODULE_IMPORT_NS)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0))
+ 	MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
++#endif
+ #endif
+ 
+ 	fp = filp_open(path, flag, mode);
+@@ -508,7 +510,9 @@ static int isFileReadable(const char *path, u32 *sz)
+ 	char buf;
+ 
+ #if defined(MODULE_IMPORT_NS)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0))
+ 	MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
++#endif
+ #endif
+ 
+ 	fp = filp_open(path, O_RDONLY, 0);
+
+From 91d168fc5aa818b4e85aa5b2b43d7f25470e925c Mon Sep 17 00:00:00 2001
+From: Soham Nandy <soham.nandy2006@gmail.com>
+Date: Mon, 7 Apr 2025 10:25:03 +0530
+Subject: [PATCH 2/2] rtl8852au(fix): get_tx_power callback by adding link_id
+ parameter
+
+kernel versions >6.14 cfg80211_ops was updated to include an unsigned
+int link_id parameter.
+---
+ os_dep/linux/ioctl_cfg80211.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
+index 277dffb..3d7620e 100755
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -4454,6 +4454,10 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
+ static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+ 	struct wireless_dev *wdev,
++	
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0))
++	unsigned int link_id,
++#endif
+ #endif
+ 	int *dbm)
+ {


### PR DESCRIPTION
for kernels >= 6.13 and 6.14


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
