### PR TITLE
treewide: substitute pname for strings (python3Packages.[s-z0-9_].*)

### DIFF
--- a/pkgs/development/python-modules/sacremoses/default.nix
+++ b/pkgs/development/python-modules/sacremoses/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "alvations";
-    repo = pname;
+    repo = "sacremoses";
     rev = version;
     sha256 = "1gzr56w8yx82mn08wax5m0xyg15ym4ri5l80gmagp8r53443j770";
   };

--- a/pkgs/development/python-modules/sarge/default.nix
+++ b/pkgs/development/python-modules/sarge/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "vsajip";
-    repo = pname;
+    repo = "sarge";
     rev = version;
     hash = "sha256-bT1DbcQi+SbeRBsL7ILuQbSnAj3BBB4+FNl+Zek5xU4=";
   };

--- a/pkgs/development/python-modules/schemainspect/default.nix
+++ b/pkgs/development/python-modules/schemainspect/default.nix
@@ -14,7 +14,7 @@
   postgresql,
   postgresqlTestHook,
 }:
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "schemainspect";
   version = "3.1.1663587362";
   format = "pyproject";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "djrobstep";
-    repo = pname;
+    repo = "schemainspect";
     # no tags on github, version patch number is unix time.
     rev = "066262d6fb4668f874925305a0b7dbb3ac866882";
     hash = "sha256-SYpQQhlvexNc/xEgSIk8L8J+Ta+3OZycGLeZGQ6DWzk=";

--- a/pkgs/development/python-modules/scikit-learn-extra/default.nix
+++ b/pkgs/development/python-modules/scikit-learn-extra/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "scikit-learn-contrib";
-    repo = pname;
+    repo = "scikit-learn-extra";
     tag = "v${version}";
     sha256 = "sha256-dHOwo6NIuhcvIehpuJQ621JEg5O3mnXycAhpTZKaxns=";
   };

--- a/pkgs/development/python-modules/scim2-filter-parser/default.nix
+++ b/pkgs/development/python-modules/scim2-filter-parser/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "15five";
-    repo = pname;
+    repo = "scim2-filter-parser";
     tag = version;
     hash = "sha256-KmtOtI/5HT0lVwvXQFTlEwMeptoa4cA5hTSgSULxhIc=";
   };

--- a/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
+++ b/pkgs/development/python-modules/scrapy-fake-useragent/default.nix
@@ -12,7 +12,7 @@
   scrapy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "scrapy-fake-useragent";
   version = "1.4.4";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   # PyPi tarball is corrupted
   src = fetchFromGitHub {
     owner = "alecxe";
-    repo = pname;
+    repo = "scrapy-fake-useragent";
     rev = "59c20d38c58c76618164760d546aa5b989a79b8b"; # no tags
     hash = "sha256-khQMOQrrdHokvNqfaMWqXV7AzwGxTuxaLsZoLkNpZ3k=";
   };

--- a/pkgs/development/python-modules/screeninfo/default.nix
+++ b/pkgs/development/python-modules/screeninfo/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "rr-";
-    repo = pname;
+    repo = "screeninfo";
     tag = version;
     hash = "sha256-TEy4wff0eRRkX98yK9054d33Tm6G6qWrd9Iv+ITcFmA=";
   };

--- a/pkgs/development/python-modules/sdds/default.nix
+++ b/pkgs/development/python-modules/sdds/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pylhc";
-    repo = pname;
+    repo = "sdds";
     tag = "v${version}";
     hash = "sha256-h1gEqzmKCUr8+w3Fv8lv35/0itZwela//AQsD3u0UJA=";
   };

--- a/pkgs/development/python-modules/seatconnect/default.nix
+++ b/pkgs/development/python-modules/seatconnect/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "farfar";
-    repo = pname;
+    repo = "seatconnect";
     tag = version;
     hash = "sha256-HITVrI0o94a61gy/TYSGFtLBYX4Rw/dK1o2/KsvHLTQ=";
   };

--- a/pkgs/development/python-modules/segyio/default.nix
+++ b/pkgs/development/python-modules/segyio/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "equinor";
-    repo = pname;
+    repo = "segyio";
     tag = "v${version}";
     hash = "sha256-+N2JvHBxpdbysn4noY/9LZ4npoQ9143iFEzaxoafnms=";
   };

--- a/pkgs/development/python-modules/sensor-state-data/default.nix
+++ b/pkgs/development/python-modules/sensor-state-data/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Bluetooth-Devices";
-    repo = pname;
+    repo = "sensor-state-data";
     tag = "v${version}";
     hash = "sha256-9GdBKUhueis8pnQP5ZNxvEyRXVGINTueVzLOR4xx5mU=";
   };

--- a/pkgs/development/python-modules/serialio/default.nix
+++ b/pkgs/development/python-modules/serialio/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tiagocoutinho";
-    repo = pname;
+    repo = "serialio";
     tag = "v${version}";
     hash = "sha256-9TRGT0wpoRRcHqnH1XzlMBh0IcVzdEcOzN7hkeYnoW4=";
   };

--- a/pkgs/development/python-modules/serializable/default.nix
+++ b/pkgs/development/python-modules/serializable/default.nix
@@ -7,14 +7,14 @@
   typechecks,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "serializable";
   version = "unstable-2023-07-13";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "iskandr";
-    repo = pname;
+    repo = "serializable";
     # See https://github.com/iskandr/serializable/issues/7. As of 2023-07-13,
     # they do no have version tags.
     rev = "ed309a6f8f2590b525fc0f93c00549223c8c944f";

--- a/pkgs/development/python-modules/servefile/default.nix
+++ b/pkgs/development/python-modules/servefile/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sebageek";
-    repo = pname;
+    repo = "servefile";
     tag = "v${version}";
     hash = "sha256-hIqXwhmvstCslsCO973oK5FF2c8gZJ0wNUI/z8W+OjU=";
   };

--- a/pkgs/development/python-modules/service-identity/default.nix
+++ b/pkgs/development/python-modules/service-identity/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pyca";
-    repo = pname;
+    repo = "service-identity";
     tag = version;
     hash = "sha256-onxCUWqGVeenLqB5lpUpj3jjxTM61ogXCQOGnDnClT4=";
   };

--- a/pkgs/development/python-modules/setuptools-odoo/default.nix
+++ b/pkgs/development/python-modules/setuptools-odoo/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "acsone";
-    repo = pname;
+    repo = "setuptools-odoo";
     tag = version;
     hash = "sha256-38YlkDH/PuJ1yvQ43OYmdnRd1SGJULv6fC/+fitLDJ8=";
   };

