### PR TITLE
treewide: substitute pname for strings (python3Packages.[j-r].*)

### DIFF
--- a/pkgs/development/python-modules/jax-jumpy/default.nix
+++ b/pkgs/development/python-modules/jax-jumpy/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Farama-Foundation";
-    repo = pname;
+    repo = "jumpy";
     rev = version;
     hash = "sha256-tPQ/v2AVnAEC+08BVAvvgJ8Pj89nXZSn2tQ6nxXuSfA=";
   };

--- a/pkgs/development/python-modules/jc/default.nix
+++ b/pkgs/development/python-modules/jc/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "kellyjonbrazil";
-    repo = pname;
+    repo = "jc";
     tag = "v${version}";
     hash = "sha256-tv466jVjLtmn2U8t3sSyQLuzGcVf0RHtE+cFd8j8T5k=";
   };

--- a/pkgs/development/python-modules/jieba/default.nix
+++ b/pkgs/development/python-modules/jieba/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   # no tests in PyPI tarball
   src = fetchFromGitHub {
     owner = "fxsjy";
-    repo = pname;
+    repo = "jieba";
     rev = "v${version}";
     sha256 = "028vmd6sj6wn9l1ilw7qfmlpyiysnlzdgdlhwxs6j4fvq0gyrwxk";
   };

--- a/pkgs/development/python-modules/jishaku/default.nix
+++ b/pkgs/development/python-modules/jishaku/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Gorialis";
-    repo = pname;
+    repo = "jishaku";
     tag = version;
     hash = "sha256-+J8Tr8jPN9K3eHLOuJTaP3We5A1kiyn9/yI1KChbuMY=";
   };

--- a/pkgs/development/python-modules/jmp/default.nix
+++ b/pkgs/development/python-modules/jmp/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "deepmind";
-    repo = pname;
+    repo = "jmp";
     tag = "v${version}";
     hash = "sha256-+PefZU1209vvf1SfF8DXiTvKYEnZ4y8iiIr8yKikx9Y=";
   };

--- a/pkgs/development/python-modules/jpylyzer/default.nix
+++ b/pkgs/development/python-modules/jpylyzer/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "openpreserve";
-    repo = pname;
+    repo = "jpylyzer";
     rev = version;
     hash = "sha256-P42qAks8suI/Xknwd8WAkymbGE7RApRa/a11J/V4LA0=";
   };

--- a/pkgs/development/python-modules/jsonlines/default.nix
+++ b/pkgs/development/python-modules/jsonlines/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "wbolster";
-    repo = pname;
+    repo = "jsonlines";
     rev = version;
     hash = "sha256-KNEJdAxEgd0NGPnk9J51C3yUN2e6Cvvevth0iKOMlhE=";
   };

--- a/pkgs/development/python-modules/jsonrpc-async/default.nix
+++ b/pkgs/development/python-modules/jsonrpc-async/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "emlove";
-    repo = pname;
+    repo = "jsonrpc-async";
     rev = version;
     hash = "sha256-KOnycsOZFDEVj8CJDwGbdtbOpMPQMVdrXbHG0fzr9PI=";
   };

--- a/pkgs/development/python-modules/jsonschema-spec/default.nix
+++ b/pkgs/development/python-modules/jsonschema-spec/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "p1c2u";
-    repo = pname;
+    repo = "jsonschema-spec";
     tag = version;
     hash = "sha256-rCepDnVAOEsokKjWCuqDYbGIq6/wn4rsQRx5dXTUsYo=";
   };

--- a/pkgs/development/python-modules/jsonstreams/default.nix
+++ b/pkgs/development/python-modules/jsonstreams/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dcbaker";
-    repo = pname;
+    repo = "jsonstreams";
     rev = version;
     sha256 = "0qw74wz9ngz9wiv89vmilbifsbvgs457yn1bxnzhrh7g4vs2wcav";
   };

--- a/pkgs/development/python-modules/junitparser/default.nix
+++ b/pkgs/development/python-modules/junitparser/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "weiwei";
-    repo = pname;
+    repo = "junitparser";
     rev = version;
     hash = "sha256-rhDP05GSWT4K6Z2ip8C9+e3WbvBJOwP0vctvANBs7cw=";
   };

--- a/pkgs/development/python-modules/justbackoff/default.nix
+++ b/pkgs/development/python-modules/justbackoff/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "alexferl";
-    repo = pname;
+    repo = "justbackoff";
     rev = "v${version}";
     sha256 = "097j6jxgl4b3z46x9y9z10643vnr9v831vhagrxzrq6nviil2z6l";
   };

--- a/pkgs/development/python-modules/justbases/default.nix
+++ b/pkgs/development/python-modules/justbases/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mulkieran";
-    repo = pname;
+    repo = "justbases";
     tag = "v${version}";
     hash = "sha256-XraUh3beI2JqKPRHYN5W3Tn3gg0GJCwhnhHIOFdzh6U=";
   };

--- a/pkgs/development/python-modules/justbytes/default.nix
+++ b/pkgs/development/python-modules/justbytes/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mulkieran";
-    repo = pname;
+    repo = "justbytes";
     tag = "v${version}";
     hash = "sha256-+jwIK1ZU+j58VoOfZAm7GdFy7KHU28khwzxhYhcws74=";
   };

--- a/pkgs/development/python-modules/kajiki/default.nix
+++ b/pkgs/development/python-modules/kajiki/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jackrosenthal";
-    repo = pname;
+    repo = "kajiki";
     tag = "v${version}";
     hash = "sha256-EbXe4Jh2IKAYw9GE0kFgKVv9c9uAOiFFYaMF8CGaOfg=";
   };

--- a/pkgs/development/python-modules/kaldi-active-grammar/default.nix
+++ b/pkgs/development/python-modules/kaldi-active-grammar/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "daanzu";
-    repo = pname;
+    repo = "kaldi-active-grammar";
     rev = "v${version}";
     sha256 = "0lilk6yjzcy31avy2z36bl9lr60gzwhmyqwqn8akq11qc3mbffsk";
   };

--- a/pkgs/development/python-modules/karton-asciimagic/default.nix
+++ b/pkgs/development/python-modules/karton-asciimagic/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
-    repo = pname;
+    repo = "karton-asciimagic";
     tag = "v${version}";
     hash = "sha256-sY5ik9efzLBa6Fbh17Vh4q7PlwOGYjuodU9yvp/8E3k=";
   };

--- a/pkgs/development/python-modules/karton-config-extractor/default.nix
+++ b/pkgs/development/python-modules/karton-config-extractor/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
-    repo = pname;
+    repo = "karton-config-extractor";
     tag = "v${version}";
     hash = "sha256-a9wSw25q0blgAkR2s3brW7jGHJSLjx1yXjMmhMJNUFk=";
   };

--- a/pkgs/development/python-modules/karton-dashboard/default.nix
+++ b/pkgs/development/python-modules/karton-dashboard/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
-    repo = pname;
+    repo = "karton-dashboard";
     tag = "v${version}";
     hash = "sha256-VzBC7IATF8QBtTXMv4vmorAzBlImEsayjenQ2Uz5jIo=";
   };

--- a/pkgs/development/python-modules/karton-mwdb-reporter/default.nix
+++ b/pkgs/development/python-modules/karton-mwdb-reporter/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
-    repo = pname;
+    repo = "karton-mwdb-reporter";
     tag = "v${version}";
     hash = "sha256-KJh9uJzVGYEEk1ed56ynKA/+dK9ouDB7L06xERjfjdc=";
   };

--- a/pkgs/development/python-modules/karton-yaramatcher/default.nix
+++ b/pkgs/development/python-modules/karton-yaramatcher/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
-    repo = pname;
+    repo = "karton-yaramatcher";
     tag = "v${version}";
     hash = "sha256-URGW8FyJZ3ktrwolls5ElSWn8FD6vWCA+Eu0aGtPh6U=";
   };

--- a/pkgs/development/python-modules/keyboard/default.nix
+++ b/pkgs/development/python-modules/keyboard/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "boppreh";
-    repo = pname;
+    repo = "keyboard";
     rev = "v${version}";
     hash = "sha256-U4GWhPp28azBE3Jn9xpLxudOKx0PjnYO77EM2HsJ9lM=";
   };

--- a/pkgs/development/python-modules/kiss-headers/default.nix
+++ b/pkgs/development/python-modules/kiss-headers/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Ousret";
-    repo = pname;
+    repo = "kiss-headers";
     tag = version;
     hash = "sha256-WeAzlC1yT+0nPSuB278z8T0XvPjbre051f/Rva5ujAk=";
   };

--- a/pkgs/development/python-modules/klaus/default.nix
+++ b/pkgs/development/python-modules/klaus/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jonashaag";
-    repo = pname;
+    repo = "klaus";
     rev = version;
     hash = "sha256-GflSDhBmMsQ34o3ApraEJ6GmlXXP2kK6WW3lsfr6b7g=";
   };

--- a/pkgs/development/python-modules/kml2geojson/default.nix
+++ b/pkgs/development/python-modules/kml2geojson/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mrcagney";
-    repo = pname;
+    repo = "kml2geojson";
     rev = version;
     hash = "sha256-iJEcXpvy+Y3MkxAF2Q1Tkcx8GxUVjeVzv6gl134zdiI=";
   };

--- a/pkgs/development/python-modules/kornia/default.nix
+++ b/pkgs/development/python-modules/kornia/default.nix
@@ -17,8 +17,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "kornia";
+    repo = "kornia";
     tag = "v${version}";
     hash = "sha256-pMCGL33DTnMLlxRbhBhRuR/ZA575+kbUJ59N3nuqpdI=";
   };

--- a/pkgs/development/python-modules/lanms-neo/default.nix
+++ b/pkgs/development/python-modules/lanms-neo/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage {
 
   src = fetchFromGitHub {
     owner = "gen-ko";
-    repo = pname;
+    repo = "lanms-neo";
     rev = "6510e19e731a1e105d42b2fbda64de41c169ce2e";
     hash = "sha256-0fs4RNN1ptiir7GfR9B8HK0VqTkk5PbVJxgKiDId3po=";
   };

--- a/pkgs/development/python-modules/laszip/default.nix
+++ b/pkgs/development/python-modules/laszip/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tmontaigu";
-    repo = pname;
+    repo = "laszip-python";
     rev = version;
     hash = "sha256-MiPzL9TDCf1xnCv7apwdfcpkFnBRi4PO/atTQxqL8cw=";
   };

--- a/pkgs/development/python-modules/libnacl/default.nix
+++ b/pkgs/development/python-modules/libnacl/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "saltstack";
-    repo = pname;
+    repo = "libnacl";
     rev = "v${version}";
     hash = "sha256-phECLGDcBfDi/r2y0eGtqgIX/hvirtBqO8UUvEJ66zo=";
   };

--- a/pkgs/development/python-modules/lightparam/default.nix
+++ b/pkgs/development/python-modules/lightparam/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "portugueslab";
-    repo = pname;
+    repo = "lightparam";
     rev = "v${version}";
     sha256 = "13hlkvjcyz2lhvlfqyavja64jccbidshhs39sl4fibrn9iq34s3i";
   };

--- a/pkgs/development/python-modules/limiter/default.nix
+++ b/pkgs/development/python-modules/limiter/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "alexdelorenzo";
-    repo = pname;
+    repo = "limiter";
     rev = "v${version}";
     hash = "sha256-2Et4ozVf9t+tp2XtLbDk/LgLIU+jQAEAlU8hA5lpxdk=";
   };

--- a/pkgs/development/python-modules/lineedit/default.nix
+++ b/pkgs/development/python-modules/lineedit/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "randy3k";
-    repo = pname;
+    repo = "lineedit";
     rev = "v${version}";
     sha256 = "fq2NpjIQkIq1yzXEUxi6cz80kutVqcH6MqJXHtpTFsk=";
   };

--- a/pkgs/development/python-modules/linkify-it-py/default.nix
+++ b/pkgs/development/python-modules/linkify-it-py/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tsutsu3";
-    repo = pname;
+    repo = "linkify-it-py";
     tag = "v${version}";
     hash = "sha256-BLwIityUZDVdSbvTpLf6QUlZUavWzG/45Nfffn18/vU=";
   };

--- a/pkgs/development/python-modules/liquidctl/default.nix
+++ b/pkgs/development/python-modules/liquidctl/default.nix
@@ -26,8 +26,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "liquidctl";
+    repo = "liquidctl";
     tag = "v${version}";
     hash = "sha256-ifYPUAF0lR9aCwiseNQZXbq+d+CXD/MwnZQhAM1TRLI=";
   };

--- a/pkgs/development/python-modules/livelossplot/default.nix
+++ b/pkgs/development/python-modules/livelossplot/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "stared";
-    repo = pname;
+    repo = "livelossplot";
     tag = "v${version}";
     hash = "sha256-qC1FBFJyf2IlDIffJ5Xs89WcN/GFA/8maODhc1u2xhA=";
   };

--- a/pkgs/development/python-modules/lm-format-enforcer/default.nix
+++ b/pkgs/development/python-modules/lm-format-enforcer/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "noamgat";
-    repo = pname;
+    repo = "lm-format-enforcer";
     tag = "v${version}";
     hash = "sha256-8BsfA1R/X+wA0H0MqQKn+CljUIT8VdoInoczSGvu74o=";
   };

--- a/pkgs/development/python-modules/loca/default.nix
+++ b/pkgs/development/python-modules/loca/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromSourcehut {
     owner = "~cnx";
-    repo = pname;
+    repo = "loca";
     rev = version;
     sha256 = "1l6jimw3wd81nz1jrzsfw1zzsdm0jm998xlddcqaq0h38sx69w8g";
   };

--- a/pkgs/development/python-modules/logging-journald/default.nix
+++ b/pkgs/development/python-modules/logging-journald/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mosquito";
-    repo = pname;
+    repo = "logging-journald";
     tag = version;
     hash = "sha256-RQ9opkAOZfhYuqOXJ2Mtnig8soL+lCveYH2YdXL1AGM=";
   };

--- a/pkgs/development/python-modules/logster/default.nix
+++ b/pkgs/development/python-modules/logster/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "etsy";
-    repo = pname;
+    repo = "logster";
     rev = version;
     sha256 = "06ac5hydas24h2cn8l5i69v1z0min5hwh6a1lcm1b08xnvpsi85q";
   };

--- a/pkgs/development/python-modules/loguru/default.nix
+++ b/pkgs/development/python-modules/loguru/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Delgan";
-    repo = pname;
+    repo = "loguru";
     tag = version;
     hash = "sha256-tccEzzs9TtFAZM9s43cskF9llc81Ng28LqedjLiE1m4=";
   };

--- a/pkgs/development/python-modules/luddite/default.nix
+++ b/pkgs/development/python-modules/luddite/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jumptrading";
-    repo = pname;
+    repo = "luddite";
     tag = "v${version}";
     hash = "sha256-iJ3h1XRBzLd4cBKFPNOlIV5Z5XJ/miscfIdkpPIpbJ8=";
   };

--- a/pkgs/development/python-modules/luhn/default.nix
+++ b/pkgs/development/python-modules/luhn/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mmcloughlin";
-    repo = pname;
+    repo = "luhn";
     rev = version;
     hash = "sha256-ZifaCjOVhWdXuzi5n6V+6eVN5vrEHKgUdpSOXoMyR18=";
   };

