### PR TITLE
treewide: substitute pname for strings (python3Packages.[a-i].*)

### DIFF
--- a/pkgs/development/python-modules/add-trailing-comma/default.nix
+++ b/pkgs/development/python-modules/add-trailing-comma/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "asottile";
-    repo = pname;
+    repo = "add-trailing-comma";
     rev = "v${version}";
     hash = "sha256-B+wjBy42RwabVz/6qEMGpB0JmwJ9hqSskwcNj4x/B/k=";
   };

--- a/pkgs/development/python-modules/advocate/default.nix
+++ b/pkgs/development/python-modules/advocate/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "JordanMilne";
-    repo = pname;
+    repo = "advocate";
     rev = "v${version}";
     hash = "sha256-opObkjkad+yrLE2b7DULHjGuNeVhu4fEmSavgA39YPw=";
   };

--- a/pkgs/development/python-modules/aggdraw/default.nix
+++ b/pkgs/development/python-modules/aggdraw/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pytroll";
-    repo = pname;
+    repo = "aggdraw";
     rev = "v${version}";
     hash = "sha256-J9+mxlUxOoRBFdz+p8me2T93jaov5rNvKbAZ2YX/VhA=";
   };

--- a/pkgs/development/python-modules/aioblescan/default.nix
+++ b/pkgs/development/python-modules/aioblescan/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "frawau";
-    repo = pname;
+    repo = "aioblescan";
     tag = version;
     hash = "sha256-JeA9jX566OSRiejdnlifbcNGm0J0C+xzA6zXDUyZ6jc=";
   };

--- a/pkgs/development/python-modules/aiodocker/default.nix
+++ b/pkgs/development/python-modules/aiodocker/default.nix
@@ -6,7 +6,7 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "aiodocker";
   # unstable includes support for python 3.10+
   version = "unstable-2022-01-20";
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "aio-libs";
-    repo = pname;
+    repo = "aiodocker";
     rev = "f1dbdc3d42147f4c2ab5e6802acf6f7d0f885be4";
     sha256 = "RL5Ck4wsBZO88afmoojeFKbdIeCjDo/SwNqUcERH6Ls=";
   };

--- a/pkgs/development/python-modules/aioemonitor/default.nix
+++ b/pkgs/development/python-modules/aioemonitor/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bdraco";
-    repo = pname;
+    repo = "aioemonitor";
     rev = "v${version}";
     sha256 = "0h8zqqy8v8r1fl9bp3m8icr2sy44p0mbfl1hbb0zni17r9r50dhn";
   };

--- a/pkgs/development/python-modules/aiohttp-wsgi/default.nix
+++ b/pkgs/development/python-modules/aiohttp-wsgi/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "etianen";
-    repo = pname;
+    repo = "aiohttp-wsgi";
     rev = "v${version}";
     hash = "sha256-3Q00FidZWV1KueuHyHKQf1PsDJGOaRW6v/kBy7lzD4Q=";
   };

--- a/pkgs/development/python-modules/aiohwenergy/default.nix
+++ b/pkgs/development/python-modules/aiohwenergy/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "DCSBL";
-    repo = pname;
+    repo = "aiohwenergy";
     rev = version;
     hash = "sha256-WfkwIxyDzLNzhWNWST/V3iN9Bhu2oXDwGiA5UXCq5ho=";
   };

--- a/pkgs/development/python-modules/aiokef/default.nix
+++ b/pkgs/development/python-modules/aiokef/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "basnijholt";
-    repo = pname;
+    repo = "aiokef";
     rev = "v${version}";
     sha256 = "0ms0dwrpj80w55svcppbnp7vyl5ipnjfp1c436k5c7pph4q5pxk9";
   };

--- a/pkgs/development/python-modules/aiolimiter/default.nix
+++ b/pkgs/development/python-modules/aiolimiter/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mjpieters";
-    repo = pname;
+    repo = "aiolimiter";
     tag = "v${version}";
     hash = "sha256-wgHR0GzaPXlhL4ErklFqmWNFO49dvd5X5MgyYHVH4Eo=";
   };

--- a/pkgs/development/python-modules/aiolookin/default.nix
+++ b/pkgs/development/python-modules/aiolookin/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ANMalko";
-    repo = pname;
+    repo = "aiolookin";
     tag = "v${version}";
     hash = "sha256-G3/lUgV60CMLskUo83TlvLLIfJtu5DEz+94mdVI4OrI=";
   };

--- a/pkgs/development/python-modules/aionanoleaf/default.nix
+++ b/pkgs/development/python-modules/aionanoleaf/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "milanmeu";
-    repo = pname;
+    repo = "aionanoleaf";
     tag = "v${version}";
     hash = "sha256-f0TyXhuAzI0s0n6sXH9mKWA4nad2YchZkQ0+jw/Bmv0=";
   };

--- a/pkgs/development/python-modules/aiopg/default.nix
+++ b/pkgs/development/python-modules/aiopg/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "aio-libs";
-    repo = pname;
+    repo = "aiopg";
     rev = "v${version}";
     hash = "sha256-GD5lRSUjASTwBk5vEK8v3xD8eNyxpwSrO3HHvtwubmk=";
   };

--- a/pkgs/development/python-modules/aiopurpleair/default.nix
+++ b/pkgs/development/python-modules/aiopurpleair/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bachya";
-    repo = pname;
+    repo = "aiopurpleair";
     tag = version;
     hash = "sha256-2Ngo2pvzwcgQvpyW5Q97VQN/tGSVhVJwRj0DMaPn+O4=";
   };

--- a/pkgs/development/python-modules/aiopyarr/default.nix
+++ b/pkgs/development/python-modules/aiopyarr/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tkdrob";
-    repo = pname;
+    repo = "aiopyarr";
     tag = version;
     hash = "sha256-CzNB6ymvDTktiOGdcdCvWLVQ3mKmbdMpc/vezSXCpG4=";
   };

--- a/pkgs/development/python-modules/aiopylgtv/default.nix
+++ b/pkgs/development/python-modules/aiopylgtv/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bendavid";
-    repo = pname;
+    repo = "aiopylgtv";
     rev = version;
     hash = "sha256-NkWJGy5QUrhpbARoscrXy/ilCjAz01YxeVTH0I+IjNM=";
   };

--- a/pkgs/development/python-modules/aioqsw/default.nix
+++ b/pkgs/development/python-modules/aioqsw/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Noltari";
-    repo = pname;
+    repo = "aioqsw";
     tag = version;
     hash = "sha256-h/rTwMF3lc/hWwpzCvK6UMq0rjq3xkw/tEY3BqOPS2s=";
   };

--- a/pkgs/development/python-modules/aiorecollect/default.nix
+++ b/pkgs/development/python-modules/aiorecollect/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bachya";
-    repo = pname;
+    repo = "aiorecollect";
     tag = version;
     hash = "sha256-Rj0+r7eERLY5VzmuDQH/TeVLfmvmKwPqcvd1b/To0Ts=";
   };

--- a/pkgs/development/python-modules/aioridwell/default.nix
+++ b/pkgs/development/python-modules/aioridwell/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bachya";
-    repo = pname;
+    repo = "aioridwell";
     tag = version;
     hash = "sha256-B5k8uXDHq0U6fJVW8oy2sWUj5OIVGUfe9EtCjnIr3OE=";
   };

--- a/pkgs/development/python-modules/aiosenz/default.nix
+++ b/pkgs/development/python-modules/aiosenz/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "milanmeu";
-    repo = pname;
+    repo = "aiosenz";
     rev = version;
     hash = "sha256-ODdWPS14zzptxuS6mff51f0s1SYnIqjF40DmvT0sL0w=";
   };

--- a/pkgs/development/python-modules/aiosignal/default.nix
+++ b/pkgs/development/python-modules/aiosignal/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "aio-libs";
-    repo = pname;
+    repo = "aiosignal";
     rev = "v${version}";
     hash = "sha256-CvNarJpSq8EKnt+PuSerMK/ZVbxL9rp7rQ4dkWykG1M=";
   };

--- a/pkgs/development/python-modules/aiowatttime/default.nix
+++ b/pkgs/development/python-modules/aiowatttime/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bachya";
-    repo = pname;
+    repo = "aiowatttime";
     tag = version;
     hash = "sha256-c5L+Nx+CoWEc6Bs61GOHPBelExe5I7EOlMQ+QV6nktI=";
   };

--- a/pkgs/development/python-modules/airtouch4pyapi/default.nix
+++ b/pkgs/development/python-modules/airtouch4pyapi/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "LonePurpleWolf";
-    repo = pname;
+    repo = "airtouch4pyapi";
     tag = "v${version}";
     hash = "sha256-RiRwebumidn0nijL/e9J74ZYx0DASi1up5BTNxYoGEA=";
   };

--- a/pkgs/development/python-modules/aladdin-connect/default.nix
+++ b/pkgs/development/python-modules/aladdin-connect/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "shoejosh";
-    repo = pname;
+    repo = "aladdin-connect";
     tag = version;
     hash = "sha256-kLvMpSGa5WyDOH3ejAJyFGsB9IiMXp+nvVxM/ZkxyFw=";
   };

--- a/pkgs/development/python-modules/allpairspy/default.nix
+++ b/pkgs/development/python-modules/allpairspy/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "thombashi";
-    repo = pname;
+    repo = "allpairspy";
     tag = "v${version}";
     hash = "sha256-0wzoQDHB7Tt80ZTlKrNxFutztsgUuin5D2eb80c4PBI=";
   };

--- a/pkgs/development/python-modules/amqtt/default.nix
+++ b/pkgs/development/python-modules/amqtt/default.nix
@@ -17,7 +17,7 @@
   websockets,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "amqtt";
   version = "unstable-2022-05-29";
   format = "pyproject";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Yakifo";
-    repo = pname;
+    repo = "amqtt";
     rev = "09ac98d39a711dcff0d8f22686916e1c2495144b";
     hash = "sha256-8T1XhBSOiArlUQbQ41LsUogDgOurLhf+M8mjIrrAC4s=";
   };

--- a/pkgs/development/python-modules/ancp-bids/default.nix
+++ b/pkgs/development/python-modules/ancp-bids/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   # `tests/data` dir missing from PyPI dist
   src = fetchFromGitHub {
     owner = "ANCPLabOldenburg";
-    repo = pname;
+    repo = "ancp-bids";
     tag = version;
     hash = "sha256-vmw8SAikvbaHnPOthBQxTbyvDwnnZwCOV97aUogIgxw=";
   };

--- a/pkgs/development/python-modules/androguard/default.nix
+++ b/pkgs/development/python-modules/androguard/default.nix
@@ -39,8 +39,8 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    repo = pname;
-    owner = pname;
+    repo = "androguard";
+    owner = "androguard";
     tag = "v${version}";
     sha256 = "sha256-qz6x7UgYXal1DbQGzi4iKnSGEn873rKibKme/pF7tLk=";
   };