--- a/pkgs/development/python-modules/seventeentrack/default.nix
+++ b/pkgs/development/python-modules/seventeentrack/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "McSwindler";
-    repo = pname;
+    repo = "seventeentrack";
     rev = version;
     hash = "sha256-vMdRXcd0es/LjgsVyWItSLFzlSTEa3oaA6lr/NL4i8U=";
   };

--- a/pkgs/development/python-modules/sharkiq/default.nix
+++ b/pkgs/development/python-modules/sharkiq/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "JeffResc";
-    repo = pname;
+    repo = "sharkiq";
     tag = "v${version}";
     hash = "sha256-adSBFH5nGVPo7OBMak6rN5HA5uMKZCqnIVXBnR7REgQ=";
   };

--- a/pkgs/development/python-modules/shellingham/default.nix
+++ b/pkgs/development/python-modules/shellingham/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sarugaku";
-    repo = pname;
+    repo = "shellingham";
     tag = version;
     hash = "sha256-xeBo3Ok+XPrHN4nQd7M8/11leSV/8z1f7Sj33+HFVtQ=";
   };

--- a/pkgs/development/python-modules/showit/default.nix
+++ b/pkgs/development/python-modules/showit/default.nix
@@ -7,14 +7,14 @@
   pytest,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "showit";
   version = "1.1.4";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "freeman-lab";
-    repo = pname;
+    repo = "showit";
     rev = "ef76425797c71fbe3795b4302c49ab5be6b0bacb"; # no tags in repo
     sha256 = "0xd8isrlwwxlgji90lly1sq4l2a37rqvhsmyhv7bd3aj1dyjmdr6";
   };

--- a/pkgs/development/python-modules/shutilwhich/default.nix
+++ b/pkgs/development/python-modules/shutilwhich/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mbr";
-    repo = pname;
+    repo = "shutilwhich";
     rev = version;
     sha256 = "05fwcjn86w8wprck04iv1zccfi39skdf0lhwpb4b9gpvklyc9mj0";
   };

--- a/pkgs/development/python-modules/simber/default.nix
+++ b/pkgs/development/python-modules/simber/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "deepjyoti30";
-    repo = pname;
+    repo = "simber";
     tag = version;
     hash = "sha256-kHoFZD7nhVxJu9MqePLkL7KTG2saPecY9238c/oeEco=";
   };

--- a/pkgs/development/python-modules/simplehound/default.nix
+++ b/pkgs/development/python-modules/simplehound/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "robmarkcole";
-    repo = pname;
+    repo = "simplehound";
     rev = "v${version}";
     sha256 = "1b5m3xjmk0l6ynf0yvarplsfsslgklalfcib7sikxg3v5hiv9qwh";
   };

--- a/pkgs/development/python-modules/simplejson/default.nix
+++ b/pkgs/development/python-modules/simplejson/default.nix
@@ -15,8 +15,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "simplejson";
+    repo = "simplejson";
     tag = "v${version}";
     hash = "sha256-wE/jqBMXVtmbc/78X4lgfvuj074CrzfLJL1CM6LCfas=";
   };

--- a/pkgs/development/python-modules/single-version/default.nix
+++ b/pkgs/development/python-modules/single-version/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hongquan";
-    repo = pname;
+    repo = "single-version";
     tag = "v${version}";
     hash = "sha256-dUmJhNCPuq/7WGzFQXLjb8JrQgQn7qyBqzPWaKzD9hc=";
   };

--- a/pkgs/development/python-modules/skrl/default.nix
+++ b/pkgs/development/python-modules/skrl/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Toni-SM";
-    repo = pname;
+    repo = "skrl";
     tag = version;
     hash = "sha256-5lkoYAmMIWqK3+E3WxXMWS9zal2DhZkfl30EkrHKpdI=";
   };

--- a/pkgs/development/python-modules/skytemple-eventserver/default.nix
+++ b/pkgs/development/python-modules/skytemple-eventserver/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
-    repo = pname;
+    repo = "skytemple-eventserver";
     rev = version;
     hash = "sha256-PWLGPORNprTfG+jgXI1sxyVkRTwSEib4SZhPdOBchwE=";
   };

--- a/pkgs/development/python-modules/skytemple-icons/default.nix
+++ b/pkgs/development/python-modules/skytemple-icons/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
-    repo = pname;
+    repo = "skytemple-icons";
     rev = version;
     sha256 = "0wagdvzks9irdl5lj8sfqkkvfwwmdpvjyzx6424shvpp5mk28dcv";
   };

--- a/pkgs/development/python-modules/slicedimage/default.nix
+++ b/pkgs/development/python-modules/slicedimage/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "spacetx";
-    repo = pname;
+    repo = "slicedimage";
     rev = version;
     sha256 = "1vpg8varvfx0nj6xscdfm7m118hzsfz7qfzn28r9rsfvrhr0dlcw";
   };

--- a/pkgs/development/python-modules/smbus2/default.nix
+++ b/pkgs/development/python-modules/smbus2/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "kplindegaard";
-    repo = pname;
+    repo = "smbus2";
     tag = version;
     hash = "sha256-3ZAjviVLO/c27NzrPcWf6RlZYclYkmUmOskTP9TVbNM=";
   };

--- a/pkgs/development/python-modules/snakemake-executor-plugin-cluster-generic/default.nix
+++ b/pkgs/development/python-modules/snakemake-executor-plugin-cluster-generic/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "snakemake";
-    repo = pname;
+    repo = "snakemake-executor-plugin-cluster-generic";
     tag = "v${version}";
     hash = "sha256-RHMefoJOZb6TjRsFCORLFdHtI5ZpTsV6CHrjHKMat9o=";
   };

--- a/pkgs/development/python-modules/snakemake-interface-logger-plugins/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-logger-plugins/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "snakemake";
-    repo = pname;
+    repo = "snakemake-interface-logger-plugins";
     tag = "v${version}";
     hash = "sha256-VHbta+R2a/K2L03IRu/Ya7dJzshIAvyK9cNIRbx8QqM=";
   };

--- a/pkgs/development/python-modules/snakemake-interface-report-plugins/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-report-plugins/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "snakemake";
-    repo = pname;
+    repo = "snakemake-interface-report-plugins";
     tag = "v${version}";
     hash = "sha256-yk2fYlueaobXJgF7ob6jTccEz8r0geq1HFVsa+ZO30Q=";
   };

