### PR TITLE
opensmtpd-table-*: fix meta.description

### DIFF
--- a/pkgs/by-name/op/opensmtpd-table-ldap/package.nix
+++ b/pkgs/by-name/op/opensmtpd-table-ldap/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.opensmtpd.org/";
-    description = "ldap table for the OpenSMTPD mail server";
+    description = "LDAP tables for the OpenSMTPD mail server";
     changelog = "https://github.com/OpenSMTPD/table-ldap/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/op/opensmtpd-table-mysql/package.nix
+++ b/pkgs/by-name/op/opensmtpd-table-mysql/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.opensmtpd.org/";
-    description = "ldap table for the OpenSMTPD mail server";
+    description = "MySQL or MariaDB tables for the OpenSMTPD mail server";
     changelog = "https://github.com/OpenSMTPD/table-mysql/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/op/opensmtpd-table-passwd/package.nix
+++ b/pkgs/by-name/op/opensmtpd-table-passwd/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.opensmtpd.org/";
-    description = "passwd table for the OpenSMTPD mail server";
+    description = "passwd tables for the OpenSMTPD mail server";
     changelog = "https://github.com/OpenSMTPD/table-passwd/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/op/opensmtpd-table-postgres/package.nix
+++ b/pkgs/by-name/op/opensmtpd-table-postgres/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.opensmtpd.org/";
-    description = "ldap table for the OpenSMTPD mail server";
+    description = "PostgreSQL tables for the OpenSMTPD mail server";
     changelog = "https://github.com/OpenSMTPD/table-postgres/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/op/opensmtpd-table-redis/package.nix
+++ b/pkgs/by-name/op/opensmtpd-table-redis/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.opensmtpd.org/";
-    description = "ldap table for the OpenSMTPD mail server";
+    description = "Redis tables for the OpenSMTPD mail server";
     changelog = "https://github.com/OpenSMTPD/table-redis/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/op/opensmtpd-table-socketmap/package.nix
+++ b/pkgs/by-name/op/opensmtpd-table-socketmap/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.opensmtpd.org/";
-    description = "ldap table for the OpenSMTPD mail server";
+    description = "socketmap tables the OpenSMTPD mail server";
     changelog = "https://github.com/OpenSMTPD/table-socketmap/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/op/opensmtpd-table-sqlite/package.nix
+++ b/pkgs/by-name/op/opensmtpd-table-sqlite/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.opensmtpd.org/";
-    description = "ldap table for the OpenSMTPD mail server";
+    description = "SQLite tables for the OpenSMTPD mail server";
     changelog = "https://github.com/OpenSMTPD/table-sqlite/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Package descriptions all mentioned ldap. I based them all on the wording in the man pages from the repos.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
