### PR TITLE
gdcm: 3.0.24 -> 3.0.25

### DIFF
--- a/pkgs/development/libraries/gdcm/add-missing-losslylosslessarray-in-TestTransferSyntax.patch
+++ b/pkgs/development/libraries/gdcm/add-missing-losslylosslessarray-in-TestTransferSyntax.patch
@@ -1,0 +1,14 @@
+diff --git a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestTransferSyntax.cxx b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestTransferSyntax.cxx
+index 7ad350d..6f962ce 100644
+--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestTransferSyntax.cxx
++++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestTransferSyntax.cxx
+@@ -43,6 +43,9 @@ static const int losslylosslessarray[][3] = {
+     { 1, 0, 1 }, //    MPEG2MainProfileHighLevel
+     { 1, 0, 1 }, //    MPEG4AVCH264HighProfileLevel4_1
+     { 1, 0, 1 }, //    MPEG4AVCH264BDcompatibleHighProfileLevel4_1
++    { 0, 1, 1 }, //    HTJ2KLossless
++    { 0, 1, 1 }, //    HTJ2KRPCLLossless
++    { 1, 0, 1 }, //    HTJ2K
+ };
+ 
+ static int TestTransferSyntaxAll()

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   enableVTK ? true,
   vtk,
@@ -18,14 +19,26 @@
 
 stdenv.mkDerivation rec {
   pname = if enablePython then "python-gdcm" else "gdcm";
-  version = "3.0.24";
+  version = "3.0.25";
 
   src = fetchFromGitHub {
     owner = "malaterre";
     repo = "GDCM";
     tag = "v${version}";
-    hash = "sha256-Zlb6UCP4aFZOJJNhFQBBrwzst+f37gs1zaCBMTOUgZE=";
+    hash = "sha256-PYVVlSqeAZCWvnWPqqWGQIWatMfPYqnrXc7cqi8UseU=";
   };
+
+  patches =
+    [
+      ./add-missing-losslylosslessarray-in-TestTransferSyntax.patch
+    ]
+    ++ lib.optionals (lib.versionOlder vtk.version "9.3") [
+      (fetchpatch2 {
+        url = "https://github.com/malaterre/GDCM/commit/3be6c2fa0945c91889bcf06e8c20e88f69692dd5.patch?full_index=1";
+        hash = "sha256-Yt5f4mxhP5n+L0A/CRq3CxKCqUT7LZ8uKdbCf9P71Zc=";
+        revert = true;
+      })
+    ];
 
   cmakeFlags =
     [

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -15,6 +15,7 @@
   openjpeg,
   zlib,
   pkg-config,
+  ctestCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -108,11 +109,10 @@ stdenv.mkDerivation rec {
       "TestRescaler2"
     ];
 
-  checkPhase = ''
-    runHook preCheck
-    ctest --exclude-regex '^(${lib.concatStringsSep "|" disabledTests})$'
-    runHook postCheck
-  '';
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
+
   doCheck = true;
   # note that when the test data is available to the build via `fetchSubmodules = true`,
   # a number of additional but much slower tests are enabled


### PR DESCRIPTION
part of [pr 407910](https://github.com/NixOS/nixpkgs/pull/407910)

required for updating vtk.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
