### PR TITLE
workflows/eval: drop process job

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -98,11 +98,11 @@ jobs:
           path: merged
           merge-multiple: true
 
-      - name: Check out the PR at the test merge commit
+      - name: Check out the PR at the target commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ needs.prepare.outputs.mergedSha }}
-          path: untrusted
+          ref: ${{ needs.prepare.outputs.targetSha }}
+          path: trusted
 
       - name: Install Nix
         uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
@@ -111,7 +111,7 @@ jobs:
 
       - name: Combine all output paths and eval stats
         run: |
-          nix-build untrusted/ci -A eval.combine \
+          nix-build trusted/ci -A eval.combine \
             --arg evalDir ./merged \
             --out-link combined
 
@@ -168,9 +168,8 @@ jobs:
         env:
           AUTHOR_ID: ${{ github.event.pull_request.user.id }}
         run: |
-          git -C untrusted fetch --depth 1 origin ${{ needs.prepare.outputs.targetSha }}
-          git -C untrusted worktree add ../trusted ${{ needs.prepare.outputs.targetSha }}
-          git -C untrusted diff --name-only ${{ needs.prepare.outputs.targetSha }} \
+          git -C trusted fetch --depth 1 origin ${{ needs.prepare.outputs.mergedSha }}
+          git -C trusted diff --name-only ${{ needs.prepare.outputs.mergedSha }} \
             | jq --raw-input --slurp 'split("\n")[:-1]' > touched-files.json
 
           # Use the target branch to get accurate maintainer info

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -74,14 +74,15 @@ jobs:
         run: |
           nix-build untrusted/ci -A eval.singleSystem \
             --argstr evalSystem "$MATRIX_SYSTEM" \