--- a/pkgs/development/python-modules/snakemake-interface-storage-plugins/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-storage-plugins/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "snakemake";
-    repo = pname;
+    repo = "snakemake-interface-storage-plugins";
     tag = "v${version}";
     hash = "sha256-mGpKmKWWL4ue9Dddjs4fXCaITrC97yHC58Jh2vclXAY=";
   };

--- a/pkgs/development/python-modules/snakemake-storage-plugin-fs/default.nix
+++ b/pkgs/development/python-modules/snakemake-storage-plugin-fs/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "snakemake";
-    repo = pname;
+    repo = "snakemake-storage-plugin-fs";
     tag = "v${version}";
     hash = "sha256-Y+Fofz4D/CWgdG3lOneadRu/VfJ23D4Dz751j9rUKNo=";
   };

--- a/pkgs/development/python-modules/snakemake-storage-plugin-xrootd/default.nix
+++ b/pkgs/development/python-modules/snakemake-storage-plugin-xrootd/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "snakemake";
-    repo = pname;
+    repo = "snakemake-storage-plugin-xrootd";
     tag = "v${version}";
     hash = "sha256-vfMAgOTmT3uzUZHXeKsd8Ze3+b3nFsVHDhkPG+xvz+k=";
   };

--- a/pkgs/development/python-modules/snorkel/default.nix
+++ b/pkgs/development/python-modules/snorkel/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage {
 
   src = fetchFromGitHub {
     owner = "snorkel-team";
-    repo = pname;
+    repo = "snorkel";
     tag = "v${version}";
     hash = "sha256-1DgkMHYToiI3266yCND1bXiui80x8AaBttxM83kJImw=";
   };

--- a/pkgs/development/python-modules/snuggs/default.nix
+++ b/pkgs/development/python-modules/snuggs/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   # Pypi doesn't ship the tests, so we fetch directly from GitHub
   src = fetchFromGitHub {
     owner = "mapbox";
-    repo = pname;
+    repo = "snuggs";
     rev = version;
     sha256 = "1p3lh9s2ylsnrzbs931y2vn7mp2y2xskgqmh767c9l1a33shfgwf";
   };

--- a/pkgs/development/python-modules/socialscan/default.nix
+++ b/pkgs/development/python-modules/socialscan/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "iojw";
-    repo = pname;
+    repo = "socialscan";
     tag = "v${version}";
     hash = "sha256-4JJVhB6x1NGagtfzE03Jae2GOr25hh+4l7gQ23zc7Ck=";
   };

--- a/pkgs/development/python-modules/sockio/default.nix
+++ b/pkgs/development/python-modules/sockio/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tiagocoutinho";
-    repo = pname;
+    repo = "sockio";
     tag = "v${version}";
     hash = "sha256-NSGd7/k1Yr408dipMNBSPRSwQ+wId7VLxgqMM/UmN/Q=";
   };

--- a/pkgs/development/python-modules/solo-python/default.nix
+++ b/pkgs/development/python-modules/solo-python/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "solokeys";
-    repo = pname;
+    repo = "solo-python";
     rev = version;
     hash = "sha256-XVPYr7JwxeZfZ68+vQ7a7MNiAfJ2bvMbM3R1ryVJ+OU=";
   };

--- a/pkgs/development/python-modules/sparklines/default.nix
+++ b/pkgs/development/python-modules/sparklines/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "deeplook";
-    repo = pname;
+    repo = "sparklines";
     tag = "v${version}";
     sha256 = "sha256-oit1bDqP96wwfTRCV8V0N9P/+pkdW2WYOWT6u3lb4Xs=";
   };

--- a/pkgs/development/python-modules/sphinx-fortran/default.nix
+++ b/pkgs/development/python-modules/sphinx-fortran/default.nix
@@ -9,14 +9,14 @@
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "sphinx-fortran";
   version = "unstable-2022-03-02";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "VACUMM";
-    repo = pname;
+    repo = "sphinx-fortran";
     rev = "394ae990b43ed43fcff8beb048632f5e99794264";
     hash = "sha256-IVKu5u9gqs7/9EZrf4ZYd12K6J31u+/B8kk4+8yfohM=";
   };

--- a/pkgs/development/python-modules/sphinx-pytest/default.nix
+++ b/pkgs/development/python-modules/sphinx-pytest/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "chrisjsewell";
-    repo = pname;
+    repo = "sphinx-pytest";
     tag = "v${version}";
     hash = "sha256-oSBBt+hSMs4mvGqibQHoYHXr2j/bpsGOnIMfwfTfWKQ=";
   };

--- a/pkgs/development/python-modules/sqlalchemy-views/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-views/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    repo = pname;
+    repo = "sqlalchemy-views";
     owner = "jklukas";
     tag = "v${version}";
     hash = "sha256-MJgikWXo3lpMsSYbb5sOSOTbJPOx5gEghW1V9jKvHKU=";

--- a/pkgs/development/python-modules/sqlbag/default.nix
+++ b/pkgs/development/python-modules/sqlbag/default.nix
@@ -17,14 +17,14 @@
   postgresql,
   postgresqlTestHook,
 }:
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "sqlbag";
   version = "0.1.1617247075";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "djrobstep";
-    repo = pname;
+    repo = "sqlbag";
     # no tags on github, version patch number is unix time.
     rev = "eaaeec4158ffa139fba1ec30d7887f4d836f4120";
     hash = "sha256-lipgnkqrzjzqwbhtVcWDQypBNzq6Dct/qoM8y/FNiNs=";

--- a/pkgs/development/python-modules/sqlite-fts4/default.nix
+++ b/pkgs/development/python-modules/sqlite-fts4/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "simonw";
-    repo = pname;
+    repo = "sqlite-fts4";
     tag = version;
     hash = "sha256-Ibiows3DSnzjIUv7U9tYNVnDaecBBxjXzDqxbIlNhhU=";
   };

--- a/pkgs/development/python-modules/sqltrie/default.nix
+++ b/pkgs/development/python-modules/sqltrie/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "iterative";
-    repo = pname;
+    repo = "sqltrie";
     tag = version;
     hash = "sha256-D1vYXyh/i0wy7sttW117vsMbUlQJ/mq7rlxLMJWoki0=";
   };

