### PR TITLE
otb: include legacy vcl header file

### DIFF
--- a/pkgs/by-name/ot/otb/package.nix
+++ b/pkgs/by-name/ot/otb/package.nix
@@ -234,9 +234,17 @@ stdenv.mkDerivation (finalAttrs: {
     ./1-otb-swig-include-itk.diff
   ];
 
-  postPatch = (
-    "substituteInPlace Modules/Core/Wrappers/SWIG/src/python/CMakeLists.txt --replace-fail '''$''{ITK_INCLUDE_DIRS}' ${otb-itk}/include/ITK-${itkMajorMinorVersion}"
-  );
+  postPatch =
+    ''
+      substituteInPlace Modules/Core/Wrappers/SWIG/src/python/CMakeLists.txt \
+        --replace-fail ''\'''${ITK_INCLUDE_DIRS}' "${otb-itk}/include/ITK-${itkMajorMinorVersion}"
+    ''
+    # Add the header file "vcl_legacy_aliases.h", which defines the legacy vcl_* functions.
+    # This patch fixes the unreproducible build of OTB.
+    # See https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2484.
+    + ''
+      sed -i '/#include "vcl_compiler.h"/a #include "vcl_legacy_aliases.h"' Modules/Core/Mosaic/include/otbMosaicFunctors.h
+    '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
part of https://github.com/NixOS/nixpkgs/pull/407910

It's not a regression caused by updating vtk. 

related hydra build succeed https://hydra.nixos.org/build/298128281
though it failed on my local build 
```
[ 34%] [32m[1mLinking CXX executable ../../../../bin/OTBImageNoiseHeaderTest1[0m
[ 34%] [32m[1mLinking CXX executable ../../../bin/OTBIndicesHeaderTest1[0m
In file included from [01m[K/build/source/build/Modules/Core/Mosaic/test/OTBMosaicHeaderTest1.cxx:23[m[K:
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:[m[K In constructor '[01m[Kotb::Functor::RGB2LAB<TInput, TOutput>::[01;32m[KRGB2LAB[m[K()[m[K':
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:61:22:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_sqrt[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_sqrt[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
   61 |     D1[0][0] = 1.0 / [01;31m[Kvcl_sqrt[m[K(3.0);
      |                      [01;31m[K^~~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:61:22:[m[K [01;36m[Knote: [m[K(if you use '[01m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K', G++ will accept your code, but allowing the use of an undeclared name is deprecated)
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:62:22:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_sqrt[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_sqrt[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
   62 |     D1[1][1] = 1.0 / [01;31m[Kvcl_sqrt[m[K(6.0);
      |                      [01;31m[K^~~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:63:22:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_sqrt[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_sqrt[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
   63 |     D1[2][2] = 1.0 / [01;31m[Kvcl_sqrt[m[K(2.0);
      |                      [01;31m[K^~~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:[m[K In member function '[01m[KTOutput otb::Functor::RGB2LAB<TInput, TOutput>::[01;32m[Koperator()[m[K(const TInput&) const[m[K':
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:108:26:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_log[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_log[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  108 |     const double log10 = [01;31m[Kvcl_log[m[K(10);
      |                          [01;31m[K^~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:109:26:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_log[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_log[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  109 |     lms[0][0]          = [01;31m[Kvcl_log[m[K(lms[0][0]) / log10;
      |                          [01;31m[K^~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:110:26:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_log[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_log[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  110 |     lms[1][0]          = [01;31m[Kvcl_log[m[K(lms[1][0]) / log10;
      |                          [01;31m[K^~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:111:26:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_log[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_log[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  111 |     lms[2][0]          = [01;31m[Kvcl_log[m[K(lms[2][0]) / log10;
      |                          [01;31m[K^~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:[m[K In constructor '[01m[Kotb::Functor::LAB2RGB<TInput, TOutput>::[01;32m[KLAB2RGB[m[K()[m[K':
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:162:22:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_sqrt[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_sqrt[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  162 |     D1[0][0] = 1.0 / [01;31m[Kvcl_sqrt[m[K(3.0);
      |                      [01;31m[K^~~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:163:22:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_sqrt[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_sqrt[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  163 |     D1[1][1] = 1.0 / [01;31m[Kvcl_sqrt[m[K(6.0);
      |                      [01;31m[K^~~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:164:22:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_sqrt[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_sqrt[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  164 |     D1[2][2] = 1.0 / [01;31m[Kvcl_sqrt[m[K(2.0);
      |                      [01;31m[K^~~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:[m[K In member function '[01m[KTOutput otb::Functor::LAB2RGB<TInput, TOutput>::[01;32m[Koperator()[m[K(const TInput&) const[m[K':
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:207:17:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_pow[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_pow[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  207 |     lms[0][0] = [01;31m[Kvcl_pow[m[K(10.0, lms[0][0]);
      |                 [01;31m[K^~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:208:17:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_pow[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_pow[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  208 |     lms[1][0] = [01;31m[Kvcl_pow[m[K(10.0, lms[1][0]);
      |                 [01;31m[K^~~~~~~[m[K
[01m[K/build/source/Modules/Core/Mosaic/include/otbMosaicFunctors.h:209:17:[m[K [01;31m[Kerror: [m[Kthere are no arguments to '[01m[Kvcl_pow[m[K' that depend on a template parameter, so a declaration of '[01m[Kvcl_pow[m[K' must be available [[01;31m[K]8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-fpermissive-fpermissive]8;;[m[K]
  209 |     lms[2][0] = [01;31m[Kvcl_pow[m[K(10.0, lms[2][0]);
      |                 [01;31m[K^~~~~~~[m[K
```



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
