### PR TITLE
kubo: 0.34.1 -> 0.35.0

### DIFF
--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -161,7 +161,7 @@ in
       autoMount = lib.mkOption {
         type = lib.types.bool;
         default = false;
-        description = "Whether Kubo should try to mount /ipfs and /ipns at startup.";
+        description = "Whether Kubo should try to mount /ipfs, /ipns and /mfs at startup.";
       };
 
       autoMigrate = lib.mkOption {
@@ -235,6 +235,12 @@ in
               type = lib.types.str;
               default = "/ipns";
               description = "Where to mount the IPNS namespace to";
+            };
+
+            Mounts.MFS = lib.mkOption {
+              type = lib.types.str;
+              default = "/mfs";
+              description = "Where to mount the MFS namespace to";
             };
           };
         };
@@ -356,6 +362,7 @@ in
         ${cfg.dataDir}.d = defaultConfig;
         ${cfg.settings.Mounts.IPFS}.d = lib.mkIf (cfg.autoMount) defaultConfig;
         ${cfg.settings.Mounts.IPNS}.d = lib.mkIf (cfg.autoMount) defaultConfig;
+        ${cfg.settings.Mounts.MFS}.d = lib.mkIf (cfg.autoMount) defaultConfig;
       };
 
     # The hardened systemd unit breaks the fuse-mount function according to documentation in the unit file itself
@@ -401,8 +408,8 @@ in
               ipfs --offline config replace -
           '';
         postStop = lib.mkIf cfg.autoMount ''
-          # After an unclean shutdown the fuse mounts at cfg.settings.Mounts.IPFS and cfg.settings.Mounts.IPNS are locked
-          umount --quiet '${cfg.settings.Mounts.IPFS}' '${cfg.settings.Mounts.IPNS}' || true
+          # After an unclean shutdown the fuse mounts at cfg.settings.Mounts.IPFS, cfg.settings.Mounts.IPNS and cfg.settings.Mounts.MFS are locked
+          umount --quiet '${cfg.settings.Mounts.IPFS}' '${cfg.settings.Mounts.IPNS}' '${cfg.settings.Mounts.MFS}' || true
         '';
         serviceConfig = {
           ExecStart = [

--- a/nixos/tests/kubo/kubo-fuse.nix
+++ b/nixos/tests/kubo/kubo-fuse.nix
@@ -43,11 +43,39 @@
         machine.succeed(f"diff /tmp/test.txt /ipfs/{ipfs_hash}")
 
 
-    with subtest("Unmounting of /ipns and /ipfs"):
+    with subtest("/mfs/ FUSE mountpoint"):
+        with subtest("Write the test file in three different ways"):
+            machine.succeed("cp /tmp/test.txt /mfs/test-1.txt")
+            machine.succeed("su alice -c 'ipfs files write --create /test-2.txt < /tmp/test.txt'")
+            machine.succeed(f"ipfs files cp /ipfs/{ipfs_hash} /test-3.txt")
+
+        with subtest("Show the files (for debugging)"):
+            # Different hashes for the different ways of adding the file to the MFS probably come from different linking structures of the merkle tree. Copying the file to /mfs with `cp` is even non-deterministic.
+            machine.succeed("ipfs files ls --long >&2")
+            machine.succeed("ls -l /mfs >&2")
+
+        with subtest("Check that everyone has permission to read the file (because of Mounts.FuseAllowOther)"):
+            machine.succeed("su alice -c 'cat /mfs/test-1.txt' | grep fnord3")
+            machine.succeed("su bob -c 'cat /mfs/test-1.txt' | grep fnord3")
+
+        with subtest("Check the file contents"):
+            machine.succeed("diff /tmp/test.txt /mfs/test-1.txt")
+            machine.succeed("diff /tmp/test.txt /mfs/test-2.txt")
+            machine.succeed("diff /tmp/test.txt /mfs/test-3.txt")
+
+        with subtest("Check the CID extended attribute"):
+            output = machine.succeed(
+                "getfattr --only-values --name=ipfs_cid /mfs/test-3.txt"
+            ).strip()
+            assert ipfs_hash == output, f"Expected {ipfs_hash} but got {output}"
+
+
+    with subtest("Unmounting of /ipns, /ipfs and /mfs"):
         # Force Kubo to crash and wait for it to restart
         machine.systemctl("kill --signal=SIGKILL ipfs.service")
         machine.wait_for_unit("ipfs.service", timeout = 30)
 
         machine.succeed(f"diff /tmp/test.txt /ipfs/{ipfs_hash}")
+        machine.succeed("diff /tmp/test.txt /mfs/test-3.txt")
   '';
 }

--- a/pkgs/by-name/ku/kubo/package.nix
+++ b/pkgs/by-name/ku/kubo/package.nix
@@ -8,7 +8,7 @@
 
 buildGoModule rec {
   pname = "kubo";
-  version = "0.34.1"; # When updating, also check if the repo version changed and adjust repoVersion below
+  version = "0.35.0"; # When updating, also check if the repo version changed and adjust repoVersion below
   rev = "v${version}";
 
   passthru.repoVersion = "16"; # Also update kubo-migrator when changing the repo version
@@ -16,7 +16,7 @@ buildGoModule rec {
   # Kubo makes changes to its source tarball that don't match the git source.
   src = fetchurl {
     url = "https://github.com/ipfs/kubo/releases/download/${rev}/kubo-source.tar.gz";
-    hash = "sha256-wrAnmPfls7LFO3gQBISSmn4ucuUVmzvYEoz+eVc/A5M=";
+    hash = "sha256-OubXaa2JWbEaakDV6pExm5PkiZ5XPd9uG+S4KwWb0xQ=";
   };
 
   # tarball contains multiple files/directories


### PR DESCRIPTION
https://github.com/ipfs/kubo/releases/tag/v0.35.0

This version introduces a new FUSE mount point, requiring some changes.
I also extended the NixOS test to test this new functionality.

Closes #409538.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