--- a/pkgs/development/python-modules/squarify/default.nix
+++ b/pkgs/development/python-modules/squarify/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "laserson";
-    repo = pname;
+    repo = "squarify";
     tag = "v${version}";
     hash = "sha256-zSv+6xT9H4WyShRnwjjcNMjY19AFlQ6bw9Mh9p2rL08=";
   };

--- a/pkgs/development/python-modules/srvlookup/default.nix
+++ b/pkgs/development/python-modules/srvlookup/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "gmr";
-    repo = pname;
+    repo = "srvlookup";
     tag = version;
     hash = "sha256-iXbi25HsoNX0hnhwZoFik5ddlJ7i+xml3HGaezj3jgY=";
   };

--- a/pkgs/development/python-modules/stanza/default.nix
+++ b/pkgs/development/python-modules/stanza/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "stanfordnlp";
-    repo = pname;
+    repo = "stanza";
     tag = "v${version}";
     hash = "sha256-0uqEyiY+gX9P2r2H+qF4t8OUUumjikBZjk4psFf9l30=";
   };

--- a/pkgs/development/python-modules/staticjinja/default.nix
+++ b/pkgs/development/python-modules/staticjinja/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   # No tests in pypi
   src = fetchFromGitHub {
     owner = "staticjinja";
-    repo = pname;
+    repo = "staticjinja";
     rev = version;
     hash = "sha256-LfJTQhZtnTOm39EWF1m2MP5rxz/5reE0G1Uk9L7yx0w=";
   };

--- a/pkgs/development/python-modules/statmake/default.nix
+++ b/pkgs/development/python-modules/statmake/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "daltonmaag";
-    repo = pname;
+    repo = "statmake";
     tag = "v${version}";
     hash = "sha256-3BZ71JVvj7GCojM8ycu160viPj8BLJ1SiW86Df2fzsw=";
   };

--- a/pkgs/development/python-modules/stemming/default.nix
+++ b/pkgs/development/python-modules/stemming/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage {
   # Pypi source package doesn't contain tests
   src = fetchFromGitHub {
     owner = "nmstoker";
-    repo = pname;
+    repo = "stemming";
     rev = "477d0e354e79843f5ec241ba3603bcb5b843c3c4";
     hash = "sha256-wnmBCbxnCZ9mN1J7sLcN7OynMcvqgAnhEgpAwW2/xz4=";
   };

--- a/pkgs/development/python-modules/stopit/default.nix
+++ b/pkgs/development/python-modules/stopit/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   # tests are missing from the PyPi tarball
   src = fetchFromGitHub {
     owner = "glenfant";
-    repo = pname;
+    repo = "stopit";
     rev = version;
     hash = "sha256-uXJUA70JOGWT2NmS6S7fPrTWAJZ0mZ/hICahIUzjfbw=";
   };

--- a/pkgs/development/python-modules/sumtypes/default.nix
+++ b/pkgs/development/python-modules/sumtypes/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "radix";
-    repo = pname;
+    repo = "sumtypes";
     rev = version;
     hash = "sha256-qwQyFKVnGEqHUqFmUSnHVvedsp2peM6rJZcS90paLOo=";
   };

--- a/pkgs/development/python-modules/sybil/default.nix
+++ b/pkgs/development/python-modules/sybil/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "simplistix";
-    repo = pname;
+    repo = "sybil";
     tag = version;
     hash = "sha256-ov8b8NPBbiqB/pcKgdD2D+xNSxUM1uGK8EP+20K7eGQ=";
   };

--- a/pkgs/development/python-modules/syncer/default.nix
+++ b/pkgs/development/python-modules/syncer/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "miyakogi";
-    repo = pname;
+    repo = "syncer";
     rev = "v${version}";
     sha256 = "sha256-3EYWy6LuZ/3i+9d0QaclCqWMMw5O3WzhTY3LUL5iMso=";
   };

--- a/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
+++ b/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "easypost";
-    repo = pname;
+    repo = "syslog-rfc5424-formatter";
     tag = "v${version}";
     hash = "sha256-dvRSOMXRmZf0vEEyX6H7OBSfo/PgyOLKuDS8X6g4qe0=";
   };

--- a/pkgs/development/python-modules/sysrsync/default.nix
+++ b/pkgs/development/python-modules/sysrsync/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "gchamon";
-    repo = pname;
+    repo = "sysrsync";
     tag = version;
     hash = "sha256-2Sz3JrNmIGOnad+qjRzbAgsFEzDtwBT0KLEFyQKZra4=";
   };

--- a/pkgs/development/python-modules/tahoma-api/default.nix
+++ b/pkgs/development/python-modules/tahoma-api/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "philklei";
-    repo = pname;
+    repo = "tahoma-api";
     rev = "v${version}";
     hash = "sha256-YwOKSBlN4lNyS+hfdbQDUq1gc14FBof463ofxtUVLC4=";
   };

--- a/pkgs/development/python-modules/tank-utility/default.nix
+++ b/pkgs/development/python-modules/tank-utility/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "krismolendyke";
-    repo = pname;
+    repo = "tank-utility";
     tag = version;
     hash = "sha256-h9y3X+FSzSFt+bd/chz+x0nocHaKZ8DvreMxAYMs8/E=";
   };

--- a/pkgs/development/python-modules/tcolorpy/default.nix
+++ b/pkgs/development/python-modules/tcolorpy/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "thombashi";
-    repo = pname;
+    repo = "tcolorpy";
     tag = "v${version}";
     hash = "sha256-0AXpwRQgBisO4360J+Xd4+EWzDtDJ64UpSUmDnSYjKE=";
   };

--- a/pkgs/development/python-modules/tensorly/default.nix
+++ b/pkgs/development/python-modules/tensorly/default.nix
@@ -17,8 +17,8 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
+    owner = "tensorly";
+    repo = "tensorly";
     tag = version;
     hash = "sha256-A6Zlp8fa7XFgf4qpg7SEtNLlYSNtDGLuRUEfzD+crQc=";
   };

--- a/pkgs/development/python-modules/termgraph/default.nix
+++ b/pkgs/development/python-modules/termgraph/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "mkaz";
-    repo = pname;
+    repo = "termgraph";
     tag = "v${version}";
     hash = "sha256-0J9mEpDIdNEYwO+A+HBOaSw+Ct+HsbSPwGQYuYH6NN8=";
   };