--- a/pkgs/development/python-modules/lyricwikia/default.nix
+++ b/pkgs/development/python-modules/lyricwikia/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "enricobacis";
-    repo = pname;
+    repo = "lyricwikia";
     tag = version;
     hash = "sha256-P88DrRAa2zptt8JLy0/PLi0oZ/BghF/XGSP0kOObi7E=";
   };

--- a/pkgs/development/python-modules/lzallright/default.nix
+++ b/pkgs/development/python-modules/lzallright/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "vlaci";
-    repo = pname;
+    repo = "lzallright";
     rev = "v${version}";
     hash = "sha256-E4Eaah58JCbxXfmpqFS2Emi1/eo2L3qyJP+vWH3PHPg=";
   };

--- a/pkgs/development/python-modules/macholib/default.nix
+++ b/pkgs/development/python-modules/macholib/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ronaldoussoren";
-    repo = pname;
+    repo = "macholib";
     rev = "v${version}";
     hash = "sha256-bTql10Ceny4fBCxnEWz1m1wi03EWMDW9u99IQiWYbnY=";
   };

--- a/pkgs/development/python-modules/macropy/default.nix
+++ b/pkgs/development/python-modules/macropy/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "lihaoyi";
-    repo = pname;
+    repo = "macropy";
     rev = "v${version}";
     sha256 = "1bd2fzpa30ddva3f8lw2sbixxf069idwib8srd64s5v46ricm2cf";
   };

--- a/pkgs/development/python-modules/markdown-include/default.nix
+++ b/pkgs/development/python-modules/markdown-include/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   # only wheel on pypi
   src = fetchFromGitHub {
     owner = "cmacmackin";
-    repo = pname;
+    repo = "markdown-include";
     tag = "v${version}";
     hash = "sha256-1MEk0U00a5cpVhqnDZkwBIk4NYgsRXTVsI/ANNQ/OH0=";
   };

--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "executablebooks";
-    repo = pname;
+    repo = "markdown-it-py";
     tag = "v${version}";
     hash = "sha256-cmjLElJA61EysTUFMVY++Kw0pI4wOIXOyCY3To9fpQc=";
   };

--- a/pkgs/development/python-modules/matchpy/default.nix
+++ b/pkgs/development/python-modules/matchpy/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "HPAC";
-    repo = pname;
+    repo = "matchpy";
     rev = version;
     hash = "sha256-n5rXIjqVQZzEbfIZVQiGLh2PR1DHAJ9gumcrbvwnasA=";
   };

--- a/pkgs/development/python-modules/mbstrdecoder/default.nix
+++ b/pkgs/development/python-modules/mbstrdecoder/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "thombashi";
-    repo = pname;
+    repo = "mbstrdecoder";
     tag = "v${version}";
     hash = "sha256-rJ3Q7/xYPO0jBuzhYm2aIhPar2tbJIxHnHR0y0HWtik=";
   };

--- a/pkgs/development/python-modules/mcstatus/default.nix
+++ b/pkgs/development/python-modules/mcstatus/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "py-mine";
-    repo = pname;
+    repo = "mcstatus";
     tag = "v${version}";
     hash = "sha256-P8Su5P/ztyoXZBVvm5uCMDn4ezeg11oRSQ0QCyIJbVw=";
   };

--- a/pkgs/development/python-modules/mdformat-beautysh/default.nix
+++ b/pkgs/development/python-modules/mdformat-beautysh/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hukkin";
-    repo = pname;
+    repo = "mdformat-beautysh";
     tag = version;
     hash = "sha256-mH9PN6QsPmnIzh/0vxa+5mYLzANUHRruXC0ql4h8myw=";
   };

--- a/pkgs/development/python-modules/mdformat-footnote/default.nix
+++ b/pkgs/development/python-modules/mdformat-footnote/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "executablebooks";
-    repo = pname;
+    repo = "mdformat-footnote";
     tag = "v${version}";
     hash = "sha256-DUCBWcmB5i6/HkqxjlU3aTRO7i0n2sj+e/doKB8ffeo=";
   };

--- a/pkgs/development/python-modules/mdformat-simple-breaks/default.nix
+++ b/pkgs/development/python-modules/mdformat-simple-breaks/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "csala";
-    repo = pname;
+    repo = "mdformat-simple-breaks";
     tag = "v${version}";
     hash = "sha256-4lJHB4r9lI2uGJ/BmFFc92sumTRKBBwiRmGBdQkzfd0=";
   };

--- a/pkgs/development/python-modules/mdformat-tables/default.nix
+++ b/pkgs/development/python-modules/mdformat-tables/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "executablebooks";
-    repo = pname;
+    repo = "mdformat-tables";
     tag = "v${version}";
     hash = "sha256-7MbpGBGprhGrQ9P31HUU2h0bjyHWap6DETVN/dCDA1w=";
   };

--- a/pkgs/development/python-modules/mdformat-toc/default.nix
+++ b/pkgs/development/python-modules/mdformat-toc/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hukkin";
-    repo = pname;
+    repo = "mdformat-toc";
     tag = version;
     hash = "sha256-3EX6kGez408tEYiR9VSvi3GTrb4ds+HJwpFflv77nkg=";
   };

--- a/pkgs/development/python-modules/mdit-py-plugins/default.nix
+++ b/pkgs/development/python-modules/mdit-py-plugins/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "executablebooks";
-    repo = pname;
+    repo = "mdit-py-plugins";
     tag = "v${version}";
     hash = "sha256-aY2DMLh1OkWVcN6A29FLba1ETerf/EOqSjHVpsdE21M=";
   };

--- a/pkgs/development/python-modules/mdurl/default.nix
+++ b/pkgs/development/python-modules/mdurl/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hukkin";
-    repo = pname;
+    repo = "mdurl";
     rev = version;
     hash = "sha256-wxV8DKeTwKpFTUBuGTQXaVHc0eW1//Y+2V8Kgs85TDM=";
   };

--- a/pkgs/development/python-modules/mdutils/default.nix
+++ b/pkgs/development/python-modules/mdutils/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "didix21";
-    repo = pname;
+    repo = "mdutils";
     tag = "v${version}";
     hash = "sha256-xF6z63CjL/qSBQsm/fSTQhwpg9yJU4qrY06cjn1PbCk=";
   };

--- a/pkgs/development/python-modules/meep/default.nix
+++ b/pkgs/development/python-modules/meep/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "NanoComp";
-    repo = pname;
+    repo = "meep";
     tag = "v${version}";
     hash = "sha256-9cQHvwUAeop5dRMVvedph+KQvTcmnkHdfqPQlSY280c=";
   };

--- a/pkgs/development/python-modules/mercantile/default.nix
+++ b/pkgs/development/python-modules/mercantile/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mapbox";
-    repo = pname;
+    repo = "mercantile";
     rev = version;
     hash = "sha256-DiDXO2XnD3We6NhP81z7aIHzHrHDi/nkqy98OT9986w=";
   };

--- a/pkgs/development/python-modules/meteocalc/default.nix
+++ b/pkgs/development/python-modules/meteocalc/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "malexer";
-    repo = pname;
+    repo = "meteocalc";
     rev = version;
     hash = "sha256-WuIW6hROQkjMfbCLUouECIrp4s6oCd2/N79hsrTbVTk=";
   };

--- a/pkgs/development/python-modules/mhcgnomes/default.nix
+++ b/pkgs/development/python-modules/mhcgnomes/default.nix
@@ -7,14 +7,14 @@
   serializable,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "mhcgnomes";
   version = "1.8.6";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "pirl-unc";
-    repo = pname;
+    repo = "mhcgnomes";
     # See https://github.com/pirl-unc/mhcgnomes/issues/20. As of 2023-07-13,
     # they do no have version tags.
     rev = "c7e779b60e35a031f6e0f0ea6ae70e8a8e7671c6";

--- a/pkgs/development/python-modules/midea-beautiful-air/default.nix
+++ b/pkgs/development/python-modules/midea-beautiful-air/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nbogojevic";
-    repo = pname;
+    repo = "midea-beautiful-air";
     tag = "v${version}";
     hash = "sha256-786Q085bv8Zsm0c55I4XalRhEfwElRTJds5qnb0cWhk=";
   };

--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "midea-lan";
-    repo = pname;
+    repo = "midea-local";
     tag = "v${version}";
     hash = "sha256-zXOxgPFX6TRdFnQ0OqqEu1sy9MmlfxEg7KedQWxYv48=";
   };

--- a/pkgs/development/python-modules/minimock/default.nix
+++ b/pkgs/development/python-modules/minimock/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "lowks";
-    repo = pname;
+    repo = "minimock";
     rev = "v${version}";
     hash = "sha256-Ut3iKc7Sr28uGgWCV3K3CS+gBta2icvbUPMjjo4fflU=";
   };

--- a/pkgs/development/python-modules/mkdocs-redirects/default.nix
+++ b/pkgs/development/python-modules/mkdocs-redirects/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mkdocs";
-    repo = pname;
+    repo = "mkdocs-redirects";
     tag = "v${version}";
     hash = "sha256-YsMA00yajeGSqSB6CdKxGqyClC9Cgc3ImRBTucHEHhs=";
   };

--- a/pkgs/development/python-modules/mkdocs/default.nix
+++ b/pkgs/development/python-modules/mkdocs/default.nix
@@ -42,8 +42,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "mkdocs";
+    repo = "mkdocs";
     tag = version;
     hash = "sha256-JQSOgV12iYE6FubxdoJpWy9EHKFxyKoxrm/7arCn9Ak=";
   };

--- a/pkgs/development/python-modules/mock-open/default.nix
+++ b/pkgs/development/python-modules/mock-open/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   # no tests in PyPI tarball
   src = fetchFromGitHub {
     owner = "nivbend";
-    repo = pname;
+    repo = "mock-open";
     rev = "v${version}";
     sha256 = "0qlz4y8jqxsnmqg03yp9f87rmnjrvmxm5qvm6n1218gm9k5dixbm";
   };

--- a/pkgs/development/python-modules/mongoengine/default.nix
+++ b/pkgs/development/python-modules/mongoengine/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "MongoEngine";
-    repo = pname;
+    repo = "mongoengine";
     tag = "v${version}";
     hash = "sha256-trWCKmCa+q+qtzF0HKCZMnko1cvvpwJvczLFuKtB83E=";
   };

--- a/pkgs/development/python-modules/moonraker-api/default.nix
+++ b/pkgs/development/python-modules/moonraker-api/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cmroche";
-    repo = pname;
+    repo = "moonraker-api";
     tag = "v${version}";
     hash = "sha256-AwSHF9BbxKBXIQdG4OX1vYYP/ST4jSz3uMMDUx0MSEg=";
   };

--- a/pkgs/development/python-modules/motioneye-client/default.nix
+++ b/pkgs/development/python-modules/motioneye-client/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dermotduffy";
-    repo = pname;
+    repo = "motioneye-client";
     rev = "v${version}";
     hash = "sha256-kgFSd5RjO+OtnPeAOimPTDVEfJ47rXh2Ku5xEYStHv8=";
   };

--- a/pkgs/development/python-modules/mpl-scatter-density/default.nix
+++ b/pkgs/development/python-modules/mpl-scatter-density/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "astrofrog";
-    repo = pname;
+    repo = "mpl-scatter-density";
     tag = "v${version}";
     hash = "sha256-pDiKJAN/4WFf5icNU/ZGOvw0jqN3eGZHgilm2oolpbE=";
   };

--- a/pkgs/development/python-modules/mpldatacursor/default.nix
+++ b/pkgs/development/python-modules/mpldatacursor/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "joferkington";
-    repo = pname;
+    repo = "mpldatacursor";
     rev = "v${version}";
     sha256 = "0i1lwl6x6hgjq4xwsc138i4v5895lmnpfqwpzpnj5mlck6fy6rda";
   };

--- a/pkgs/development/python-modules/multimethod/default.nix
+++ b/pkgs/development/python-modules/multimethod/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "coady";
-    repo = pname;
+    repo = "multimethod";
     tag = "v${version}";
     hash = "sha256-/91re2K+nVKULJOjDoimpOukQlLlsMS9blkVQWit2eI=";
   };

--- a/pkgs/development/python-modules/multiprocess/default.nix
+++ b/pkgs/development/python-modules/multiprocess/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "uqfoundation";
-    repo = pname;
+    repo = "multiprocess";
     tag = version;
     hash = "sha256-TKD0iQv5Go4PrKWtVOF6FJG1tkvs3APxPlhDVEs7YXE=";
   };

--- a/pkgs/development/python-modules/mutf8/default.nix
+++ b/pkgs/development/python-modules/mutf8/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "TkTech";
-    repo = pname;
+    repo = "mutf8";
     rev = "v${version}";
     hash = "sha256-4Ojn3t0EbOVdrYEiY8JegJuvW9sz8jt9tKFwOluiGQo=";
   };

--- a/pkgs/development/python-modules/mwdblib/default.nix
+++ b/pkgs/development/python-modules/mwdblib/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
-    repo = pname;
+    repo = "mwdblib";
     tag = "v${version}";
     hash = "sha256-+hh7SJFITpLumIuzNgBbXtFh+26tUG66UFv6DLDk5ag=";
   };

--- a/pkgs/development/python-modules/myhome/default.nix
+++ b/pkgs/development/python-modules/myhome/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "speijnik";
-    repo = pname;
+    repo = "myhome";
     rev = "v${version}";
     hash = "sha256-DJzwvgvSA9Q0kpueUoQV64pdDDNA7WzGu7r+g5aqutk=";
   };

--- a/pkgs/development/python-modules/myst-parser/default.nix
+++ b/pkgs/development/python-modules/myst-parser/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "executablebooks";
-    repo = pname;
+    repo = "myst-parser";
     tag = "v${version}";
     hash = "sha256-/Prauz4zuJY39EK2BmgBbH1uwjF4K38e5X5hPYwRBl0=";
   };

--- a/pkgs/development/python-modules/name-that-hash/default.nix
+++ b/pkgs/development/python-modules/name-that-hash/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "HashPals";
-    repo = pname;
+    repo = "name-that-hash";
     rev = version;
     hash = "sha256-zOb4BS3zG1x8GLXAooqqvMOw0fNbw35JuRWOdGP26/8=";
   };

--- a/pkgs/development/python-modules/names/default.nix
+++ b/pkgs/development/python-modules/names/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "treyhunner";
-    repo = pname;
+    repo = "names";
     rev = version;
     sha256 = "0jfn11bl05k3qkqw0f4vi2i2lhllxdrbb1732qiisdy9fbvv8611";
   };

--- a/pkgs/development/python-modules/napari-plugin-engine/default.nix
+++ b/pkgs/development/python-modules/napari-plugin-engine/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "napari";
-    repo = pname;
+    repo = "napari-plugin-engine";
     tag = "v${version}";
     hash = "sha256-cKpCAEYYRq3UPje7REjzhEe1J9mmrtXs8TBnxWukcNE=";
   };

--- a/pkgs/development/python-modules/nbclient/default.nix
+++ b/pkgs/development/python-modules/nbclient/default.nix
@@ -27,7 +27,7 @@ let
 
     src = fetchFromGitHub {
       owner = "jupyter";
-      repo = pname;
+      repo = "nbclient";
       tag = "v${version}";
       hash = "sha256-+qSed6yy4YVZ25GigNTap+kMaoDiMYSJO85wurbzeDs=";
     };

