### PR TITLE
bfr: fix broken build because of stricter GCC default checks

### DIFF
--- a/pkgs/by-name/bf/bfr/configure-log-compiler-errors-to-stderr.patch
+++ b/pkgs/by-name/bf/bfr/configure-log-compiler-errors-to-stderr.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 53e90a7..4afeb58 100755
+--- a/configure
++++ b/configure
+@@ -411,7 +411,7 @@ if test "$silent" = yes; then
+ else
+   exec 6>&1
+ fi
+-exec 5>./config.log
++exec 5>&2
+ 
+ echo "\
+ This file contains any messages produced by compilers while

--- a/pkgs/by-name/bf/bfr/fix-gcc-complaining-about-invalid-configure-example-code.patch
+++ b/pkgs/by-name/bf/bfr/fix-gcc-complaining-about-invalid-configure-example-code.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 53e90a7..cc80615 100755
+--- a/configure
++++ b/configure
+@@ -908,7 +908,7 @@ cat > conftest.$ac_ext << EOF
+ #line 909 "configure"
+ #include "confdefs.h"
+ 
+-main(){return(0);}
++int main(){return(0);}
+ EOF
+ if { (eval echo configure:914: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+   ac_cv_prog_cc_works=yes

--- a/pkgs/by-name/bf/bfr/package.nix
+++ b/pkgs/by-name/bf/bfr/package.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    ./configure-log-compiler-errors-to-stderr.patch
+    ./fix-gcc-complaining-about-invalid-configure-example-code.patch
+
     (fetchurl {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-misc/bfr/files/bfr-1.6-perl.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
       sha256 = "1pk9jm3c1qzs727lh0bw61w3qbykaqg4jblywf9pvq5bypk88qfj";


### PR DESCRIPTION
GCC now complains if `main` has no explicitly declared return type. Because `bfr`'s `configure` script uses a very minimal C application to check whether GCC works _at all_ (literally: `main(){return(0);}`), this caused configure failures.

Another issue with the `configure` script is that it logs the compiler errors for its checks to `configure.log` (and not to stdout or stderr), which means that the root cause wasn't logged during the failed nix build.

I added a patch that rewires the compiler error file descriptor so that it will simply log to stderr and another patch that fixes the missing return type in the C example.

Unfortunately, it looks like the server isn't serving the source files anymore (and finding an official upstream repo which I could send a PR to seems... non-trivial).

Part of #ZurichZHF
Works towards https://github.com/NixOS/nixpkgs/issues/403336

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
