### PR TITLE
mcpo: init at 0.0.18

### DIFF
--- a/pkgs/by-name/mc/mcpo/package.nix
+++ b/pkgs/by-name/mc/mcpo/package.nix
@@ -1,0 +1,4 @@
+{ python3Packages }:
+
+with python3Packages;
+toPythonApplication mcpo

--- a/pkgs/development/python-modules/mcpo/default.nix
+++ b/pkgs/development/python-modules/mcpo/default.nix
@@ -15,16 +15,18 @@
   pydantic-core,
   pydantic-settings,
   pyjwt,
+  pytest-asyncio,
   pytestCheckHook,
   python-dotenv,
   pythonOlder,
   typer,
   uvicorn,
+  watchdog,
 }:
 
 buildPythonPackage rec {
   pname = "mcpo";
-  version = "0.0.16";
+  version = "0.0.17";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -33,7 +35,7 @@ buildPythonPackage rec {
     owner = "open-webui";
     repo = "mcpo";
     tag = "v${version}";
-    hash = "sha256-T4eAhPgm1ysf/+ZmqZxAoc0SwQbkl8x8lBGwamMYcpU=";
+    hash = "sha256-oubMRHiG6JbfMI5MYmRt4yNDI8Moi4h7iBZPgkdPGd4=";
   };
 
   build-system = [
@@ -52,9 +54,11 @@ buildPythonPackage rec {
     python-dotenv
     typer
     uvicorn
+    watchdog
   ];
 
   nativeCheckInputs = [
+    pytest-asyncio
     pytestCheckHook
   ];
 
@@ -64,6 +68,7 @@ buildPythonPackage rec {
     description = "Simple, secure MCP-to-OpenAPI proxy server";
     homepage = "https://github.com/open-webui/mcpo/";
     license = lib.licenses.mit;
+    mainProgram = "mcpo";
     maintainers = with lib.maintainers; [ codgician ];
   };
 }

--- a/pkgs/development/python-modules/mcpo/default.nix
+++ b/pkgs/development/python-modules/mcpo/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "mcpo";
-  version = "0.0.14";
+  version = "0.0.15";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     owner = "open-webui";
     repo = "mcpo";
     tag = "v${version}";
-    hash = "sha256-viwf0wjNvp/MyJHHYrWOqQe/bUJp6y7Yu9uVan7gC/U=";
+    hash = "sha256-b9zCeMwZdss/5bR6t7rvNWhVRJ8p3aIDEKwezU+CzB0=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/mcpo/default.nix
+++ b/pkgs/development/python-modules/mcpo/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "mcpo";
-  version = "0.0.17";
+  version = "0.0.18";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     owner = "open-webui";
     repo = "mcpo";
     tag = "v${version}";
-    hash = "sha256-oubMRHiG6JbfMI5MYmRt4yNDI8Moi4h7iBZPgkdPGd4=";
+    hash = "sha256-wTLQx6ws2inpmV+o7uFmjLzRKaipM6DZy+QxumzvSkw=";
   };
 
   build-system = [
@@ -60,6 +60,12 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Tests failing in sandbox
+    "test_reload_config_handler"
+    "test_validate_server_config_disabled_tools_invalid"
   ];
 
   pythonImportsCheck = [ "mcpo" ];

--- a/pkgs/development/python-modules/mcpo/default.nix
+++ b/pkgs/development/python-modules/mcpo/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build system
+  hatchling,
+
+  # dependencies
+  click,
+  fastapi,
+  mcp,
+  passlib,
+  pydantic,
+  pydantic-core,
+  pydantic-settings,
+  pyjwt,
+  pytestCheckHook,
+  python-dotenv,
+  pythonOlder,
+  typer,
+  uvicorn,
+}:
+
+buildPythonPackage rec {
+  pname = "mcpo";
+  version = "0.0.14";
+  pyproject = true;
+
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "open-webui";
+    repo = "mcpo";
+    tag = "v${version}";
+    hash = "sha256-viwf0wjNvp/MyJHHYrWOqQe/bUJp6y7Yu9uVan7gC/U=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    click
+    fastapi
+    mcp
+    passlib
+    pydantic
+    pydantic-core
+    pydantic-settings
+    pyjwt
+    python-dotenv
+    typer
+    uvicorn
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "mcpo" ];
+
+  meta = {
+    description = "Simple, secure MCP-to-OpenAPI proxy server";
+    homepage = "https://github.com/open-webui/mcpo/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ codgician ];
+  };
+}

--- a/pkgs/development/python-modules/mcpo/default.nix
+++ b/pkgs/development/python-modules/mcpo/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "mcpo";
-  version = "0.0.15";
+  version = "0.0.16";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     owner = "open-webui";
     repo = "mcpo";
     tag = "v${version}";
-    hash = "sha256-b9zCeMwZdss/5bR6t7rvNWhVRJ8p3aIDEKwezU+CzB0=";
+    hash = "sha256-T4eAhPgm1ysf/+ZmqZxAoc0SwQbkl8x8lBGwamMYcpU=";
   };
 
   build-system = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9303,6 +9303,8 @@ self: super: with self; {
 
   mcpadapt = callPackage ../development/python-modules/mcpadapt { };
 
+  mcpo = callPackage ../development/python-modules/mcpo { };
+
   mcstatus = callPackage ../development/python-modules/mcstatus { };
 
   mcuuid = callPackage ../development/python-modules/mcuuid { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added open-webui/mcpo: https://github.com/open-webui/mcpo, a simple, secure MCP-to-OpenAPI proxy server. 

Fix #409642. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
