### PR TITLE
glabels: fix build by applying custom fix

### DIFF
--- a/pkgs/by-name/gl/glabels/fix_return_param.patch
+++ b/pkgs/by-name/gl/glabels/fix_return_param.patch
@@ -1,0 +1,58 @@
+diff --git a/src/merge-properties-dialog.c b/src/merge-properties-dialog.c
+index 064223b..57d8b30 100644
+--- a/src/merge-properties-dialog.c
++++ b/src/merge-properties-dialog.c
+@@ -222,18 +222,17 @@ gl_merge_properties_dialog_finalize (GObject *object)
+ /*****************************************************************************/
+ /* NEW merge properties dialog.                                              */
+ /*****************************************************************************/
+-GtkWidget*
++glMergePropertiesDialog*
+ gl_merge_properties_dialog_new (glLabel   *label,
+ 	                        GtkWindow *window)
+ {
+-	GtkWidget *dialog;
++	glMergePropertiesDialog *dialog;
+ 
+ 	gl_debug (DEBUG_MERGE, "START");
+ 
+-	dialog = GTK_WIDGET (g_object_new (GL_TYPE_MERGE_PROPERTIES_DIALOG, NULL));
++	dialog = GL_MERGE_PROPERTIES_DIALOG (g_object_new (GL_TYPE_MERGE_PROPERTIES_DIALOG, NULL));
+ 
+-	gl_merge_properties_dialog_construct (GL_MERGE_PROPERTIES_DIALOG (dialog),
+-					      label, window);
++	gl_merge_properties_dialog_construct (dialog, label, window);
+ 
+ 	gl_debug (DEBUG_MERGE, "END");
+ 
+diff --git a/src/merge-properties-dialog.h b/src/merge-properties-dialog.h
+index 33be5d1..c8c6281 100644
+--- a/src/merge-properties-dialog.h
++++ b/src/merge-properties-dialog.h
+@@ -57,10 +57,10 @@ struct  _glMergePropertiesDialogClass
+ 	GtkDialogClass                  parent_class;
+ };
+ 
+-GType      gl_merge_properties_dialog_get_type    (void) G_GNUC_CONST;
++GType      gl_merge_properties_dialog_get_type          (void) G_GNUC_CONST;
+ 
+-GtkWidget *gl_merge_properties_dialog_new         (glLabel   *label,
+-	                                           GtkWindow *window);
++glMergePropertiesDialog *gl_merge_properties_dialog_new (glLabel   *label,
++	                                                 GtkWindow *window);
+ 
+ G_END_DECLS
+ 
+diff --git a/src/pixbuf-cache.c b/src/pixbuf-cache.c
+index 77b2fc5..8b0f84f 100644
+--- a/src/pixbuf-cache.c
++++ b/src/pixbuf-cache.c
+@@ -125,7 +125,7 @@ gl_pixbuf_cache_add_pixbuf (GHashTable *pixbuf_cache,
+ 	record = g_new0 (CacheRecord, 1);
+ 	record->key        = g_strdup (name);
+ 	record->references = 0; /* Nobody has referenced it yet. */
+-	record->pixbuf     = g_object_ref (G_OBJECT (pixbuf));
++	record->pixbuf     = (GdkPixbuf *) (g_object_ref (G_OBJECT (pixbuf)));
+ 
+ 	g_hash_table_insert (pixbuf_cache, record->key, record);
+ 

--- a/pkgs/by-name/gl/glabels/package.nix
+++ b/pkgs/by-name/gl/glabels/package.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/jimevins/glabels/commit/f64e3f34e3631330fff2fb48ab271ff9c6160229.patch";
       sha256 = "13q6g4bxzvzwjnvzkvijds2b6yvc4xqbdwgqnwmj65ln6ngxz8sa";
     })
+    ./fix_return_param.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Applied a custom patch that adjusts some compilation issues in the GTK files with invalid types and changes those sections to cast to the correct type instead. Also the binary has been locally run and tested on x86_64-linux to see if it still works like expected.

#ZurichZHF

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