--- a/pkgs/development/python-modules/ndspy/default.nix
+++ b/pkgs/development/python-modules/ndspy/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "RoadrunnerWMC";
-    repo = pname;
+    repo = "ndspy";
     tag = "v${version}";
     hash = "sha256-PQONVEuh5Fg2LHr4gq0XTGcOpps/s9FSgoyDn4BCcik=";
   };

--- a/pkgs/development/python-modules/nh3/default.nix
+++ b/pkgs/development/python-modules/nh3/default.nix
@@ -12,7 +12,7 @@ let
   version = "0.2.21";
   src = fetchFromGitHub {
     owner = "messense";
-    repo = pname;
+    repo = "nh3";
     rev = "v${version}";
     hash = "sha256-DskjcKjdz1HmKzmA568zRCjh4UK1/LBD5cSIu7Rfwok=";
   };

--- a/pkgs/development/python-modules/nmapthon2/default.nix
+++ b/pkgs/development/python-modules/nmapthon2/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cblopez";
-    repo = pname;
+    repo = "nmapthon2";
     rev = "v${version}";
     hash = "sha256-4Na75TdKDywUomJF4tDWUWwCCtcOSxBUMOF7+FDhbpY=";
   };

--- a/pkgs/development/python-modules/notify-py/default.nix
+++ b/pkgs/development/python-modules/notify-py/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ms7m";
-    repo = pname;
+    repo = "notify-py";
     tag = "v${version}";
     hash = "sha256-4PJ/0dLG3bWDuF1G/qUmvNaIUFXgPP2S/0uhZz86WRA=";
   };

--- a/pkgs/development/python-modules/nptyping/default.nix
+++ b/pkgs/development/python-modules/nptyping/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ramonhagenaars";
-    repo = pname;
+    repo = "nptyping";
     tag = "v${version}";
     hash = "sha256-hz4YrcvARCAA7TXapmneIwle/F4pzcIYLPSmiFHC0VQ=";
   };

--- a/pkgs/development/python-modules/nsz/default.nix
+++ b/pkgs/development/python-modules/nsz/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nicoboss";
-    repo = pname;
+    repo = "nsz";
     tag = version;
     hash = "sha256-ch4HzQFa95o3HMsi7R0LpPWmhN/Z9EYfrmCdUZLwPSE=";
   };

--- a/pkgs/development/python-modules/numdifftools/default.nix
+++ b/pkgs/development/python-modules/numdifftools/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pbrod";
-    repo = pname;
+    repo = "numdifftools";
     rev = "v${version}";
     hash = "sha256-HYacLaowSDdrwkxL1h3h+lw/8ahzaecpXEnwrCqMCWk=";
   };

--- a/pkgs/development/python-modules/nxt-python/default.nix
+++ b/pkgs/development/python-modules/nxt-python/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "schodet";
-    repo = pname;
+    repo = "nxt-python";
     tag = version;
     hash = "sha256-ffJ7VhXT5I7i5JYfnjFBaud0CxoVBFWx6kRdAz+Ry00=";
   };

--- a/pkgs/development/python-modules/oasatelematics/default.nix
+++ b/pkgs/development/python-modules/oasatelematics/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "panosmz";
-    repo = pname;
+    repo = "oasatelematics";
     rev = "v${version}";
     hash = "sha256-3O7XbNVj1S3ZwheklEhm0ivw16Tj7drML/xYC9383Kg=";
   };

--- a/pkgs/development/python-modules/ofxtools/default.nix
+++ b/pkgs/development/python-modules/ofxtools/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   # PyPI distribution does not include tests
   src = fetchFromGitHub {
     owner = "csingley";
-    repo = pname;
+    repo = "ofxtools";
     rev = version;
     hash = "sha256-NsImnD+erhpakQnl1neuHfSKiV6ipNBMPGKMDM0gwWc=";
   };

--- a/pkgs/development/python-modules/oletools/default.nix
+++ b/pkgs/development/python-modules/oletools/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "decalage2";
-    repo = pname;
+    repo = "oletools";
     rev = "v${version}";
     hash = "sha256-ons1VeWStxUZw2CPpnX9p5I3Q7cMhi34JU8TeuUDt+Y=";
   };

--- a/pkgs/development/python-modules/opcua-widgets/default.nix
+++ b/pkgs/development/python-modules/opcua-widgets/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "FreeOpcUa";
-    repo = pname;
+    repo = "opcua-widgets";
     rev = version;
     hash = "sha256-ABJlKYN5H/1k8ynvSTSoJBX12vTTyavuNUAmTJ84mn0=";
   };

--- a/pkgs/development/python-modules/openapi-schema-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-schema-validator/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "p1c2u";
-    repo = pname;
+    repo = "openapi-schema-validator";
     tag = version;
     hash = "sha256-1Y049W4TbqvKZRwnvPVwyLq6CH6NQDrEfJknuMn8dGo=";
   };

--- a/pkgs/development/python-modules/opensimplex/default.nix
+++ b/pkgs/development/python-modules/opensimplex/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "lmas";
-    repo = pname;
+    repo = "opensimplex";
     rev = "v${version}";
     sha256 = "C/MTKTHjxMsOgzuXvokw039Kv6N/PgBoOqKleWPLpw0=";
   };

--- a/pkgs/development/python-modules/opuslib/default.nix
+++ b/pkgs/development/python-modules/opuslib/default.nix
@@ -11,7 +11,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "opuslib";
   version = "3.0.3";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "orion-labs";
-    repo = pname;
+    repo = "opuslib";
     rev = "92109c528f9f6c550df5e5325ca0fcd4f86b0909";
     hash = "sha256-NxmC/4TTIEDVzrfMPN4PcT1JY4QCw8IBMy80XiM/o00=";
   };

--- a/pkgs/development/python-modules/ormar/default.nix
+++ b/pkgs/development/python-modules/ormar/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "collerek";
-    repo = pname;
+    repo = "ormar";
     tag = version;
     hash = "sha256-jg1qgOJiRBJCRThhq/jaXNmSoL0FmceIOWMKNxtyGJI=";
   };

--- a/pkgs/development/python-modules/oscrypto/default.nix
+++ b/pkgs/development/python-modules/oscrypto/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "wbond";
-    repo = pname;
+    repo = "oscrypto";
     rev = version;
     hash = "sha256-CmDypmlc/kb6ONCUggjT1Iqd29xNSLRaGh5Hz36dvOw=";
   };

--- a/pkgs/development/python-modules/ospd/default.nix
+++ b/pkgs/development/python-modules/ospd/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "greenbone";
-    repo = pname;
+    repo = "ospd";
     tag = "v${version}";
     hash = "sha256-dZgs+G2vJQIKnN9xHcNeNViG7mOIdKb+Ms2AKE+FC4M=";
   };

--- a/pkgs/development/python-modules/ossfs/default.nix
+++ b/pkgs/development/python-modules/ossfs/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "fsspec";
-    repo = pname;
+    repo = "ossfs";
     tag = version;
     hash = "sha256-2i7zxLCi4wNCwzWNUbC6lvvdRkK+ksUWds+H6QG6bW4=";
   };

--- a/pkgs/development/python-modules/ovmfvartool/default.nix
+++ b/pkgs/development/python-modules/ovmfvartool/default.nix
@@ -5,14 +5,14 @@
   pyyaml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "ovmfvartool";
   version = "unstable-2022-09-04";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "hlandau";
-    repo = pname;
+    repo = "ovmfvartool";
     rev = "45e6b1e53967ee6590faae454c076febce096931";
     hash = "sha256-XbvcE/MXNj5S5N7A7jxdwgEE5yMuB82Xg+PYBsFRIm0=";
   };

--- a/pkgs/development/python-modules/palace/default.nix
+++ b/pkgs/development/python-modules/palace/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromSourcehut {
     owner = "~cnx";
-    repo = pname;
+    repo = "palace";
     rev = version;
     sha256 = "1z0m35y4v1bg6vz680pwdicm9ssryl0q6dm9hfpb8hnifmridpcj";
   };

--- a/pkgs/development/python-modules/param/default.nix
+++ b/pkgs/development/python-modules/param/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "holoviz";
-    repo = pname;
+    repo = "param";
     tag = "v${version}";
     hash = "sha256-3aqABliOk+JtR84J/qiwda4yAkVgG2lJWewhQuSUgtA=";
   };

--- a/pkgs/development/python-modules/pathable/default.nix
+++ b/pkgs/development/python-modules/pathable/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "p1c2u";
-    repo = pname;
+    repo = "pathable";
     tag = version;
     hash = "sha256-nN5jpI0Zi5ofdSuN9QbTHDXPmQRq9KAn8SoHuNDpZaw=";
   };

--- a/pkgs/development/python-modules/pathos/default.nix
+++ b/pkgs/development/python-modules/pathos/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "uqfoundation";
-    repo = pname;
+    repo = "pathos";
     tag = version;
     hash = "sha256-oVqWrX40umazNw/ET/s3pKUwvh8ctgF9sS0U8WwFQkA=";
   };

--- a/pkgs/development/python-modules/patiencediff/default.nix
+++ b/pkgs/development/python-modules/patiencediff/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "breezy-team";
-    repo = pname;
+    repo = "patiencediff";
     tag = "v${version}";
     hash = "sha256-SFu1oN1yE9tKeBgWhgWjDpR31AptGrls0D5kKQed+HI=";
   };

--- a/pkgs/development/python-modules/patool/default.nix
+++ b/pkgs/development/python-modules/patool/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   #pypi doesn't have test data
   src = fetchFromGitHub {
     owner = "wummel";
-    repo = pname;
+    repo = "patool";
     tag = version;
     hash = "sha256-mt/GUIRJHB2/Rritc+uNkolZzguYy2G/NKnSKNxKsLk=";
   };

--- a/pkgs/development/python-modules/pcapy-ng/default.nix
+++ b/pkgs/development/python-modules/pcapy-ng/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "stamparm";
-    repo = pname;
+    repo = "pcapy-ng";
     rev = version;
     hash = "sha256-6LA2n7Kv0MiZcqUJpi0lDN4Q+GcOttYw7hJwVqK/DU0=";
   };

--- a/pkgs/development/python-modules/pcodedmp/default.nix
+++ b/pkgs/development/python-modules/pcodedmp/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bontchev";
-    repo = pname;
+    repo = "pcodedmp";
     rev = version;
     hash = "sha256-SYOFGMvrzxDPMACaCvqwU28Mh9LEuvFBGvAph4X+geo=";
   };

--- a/pkgs/development/python-modules/pem/default.nix
+++ b/pkgs/development/python-modules/pem/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hynek";
-    repo = pname;
+    repo = "pem";
     tag = version;
     hash = "sha256-rVYlnvISGugh9qvf3mdrIyELmeOUU4g6291HeoMkoQc=";
   };

--- a/pkgs/development/python-modules/perfplot/default.nix
+++ b/pkgs/development/python-modules/perfplot/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nschloe";
-    repo = pname;
+    repo = "perfplot";
     tag = "v${version}";
     hash = "sha256-bu6eYQukhLE8sLkS3PbqTgXOqJFXJYXTcXAhmjaq48g=";
   };

--- a/pkgs/development/python-modules/pescea/default.nix
+++ b/pkgs/development/python-modules/pescea/default.nix
@@ -9,7 +9,7 @@
   pythonOlder,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pescea";
   version = "1.0.12";
   format = "setuptools";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "lazdavila";
-    repo = pname;
+    repo = "pescea";
     # https://github.com/lazdavila/pescea/issues/4
     rev = "a3dd7deedc64205e24adbc4ff406a2f6aed3b240";
     hash = "sha256-5TkFrGaSkQOORhf5a7SjkzggFLPyqe9k3M0B4ljhWTQ=";

--- a/pkgs/development/python-modules/piccata/default.nix
+++ b/pkgs/development/python-modules/piccata/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "NordicSemiconductor";
-    repo = pname;
+    repo = "piccata";
     tag = version;
     hash = "sha256-Vuhwt+esTkvyEIRVYaRGvNMTAXVWBBv/6lpaxN5RrBA=";
   };

--- a/pkgs/development/python-modules/picobox/default.nix
+++ b/pkgs/development/python-modules/picobox/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ikalnytskyi";
-    repo = pname;
+    repo = "picobox";
     tag = version;
     hash = "sha256-JtrwUVo3b4G34OUShX4eJS2IVubl4vBmEtB/Jhk4eJI=";
   };

--- a/pkgs/development/python-modules/picosvg/default.nix
+++ b/pkgs/development/python-modules/picosvg/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "googlefonts";
-    repo = pname;
+    repo = "picosvg";
     tag = "v${version}";
     hash = "sha256-ocdHF0kYnfllpvul32itu1QtlDrqVeq5sT8Ecb5V1yk=";
   };

--- a/pkgs/development/python-modules/pilkit/default.nix
+++ b/pkgs/development/python-modules/pilkit/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "matthewwithanm";
-    repo = pname;
+    repo = "pilkit";
     tag = version;
     hash = "sha256-NmD9PFCkz3lz4AnGoQUpkt35q0zvDVm+kx7lVDFBcHk=";
   };

--- a/pkgs/development/python-modules/pims/default.nix
+++ b/pkgs/development/python-modules/pims/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "soft-matter";
-    repo = pname;
+    repo = "pims";
     tag = "v${version}";
     hash = "sha256-3SBZk11w6eTZFmETMRJaYncxY38CYne1KzoF5oRgzuY=";
   };

--- a/pkgs/development/python-modules/pinboard/default.nix
+++ b/pkgs/development/python-modules/pinboard/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "lionheart";
-    repo = pname;
+    repo = "pinboard";
     rev = version;
     sha256 = "0ppc3vwv48ahqx6n5c7d7066zhi31cjdik0ma9chq6fscq2idgdf";
   };

--- a/pkgs/development/python-modules/pip-requirements-parser/default.nix
+++ b/pkgs/development/python-modules/pip-requirements-parser/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nexB";
-    repo = pname;
+    repo = "pip-requirements-parser";
     tag = "v${version}";
     hash = "sha256-UMrwDXxk+sD3P2jk7s95y4OX6DRBjWWZZ8IhkR6tnZ4=";
   };

--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -36,7 +36,7 @@ let
 
     src = fetchFromGitHub {
       owner = "pypa";
-      repo = pname;
+      repo = "pip";
       tag = version;
       hash = "sha256-V069rAL6U5KBnSc09LRCu0M7qQCH5NbMghVttlmIoRY=";
     };

--- a/pkgs/development/python-modules/pipetools/default.nix
+++ b/pkgs/development/python-modules/pipetools/default.nix
@@ -6,14 +6,14 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pipetools";
   version = "1.1.0";
 
   # Used github as the src since the pypi package does not include the tests
   src = fetchFromGitHub {
     owner = "0101";
-    repo = pname;
+    repo = "pipetools";
     rev = "6cba9fadab07a16fd85eed16d5cffc609f84c62b";
     hash = "sha256-BoZFePQCQfz1dkct5p/WQLuXoNX3eLcnKf3Mf0fG6u8=";
   };

