### PR TITLE
texlivePackages: generate fixed-hashes.nix with standard formatting

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/generate-fixed-hashes.nix
+++ b/pkgs/tools/typesetting/tex/texlive/generate-fixed-hashes.nix
@@ -40,7 +40,7 @@ let
 
   hash = fod: fod.outputHash or (builtins.readFile (computeHash fod));
 
-  hashes = fods: concatMapStrings ({ tlType, ... }@p: ''${tlType}="${hash p}";'') fods;
+  hashes = fods: concatMapStrings ({ tlType, ... }@p: "    ${tlType} = \"${hash p}\";\n") fods;
 
   hashLine =
     {
@@ -54,22 +54,15 @@ let
       # NOTE: the fixed naming scheme must match default.nix
       fixedName = "${pname}-${toString revision}${extraRevision}";
     in
-    optionalString (fods != [ ]) ''
-      ${strings.escapeNixIdentifier fixedName}={${hashes fods}};
-    '';
+    optionalString (fods != [ ]) "  ${strings.escapeNixIdentifier fixedName} = {\n${hashes fods}  };\n";
 in
 {
   # fixedHashesNix uses 'import from derivation' which does not parallelize well
   # you should build newHashes first, before evaluating (and building) fixedHashesNix
   newHashes = map computeHash (filter (fod: !fod ? outputHash) fods);
 
-  fixedHashesNix =
-    runCommand "fixed-hashes.nix"
-      {
-        unformatted = writeText "fixed-hashes.nix" "{${concatMapStrings hashLine sorted}}";
-        nativeBuildInputs = [ pkgs.nixfmt ];
-      }
-      ''
-        cat "$unformatted" | nixfmt > "$out"
-      '';
+  fixedHashesNix = writeText "fixed-hashes.nix" ''
+    {
+    ${concatMapStrings hashLine sorted}}
+  '';
 }


### PR DESCRIPTION
Update `generate-fixed-hashes.nix` so that the output satisfies the new formatting requirements.

## Things done
The result of building `fixedHashesNix` from `generate-fixed-hashes.nix` is identical to the current `fixed-hashes.nix`.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
