### PR TITLE
imager: fix numpy header detection

### DIFF
--- a/pkgs/by-name/im/imager/numpy-header.patch
+++ b/pkgs/by-name/im/imager/numpy-header.patch
@@ -1,0 +1,26 @@
+diff --git a/admin/gildas-env.sh b/admin/gildas-env.sh
+index acb06f9..b25ecd5 100644
+--- a/admin/gildas-env.sh
++++ b/admin/gildas-env.sh
+@@ -441,7 +441,7 @@ EOF
+ 		    # Now search for Numpy
+ 		    if python -c "import numpy" > /dev/null 2>&1; then
+ 			NUMPY_PRESENT=yes
+-			NUMPY_INC_DIR=`python -c "import numpy; print(numpy.__path__[0] + '/core/include')"`
++			NUMPY_INC_DIR=`python -c "import numpy; print(numpy.get_include())"`
+ 			if [ -e "$NUMPY_INC_DIR/numpy/arrayobject.h" ]; then
+ 			    NUMPY_INC_PRESENT=yes
+ 			else
+diff --git a/utilities/etc/setup.py.src b/utilities/etc/setup.py.src
+index 9a4da86..110a0d1 100644
+--- a/utilities/etc/setup.py.src
++++ b/utilities/etc/setup.py.src
+@@ -75,7 +75,7 @@ mod_extras = mod_extras.split()
+ 
+ if (os.environ.get('NUMPY_PRESENT') == "yes"):
+    import numpy
+-   mod_inc_dirs.append(numpy.__path__[0] + '/core/include')
++   mod_inc_dirs.append(numpy.get_include())
+ else:
+    raise Exception("Numpy python package should be present. Aborting.")
+ 

--- a/pkgs/by-name/im/imager/package.nix
+++ b/pkgs/by-name/im/imager/package.nix
@@ -59,6 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./clang.patch
     # Replace hardcoded cpp with GAG_CPP (see below).
     ./cpp-darwin.patch
+    # Fix the numpy header detection with numpy > 2.0.0
+    # Patch submitted upstream, it will be included in the next release.
+    ./numpy-header.patch
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-unused-command-line-argument";


### PR DESCRIPTION
With recent Numpy versions (> 2.0.0), the header files are located in `_core/include` instead of `core/include`, and the configure script does not detect them. Use the `numpy.get_include()` function for the detection in that script.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