--- a/pkgs/development/python-modules/ansi/default.nix
+++ b/pkgs/development/python-modules/ansi/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tehmaze";
-    repo = pname;
+    repo = "ansi";
     tag = "ansi-${version}";
     hash = "sha256-PmgB1glksu4roQeZ1o7uilMJNm9xaYqw680N2z+tUUM=";
   };

--- a/pkgs/development/python-modules/ansiconv/default.nix
+++ b/pkgs/development/python-modules/ansiconv/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ansible";
-    repo = pname;
+    repo = "ansiconv";
     rev = "v${version}";
     sha256 = "0ljfpl8x069arzginvpi1v6hlaq4x2qpjqj01qds2ylz33scq8r4";
   };

--- a/pkgs/development/python-modules/aqualogic/default.nix
+++ b/pkgs/development/python-modules/aqualogic/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "swilson";
-    repo = pname;
+    repo = "aqualogic";
     rev = version;
     hash = "sha256-hBg02Wypd+MyqM2SUD53djhm5OMP2QAmsp8Stf+UT2c=";
   };

--- a/pkgs/development/python-modules/arc4/default.nix
+++ b/pkgs/development/python-modules/arc4/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "manicmaniac";
-    repo = pname;
+    repo = "arc4";
     rev = version;
     hash = "sha256-DlZIygf5v3ZNY2XFmrKOA15ccMo3Rv0kf6hZJ0CskeQ=";
   };

--- a/pkgs/development/python-modules/aria2p/default.nix
+++ b/pkgs/development/python-modules/aria2p/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pawamoy";
-    repo = pname;
+    repo = "aria2p";
     tag = version;
     hash = "sha256-JEXTCDfFjxI1hooiEQq0KIGGoS2F7fyzOM0GMl+Jr7w=";
   };

--- a/pkgs/development/python-modules/arpy/default.nix
+++ b/pkgs/development/python-modules/arpy/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "viraptor";
-    repo = pname;
+    repo = "arpy";
     rev = version;
     hash = "sha256-jD1XJJhcpJymn0CwZ65U06xLKm1JjHffmx/umEO7a5s=";
   };

--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "1p8hv4gsyqsdr0gafcq497n52pybiqmc22di8ai4nsj60fv0km45";
     rev = "v${version}";
     owner = "kimgr";
-    repo = pname;
+    repo = "asn1ate";
   };
 
   propagatedBuildInputs = [ pyparsing ];

--- a/pkgs/development/python-modules/assay/default.nix
+++ b/pkgs/development/python-modules/assay/default.nix
@@ -5,14 +5,14 @@
   pythonAtLeast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "assay";
   version = "0-unstable-2024-05-09";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "brandon-rhodes";
-    repo = pname;
+    repo = "assay";
     rev = "74617d70e77afa09f58b3169cf496679ac5d5621";
     hash = "sha256-zYpLtcXZ16EJWKSCqxFkSz/G9PwIZEQGBrYiJKuqnc4=";
   };

--- a/pkgs/development/python-modules/assertpy/default.nix
+++ b/pkgs/development/python-modules/assertpy/default.nix
@@ -11,8 +11,8 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "assertpy";
+    repo = "assertpy";
     rev = version;
     sha256 = "0hnfh45cmqyp7zasrllwf8gbq3mazqlhhk0sq1iqlh6fig0yfq2f";
   };

--- a/pkgs/development/python-modules/asyncio-throttle/default.nix
+++ b/pkgs/development/python-modules/asyncio-throttle/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hallazzang";
-    repo = pname;
+    repo = "asyncio-throttle";
     rev = "v${version}";
     sha256 = "1hsjcymdcm0hf4l68scf9n8j7ba89azgh96xhxrnyvwxfs5acnmv";
   };

--- a/pkgs/development/python-modules/asyncmy/default.nix
+++ b/pkgs/development/python-modules/asyncmy/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "long2ice";
-    repo = pname;
+    repo = "asyncmy";
     tag = "v${version}";
     hash = "sha256-HQZmt22yPYaWfJzL20+jBc855HR4dVW983Z0LrN1Xa0=";
   };

--- a/pkgs/development/python-modules/atlassian-python-api/default.nix
+++ b/pkgs/development/python-modules/atlassian-python-api/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "atlassian-api";
-    repo = pname;
+    repo = "atlassian-python-api";
     tag = version;
     hash = "sha256-m8B6t9tTlef8cdsh/wnsc0iyNLsB0RYjUhq/bA9MeII=";
   };

--- a/pkgs/development/python-modules/aurorapy/default.nix
+++ b/pkgs/development/python-modules/aurorapy/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitLab {
     owner = "energievalsabbia";
-    repo = pname;
+    repo = "aurorapy";
     rev = version;
     hash = "sha256-rGwfGq3zdoG9NCGqVN29Q4bWApk5B6CRdsW9ctWgOec=";
   };

--- a/pkgs/development/python-modules/avea/default.nix
+++ b/pkgs/development/python-modules/avea/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "k0rventen";
-    repo = pname;
+    repo = "avea";
     rev = "v${version}";
     sha256 = "1dirf0zdf4hb941w1dvh97vsvcy4h3w9r8jwdgr1ggmhdf9kfx4v";
   };

--- a/pkgs/development/python-modules/babelfont/default.nix
+++ b/pkgs/development/python-modules/babelfont/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   # PyPI source tarballs omit tests, fetch from Github instead
   src = fetchFromGitHub {
     owner = "simoncozens";
-    repo = pname;
+    repo = "babelfont";
     tag = "v${version}";
     hash = "sha256-XNoyM3kjKRc0NWA94ufzC2DBzAsufJNJbzFDUbLu8Lc=";
   };

--- a/pkgs/development/python-modules/backoff/default.nix
+++ b/pkgs/development/python-modules/backoff/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "litl";
-    repo = pname;
+    repo = "backoff";
     tag = "v${version}";
     hash = "sha256-g8bYGJ6Kw6y3BUnuoP1IAye5CL0geH5l7pTb3xxq7jI=";
   };

--- a/pkgs/development/python-modules/base58check/default.nix
+++ b/pkgs/development/python-modules/base58check/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "joeblackwaslike";
-    repo = pname;
+    repo = "base58check";
     rev = "v${version}";
     hash = "sha256-Tig6beLRDsXC//x4+t/z2BGaJQWzcP0J+QEKx3D0rhs=";
   };

--- a/pkgs/development/python-modules/bashlex/default.nix
+++ b/pkgs/development/python-modules/bashlex/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "idank";
-    repo = pname;
+    repo = "bashlex";
     rev = version;
     hash = "sha256-ddZN91H95RiTLXx4lpES1Dmz7nNsSVUeuFuOEpJ7LQI=";
   };

--- a/pkgs/development/python-modules/bbox/default.nix
+++ b/pkgs/development/python-modules/bbox/default.nix
@@ -12,7 +12,7 @@
   pyquaternion,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "bbox";
   version = "0.9.4";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "varunagrawal";
-    repo = pname;
+    repo = "bbox";
     # matches 0.9.4 on PyPi + tests
     rev = "d3f07ed0e38b6015cf4181e3b3edae6a263f8565";
     hash = "sha256-FrJ8FhlqwmnEB/QvPlkDfqZncNGPhwY9aagM9yv1LGs=";

--- a/pkgs/development/python-modules/beautifultable/default.nix
+++ b/pkgs/development/python-modules/beautifultable/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pri22296";
-    repo = pname;
+    repo = "beautifultable";
     rev = "v${version}";
     hash = "sha256-/SReCEvSwiNjBoz/3tGJ9zUNBAag4mLsHlUXwm47zCw=";
   };

--- a/pkgs/development/python-modules/beautysh/default.nix
+++ b/pkgs/development/python-modules/beautysh/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "lovesegfault";
-    repo = pname;
+    repo = "beautysh";
     rev = "v${version}";
     hash = "sha256-rPeGRcyNK45Y7OvtzaIH93IIzexBf/jM1SzYP0phQ1o=";
   };

--- a/pkgs/development/python-modules/bitstring/default.nix
+++ b/pkgs/development/python-modules/bitstring/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "scott-griffiths";
-    repo = pname;
+    repo = "bitstring";
     tag = "bitstring-${version}";
     hash = "sha256-ZABAd42h+BqcpKTFV5PxcBN3F8FKV6Qw3rhP13eX57k=";
   };

--- a/pkgs/development/python-modules/bitvavo-aio/default.nix
+++ b/pkgs/development/python-modules/bitvavo-aio/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cyberjunky";
-    repo = pname;
+    repo = "bitvavo-aio";
     rev = version;
     sha256 = "1d9nbbvv7xnkixj03sfhs2da5j3i2m7p73r7j1yb7b39zas2rbig";
   };

--- a/pkgs/development/python-modules/bjoern/default.nix
+++ b/pkgs/development/python-modules/bjoern/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   # tests are not published to pypi anymore
   src = fetchFromGitHub {
     owner = "jonashaag";
-    repo = pname;
+    repo = "bjoern";
     rev = version;
     hash = "sha256-d7u/lEh2Zr5NYWYu4Zr7kgyeOIQuHQLYrZeiZMHbpio=";
     fetchSubmodules = true; # fetch http-parser and statsd-c-client submodules

--- a/pkgs/development/python-modules/black-macchiato/default.nix
+++ b/pkgs/development/python-modules/black-macchiato/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "wbolster";
-    repo = pname;
+    repo = "black-macchiato";
     rev = version;
     sha256 = "0lc9w50nlbmlzj44krk7kxcia202fhybbnwfh77xixlc7vb4rayl";
   };

--- a/pkgs/development/python-modules/bleak/default.nix
+++ b/pkgs/development/python-modules/bleak/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hbldh";
-    repo = pname;
+    repo = "bleak";
     tag = "v${version}";
     hash = "sha256-kPeKQcJETZE6+btQsmCgb37yRI2Klg0lZ1ZIrm8ODow=";
   };

--- a/pkgs/development/python-modules/blobfile/default.nix
+++ b/pkgs/development/python-modules/blobfile/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "christopher-hesse";
-    repo = pname;
+    repo = "blobfile";
     tag = "v${version}";
     hash = "sha256-/v48rLvlN4lsfWKJvXRNuIO6jdsCgRcSPlJzdOfl3xk=";
   };

--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "duckinator";
-    repo = pname;
+    repo = "bork";
     tag = "v${version}";
     hash = "sha256-YqvtOwd00TXD4I3fIQolvjHnjREvQgbdrEO9Z96v1Kk=";
   };

--- a/pkgs/development/python-modules/bravado-core/default.nix
+++ b/pkgs/development/python-modules/bravado-core/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Yelp";
-    repo = pname;
+    repo = "bravado-core";
     rev = "v${version}";
     hash = "sha256-kyHmZNPl5lLKmm5i3TSi8Tfi96mQHqaiyBfceBJcOdw=";
   };