-            --arg chunkSize 10000
+            --arg chunkSize 10000 \
+            --out-link merged
           # If it uses too much memory, slightly decrease chunkSize
 
       - name: Upload the output paths and eval stats
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: intermediate-${{ matrix.system }}
-          path: result/*
+          name: merged-${{ matrix.system }}
+          path: merged/*
 
   process:
     name: Process
@@ -93,8 +94,8 @@ jobs:
       - name: Download output paths and eval stats for all systems
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          pattern: intermediate-*
-          path: intermediate
+          pattern: merged-*
+          path: merged
           merge-multiple: true
 
       - name: Check out the PR at the test merge commit
@@ -111,14 +112,14 @@ jobs:
       - name: Combine all output paths and eval stats
         run: |
           nix-build untrusted/ci -A eval.combine \
-            --arg resultsDir ./intermediate \
-            -o prResult
+            --arg evalDir ./merged \
+            --out-link combined
 
       - name: Upload the combined results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: result
-          path: prResult/*
+          name: combined
+          path: combined/*
 
       - name: Get target run id
         if: needs.prepare.outputs.targetSha
@@ -156,8 +157,8 @@ jobs:
       - uses: actions/download-artifact@v4
         if: steps.targetRunId.outputs.targetRunId
         with:
-          name: result
-          path: targetResult
+          name: combined
+          path: target
           merge-multiple: true
           github-token: ${{ github.token }}
           run-id: ${{ steps.targetRunId.outputs.targetRunId }}
@@ -174,15 +175,15 @@ jobs:
 
           # Use the target branch to get accurate maintainer info
           nix-build trusted/ci -A eval.compare \
-            --arg beforeResultDir ./targetResult \
-            --arg afterResultDir "$(realpath prResult)" \
+            --arg beforeDir ./target \
+            --arg afterDir "$(realpath combined)" \
             --arg touchedFilesJson ./touched-files.json \
             --argstr githubAuthorId "$AUTHOR_ID" \
-            -o comparison
+            --out-link comparison
 
           cat comparison/step-summary.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload the combined results
+      - name: Upload the comparison results
         if: steps.targetRunId.outputs.targetRunId
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -211,7 +212,7 @@ jobs:
           permission-members: read
           permission-pull-requests: write
 
-      - name: Download process result
+      - name: Download comparison result
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: comparison

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -84,18 +84,82 @@ jobs:
           name: merged-${{ matrix.system }}
           path: merged/*
 
+      - name: Get target run id
+        if: needs.prepare.outputs.targetSha
+        id: targetRunId
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MATRIX_SYSTEM: ${{ matrix.system }}
+          REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ needs.prepare.outputs.targetSha }}
+        run: |
+          # Get the latest eval.yml workflow run for the PR's target commit
+          if ! run=$(gh api --method GET /repos/"$REPOSITORY"/actions/workflows/eval.yml/runs \
+            -f head_sha="$TARGET_SHA" -f event=push \
+            --jq '.workflow_runs | sort_by(.run_started_at) | .[-1]') \
+            || [[ -z "$run" ]]; then
+            echo "Could not find an eval.yml workflow run for $TARGET_SHA, cannot make comparison"
+            exit 1
+          fi
+          echo "Comparing against $(jq .html_url <<< "$run")"
+          runId=$(jq .id <<< "$run")
+
+          if ! job=$(gh api --method GET /repos/"$REPOSITORY"/actions/runs/"$runId"/jobs \
+            --jq ".jobs[] | select (.name == \"Outpaths ($MATRIX_SYSTEM)\")") \
+            || [[ -z "$job" ]]; then
+            echo "Could not find the Outpaths ($MATRIX_SYSTEM) job for workflow run $runId, cannot make comparison"
+            exit 1
+          fi
+          jobId=$(jq .id <<< "$job")
+          conclusion=$(jq -r .conclusion <<< "$job")
+
+          while [[ "$conclusion" == null || "$conclusion" == "" ]]; do
+            echo "Job not done, waiting 10 seconds before checking again"
+            sleep 10
+            conclusion=$(gh api /repos/"$REPOSITORY"/actions/jobs/"$jobId" --jq '.conclusion')
+          done
+
+          if [[ "$conclusion" != "success" ]]; then
+            echo "Job was not successful (conclusion: $conclusion), cannot make comparison"
+            exit 1
+          fi
+
+          echo "targetRunId=$runId" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@v4
+        if: steps.targetRunId.outputs.targetRunId
+        with:
+          run-id: ${{ steps.targetRunId.outputs.targetRunId }}
+          name: merged-${{ matrix.system }}
+          path: target
+          github-token: ${{ github.token }}
+          merge-multiple: true
+
+      - name: Upload the output paths and eval stats
+        if: steps.targetRunId.outputs.targetRunId
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: target-${{ matrix.system }}
+          path: target/*
+
   process:
     name: Process
     runs-on: ubuntu-24.04-arm
     needs: [ prepare, outpaths ]
-    outputs:
-      targetRunId: ${{ steps.targetRunId.outputs.targetRunId }}
+    if: needs.prepare.outputs.targetSha
     steps:
-      - name: Download output paths and eval stats for all systems
+      - name: Download output paths and eval stats for all systems (PR)
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: merged-*
           path: merged
+          merge-multiple: true
+
+      - name: Download output paths and eval stats for all systems (target)
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: target-*
+          path: target
           merge-multiple: true
 
       - name: Check out the PR at the target commit
@@ -109,62 +173,20 @@ jobs:
         with:
           extra_nix_config: sandbox = true
 
-      - name: Combine all output paths and eval stats
+      - name: Combine all output paths and eval stats (PR)
         run: |
           nix-build trusted/ci -A eval.combine \
             --arg evalDir ./merged \
-            --out-link combined
+            --out-link combinedMerged
 
-      - name: Upload the combined results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: combined
-          path: combined/*
-
-      - name: Get target run id
+      - name: Combine all output paths and eval stats (target)
         if: needs.prepare.outputs.targetSha
-        id: targetRunId
-        env:
-          REPOSITORY: ${{ github.repository }}
-          TARGET_SHA: ${{ needs.prepare.outputs.targetSha }}
-          GH_TOKEN: ${{ github.token }}
         run: |
-          # Get the latest eval.yml workflow run for the PR's target commit
-          if ! run=$(gh api --method GET /repos/"$REPOSITORY"/actions/workflows/eval.yml/runs \
-            -f head_sha="$TARGET_SHA" -f event=push \
-            --jq '.workflow_runs | sort_by(.run_started_at) | .[-1]') \
-            || [[ -z "$run" ]]; then
-            echo "Could not find an eval.yml workflow run for $TARGET_SHA, cannot make comparison"
-            exit 1
-          fi
-          echo "Comparing against $(jq .html_url <<< "$run")"
-          runId=$(jq .id <<< "$run")
-          conclusion=$(jq -r .conclusion <<< "$run")
-
-          while [[ "$conclusion" == null || "$conclusion" == "" ]]; do
-            echo "Workflow not done, waiting 10 seconds before checking again"
-            sleep 10
-            conclusion=$(gh api /repos/"$REPOSITORY"/actions/runs/"$runId" --jq '.conclusion')
-          done
-
-          if [[ "$conclusion" != "success" ]]; then
-            echo "Workflow was not successful (conclusion: $conclusion), cannot make comparison"
-            exit 1
-          fi
-
-          echo "targetRunId=$runId" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/download-artifact@v4
-        if: steps.targetRunId.outputs.targetRunId
-        with:
-          name: combined
-          path: target
-          merge-multiple: true
-          github-token: ${{ github.token }}
-          run-id: ${{ steps.targetRunId.outputs.targetRunId }}
+          nix-build trusted/ci -A eval.combine \
+            --arg evalDir ./target \
+            -o combinedTarget
 
       - name: Compare against the target branch
-        if: steps.targetRunId.outputs.targetRunId
         env:
           AUTHOR_ID: ${{ github.event.pull_request.user.id }}
         run: |
@@ -174,8 +196,8 @@ jobs:
 
           # Use the target branch to get accurate maintainer info
           nix-build trusted/ci -A eval.compare \
-            --arg beforeDir ./target \
-            --arg afterDir "$(realpath combined)" \
+            --arg beforeDir "$(realpath combinedTarget)" \
+            --arg afterDir "$(realpath combinedMerged)" \
             --arg touchedFilesJson ./touched-files.json \
             --argstr githubAuthorId "$AUTHOR_ID" \
             --out-link comparison
@@ -183,7 +205,6 @@ jobs:
           cat comparison/step-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload the comparison results
-        if: steps.targetRunId.outputs.targetRunId
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: comparison
@@ -194,7 +215,7 @@ jobs:
     name: Tag
     runs-on: ubuntu-24.04-arm
     needs: [ prepare, process ]
-    if: needs.process.outputs.targetRunId
+    if: needs.prepare.outputs.targetSha
     permissions:
       pull-requests: write
       statuses: write

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -153,11 +153,14 @@ jobs:
           name: diff-${{ matrix.system }}
           path: diff/*
 
-  process:
-    name: Process
+  tag:
+    name: Tag
     runs-on: ubuntu-24.04-arm
     needs: [ prepare, outpaths ]
     if: needs.prepare.outputs.targetSha
+    permissions:
+      pull-requests: write
+      statuses: write
     steps:
       - name: Download output paths and eval stats for all systems
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -205,46 +208,6 @@ jobs:
         with:
           name: comparison
           path: comparison/*
-
-  # Separate job to have a very tightly scoped PR write token
-  tag:
-    name: Tag
-    runs-on: ubuntu-24.04-arm
-    needs: [ prepare, process ]
-    if: needs.prepare.outputs.targetSha
-    permissions:
-      pull-requests: write
-      statuses: write
-    steps:
-      # See ./codeowners-v2.yml, reuse the same App because we need the same permissions
-      # Can't use the token received from permissions above, because it can't get enough permissions
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        if: vars.OWNER_APP_ID
-        id: app-token
-        with:
-          app-id: ${{ vars.OWNER_APP_ID }}
-          private-key: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
-          permission-administration: read
-          permission-members: read
-          permission-pull-requests: write
-
-      - name: Download comparison result
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-        with:
-          name: comparison
-          path: comparison
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
-
-      # Important: This workflow job runs with extra permissions,
-      # so we need to make sure to not run untrusted code from PRs
-      - name: Check out Nixpkgs at the target commit
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ needs.prepare.outputs.targetSha }}
-          path: trusted
-          sparse-checkout: ci
 
       - name: Build the requestReviews derivation
         run: nix-build trusted/ci -A requestReviews
@@ -302,6 +265,18 @@ jobs:
             -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/$GITHUB_REPOSITORY/statuses/$PR_HEAD_SHA" \
             -f "context=Eval / Summary" -f "state=success" -f "description=$description" -f "target_url=$target_url"
+
+      # See ./codeowners-v2.yml, reuse the same App because we need the same permissions
+      # Can't use the token received from permissions above, because it can't get enough permissions
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        if: vars.OWNER_APP_ID
+        id: app-token
+        with:
+          app-id: ${{ vars.OWNER_APP_ID }}
+          private-key: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
+          permission-administration: read
+          permission-members: read
+          permission-pull-requests: write
 
       - name: Requesting maintainer reviews
         if: ${{ steps.app-token.outputs.token && github.repository_owner == 'NixOS' }}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -135,12 +135,23 @@ jobs:
           github-token: ${{ github.token }}
           merge-multiple: true
 
-      - name: Upload the output paths and eval stats
+      - name: Compare outpaths against the target branch
+        if: steps.targetRunId.outputs.targetRunId
+        env:
+          MATRIX_SYSTEM: ${{ matrix.system }}
+        run: |
+          nix-build untrusted/ci -A eval.diff \
+            --arg beforeDir ./target \
+            --arg afterDir "$(readlink ./merged)" \
+            --argstr evalSystem "$MATRIX_SYSTEM" \
+            --out-link diff
+
+      - name: Upload outpaths diff and stats
         if: steps.targetRunId.outputs.targetRunId
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: target-${{ matrix.system }}
-          path: target/*
+          name: diff-${{ matrix.system }}
+          path: diff/*
 
   process:
     name: Process
@@ -148,18 +159,11 @@ jobs:
     needs: [ prepare, outpaths ]
     if: needs.prepare.outputs.targetSha
     steps:
-      - name: Download output paths and eval stats for all systems (PR)
+      - name: Download output paths and eval stats for all systems
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          pattern: merged-*
-          path: merged
-          merge-multiple: true
-
-      - name: Download output paths and eval stats for all systems (target)
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-        with:
-          pattern: target-*
-          path: target
+          pattern: diff-*
+          path: diff
           merge-multiple: true
 
       - name: Check out the PR at the target commit
@@ -173,18 +177,11 @@ jobs:
         with:
           extra_nix_config: sandbox = true
 
-      - name: Combine all output paths and eval stats (PR)
+      - name: Combine all output paths and eval stats
         run: |
           nix-build trusted/ci -A eval.combine \
-            --arg evalDir ./merged \
-            --out-link combinedMerged
-
-      - name: Combine all output paths and eval stats (target)
-        if: needs.prepare.outputs.targetSha
-        run: |
-          nix-build trusted/ci -A eval.combine \
-            --arg evalDir ./target \
-            -o combinedTarget
+            --arg diffDir ./diff \
+            --out-link combined
 
       - name: Compare against the target branch
         env:
@@ -196,8 +193,7 @@ jobs:
 
           # Use the target branch to get accurate maintainer info
           nix-build trusted/ci -A eval.compare \
-            --arg beforeDir "$(realpath combinedTarget)" \
-            --arg afterDir "$(realpath combinedMerged)" \
+            --arg combinedDir "$(realpath ./combined)" \
             --arg touchedFilesJson ./touched-files.json \
             --argstr githubAuthorId "$AUTHOR_ID" \
             --out-link comparison

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -7,8 +7,7 @@
   python3,
 }:
 {
-  beforeDir,
-  afterDir,
+  combinedDir,
   touchedFilesJson,
   githubAuthorId,
   byName ? false,
@@ -66,7 +65,6 @@ let
       Example: { name = "python312Packages.numpy"; platform = "x86_64-linux"; }
   */
   inherit (import ./utils.nix { inherit lib; })
