### PR TITLE
nixos/vmalert: support multiple instances

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -23,6 +23,9 @@
 
 - Added `rewriteURL` attribute to the nixpkgs `config`, to allow for rewriting the URLs downloaded by `fetchurl`.
 
+- `vmalert` now supports multiple instances with the option `services.vmalert.instances."".enable`
+  et al..
+
 ## Nixpkgs Library {#sec-nixpkgs-release-25.11-lib}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -105,7 +105,7 @@ In addition to numerous new and updated packages, this release has the following
 
 - [ivpn](https://www.ivpn.net/), a secure, private VPN with fast WireGuard connections. Available as [services.ivpn](#opt-services.ivpn.enable).
 
-- [vmalert](https://victoriametrics.com/), an alerting engine for VictoriaMetrics. Available as [services.vmalert](#opt-services.vmalert.enable).
+- [vmalert](https://victoriametrics.com/), an alerting engine for VictoriaMetrics. Available as [services.vmalert.instances](#opt-services.vmalert.instances._name_.enable).
 
 - [jellyseerr](https://github.com/Fallenbagel/jellyseerr), a web-based requests manager for Jellyfin, forked from Overseerr. Available as [services.jellyseerr](#opt-services.jellyseerr.enable).
 

--- a/nixos/modules/services/monitoring/vmalert.nix
+++ b/nixos/modules/services/monitoring/vmalert.nix
@@ -10,9 +10,9 @@ let
 
   format = pkgs.formats.yaml { };
 
-  confOpts = concatStringsSep " \\\n" (
-    mapAttrsToList mkLine (filterAttrs (_: v: v != false) cfg.settings)
-  );
+  mkConfOpts =
+    settings:
+    concatStringsSep " \\\n" (mapAttrsToList mkLine (filterAttrs (_: v: v != false) settings));
   confType =
     with types;
     let
@@ -33,124 +33,171 @@ let
       concatMapStringsSep " " (v: "-${key}=${escapeShellArg (toString v)}") value
     else
       "-${key}=${escapeShellArg (toString value)}";
+
+  vmalertName = name: "vmalert" + lib.optionalString (name != "") ("-" + name);
+  enabledInstances = lib.filterAttrs (name: conf: conf.enable) config.services.vmalert.instances;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "vmalert" "enable" ]
+      [ "services" "vmalert" "instances" "" "enable" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "vmalert" "rules" ]
+      [ "services" "vmalert" "instances" "" "rules" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "vmalert" "settings" ]
+      [ "services" "vmalert" "instances" "" "settings" ]
+    )
+  ];
+
   # interface
-  options.services.vmalert = {
-    enable = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Wether to enable VictoriaMetrics's `vmalert`.
+  options.services.vmalert.package = mkPackageOption pkgs "victoriametrics" { };
 
-        `vmalert` evaluates alerting and recording rules against a data source, sends notifications via Alertmanager.
-      '';
-    };
+  options.services.vmalert.instances = mkOption {
+    default = { };
 
-    package = mkPackageOption pkgs "victoriametrics" { };
+    description = ''
+      Define multiple instances of vmalert.
+    '';
 
-    settings = mkOption {
-      type = types.submodule {
-        freeformType = confType;
-        options = {
+    type = types.attrsOf (
+      types.submodule (
+        { name, config, ... }:
+        {
+          options = {
+            enable = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Wether to enable VictoriaMetrics's `vmalert`.
 
-          "datasource.url" = mkOption {
-            type = types.nonEmptyStr;
-            example = "http://localhost:8428";
-            description = ''
-              Datasource compatible with Prometheus HTTP API.
-            '';
+                `vmalert` evaluates alerting and recording rules against a data source, sends notifications via Alertmanager.
+              '';
+            };
+
+            settings = mkOption {
+              type = types.submodule {
+                freeformType = confType;
+                options = {
+
+                  "datasource.url" = mkOption {
+                    type = types.nonEmptyStr;
+                    example = "http://localhost:8428";
+                    description = ''
+                      Datasource compatible with Prometheus HTTP API.
+                    '';
+                  };
+
+                  "notifier.url" = mkOption {
+                    type = with types; listOf nonEmptyStr;
+                    default = [ ];
+                    example = [ "http://127.0.0.1:9093" ];
+                    description = ''
+                      Prometheus Alertmanager URL. List all Alertmanager URLs if it runs in the cluster mode to ensure high availability.
+                    '';
+                  };
+
+                  "rule" = mkOption {
+                    type = with types; listOf path;
+                    description = ''
+                      Path to the files with alerting and/or recording rules.
+
+                      ::: {.note}
+                      Consider using the {option}`services.vmalert.instances.<name>.rules` option as a convenient alternative for declaring rules
+                      directly in the `nix` language.
+                      :::
+                    '';
+                  };
+
+                };
+              };
+              default = { };
+              example = {
+                "datasource.url" = "http://localhost:8428";
+                "datasource.disableKeepAlive" = true;
+                "datasource.showURL" = false;
+                "rule" = [
+                  "http://<some-server-addr>/path/to/rules"
+                  "dir/*.yaml"
+                ];
+              };
+              description = ''
+                `vmalert` configuration, passed via command line flags. Refer to
+                <https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/vmalert/README.md#configuration>
+                for details on supported values.
+              '';
+            };
+
+            rules = mkOption {
+              type = format.type;
+              default = { };
+              example = {
+                group = [
+                  {
+                    name = "TestGroup";
+                    rules = [
+                      {
+                        alert = "ExampleAlertAlwaysFiring";
+                        expr = ''
+                          sum by(job)
+                          (up == 1)
+                        '';
+                      }
+                    ];
+                  }
+                ];
+              };
+              description = ''
+                A list of the given alerting or recording rules against configured `"datasource.url"` compatible with
+                Prometheus HTTP API for `vmalert` to execute. Refer to
+                <https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/vmalert/README.md#rules>
+                for details on supported values.
+              '';
+            };
           };
 
-          "notifier.url" = mkOption {
-            type = with types; listOf nonEmptyStr;
-            default = [ ];
-            example = [ "http://127.0.0.1:9093" ];
-            description = ''
-              Prometheus Alertmanager URL. List all Alertmanager URLs if it runs in the cluster mode to ensure high availability.
-            '';
-          };
-
-          "rule" = mkOption {
-            type = with types; listOf path;
-            description = ''
-              Path to the files with alerting and/or recording rules.
-
-              ::: {.note}
-              Consider using the {option}`services.vmalert.rules` option as a convenient alternative for declaring rules
-              directly in the `nix` language.
-              :::
-            '';
-          };
-
-        };
-      };
-      default = { };
-      example = {
-        "datasource.url" = "http://localhost:8428";
-        "datasource.disableKeepAlive" = true;
-        "datasource.showURL" = false;
-        "rule" = [
-          "http://<some-server-addr>/path/to/rules"
-          "dir/*.yaml"
-        ];
-      };
-      description = ''
-        `vmalert` configuration, passed via command line flags. Refer to
-        <https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/vmalert/README.md#configuration>
-        for details on supported values.
-      '';
-    };
-
-    rules = mkOption {
-      type = format.type;
-      default = { };
-      example = {
-        group = [
-          {
-            name = "TestGroup";
-            rules = [
-              {
-                alert = "ExampleAlertAlwaysFiring";
-                expr = ''
-                  sum by(job)
-                  (up == 1)
-                '';
-              }
+          config = {
+            settings.rule = [
+              "/etc/${vmalertName name}/rules.yml"
             ];
-          }
-        ];
-      };
-      description = ''
-        A list of the given alerting or recording rules against configured `"datasource.url"` compatible with
-        Prometheus HTTP API for `vmalert` to execute. Refer to
-        <https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/app/vmalert/README.md#rules>
-        for details on supported values.
-      '';
-    };
+          };
+        }
+      )
+    );
   };
 
   # implementation
-  config = mkIf cfg.enable {
+  config = mkIf (enabledInstances != { }) {
+    environment.etc = lib.mapAttrs' (
+      name:
+      { rules, ... }:
+      lib.nameValuePair "${vmalertName name}/rules.yml" {
+        source = format.generate "rules.yml" rules;
+      }
+    ) enabledInstances;
 
-    environment.etc."vmalert/rules.yml".source = format.generate "rules.yml" cfg.rules;
+    systemd.services = lib.mapAttrs' (
+      name:
+      { settings, ... }:
+      let
+        name' = vmalertName name;
+      in
+      lib.nameValuePair name' {
+        description = "vmalert service";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        reloadTriggers = [ config.environment.etc."${name'}/rules.yml".source ];
 
-    services.vmalert.settings.rule = [
-      "/etc/vmalert/rules.yml"
-    ];
-
-    systemd.services.vmalert = {
-      description = "vmalert service";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
-      reloadTriggers = [ config.environment.etc."vmalert/rules.yml".source ];
-
-      serviceConfig = {
-        DynamicUser = true;
-        Restart = "on-failure";
-        ExecStart = "${cfg.package}/bin/vmalert ${confOpts}";
-        ExecReload = ''${pkgs.coreutils}/bin/kill -SIGHUP "$MAINPID"'';
-      };
-    };
+        serviceConfig = {
+          DynamicUser = true;
+          Restart = "on-failure";
+          ExecStart = "${cfg.package}/bin/vmalert ${mkConfOpts settings}";
+          ExecReload = ''${pkgs.coreutils}/bin/kill -SIGHUP "$MAINPID"'';
+        };
+      }
+    ) enabledInstances;
   };
 }

--- a/nixos/tests/victoriametrics/vmalert.nix
+++ b/nixos/tests/victoriametrics/vmalert.nix
@@ -55,7 +55,7 @@ import ../make-test-python.nix (
             };
           };
 
-          services.vmalert = {
+          services.vmalert.instances."" = {
             enable = true;
             settings = {
               "datasource.url" = "http://localhost:8428"; # victoriametrics' api


### PR DESCRIPTION
vmalert only supports a single datasource for querying metrics and managing alerts. Because of that, we need two instances to manage alerts for both VictoriaLogs and VictoriaMetrics.

This is strongly inspired by the change made to Redis, i.e. a new `instances` option was introduced with each option inside it. With `mkRenamedOptionModule` it's ensured that existing configurations still evaluate to the same result.

Also, upstream suggests to run two instances of vmalert for VM & VL, though there are alternatives: https://docs.victoriametrics.com/victorialogs/vmalert/#how-to-use-one-vmalert-for-victorialogs-and-victoriametrics-rules-in-the-same-time

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