--- a/pkgs/development/python-modules/brotli-asgi/default.nix
+++ b/pkgs/development/python-modules/brotli-asgi/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage {
 
   src = fetchFromGitHub {
     owner = "fullonic";
-    repo = pname;
+    repo = "brotli-asgi";
     rev = "v${version}";
     hash = "sha256-hQ6CSXnAoUSaKUSmE+2GHZemkFqd8Dc5+OvcUD7/r5Y=";
   };

--- a/pkgs/development/python-modules/brotli/default.nix
+++ b/pkgs/development/python-modules/brotli/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "google";
-    repo = pname;
+    repo = "brotli";
     tag = "v${version}";
     hash = "sha256-U1vAupUthD5W0xvlOKdgm9MAVLqsVyZUaFdeLsDAbDM=";
     # .gitattributes is not correct or GitHub does not parse it correct and the archive is missing the test data

--- a/pkgs/development/python-modules/brottsplatskartan/default.nix
+++ b/pkgs/development/python-modules/brottsplatskartan/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "chrillux";
-    repo = pname;
+    repo = "brottsplatskartan";
     rev = version;
     sha256 = "07iwmnchvpw156j23yfccg4c32izbwm8b02bjr1xgmcwzbq21ks9";
   };

--- a/pkgs/development/python-modules/bunch/default.nix
+++ b/pkgs/development/python-modules/bunch/default.nix
@@ -5,7 +5,7 @@
   pythonOlder,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "bunch";
   version = "unstable-2017-11-21";
   format = "setuptools";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   # Use a fork as upstream is dead
   src = fetchFromGitHub {
     owner = "olivecoder";
-    repo = pname;
+    repo = "bunch";
     rev = "71ac9d5c712becd4c502ab3099203731a0f1122e";
     hash = "sha256-XOgzJkcIqkAJFsKAyt2jSEIxcc0h2gFC15xy5kAs+7s=";
   };

--- a/pkgs/development/python-modules/bytecode/default.nix
+++ b/pkgs/development/python-modules/bytecode/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "vstinner";
-    repo = pname;
+    repo = "bytecode";
     tag = version;
     hash = "sha256-74qEwAYHXV4HakJQ05A9K7LuO0xP28Hub6no09KO4r4=";
   };

--- a/pkgs/development/python-modules/bytewax/default.nix
+++ b/pkgs/development/python-modules/bytewax/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bytewax";
-    repo = pname;
+    repo = "bytewax";
     tag = "v${version}";
     hash = "sha256-O5q1Jd3AMUaQwfQM249CUnkjqEkXybxtM9SOISoULZk=";
   };

--- a/pkgs/development/python-modules/cachelib/default.nix
+++ b/pkgs/development/python-modules/cachelib/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pallets";
-    repo = pname;
+    repo = "cachelib";
     tag = version;
     hash = "sha256-8jg+zfdIATvu/GSFvqHl4cNMu+s2IFWC22vPZ7Q3WYI=";
   };

--- a/pkgs/development/python-modules/cachey/default.nix
+++ b/pkgs/development/python-modules/cachey/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.6";
   src = fetchFromGitHub {
     owner = "dask";
-    repo = pname;
+    repo = "cachey";
     rev = version;
     hash = "sha256-5USmuufrrWtmgibpfkjo9NtgN30hdl8plJfythmxM4s=";
   };

--- a/pkgs/development/python-modules/callee/default.nix
+++ b/pkgs/development/python-modules/callee/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Xion";
-    repo = pname;
+    repo = "callee";
     tag = version;
     hash = "sha256-dsXMY3bW/70CmTfCuy5KjxPa+NLCzxzWv5e1aV2NEWE=";
   };

--- a/pkgs/development/python-modules/cart/default.nix
+++ b/pkgs/development/python-modules/cart/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CybercentreCanada";
-    repo = pname;
+    repo = "cart";
     tag = "v${version}";
     hash = "sha256-oeWeay1Pr9T4oR3XSrwv9hRr/sLTel1Bt6BG6jHXxIA=";
   };

--- a/pkgs/development/python-modules/certvalidator/default.nix
+++ b/pkgs/development/python-modules/certvalidator/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "wbond";
-    repo = pname;
+    repo = "certvalidator";
     rev = version;
     hash = "sha256-yVF7t4FuU3C9fDg67JeM7LWZZh/mv5F4EKmjlO4AuBY=";
   };

--- a/pkgs/development/python-modules/chacha20poly1305-reuseable/default.nix
+++ b/pkgs/development/python-modules/chacha20poly1305-reuseable/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage {
 
   src = fetchFromGitHub {
     owner = "bdraco";
-    repo = pname;
+    repo = "chacha20poly1305-reuseable";
     tag = "v${version}";
     hash = "sha256-i6bhqfYo+gFTf3dqOBSQqGN4WPqbUR05StdwZvrVckI=";
   };

--- a/pkgs/development/python-modules/chalice/default.nix
+++ b/pkgs/development/python-modules/chalice/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "aws";
-    repo = pname;
+    repo = "chalice";
     tag = version;
     hash = "sha256-m3pSD4fahBW6Yt/w07Co4fTZD7k6as5cPwoK5QSry6M=";
   };

--- a/pkgs/development/python-modules/cheetah3/default.nix
+++ b/pkgs/development/python-modules/cheetah3/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CheetahTemplate3";
-    repo = pname;
+    repo = "cheetah3";
     tag = version;
     hash = "sha256-yIdswcCuoDR3R/Subl22fKB55pgw/sDkrPy+vwNgaxI=";
   };

--- a/pkgs/development/python-modules/chirpstack-api/default.nix
+++ b/pkgs/development/python-modules/chirpstack-api/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "brocaar";
-    repo = pname;
+    repo = "chirpstack-api";
     rev = "v${version}";
     hash = "sha256-69encHMk0eXE2Av87ysKvxoiXog5o68qCUlOx/lgHFU=";
   };

--- a/pkgs/development/python-modules/circuitbreaker/default.nix
+++ b/pkgs/development/python-modules/circuitbreaker/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "fabfuel";
-    repo = pname;
+    repo = "circuitbreaker";
     tag = version;
     hash = "sha256-7BpYGhha0PTYzsE9CsN4KxfJW/wm2i6V+uAeamBREBQ=";
   };

--- a/pkgs/development/python-modules/class-doc/default.nix
+++ b/pkgs/development/python-modules/class-doc/default.nix
@@ -8,14 +8,14 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "class-doc";
   version = "0.2.6";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "danields761";
-    repo = pname;
+    repo = "class-doc";
     rev = "9b122d85ce667d096ebee75a49350bbdbd48686d"; # no 0.2.6 version tag
     hash = "sha256-4Sn/TuBvBpl1nvJBg327+sVrjGavkYKEYP32DwLWako=";
   };

--- a/pkgs/development/python-modules/classify-imports/default.nix
+++ b/pkgs/development/python-modules/classify-imports/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "asottile";
-    repo = pname;
+    repo = "classify-imports";
     rev = "v${version}";
     hash = "sha256-f5wZfisKz9WGdq6u0rd/zg2CfMwWvQeR8xZQNbD7KfU=";
   };

--- a/pkgs/development/python-modules/cleo/default.nix
+++ b/pkgs/development/python-modules/cleo/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "python-poetry";
-    repo = pname;
+    repo = "cleo";
     tag = version;
     hash = "sha256-+OvE09hbF6McdXpXdv5UBdZ0LiSOTL8xyE/+bBNIFNk=";
   };

--- a/pkgs/development/python-modules/click-command-tree/default.nix
+++ b/pkgs/development/python-modules/click-command-tree/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "whwright";
-    repo = pname;
+    repo = "click-command-tree";
     tag = version;
     hash = "sha256-oshAHCGe8p5BQ0W21bXSxrTCEFgIxZ6BmUEiWB1xAoI=";
   };

--- a/pkgs/development/python-modules/click-shell/default.nix
+++ b/pkgs/development/python-modules/click-shell/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   # PyPi release is missing tests
   src = fetchFromGitHub {
     owner = "clarkperkins";
-    repo = pname;
+    repo = "click-shell";
     tag = version;
     hash = "sha256-4QpQzg0yFuOFymGiTI+A8o6LyX78iTJMqr0ernYbilI=";
   };

--- a/pkgs/development/python-modules/clintermission/default.nix
+++ b/pkgs/development/python-modules/clintermission/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sebageek";
-    repo = pname;
+    repo = "clintermission";
     tag = "v${version}";
     hash = "sha256-e7C9IDr+mhVSfU8lMywjX1BYwFo/qegPNzabak7UPcY=";
   };

--- a/pkgs/development/python-modules/clip/default.nix
+++ b/pkgs/development/python-modules/clip/default.nix
@@ -9,14 +9,14 @@
   tqdm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "clip";
   version = "unstable-2022-11-17";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "openai";
-    repo = pname;
+    repo = "clip";
     rev = "d50d76daa670286dd6cacf3bcd80b5e4823fc8e1";
     hash = "sha256-GAitNBb5CzFVv2+Dky0VqSdrFIpKKtoAoyqeLoDaHO4=";
   };

--- a/pkgs/development/python-modules/clldutils/default.nix
+++ b/pkgs/development/python-modules/clldutils/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "clld";
-    repo = pname;
+    repo = "clldutils";
     rev = "v${version}";
     hash = "sha256-OD+WJ9JuYZb/oXDgVqL4i5YlcVEt0+swq0SB3cutyRo=";
   };

--- a/pkgs/development/python-modules/codepy/default.nix
+++ b/pkgs/development/python-modules/codepy/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "inducer";
-    repo = pname;
+    repo = "codepy";
     rev = "v${version}";
     hash = "sha256-viMfB/nDrvDA/IGRZEX+yXylxbbmqbh/fgdYXBzK0zM=";
   };

--- a/pkgs/development/python-modules/colorful/default.nix
+++ b/pkgs/development/python-modules/colorful/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "timofurrer";
-    repo = pname;
+    repo = "colorful";
     tag = "v${version}";
     hash = "sha256-8rHJIsHiyfjmjlGiEyrzvEwKgi1kP4Njm731mlFDMIU=";
   };

--- a/pkgs/development/python-modules/colorzero/default.nix
+++ b/pkgs/development/python-modules/colorzero/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "waveform80";
-    repo = pname;
+    repo = "colorzero";
     tag = "release-${version}";
     hash = "sha256-0NoQsy86OHQNLZsTEuF5s2MlRUoacF28jNeHgFKAH14=";
   };

--- a/pkgs/development/python-modules/colout/default.nix
+++ b/pkgs/development/python-modules/colout/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nojhan";
-    repo = pname;
+    repo = "colout";
     tag = "v${version}";
     hash = "sha256-7Dtf87erBElqVgqRx8BYHYOWv1uI84JJ0LHrcneczCI=";
   };

