### PR TITLE
task-master-ai: init at 0.15.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20858,6 +20858,12 @@
     githubId = 3302;
     name = "Renzo Carbonara";
   };
+  repparw = {
+    email = "ubritos@gmail.com";
+    github = "repparw";
+    githubId = 45952970;
+    name = "repparw";
+  };
   reputable2772 = {
     name = "Reputable2772";
     github = "Reputable2772";

--- a/pkgs/by-name/ta/task-master-ai/package.nix
+++ b/pkgs/by-name/ta/task-master-ai/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "task-master-ai";
+  version = "0.15.0";
+
+  src = fetchFromGitHub {
+    owner = "eyaltoledano";
+    repo = "claude-task-master";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cCfyQ9xU8axuZyTTVsrYVuic6DPHnAc4YX7aKj2MmSE=";
+  };
+
+  npmDepsHash = "sha256-UNGJ64E12ppo37gJBDNpyRFYfNEJMH5mRnK3HyWcy8E=";
+
+  dontNpmBuild = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Node.js agentic AI workflow orchestrator";
+    homepage = "https://task-master.dev";
+    changelog = "https://github.com/eyaltoledano/claude-task-master/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = licenses.mit;
+    mainProgram = "task-master-ai";
+    maintainers = [ maintainers.repparw ];
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
First try at contributing to nixpkgs so please correct me if anything is wrong

Packaged task-master-ai

"An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others."

[homepage](https://www.task-master.dev/)
[github](https://github.com/eyaltoledano/claude-task-master)

see #407451 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