--- a/pkgs/development/python-modules/termplotlib/default.nix
+++ b/pkgs/development/python-modules/termplotlib/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nschloe";
-    repo = pname;
+    repo = "termplotlib";
     rev = "v${version}";
     sha256 = "1qfrv2w7vb2bbjvd5lqfq57c23iqkry0pwmif1ha3asmz330rja1";
   };

--- a/pkgs/development/python-modules/tesla-wall-connector/default.nix
+++ b/pkgs/development/python-modules/tesla-wall-connector/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "einarhauks";
-    repo = pname;
+    repo = "tesla-wall-connector";
     rev = version;
     hash = "sha256-GblKXWV9h37E3bxNsx17hEe0uDm8ahzJUx8wiE+Vc38=";
   };

--- a/pkgs/development/python-modules/test-tube/default.nix
+++ b/pkgs/development/python-modules/test-tube/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "williamFalcon";
-    repo = pname;
+    repo = "test-tube";
     rev = version;
     sha256 = "0w60xarmcw06gc4002sy7bjfykdz34gbgniswxkl0lw8a1v0xn2m";
   };

--- a/pkgs/development/python-modules/testbook/default.nix
+++ b/pkgs/development/python-modules/testbook/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nteract";
-    repo = pname;
+    repo = "testbook";
     rev = version;
     hash = "sha256-qaDgae/5TRpjmjOf7aom7TC5HLHp0PHM/ds47AKtq8U=";
   };

--- a/pkgs/development/python-modules/threadpoolctl/default.nix
+++ b/pkgs/development/python-modules/threadpoolctl/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "joblib";
-    repo = pname;
+    repo = "threadpoolctl";
     tag = version;
     hash = "sha256-yICErKIHc9XKiWg9C9EH0il9zhbbkGntw6mlYDibr9g=";
   };

--- a/pkgs/development/python-modules/threat9-test-bed/default.nix
+++ b/pkgs/development/python-modules/threat9-test-bed/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "threat9";
-    repo = pname;
+    repo = "threat9-test-bed";
     rev = "v${version}";
     hash = "sha256-0YSjMf2gDdrvkDaT77iwfCkiDDXKHnZyI8d7JmBSuCg=";
   };

--- a/pkgs/development/python-modules/throttler/default.nix
+++ b/pkgs/development/python-modules/throttler/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "uburuntu";
-    repo = pname;
+    repo = "throttler";
     tag = "v${version}";
     hash = "sha256-fE35zPjBUn4e1VRkkIUMtYJ/+LbnUxnxyfnU+UEPwr4=";
   };

--- a/pkgs/development/python-modules/tikzplotlib/default.nix
+++ b/pkgs/development/python-modules/tikzplotlib/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "nschloe";
-    repo = pname;
+    repo = "tikzplotlib";
     rev = "v${version}";
     hash = "sha256-PLExHhEnxkEiXsE0rqvpNWwVZ+YoaDa2BTx8LktdHl0=";
   };

--- a/pkgs/development/python-modules/timeago/default.nix
+++ b/pkgs/development/python-modules/timeago/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hustcc";
-    repo = pname;
+    repo = "timeago";
     rev = version;
     sha256 = "sha256-PqORJKAVrjezU/yP2ky3gb1XsM8obDI3GQzi+mok/OM=";
   };

--- a/pkgs/development/python-modules/timeslot/default.nix
+++ b/pkgs/development/python-modules/timeslot/default.nix
@@ -7,14 +7,14 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "timeslot";
   version = "0.1.2";
 
   # pypi distribution doesn't include tests, so build from source instead
   src = fetchFromGitHub {
     owner = "ErikBjare";
-    repo = pname;
+    repo = "timeslot";
     rev = "af35445e96cbb2f3fb671a75aac6aa93e4e7e7a6";
     sha256 = "sha256-GEhg2iMsYMfalT7L9TCd1KHU6oa/wTl5m3mRC0zOH9Q=";
   };

--- a/pkgs/development/python-modules/timetagger/default.nix
+++ b/pkgs/development/python-modules/timetagger/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "almarklein";
-    repo = pname;
+    repo = "timetagger";
     tag = "v${version}";
     hash = "sha256-YzMVjIsi7MGIwt828xE3FYobrh9CUz5FqCIogXjmOcM=";
   };

--- a/pkgs/development/python-modules/tmb/default.nix
+++ b/pkgs/development/python-modules/tmb/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "alemuro";
-    repo = pname;
+    repo = "tmb";
     rev = version;
     hash = "sha256-XuRhRmeTXAplb14UwISyzaqEIrFeg8/aCdMxUccMUos=";
   };

--- a/pkgs/development/python-modules/token-bucket/default.nix
+++ b/pkgs/development/python-modules/token-bucket/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "falconry";
-    repo = pname;
+    repo = "token-bucket";
     tag = version;
     hash = "sha256-dazqJRpC8FUHOhgKFzDnIl5CT2L74J2o2Hsm0IQf4Cg=";
   };

--- a/pkgs/development/python-modules/tokenize-rt/default.nix
+++ b/pkgs/development/python-modules/tokenize-rt/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "asottile";
-    repo = pname;
+    repo = "tokenize-rt";
     rev = "v${version}";
     hash = "sha256-7ykczY73KkqR99tYLL/5bgr9bqU444qHs2ONz+ldVyg=";
   };

--- a/pkgs/development/python-modules/tokentrim/default.nix
+++ b/pkgs/development/python-modules/tokentrim/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "KillianLucas";
-    repo = pname;
+    repo = "tokentrim";
     tag = "v${version}";
     hash = "sha256-zr2SLT3MBuMD98g9fdS0mLuijcssRQ/S3+tCq2Cw1/4=";
   };

--- a/pkgs/development/python-modules/tomli/default.nix
+++ b/pkgs/development/python-modules/tomli/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "hukkin";
-    repo = pname;
+    repo = "tomli";
     rev = version;
     hash = "sha256-4MWp9pPiUZZkjvGXzw8/gDele743NBj8uG4jvK2ohUM=";
   };

--- a/pkgs/development/python-modules/trackpy/default.nix
+++ b/pkgs/development/python-modules/trackpy/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "soft-matter";
-    repo = pname;
+    repo = "trackpy";
     tag = "v${version}";
     hash = "sha256-6i1IfdxgV6bpf//mXATpnsQ0zN26S8rlL0/1ql68sd8=";
   };