--- a/pkgs/development/python-modules/confection/default.nix
+++ b/pkgs/development/python-modules/confection/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "explosion";
-    repo = pname;
+    repo = "confection";
     tag = "v${version}";
     hash = "sha256-1XIo9Hg4whYS1AkFeX8nVnpv+IvnpmyydHYdVYS0xZc=";
   };

--- a/pkgs/development/python-modules/configobj/default.nix
+++ b/pkgs/development/python-modules/configobj/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "DiffSK";
-    repo = pname;
+    repo = "configobj";
     tag = "v${version}";
     hash = "sha256-duPCGBaHCXp4A6ZHLnyL1SZtR7K4FJ4hs5wCE1V9WB4=";
   };

--- a/pkgs/development/python-modules/confuse/default.nix
+++ b/pkgs/development/python-modules/confuse/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "beetbox";
-    repo = pname;
+    repo = "confuse";
     rev = "v${version}";
     hash = "sha256-zdH5DNXnuAfYTuaG9EIKiXL2EbLSfzYjPSkC3G06bU8=";
   };

--- a/pkgs/development/python-modules/connio/default.nix
+++ b/pkgs/development/python-modules/connio/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tiagocoutinho";
-    repo = pname;
+    repo = "connio";
     tag = "v${version}";
     hash = "sha256-fPM7Ya69t0jpZhKM2MTk6BwjvoW3a8SV3k000LB9Ypo=";
   };

--- a/pkgs/development/python-modules/convertdate/default.nix
+++ b/pkgs/development/python-modules/convertdate/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "fitnr";
-    repo = pname;
+    repo = "convertdate";
     rev = "v${version}";
     hash = "sha256-iOHK3UJulXJJR50nhiVgfk3bt+CAtG3BRySJ8DkBuJE=";
   };

--- a/pkgs/development/python-modules/crc32c/default.nix
+++ b/pkgs/development/python-modules/crc32c/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ICRAR";
-    repo = pname;
+    repo = "crc32c";
     tag = "v${version}";
     hash = "sha256-WBFiAbdzV719vPdZkRGei2+Y33RroMZ7FeQmWo/OfE0=";
   };

--- a/pkgs/development/python-modules/cryptg/default.nix
+++ b/pkgs/development/python-modules/cryptg/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cher-nov";
-    repo = pname;
+    repo = "cryptg";
     rev = "v${version}";
     hash = "sha256-GCTVxCJQvpvHpzaU+OaFM/AKoRvxLyA0u6VIV+94UTY=";
   };

--- a/pkgs/development/python-modules/crysp/default.nix
+++ b/pkgs/development/python-modules/crysp/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bdcht";
-    repo = pname;
+    repo = "crysp";
     rev = "v${version}";
     hash = "sha256-51SKS6OOXIFT1L3YICR6a4QGSz/rbB8V+Z0u0jMO474=";
   };

--- a/pkgs/development/python-modules/dacite/default.nix
+++ b/pkgs/development/python-modules/dacite/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "konradhalas";
-    repo = pname;
+    repo = "dacite";
     tag = "v${version}";
     hash = "sha256-lvObQ+jyBH2s4GOwyDXEAYmG7ZGQN9WDqL8ftNItPCQ=";
   };

--- a/pkgs/development/python-modules/databricks-cli/default.nix
+++ b/pkgs/development/python-modules/databricks-cli/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "databricks";
-    repo = pname;
+    repo = "databricks-cli";
     tag = version;
     hash = "sha256-dH95C2AY/B6F9BROr6rh+gVtKqxsg1gyEU5MzCd5aqs=";
   };

--- a/pkgs/development/python-modules/datasette-publish-fly/default.nix
+++ b/pkgs/development/python-modules/datasette-publish-fly/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "simonw";
-    repo = pname;
+    repo = "datasette-publish-fly";
     tag = version;
     hash = "sha256-diaxr+fNNgkJvLGkLo+lK0ThTsXYDePFsvTetMbDRMk=";
   };

--- a/pkgs/development/python-modules/datasette-template-sql/default.nix
+++ b/pkgs/development/python-modules/datasette-template-sql/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "simonw";
-    repo = pname;
+    repo = "datasette-template-sql";
     rev = version;
     hash = "sha256-VmdIEDk3iCBFrTPMm6ud00Z5CWqO0Wk707IQ4oVx5ak=";
   };

--- a/pkgs/development/python-modules/datasette/default.nix
+++ b/pkgs/development/python-modules/datasette/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "simonw";
-    repo = pname;
+    repo = "datasette";
     tag = version;
     hash = "sha256-kVtldBuDy19DmyxEQLtAjs1qiNIjaT8+rnHlFfGNHec=";
   };

--- a/pkgs/development/python-modules/datatable/default.nix
+++ b/pkgs/development/python-modules/datatable/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "h2oai";
-    repo = pname;
+    repo = "datatable";
     rev = "9522f0833d3e965656396de4fffebd882d39c25d";
     hash = "sha256-lEXQwhx2msnJkkRrTkAwYttlYTISyH/Z7dSalqRrOhI=";
   };

--- a/pkgs/development/python-modules/dbt-common/default.nix
+++ b/pkgs/development/python-modules/dbt-common/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dbt-labs";
-    repo = pname;
+    repo = "dbt-common";
     rev = "03e09c01f20573975e8e17776a4b7c9088b3f212"; # They don't tag releases
     hash = "sha256-KqnwlFZZRYuWRflMzjrqCPBnzY9q/pPhceM2DGqz5bw=";
   };

--- a/pkgs/development/python-modules/dbus-python-client-gen/default.nix
+++ b/pkgs/development/python-modules/dbus-python-client-gen/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "stratis-storage";
-    repo = pname;
+    repo = "dbus-python-client-gen";
     tag = "v${version}";
     hash = "sha256-4Y4cL254ZlZKF6d6cStIOya3J4ZfypuumwKOdDNzuNc=";
   };

--- a/pkgs/development/python-modules/dbus-signature-pyparsing/default.nix
+++ b/pkgs/development/python-modules/dbus-signature-pyparsing/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "stratis-storage";
-    repo = pname;
+    repo = "dbus-signature-pyparsing";
     rev = "v${version}";
     hash = "sha256-+jY8kg3jBDpZr5doih3DiyUEcSskq7TgubmW3qdBoZM=";
   };

--- a/pkgs/development/python-modules/debuglater/default.nix
+++ b/pkgs/development/python-modules/debuglater/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ploomber";
-    repo = pname;
+    repo = "debuglater";
     tag = version;
     hash = "sha256-o9IAk3EN8ghEft7Y7Xx+sEjWMNgoyiZ0eiBqnCyXkm8=";
   };

--- a/pkgs/development/python-modules/decli/default.nix
+++ b/pkgs/development/python-modules/decli/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "woile";
-    repo = pname;
+    repo = "decli";
     tag = "v${version}";
     hash = "sha256-FZYKNKkQExx/YBn5y/W0+0aMlenuwEctYTL7LAXMZGE=";
   };

--- a/pkgs/development/python-modules/deepwave/default.nix
+++ b/pkgs/development/python-modules/deepwave/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ar4";
-    repo = pname;
+    repo = "deepwave";
     rev = "v${version}";
     hash = "sha256-DOOy+B12jgwJzQ90qzX50OFxYLPRcVdVYSE5gi3pqDM=";
   };

--- a/pkgs/development/python-modules/deploykit/default.nix
+++ b/pkgs/development/python-modules/deploykit/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "numtide";
-    repo = pname;
+    repo = "deploykit";
     rev = version;
     hash = "sha256-7PiXq1bQJ1jswLHNqCDSYZabgfp8HRuRt5YPGzd5Ej0=";
   };

--- a/pkgs/development/python-modules/desktop-entry-lib/default.nix
+++ b/pkgs/development/python-modules/desktop-entry-lib/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "JakobDev";
-    repo = pname;
+    repo = "desktop-entry-lib";
     rev = version;
     hash = "sha256-+c+FuLv88wc4yVw3iyFFtfbocnWzTCIe2DS0SWoj+VI=";
   };

--- a/pkgs/development/python-modules/detect-secrets/default.nix
+++ b/pkgs/development/python-modules/detect-secrets/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Yelp";
-    repo = pname;
+    repo = "detect-secrets";
     tag = "v${version}";
     hash = "sha256-pNLAZUJhjZ3b01XaltJUJ9O7Blv6/pHQrRvURe7MJ5A=";
     leaveDotGit = true;

--- a/pkgs/development/python-modules/dicom-numpy/default.nix
+++ b/pkgs/development/python-modules/dicom-numpy/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "innolitics";
-    repo = pname;
+    repo = "dicom-numpy";
     tag = "v${version}";
     hash = "sha256-pgmREQlstr0GY2ThIWt4hbcSWmaNWgkr2gO4PSgGHqE=";
   };

--- a/pkgs/development/python-modules/dicom2nifti/default.nix
+++ b/pkgs/development/python-modules/dicom2nifti/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   # no tests in PyPI dist
   src = fetchFromGitHub {
     owner = "icometrix";
-    repo = pname;
+    repo = "dicom2nifti";
     tag = version;
     hash = "sha256-lPaBKqYO8B138fCgeKH6vpwGQhN3JCOnDj5PgaYfRPA=";
   };

--- a/pkgs/development/python-modules/dicomweb-client/default.nix
+++ b/pkgs/development/python-modules/dicomweb-client/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ImagingDataCommons";
-    repo = pname;
+    repo = "dicomweb-client";
     tag = "v${version}";
     hash = "sha256-D3j5EujrEdGTfR8/V3o2VJ/VkGdZ8IifPYMhP4ppXhw=";
   };

--- a/pkgs/development/python-modules/dictdiffer/default.nix
+++ b/pkgs/development/python-modules/dictdiffer/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "inveniosoftware";
-    repo = pname;
+    repo = "dictdiffer";
     rev = "v${version}";
     hash = "sha256-lQyPs3lQWtsvNPuvvwJUTDzrFaOX5uwGuRHe3yWUheU=";
   };

--- a/pkgs/development/python-modules/dill/default.nix
+++ b/pkgs/development/python-modules/dill/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "uqfoundation";
-    repo = pname;
+    repo = "dill";
     tag = version;
     hash = "sha256-p+W0ppNMfSgplKsQjaTnTrMvQ5poF/E/xSzsiLf9h58=";
   };

--- a/pkgs/development/python-modules/dinghy/default.nix
+++ b/pkgs/development/python-modules/dinghy/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nedbat";
-    repo = pname;
+    repo = "dinghy";
     tag = version;
     hash = "sha256-51BXQdDxlI6+3ctDSa/6tyRXBb1E9BVej9qy7WtkOGM=";
   };

