### PR TITLE
linux-it87: Update homepage to reflect new src repo

### DIFF
--- a/pkgs/os-specific/linux/it87/default.nix
+++ b/pkgs/os-specific/linux/it87/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Patched module for IT87xx superio chip sensors support";
-    homepage = "https://github.com/hannesha/it87";
+    homepage = "https://github.com/frankcrawford/it87";
     license = licenses.gpl2Plus;
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
The homepage was still the old unmaintained repo, which lead to confusion.

*I did not run any tests, because it is just a metadata change.*