--- a/pkgs/development/python-modules/traittypes/default.nix
+++ b/pkgs/development/python-modules/traittypes/default.nix
@@ -11,7 +11,7 @@
   traitlets,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "traittypes";
   version = "0.2.1-unstable-2020-07-17";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "jupyter-widgets";
-    repo = pname;
+    repo = "traittypes";
     rev = "af2ebeec9e58b73a12d4cf841bd506d6eadb8868";
     hash = "sha256-q7kt8b+yDHsWML/wCeND9PrZMVjemhzG7Ih1OtHbnTw=";
   };

--- a/pkgs/development/python-modules/transforms3d/default.nix
+++ b/pkgs/development/python-modules/transforms3d/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "matthew-brett";
-    repo = pname;
+    repo = "transforms3d";
     tag = version;
     hash = "sha256-9wICu7zNYF54e6xcDpZxqctB4GVu5Knf79Z36016Rpw=";
   };

--- a/pkgs/development/python-modules/translitcodec/default.nix
+++ b/pkgs/development/python-modules/translitcodec/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage {
 
   src = fetchFromGitHub {
     owner = "claudep";
-    repo = pname;
+    repo = "translitcodec";
     rev = "version-${version}";
     hash = "sha256-/EKquTchx9i3fZqJ6AMzHYP9yCORvwbuUQ95WJQOQbI=";
   };

--- a/pkgs/development/python-modules/treeo/default.nix
+++ b/pkgs/development/python-modules/treeo/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cgarciae";
-    repo = pname;
+    repo = "treeo";
     tag = version;
     hash = "sha256-0py7sKjq6WqdsZwTq61jqaIbULTfwtpz29TTpt8M2Zw=";
   };

--- a/pkgs/development/python-modules/treex/default.nix
+++ b/pkgs/development/python-modules/treex/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cgarciae";
-    repo = pname;
+    repo = "treex";
     tag = version;
     hash = "sha256-ObOnbtAT4SlrwOms1jtn7/XKZorGISGY6VuhQlC3DaQ=";
   };

--- a/pkgs/development/python-modules/trino-python-client/default.nix
+++ b/pkgs/development/python-modules/trino-python-client/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    repo = pname;
+    repo = "trino-python-client";
     owner = "trinodb";
     tag = version;
     hash = "sha256-Nr7p7x5cxxuPv2NUh1uMth97OQ+H2KBlu0SHVJ7Zu1M=";

--- a/pkgs/development/python-modules/troposphere/default.nix
+++ b/pkgs/development/python-modules/troposphere/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cloudtools";
-    repo = pname;
+    repo = "troposphere";
     tag = version;
     hash = "sha256-IqWgqkxJ4EFNt9z58cuCqSTnlbMNi7bFhA04hgQjG8E=";
   };

--- a/pkgs/development/python-modules/ttach/default.nix
+++ b/pkgs/development/python-modules/ttach/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "qubvel";
-    repo = pname;
+    repo = "ttach";
     tag = "v${version}";
     hash = "sha256-R6QO+9hv0eI7dZW5iJf096+LU1q+vnmOpveurgZemPc=";
   };

--- a/pkgs/development/python-modules/ttkbootstrap/default.nix
+++ b/pkgs/development/python-modules/ttkbootstrap/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "israel-dryer";
-    repo = pname;
+    repo = "ttkbootstrap";
     tag = "v${version}";
     hash = "sha256-Pkp45lB1Xeu9ZoLjKS8aSW2By/k3ID1qwMig/jdYHh4=";
   };

--- a/pkgs/development/python-modules/ttp/default.nix
+++ b/pkgs/development/python-modules/ttp/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "dmulyalin";
-    repo = pname;
+    repo = "ttp";
     tag = version;
     hash = "sha256-IWqPFspERBVkjsTYTAkOTOrugq4fD65Q140G3SCEV0w=";
   };

--- a/pkgs/development/python-modules/tuyaha/default.nix
+++ b/pkgs/development/python-modules/tuyaha/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "PaulAnnekov";
-    repo = pname;
+    repo = "tuyaha";
     rev = version;
     hash = "sha256-PTIw/2NRHHiqV6E5oj2pMeGq1uApevKfT2n5zV8AQmM=";
   };

--- a/pkgs/development/python-modules/typechecks/default.nix
+++ b/pkgs/development/python-modules/typechecks/default.nix
@@ -4,14 +4,14 @@
   lib,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "typechecks";
   version = "unstable-2023-07-13";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "openvax";
-    repo = pname;
+    repo = "typechecks";
     # See https://github.com/openvax/typechecks/issues/2. As of 2023-07-13,
     # they do no have version tags.
     rev = "5340b4e8a2f419b3a7aa816a5b19e2e0a6ce0679";

--- a/pkgs/development/python-modules/typesystem/default.nix
+++ b/pkgs/development/python-modules/typesystem/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "encode";
-    repo = pname;
+    repo = "typesystem";
     rev = version;
     hash = "sha256-fjnheHWjIDbJY1iXCRKCpqTCwtUWK9YXbynRCZquQ7c=";
   };

--- a/pkgs/development/python-modules/uarray/default.nix
+++ b/pkgs/development/python-modules/uarray/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Quansight-Labs";
-    repo = pname;
+    repo = "uarray";
     tag = version;
     hash = "sha256-eCrmmP+9TI+T8Km8MOz0EqseneFwPizlnZloK5yNLcM=";
   };

--- a/pkgs/development/python-modules/uasiren/default.nix
+++ b/pkgs/development/python-modules/uasiren/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage {
 
   src = fetchFromGitHub {
     owner = "PaulAnnekov";
-    repo = pname;
+    repo = "uasiren";
     rev = "v${version}";
     hash = "sha256-NHrnG5Vhz+JZgcTJyfIgGz0Ye+3dFVv2zLCCqw2++oM=";
   };

--- a/pkgs/development/python-modules/ukkonen/default.nix
+++ b/pkgs/development/python-modules/ukkonen/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "asottile";
-    repo = pname;
+    repo = "ukkonen";
     rev = "v${version}";
     sha256 = "jG6VP/P5sadrdrmneH36/ExSld9blyMAAG963QS9+p0=";
   };

--- a/pkgs/development/python-modules/unicrypto/default.nix
+++ b/pkgs/development/python-modules/unicrypto/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "skelsec";
-    repo = pname;
+    repo = "unicrypto";
     tag = version;
     hash = "sha256-mZEnYVM5r4utiGwM7bp2SwaDjYsH8AR/Qm5UdPNke0w=";
   };