--- a/pkgs/development/python-modules/django-celery-email/default.nix
+++ b/pkgs/development/python-modules/django-celery-email/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pmclanahan";
-    repo = pname;
+    repo = "django-celery-email";
     rev = version;
     hash = "sha256-LBavz5Nh2ObmIwLCem8nHvsuKgPwkzbS/OzFPmSje/M=";
   };

--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -31,8 +31,8 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "django-extensions";
+    repo = "django-extensions";
     tag = version;
     hash = "sha256-WgO/bDe4anQCc1q2Gdq3W70yDqDgmsvn39Qf9ZNVXuE=";
   };

--- a/pkgs/development/python-modules/django-graphiql-debug-toolbar/default.nix
+++ b/pkgs/development/python-modules/django-graphiql-debug-toolbar/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "flavors";
-    repo = pname;
+    repo = "django-graphiql-debug-toolbar";
     rev = version;
     sha256 = "0fikr7xl786jqfkjdifymqpqnxy4qj8g3nlkgfm24wwq0za719dw";
   };

--- a/pkgs/development/python-modules/django-logentry-admin/default.nix
+++ b/pkgs/development/python-modules/django-logentry-admin/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "yprez";
-    repo = pname;
+    repo = "django-logentry-admin";
     rev = "v${version}";
     sha256 = "1bndxgvisw8kk52zfdifvly6dl4833wqilxf77pg473172yaf5gq";
   };

--- a/pkgs/development/python-modules/django-login-required-middleware/default.nix
+++ b/pkgs/development/python-modules/django-login-required-middleware/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CleitonDeLima";
-    repo = pname;
+    repo = "django-login-required-middleware";
     tag = version;
     hash = "sha256-WFQ/JvKh6gkUxPV27QBd2TzwFS8hfQGmcTInTnmh6iA=";
   };

--- a/pkgs/development/python-modules/django-postgresql-netfields/default.nix
+++ b/pkgs/development/python-modules/django-postgresql-netfields/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jimfunk";
-    repo = pname;
+    repo = "django-postgresql-netfields";
     rev = "v${version}";
     hash = "sha256-76vGvxxfNZQBCCsTkkSgQZ8PpFspWxJQDj/xq9iOSTU=";
   };

--- a/pkgs/development/python-modules/django-prometheus/default.nix
+++ b/pkgs/development/python-modules/django-prometheus/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "korfuri";
-    repo = pname;
+    repo = "django-prometheus";
     rev = "v${version}";
     hash = "sha256-JiLH+4mmNdb9BN81J5YFiMPna/3gaKUK6ARjmCa3fE8=";
   };

--- a/pkgs/development/python-modules/django-rq/default.nix
+++ b/pkgs/development/python-modules/django-rq/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "rq";
-    repo = pname;
+    repo = "django-rq";
     tag = "v${version}";
     hash = "sha256-f4ilMKMWNr/NVKRhylr0fFiKFEKHXU/zIlPnq7fCYNs=";
   };

--- a/pkgs/development/python-modules/django-timezone-field/default.nix
+++ b/pkgs/development/python-modules/django-timezone-field/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mfogel";
-    repo = pname;
+    repo = "django-timezone-field";
     rev = version;
     hash = "sha256-q06TuYkBA4z6tJdT3an6Z8o1i/o85XbYa1JYZBHC8lI=";
   };

--- a/pkgs/development/python-modules/django-vite/default.nix
+++ b/pkgs/development/python-modules/django-vite/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "MrBin99";
-    repo = pname;
+    repo = "django-vite";
     tag = version;
     hash = "sha256-S5DpU0Sw0TOY1SNici6djeTrvg4gehH/a2UCzju1e/s=";
   };

--- a/pkgs/development/python-modules/docformatter/default.nix
+++ b/pkgs/development/python-modules/docformatter/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "PyCQA";
-    repo = pname;
+    repo = "docformatter";
     tag = "v${version}";
     hash = "sha256-eLjaHso1p/nD9K0E+HkeBbnCnvjZ1sdpfww9tzBh0TI=";
   };

--- a/pkgs/development/python-modules/docstring-to-markdown/default.nix
+++ b/pkgs/development/python-modules/docstring-to-markdown/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "python-lsp";
-    repo = pname;
+    repo = "docstring-to-markdown";
     tag = "v${version}";
     hash = "sha256-ykqY7LFIOTuAddYkKDzIltq8FpLVz4v2ZA3Y0cZH9ms=";
   };

--- a/pkgs/development/python-modules/doit-py/default.nix
+++ b/pkgs/development/python-modules/doit-py/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pydoit";
-    repo = pname;
+    repo = "doit-py";
     rev = version;
     hash = "sha256-DBl6/no04ZGRHHmN9gkEtBmAMgmyZWcfPCcFz0uxAv4=";
   };

--- a/pkgs/development/python-modules/dparse2/default.nix
+++ b/pkgs/development/python-modules/dparse2/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nexB";
-    repo = pname;
+    repo = "dparse2";
     tag = version;
     hash = "sha256-JUTL+SVf1RRIXQqwFR7MnExsgGseSiO0a5YzzcqdXHw=";
   };

--- a/pkgs/development/python-modules/dufte/default.nix
+++ b/pkgs/development/python-modules/dufte/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nschloe";
-    repo = pname;
+    repo = "dufte";
     rev = "v${version}";
     hash = "sha256:0ccsmpj160xj6w503a948aw8icj55mw9414xnmijmmjvlwhm0p48";
   };

--- a/pkgs/development/python-modules/dungeon-eos/default.nix
+++ b/pkgs/development/python-modules/dungeon-eos/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
-    repo = pname;
+    repo = "dungeon-eos";
     rev = version;
     hash = "sha256-Z1fGtslXP8zcZmVeWjRrbcM2ZJsfbrWjpLWZ49uSCRY=";
   };

--- a/pkgs/development/python-modules/echo/default.nix
+++ b/pkgs/development/python-modules/echo/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "glue-viz";
-    repo = pname;
+    repo = "echo";
     tag = "v${version}";
     sha256 = "sha256-RlTscoStJQ0vjrrk14xHRsMZOJt8eJSqinc4rY/lW4k=";
   };

--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "olofk";
-    repo = pname;
+    repo = "edalize";
     tag = "v${version}";
     hash = "sha256-5c3Szq0tXQdlyzFTFCla44qB/O6RK8vezVOaFOv8sw4=";
   };

--- a/pkgs/development/python-modules/editdistance-s/default.nix
+++ b/pkgs/development/python-modules/editdistance-s/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "asottile";
-    repo = pname;
+    repo = "editdistance-s";
     rev = "v${version}";
     sha256 = "0w2qd5b6a3c3ahd0xy9ykq4wzqk0byqwdqrr26dyn8j2425j46lg";
   };

--- a/pkgs/development/python-modules/editdistance/default.nix
+++ b/pkgs/development/python-modules/editdistance/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "roy-ht";
-    repo = pname;
+    repo = "editdistance";
     tag = "v${version}";
     hash = "sha256-Ncdg8S/UHYqJ1uFnHk9qhHMM3Lrop00woSu3PLKvuBI=";
   };

--- a/pkgs/development/python-modules/einops/default.nix
+++ b/pkgs/development/python-modules/einops/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "arogozhnikov";
-    repo = pname;
+    repo = "einops";
     tag = "v${version}";
     hash = "sha256-6x9AttvSvgYrHaS5ESKOwyEnXxD2BitYTGtqqSKur+0=";
   };

--- a/pkgs/development/python-modules/elegy/default.nix
+++ b/pkgs/development/python-modules/elegy/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "poets-ai";
-    repo = pname;
+    repo = "elegy";
     tag = version;
     hash = "sha256-FZmLriYhsX+zyQKCtCjbOy6MH+AvjzHRNUyaDSXGlLI=";
   };

--- a/pkgs/development/python-modules/elmax-api/default.nix
+++ b/pkgs/development/python-modules/elmax-api/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "albertogeniola";
-    repo = pname;
+    repo = "elmax-api";
     tag = "v${version}";
     hash = "sha256-BYVfP8B+p4J4gW+64xh9bT9sDcu/lk0R+MvLsYLwRfQ=";
   };

--- a/pkgs/development/python-modules/embedding-reader/default.nix
+++ b/pkgs/development/python-modules/embedding-reader/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "rom1504";
-    repo = pname;
+    repo = "embedding-reader";
     tag = version;
     hash = "sha256-paN6rAyH3L7qCfWPr5kXo9Xl57gRMhdcDnoyLJ7II2w=";
   };

--- a/pkgs/development/python-modules/emcee/default.nix
+++ b/pkgs/development/python-modules/emcee/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dfm";
-    repo = pname;
+    repo = "emcee";
     tag = "v${version}";
     hash = "sha256-JVZK3kvDwWENho0OxZ9OxATcm3XpGmX+e7alPclRsHY=";
   };

--- a/pkgs/development/python-modules/enaml/default.nix
+++ b/pkgs/development/python-modules/enaml/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nucleic";
-    repo = pname;
+    repo = "enaml";
     tag = version;
     hash = "sha256-XwBvPABg4DomI5JNuqaRTINsPgjn8h67rO/ZkSRQ39o=";
   };

--- a/pkgs/development/python-modules/enamlx/default.nix
+++ b/pkgs/development/python-modules/enamlx/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "frmdstryr";
-    repo = pname;
+    repo = "enamlx";
     tag = "v${version}";
     hash = "sha256-C3/G0bnu1EQh0elqdrpCwkFPZU4qmkUX7WRSRK9nkM4=";
   };

--- a/pkgs/development/python-modules/energyflip-client/default.nix
+++ b/pkgs/development/python-modules/energyflip-client/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dennisschroer";
-    repo = pname;
+    repo = "energyflip-client";
     tag = "v${version}";
     hash = "sha256-neuZ6pZWW/Rgexu/iCEymjnxi5l/IuLKPFn6S9U4DgU=";
   };

--- a/pkgs/development/python-modules/enturclient/default.nix
+++ b/pkgs/development/python-modules/enturclient/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hfurubotten";
-    repo = pname;
+    repo = "enturclient";
     rev = "v${version}";
     hash = "sha256-Y2sBPikCAxumylP1LUy8XgjBRCWaNryn5XHSrRjJIIo=";
   };

--- a/pkgs/development/python-modules/eradicate/default.nix
+++ b/pkgs/development/python-modules/eradicate/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "wemake-services";
-    repo = pname;
+    repo = "eradicate";
     tag = version;
     hash = "sha256-ikiqNe1a+OeRraNBbtAx6v3LsTajWlgxm4wR2Tcbmjk=";
   };

--- a/pkgs/development/python-modules/eternalegypt/default.nix
+++ b/pkgs/development/python-modules/eternalegypt/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "amelchio";
-    repo = pname;
+    repo = "eternalegypt";
     tag = "v${version}";
     hash = "sha256-ubKepd3yBaoYrIUe5WCt1zd4CjvU7SeftOR+2cBaEf0=";
   };

