### PR TITLE
feedbackd: 0.8.1 -> 0.8.2

### DIFF
--- a/nixos/modules/programs/feedbackd.nix
+++ b/nixos/modules/programs/feedbackd.nix
@@ -17,10 +17,15 @@ in
         Your user needs to be in the `feedbackd` group to trigger effects
       '';
       package = lib.mkPackageOption pkgs "feedbackd" { };
+      theme-package = lib.mkPackageOption pkgs "feedbackd-device-themes" {
+        nullable = true;
+      };
     };
   };
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [
+      cfg.package
+    ] ++ (if cfg.theme-package != null then [ cfg.theme-package ] else [ ]);
 
     services.dbus.packages = [ cfg.package ];
     services.udev.packages = [ cfg.package ];

--- a/pkgs/by-name/fe/feedbackd-device-themes/package.nix
+++ b/pkgs/by-name/fe/feedbackd-device-themes/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  json-glib,
+  feedbackd,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "feedbackd-device-themes";
+  version = "0.8.3";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "agx";
+    repo = "feedbackd-device-themes";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-z+A2G1g2gNfC0cVWUO/LT3QVvXeotcBd+5UEpEtcPfY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    json-glib # Provides json-glib-validate
+  ];
+
+  nativeCheckInputs = [
+    feedbackd # Provides fbd-theme-validate
+  ];
+
+  mesonFlags = [
+    (lib.mesonOption "validate" (if finalAttrs.doCheck then "enabled" else "disabled"))
+  ];
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "Device specific feedback themes for Feedbackd";
+    homepage = "https://gitlab.freedesktop.org/agx/feedbackd-device-themes";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [
+      pacman99
+      Luflosi
+    ];
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/by-name/fe/feedbackd/package.nix
+++ b/pkgs/by-name/fe/feedbackd/package.nix
@@ -111,6 +111,8 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = nix-update-script { };
   };
 
+  strictDeps = true;
+
   meta = with lib; {
     description = "Daemon to provide haptic (and later more) feedback on events";
     homepage = "https://source.puri.sm/Librem5/feedbackd";

--- a/pkgs/by-name/fe/feedbackd/package.nix
+++ b/pkgs/by-name/fe/feedbackd/package.nix
@@ -25,16 +25,16 @@
 
 let
   themes = fetchFromGitLab {
-    domain = "source.puri.sm";
-    owner = "Librem5";
+    domain = "gitlab.freedesktop.org";
+    owner = "agx";
     repo = "feedbackd-device-themes";
-    rev = "v0.4.0";
-    hash = "sha256-kY/+DyRxKEUzq7ctl6Va14AKUCpWU7NRQhJOwhtkJp8=";
+    rev = "v0.8.3";
+    hash = "sha256-z+A2G1g2gNfC0cVWUO/LT3QVvXeotcBd+5UEpEtcPfY=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "feedbackd";
-  version = "0.8.1";
+  version = "0.8.2";
 
   outputs = [
     "out"
@@ -43,11 +43,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitLab {
-    domain = "source.puri.sm";
-    owner = "Librem5";
+    domain = "gitlab.freedesktop.org";
+    owner = "agx";
     repo = "feedbackd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-J2BNDF9TyW+srW0pGbGt4/Uw4KPVf/Ke+HJVBldmfCA=";
+    hash = "sha256-Hd+kHLr+d1+mg9BbD1pCfVZuwmf7Hk02xmDTmR3foh4=";
   };
 
   depsBuildBuild = [
@@ -114,9 +114,15 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   meta = with lib; {
-    description = "Daemon to provide haptic (and later more) feedback on events";
-    homepage = "https://source.puri.sm/Librem5/feedbackd";
-    license = licenses.gpl3Plus;
+    description = "Theme based Haptic, Visual and Audio Feedback";
+    homepage = "https://gitlab.freedesktop.org/agx/feedbackd/";
+    license = with licenses; [
+      # feedbackd
+      gpl3Plus
+
+      # libfeedback library
+      lgpl21Plus
+    ];
     maintainers = with maintainers; [
       pacman99
       Luflosi

--- a/pkgs/by-name/fe/feedbackd/package.nix
+++ b/pkgs/by-name/fe/feedbackd/package.nix
@@ -20,18 +20,10 @@
   dbus,
   gmobile,
   umockdev,
+  feedbackd-device-themes,
   nix-update-script,
 }:
 
-let
-  themes = fetchFromGitLab {
-    domain = "gitlab.freedesktop.org";
-    owner = "agx";
-    repo = "feedbackd-device-themes";
-    rev = "v0.8.3";
-    hash = "sha256-z+A2G1g2gNfC0cVWUO/LT3QVvXeotcBd+5UEpEtcPfY=";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "feedbackd";
   version = "0.8.2";
@@ -93,7 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     mkdir -p $out/lib/udev/rules.d
     sed "s|/usr/libexec/|$out/libexec/|" < $src/data/90-feedbackd.rules > $out/lib/udev/rules.d/90-feedbackd.rules
-    cp ${themes}/data/* $out/share/feedbackd/themes/
   '';
 
   postFixup = ''


### PR DESCRIPTION
https://gitlab.freedesktop.org/agx/feedbackd/-/tags/v0.8.2

According to the https://source.puri.sm/Librem5/feedbackd/ README:
As of 2025-04-20 Upstream development moved to FDO's gitlab. The new location for code and issues is at https://gitlab.freedesktop.org/agx/feedbackd/
The packaging for the Librem 5 and PureOS continues to live at https://source.puri.sm/Librem5/debs/pkg-feedbackd.

Also separate out the `feedbackd-device-themes` package for the following reasons:
- Previously the update script did not see this "package" and did not update it
- Now we can run the test suite of `feedbackd-device-themes`
- This allows a user to only change a device theme, while not recompiling `feedbackd`
- Updating only `feedbackd-device-themes` would result in an awkward commit message where we would claim to update a seemingly non-existing package
- Previous commits that updated both `feedbackd` and `feedbackd-device-themes` at the same time did not mention the update to `feedbackd-device-themes` in the title of the commit message
- They are separate projects after all, with the only direct dependency between the two packages existing in the test suite of `feedbackd-device-themes`
- [Most other distributions also package this package](https://repology.org/project/feedbackd-device-themes/versions) separately from feedbackd

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
