### PR TITLE
cfclient: init at 2025.2

### DIFF
--- a/pkgs/by-name/cf/cfclient/package.nix
+++ b/pkgs/by-name/cf/cfclient/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  qt6,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "cfclient";
+  version = "2025.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bitcraze";
+    repo = "crazyflie-clients-python";
+    tag = version;
+    hash = "sha256-LCGTMLIfGH59KFwQACyuEQTh/zkGgzXd3e6MkFTgKhA=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [
+    qt6.qtbase
+  ];
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+  ];
+
+  dontWrapQtApps = true;
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonRelaxDeps = [
+    "numpy"
+    "pyqt6"
+    "vispy"
+  ];
+
+  dependencies = with python3Packages; [
+    appdirs
+    cflib
+    numpy
+    pyopengl
+    pyserial
+    pysdl2
+    pyqtgraph
+    pyqt6
+    pyqt6-sip
+    pyyaml
+    pyzmq
+    scipy
+    setuptools
+    vispy
+  ];
+
+  # No tests
+  doCheck = false;
+
+  # Use wrapQtApp for Python scripts as the manual mentions that wrapQtAppsHook only applies to binaries
+  postFixup = ''
+    wrapQtApp "$out/bin/cfclient" \
+      --set QT_QPA_PLATFORM "wayland" \
+      --set XDG_CURRENT_DESKTOP "Wayland" \
+      ''${qtWrapperArgs[@]}
+  '';
+
+  meta = {
+    description = "Host applications and library for Crazyflie drones written in Python";
+    homepage = "https://github.com/bitcraze/crazyflie-clients-python";
+    changelog = "https://github.com/bitcraze/crazyflie-clients-python/releases/tag/${version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.brianmcgillion ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/cflib/default.nix
+++ b/pkgs/development/python-modules/cflib/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  libusb-package,
+  numpy,
+  packaging,
+  pyserial,
+  pyusb,
+  scipy,
+  pytestCheckHook,
+  pyyaml,
+  udevCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "cflib";
+  version = "0.1.28";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bitcraze";
+    repo = "crazyflie-lib-python";
+    tag = version;
+    hash = "sha256-vGqwQVD80NcFJosVAmqj66uxYNoVtAqzVhVQiuWP5yM=";
+  };
+
+  strictDeps = true;
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonRelaxDeps = [ "numpy" ];
+
+  dependencies = [
+    libusb-package
+    numpy
+    packaging
+    pyserial
+    pyusb
+    scipy
+  ];
+
+  disabledTestPaths = [
+    # exception: Cannot find a Crazyradio Dongle (HW required)
+    "sys_test/single_cf_grounded/"
+    "sys_test/swarm_test_rig/"
+  ];
+
+  pythonImportsCheck = [ "cflib" ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pyyaml
+  ];
+
+  # The udevCheckHook is used to verify udev rules
+  # requires diInstallCheck to be enabled, which is default for pythonPackages
+  nativeInstallCheckInputs = [
+    udevCheckHook
+  ];
+
+  # Install udev rules as defined
+  # https://www.bitcraze.io/documentation/repository/crazyflie-lib-python/master/installation/usb_permissions/
+  postInstall = ''
+    # Install udev rules
+    mkdir -p $out/etc/udev/rules.d
+
+    cat <<EOF > $out/etc/udev/rules.d/99-bitcraze.rules
+    # Crazyradio (normal operation)
+    SUBSYSTEM=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="7777", MODE="0664", GROUP="plugdev"
+    # Bootloader
+    SUBSYSTEM=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="0101", MODE="0664", GROUP="plugdev"
+    # Crazyflie (over USB)
+    SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0664", GROUP="plugdev"
+    EOF
+  '';
+
+  meta = {
+    description = "Python library for the Crazyflie quadcopter by Bitcraze";
+    homepage = "https://github.com/bitcraze/crazyflie-lib-python";
+    changelog = "https://github.com/bitcraze/crazyflie-lib-python/releases/tag/${version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.brianmcgillion ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/libusb-package/default.nix
+++ b/pkgs/development/python-modules/libusb-package/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  tomli,
+  importlib-resources,
+  libusb1,
+}:
+
+buildPythonPackage rec {
+  pname = "libusb-package";
+  version = "1.0.26.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pyocd";
+    repo = "libusb-package";
+    tag = "v${version}";
+    hash = "sha256-4zTyaidpSlledTcEztWzRgwj43oNV7xWrhMXCE9Qz3k=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+    tomli
+  ];
+
+  dependencies = [
+    importlib-resources
+    libusb1
+  ];
+
+  meta = {
+    description = "Python package for simplified libusb distribution and usage with pyOCD";
+    homepage = "https://github.com/pyocd/libusb-package";
+    changelog = "https://github.com/pyocd/libusb-package/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.brianmcgillion ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2366,6 +2366,8 @@ self: super: with self; {
 
   cfgv = callPackage ../development/python-modules/cfgv { };
 
+  cflib = callPackage ../development/python-modules/cflib { };
+
   cfn-flip = callPackage ../development/python-modules/cfn-flip { };
 
   cfn-lint = callPackage ../development/python-modules/cfn-lint { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8041,6 +8041,10 @@ self: super: with self; {
   libtorrent-rasterbar =
     (toPythonModule (pkgs.libtorrent-rasterbar.override { python3 = python; })).python;
 
+  libusb-package = callPackage ../development/python-modules/libusb-package {
+    inherit (pkgs) libusb1;
+  };
+
   libusb1 = callPackage ../development/python-modules/libusb1 { inherit (pkgs) libusb1; };
 
   libusbsio = callPackage ../development/python-modules/libusbsio { inherit (pkgs) libusbsio; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces the control interface and application to control the research quadcopter called the Crazyflie

https://www.bitcraze.io/products/crazyflie-2-1-plus/

The main application and the control / flashing software are included in this PR from the following sources.

https://github.com/bitcraze/crazyflie-clients-python
https://github.com/bitcraze/crazyflie-lib-python

unfortunately no drones included :) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
