### PR TITLE
nixos/borgmatic: do not create source directories for empty databases

### DIFF
--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -17,7 +17,7 @@ let
   addRequiredBinaries =
     s:
     s
-    // {
+    // (lib.optionalAttrs (s ? postgresql_databases && s.postgresql_databases != [ ]) {
       postgresql_databases = map (
         d:
         let
@@ -33,7 +33,9 @@ let
           psql_command = "${as_user}${postgresql}/bin/psql";
         }
         // d
-      ) (s.postgresql_databases or [ ]);
+      ) s.postgresql_databases;
+    })
+    // (lib.optionalAttrs (s ? mariadb_databases && s.mariadb_databases != [ ]) {
       mariadb_databases = map (
         d:
         {
@@ -41,7 +43,9 @@ let
           mariadb_command = "${mysql}/bin/mariadb";
         }
         // d
-      ) (s.mariadb_databases or [ ]);
+      ) s.mariadb_databases;
+    })
+    // (lib.optionalAttrs (s ? mysql_databases && s.mysql_databases != [ ]) {
       mysql_databases = map (
         d:
         {
@@ -49,8 +53,8 @@ let
           mysql_command = "${mysql}/bin/mysql";
         }
         // d
-      ) (s.mysql_databases or [ ]);
-    };
+      ) s.mysql_databases;
+    });
 
   repository =
     with lib.types;
@@ -149,7 +153,9 @@ in
   config =
     let
       configFiles =
-        (lib.optionalAttrs (cfg.settings != null) { "borgmatic/config.yaml".source = cfgfile; })
+        (lib.optionalAttrs (cfg.settings != null) {
+          "borgmatic/config.yaml".source = cfgfile;
+        })
         // lib.mapAttrs' (
           name: value:
           lib.nameValuePair "borgmatic.d/${name}.yaml" {


### PR DESCRIPTION
Commit b873990 introduced a bug in nixos/borgmatic:

During creation of the borgmatic config, unspecified or empty database dump instructions were created.
E.g.: Absence of the option `mysql_databases` or setting `mysql_databases = [ ]` created the entry `mysql_databases = [ ]` in the generated config.

This causes borgmatic to try and backup an empty directory, where databases would have been dumped. Usually this just causes a warning but when `source_directories_must_exists = true` is set, backups fail.

The proposed changes fix this problem by only including each database instructions in the outputted config when they are not empty.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