--- a/pkgs/development/python-modules/pkce/default.nix
+++ b/pkgs/development/python-modules/pkce/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "RomeoDespres";
-    repo = pname;
+    repo = "pkce";
     rev = version;
     hash = "sha256-dOHCu0pDXk9LM4Yobaz8GAfVpBd8rXlty+Wfhx+WPME=";
   };

--- a/pkgs/development/python-modules/plac/default.nix
+++ b/pkgs/development/python-modules/plac/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ialbert";
-    repo = pname;
+    repo = "plac";
     tag = "v${version}";
     hash = "sha256-EWwDtS2cRLBe4aZuH72hgg2BQnVJQ39GmPx05NxTNjE=";
   };

--- a/pkgs/development/python-modules/plantuml-markdown/default.nix
+++ b/pkgs/development/python-modules/plantuml-markdown/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mikitex70";
-    repo = pname;
+    repo = "plantuml-markdown";
     tag = version;
     hash = "sha256-DgHWqwPsZ5q1XqrfaAiUslKnJdHX4Pzw9lygF3iaxz4=";
   };

--- a/pkgs/development/python-modules/pleroma-bot/default.nix
+++ b/pkgs/development/python-modules/pleroma-bot/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "robertoszek";
-    repo = pname;
+    repo = "pleroma-bot";
     rev = version;
     hash = "sha256-vJxblpf3NMSyYMHeWG7vHP5AeluTtMtVxOsHgvGDHeA=";
   };

--- a/pkgs/development/python-modules/plotext/default.nix
+++ b/pkgs/development/python-modules/plotext/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "piccolomo";
-    repo = pname;
+    repo = "plotext";
     tag = version;
     hash = "sha256-4cuStXnZFTlOoBp9w+LrTZavCWEaQdZMY4apGNKvBXE=";
   };

--- a/pkgs/development/python-modules/plyer/default.nix
+++ b/pkgs/development/python-modules/plyer/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "kivy";
-    repo = pname;
+    repo = "plyer";
     tag = version;
     sha256 = "sha256-7Icb2MVj5Uit86lRHxal6b7y9gIJ3UT2HNqpA9DYWVE=";
   };

--- a/pkgs/development/python-modules/pmdsky-debug-py/default.nix
+++ b/pkgs/development/python-modules/pmdsky-debug-py/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
-    repo = pname;
+    repo = "pmdsky-debug-py";
     rev = version;
     sha256 = "sha256-JTvLyYUwOEp1O0rtO313VIT6AYOqXWVFUleTrb6BN6Q=";
   };

--- a/pkgs/development/python-modules/poetry-dynamic-versioning/default.nix
+++ b/pkgs/development/python-modules/poetry-dynamic-versioning/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mtkennerly";
-    repo = pname;
+    repo = "poetry-dynamic-versioning";
     tag = "v${version}";
     hash = "sha256-V5UuODRwm829c1KPdQm9oqeN6YdcCo1ODDsEHbm4e/Y=";
   };

--- a/pkgs/development/python-modules/polarizationsolver/default.nix
+++ b/pkgs/development/python-modules/polarizationsolver/default.nix
@@ -8,14 +8,14 @@
   fields,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "polarizationsolver";
   version = "unstable-2021-11-02";
   format = "setuptools";
 
   src = fetchFromGitLab {
     owner = "reinholdt";
-    repo = pname;
+    repo = "polarizationsolver";
     rev = "00424ac4d1862257a55e4b16543f63ace3fe8c22";
     hash = "sha256-LACf8Xw+o/uJ3+PD/DE/o7nwKY7fv3NyYbpjCrTTnBU=";
   };

--- a/pkgs/development/python-modules/polyline/default.nix
+++ b/pkgs/development/python-modules/polyline/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "frederickjansen";
-    repo = pname;
+    repo = "polyline";
     tag = "v${version}";
     hash = "sha256-fbGGfZdme4OiIGNlXG1uVl1xP+rPVI9l5hjHM0gwAsE=";
   };

--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    repo = pname;
+    repo = "pomegranate";
     owner = "jmschrei";
     tag = "v${version}";
     hash = "sha256-p2Gn0FXnsAHvRUeAqx4M1KH0+XvDl3fmUZZ7MiMvPSs=";

--- a/pkgs/development/python-modules/powerline/default.nix
+++ b/pkgs/development/python-modules/powerline/default.nix
@@ -19,8 +19,8 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "powerline";
+    repo = "powerline";
     tag = version;
     hash = "sha256-snJrfUvP11lBIy6F0WtqJt9fiYm5jxMwm9u3u5XFO84=";
   };

--- a/pkgs/development/python-modules/pre-commit-hooks/default.nix
+++ b/pkgs/development/python-modules/pre-commit-hooks/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pre-commit";
-    repo = pname;
+    repo = "pre-commit-hooks";
     tag = "v${version}";
     hash = "sha256-BYNi/xtdichqsn55hqr1MSFwWpH+7cCbLfqmpn9cxto=";
   };

--- a/pkgs/development/python-modules/pretend/default.nix
+++ b/pkgs/development/python-modules/pretend/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "alex";
-    repo = pname;
+    repo = "pretend";
     rev = "v${version}";
     hash = "sha256-OqMfeIMFNBBLq6ejR3uOCIHZ9aA4zew7iefVlAsy1JQ=";
   };

--- a/pkgs/development/python-modules/prodict/default.nix
+++ b/pkgs/development/python-modules/prodict/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ramazanpolat";
-    repo = pname;
+    repo = "prodict";
     rev = version;
     hash = "sha256-c46JEQFg4KRwerqpMSgh6+tYRpKTOX02Lzsq4/meS3o=";
   };

--- a/pkgs/development/python-modules/prompthub-py/default.nix
+++ b/pkgs/development/python-modules/prompthub-py/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage {
   # Pypi source package doesn't contain tests
   src = fetchFromGitHub {
     owner = "deepset-ai";
-    repo = pname;
+    repo = "prompthub-py";
     rev = "v${version}";
     hash = "sha256-FA4IfhHViSL1u4pgd7jh40rEcS0BldSFDwCPG5irk1g=";
   };

--- a/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
-    repo = pname;
+    repo = "protonvpn-nm-lib";
     tag = version;
     hash = "sha256-n3jfBHMYqyQZgvFFJcylNbTWZ3teuqhdelTfpNrwWuA=";
   };

--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "adobe-type-tools";
-    repo = pname;
+    repo = "psautohint";
     rev = "v${version}";
     sha256 = "125nx7accvbk626qlfar90va1995kp9qfrz6a978q4kv2kk37xai";
     fetchSubmodules = true; # data dir for tests

--- a/pkgs/development/python-modules/psd-tools/default.nix
+++ b/pkgs/development/python-modules/psd-tools/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "psd-tools";
-    repo = pname;
+    repo = "psd-tools";
     tag = "v${version}";
     hash = "sha256-n3OqyItvKXD6NjCm/FgEuu1G5apTmUypwKJ+Y2DCmEg=";
   };

--- a/pkgs/development/python-modules/psygnal/default.nix
+++ b/pkgs/development/python-modules/psygnal/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pyapp-kit";
-    repo = pname;
+    repo = "psygnal";
     tag = "v${version}";
     hash = "sha256-ZEN8S2sI1usXl5A1Ow1+l4BBB6qNnlVt/nvFtAX4maY=";
   };

--- a/pkgs/development/python-modules/pulp/default.nix
+++ b/pkgs/development/python-modules/pulp/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "coin-or";
-    repo = pname;
+    repo = "pulp";
     tag = version;
     hash = "sha256-lpbk1GeC8F/iLGV8G5RPHghnaM9eL82YekUYEt9+mvc=";
   };

--- a/pkgs/development/python-modules/pvextractor/default.nix
+++ b/pkgs/development/python-modules/pvextractor/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "radio-astro-tools";
-    repo = pname;
+    repo = "pvextractor";
     tag = "v${version}";
     sha256 = "sha256-TjwoTtoGWU6C6HdFuS+gJj69PUnfchPHs7UjFqwftVQ=";
   };

--- a/pkgs/development/python-modules/py-air-control/default.nix
+++ b/pkgs/development/python-modules/py-air-control/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "rgerganov";
-    repo = pname;
+    repo = "py-air-control";
     rev = "v${version}";
     sha256 = "0mkggl5hwmj90djxbbz4svim6iv7xl8k324cb4rlc75p5rgcdwmh";
   };

--- a/pkgs/development/python-modules/py-canary/default.nix
+++ b/pkgs/development/python-modules/py-canary/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "snjoetw";
-    repo = pname;
+    repo = "py-canary";
     tag = version;
     hash = "sha256-zylWkssU85eSfR+Di7vQGTr6hOQkqXCObv/PCDHoKHA=";
   };

--- a/pkgs/development/python-modules/py-cid/default.nix
+++ b/pkgs/development/python-modules/py-cid/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ipld";
-    repo = pname;
+    repo = "py-cid";
     rev = "v${version}";
     hash = "sha256-aN7ee25ghKKa90+FoMDCdGauToePc5AzDLV3tONvh4U=";
   };

--- a/pkgs/development/python-modules/py-cpuinfo/default.nix
+++ b/pkgs/development/python-modules/py-cpuinfo/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "workhorsy";
-    repo = pname;
+    repo = "py-cpuinfo";
     rev = "v${version}";
     hash = "sha256-Q5u0guAqDVhf6bvJTzNvCpWbIzjxxAjE7s0OuXj9T4Q=";
   };

--- a/pkgs/development/python-modules/py-desmume/default.nix
+++ b/pkgs/development/python-modules/py-desmume/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
-    repo = pname;
+    repo = "py-desmume";
     tag = version;
     hash = "sha256-aH7f/BI89VLUGqwA8Y7ThSpmKxWffYRETT/+EjPVTg8=";
     fetchSubmodules = true;

--- a/pkgs/development/python-modules/py-dormakaba-dkey/default.nix
+++ b/pkgs/development/python-modules/py-dormakaba-dkey/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "emontnemery";
-    repo = pname;
+    repo = "py-dormakaba-dkey";
     tag = version;
     hash = "sha256-kS99du9EZwki6J2q+nI44rx/AWIPtq7wXR/61ZcyUSM=";
   };

--- a/pkgs/development/python-modules/py-libzfs/default.nix
+++ b/pkgs/development/python-modules/py-libzfs/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "truenas";
-    repo = pname;
+    repo = "py-libzfs";
     rev = "TS-${version}";
     hash = "sha256-Uiu0RNE06++iNWUNcKpbZvreT2D7/EqHlFZJXKe3F4A=";
   };

--- a/pkgs/development/python-modules/py-multiaddr/default.nix
+++ b/pkgs/development/python-modules/py-multiaddr/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "multiformats";
-    repo = pname;
+    repo = "py-multiaddr";
     rev = "v${version}";
     hash = "sha256-cGM7iYQPP+UOkbTxRhzuED0pkcydFCO8vpx9wTc0/HI=";
   };

--- a/pkgs/development/python-modules/py-multicodec/default.nix
+++ b/pkgs/development/python-modules/py-multicodec/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "multiformats";
-    repo = pname;
+    repo = "py-multicodec";
     tag = "v${version}";
     hash = "sha256-2aK+bfhqCMqSO+mtrHIfNQmQpQHpwd7yHseI/3O7Sp4=";
   };

--- a/pkgs/development/python-modules/py-multihash/default.nix
+++ b/pkgs/development/python-modules/py-multihash/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "multiformats";
-    repo = pname;
+    repo = "py-multihash";
     tag = "v${version}";
     hash = "sha256-z1lmSypGCMFWJNzNgV9hx/IStyXbpd5jvrptFpewuOA=";
   };

--- a/pkgs/development/python-modules/py-nightscout/default.nix
+++ b/pkgs/development/python-modules/py-nightscout/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "marciogranzotto";
-    repo = pname;
+    repo = "py-nightscout";
     rev = "v${version}";
     sha256 = "0kslmm3wrxhm307nqmjmq8i8vy1x6mjaqlgba0hgvisj6b4hx65k";
   };

--- a/pkgs/development/python-modules/py-ubjson/default.nix
+++ b/pkgs/development/python-modules/py-ubjson/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Iotic-Labs";
-    repo = pname;
+    repo = "py-ubjson";
     rev = "v${version}";
     sha256 = "1frn97xfa88zrfmpnvdk1pc03yihlchhph99bhjayvzlfcrhm5v3";
   };

--- a/pkgs/development/python-modules/pyaftership/default.nix
+++ b/pkgs/development/python-modules/pyaftership/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ludeeus";
-    repo = pname;
+    repo = "pyaftership";
     tag = version;
     hash = "sha256-njlDScmxIYWxB4EL9lOSGCXqZDzP999gI9EkpcZyFlE=";
   };

--- a/pkgs/development/python-modules/pyahocorasick/default.nix
+++ b/pkgs/development/python-modules/pyahocorasick/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "WojciechMula";
-    repo = pname;
+    repo = "pyahocorasick";
     tag = version;
     hash = "sha256-SCIgu0uEjiSUiIP0WesJG+y+3ZqFBfI5PdgUzviOVrs=";
   };

--- a/pkgs/development/python-modules/pyaxmlparser/default.nix
+++ b/pkgs/development/python-modules/pyaxmlparser/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "appknox";
-    repo = pname;
+    repo = "pyaxmlparser";
     rev = "v${version}";
     hash = "sha256-NtAsO/I1jDEv676yhAgLguQnB/kHdAqPoLt2QFWbvmw=";
   };

--- a/pkgs/development/python-modules/pyblackbird/default.nix
+++ b/pkgs/development/python-modules/pyblackbird/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "koolsb";
-    repo = pname;
+    repo = "pyblackbird";
     tag = version;
     hash = "sha256-+ehzrr+RrwFKOOuxBq3+mwnuMPxZFV4QTZG1IRgsbLc=";
   };

--- a/pkgs/development/python-modules/pybluez/default.nix
+++ b/pkgs/development/python-modules/pybluez/default.nix
@@ -7,14 +7,14 @@
   gattlib,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pybluez";
   version = "unstable-2022-01-28";
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "pybluez";
+    repo = "pybluez";
     rev = "5096047f90a1f6a74ceb250aef6243e144170f92";
     hash = "sha256-GA58DfCFaVzZQA1HYpGQ68bznrt4SX1ojyOVn8hyCGo=";
   };

--- a/pkgs/development/python-modules/pybravia/default.nix
+++ b/pkgs/development/python-modules/pybravia/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Drafteed";
-    repo = pname;
+    repo = "pybravia";
     tag = "v${version}";
     hash = "sha256-1LfYEVclRneU3eD52kvzjLYyGdzYSWVDQ5EADOviglw=";
   };

--- a/pkgs/development/python-modules/pycapnp/default.nix
+++ b/pkgs/development/python-modules/pycapnp/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "capnproto";
-    repo = pname;
+    repo = "pycapnp";
     tag = "v${version}";
     sha256 = "sha256-SVeBRJMMR1Z8+S+QoiUKGRFGUPS/MlmWLi1qRcGcPoE=";
   };

--- a/pkgs/development/python-modules/pycarwings2/default.nix
+++ b/pkgs/development/python-modules/pycarwings2/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "filcole";
-    repo = pname;
+    repo = "pycarwings2";
     rev = "v${version}";
     hash = "sha256-kqj/NZXqgPUsOnnzMPmIlICHek7RBxksmL3reNBK+bo=";
   };

