### PR TITLE
eduke32: automatically update VC_REV, add update script, remove gtk2

### DIFF
--- a/pkgs/by-name/ed/eduke32/package.nix
+++ b/pkgs/by-name/ed/eduke32/package.nix
@@ -16,6 +16,7 @@
   SDL2,
   SDL2_mixer,
   graphicsmagick,
+  unstableGitUpdater,
 }:
 
 let
@@ -177,6 +178,8 @@ stdenv.mkDerivation (finalAttrs: {
     + ''
       runHook postInstall
     '';
+
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {
     description = "Enhanched port of Duke Nukem 3D for various platforms";

--- a/pkgs/by-name/ed/eduke32/package.nix
+++ b/pkgs/by-name/ed/eduke32/package.nix
@@ -33,7 +33,14 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "terminx";
     repo = "eduke32";
     rev = "b8759847124c2c53a165a02efef4a0c778674baf";
-    hash = "sha256-PudO6EKCh6UpoY6GT/J0hkVteKNIAO4Q454jIzaegMg=";
+    hash = "sha256-+XaIoCP6TA5QMzs/VxXIv1NP8X4i9rIm6iw+pFH8Q6Q=";
+    deepClone = true;
+    leaveDotGit = true;
+    postFetch = ''
+      cd $out
+      git rev-list --count HEAD > VC_REV
+      rm -rf .git
+    '';
   };
 
   patches = [
@@ -83,8 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [
     "SDLCONFIG=${SDL2}/bin/sdl2-config"
-    # git rev-list --count HEAD
-    "VC_REV=10619"
     "VC_HASH=${lib.substring 0 9 finalAttrs.src.rev}"
     "VC_BRANCH=master"
   ];
@@ -93,6 +98,10 @@ stdenv.mkDerivation (finalAttrs: {
     "duke3d"
     "sw"
   ];
+
+  preConfigure = ''
+    appendToVar makeFlags "VC_REV=$(cat VC_REV)"
+  '';
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/by-name/ed/eduke32/package.nix
+++ b/pkgs/by-name/ed/eduke32/package.nix
@@ -9,12 +9,12 @@
   copyDesktopItems,
   alsa-lib,
   flac,
-  gtk2,
   libvorbis,
   libvpx,
   libGL,
   SDL2,
   SDL2_mixer,
+  xorg,
   graphicsmagick,
   unstableGitUpdater,
 }:
@@ -60,8 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       alsa-lib
-      gtk2
       libGL
+      xorg.libX11
     ];
 
   nativeBuildInputs =
@@ -93,6 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     "SDLCONFIG=${SDL2}/bin/sdl2-config"
     "VC_HASH=${lib.substring 0 9 finalAttrs.src.rev}"
     "VC_BRANCH=master"
+    "HAVE_GTK2=0"
   ];
 
   buildFlags = [


### PR DESCRIPTION
CC https://github.com/NixOS/nixpkgs/issues/410814

gtk2 is used for the startup window, but we never actually used it
because we never added gtk2 to LD_LIBRARY_PATH.

Upstream is aware of gtk2 EOL, and there is a pending merge request for an imgui based alternative.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
