### PR TITLE
kchmviewer: enable on unix

### DIFF
--- a/pkgs/applications/misc/kchmviewer/default.nix
+++ b/pkgs/applications/misc/kchmviewer/default.nix
@@ -10,31 +10,31 @@
   qtwebengine,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kchmviewer";
   version = "8.0";
 
   src = fetchFromGitHub {
     owner = "gyunaev";
-    repo = pname;
-    rev = "RELEASE_${lib.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "sha256-YNpiBf6AFBCRbAZRPODvqGbQQedJJJrZFQIQyzIeBlw=";
+    repo = "kchmviewer";
+    tag = "RELEASE_${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
+    hash = "sha256-YNpiBf6AFBCRbAZRPODvqGbQQedJJJrZFQIQyzIeBlw=";
   };
 
   patches = [
     # remove unused webkit
     (fetchpatch {
       url = "https://github.com/gyunaev/kchmviewer/commit/a4a3984465cb635822953350c571950ae726b539.patch";
-      sha256 = "sha256-nHW18a4SrTG4fETJmKS4ojHXwnX1d1uN1m4H0GIuI28=";
+      hash = "sha256-nHW18a4SrTG4fETJmKS4ojHXwnX1d1uN1m4H0GIuI28=";
     })
     # QtWebengine fixes
     (fetchpatch {
       url = "https://github.com/gyunaev/kchmviewer/commit/9ac73e7ad15de08aab6b1198115be2eb44da7afe.patch";
-      sha256 = "sha256-qg2ytqA2On7jg19WZmHIOU7vLQI2hoyqItySLEA64SY=";
+      hash = "sha256-qg2ytqA2On7jg19WZmHIOU7vLQI2hoyqItySLEA64SY=";
     })
     (fetchpatch {
       url = "https://github.com/gyunaev/kchmviewer/commit/99a6d94bdfce9c4578cce82707e71863a71d1453.patch";
-      sha256 = "sha256-o8JkaMmcJObmMt+o/6ooCAPCi+yRAWDAgxV+tR5eHfY=";
+      hash = "sha256-o8JkaMmcJObmMt+o/6ooCAPCi+yRAWDAgxV+tR5eHfY=";
     })
     # Fix build on macOS
     (fetchpatch {
@@ -72,12 +72,12 @@ stdenv.mkDerivation rec {
         install -Dm644 packages/kchmviewer.desktop -t $out/share/applications
       '';
 
-  meta = with lib; {
+  meta = {
     description = "CHM (Winhelp) files viewer";
     mainProgram = "kchmviewer";
     homepage = "http://www.ulduzsoft.com/linux/kchmviewer/";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ sikmir ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ sikmir ];
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/applications/misc/kchmviewer/default.nix
+++ b/pkgs/applications/misc/kchmviewer/default.nix
@@ -36,6 +36,15 @@ stdenv.mkDerivation rec {
       url = "https://github.com/gyunaev/kchmviewer/commit/99a6d94bdfce9c4578cce82707e71863a71d1453.patch";
       sha256 = "sha256-o8JkaMmcJObmMt+o/6ooCAPCi+yRAWDAgxV+tR5eHfY=";
     })
+    # Fix build on macOS
+    (fetchpatch {
+      url = "https://github.com/gyunaev/kchmviewer/pull/35/commits/b68ed6fe72eaf9ee4e7e42925f5071fbd02dc6b3.patch";
+      hash = "sha256-sJA0RE0Z83tYv0S42yQYWKKeLhW+YDsrxLkY5aMKKT4=";
+    })
+    (fetchpatch {
+      url = "https://github.com/gyunaev/kchmviewer/pull/35/commits/d307e4e829c5a6f57ab0040f786c3da7fd2f0a99.patch";
+      hash = "sha256-FWYfqG8heL6AnhevueCWHQc+c6Yj4+DuIdjIwXVZ+O4=";
+    })
   ];
 
   buildInputs = [
@@ -49,11 +58,19 @@ stdenv.mkDerivation rec {
     wrapQtAppsHook
   ];
 
-  postInstall = ''
-    install -Dm755 bin/kchmviewer -t $out/bin
-    install -Dm644 packages/kchmviewer.png -t $out/share/pixmaps
-    install -Dm644 packages/kchmviewer.desktop -t $out/share/applications
-  '';
+  postInstall =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        mkdir -p $out/{Applications,bin}
+        mv bin/kchmviewer.app $out/Applications
+        ln -s $out/Applications/kchmviewer.app/Contents/MacOS/kchmviewer $out/bin/kchmviewer
+      ''
+    else
+      ''
+        install -Dm755 bin/kchmviewer -t $out/bin
+        install -Dm644 packages/kchmviewer.png -t $out/share/pixmaps
+        install -Dm644 packages/kchmviewer.desktop -t $out/share/applications
+      '';
 
   meta = with lib; {
     description = "CHM (Winhelp) files viewer";
@@ -61,6 +78,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.ulduzsoft.com/linux/kchmviewer/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ sikmir ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/kc/kchmviewer/package.nix
+++ b/pkgs/by-name/kc/kchmviewer/package.nix
@@ -3,11 +3,9 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
-  qmake,
-  wrapQtAppsHook,
+  qt5,
   chmlib,
   libzip,
-  qtwebengine,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,12 +48,12 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     chmlib
     libzip
-    qtwebengine
+    qt5.qtwebengine
   ];
 
   nativeBuildInputs = [
-    qmake
-    wrapQtAppsHook
+    qt5.qmake
+    qt5.wrapQtAppsHook
   ];
 
   postInstall =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13017,8 +13017,6 @@ with pkgs;
 
   kapow = libsForQt5.callPackage ../applications/misc/kapow { };
 
-  kchmviewer = libsForQt5.callPackage ../applications/misc/kchmviewer { };
-
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };
 
   k4dirstat = libsForQt5.callPackage ../applications/misc/k4dirstat { };


### PR DESCRIPTION
## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