--- a/pkgs/development/python-modules/pycec/default.nix
+++ b/pkgs/development/python-modules/pycec/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "konikvranik";
-    repo = pname;
+    repo = "pycec";
     tag = "v${version}";
     hash = "sha256-5KQyHjAvHWeHFqcFHFJxDOPwWuVcFAN2wVdz9a77dzU=";
   };

--- a/pkgs/development/python-modules/pycfdns/default.nix
+++ b/pkgs/development/python-modules/pycfdns/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ludeeus";
-    repo = pname;
+    repo = "pycfdns";
     tag = version;
     hash = "sha256-bLzDakxKq8fcjEKSxc6D5VN9gfAu1M3/zaAU2UYnwSs=";
   };

--- a/pkgs/development/python-modules/pychannels/default.nix
+++ b/pkgs/development/python-modules/pychannels/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "fancybits";
-    repo = pname;
+    repo = "pychannels";
     rev = version;
     hash = "sha256-E+VL4mJ2KxS5bJZc3Va+wvyVjT55LJz+1wHkxDRa85s=";
   };

--- a/pkgs/development/python-modules/pycketcasts/default.nix
+++ b/pkgs/development/python-modules/pycketcasts/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nwithan8";
-    repo = pname;
+    repo = "pycketcasts";
     rev = version;
     hash = "sha256-O4j89fE7fYPthhCH8b2gGskkelEA4mU6GvSbKIl+4Mk=";
   };

--- a/pkgs/development/python-modules/pyclimacell/default.nix
+++ b/pkgs/development/python-modules/pyclimacell/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "raman325";
-    repo = pname;
+    repo = "pyclimacell";
     rev = "v${version}";
     hash = "sha256-jWHjnebg4Aar48gid7bB7XYXOQtSqbmVmASsZd0YoPc=";
   };

--- a/pkgs/development/python-modules/pyclip/default.nix
+++ b/pkgs/development/python-modules/pyclip/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "spyoungtech";
-    repo = pname;
+    repo = "pyclip";
     tag = "v${version}";
     hash = "sha256-0nOkNgT8XCwtXI9JZntkhoMspKQU602rTKBFajVKBoM=";
   };

--- a/pkgs/development/python-modules/pycm/default.nix
+++ b/pkgs/development/python-modules/pycm/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sepandhaghighi";
-    repo = pname;
+    repo = "pycm";
     tag = "v${version}";
     hash = "sha256-JX75UEaONL+2n6xePE2hbIEMmnt0RknWNWgpbMwNyhw=";
   };

--- a/pkgs/development/python-modules/pycyphal/default.nix
+++ b/pkgs/development/python-modules/pycyphal/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "OpenCyphal";
-    repo = pname;
+    repo = "pycyphal";
     tag = version;
     hash = "sha256-XkH0wss8ueh/Wwz0lhvQShOp3a4X9lNdosT/sMe7p4Q=";
     fetchSubmodules = true;

--- a/pkgs/development/python-modules/pydiscourse/default.nix
+++ b/pkgs/development/python-modules/pydiscourse/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pydiscourse";
-    repo = pname;
+    repo = "pydiscourse";
     tag = "v${version}";
     hash = "sha256-KqJ6ag4owG7US5Q4Ygjq263ds1o/JhEJ3bNa8YecYtE=";
   };

--- a/pkgs/development/python-modules/pydruid/default.nix
+++ b/pkgs/development/python-modules/pydruid/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
-    repo = pname;
+    repo = "pydruid";
     owner = "druid-io";
     tag = version;
     hash = "sha256-9+xomjSwWDVHkret/mqAZKWOPFRMvVB3CWtFPzrT81k=";

--- a/pkgs/development/python-modules/pyduke-energy/default.nix
+++ b/pkgs/development/python-modules/pyduke-energy/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mjmeli";
-    repo = pname;
+    repo = "pyduke-energy";
     tag = "v${version}";
     hash = "sha256-7KkUpsHg3P2cF0bVl3FzyAQwzeaCmg+vzRHlM/TIcNA=";
   };

--- a/pkgs/development/python-modules/pyeverlights/default.nix
+++ b/pkgs/development/python-modules/pyeverlights/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "joncar";
-    repo = pname;
+    repo = "pyeverlights";
     rev = version;
     sha256 = "16xpq933j8yydq78fnf4f7ivyw5a45ix4mfycpmm91aj549p6pm0";
   };

--- a/pkgs/development/python-modules/pyevilgenius/default.nix
+++ b/pkgs/development/python-modules/pyevilgenius/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
-    repo = pname;
+    repo = "pyevilgenius";
     rev = version;
     hash = "sha256-wjC32oq/lW3Z4XB+4SILRKIOuCgBKk1gruOo4uc/4/o=";
   };

--- a/pkgs/development/python-modules/pyevmasm/default.nix
+++ b/pkgs/development/python-modules/pyevmasm/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "crytic";
-    repo = pname;
+    repo = "pyevmasm";
     rev = version;
     sha256 = "134q0z0dqzxzr0jw5jr98kp90kx2dl0qw9smykwxdgq555q1l6qa";
   };

--- a/pkgs/development/python-modules/pyflexit/default.nix
+++ b/pkgs/development/python-modules/pyflexit/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Sabesto";
-    repo = pname;
+    repo = "pyflexit";
     rev = version;
     sha256 = "1ajlqr3z6zj4fyslqzpwpfkvh8xjx94wsznzij0vx0q7jp43bqig";
   };

--- a/pkgs/development/python-modules/pyflic/default.nix
+++ b/pkgs/development/python-modules/pyflic/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "soldag";
-    repo = pname;
+    repo = "pyflic";
     rev = version;
     sha256 = "sha256-K1trMBZfc1aHSNSddq0v//Gv8ySgT/ONQYgrKWzw2qs=";
   };

--- a/pkgs/development/python-modules/pyfzf/default.nix
+++ b/pkgs/development/python-modules/pyfzf/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nk412";
-    repo = pname;
+    repo = "pyfzf";
     rev = version;
     hash = "sha256-w+ZjQGFd/lR2TiTHc2uQSJXORmzJJZXsr9BO4PIw/Co=";
   };

--- a/pkgs/development/python-modules/pyhcl/default.nix
+++ b/pkgs/development/python-modules/pyhcl/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "virtuald";
-    repo = pname;
+    repo = "pyhcl";
     rev = version;
     sha256 = "0rcpx4vvj2c6wxp31vay7a2xa5p62kabi91vps9plj6710yz29nc";
   };

--- a/pkgs/development/python-modules/pyhepmc/default.nix
+++ b/pkgs/development/python-modules/pyhepmc/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "scikit-hep";
-    repo = pname;
+    repo = "pyhepmc";
     tag = "v${version}";
     hash = "sha256-yh02Z1nPGjghZYHkPBlClDEztq4VQsW3H+kuco/lBpk=";
     fetchSubmodules = true;

--- a/pkgs/development/python-modules/pyhocon/default.nix
+++ b/pkgs/development/python-modules/pyhocon/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "chimpler";
-    repo = pname;
+    repo = "pyhocon";
     tag = version;
     hash = "sha256-xXx30uxJ8+KPVdYC6yRzEDJbwYSzIO/Gy1xrehvI5ZE=";
   };

--- a/pkgs/development/python-modules/pyhomepilot/default.nix
+++ b/pkgs/development/python-modules/pyhomepilot/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nico0302";
-    repo = pname;
+    repo = "pyhomepilot";
     rev = "v${version}";
     sha256 = "00gmqx8cwsd15iccnlr8ypgqrdg6nw9ha518cfk7pyp8vhw1ziwy";
   };

--- a/pkgs/development/python-modules/pyialarm/default.nix
+++ b/pkgs/development/python-modules/pyialarm/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "RyuzakiKK";
-    repo = pname;
+    repo = "pyialarm";
     rev = "v${version}";
     hash = "sha256-rOdeYewjoFVbHdNPHN6ZC2g6X5yr84/JFE6tGSDIoRU=";
   };

--- a/pkgs/development/python-modules/pyicloud/default.nix
+++ b/pkgs/development/python-modules/pyicloud/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "picklepete";
-    repo = pname;
+    repo = "pyicloud";
     rev = version;
     hash = "sha256-2E1pdHHt8o7CGpdG+u4xy5OyNCueUGVw5CY8oicYd5w=";
   };

--- a/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
+++ b/pkgs/development/python-modules/pyinstaller-versionfile/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "DudeNr33";
-    repo = pname;
+    repo = "pyinstaller-versionfile";
     rev = "v${version}";
     hash = "sha256-lz1GuiXU+r8sMld5SsG3qS+FOsWfbvkQmO2bxAR3XcY=";
   };

--- a/pkgs/development/python-modules/pyinstrument/default.nix
+++ b/pkgs/development/python-modules/pyinstrument/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "joerick";
-    repo = pname;
+    repo = "pyinstrument";
     tag = "v${version}";
     hash = "sha256-uJ9KRgSETuxpeEIpBKFz66+Qci86jy36lKkUKpvmKIg=";
   };

--- a/pkgs/development/python-modules/pyjsparser/default.nix
+++ b/pkgs/development/python-modules/pyjsparser/default.nix
@@ -6,14 +6,14 @@
 }:
 
 let
-  pyjsparser = buildPythonPackage rec {
+  pyjsparser = buildPythonPackage {
     pname = "pyjsparser";
     version = "2.7.1";
     format = "setuptools";
 
     src = fetchFromGitHub {
       owner = "PiotrDabkowski";
-      repo = pname;
+      repo = "pyjsparser";
       rev = "5465d037b30e334cb0997f2315ec1e451b8ad4c1";
       hash = "sha256-Hqay9/qsjUfe62U7Q79l0Yy01L2Bnj5xNs6427k3Br8=";
     };

--- a/pkgs/development/python-modules/pykka/default.nix
+++ b/pkgs/development/python-modules/pykka/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jodal";
-    repo = pname;
+    repo = "pykka";
     tag = "v${version}";
     hash = "sha256-n9TgXcmUEIQdqtrY+9T+EtPys+7OzXCemRwNPj1xPDw=";
   };

--- a/pkgs/development/python-modules/pykostalpiko/default.nix
+++ b/pkgs/development/python-modules/pykostalpiko/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Florian7843";
-    repo = pname;
+    repo = "pykostalpiko";
     rev = "v${version}";
     hash = "sha256-kmzFsOgmMb8bOkulg7G6vXEPdb0xizh7u5LjnHfEWWQ=";
   };

--- a/pkgs/development/python-modules/pykulersky/default.nix
+++ b/pkgs/development/python-modules/pykulersky/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "emlove";
-    repo = pname;
+    repo = "pykulersky";
     rev = version;
     hash = "sha256-BaGcsHlQpuEnUn8OgSUsJi2q89vFl7vpkinviKnUZJk=";
   };

--- a/pkgs/development/python-modules/pyld/default.nix
+++ b/pkgs/development/python-modules/pyld/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "digitalbazaar";
-    repo = pname;
+    repo = "pyld";
     rev = version;
     sha256 = "0z2vkllw8bvzxripwb6l757r7av5qwhzsiy4061gmlhq8z8gq961";
   };

--- a/pkgs/development/python-modules/pylibdmtx/default.nix
+++ b/pkgs/development/python-modules/pylibdmtx/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "NaturalHistoryMuseum";
-    repo = pname;
+    repo = "pylibdmtx";
     rev = "v${version}";
     hash = "sha256-vNWzhO4V0mj4eItZ0Z5UG9RBCqprIcgMGNyIe1+mXWY=";
   };

--- a/pkgs/development/python-modules/pylint-celery/default.nix
+++ b/pkgs/development/python-modules/pylint-celery/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "PyCQA";
-    repo = pname;
+    repo = "pylint-celery";
     rev = version;
     sha256 = "05fhwraq12c2724pn4py1bjzy5rmsrb1x68zck73nlp5icba6yap";
   };

--- a/pkgs/development/python-modules/pylru/default.nix
+++ b/pkgs/development/python-modules/pylru/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jlhutch";
-    repo = pname;
+    repo = "pylru";
     rev = "v${version}";
     hash = "sha256-dTYiD+/zt0ZSP+sefYyeD87To1nRXyoFodlBg8pm1YE=";
   };

--- a/pkgs/development/python-modules/pyls-spyder/default.nix
+++ b/pkgs/development/python-modules/pyls-spyder/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "spyder-ide";
-    repo = pname;
+    repo = "pyls-spyder";
     rev = "v${version}";
     sha256 = "11ajbsia60d4c9s6m6rbvaqp1d69fcdbq6a98lkzkkzv2b9pdhkk";
   };

--- a/pkgs/development/python-modules/pymailgunner/default.nix
+++ b/pkgs/development/python-modules/pymailgunner/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pschmitt";
-    repo = pname;
+    repo = "pymailgunner";
     rev = version;
     hash = "sha256-QKwpW1aeN6OI76Kocow1Zhghq4/fl/cMPexny0MTwQs=";
   };

--- a/pkgs/development/python-modules/pymanopt/default.nix
+++ b/pkgs/development/python-modules/pymanopt/default.nix
@@ -26,8 +26,8 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "pymanopt";
+    repo = "pymanopt";
     tag = version;
     hash = "sha256-LOEulticgCWZBCf3qj5KFBHt0lMd4H85368IhG3DQ4g=";
   };

--- a/pkgs/development/python-modules/pymarshal/default.nix
+++ b/pkgs/development/python-modules/pymarshal/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "stargateaudio";
-    repo = pname;
+    repo = "pymarshal";
     rev = version;
     hash = "sha256-Ds8JV2mtLRcKXBvPs84Hdj3MxxqpeV5muKCSlAFCj1A=";
   };

--- a/pkgs/development/python-modules/pymata-express/default.nix
+++ b/pkgs/development/python-modules/pymata-express/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "MrYsLab";
-    repo = pname;
+    repo = "pymata-express";
     rev = version;
     sha256 = "1mibyn84kjahrv3kn51yl5mhkyig4piv6wanggzjflh5nm96bhy8";
   };

--- a/pkgs/development/python-modules/pymorphy3/default.nix
+++ b/pkgs/development/python-modules/pymorphy3/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "no-plagiarism";
-    repo = pname;
+    repo = "pymorphy3";
     tag = version;
     hash = "sha256-xqz9BW6vaYnDE+rPEhAO4igPYLZNwZLj42BnnJ7Uk1M=";
   };

--- a/pkgs/development/python-modules/pymysensors/default.nix
+++ b/pkgs/development/python-modules/pymysensors/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "theolind";
-    repo = pname;
+    repo = "pymysensors";
     rev = version;
     hash = "sha256-3t9YrSJf02kc5CuTqPBc/qNJV7yy7Vke4WqhtuOaAYo=";
   };

--- a/pkgs/development/python-modules/pynello/default.nix
+++ b/pkgs/development/python-modules/pynello/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pschmitt";
-    repo = pname;
+    repo = "pynello";
     rev = version;
     hash = "sha256-sUy37sEPEMyFYFVBzFVdcg31nZAyC+Ricm4LqxmjuQQ=";
   };

--- a/pkgs/development/python-modules/pynetgear/default.nix
+++ b/pkgs/development/python-modules/pynetgear/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "MatMaul";
-    repo = pname;
+    repo = "pynetgear";
     tag = version;
     hash = "sha256-5Lj2cK/SOGgaPu8dI9X3Leg4dPAY7tdIHCzFnNaube8=";
   };