-    diff
     groupByKernel
     convertToPackagePlatformAttrs
     groupByPlatform
@@ -74,22 +72,10 @@ let
     getLabels
     ;
 
-  getAttrs =
-    dir:
-    let
-      raw = builtins.readFile "${dir}/outpaths.json";
-      # The file contains Nix paths; we need to ignore them for evaluation purposes,
-      # else there will be a "is not allowed to refer to a store path" error.
-      data = builtins.unsafeDiscardStringContext raw;
-    in
-    builtins.fromJSON data;
-  beforeAttrs = getAttrs beforeDir;
-  afterAttrs = getAttrs afterDir;
-
   # Attrs
   # - keys: "added", "changed" and "removed"
   # - values: lists of `packagePlatformPath`s
-  diffAttrs = diff beforeAttrs afterAttrs;
+  diffAttrs = builtins.fromJSON (builtins.readFile "${combinedDir}/combined-diff.json");
 
   rebuilds = diffAttrs.added ++ diffAttrs.changed;
   rebuildsPackagePlatformAttrs = convertToPackagePlatformAttrs rebuilds;
@@ -149,8 +135,8 @@ runCommand "compare"
     maintainers = builtins.toJSON maintainers;
     passAsFile = [ "maintainers" ];
     env = {
-      BEFORE_DIR = "${beforeDir}";
-      AFTER_DIR = "${afterDir}";
+      BEFORE_DIR = "${combinedDir}/before";
+      AFTER_DIR = "${combinedDir}/after";
     };
   }
   ''

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -7,8 +7,8 @@
   python3,
 }:
 {
-  beforeResultDir,
-  afterResultDir,
+  beforeDir,
+  afterDir,
   touchedFilesJson,
   githubAuthorId,
   byName ? false,
@@ -20,7 +20,7 @@ let
 
     ---
     Inputs:
-    - beforeResultDir, afterResultDir: The evaluation result from before and after the change.
+    - beforeDir, afterDir: The evaluation result from before and after the change.
       They can be obtained by running `nix-build -A ci.eval.full` on both revisions.
 
     ---
@@ -83,8 +83,8 @@ let
       data = builtins.unsafeDiscardStringContext raw;
     in
     builtins.fromJSON data;
-  beforeAttrs = getAttrs beforeResultDir;
-  afterAttrs = getAttrs afterResultDir;
+  beforeAttrs = getAttrs beforeDir;
+  afterAttrs = getAttrs afterDir;
 
   # Attrs
   # - keys: "added", "changed" and "removed"
@@ -149,8 +149,8 @@ runCommand "compare"
     maintainers = builtins.toJSON maintainers;
     passAsFile = [ "maintainers" ];
     env = {
-      BEFORE_DIR = "${beforeResultDir}";
-      AFTER_DIR = "${afterResultDir}";
+      BEFORE_DIR = "${beforeDir}";
+      AFTER_DIR = "${afterDir}";
     };
   }
   ''

