### PR TITLE
python3Packages.kinparse: unstable 2019-12-18 -> 1.2.3

### DIFF
--- a/pkgs/development/python-modules/kinparse/default.nix
+++ b/pkgs/development/python-modules/kinparse/default.nix
@@ -2,37 +2,49 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pytest,
-  future,
   pyparsing,
+  pytestCheckHook,
+  setuptools,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "kinparse";
-  version = "unstable-2019-12-18";
-  format = "setuptools";
+  version = "1.2.3";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "xesscorp";
     repo = "kinparse";
-    rev = "eeb3f346d57a67a471bdf111f39bef8932644481";
-    sha256 = "1nrjnybwzy93c79yylcwmb4lvkx7hixavnjwffslz0zwn32l0kx3";
+    tag = version;
+    hash = "sha256-170e2uhqpk6u/hahivWYubr3Ptb8ijymJSxhxrAfuyI=";
   };
+
+  # Remove python2 build support as it breaks python >= 3.13
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace-fail "universal = 1" "universal = 0"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pyparsing ];
+
+  pythonRemoveDeps = [ "future" ];
+
+  preCheck = ''
+    substituteInPlace tests/test_kinparse.py \
+      --replace-fail "data/" "$src/tests/data/"
+  '';
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "kinparse" ];
 
-  nativeCheckInputs = [ pytest ];
-
-  propagatedBuildInputs = [
-    future
-    pyparsing
-  ];
-
-  meta = with lib; {
+  meta = {
     description = "Parser for KiCad EESCHEMA netlists";
     mainProgram = "kinparse";
     homepage = "https://github.com/xesscorp/kinparse";
-    license = licenses.mit;
-    maintainers = with maintainers; [ matthuszagh ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthuszagh ];
   };
 }


### PR DESCRIPTION
1. Modernized build
2. Disable "universal" wheel (requires unsupported `python3.future` which is supposedly optional)
3. Disable testing due to https://github.com/devbisme/kinparse/issues/19 (test changes to make python 2 work broke python 3)
4. Version bump

Note: No release notes or diff given

Tracking: #410837

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