--- a/pkgs/development/python-modules/pynrrd/default.nix
+++ b/pkgs/development/python-modules/pynrrd/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mhe";
-    repo = pname;
+    repo = "pynrrd";
     tag = "v${version}";
     hash = "sha256-qu3s3XswJCUchqYfYMuqIzI4sfeXrttvXSEW9/GSENA=";
   };

--- a/pkgs/development/python-modules/pyobihai/default.nix
+++ b/pkgs/development/python-modules/pyobihai/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ejpenney";
-    repo = pname;
+    repo = "pyobihai";
     tag = version;
     hash = "sha256-tDPu/ceH7+7AnxokADDfl+G56B0+ri8RxXxXEyWa61Q=";
   };

--- a/pkgs/development/python-modules/pyosf/default.nix
+++ b/pkgs/development/python-modules/pyosf/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "psychopy";
-    repo = pname;
+    repo = "pyosf";
     tag = "v${version}";
     hash = "sha256-Yhb6HSnLdFzWouse/RKZ8SIbMia/hhD8TAovdqmvd7o=";
   };

--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "JessicaTegner";
-    repo = pname;
+    repo = "pypandoc";
     tag = "v${version}";
     hash = "sha256-9fpits8O/50maM/e1lVVqBoTwUmcI+/IAYhVX1Pt6ZE=";
   };

--- a/pkgs/development/python-modules/pyparsing/default.nix
+++ b/pkgs/development/python-modules/pyparsing/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pyparsing";
-    repo = pname;
+    repo = "pyparsing";
     tag = version;
     hash = "sha256-irRSylY16Vcm2zsue1Iv+1eqYGZSAqhkqHrdjdhznlM=";
   };

--- a/pkgs/development/python-modules/pyparted/default.nix
+++ b/pkgs/development/python-modules/pyparted/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   disabled = isPyPy;
 
   src = fetchFromGitHub {
-    repo = pname;
+    repo = "pyparted";
     owner = "dcantrell";
     tag = "v${version}";
     hash = "sha256-AiUCCrEbDD0OxrvXs1YN3/1IE7SuVasC2YCirIG58iU=";

--- a/pkgs/development/python-modules/pypcap/default.nix
+++ b/pkgs/development/python-modules/pypcap/default.nix
@@ -7,14 +7,14 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pypcap";
   version = "1.3.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "pynetwork";
-    repo = pname;
+    repo = "pypcap";
     # No release was tagged and PyPI doesn't contain tests.
     rev = "968859f0ffb5b7c990506dffe82457b7de23a026";
     hash = "sha256-NfyEC3qEBm6TjebcDIsoz8tJWaJ625ZFPfx7AMyynWE=";

--- a/pkgs/development/python-modules/pyprusalink/default.nix
+++ b/pkgs/development/python-modules/pyprusalink/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
-    repo = pname;
+    repo = "pyprusalink";
     tag = version;
     hash = "sha256-Opip696hXV1gqFC1cWfrSCkrsldl7M7XZAqUaVkDy7M=";
   };

--- a/pkgs/development/python-modules/pypsrp/default.nix
+++ b/pkgs/development/python-modules/pypsrp/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jborean93";
-    repo = pname;
+    repo = "pypsrp";
     tag = "v${version}";
     hash = "sha256-Pwfc9e39sYPdcHN1cZtxxGEglEYzPp4yOYLD5/4SSiU=";
   };

--- a/pkgs/development/python-modules/pyqvrpro/default.nix
+++ b/pkgs/development/python-modules/pyqvrpro/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "oblogic7";
-    repo = pname;
+    repo = "pyqvrpro";
     rev = "v${version}";
     hash = "sha256-lOd2AqnrkexNqT/usmJts5NW7vJtV8CRsliYgkhgRaU=";
   };

--- a/pkgs/development/python-modules/pyrad/default.nix
+++ b/pkgs/development/python-modules/pyrad/default.nix
@@ -6,14 +6,14 @@
   poetry-core,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pyrad";
   version = "2.4-unstable-2024-07-24";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyradius";
-    repo = pname;
+    repo = "pyrad";
     rev = "f42a57cb0e80de42949810057d36df7c4a6b5146";
     hash = "sha256-5SPVeBL1oMZ/XXgKch2Hbk6BRU24HlVl4oXZ2agF1h8=";
   };

--- a/pkgs/development/python-modules/pyrituals/default.nix
+++ b/pkgs/development/python-modules/pyrituals/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "milanmeu";
-    repo = pname;
+    repo = "pyrituals";
     rev = version;
     sha256 = "0ynjz7khp67bwxjp580w3zijxr9yn44nmnbvkxjxq9scyb2mjf6g";
   };

--- a/pkgs/development/python-modules/pyrmvtransport/default.nix
+++ b/pkgs/development/python-modules/pyrmvtransport/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cgtobi";
-    repo = pname;
+    repo = "pyrmvtransport";
     rev = "v${version}";
     hash = "sha256-nFxGEyO+wyRzPayjjv8WNIJ+XIWbVn0dyyjQKHiyr40=";
   };

--- a/pkgs/development/python-modules/pysaj/default.nix
+++ b/pkgs/development/python-modules/pysaj/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "fredericvl";
-    repo = pname;
+    repo = "pysaj";
     rev = "v${version}";
     hash = "sha256-7mN6GPRbXfEUfCrCrCs71SSt4x2Ch2y3a5rfXnuwVA0=";
   };

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pyscf";
-    repo = pname;
+    repo = "pyscf";
     tag = "v${version}";
     hash = "sha256-UTeZXlNuSWDOcBRVbUUWJ3mQnZZQr17aTw6rRA5DRNI=";
   };

--- a/pkgs/development/python-modules/pyschemes/default.nix
+++ b/pkgs/development/python-modules/pyschemes/default.nix
@@ -6,14 +6,14 @@
   fetchpatch,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pyschemes";
   version = "unstable-2017-11-08";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "spy16";
-    repo = pname;
+    repo = "pyschemes";
     rev = "ca6483d13159ba65ba6fc2f77b90421c40f2bbf2";
     hash = "sha256-PssucudvlE8mztwVme70+h+2hRW/ri9oV9IZayiZhdU=";
   };

--- a/pkgs/development/python-modules/pyshark/default.nix
+++ b/pkgs/development/python-modules/pyshark/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "KimiNewt";
-    repo = pname;
+    repo = "pyshark";
     tag = "v${version}";
     hash = "sha256-kzJDzUK6zknUyXPdKc4zMvWim4C5NQCSJSS45HI6hKM=";
   };

--- a/pkgs/development/python-modules/pyshp/default.nix
+++ b/pkgs/development/python-modules/pyshp/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "GeospatialPython";
-    repo = pname;
+    repo = "pyshp";
     rev = version;
     hash = "sha256-yfxhgk8a1rdpGVkE1sjJqT6tiFLimhu2m2SjGxLI6wo=";
   };

--- a/pkgs/development/python-modules/pysmappee/default.nix
+++ b/pkgs/development/python-modules/pysmappee/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "smappee";
-    repo = pname;
+    repo = "pysmappee";
     rev = version;
     hash = "sha256-Ffi55FZsZUKDcS4qV46NpRK3VP6axzrL2BO+hYW7J9E=";
   };

--- a/pkgs/development/python-modules/pysmartapp/default.nix
+++ b/pkgs/development/python-modules/pysmartapp/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "andrewsayre";
-    repo = pname;
+    repo = "pysmartapp";
     rev = version;
     hash = "sha256-RiRGOO5l5hcHllyDDGLtQHr51JOTZhAa/wK8BfMqmAY=";
   };

--- a/pkgs/development/python-modules/pysmt/default.nix
+++ b/pkgs/development/python-modules/pysmt/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pysmt";
-    repo = pname;
+    repo = "pysmt";
     rev = "v${version}";
     hash = "sha256-HmEdCJOF04h0z5UPpfYa07b78EEBj5KyVAk6aNRFPEo=";
   };

--- a/pkgs/development/python-modules/pysnooz/default.nix
+++ b/pkgs/development/python-modules/pysnooz/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "AustinBrunkhorst";
-    repo = pname;
+    repo = "pysnooz";
     tag = "v${version}";
     hash = "sha256-jOXmaJprU35sdNRrBBx/YUyiDyyaE1qodWksXkTSEe0=";
   };

--- a/pkgs/development/python-modules/pysnow/default.nix
+++ b/pkgs/development/python-modules/pysnow/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "rbw";
-    repo = pname;
+    repo = "pysnow";
     rev = version;
     hash = "sha256-nKOPCkS2b3ObmBnk/7FTv4o4vwUX+tOtZI5OQQ4HSTY=";
   };

--- a/pkgs/development/python-modules/pysonos/default.nix
+++ b/pkgs/development/python-modules/pysonos/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   # pypi package is missing test fixtures
   src = fetchFromGitHub {
     owner = "amelchio";
-    repo = pname;
+    repo = "pysonos";
     rev = "v${version}";
     hash = "sha256-gBOknYHL5nQWFVhCbLN0Ah+1fovcNY4P2myryZnUadk=";
   };

--- a/pkgs/development/python-modules/pyspcwebgw/default.nix
+++ b/pkgs/development/python-modules/pyspcwebgw/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mbrrg";
-    repo = pname;
+    repo = "pyspcwebgw";
     tag = "v${version}";
     hash = "sha256-gdIrbr25GXaX26B1f7u0NKbqqnAC2tmMFZspzW6I4HI=";
   };

--- a/pkgs/development/python-modules/pyspf/default.nix
+++ b/pkgs/development/python-modules/pyspf/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sdgathman";
-    repo = pname;
+    repo = "pyspf";
     rev = "pyspf-${version}";
     sha256 = "0bmimlmwrq9glnjc4i6pwch30n3y5wyqmkjfyayxqxkfrixqwydi";
   };

--- a/pkgs/development/python-modules/pyspinel/default.nix
+++ b/pkgs/development/python-modules/pyspinel/default.nix
@@ -6,7 +6,7 @@
   pythonOlder,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pyspinel";
   version = "unstable-2021-08-19";
   format = "setuptools";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "openthread";
-    repo = pname;
+    repo = "pyspinel";
     rev = "50d104e29eacd92d229f0b7179ec1067f5851c17";
     sha256 = "0s2r00zb909cq3dd28i91qbl0nz8cga3g98z84gq5jqkjpiy8269";
   };

--- a/pkgs/development/python-modules/pyspnego/default.nix
+++ b/pkgs/development/python-modules/pyspnego/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jborean93";
-    repo = pname;
+    repo = "pyspnego";
     tag = "v${version}";
     hash = "sha256-5aGHCw0d1aFcHLPRMkya0hlHV30aTKshbcOjfPMOFko=";
   };

--- a/pkgs/development/python-modules/pysubs2/default.nix
+++ b/pkgs/development/python-modules/pysubs2/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tkarabela";
-    repo = pname;
+    repo = "pysubs2";
     rev = version;
     hash = "sha256-fKSb7MfBHGft8Tp6excjfkVXKnHRER11X0QxbR1zD4I=";
   };

--- a/pkgs/development/python-modules/pysvg-py3/default.nix
+++ b/pkgs/development/python-modules/pysvg-py3/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "alorence";
-    repo = pname;
+    repo = "pysvg-py3";
     rev = version;
     sha256 = "1slync0knpcjgl4xpym8w4249iy6vmrwbarpnbjzn9xca8g1h2f0";
   };

--- a/pkgs/development/python-modules/pytaglib/default.nix
+++ b/pkgs/development/python-modules/pytaglib/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "supermihi";
-    repo = pname;
+    repo = "pytaglib";
     tag = "v${version}";
     hash = "sha256-K9K30NFBcmxlYDQQ4YUhGzaPNVmLt0/L0JDrCtyKwLA=";
   };

--- a/pkgs/development/python-modules/pytautulli/default.nix
+++ b/pkgs/development/python-modules/pytautulli/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ludeeus";
-    repo = pname;
+    repo = "pytautulli";
     tag = version;
     hash = "sha256-5wE8FjLFu1oQkVqnWsbp253dsQ1/QGWC6hHSIFwLajY=";
   };

--- a/pkgs/development/python-modules/pyte/default.nix
+++ b/pkgs/development/python-modules/pyte/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "selectel";
-    repo = pname;
+    repo = "pyte";
     rev = version;
     hash = "sha256-u24ltX/LEteiZ2a/ioKqxV2AZgrFmKOHXmySmw21sLE=";
   };

--- a/pkgs/development/python-modules/pytesseract/default.nix
+++ b/pkgs/development/python-modules/pytesseract/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "madmaze";
-    repo = pname;
+    repo = "pytesseract";
     tag = "v${version}";
     hash = "sha256-gQMeck6ojlIwyiOCBBhzHHrjQfBMelVksVGd+fyxWZk=";
   };

--- a/pkgs/development/python-modules/pytest-cid/default.nix
+++ b/pkgs/development/python-modules/pytest-cid/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ntninja";
-    repo = pname;
+    repo = "pytest-cid";
     tag = "v${version}";
     hash = "sha256-dcL/i5+scmdXh7lfE8+32w9PdHWf+mkunJL1vpJ5+Co=";
   };

--- a/pkgs/development/python-modules/pytest-datafiles/default.nix
+++ b/pkgs/development/python-modules/pytest-datafiles/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "omarkohl";
-    repo = pname;
+    repo = "pytest-datafiles";
     tag = version;
     hash = "sha256-YFD8M5TG6VtLRX04R3u0jtYDDlaK32D4ArWxS6x2b/E=";
   };

--- a/pkgs/development/python-modules/pytest-error-for-skips/default.nix
+++ b/pkgs/development/python-modules/pytest-error-for-skips/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jankatins";
-    repo = pname;
+    repo = "pytest-error-for-skips";
     rev = version;
     sha256 = "04i4jd3bg4lgn2jfh0a0dzg3ml9b2bjv2ndia6b64w96r3r4p3qr";
   };

--- a/pkgs/development/python-modules/pytest-golden/default.nix
+++ b/pkgs/development/python-modules/pytest-golden/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "oprypin";
-    repo = pname;
+    repo = "pytest-golden";
     tag = "v${version}";
     hash = "sha256-l5fXWDK6gWJc3dkYFTokI9tWvawMRnF0td/lSwqkYXE=";
   };

--- a/pkgs/development/python-modules/pytest-isort/default.nix
+++ b/pkgs/development/python-modules/pytest-isort/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "stephrdev";
-    repo = pname;
+    repo = "pytest-isort";
     tag = version;
     hash = "sha256-fMt2tYc+Ngb57T/VJYxI2UN25qvIrgIsEoImVIitDK4=";
   };

--- a/pkgs/development/python-modules/pytest-logdog/default.nix
+++ b/pkgs/development/python-modules/pytest-logdog/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ods";
-    repo = pname;
+    repo = "pytest-logdog";
     rev = version;
     hash = "sha256-Tmoq+KAGzn0MMj29rukDfAc4LSIwC8DoMTuBAppV32I=";
   };

