### PR TITLE
kdePackages.kate: split `kate` and `kwrite`

### DIFF
--- a/pkgs/kde/gear/default.nix
+++ b/pkgs/kde/gear/default.nix
@@ -196,6 +196,7 @@
   kweather = callPackage ./kweather { };
   kweathercore = callPackage ./kweathercore { };
   kwordquiz = callPackage ./kwordquiz { };
+  kwrite = callPackage ./kate { project = "kwrite"; };
   libgravatar = callPackage ./libgravatar { };
   libkcddb = callPackage ./libkcddb { };
   libkcompactdisc = callPackage ./libkcompactdisc { };

--- a/pkgs/kde/gear/kate/default.nix
+++ b/pkgs/kde/gear/kate/default.nix
@@ -1,4 +1,38 @@
-{ mkKdeDerivation }:
+{
+  lib,
+  mkKdeDerivation,
+  project ? "kate",
+}:
+let
+  inherit (lib) assertOneOf optionalString;
+in
+assert assertOneOf "project" project [
+  "kate"
+  "kwrite"
+];
 mkKdeDerivation {
   pname = "kate";
+
+  postPatch =
+    optionalString (project == "kate") ''
+      substituteInPlace doc/CMakeLists.txt --replace-fail 'ecm_optional_add_subdirectory(kwrite)' '''
+      substituteInPlace apps/CMakeLists.txt --replace-fail 'ecm_optional_add_subdirectory(kwrite)' '''
+      for i in $(find 'po' -path '*/docs/*' -type d -name kwrite); do
+        rm -rfv $i
+      done
+    ''
+    + optionalString (project == "kwrite") ''
+      substituteInPlace doc/CMakeLists.txt --replace-fail 'ecm_optional_add_subdirectory(kate)' '''
+      substituteInPlace doc/CMakeLists.txt --replace-fail 'ecm_optional_add_subdirectory(katepart)' '''
+      substituteInPlace apps/CMakeLists.txt --replace-fail 'ecm_optional_add_subdirectory(kate)' '''
+      substituteInPlace CMakeLists.txt --replace-fail 'ecm_optional_add_subdirectory(addons)' '''
+      for i in $(find 'po' -path '*/docs/*' -type d \( -name katepart -o -name kate \)); do
+        rm -rfv $i
+      done
+    '';
+
+  meta = {
+    mainProgram = project;
+    maintainers = with lib.maintainers; [ sigmasquadron ];
+  };
 }


### PR DESCRIPTION
WIP experimental patch; do not merge. This works fine from my testing, and doesn't immediately break anything important, but I imagine these two packages are in the same repository for a good reason, so splitting them like this is probably ill-advised. Still, every other distro does it through far worse methods.

This splits the 'kdePackages.kate' derivation into one derivation that builds 'kate' while patching out 'kwrite', and another that does the opposite. This reduces the overall closure size of either derivation, and allows us to follow in Fedora's footsteps and ship our Plasma module with only one text editor.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