--- a/pkgs/development/python-modules/unifiled/default.nix
+++ b/pkgs/development/python-modules/unifiled/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "florisvdk";
-    repo = pname;
+    repo = "unifiled";
     rev = "v${version}";
     sha256 = "1nmqxxhwa0isxdb889nhbp7w4axj1mcrwd3pr9d8nhpw4yj9h3vq";
   };

--- a/pkgs/development/python-modules/upnpy/default.nix
+++ b/pkgs/development/python-modules/upnpy/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "5kyc0d3r";
-    repo = pname;
+    repo = "upnpy";
     rev = "v${version}";
     sha256 = "17rqcmmwsl0m4722b1cr74f80kqwq7cgxsy7lq9c88zf6srcgjsf";
   };

--- a/pkgs/development/python-modules/usb-devices/default.nix
+++ b/pkgs/development/python-modules/usb-devices/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Bluetooth-Devices";
-    repo = pname;
+    repo = "usb-devices";
     tag = "v${version}";
     hash = "sha256-Nfdl5oRIdOfAo5PFAJJpadRyu2zeEkmYzxDQxbvpt6c=";
   };

--- a/pkgs/development/python-modules/uvcclient/default.nix
+++ b/pkgs/development/python-modules/uvcclient/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "kk7ds";
-    repo = pname;
+    repo = "uvcclient";
     tag = "v${version}";
     hash = "sha256-V7xIvZ9vIXHPpkEeJZ6QedWk+4ZVNwCzj5ffLyixFz4=";
   };

--- a/pkgs/development/python-modules/vaa/default.nix
+++ b/pkgs/development/python-modules/vaa/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "life4";
-    repo = pname;
+    repo = "vaa";
     tag = "v.${version}";
     hash = "sha256-24GTTJSZ55ejyHoWP1/S3DLTKvOolAJr9UhWoOm84CU=";
   };

--- a/pkgs/development/python-modules/viewstate/default.nix
+++ b/pkgs/development/python-modules/viewstate/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "yuvadm";
-    repo = pname;
+    repo = "viewstate";
     tag = "v${version}";
     sha256 = "sha256-cXT5niE3rNdqmNqnITWy9c9/MF0gZ6LU2i1uzfOzkUI=";
   };

--- a/pkgs/development/python-modules/virtualenv-clone/default.nix
+++ b/pkgs/development/python-modules/virtualenv-clone/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "edwardgeorge";
-    repo = pname;
+    repo = "virtualenv-clone";
     rev = version;
     hash = "sha256-qrN74IwLRqiVPxU8gVhdiM34yBmiS/5ot07uroYPDVw=";
   };

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -235,7 +235,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "vllm-project";
-    repo = pname;
+    repo = "vllm";
     tag = "v${version}";
     hash = "sha256-LiEBkVwJTT4WoCTk9pI0ykTjmv1pDMzksmFwVktoxMY=";
   };

--- a/pkgs/development/python-modules/vulcan-api/default.nix
+++ b/pkgs/development/python-modules/vulcan-api/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "kapi2289";
-    repo = pname;
+    repo = "vulcan-api";
     tag = "v${version}";
     hash = "sha256-oWtyqFacWkKhv4QvbZCuq3KHlM/o7SfENg90O/ygXUw=";
   };

--- a/pkgs/development/python-modules/vxi11/default.nix
+++ b/pkgs/development/python-modules/vxi11/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   # no tests in PyPI tarball
   src = fetchFromGitHub {
     owner = "python-ivi";
-    repo = pname;
+    repo = "python-vxi11";
     rev = "v${version}";
     sha256 = "1xv7chp7rm0vrvbz6q57fpwhlgjz461h08q9zgmkcl2l0w96hmsn";
   };

--- a/pkgs/development/python-modules/wagtail-factories/default.nix
+++ b/pkgs/development/python-modules/wagtail-factories/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    repo = pname;
+    repo = "wagtail-factories";
     owner = "wagtail";
     tag = version;
     sha256 = "sha256-jo8VwrmxHBJnORmuR6eTLrf/eupNL2vhXcw81EzfTxM=";

--- a/pkgs/development/python-modules/warlock/default.nix
+++ b/pkgs/development/python-modules/warlock/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bcwaldon";
-    repo = pname;
+    repo = "warlock";
     tag = version;
     hash = "sha256-HOCLzFYmOL/tCXT+NO/tCZuVXVowNEPP3g33ZYg4+6Q=";
   };

--- a/pkgs/development/python-modules/waterfurnace/default.nix
+++ b/pkgs/development/python-modules/waterfurnace/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sdague";
-    repo = pname;
+    repo = "waterfurnace";
     tag = "v${version}";
     sha256 = "1ba247fw1fvi7zy31zj2wbjq7fajrbxhp139cl9jj67rfvxfv8xf";
   };

--- a/pkgs/development/python-modules/websockify/default.nix
+++ b/pkgs/development/python-modules/websockify/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "novnc";
-    repo = pname;
+    repo = "websockify";
     tag = "v${version}";
     hash = "sha256-b57L4o071zEt/gX9ZVzEpcnp0RCeo3peZrby2mccJgQ=";
   };

--- a/pkgs/development/python-modules/webthing-ws/default.nix
+++ b/pkgs/development/python-modules/webthing-ws/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "home-assistant-ecosystem";
-    repo = pname;
+    repo = "webthing-ws";
     tag = version;
     hash = "sha256-j7nc4yJczDs28RVFDHeQ2ZIG9mIW2m25AAeErVKi4E4=";
   };

--- a/pkgs/development/python-modules/whatthepatch/default.nix
+++ b/pkgs/development/python-modules/whatthepatch/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "cscorley";
-    repo = pname;
+    repo = "whatthepatch";
     tag = version;
     hash = "sha256-0pkkwVo9yaFEZyitfpKMC8EVr8HgPLUkrGWmyYOdZNE=";
   };

--- a/pkgs/development/python-modules/whodap/default.nix
+++ b/pkgs/development/python-modules/whodap/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "pogzyb";
-    repo = pname;
+    repo = "whodap";
     tag = "v${version}";
     hash = "sha256-kw7bmkpDNb/PK/Q2tSbG+ju0G+6tdSy3RaNDaNOVYnE=";
   };

