### PR TITLE
uutils-coreutils: 0.0.30 -> 0.1.0

### DIFF
--- a/pkgs/by-name/uu/uutils-coreutils/package.nix
+++ b/pkgs/by-name/uu/uutils-coreutils/package.nix
@@ -10,26 +10,46 @@
 
   prefix ? "uutils-",
   buildMulticallBinary ? true,
+
+  selinuxSupport ? false,
+  libselinux,
+
+  acl,
 }:
+
+assert selinuxSupport -> lib.meta.availableOn stdenv.hostPlatform libselinux;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "uutils-coreutils";
-  version = "0.0.30";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "uutils";
     repo = "coreutils";
     tag = finalAttrs.version;
-    hash = "sha256-OZ9AsCJmQmn271OzEmqSZtt1OPn7zHTScQiiqvPhqB0=";
+    hash = "sha256-nKKjc6Bui7k50SR7BY09dRGt3Za1Ch/E+3KiCO5KtOg=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "uutils-coreutils-${finalAttrs.version}";
-    hash = "sha256-DsVLp2Y15k+KQI7S6A4hylOhJN016MEdEWx9VQIQEgQ=";
+    hash = "sha256-PTIypl9uqFkp6GrF7Pp40AItbWFlXT2V2x/C8L2J8S0=";
   };
 
+  patches = [
+    ./selinux_no_auto_detect.diff
+  ];
+
+  buildInputs =
+    lib.optionals (lib.meta.availableOn stdenv.hostPlatform acl) [
+      acl
+    ]
+    ++ lib.optionals selinuxSupport [
+      libselinux
+    ];
+
   nativeBuildInputs = [
+    rustPlatform.bindgenHook
     rustPlatform.cargoSetupHook
     python3Packages.sphinx
   ];
@@ -39,10 +59,34 @@ stdenv.mkDerivation (finalAttrs: {
       "CARGO=${lib.getExe cargo}"
       "PREFIX=${placeholder "out"}"
       "PROFILE=release"
+      "SELINUX_ENABLED=${if selinuxSupport then "1" else "0"}"
       "INSTALLDIR_MAN=${placeholder "out"}/share/man/man1"
+      # Explicitly enable acl, and if requested selinux.
+      # We cannot rely on SELINUX_ENABLED here since our explicit assignment
+      # overrides its effect in the makefile.
+      "BUILD_SPEC_FEATURE=${
+        lib.concatStringsSep "," (
+          # We can always enable acl, on non-Linux, libc provides the headers,
+          # only in Linux we need to add the acl lib to buildInputs.
+          [
+            "feat_acl"
+          ]
+          ++ (lib.optionals selinuxSupport [
+            "feat_selinux"
+          ])
+        )
+      }"
     ]
     ++ lib.optionals (prefix != null) [ "PROG_PREFIX=${prefix}" ]
     ++ lib.optionals buildMulticallBinary [ "MULTICALL=y" ];
+
+  env = lib.optionalAttrs selinuxSupport {
+    SELINUX_INCLUDE_DIR = ''${libselinux.dev}/include'';
+    SELINUX_LIB_DIR = lib.makeLibraryPath [
+      libselinux
+    ];
+    SELINUX_STATIC = "0";
+  };
 
   # too many impure/platform-dependent tests
   doCheck = false;

--- a/pkgs/by-name/uu/uutils-coreutils/selinux_no_auto_detect.diff
+++ b/pkgs/by-name/uu/uutils-coreutils/selinux_no_auto_detect.diff
@@ -1,0 +1,37 @@
+diff --git a/GNUmakefile b/GNUmakefile
+index f46126a82..44be8f13b 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -57,20 +57,6 @@ TOYBOX_ROOT := $(BASEDIR)/tmp
+ TOYBOX_VER  := 0.8.12
+ TOYBOX_SRC  := $(TOYBOX_ROOT)/toybox-$(TOYBOX_VER)
+ 
+-
+-ifdef SELINUX_ENABLED
+-	override SELINUX_ENABLED := 0
+-# Now check if we should enable it (only on non-Windows)
+-	ifneq ($(OS),Windows_NT)
+-		ifeq ($(shell if [ -x /sbin/selinuxenabled ] && /sbin/selinuxenabled 2>/dev/null; then echo 0; else echo 1; fi),0)
+-			override SELINUX_ENABLED := 1
+-$(info /sbin/selinuxenabled successful)
+-	    else
+-$(info SELINUX_ENABLED=1 but /sbin/selinuxenabled failed)
+-		endif
+-	endif
+-endif
+-
+ # Possible programs
+ PROGS       := \
+ 	base32 \
+@@ -181,8 +167,10 @@ SELINUX_PROGS := \
+ 
+ ifneq ($(OS),Windows_NT)
+ 	PROGS := $(PROGS) $(UNIX_PROGS)
++	ifeq ($(SELINUX_ENABLED),1)
+ # Build the selinux command even if not on the system
+-	PROGS := $(PROGS) $(SELINUX_PROGS)
++		PROGS := $(PROGS) $(SELINUX_PROGS)
++	endif
+ endif
+ 
+ UTILS ?= $(PROGS)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/uutils/coreutils/compare/refs/tags/0.0.30...refs/tags/0.1.0
Changelog: https://github.com/uutils/coreutils/releases/tag/0.1.0

cc @siraben 

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
