### PR TITLE
python3Packages.contexttimer: unstable-2019-03-30 -> 2024-09-05

### DIFF
--- a/pkgs/development/python-modules/contexttimer/default.nix
+++ b/pkgs/development/python-modules/contexttimer/default.nix
@@ -1,47 +1,45 @@
 {
   lib,
   buildPythonPackage,
-  pythonAtLeast,
   fetchFromGitHub,
+  pythonOlder,
+  setuptools,
   mock,
-  fetchpatch,
-  python,
+  pytestCheckHook,
 }:
 
 buildPythonPackage {
   pname = "contexttimer";
-  version = "unstable-2019-03-30";
-  format = "setuptools";
-
-  disabled = pythonAtLeast "3.12";
+  version = "unstable-2024-09-05";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "brouberol";
     repo = "contexttimer";
-    rev = "a866f420ed4c10f29abf252c58b11f9db6706100";
-    hash = "sha256-Fc1vK1KSZWgBPtBf5dVydF6dLHEGAOslWMV0FLRdj8w=";
+    rev = "8e77927b8b75365f8e2bc456d2457b3e47c67815";
+    hash = "sha256-LCyXJa+7XkfxzcLGonv1yfOW+gZhLFBAbBT+5IP39qA=";
   };
 
-  patches = [
-    # https://github.com/brouberol/contexttimer/pull/16
-    (fetchpatch {
-      url = "https://github.com/brouberol/contexttimer/commit/dd65871f3f25a523a47a74f2f5306c57048592b0.patch";
-      hash = "sha256-vNBuFXvuvb6hWPzg4W4iyKbd4N+vofhxsKydEkc25E4=";
-    })
+  disabled = pythonOlder "3.12";
+
+  build-system = [ setuptools ];
+
+  preCheck = ''
+    substituteInPlace tests/test_timer.py \
+      --replace-fail "assertRegexpMatches" "assertRegex"
+  '';
+
+  nativeCheckInputs = [
+    mock
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [ "contexttimer" ];
 
-  nativeCheckInputs = [ mock ];
-
-  checkPhase = ''
-    ${python.interpreter} -m unittest tests/test_timer.py
-  '';
-
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/brouberol/contexttimer";
     description = "Timer as a context manager";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ atila ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ atila ];
   };
 }


### PR DESCRIPTION
While sweeping packages with unstable commits < 2020:

Bumped contexttimer to a late 2024 update (latest).

Tracking: #410837

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
