### PR TITLE
openvscode-server: remove bendlas as maintainer

### DIFF
--- a/pkgs/servers/openvscode-server/default.nix
+++ b/pkgs/servers/openvscode-server/default.nix
@@ -245,7 +245,6 @@ stdenv.mkDerivation (finalAttrs: {
       dguenther
       ghuntley
       emilytrau
-      bendlas
     ];
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
Had another run-in with one of our valued reviewer-main characters.

As I detailed in https://github.com/NixOS/nixpkgs/pull/410777#issuecomment-2907939623, if taking another contributor's code from their unfinished PR - against their objection - is a borderline hostile action, then volunteering them as package maintainer in the process is just insulting and patronizing to the highest degree. And then the self-merge, while leaving the original PR open for me to clean up. @ doronbehar should be ashamed.

I am urging @NixOS/moderation to take action and clarify that this kind of behavior will not be tolerated!

Also, I'm self-merging this PR, and I'm not asking, not daring, I'm DEMANDING, that @NixOS/moderation give me a second formal warning for it! Anything is better than this hell of entitlement, unclear responsibilities, cavalier attitude and worst of all: selective enforcement, that y'all have been creating!

Otherwise, finally lay out some steps, that give at least some semblance of formality to your "process", you absolute cowards!

However much I agree with us, the community, taking and protecting the trade marks from DS, the emergence of "rewiewer-mains" and the role that moderation has been taking in it is more than questionable. I urge you to re-evaluate the role, that you've been taking within the community. I'll be sure to do the same for my part!