### PR TITLE
lib/attrsets: make getFirstOutput support strings

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1320,6 +1320,9 @@
   "outputlib": [
     "index.html#outputlib"
   ],
+  "outputinclude": [
+    "index.html#outputinclude"
+  ],
   "outputdoc": [
     "index.html#outputdoc"
   ],

--- a/doc/stdenv/multiple-output.chapter.md
+++ b/doc/stdenv/multiple-output.chapter.md
@@ -60,7 +60,7 @@ The support code currently recognizes some particular kinds of outputs and eithe
 
 #### `$outputDev` {#outputdev}
 
-is for development-only files. These include C(++) headers (`include/`), pkg-config (`lib/pkgconfig/`), cmake (`lib/cmake/`) and aclocal files (`share/aclocal/`). They go to `dev` or `out` by default.
+is for development-only files. These include C(++) headers (`include/`, unless [`$outputInclude`](#outputinclude) is set), pkg-config (`lib/pkgconfig/`), cmake (`lib/cmake/`) and aclocal files (`share/aclocal/`). They go to `dev` or `out` by default.
 
 #### `$outputBin` {#outputbin}
 
@@ -69,6 +69,10 @@ is meant for user-facing binaries, typically residing in `bin/`. They go to `bin
 #### `$outputLib` {#outputlib}
 
 is meant for libraries, typically residing in `lib/` and `libexec/`. They go to `lib` or `out` by default.
+
+#### `$outputInclude` {#outputinclude}
+
+is for development-only files that go in `include/`. Defaults to [`$outputDev`](#outputdev).
 
 #### `$outputDoc` {#outputdoc}
 

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1748,7 +1748,7 @@ rec {
 
   /**
     Get the first of the `outputs` provided by the package, or the default.
-    This function is alligned with `_overrideFirst()` from the `multiple-outputs.sh` setup hook.
+    This function is aligned with `_overrideFirst()` from the `multiple-outputs.sh` setup hook.
     Like `getOutput`, the function is idempotent.
 
     # Inputs

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -28,6 +28,7 @@ let
     groupBy
     take
     foldl
+    optionals
     ;
 in
 
@@ -1780,7 +1781,7 @@ rec {
   getFirstOutput =
     candidates: pkg:
     let
-      outputs = builtins.filter (name: hasAttr name pkg) candidates;
+      outputs = optionals (isAttrs pkg) (builtins.filter (name: hasAttr name pkg) candidates);
       output = builtins.head outputs;
     in
     if pkg.outputSpecified or false || outputs == [ ] then pkg else pkg.${output};

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -61,6 +61,7 @@ let
     genList
     getExe
     getExe'
+    getFirstOutput
     getLicenseFromSpdxIdOr
     groupBy
     groupBy'
@@ -143,6 +144,16 @@ let
       expr = builtins.seq drv.drvPath drv.name;
       inherit expected;
     };
+
+  basicTestDerivation = lib.extendDerivation true { } (derivation {
+    name = "test";
+    builder = "builder";
+    system = "system";
+    outputs = [
+      "first"
+      "second"
+    ];
+  });
 
 in
 
@@ -2018,6 +2029,31 @@ runTests {
       valuesNotNeeded = 3;
       trivialAcc = 121;
     };
+  };
+
+  testGetFirstOutputFirst = {
+    expr = getFirstOutput [ "out" "first" ] basicTestDerivation;
+    expected = basicTestDerivation.first;
+  };
+
+  testGetFirstOutputSecond = {
+    expr = getFirstOutput [ "out" "second" ] basicTestDerivation;
+    expected = basicTestDerivation.second;
+  };
+
+  testGetFirstOutputEmpty = {
+    expr = getFirstOutput [ ] basicTestDerivation;
+    expected = basicTestDerivation;
+  };
+
+  testGetFirstOutputNonExisting = {
+    expr = getFirstOutput [ "out" "third" ] basicTestDerivation;
+    expected = basicTestDerivation;
+  };
+
+  testGetFirstOutputWithOutputSpecified = {
+    expr = getFirstOutput [ "out" "first" ] basicTestDerivation.second;
+    expected = basicTestDerivation.second;
   };
 
   testMergeAttrsListExample1 = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2056,6 +2056,16 @@ runTests {
     expected = basicTestDerivation.second;
   };
 
+  testGetFirstOutputWithPath = {
+    expr = getFirstOutput [ "out" "first" ] ./misc.nix;
+    expected = ./misc.nix;
+  };
+
+  testGetFirstOutputWithString = {
+    expr = getFirstOutput [ "out" "first" ] "./misc.nix";
+    expected = "./misc.nix";
+  };
+
   testMergeAttrsListExample1 = {
     expr = attrsets.mergeAttrsList [
       {

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -453,7 +453,7 @@ lib.makeOverridable
               "out"
               "lib"
             ];
-        outputDev = if buildTests then [ "out" ] else [ "lib" ];
+        outputDev = if buildTests then "out" else "lib";
 
         meta = {
           mainProgram = crateName;


### PR DESCRIPTION
EDIT: title was _"lib/attrsets: make getBin and co respect outputBin if set"_

As a motivating example I added a commit that sets `sdl2-compat.meta.mainProgram` (to match `SDL_compat`). It installs its binary to `$dev/bin/` due to `outoutBin = "dev"`, since the binary is typically only used during `configurePhase`. This change makes `lib.getExe sdl2-compat` point at the right path.

- **lib/attrsets: make getFirstOutput support strings**
- **buildRustCrate: change `outputDev` from `listOf str` to `str`**
- ~~lib/attrsets: make getBin and co respect outputBin if set~~
- **doc/stdenv/multiple-output: document `$outputInclude`**
- ~~sdl2-compat: set meta.mainProgram~~

EDIT: dropped two commits, since this path is not the way to go, but the fixes along the way still apply. I'll open a treewide pr for the alternative approach


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