--- a/pkgs/development/python-modules/executing/default.nix
+++ b/pkgs/development/python-modules/executing/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "alexmojaki";
-    repo = pname;
+    repo = "executing";
     rev = "v${version}";
     hash = "sha256-2BT4VTZBAJx8Gk4qTTyhSoBMjJvKzmL4PO8IfTpN+2g=";
   };

--- a/pkgs/development/python-modules/expects/default.nix
+++ b/pkgs/development/python-modules/expects/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jaimegildesagredo";
-    repo = pname;
+    repo = "expects";
     rev = "v${version}";
     sha256 = "0mk1mhh8n9ly820krkhazn1w96f10vmgh21y2wr44sn8vwr4ngyy";
   };

--- a/pkgs/development/python-modules/f90nml/default.nix
+++ b/pkgs/development/python-modules/f90nml/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "marshallward";
-    repo = pname;
+    repo = "f90nml";
     rev = "v" + version;
     hash = "sha256-nSpVBAS2VvXIQwYK/qVVzEc13bicAQ+ScXpO4Rn2O+8=";
   };

--- a/pkgs/development/python-modules/fabulous/default.nix
+++ b/pkgs/development/python-modules/fabulous/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jart";
-    repo = pname;
+    repo = "fabulous";
     rev = version;
     hash = "sha256-hchlxuB5QP+VxCx+QZ2739/mR5SQmYyE+9kXLKJ2ij4=";
   };

--- a/pkgs/development/python-modules/fairseq/default.nix
+++ b/pkgs/development/python-modules/fairseq/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pytorch";
-    repo = pname;
+    repo = "fairseq";
     rev = "v${version}";
     hash = "sha256-XX/grU5ljQCwx33miGoFc/7Uj9fZDtmhm4Fz7L4U+Bc=";
   };

--- a/pkgs/development/python-modules/farama-notifications/default.nix
+++ b/pkgs/development/python-modules/farama-notifications/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Farama-Foundation";
-    repo = pname;
+    repo = "farama-notifications";
     rev = version;
     hash = "sha256-UUrJ/5t5x54xs1gweNUhwqrMJQXiyrUPn1bBfTsiPcw=";
   };

--- a/pkgs/development/python-modules/fastavro/default.nix
+++ b/pkgs/development/python-modules/fastavro/default.nix
@@ -24,8 +24,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "fastavro";
+    repo = "fastavro";
     tag = version;
     hash = "sha256-/YZFrEs7abm+oPn9yyLMV1X/G5VZ/s+ThpvzoQtYQu0=";
   };

--- a/pkgs/development/python-modules/fastdtw/default.nix
+++ b/pkgs/development/python-modules/fastdtw/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "slaypni";
-    repo = pname;
+    repo = "fastdtw";
     rev = "v${version}";
     sha256 = "0irc5x4ahfp7f7q4ic97qa898s2awi0vdjznahxrfjirn8b157dw";
   };

--- a/pkgs/development/python-modules/fasteners/default.nix
+++ b/pkgs/development/python-modules/fasteners/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "harlowja";
-    repo = pname;
+    repo = "fasteners";
     tag = version;
     hash = "sha256-XFa1ItFqkSYE940p/imWFp5e9gS6n+D1uM6Cj+Vzmmg=";
   };

--- a/pkgs/development/python-modules/fastnumbers/default.nix
+++ b/pkgs/development/python-modules/fastnumbers/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "SethMMorton";
-    repo = pname;
+    repo = "fastnumbers";
     tag = version;
     hash = "sha256-TC9+xOvskABpChlrSJcHy6O7D7EnIKL6Ekt/vaLBX2E=";
   };

--- a/pkgs/development/python-modules/fastrlock/default.nix
+++ b/pkgs/development/python-modules/fastrlock/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "scoder";
-    repo = pname;
+    repo = "fastrlock";
     tag = "v${version}";
     hash = "sha256-NB/AR6g1ZP5Atc0zwZNuXLsxg8BM67rWnx3Q6Pb0k5k=";
   };

--- a/pkgs/development/python-modules/fixerio/default.nix
+++ b/pkgs/development/python-modules/fixerio/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "amatellanes";
-    repo = pname;
+    repo = "fixerio";
     rev = "v${version}";
     sha256 = "009h1mys175xdyznn5bl980vly40544s4ph1zcgqwg2i2ic93gvb";
   };

--- a/pkgs/development/python-modules/flake8-bugbear/default.nix
+++ b/pkgs/development/python-modules/flake8-bugbear/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "PyCQA";
-    repo = pname;
+    repo = "flake8-bugbear";
     tag = version;
     hash = "sha256-ZMIpQUF+aXiq2NG0v19UwhWszrW/l50aJmG4YDV0+Wg=";
   };

--- a/pkgs/development/python-modules/flake8-docstrings/default.nix
+++ b/pkgs/development/python-modules/flake8-docstrings/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "PyCQA";
-    repo = pname;
+    repo = "flake8-docstrings";
     tag = version;
     hash = "sha256-EafLWySeHB81HRcXiDs56lbUZzGvnT87WVqln0PoLCk=";
   };

--- a/pkgs/development/python-modules/flask-bcrypt/default.nix
+++ b/pkgs/development/python-modules/flask-bcrypt/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "maxcountryman";
-    repo = pname;
+    repo = "flask-bcrypt";
     rev = version;
     hash = "sha256-WlIholi/nzq6Ikc0LS6FhG0Q5Kz0kvvAlA2YJ7EksZ4=";
   };

--- a/pkgs/development/python-modules/flask-expects-json/default.nix
+++ b/pkgs/development/python-modules/flask-expects-json/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Fischerfredl";
-    repo = pname;
+    repo = "flask-expects-json";
     rev = version;
     hash = "sha256-CUxuwqjjAb9Fy6xWtX1WtSANYaYr5//vY8k89KghYoQ=";
   };

--- a/pkgs/development/python-modules/flask-mongoengine/default.nix
+++ b/pkgs/development/python-modules/flask-mongoengine/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "MongoEngine";
-    repo = pname;
+    repo = "flask-mongoengine";
     rev = "d4526139cb1e2e94111ab7de96bb629d574c1690";
     hash = "sha256-oMQU9Z8boc0q+0KzIQAZ8qSyxiITDY0M9FCg75S9MEY=";
   };

--- a/pkgs/development/python-modules/flask-paranoid/default.nix
+++ b/pkgs/development/python-modules/flask-paranoid/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "miguelgrinberg";
-    repo = pname;
+    repo = "flask-paranoid";
     rev = "v${version}";
     hash = "sha256-tikD8efc3Q3xIQnaC3SSBaCRQxMI1HzXxeupvYeNnE4=";
   };

--- a/pkgs/development/python-modules/flatdict/default.nix
+++ b/pkgs/development/python-modules/flatdict/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "gmr";
-    repo = pname;
+    repo = "flatdict";
     rev = version;
     hash = "sha256-CWsTiCNdIKSQtjpQC07lhZoU1hXT/MGpXdj649x2GlU=";
   };

--- a/pkgs/development/python-modules/flatten-dict/default.nix
+++ b/pkgs/development/python-modules/flatten-dict/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ianlini";
-    repo = pname;
+    repo = "flatten-dict";
     rev = version;
     hash = "sha256-uHenKoD4eLm9sMREVuV0BB/oUgh4NMiuj+IWd0hlxNQ=";
   };

--- a/pkgs/development/python-modules/flowlogs-reader/default.nix
+++ b/pkgs/development/python-modules/flowlogs-reader/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "obsrvbl";
-    repo = pname;
+    repo = "flowlogs-reader";
     # https://github.com/obsrvbl/flowlogs-reader/issues/57
     tag = "v${version}";
     hash = "sha256-9UwCRLRKuIFRTh3ntAzlXCyN175J1wobT3GSLAhl+08=";

--- a/pkgs/development/python-modules/flyingsquid/default.nix
+++ b/pkgs/development/python-modules/flyingsquid/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage {
 
   src = fetchFromGitHub {
     owner = "HazyResearch";
-    repo = pname;
+    repo = "flyingsquid";
     rev = "28a713a9ac501b7597c2489468ae189943d00685";
     hash = "sha256-DPHTSxDD4EW3nrNk2fk0pKJI/8+pQ7Awywd8nxhBruo=";
   };

--- a/pkgs/development/python-modules/fontpens/default.nix
+++ b/pkgs/development/python-modules/fontpens/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "robotools";
-    repo = pname;
+    repo = "fontpens";
     tag = "v${version}";
     sha256 = "13msj0s7mg45klzbnd2w4f4ljb16bp9m0s872s6hczn0j7jmyz11";
   };

--- a/pkgs/development/python-modules/formulae/default.nix
+++ b/pkgs/development/python-modules/formulae/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bambinos";
-    repo = pname;
+    repo = "formulae";
     tag = version;
     hash = "sha256-SSyQa7soIp+wSXX5wek9LG95q7J7K34mztzx01lPiWo=";
   };

--- a/pkgs/development/python-modules/fortiosapi/default.nix
+++ b/pkgs/development/python-modules/fortiosapi/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "fortinet-solutions-cse";
-    repo = pname;
+    repo = "fortiosapi";
     tag = "v${version}";
     hash = "sha256-M71vleEhRYnlf+RSGT1GbCy5NEZaG0hWmJo01n9s6Rg=";
   };

--- a/pkgs/development/python-modules/fqdn/default.nix
+++ b/pkgs/development/python-modules/fqdn/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ypcrts";
-    repo = pname;
+    repo = "fqdn";
     rev = "v${version}";
     hash = "sha256-T0CdWWr8p3JVhp3nol5hyxsrD3951JE2EDpFt+m+3bE=";
   };

--- a/pkgs/development/python-modules/funcparserlib/default.nix
+++ b/pkgs/development/python-modules/funcparserlib/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "vlasovskikh";
-    repo = pname;
+    repo = "funcparserlib";
     rev = version;
     hash = "sha256-LE9ItCaEzEGeahpM3M3sSnDBXEr6uX5ogEkO5x2Jgzc=";
   };

--- a/pkgs/development/python-modules/gbinder-python/default.nix
+++ b/pkgs/development/python-modules/gbinder-python/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "erfanoabdi";
-    repo = pname;
+    repo = "gbinder-python";
     rev = version;
     sha256 = "1X9gAux9w/mCEVmE3Yqvvq3kU7hu4iAFaZWNZZZxt3E=";
   };

--- a/pkgs/development/python-modules/gekitchen/default.nix
+++ b/pkgs/development/python-modules/gekitchen/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ajmarks";
-    repo = pname;
+    repo = "gekitchen";
     rev = "v${version}";
     hash = "sha256-eKGundh7j9LqFd71bx86rNBVu2iAcgLN25JfFa39+VA=";
   };

