### PR TITLE
python3Packages.sanic-ext: init at 24.12.0

### DIFF
--- a/pkgs/development/python-modules/sanic-ext/default.nix
+++ b/pkgs/development/python-modules/sanic-ext/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # Build system
+  setuptools,
+
+  # Dependencies
+  pyyaml,
+
+  # Test dependencies
+  pytestCheckHook,
+
+  sanic-testing,
+  attrs,
+  coverage,
+  msgspec,
+  pydantic,
+  pytest,
+  pytest-cov,
+  pytest-asyncio,
+  tox,
+  jinja2,
+}:
+
+buildPythonPackage rec {
+  pname = "sanic-ext";
+  version = "24.12.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sanic-org";
+    repo = "sanic-ext";
+    tag = "v${version}";
+    hash = "sha256-H1tqiPQ4SwlNGj7GtB2h7noZpU+gbGXIbmRK1TSSqVA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+
+    sanic-testing
+    attrs
+    coverage
+    msgspec
+    pydantic
+    pytest
+    pytest-cov
+    pytest-asyncio
+    tox
+    jinja2
+  ];
+
+  disabledTests = [
+    "test_models[FooPydanticDataclass]" # KeyError: 'paths'
+    "test_pydantic_base_model[AlertResponsePydanticBaseModel-True]" # AssertionError: assert 'AlertPydanticBaseModel' in {'AlertResponsePydanticBaseModel': ... }
+    "test_pydantic_base_model[AlertResponsePydanticDataclass-True]" # AssertionError: assert 'AlertPydanticDataclass' in {'AlertResponsePydanticDataclass': ... }
+  ];
+
+  pythonImportsCheck = [ "sanic_ext" ];
+
+  meta = {
+    description = "Common, officially supported extension plugins for the Sanic web server framework";
+    homepage = "https://github.com/sanic-org/sanic-ext/";
+    changelog = "https://github.com/sanic-org/sanic-ext/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ p0lyw0lf ];
+  };
+}

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -13,6 +13,7 @@
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
+  sanic-ext,
   sanic-routing,
   sanic-testing,
   setuptools,
@@ -54,9 +55,7 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    ext = [
-      # TODO: sanic-ext
-    ];
+    ext = [ sanic-ext ];
     http3 = [ aioquic ];
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15515,6 +15515,8 @@ self: super: with self; {
 
   sanic-auth = callPackage ../development/python-modules/sanic-auth { };
 
+  sanic-ext = callPackage ../development/python-modules/sanic-ext { };
+
   sanic-routing = callPackage ../development/python-modules/sanic-routing { };
 
   sanic-testing = callPackage ../development/python-modules/sanic-testing { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds the [sanic-ext](https://github.com/sanic-org/sanic-ext) package at its [latest release](https://github.com/sanic-org/sanic-ext/releases/tag/v24.12.0). These are common, officially-supported plugins for the [Sanic](https://sanic.dev) web server framework. I believe they are good to include in Nixpkgs because currently, there is a TODO comment in the sanic package about them being missing; this PR also fills that in.

NOTE: despite them having different major versions, there is actually no conflict between this PR and https://github.com/NixOS/nixpkgs/pull/409599. Very confusing, I know :P

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking: not major or breaking, so I have not added an entry
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
