### PR TITLE
high-tide: 0-unstable-2025-05-01 -> 0.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17667,6 +17667,12 @@
     github = "nikstur";
     githubId = 61635709;
   };
+  nilathedragon = {
+    email = "nilathedragon@pm.me";
+    name = "Nila The Dragon";
+    github = "nilathedragon";
+    githubId = 43315617;
+  };
   nilp0inter = {
     email = "robertomartinezp@gmail.com";
     github = "nilp0inter";

--- a/pkgs/by-name/hi/high-tide/package.nix
+++ b/pkgs/by-name/hi/high-tide/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3Packages,
+  python313Packages,
   fetchFromGitHub,
   wrapGAppsHook4,
   meson,
@@ -11,18 +11,20 @@
   libadwaita,
   gst_all_1,
   libsecret,
+  libportal,
+  nix-update-script,
 }:
 
-python3Packages.buildPythonApplication {
+python313Packages.buildPythonApplication rec {
   pname = "high-tide";
-  version = "0-unstable-2025-05-01";
+  version = "0.1.5";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "Nokse22";
     repo = "high-tide";
-    rev = "6278ff9471b7481cf0291ab2a9f6d06322506dfc";
-    hash = "sha256-4pVRVXEwz0ngjS1Vpt/o00lLYsZ6SvTCk4ivyGoQ4lQ=";
+    tag = "v${version}";
+    hash = "sha256-HoPyqsLPLfqyQbrhoPzr3n81yX1MHZVUVmq5RKDN5pI=";
   };
 
   nativeBuildInputs = [
@@ -35,7 +37,10 @@ python3Packages.buildPythonApplication {
   ];
 
   buildInputs =
-    [ libadwaita ]
+    [
+      libadwaita
+      libportal
+    ]
     ++ (with gst_all_1; [
       gstreamer
       gst-plugins-base
@@ -45,7 +50,7 @@ python3Packages.buildPythonApplication {
       libsecret
     ]);
 
-  dependencies = with python3Packages; [
+  dependencies = with python313Packages; [
     pygobject3
     tidalapi
     requests
@@ -56,11 +61,13 @@ python3Packages.buildPythonApplication {
 
   makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Libadwaita TIDAL client for Linux";
     homepage = "https://github.com/Nokse22/high-tide";
     license = with lib.licenses; [ gpl3Plus ];
-    mainProgram = "HighTide";
+    mainProgram = "high-tide";
     maintainers = with lib.maintainers; [
       nilathedragon
       nyabinary

--- a/pkgs/by-name/hi/high-tide/package.nix
+++ b/pkgs/by-name/hi/high-tide/package.nix
@@ -62,6 +62,7 @@ python3Packages.buildPythonApplication {
     license = with lib.licenses; [ gpl3Plus ];
     mainProgram = "HighTide";
     maintainers = with lib.maintainers; [
+      nilathedragon
       nyabinary
       griffi-gh
     ];


### PR DESCRIPTION
Brings High-Tide in line with the latest commit (unfortunately upstream currently does not tag / track changes). Due to flatpak support libportal is now a required dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