--- a/pkgs/development/python-modules/pytest-mockservers/default.nix
+++ b/pkgs/development/python-modules/pytest-mockservers/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Gr1N";
-    repo = pname;
+    repo = "pytest-mockservers";
     rev = version;
     hash = "sha256-Mb3wSbambC1h+lFI+fafwZzm78IvADNAsF/Uw60DFHc=";
   };

--- a/pkgs/development/python-modules/pytest-parallel/default.nix
+++ b/pkgs/development/python-modules/pytest-parallel/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage {
 
   src = fetchFromGitHub {
     owner = "kevlened";
-    repo = pname;
+    repo = "pytest-parallel";
     tag = version;
     hash = "sha256-ddpoWBTf7Zor569p6uOMjHSTx3Qa551f4mSwyTLDdBU=";
   };

--- a/pkgs/development/python-modules/pytest-param-files/default.nix
+++ b/pkgs/development/python-modules/pytest-param-files/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "chrisjsewell";
-    repo = pname;
+    repo = "pytest-param-files";
     tag = "v${version}";
     hash = "sha256-hgEEfKf9Kmah5WDNHoFWQJKLOs9Z5BDHiebXCdDc1zE=";
   };

--- a/pkgs/development/python-modules/pytest-raises/default.nix
+++ b/pkgs/development/python-modules/pytest-raises/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Lemmons";
-    repo = pname;
+    repo = "pytest-raises";
     tag = version;
     hash = "sha256-wmtWPWwe1sFbWSYxs5ZXDUZM1qvjRGMudWdjQeskaz0=";
   };

--- a/pkgs/development/python-modules/pytest-randomly/default.nix
+++ b/pkgs/development/python-modules/pytest-randomly/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
-    repo = pname;
+    repo = "pytest-randomly";
     owner = "pytest-dev";
     rev = version;
     hash = "sha256-bxbW22Nf/0hfJYSiz3xdrNCzrb7vZwuVvSIrWl0Bkv4=";

--- a/pkgs/development/python-modules/pytest-resource-path/default.nix
+++ b/pkgs/development/python-modules/pytest-resource-path/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "yukihiko-shinoda";
-    repo = pname;
+    repo = "pytest-resource-path";
     rev = "v${version}";
     sha256 = "1siv3pk4fsabz254fdzr7c0pxy124habnbw4ym66pfk883fr96g2";
   };

--- a/pkgs/development/python-modules/pytest-snapshot/default.nix
+++ b/pkgs/development/python-modules/pytest-snapshot/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "joseph-roitman";
-    repo = pname;
+    repo = "pytest-snapshot";
     tag = "v${version}";
     hash = "sha256-0PZu9wL29iEppLxxbl4D0E4WfOHe61KUUld003cRBRU=";
   };

--- a/pkgs/development/python-modules/pytest-testmon/default.nix
+++ b/pkgs/development/python-modules/pytest-testmon/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tarpas";
-    repo = pname;
+    repo = "pytest-testmon";
     tag = "v${version}";
     hash = "sha256-LSp3GkvyZ8wX6qelGy4PdCliGIzXo2nJNrYqxdSo/wM=";
   };

--- a/pkgs/development/python-modules/pytest-tornasync/default.nix
+++ b/pkgs/development/python-modules/pytest-tornasync/default.nix
@@ -7,7 +7,7 @@
   tornado,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pytest-tornasync";
   version = "0.6.0.post2";
   format = "setuptools";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "eukaryote";
-    repo = pname;
+    repo = "pytest-tornasync";
     # upstream does not keep git tags in sync with pypy releases
     # https://github.com/eukaryote/pytest-tornasync/issues/9
     rev = "c5f013f1f727f1ca1fcf8cc748bba7f4a2d79e56";

--- a/pkgs/development/python-modules/pytest-trio/default.nix
+++ b/pkgs/development/python-modules/pytest-trio/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "python-trio";
-    repo = pname;
+    repo = "pytest-trio";
     rev = "v${version}";
     sha256 = "sha256-gUH35Yk/pBD2EdCEt8D0XQKWU8BwmX5xtAW10qRhoYk=";
   };

--- a/pkgs/development/python-modules/pytest-vcr/default.nix
+++ b/pkgs/development/python-modules/pytest-vcr/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ktosiek";
-    repo = pname;
+    repo = "pytest-vcr";
     rev = version;
     sha256 = "1i6fin91mklvbi8jzfiswvwf1m91f43smpj36a17xrzk4gisfs6i";
   };

--- a/pkgs/development/python-modules/python-ctags3/default.nix
+++ b/pkgs/development/python-modules/python-ctags3/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "universal-ctags";
-    repo = pname;
+    repo = "python-ctags3";
     rev = version;
     hash = "sha256-XVsZckNVJ1H5q8FzqoVd1UWRw0zOygvRtb7arX9dwGE=";
   };

--- a/pkgs/development/python-modules/python-decouple/default.nix
+++ b/pkgs/development/python-modules/python-decouple/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "HBNetwork";
-    repo = pname;
+    repo = "python-decouple";
     tag = "v${version}";
     hash = "sha256-F9Gu7Y/dJhwOJi/ZaoVclF3+4U/N5JdvpXwgGB3SF3Q=";
   };

--- a/pkgs/development/python-modules/python-frontmatter/default.nix
+++ b/pkgs/development/python-modules/python-frontmatter/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "eyeseast";
-    repo = pname;
+    repo = "python-frontmatter";
     tag = "v${version}";
     sha256 = "sha256-Sr0RbNVk87Zu01U7nkuPUSnl1bm6G72EZDP/eDn099s=";
   };

--- a/pkgs/development/python-modules/python-fullykiosk/default.nix
+++ b/pkgs/development/python-modules/python-fullykiosk/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cgarwood";
-    repo = pname;
+    repo = "python-fullykiosk";
     tag = version;
     hash = "sha256-+JBgBi05zNgIt2cXlHjFPI6nBFR7SpMCWIQHKtnZeX4=";
   };

--- a/pkgs/development/python-modules/python-gammu/default.nix
+++ b/pkgs/development/python-modules/python-gammu/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "gammu";
-    repo = pname;
+    repo = "python-gammu";
     rev = version;
     hash = "sha256-lFQBrKWwdvUScwsBva08izZVeVDn1u+ldzixtL9YTpA=";
   };

--- a/pkgs/development/python-modules/python-ironicclient/default.nix
+++ b/pkgs/development/python-modules/python-ironicclient/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "openstack";
-    repo = pname;
+    repo = "python-ironicclient";
     tag = version;
     hash = "sha256-HqsOMvJ8SK8IEZgeClLd0TnQLBweBEru0Bw4WRSDG7s=";
   };

--- a/pkgs/development/python-modules/python-lsp-jsonrpc/default.nix
+++ b/pkgs/development/python-modules/python-lsp-jsonrpc/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "python-lsp";
-    repo = pname;
+    repo = "python-lsp-jsonrpc";
     tag = "v${version}";
     hash = "sha256-5WN/31e6WCgXVzevMuQbNjyo/2jjWDF+m48nrLKS+64=";
   };

--- a/pkgs/development/python-modules/python-ndn/default.nix
+++ b/pkgs/development/python-modules/python-ndn/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "named-data";
-    repo = pname;
+    repo = "python-ndn";
     tag = "v${version}";
     hash = "sha256-8fcBIcZ2l6mkKe9YQe5+5fh7+vK9qxzBO2kLRUONumQ=";
   };

--- a/pkgs/development/python-modules/python-pam/default.nix
+++ b/pkgs/development/python-modules/python-pam/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "FirefighterBlu3";
-    repo = pname;
+    repo = "python-pam";
     tag = "v${version}";
     hash = "sha256-MR9LYXtkbltAmn7yoyyKZn4yMHyh3rj/i/pA8nJy2xU=";
   };

--- a/pkgs/development/python-modules/python-pkcs11/default.nix
+++ b/pkgs/development/python-modules/python-pkcs11/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "danni";
-    repo = pname;
+    repo = "python-pkcs11";
     rev = "v${version}";
     sha256 = "0kncbipfpsb7m7mhv5s5b9wk604h1j08i2j26fn90pklgqll0xhv";
   };

--- a/pkgs/development/python-modules/python-rabbitair/default.nix
+++ b/pkgs/development/python-modules/python-rabbitair/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "rabbit-air";
-    repo = pname;
+    repo = "python-rabbitair";
     rev = "v${version}";
     hash = "sha256-CGr7NvnGRNTiKq5BpB/zmfgyd/2ggTbO0nj+Q+MavTs=";
   };

--- a/pkgs/development/python-modules/python-twitter/default.nix
+++ b/pkgs/development/python-modules/python-twitter/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bear";
-    repo = pname;
+    repo = "python-twitter";
     rev = "v${version}";
     sha256 = "08ydmf6dcd416cvw6xq1wxsz6b9s21f2mf9fh3y4qz9swj6n9h8z";
   };

--- a/pkgs/development/python-modules/python-utils/default.nix
+++ b/pkgs/development/python-modules/python-utils/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "WoLpH";
-    repo = pname;
+    repo = "python-utils";
     tag = "v${version}";
     hash = "sha256-lzLzYI5jShfIwQqvfA8UtPjGawXE80ww7jb/gPzpeDo=";
   };

--- a/pkgs/development/python-modules/python3-application/default.nix
+++ b/pkgs/development/python-modules/python3-application/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "AGProjects";
-    repo = pname;
+    repo = "python3-application";
     rev = "release-${version}";
     hash = "sha256-L7KN6rKkbjNmkSoy8vdMYpXSBkWN7afNpreJO0twjq8=";
   };

--- a/pkgs/development/python-modules/pytimeparse2/default.nix
+++ b/pkgs/development/python-modules/pytimeparse2/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "onegreyonewhite";
-    repo = pname;
+    repo = "pytimeparse2";
     tag = version;
     hash = "sha256-zWRbSohTvbVd3GcRRoxH/UReVGYHC0YmbNgbt8N0X48=";
   };

--- a/pkgs/development/python-modules/pytm/default.nix
+++ b/pkgs/development/python-modules/pytm/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "izar";
-    repo = pname;
+    repo = "pytm";
     tag = "v${version}";
     sha256 = "sha256-MseV1ucDCzSM36zx04g9v5euDX0t74KqUSB4+brHzt8=";
   };

--- a/pkgs/development/python-modules/pytomlpp/default.nix
+++ b/pkgs/development/python-modules/pytomlpp/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bobfang1992";
-    repo = pname;
+    repo = "pytomlpp";
     rev = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-QJeXvj1M3Vq5ctmx7RhczONsPRXAecv3WhJgKWtNK+M=";

--- a/pkgs/development/python-modules/pytricia/default.nix
+++ b/pkgs/development/python-modules/pytricia/default.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pytricia";
   version = "unstable-2019-01-16";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "jsommers";
-    repo = pname;
+    repo = "pytricia";
     rev = "4ba88f68c3125f789ca8cd1cfae156e1464bde87";
     sha256 = "0qp5774xkm700g35k5c76pck8pdzqlyzbaqgrz76a1yh67s2ri8h";
   };

--- a/pkgs/development/python-modules/pyu2f/default.nix
+++ b/pkgs/development/python-modules/pyu2f/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "google";
-    repo = pname;
+    repo = "pyu2f";
     tag = version;
     sha256 = "0mx7bn1p3n0fxyxa82wg3c719hby7vqkxv57fhf7zvhlg2zfnr0v";
   };

--- a/pkgs/development/python-modules/pyupgrade/default.nix
+++ b/pkgs/development/python-modules/pyupgrade/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "asottile";
-    repo = pname;
+    repo = "pyupgrade";
     rev = "v${version}";
     hash = "sha256-bijW1uxoaVKLO0Psv3JeAG6rKeTwGa9ZW06VU1qFrrU=";
   };

--- a/pkgs/development/python-modules/pyuptimerobot/default.nix
+++ b/pkgs/development/python-modules/pyuptimerobot/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ludeeus";
-    repo = pname;
+    repo = "pyuptimerobot";
     tag = version;
     hash = "sha256-hy/hmXxxEb44X8JUszoA1YF/41y7GkQqC4uS+Pax6WA=";
   };

--- a/pkgs/development/python-modules/pyversasense/default.nix
+++ b/pkgs/development/python-modules/pyversasense/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "imstevenxyz";
-    repo = pname;
+    repo = "pyversasense";
     rev = "v${version}";
     sha256 = "vTaDEwImWDMInwti0Jj+j+RFEtXOOKtiH5wOMD6ZmJk=";
   };

--- a/pkgs/development/python-modules/pyvis/default.nix
+++ b/pkgs/development/python-modules/pyvis/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "WestHealth";
-    repo = pname;
+    repo = "pyvis";
     tag = "v${version}";
     hash = "sha256-eo9Mk2c0hrBarCrzwmkXha3Qt4Bl1qR7Lhl9EkUx96E=";
   };

--- a/pkgs/development/python-modules/pyvmomi/default.nix
+++ b/pkgs/development/python-modules/pyvmomi/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "vmware";
-    repo = pname;
+    repo = "pyvmomi";
     tag = "v${version}";
     hash = "sha256-wJe45r9fWNkg8oWJZ47bcqoWzOvxpO4soV2SU4N0tb0=";
   };

--- a/pkgs/development/python-modules/pywaterkotte/default.nix
+++ b/pkgs/development/python-modules/pywaterkotte/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "chboland";
-    repo = pname;
+    repo = "pywaterkotte";
     tag = "v${version}";
     hash = "sha256-zK0x6LyXPPNPA20Zq+S1B1q7ZWGxQmWf4JxEfjNkPQw=";
   };

--- a/pkgs/development/python-modules/pyweatherflowrest/default.nix
+++ b/pkgs/development/python-modules/pyweatherflowrest/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "briis";
-    repo = pname;
+    repo = "pyweatherflowrest";
     tag = "v${version}";
     hash = "sha256-l1V3HgzqnnoY6sWHwfgBtcIR782RwKhekY2qOLrUMNY=";
   };

--- a/pkgs/development/python-modules/pywizlight/default.nix
+++ b/pkgs/development/python-modules/pywizlight/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sbidy";
-    repo = pname;
+    repo = "pywizlight";
     rev = "v${version}";
     hash = "sha256-JT0Ud17U9etByaDVu9+hcadymze1rfj+mEK6nqksuWc=";
   };

--- a/pkgs/development/python-modules/pyws66i/default.nix
+++ b/pkgs/development/python-modules/pyws66i/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "ssaenger";
-    repo = pname;
+    repo = "pyws66i";
     rev = "v${version}";
     hash = "sha256-NTL2+xLqSNsz4YdUTwr0nFjhm1NNgB8qDnWSoE2sizY=";
   };

--- a/pkgs/development/python-modules/pyxbe/default.nix
+++ b/pkgs/development/python-modules/pyxbe/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mborgerson";
-    repo = pname;
+    repo = "pyxbe";
     tag = "v${version}";
     hash = "sha256-iLzGGgizUbaEG1xrNq4WDaWrGtcaLwAYgn4NGYiSDBo=";
   };

--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "xdg";
-    repo = pname;
+    repo = "pyxdg";
     rev = "rel-${version}";
     hash = "sha256-TrFQzfkXabmfpGYwhxD1UVY1F645KycfSPPrMJFAe+0=";
   };