--- a/pkgs/development/python-modules/geniushub-client/default.nix
+++ b/pkgs/development/python-modules/geniushub-client/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "manzanotti";
-    repo = pname;
+    repo = "geniushub-client";
     tag = "v${version}";
     hash = "sha256-Gq2scYos7E8me1a4x7NanHRq2eYWuU2uSUwM+O1TPb8=";
   };

--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -17,8 +17,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "geopy";
+    repo = "geopy";
     tag = version;
     hash = "sha256-mlOXDEtYry1IUAZWrP2FuY/CGliUnCPYLULnLNN0n4Y=";
   };

--- a/pkgs/development/python-modules/ghrepo-stats/default.nix
+++ b/pkgs/development/python-modules/ghrepo-stats/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mrbean-bremen";
-    repo = pname;
+    repo = "ghrepo-stats";
     tag = "v${version}";
     hash = "sha256-zdBIX/uetkOAalg4uJPWXRL9WUgNN+hmqUwQDTdzrzA=";
   };

--- a/pkgs/development/python-modules/gibberish-detector/default.nix
+++ b/pkgs/development/python-modules/gibberish-detector/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "domanchi";
-    repo = pname;
+    repo = "gibberish-detector";
     rev = "v${version}";
     sha256 = "1si0fkpnk9vjkwl31sq5jkyv3rz8a5f2nh3xq7591j9wv2b6dn0b";
   };

--- a/pkgs/development/python-modules/git-revise/default.nix
+++ b/pkgs/development/python-modules/git-revise/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   # Missing tests on PyPI
   src = fetchFromGitHub {
     owner = "mystor";
-    repo = pname;
+    repo = "git-revise";
     rev = "189c9fe150e5587def75c51709246c47c93e3b4d";
     hash = "sha256-bqhRV0WtWRUKkBG2tEvctxdoYRkcrpL4JZSHYzox8so=";
   };

--- a/pkgs/development/python-modules/github-to-sqlite/default.nix
+++ b/pkgs/development/python-modules/github-to-sqlite/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dogsheep";
-    repo = pname;
+    repo = "github-to-sqlite";
     rev = version;
     hash = "sha256-KwLaaZxBBzRhiBv4p8Imb5XI1hyka9rmr/rxA6wDc7Q=";
   };

--- a/pkgs/development/python-modules/gpaw/default.nix
+++ b/pkgs/development/python-modules/gpaw/default.nix
@@ -81,7 +81,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitLab {
     owner = "gpaw";
-    repo = pname;
+    repo = "gpaw";
     rev = version;
     hash = "sha256-tdS383qT6hBr5hOqjoFS36nRSS2vdVkUR7sExwjWhng=";
   };

--- a/pkgs/development/python-modules/gpiozero/default.nix
+++ b/pkgs/development/python-modules/gpiozero/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "gpiozero";
-    repo = pname;
+    repo = "gpiozero";
     tag = "v${version}";
     hash = "sha256-ifdCFcMH6SrhKQK/TJJ5lJafSfAUzd6ZT5ANUzJGwxI=";
   };

--- a/pkgs/development/python-modules/gps3/default.nix
+++ b/pkgs/development/python-modules/gps3/default.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "gps3";
   version = "unstable-2017-11-01";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "wadda";
-    repo = pname;
+    repo = "gps3";
     rev = "91adcd7073b891b135b2a46d039ce2125cf09a09";
     hash = "sha256-sVK61l8YunKAGFTSAq/m5aUGFfnizwhqTYbdznBIKfk=";
   };

--- a/pkgs/development/python-modules/gpxpy/default.nix
+++ b/pkgs/development/python-modules/gpxpy/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tkrajina";
-    repo = pname;
+    repo = "gpxpy";
     rev = "v${version}";
     hash = "sha256-s65k0u4LIwHX9RJMJIYMkNS4/Z0wstzqYVPAjydo2iI=";
   };

--- a/pkgs/development/python-modules/gpytorch/default.nix
+++ b/pkgs/development/python-modules/gpytorch/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cornellius-gp";
-    repo = pname;
+    repo = "gpytorch";
     tag = "v${version}";
     hash = "sha256-whZjqAs3nyjKMzAGi+OnyBtboq0UuV8m11A4IzkWtec=";
   };

--- a/pkgs/development/python-modules/gradient-utils/default.nix
+++ b/pkgs/development/python-modules/gradient-utils/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Paperspace";
-    repo = pname;
+    repo = "gradient-utils";
     tag = "v${version}";
     hash = "sha256-swnl0phdOsBSP8AX/OySI/aYI9z60Ss3SsJox/mb9KY=";
   };

--- a/pkgs/development/python-modules/grafanalib/default.nix
+++ b/pkgs/development/python-modules/grafanalib/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "weaveworks";
-    repo = pname;
+    repo = "grafanalib";
     tag = "v${version}";
     hash = "sha256-vXnyAfC9avKz8U4+MJVnu2zoPD0nR2qarWYidhEPW5s=";
   };

--- a/pkgs/development/python-modules/grandalf/default.nix
+++ b/pkgs/development/python-modules/grandalf/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bdcht";
-    repo = pname;
+    repo = "grandalf";
     rev = "v${version}";
     hash = "sha256-j2SvpQvDMfwoj2PAQSxzEIyIzzJ61Eb9wgetKyni6A4=";
   };

--- a/pkgs/development/python-modules/graphene-django/default.nix
+++ b/pkgs/development/python-modules/graphene-django/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "graphql-python";
-    repo = pname;
+    repo = "graphene-django";
     tag = "v${version}";
     hash = "sha256-uMkzgXn3YRgEU46Sv5lg60cvetHir9bv0mzJGDv79DI=";
   };

--- a/pkgs/development/python-modules/graphql-server-core/default.nix
+++ b/pkgs/development/python-modules/graphql-server-core/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "graphql-python";
-    repo = pname;
+    repo = "graphql-server-core";
     rev = "v${version}";
     sha256 = "1w3biv2za2m1brwjy0z049c2m94gm1zfwxzgc6lwrsci724jv9fr";
   };

--- a/pkgs/development/python-modules/grpc-interceptor/default.nix
+++ b/pkgs/development/python-modules/grpc-interceptor/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "d5h-foss";
-    repo = pname;
+    repo = "grpc-interceptor";
     tag = "v${version}";
     hash = "sha256-GJkVCslPXShJNDrqhFtCsAK5+VaG8qFJo0RQTsiMIFY=";
   };

--- a/pkgs/development/python-modules/gruut-ipa/default.nix
+++ b/pkgs/development/python-modules/gruut-ipa/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "rhasspy";
-    repo = pname;
+    repo = "gruut-ipa";
     rev = "v${version}";
     hash = "sha256-Q2UKELoG8OaAPxIrZNCpXgeWZ2fCzb3g3SOVzCm/gg0=";
   };

--- a/pkgs/development/python-modules/habanero/default.nix
+++ b/pkgs/development/python-modules/habanero/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sckott";
-    repo = pname;
+    repo = "habanero";
     tag = "v${version}";
     hash = "sha256-tEsuCOuRXJleiv02VGLVSg0ykh3Yu77uZzE6vhf5PaQ=";
   };

--- a/pkgs/development/python-modules/hachoir/default.nix
+++ b/pkgs/development/python-modules/hachoir/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "vstinner";
-    repo = pname;
+    repo = "hachoir";
     tag = version;
     hash = "sha256-sTUJx8Xyhw4Z6juRtREw/okuVjSTSVWpSLKeZ7T8IR8=";
   };

--- a/pkgs/development/python-modules/hatch-odoo/default.nix
+++ b/pkgs/development/python-modules/hatch-odoo/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "acsone";
-    repo = pname;
+    repo = "hatch-odoo";
     tag = version;
     sha256 = "sha256-I3jaiG0Xu8B34q30p7zTs+FeBXUQiPKTAJLSVxE9gYE=";
   };

--- a/pkgs/development/python-modules/helper/default.nix
+++ b/pkgs/development/python-modules/helper/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "gmr";
-    repo = pname;
+    repo = "helper";
     rev = version;
     sha256 = "0zypjv8rncvrsgl200v7d3bn08gs48dwqvgamfqv71h07cj6zngp";
   };

--- a/pkgs/development/python-modules/hiyapyco/default.nix
+++ b/pkgs/development/python-modules/hiyapyco/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "zerwes";
-    repo = pname;
+    repo = "hiyapyco";
     tag = "release-${version}";
     hash = "sha256-uF5DblAg4q8L1tZKopcjJ14NIQVQF5flNHdZ/jnw71M=";
   };

--- a/pkgs/development/python-modules/hocr-tools/default.nix
+++ b/pkgs/development/python-modules/hocr-tools/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tmbdev";
-    repo = pname;
+    repo = "hocr-tools";
     rev = "v${version}";
     sha256 = "14f9hkp7pr677085w8iidwd0la9cjzy3pyj3rdg9b03nz9pc0w6p";
   };

--- a/pkgs/development/python-modules/hologram/default.nix
+++ b/pkgs/development/python-modules/hologram/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dbt-labs";
-    repo = pname;
+    repo = "hologram";
     tag = "v${version}";
     hash = "sha256-DboVCvByI8bTThamGBwSiQADGxIaEnTMmwmVI+4ARgc=";
   };

--- a/pkgs/development/python-modules/homepluscontrol/default.nix
+++ b/pkgs/development/python-modules/homepluscontrol/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "chemaaa";
-    repo = pname;
+    repo = "homepluscontrol";
     rev = version;
     hash = "sha256-COOGqfYiR4tueQHXuCvVxShrYS0XNltcW4mclbFWcfA=";
   };

--- a/pkgs/development/python-modules/html5-parser/default.nix
+++ b/pkgs/development/python-modules/html5-parser/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "kovidgoyal";
-    repo = pname;
+    repo = "html5-parser";
     tag = "v${version}";
     hash = "sha256-0Qn+To/d3+HMx+KhhgJBEHVYPOfIeBnngBraY7r4uSs=";
   };

--- a/pkgs/development/python-modules/http-message-signatures/default.nix
+++ b/pkgs/development/python-modules/http-message-signatures/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pyauth";
-    repo = pname;
+    repo = "http-message-signatures";
     rev = "v${version}";
     hash = "sha256-Jsivw4lNA/2oqsOGGx8D4gUPftzuys877A9RXyapnSQ=";
   };

--- a/pkgs/development/python-modules/http-parser/default.nix
+++ b/pkgs/development/python-modules/http-parser/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "benoitc";
-    repo = pname;
+    repo = "http-parser";
     tag = version;
     hash = "sha256-WHimvSaNcncwzLwwk5+ZNg7BbHF+hPr39SfidEDYfhU=";
   };

--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -20,8 +20,8 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "httplib2";
+    repo = "httplib2";
     rev = "v${version}";
     hash = "sha256-76gdiRbF535CEaNXwNqsVeVc0dKglovMPQpGsOkbd/4=";
   };

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "encode";
-    repo = pname;
+    repo = "httpx";
     tag = version;
     hash = "sha256-tB8uZm0kPRnmeOvsDdrkrHcMVIYfGanB4l/xHsTKpgE=";
   };