--- a/ci/eval/compare/utils.nix
+++ b/ci/eval/compare/utils.nix
@@ -94,32 +94,6 @@ rec {
     uniqueStrings (builtins.map (p: p.name) packagePlatformAttrs);
 
   /*
-    Computes the key difference between two attrs
-
-    {
-      added: [ <keys only in the second object> ],
-      removed: [ <keys only in the first object> ],
-      changed: [ <keys with different values between the two objects> ],
-    }
-  */
-  diff =
-    let
-      filterKeys = cond: attrs: lib.attrNames (lib.filterAttrs cond attrs);
-    in
-    old: new: {
-      added = filterKeys (n: _: !(old ? ${n})) new;
-      removed = filterKeys (n: _: !(new ? ${n})) old;
-      changed = filterKeys (
-        n: v:
-        # Filter out attributes that don't exist anymore
-        (new ? ${n})
-
-        # Filter out attributes that are the same as the new value
-        && (v != (new.${n}))
-      ) old;
-    };
-
-  /*
     Group a list of `packagePlatformAttr`s by platforms
 
     Turns

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -193,9 +193,9 @@ let
 
   combine =
     {
-      resultsDir,
+      evalDir,
     }:
-    runCommand "combined-result"
+    runCommand "combined-eval"
       {
         nativeBuildInputs = [
           jq
@@ -205,11 +205,11 @@ let
         mkdir -p $out
 
         # Combine output paths from all systems
-        cat ${resultsDir}/*/paths.json | jq -s add > $out/outpaths.json
+        cat ${evalDir}/*/paths.json | jq -s add > $out/outpaths.json
 
         mkdir -p $out/stats
 
-        for d in ${resultsDir}/*; do
+        for d in ${evalDir}/*; do
           cp -r "$d"/stats-by-chunk $out/stats/$(basename "$d")
         done
       '';
@@ -225,8 +225,8 @@ let
       quickTest ? false,
     }:
     let
-      results = symlinkJoin {
-        name = "results";
+      evals = symlinkJoin {
+        name = "evals";
         paths = map (
           evalSystem:
           singleSystem {
@@ -236,7 +236,7 @@ let
       };
     in
     combine {
-      resultsDir = results;
+      evalDir = evals;
     };
 
 in

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -191,9 +191,11 @@ let
         cat "$chunkOutputDir"/result/* | jq -s 'add | map_values(.outputs)' > $out/${evalSystem}/paths.json
       '';
 
+  diff = callPackage ./diff.nix { };
+
   combine =
     {
-      evalDir,
+      diffDir,
     }:
     runCommand "combined-eval"
       {
@@ -205,12 +207,22 @@ let
         mkdir -p $out
 
         # Combine output paths from all systems
-        cat ${evalDir}/*/paths.json | jq -s add > $out/outpaths.json
+        cat ${diffDir}/*/diff.json | jq -s '
+          reduce .[] as $item ({}; {
+            added: (.added + $item.added),
+            changed: (.changed + $item.changed),
+            removed: (.removed + $item.removed)
+          })
+        ' > $out/combined-diff.json
 
-        mkdir -p $out/stats
+        mkdir -p $out/before/stats
+        for d in ${diffDir}/before/*; do
+          cp -r "$d"/stats-by-chunk $out/before/stats/$(basename "$d")
+        done
 
-        for d in ${evalDir}/*; do
-          cp -r "$d"/stats-by-chunk $out/stats/$(basename "$d")
+        mkdir -p $out/after/stats
+        for d in ${diffDir}/after/*; do
+          cp -r "$d"/stats-by-chunk $out/after/stats/$(basename "$d")
         done
       '';
 
@@ -225,18 +237,26 @@ let
       quickTest ? false,
     }:
     let
-      evals = symlinkJoin {
-        name = "evals";
+      diffs = symlinkJoin {
+        name = "diffs";
         paths = map (
           evalSystem:
-          singleSystem {
-            inherit quickTest evalSystem chunkSize;
+          let
+            eval = singleSystem {
+              inherit quickTest evalSystem chunkSize;
+            };
+          in
+          diff {
+            inherit evalSystem;
+            # Local "full" evaluation doesn't do a real diff.
+            beforeDir = eval;
+            afterDir = eval;
           }
         ) evalSystems;
       };
     in
     combine {
-      evalDir = evals;
+      diffDir = diffs;
     };
 
 in
@@ -244,6 +264,7 @@ in
   inherit
     attrpathsSuperset
     singleSystem
+    diff
     combine
     compare
     # The above three are used by separate VMs in a GitHub workflow,

--- a/ci/eval/diff.nix
+++ b/ci/eval/diff.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  runCommand,
+  writeText,
+}:
+
+{
+  beforeDir,
+  afterDir,
+  evalSystem,
+}:
+
+let
+  /*
+    Computes the key difference between two attrs
+
+    {
+      added: [ <keys only in the second object> ],
+      removed: [ <keys only in the first object> ],
+      changed: [ <keys with different values between the two objects> ],
+    }
+  */
+  diff =
+    let
+      filterKeys = cond: attrs: lib.attrNames (lib.filterAttrs cond attrs);
+    in
+    old: new: {
+      added = filterKeys (n: _: !(old ? ${n})) new;
+      removed = filterKeys (n: _: !(new ? ${n})) old;
+      changed = filterKeys (
+        n: v:
+        # Filter out attributes that don't exist anymore
+        (new ? ${n})
+
+        # Filter out attributes that are the same as the new value
+        && (v != (new.${n}))
+      ) old;
+    };
+
+  getAttrs =
+    dir:
+    let
+      raw = builtins.readFile "${dir}/${evalSystem}/paths.json";
+      # The file contains Nix paths; we need to ignore them for evaluation purposes,
+      # else there will be a "is not allowed to refer to a store path" error.
+      data = builtins.unsafeDiscardStringContext raw;
+    in
+    builtins.fromJSON data;
+
+  beforeAttrs = getAttrs beforeDir;
+  afterAttrs = getAttrs afterDir;
+  diffAttrs = diff beforeAttrs afterAttrs;
+  diffJson = writeText "diff.json" (builtins.toJSON diffAttrs);
+in
+runCommand "diff" { } ''
+  mkdir -p $out/${evalSystem}
+
+  cp -r ${beforeDir} $out/before
+  cp -r ${afterDir} $out/after
+  cp ${diffJson} $out/${evalSystem}/diff.json
+''


### PR DESCRIPTION
With a bit of rewiring, we can run the diff of attrpaths separately for each system in the outpaths jobs. We then only pass the diff onwards - directly to the `tag` job. The `compare` step then only consists of figuring out the rebuild labels to add and which maintainers to ping. Thus, we can leave out the process job entirely. Some of this was described in https://github.com/NixOS/nixpkgs/pull/406825#issuecomment-2883157778.

This gives us:
- One job less, that's always good. Saves 1 min of CI resources per run, just doing setup, nix install and dependency download.
- Slightly faster maintainer pings and ofc faster time to completion for a CI run - that 1 min from above. `nixpkgs-review` doesn't really benefit, the comparison results still come in around the same time.
- The ability to implement very light-weight release-checks on top as discussed in https://github.com/NixOS/nixpkgs/pull/406825#issuecomment-2889030491, because each outpaths job already knows about the diff for its system.

I tried to split the commits up to make it reviewable, hopefully that works well.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
