### PR TITLE
nekoray: fix TUN functionality

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -261,6 +261,7 @@
   ./programs/nano.nix
   ./programs/nautilus-open-any-terminal.nix
   ./programs/nbd.nix
+  ./programs/nekoray.nix
   ./programs/neovim.nix
   ./programs/nethoscope.nix
   ./programs/nexttrace.nix

--- a/nixos/modules/programs/nekoray.nix
+++ b/nixos/modules/programs/nekoray.nix
@@ -1,0 +1,90 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.nekoray;
+in
+{
+  options = {
+    programs.nekoray = {
+      enable = lib.mkEnableOption "nekoray, a GUI proxy configuration manager";
+
+      package = lib.mkPackageOption pkgs "nekoray" { };
+
+      tunMode = {
+        enable = lib.mkEnableOption "TUN mode of nekoray";
+
+        setuid = lib.mkEnableOption ''
+          setting suid bit for nekobox_core to run as root, which is less
+          secure than default setcap method but closer to upstream assumptions.
+          Enable this if you find the default setcap method configured in
+          this module doesn't work for you
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    security.wrappers.nekobox_core = lib.mkIf cfg.tunMode.enable {
+      source = "${cfg.package}/share/nekoray/nekobox_core";
+      owner = "root";
+      group = "root";
+      setuid = lib.mkIf cfg.tunMode.setuid true;
+      # Taken from https://github.com/SagerNet/sing-box/blob/dev-next/release/config/sing-box.service
+      capabilities = lib.mkIf (
+        !cfg.tunMode.setuid
+      ) "cap_net_admin,cap_net_raw,cap_net_bind_service,cap_sys_ptrace,cap_dac_read_search+ep";
+    };
+
+    # avoid resolvectl password prompt popping up three times
+    # https://github.com/SagerNet/sing-tun/blob/0686f8c4f210f4e7039c352d42d762252f9d9cf5/tun_linux.go#L1062
+    # We use a hack here to determine whether the requested process is nekobox_core
+    # Detect whether its capabilities contain at least `net_admin` and `net_raw`.
+    # This does not reduce security, as we can already bypass `resolved` with them.
+    # Alternatives to consider:
+    # 1. Use suid to execute as a specific user, and check username with polkit.
+    #    However, NixOS module doesn't let us to set setuid and capabilities at the
+    #    same time, and it's tricky to make both work together because of some security
+    #    considerations in the kernel.
+    # 2. Check cmdline to get executable path. This is insecure because the process can
+    #    change its own cmdline. `/proc/<pid>/exe` is reliable but kernel forbids
+    #    checking that entry of process from different users, and polkit runs `spawn`
+    #    as an unprivileged user.
+    # 3. Put nekobox_core into a systemd service, and let polkit check service name.
+    #    This is the most secure and convenient way but requires heavy modification
+    #    to nekoray source code. Would be good to let upstream support that eventually.
+    security.polkit.extraConfig =
+      lib.mkIf (cfg.tunMode.enable && (!cfg.tunMode.setuid) && config.services.resolved.enable)
+        ''
+          polkit.addRule(function(action, subject) {
+            const allowedActionIds = [
+              "org.freedesktop.resolve1.set-domains",
+              "org.freedesktop.resolve1.set-default-route",
+              "org.freedesktop.resolve1.set-dns-servers"
+            ];
+
+            if (allowedActionIds.indexOf(action.id) !== -1) {
+              try {
+                var parentPid = polkit.spawn(["${lib.getExe' pkgs.procps "ps"}", "-o", "ppid=", subject.pid]).trim();
+                var parentCap = polkit.spawn(["${lib.getExe' pkgs.libcap "getpcaps"}", parentPid]).trim();
+                if (parentCap.includes("cap_net_admin") && parentCap.includes("cap_net_raw")) {
+                  return polkit.Result.YES;
+                } else {
+                  return polkit.Result.NOT_HANDLED;
+                }
+              } catch (e) {
+                return polkit.Result.NOT_HANDLED;
+              }
+            }
+          })
+        '';
+  };
+
+  meta.maintainers = with lib.maintainers; [ aleksana ];
+}

--- a/pkgs/by-name/ne/nekoray/core-also-check-capabilities.patch
+++ b/pkgs/by-name/ne/nekoray/core-also-check-capabilities.patch
@@ -1,0 +1,43 @@
+diff --git a/server.go b/server.go
+index c2a6be0..8aeca1c 100644
+--- a/server.go
++++ b/server.go
+@@ -11,6 +11,7 @@ import (
+ 	E "github.com/sagernet/sing/common/exceptions"
+ 	"github.com/sagernet/sing/common/metadata"
+ 	"github.com/sagernet/sing/service"
++	"golang.org/x/sys/unix"
+ 	"log"
+ 	"nekobox_core/gen"
+ 	"nekobox_core/internal/boxbox"
+@@ -359,13 +360,25 @@ func (s *server) CompileGeoSiteToSrs(ctx context.Context, in *gen.CompileGeoSite
+ }
+ 
+ func (s *server) IsPrivileged(ctx context.Context, _ *gen.EmptyReq) (*gen.IsPrivilegedResponse, error) {
+-	if runtime.GOOS == "windows" {
+-		return &gen.IsPrivilegedResponse{
+-			HasPrivilege: false,
+-		}, nil
++	ret := false
++	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
++		ret = true
++	} else if runtime.GOOS == "linux" {
++		caps := unix.CapUserHeader{
++			Version: unix.LINUX_CAPABILITY_VERSION_3,
++			Pid:     0, // current
++		}
++		var data [2]unix.CapUserData
++		err := unix.Capget(&caps, &data[0])
++		if err != nil {
++			ret = false
++		} else {
++			// CAP_NET_ADMIN = 12
++			ret = (data[0].Effective & (1 << unix.CAP_NET_ADMIN)) != 0
++		}
+ 	}
+ 
+-	return &gen.IsPrivilegedResponse{HasPrivilege: os.Geteuid() == 0}, nil
++	return &gen.IsPrivilegedResponse{HasPrivilege: ret}, nil
+ }
+ 
+ func (s *server) SpeedTest(ctx context.Context, in *gen.SpeedTestRequest) (*gen.SpeedTestResponse, error) {

--- a/pkgs/by-name/ne/nekoray/nixos-disable-setuid-request.patch
+++ b/pkgs/by-name/ne/nekoray/nixos-disable-setuid-request.patch
@@ -1,0 +1,47 @@
+diff --git a/src/global/NekoGui.cpp b/src/global/NekoGui.cpp
+index 7943d7a..5bb20cc 100644
+--- a/src/global/NekoGui.cpp
++++ b/src/global/NekoGui.cpp
+@@ -355,6 +355,12 @@ namespace NekoGui {
+     // System Utils
+ 
+     QString FindNekoBoxCoreRealPath() {
++        // find in PATH first
++        QString path = QStandardPaths::findExecutable("nekobox_core");
++        if (!path.isEmpty()) {
++            return path;
++        }
++
+         auto fn = QApplication::applicationDirPath() + "/nekobox_core";
+         auto fi = QFileInfo(fn);
+         if (fi.isSymLink()) return fi.symLinkTarget();
+diff --git a/src/ui/mainwindow.cpp b/src/ui/mainwindow.cpp
+index 9aa46b2..ba7137a 100644
+--- a/src/ui/mainwindow.cpp
++++ b/src/ui/mainwindow.cpp
+@@ -125,8 +125,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
+     NekoGui::dataStore->core_port = MkPort();
+     if (NekoGui::dataStore->core_port <= 0) NekoGui::dataStore->core_port = 19810;
+ 
+-    auto core_path = QApplication::applicationDirPath() + "/";
+-    core_path += "nekobox_core";
++    auto core_path = NekoGui::FindNekoBoxCoreRealPath();
+ 
+     QStringList args;
+     args.push_back("nekobox");
+@@ -844,6 +843,15 @@ bool MainWindow::get_elevated_permissions(int reason) {
+         return true;
+     }
+     if (NekoGui::IsAdmin()) return true;
++    QMessageBox::critical(
++        GetMessageBoxParent(),
++        tr("Unable to elevate privileges when installed with Nix"),
++        tr("Due to the read-only property of Nix store, we cannot set suid for nekobox_core. If you are using NixOS, please set `programs.nekoray.tunMode.enable` option to elevate privileges."),
++        QMessageBox::Ok
++    );
++    return false;
++    // The following code isn't effective, preserve to avoid merge conflict
++
+ #ifdef Q_OS_LINUX
+     if (!Linux_HavePkexec()) {
+         MessageBoxWarning(software_name, "Please install \"pkexec\" first.");

--- a/pkgs/by-name/ne/nekoray/package.nix
+++ b/pkgs/by-name/ne/nekoray/package.nix
@@ -60,6 +60,11 @@ stdenv.mkDerivation (finalAttrs: {
     # we already package those two files in nixpkgs
     # we can't place file at that location using our builder so we must change the search directory to be relative to the built executable
     ./search-for-geodata-in-install-location.patch
+
+    # disable suid request as it cannot be applied to nekobox_core in nix store
+    # and prompt users to use NixOS module instead. And use nekobox_core from PATH
+    # to make use of security wrappers
+    ./nixos-disable-setuid-request.patch
   ];
 
   installPhase = ''
@@ -95,6 +100,11 @@ stdenv.mkDerivation (finalAttrs: {
     pname = "nekobox-core";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/core/server";
+
+    patches = [
+      # also check cap_net_admin so we don't have to set suid
+      ./core-also-check-capabilities.patch
+    ];
 
     vendorHash = "sha256-hZiEIJ4/TcLUfT+pkqs6WfzjqppSTjKXEtQC+DS26Ug=";
 

--- a/pkgs/by-name/ne/nekoray/package.nix
+++ b/pkgs/by-name/ne/nekoray/package.nix
@@ -134,7 +134,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Mahdi-zarei/nekoray";
     license = lib.licenses.gpl3Plus;
     mainProgram = "nekoray";
-    maintainers = with lib.maintainers; [ tomasajt ];
+    maintainers = with lib.maintainers; [
+      tomasajt
+      aleksana
+    ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
So one of my proxy works in TUN mode, another has some issue with DNS lookup, but it is working on my android phone. Not sure if it's a sing-box bug or something.

Closes #337578

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