--- a/pkgs/development/python-modules/huey/default.nix
+++ b/pkgs/development/python-modules/huey/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "coleifer";
-    repo = pname;
+    repo = "huey";
     tag = version;
     hash = "sha256-Avy5aMYoeIhO7Q83s2W4o6RBMaVFdRBqa7HGNIGNOqE=";
   };

--- a/pkgs/development/python-modules/humblewx/default.nix
+++ b/pkgs/development/python-modules/humblewx/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "thetimelineproj";
-    repo = pname;
+    repo = "humblewx";
     rev = version;
     sha256 = "0fv8gwlbcj000qq34inbwgxf0xgibs590dsyqnw0mmyb7f1iq210";
   };

--- a/pkgs/development/python-modules/hydrawiser/default.nix
+++ b/pkgs/development/python-modules/hydrawiser/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ptcryan";
-    repo = pname;
+    repo = "hydrawiser";
     rev = "v${version}";
     sha256 = "161hazlpvd71xcl2ja86560wm5lnrjv210ki3ji37l6c6gwmhjdj";
   };

--- a/pkgs/development/python-modules/hyperion-py/default.nix
+++ b/pkgs/development/python-modules/hyperion-py/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dermotduffy";
-    repo = pname;
+    repo = "hyperion-py";
     rev = "v${version}";
     hash = "sha256-arcnpCQsRuiWCrAz/t4TCjTe8DRDtRuzYp8k7nnjGDk=";
   };

--- a/pkgs/development/python-modules/ibis/default.nix
+++ b/pkgs/development/python-modules/ibis/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dmulholl";
-    repo = pname;
+    repo = "ibis";
     rev = version;
     hash = "sha256-EPz9zHnxR75WoRaiHKJNiCRWFwU1TBpC4uHz62jUOqM=";
   };

--- a/pkgs/development/python-modules/icmplib/default.nix
+++ b/pkgs/development/python-modules/icmplib/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ValentinBELYN";
-    repo = pname;
+    repo = "icmplib";
     rev = "v${version}";
     hash = "sha256-PnBcGiUvftz/KYg9Qd2GaIcF3OW4lYH301uI5/M5CBI=";
   };

--- a/pkgs/development/python-modules/icnsutil/default.nix
+++ b/pkgs/development/python-modules/icnsutil/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "relikd";
-    repo = pname;
+    repo = "icnsutil";
     tag = "v${version}";
     hash = "sha256-tiq8h6s2noWLBIOIWcj8jfSqJFN01ee2uoHN4aFwn7s=";
   };

--- a/pkgs/development/python-modules/ignite/default.nix
+++ b/pkgs/development/python-modules/ignite/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pytorch";
-    repo = pname;
+    repo = "ignite";
     tag = "v${version}";
     hash = "sha256-aWm+rj/9A7oNBW5jkMg/BRuEw2gQUJ88At1wB75FgNQ=";
   };

--- a/pkgs/development/python-modules/injector/default.nix
+++ b/pkgs/development/python-modules/injector/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "python-injector";
-    repo = pname;
+    repo = "injector";
     tag = version;
     hash = "sha256-5O4vJSXfYNTrUzmv5XuT9pSUndNSvTZTxfVwiAd+0ck=";
   };

--- a/pkgs/development/python-modules/installer/default.nix
+++ b/pkgs/development/python-modules/installer/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pypa";
-    repo = pname;
+    repo = "installer";
     rev = version;
     hash = "sha256-thHghU+1Alpay5r9Dc3v7ATRFfYKV8l9qR0nbGOOX/A=";
   };

--- a/pkgs/development/python-modules/into-dbus-python/default.nix
+++ b/pkgs/development/python-modules/into-dbus-python/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "stratis-storage";
-    repo = pname;
+    repo = "into-dbus-python";
     rev = "v${version}";
     hash = "sha256-Ld/DyhVaDiWUXgqmvSmEHqFW2dcoRNM0O4X5DXE3UtM=";
   };

--- a/pkgs/development/python-modules/invocations/default.nix
+++ b/pkgs/development/python-modules/invocations/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pyinvoke";
-    repo = pname;
+    repo = "invocations";
     tag = version;
     hash = "sha256-JnhdcxhBNsYgDMcljtGKjOT1agujlao/66QifGuh6I0=";
   };

--- a/pkgs/development/python-modules/iodata/default.nix
+++ b/pkgs/development/python-modules/iodata/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "theochem";
-    repo = pname;
+    repo = "iodata";
     tag = "v${version}";
     hash = "sha256-ld6V+/8lg4Du6+mHU5XuXXyMpWwyepXurerScg/bf2Q=";
   };

--- a/pkgs/development/python-modules/ipyxact/default.nix
+++ b/pkgs/development/python-modules/ipyxact/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "olofk";
-    repo = pname;
+    repo = "ipyxact";
     rev = "v${version}";
     hash = "sha256-myD+NnqcxxaSAV7qZa8xqeciaiFqFePqIzd7sb/2GXA=";
   };

--- a/pkgs/development/python-modules/ircrobots/default.nix
+++ b/pkgs/development/python-modules/ircrobots/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jesopo";
-    repo = pname;
+    repo = "ircrobots";
     rev = "v${version}";
     hash = "sha256-slz4AH2Mi21N3aV+OrnoXoQsseS7arW2NuUZARQJsf0=";
   };

--- a/pkgs/development/python-modules/ircstates/default.nix
+++ b/pkgs/development/python-modules/ircstates/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jesopo";
-    repo = pname;
+    repo = "ircstates";
     rev = "v${version}";
     hash = "sha256-Mq9aOj6PXzPjaz3ofoPcAbur59oUWffmEg8aHt0v+0Q=";
   };

--- a/pkgs/development/python-modules/irctokens/default.nix
+++ b/pkgs/development/python-modules/irctokens/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jesopo";
-    repo = pname;
+    repo = "irctokens";
     rev = "v${version}";
     hash = "sha256-Y9NBqxGUkt48hnXxsmfydHkJmWWb+sRrElV8C7l9bpw=";
   };

--- a/pkgs/development/python-modules/ismartgate/default.nix
+++ b/pkgs/development/python-modules/ismartgate/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bdraco";
-    repo = pname;
+    repo = "ismartgate";
     tag = "v${version}";
     hash = "sha256-8c05zzDav87gTL2CI7Aoi6ALwLw76H9xj+90xH31hdE=";
   };

--- a/pkgs/development/python-modules/isoduration/default.nix
+++ b/pkgs/development/python-modules/isoduration/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bolsote";
-    repo = pname;
+    repo = "isoduration";
     rev = version;
     hash = "sha256-6LqsH+3V/K0s2YD1gvmelo+cCH+yCAmmyTYGhUegVdk=";
   };

--- a/pkgs/development/python-modules/itemdb/default.nix
+++ b/pkgs/development/python-modules/itemdb/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   # PyPI tarball doesn't include tests directory
   src = fetchFromGitHub {
     owner = "almarklein";
-    repo = pname;
+    repo = "itemdb";
     tag = "v${version}";
     sha256 = "sha256-egxQ1tGC6R5p1stYm4r05+b2HkuT+nBySTZPGqeAbSE=";
   };

--- a/pkgs/development/python-modules/itunespy/default.nix
+++ b/pkgs/development/python-modules/itunespy/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sleepyfran";
-    repo = pname;
+    repo = "itunespy";
     tag = "v${version}";
     sha256 = "sha256-QvSKJAZa8v0tGURXwo4Dwo73JqsYs1xsBHW0lcaM7bk=";
   };

--- a/pkgs/development/python-modules/itypes/default.nix
+++ b/pkgs/development/python-modules/itypes/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    repo = pname;
+    repo = "itypes";
     owner = "tomchristie";
     rev = version;
     sha256 = "1ljhjp9pacbrv2phs58vppz1dlxix01p98kfhyclvbml6dgjcr52";


### PR DESCRIPTION
Repeat of https://github.com/NixOS/nixpkgs/pull/410679, this time limited to `pkgs/development/python-modules/[a-iA-I]`, part of https://github.com/NixOS/nixpkgs/issues/346453

Should be zero rebuilds.

All candidates were made using:

```shell
#!/usr/bin/env nix-shell
#!nix-shell -I nixpkgs=. --pure -i bash -p ripgrep sd jq git git-wait lix util-linux

export NIX_PATH= # no nixpkgs-overlay plz
export NIXPKGS_ALLOW_UNFREE=1
export NIXPKGS_ALLOW_INSECURE=1
export NIXPKGS_ALLOW_BROKEN=1

git-wait restore .

test -s packages.json || ( set -x;
  time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --drv-path --out-path --show-trace --no-allow-import-from-derivation --arg config '{ allowAliases = false; }' > packages.json
)

list_attrpath_fname_col() {
    jq <packages.json 'to_entries[] | select(.value.meta.position==null|not) | "\(.key)\t\(.value.meta.position)"' -r |
        sed -e "s#\t$(realpath .)/#\t#" |
        sed -e 's#:\([0-9]*\)$#\t\1#' |
        grep . |
        grep -iv haskell |
        grep -iv /top-level/ |
        grep -iv chicken |
        grep -E 'pkgs/development/python-modules/[a-iA-I]' |
        grep -iv build |
        grep -E '/(package|default)\.nix'
}

while read attrpath fname col; do
    grep -qE 'repo *= *("\$\{pname\}"|pname);' "$fname" || continue

    echo | (

        echo "$attrpath"
        data="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)" || exit
        test -n "$data" || exit
        pname="$(jq <<<"$data" .pname -r)"
        test -n "$pname" || exit

        (set -x
            sd -F '${pname}'  "$pname"         "$fname"
            sd -F ' = pname;' " = \"$pname\";" "$fname"
        )

        data2="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)"
        if [[ "$data" = "$data2" ]]; then
            (set -x; git-wait add "$fname")
        else
            (set -x; git-wait restore "$fname")
            exit
        fi

        (set -x
            sd -F ' rec {' ' {' "$fname"
        )

        data3="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json 2>/dev/null)"

        if [[ "$data" = "$data3" ]]; then
            (set -x; git-wait add "$fname")
        else
            (set -x; git-wait restore "$fname")
        fi

    )

done < <(list_attrpath_fname_col)

git restore .

time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --drv-path --out-path --show-trace --no-allow-import-from-derivation --arg config '{ allowAliases = false; }' > packages2.json
```

`diff packages{,2}.json` is empty, indicating that no package nor src derivation has changed, nor have i introduced any eval failures. I checked and cherry-picked the changes using `GIT_DIFF_OPTS='-u20' git -c interactive.singleKey=true add --patch` along to some music. I then tested merging against master, staging and staging-next



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