--- a/pkgs/development/python-modules/wifi/default.nix
+++ b/pkgs/development/python-modules/wifi/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "rockymeza";
-    repo = pname;
+    repo = "wifi";
     rev = "v${version}";
     hash = "sha256-scg/DvApvyQZtzDgkHFJzf9gCRfJgBvZ64CG/c2Cx8E=";
   };

--- a/pkgs/development/python-modules/xmind/default.nix
+++ b/pkgs/development/python-modules/xmind/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "zhuifengshen";
-    repo = pname;
+    repo = "xmind";
     rev = "v${version}";
     sha256 = "xC1WpHz2eHb5+xShM/QUQAIYnJNyK1EKWbTXJKhDwbQ=";
   };

--- a/pkgs/development/python-modules/xpath-expressions/default.nix
+++ b/pkgs/development/python-modules/xpath-expressions/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "orf";
-    repo = pname;
+    repo = "xpath-expressions";
     rev = "v${version}";
     hash = "sha256-UAzDXrz1Tr9/OOjKAg/5Std9Qlrnizei8/3XL3hMSFA=";
   };

--- a/pkgs/development/python-modules/xpybutil/default.nix
+++ b/pkgs/development/python-modules/xpybutil/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   # Pypi only offers a wheel
   src = fetchFromGitHub {
     owner = "BurntSushi";
-    repo = pname;
+    repo = "xpybutil";
     rev = version;
     sha256 = "17gbqq955fcl29aayn8l0x14azc60cxgkvdxblz9q8x3l50w0xpg";
   };

--- a/pkgs/development/python-modules/yaswfp/default.nix
+++ b/pkgs/development/python-modules/yaswfp/default.nix
@@ -5,14 +5,14 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "yaswfp";
   version = "unstable-20210331";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "facundobatista";
-    repo = pname;
+    repo = "yaswfp";
     rev = "2a2cc6ca4c0b4d52bd2e658fb5f80fdc0db4924c";
     sha256 = "1dxdz89hlycy1rnn269fwl1f0qxgxqarkc0ivs2m77f8xba2qgj9";
   };

--- a/pkgs/development/python-modules/zadnegoale/default.nix
+++ b/pkgs/development/python-modules/zadnegoale/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bieniu";
-    repo = pname;
+    repo = "zadnegoale";
     tag = version;
     hash = "sha256-ij8xou8LXC4/BUTApIV6xSgb7ethwLyrHNJvBgxSBYM=";
   };

--- a/pkgs/development/python-modules/zigpy-deconz/default.nix
+++ b/pkgs/development/python-modules/zigpy-deconz/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "zigpy";
-    repo = pname;
+    repo = "zigpy-deconz";
     tag = version;
     hash = "sha256-el29EqCK9p3AII9LsMw+ikplHfDKNUIhaU3HJI0gfu8=";
   };

--- a/pkgs/development/python-modules/zigpy-znp/default.nix
+++ b/pkgs/development/python-modules/zigpy-znp/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "zigpy";
-    repo = pname;
+    repo = "zigpy-znp";
     tag = "v${version}";
     hash = "sha256-vYB04vEFqpqrjJMS73mtYXakp7lEIJjB+tT0SF9hpWM=";
   };

--- a/pkgs/development/python-modules/zwave-me-ws/default.nix
+++ b/pkgs/development/python-modules/zwave-me-ws/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Z-Wave-Me";
-    repo = pname;
+    repo = "zwave-me-ws";
     tag = "v${version}";
     hash = "sha256-bTchtgr+UbHCpcXMaQA3bTrhasJ79TguvAqLNlpD/2c=";
   };


### PR DESCRIPTION
Repeat of https://github.com/NixOS/nixpkgs/pull/410679, this time limited to `pkgs/development/python-modules/[s-zS-Z0-9_]`, part of https://github.com/NixOS/nixpkgs/issues/346453

Should be zero rebuilds.

All candidates were made using:

```shell
#!/usr/bin/env nix-shell
#!nix-shell -I nixpkgs=. --pure -i bash -p ripgrep sd jq git git-wait lix util-linux

export NIX_PATH= # no nixpkgs-overlay plz
export NIXPKGS_ALLOW_UNFREE=1
export NIXPKGS_ALLOW_INSECURE=1
export NIXPKGS_ALLOW_BROKEN=1

git-wait restore .

test -s packages.json || ( set -x;
  time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --drv-path --out-path --show-trace --no-allow-import-from-derivation --arg config '{ allowAliases = false; }' > packages.json
)

list_attrpath_fname_col() {
    jq <packages.json 'to_entries[] | select(.value.meta.position==null|not) | "\(.key)\t\(.value.meta.position)"' -r |
        sed -e "s#\t$(realpath .)/#\t#" |
        sed -e 's#:\([0-9]*\)$#\t\1#' |
        grep . |
        grep -iv haskell |
        grep -iv /top-level/ |
        grep -iv chicken |
        grep -E 'pkgs/development/python-modules/[s-zS-Z0-9_]' |
        grep -iv build |
        grep -E '/(package|default)\.nix'
}

while read attrpath fname col; do
    grep -qE 'repo *= *("\$\{pname\}"|pname);' "$fname" || continue

    echo | (

        echo "$attrpath"
        data="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)" || exit
        test -n "$data" || exit
        pname="$(jq <<<"$data" .pname -r)"
        test -n "$pname" || exit

        (set -x
            sd -F '${pname}'  "$pname"         "$fname"
            sd -F ' = pname;' " = \"$pname\";" "$fname"
        )

        data2="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)"
        if [[ "$data" = "$data2" ]]; then
            (set -x; git-wait add "$fname")
        else
            (set -x; git-wait restore "$fname")
            exit
        fi

        (set -x
            sd -F ' rec {' ' {' "$fname"
        )

        data3="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json 2>/dev/null)"

        if [[ "$data" = "$data3" ]]; then
            (set -x; git-wait add "$fname")
        else
            (set -x; git-wait restore "$fname")
        fi

    )

done < <(list_attrpath_fname_col)

git restore .

time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --drv-path --out-path --show-trace --no-allow-import-from-derivation --arg config '{ allowAliases = false; }' > packages2.json
```

`diff packages{,2}.json` is empty, indicating that no package nor src derivation has changed, nor have i introduced any eval failures. I checked and cherry-picked the changes using `GIT_DIFF_OPTS='-u20' git -c interactive.singleKey=true add --patch` along to some music. I then tested merging against master, staging and staging-next, and reverted one migration that would conflict with staging



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
