### PR TITLE
libe57format: 3.1.1 -> 3.2.0

### DIFF
--- a/pkgs/by-name/li/libe57format/package.nix
+++ b/pkgs/by-name/li/libe57format/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libe57format";
-  version = "3.1.1";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "asmaloney";
     repo = "libE57Format";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-bOuWh9Nkxva2v0M6+vnAya8EW/G3WQePxHakQt8T9NE=";
+    hash = "sha256-GyzfJshL2cOTEDp8eR0sqQq4GSnOdskiLi5mY1a2KW0=";
     fetchSubmodules = true; # for submodule-vendored libraries such as `gtest`
   };
 
@@ -23,23 +23,13 @@ stdenv.mkDerivation (finalAttrs: {
   libE57Format-test-data_src = fetchFromGitHub {
     owner = "asmaloney";
     repo = "libE57Format-test-data";
-    rev = "4960564a732c6444c50dfae5b2273e68837399cd";
-    hash = "sha256-k26yVbYSQJ3EMgcpjm35N1OAxarFmfMvzfTN2Hdyu8c=";
+    rev = "2171612112b06afd4fec5babe8837be69d910149";
+    hash = "sha256-JARpxp6Z2VioBfY0pZSyQU2mG/EllbaF3qteSFM9u8o=";
   };
 
   CXXFLAGS = [
     # GCC 13: error: 'int16_t' has not been declared in 'std'
     "-include cstdint"
-  ];
-
-  patches = [
-    # TODO: Remove with the next release: https://github.com/asmaloney/libE57Format/pull/299
-    (fetchpatch {
-      name = "libE57Format-Dont-force-warnings-as-errors-when-building-self.patch"; # https://github.com/apache/thrift/pull/2726
-      url = "https://github.com/asmaloney/libE57Format/commit/66bb5af15937b4c10a7f412ca4d1673f42bbad28.patch";
-      hash = "sha256-2cNURjMLP0TijYY5gbuWLE7H/PlMW936wAeOqJ/w9C0=";
-    })
-
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