--- a/pkgs/development/python-modules/pyxl3/default.nix
+++ b/pkgs/development/python-modules/pyxl3/default.nix
@@ -6,7 +6,7 @@
   isPy27,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "pyxl3";
   version = "1.4";
   format = "setuptools";
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "gvanrossum";
-    repo = pname;
+    repo = "pyxl3";
     rev = "e6588c12caee49c43faf6aa260f04d7e971f6aa8";
     hash = "sha256-8nKQgwLXPVgPxNRF4CryKJb7+llDsZHis5VctxqpIRo=";
   };

--- a/pkgs/development/python-modules/pyzerproc/default.nix
+++ b/pkgs/development/python-modules/pyzerproc/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "emlove";
-    repo = pname;
+    repo = "pyzerproc";
     tag = version;
     hash = "sha256-vS0sk/KjDhWispZvCuGlmVLLfeFymHqxwNzNqNRhg6k=";
   };

--- a/pkgs/development/python-modules/qasync/default.nix
+++ b/pkgs/development/python-modules/qasync/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "CabbageDevelopment";
-    repo = pname;
+    repo = "qasync";
     tag = "v${version}";
     hash = "sha256-oXzwilhJ1PhodQpOZjnV9gFuoDy/zXWva9LhhK3T00g=";
   };

--- a/pkgs/development/python-modules/qpageview/default.nix
+++ b/pkgs/development/python-modules/qpageview/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "frescobaldi";
-    repo = pname;
+    repo = "qpageview";
     tag = "v${version}";
     hash = "sha256-UADC+DH3eG1pqlC9BRsqGQQjJcpfwWWVq4O7aFGLxLA=";
   };

--- a/pkgs/development/python-modules/qtawesome/default.nix
+++ b/pkgs/development/python-modules/qtawesome/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "spyder-ide";
-    repo = pname;
+    repo = "qtawesome";
     tag = "v${version}";
     hash = "sha256-VjUlP+5QU9ApD09UNvF48b0gepCUpVO6U6zYaKm0KoE=";
   };

--- a/pkgs/development/python-modules/qualysclient/default.nix
+++ b/pkgs/development/python-modules/qualysclient/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "woodtechie1428";
-    repo = pname;
+    repo = "qualysclient";
     tag = "v${version}";
     hash = "sha256-+SZICysgSC4XeXC9CCl6Yxb47V9c1eMp7KcpH8J7kK0=";
   };

--- a/pkgs/development/python-modules/quantulum3/default.nix
+++ b/pkgs/development/python-modules/quantulum3/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage {
   # Pypi source package doesn't contain tests
   src = fetchFromGitHub {
     owner = "nielstron";
-    repo = pname;
+    repo = "quantulum3";
     rev = "9dafd76d3586aa5ea1b96164d86c73037e827294";
     hash = "sha256-fHztPeTbMp1aYsj+STYWzHgwdY0Q9078qXpXxtA8pPs=";
   };

--- a/pkgs/development/python-modules/questionary/default.nix
+++ b/pkgs/development/python-modules/questionary/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tmbo";
-    repo = pname;
+    repo = "questionary";
     tag = version;
     hash = "sha256-HiQsOkG3oK+hnyeFjebnVASxpZhUPGBGz69JvPO43fM=";
   };

--- a/pkgs/development/python-modules/radian/default.nix
+++ b/pkgs/development/python-modules/radian/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "randy3k";
-    repo = pname;
+    repo = "radian";
     tag = "v${version}";
     hash = "sha256-gz2VczAgVbvISzvY/v0GvZ/Erv6ipZwPU61r6OJ+3Fo=";
   };

--- a/pkgs/development/python-modules/radiotherm/default.nix
+++ b/pkgs/development/python-modules/radiotherm/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mhrivnak";
-    repo = pname;
+    repo = "radiotherm";
     rev = version;
     sha256 = "0p37pc7l2malmjfkdlh4q2cfa6dqpsk1rah2j2xil0pj57ai6bks";
   };

--- a/pkgs/development/python-modules/rainbowstream/default.nix
+++ b/pkgs/development/python-modules/rainbowstream/default.nix
@@ -17,14 +17,14 @@
   zlib,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "rainbowstream";
   version = "1.5.5";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "orakaro";
-    repo = pname;
+    repo = "rainbowstream";
     # Request for tagging, https://github.com/orakaro/rainbowstream/issues/314
     rev = "96141fac10675e0775d703f65a59c4477a48c57e";
     sha256 = "0j0qcc428lk9b3l0cr2j418gd6wd5k4160ham2zn2mmdmxn5bldg";

--- a/pkgs/development/python-modules/rank-bm25/default.nix
+++ b/pkgs/development/python-modules/rank-bm25/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage {
   # Pypi source package doesn't contain tests
   src = fetchFromGitHub {
     owner = "dorianbrown";
-    repo = pname;
+    repo = "rank-bm25";
     rev = version;
     hash = "sha256-+BxQBflMm2AvCLAFFj52Jpkqn+KErwYXU1wztintgOg=";
   };

--- a/pkgs/development/python-modules/ratelimit/default.nix
+++ b/pkgs/development/python-modules/ratelimit/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tomasbasham";
-    repo = pname;
+    repo = "ratelimit";
     rev = "v${version}";
     sha256 = "04hy3hhh5xdqcsz0lx8j18zbj88kh5ik4wyi5d3a5sfy2hx70in2";
   };

--- a/pkgs/development/python-modules/rchitect/default.nix
+++ b/pkgs/development/python-modules/rchitect/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "randy3k";
-    repo = pname;
+    repo = "rchitect";
     tag = "v${version}";
     hash = "sha256-M7OWDo3mEEOYtjIpzPIpzPMBtv2TZJKJkSfHczZYS8Y=";
   };

--- a/pkgs/development/python-modules/recommonmark/default.nix
+++ b/pkgs/development/python-modules/recommonmark/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "rtfd";
-    repo = pname;
+    repo = "recommonmark";
     rev = version;
     sha256 = "0kwm4smxbgq0c0ybkxfvlgrfb3gq9amdw94141jyykk9mmz38379";
   };

--- a/pkgs/development/python-modules/regional/default.nix
+++ b/pkgs/development/python-modules/regional/default.nix
@@ -9,7 +9,7 @@
   pythonOlder,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "regional";
   version = "1.1.2";
   format = "setuptools";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "freeman-lab";
-    repo = pname;
+    repo = "regional";
     rev = "e3a29c58982e5cd3d5700131ac96e5e0b84fb981"; # no tags in repo
     hash = "sha256-u88v9H9RZ9cgtSat73QEnHr3gZGL8DmBZ0XphMuoDw8=";
   };

--- a/pkgs/development/python-modules/releases/default.nix
+++ b/pkgs/development/python-modules/releases/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bitprophet";
-    repo = pname;
+    repo = "releases";
     rev = version;
     hash = "sha256-IgEKAUk97R3ZvqvexD/ptT8i0uf48K+DKkk4q3pn3G8=";
   };

--- a/pkgs/development/python-modules/reolink/default.nix
+++ b/pkgs/development/python-modules/reolink/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "fwestenberg";
-    repo = pname;
+    repo = "reolink";
     tag = "v${version}";
     hash = "sha256-DZcTfmzO9rBhhRN2RkgoPwUPE+LPPeZgc8kmhYU9V2I=";
   };

--- a/pkgs/development/python-modules/requests-credssp/default.nix
+++ b/pkgs/development/python-modules/requests-credssp/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jborean93";
-    repo = pname;
+    repo = "requests-credssp";
     rev = "v${version}";
     hash = "sha256-HHLEmQ+mNjMjpR6J+emrKFM+2PiYq32o7Gnoo0gUrNA=";
   };

--- a/pkgs/development/python-modules/requests-http-signature/default.nix
+++ b/pkgs/development/python-modules/requests-http-signature/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pyauth";
-    repo = pname;
+    repo = "requests-http-signature";
     rev = "v${version}";
     hash = "sha256-sW2vYqT/nY27DvEKHdptc3dUpuqKmD7PLMs+Xp+cpeU=";
   };

--- a/pkgs/development/python-modules/requests-kerberos/default.nix
+++ b/pkgs/development/python-modules/requests-kerberos/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "requests";
-    repo = pname;
+    repo = "requests-kerberos";
     rev = "v${version}";
     hash = "sha256-s1Q3zqKPSuTkiFExr+axai9Eta1xjw/cip8xzfDGR88=";
   };

--- a/pkgs/development/python-modules/resampy/default.nix
+++ b/pkgs/development/python-modules/resampy/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bmcfee";
-    repo = pname;
+    repo = "resampy";
     tag = version;
     hash = "sha256-LOWpOPAEK+ga7c3bR15QvnHmON6ARS1Qee/7U/VMlTY=";
   };

--- a/pkgs/development/python-modules/responses/default.nix
+++ b/pkgs/development/python-modules/responses/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "getsentry";
-    repo = pname;
+    repo = "responses";
     tag = version;
     hash = "sha256-eiJwu0sRtr3S4yAnbsIak7g03CNqOTS16rNXoXRQumA=";
   };

--- a/pkgs/development/python-modules/retry-decorator/default.nix
+++ b/pkgs/development/python-modules/retry-decorator/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pnpnpn";
-    repo = pname;
+    repo = "retry-decorator";
     tag = "v${version}";
     hash = "sha256-0dZq4YbPcH4ItyMnpF7B20YYLtzwniJClBK9gRndU1M=";
   };

--- a/pkgs/development/python-modules/rfc6555/default.nix
+++ b/pkgs/development/python-modules/rfc6555/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sethmlarson";
-    repo = pname;
+    repo = "rfc6555";
     rev = "v${version}";
     hash = "sha256-Lmwgusc4EQlF0GHmMTUxWzUCjBk19cvurNwbOnT+1jM=";
   };

--- a/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "RIPE-NCC";
-    repo = pname;
+    repo = "ripe-atlas-sagan";
     rev = "v${version}";
     hash = "sha256-xIBIKsQvDmVBa/C8/7Wr3WKeepHaGhoXlgatXSUtWLA=";
   };

--- a/pkgs/development/python-modules/riscof/default.nix
+++ b/pkgs/development/python-modules/riscof/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "riscv-software-src";
-    repo = pname;
+    repo = "riscof";
     tag = version;
     hash = "sha256-ToI2xI0fvnDR+hJ++T4ss5X3gc4G6Cj1uJHx0m2X7GY=";
   };

--- a/pkgs/development/python-modules/riscv-isac/default.nix
+++ b/pkgs/development/python-modules/riscv-isac/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "riscv-software-src";
-    repo = pname;
+    repo = "riscv-isac";
     tag = version;
     hash = "sha256-7CWUyYwzynFq/Qk5SzQB+ljsVVI98kPPDT63Emhqihw=";
   };

--- a/pkgs/development/python-modules/robotframework-requests/default.nix
+++ b/pkgs/development/python-modules/robotframework-requests/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "MarketSquare";
-    repo = pname;
+    repo = "robotframework-requests";
     tag = "v${version}";
     hash = "sha256-NRhf3delcqUw9vWRPL6pJzpcmRMDou2pHmUHMstF8hw=";
   };

--- a/pkgs/development/python-modules/rpi-bad-power/default.nix
+++ b/pkgs/development/python-modules/rpi-bad-power/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage {
 
   src = fetchFromGitHub {
     owner = "shenxn";
-    repo = pname;
+    repo = "rpi-bad-power";
     rev = "v${version}";
     hash = "sha256:1yvfz28blq4fdnn614n985vbs5hcw1gm3i9am53k410sfs7ilvkk";
   };

--- a/pkgs/development/python-modules/rtoml/default.nix
+++ b/pkgs/development/python-modules/rtoml/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "samuelcolvin";
-    repo = pname;
+    repo = "rtoml";
     rev = "v${version}";
     hash = "sha256-1movtKMQkQ6PEpKpSkK0Oy4AV0ee7XrS0P9m6QwZTaM=";
   };

--- a/pkgs/development/python-modules/ruffus/default.nix
+++ b/pkgs/development/python-modules/ruffus/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cgat-developers";
-    repo = pname;
+    repo = "ruffus";
     rev = "v${version}";
     sha256 = "0fnzpchwwqsy5h18fs0n90s51w25n0dx0l74j0ka6lvhjl5sxn4c";
   };

--- a/pkgs/development/python-modules/rxv/default.nix
+++ b/pkgs/development/python-modules/rxv/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "wuub";
-    repo = pname;
+    repo = "rxv";
     rev = "v${version}";
     sha256 = "0jldnlzbfg5jm1nbgv91mlvcqkswd9f2n3qj9aqlbmj1cxq19yz8";
   };


### PR DESCRIPTION
Repeat of https://github.com/NixOS/nixpkgs/pull/410679, this time limited to `pkgs/development/python-modules/[j-rJ-R]`, part of https://github.com/NixOS/nixpkgs/issues/346453

Should be zero rebuilds.

All candidates were made using:

```shell
#!/usr/bin/env nix-shell
#!nix-shell -I nixpkgs=. --pure -i bash -p ripgrep sd jq git git-wait lix util-linux

export NIX_PATH= # no nixpkgs-overlay plz
export NIXPKGS_ALLOW_UNFREE=1
export NIXPKGS_ALLOW_INSECURE=1
export NIXPKGS_ALLOW_BROKEN=1

git-wait restore .

test -s packages.json || ( set -x;
  time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --drv-path --out-path --show-trace --no-allow-import-from-derivation --arg config '{ allowAliases = false; }' > packages.json
)

list_attrpath_fname_col() {
    jq <packages.json 'to_entries[] | select(.value.meta.position==null|not) | "\(.key)\t\(.value.meta.position)"' -r |
        sed -e "s#\t$(realpath .)/#\t#" |
        sed -e 's#:\([0-9]*\)$#\t\1#' |
        grep . |
        grep -iv haskell |
        grep -iv /top-level/ |
        grep -iv chicken |
        grep -E 'pkgs/development/python-modules/[j-rJ-R]' |
        grep -iv build |
        grep -E '/(package|default)\.nix'
}

while read attrpath fname col; do
    grep -qE 'repo *= *("\$\{pname\}"|pname);' "$fname" || continue

    echo | (

        echo "$attrpath"
        data="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)" || exit
        test -n "$data" || exit
        pname="$(jq <<<"$data" .pname -r)"
        test -n "$pname" || exit

        (set -x
            sd -F '${pname}'  "$pname"         "$fname"
            sd -F ' = pname;' " = \"$pname\";" "$fname"
        )

        data2="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)"
        if [[ "$data" = "$data2" ]]; then
            (set -x; git-wait add "$fname")
        else
            (set -x; git-wait restore "$fname")
            exit
        fi

        (set -x
            sd -F ' rec {' ' {' "$fname"
        )

        data3="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json 2>/dev/null)"

        if [[ "$data" = "$data3" ]]; then
            (set -x; git-wait add "$fname")
        else
            (set -x; git-wait restore "$fname")
        fi

    )

done < <(list_attrpath_fname_col)

git restore .

time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --drv-path --out-path --show-trace --no-allow-import-from-derivation --arg config '{ allowAliases = false; }' > packages2.json
```

`diff packages{,2}.json` is empty, indicating that no package nor src derivation has changed, nor have i introduced any eval failures. I checked and cherry-picked the changes using `GIT_DIFF_OPTS='-u20' git -c interactive.singleKey=true add --patch` along to some music. I then tested merging against master, staging and staging-next



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
