### PR TITLE
nixos/tuxedo-drivers: add optional udev parameters

### DIFF
--- a/nixos/modules/hardware/tuxedo-drivers.nix
+++ b/nixos/modules/hardware/tuxedo-drivers.nix
@@ -1,7 +1,25 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.hardware.tuxedo-drivers;
   tuxedo-drivers = config.boot.kernelPackages.tuxedo-drivers;
+  udevRule =
+    attr: val:
+    let
+      # Workaround to evaluate true to "1" and false to "0".
+      # Otherwise, true evaluates to "1" and false to "".
+      newVal = if lib.isBool val then (if val then "1" else "0") else val;
+    in
+    lib.concatStringsSep ", " [
+      ''SUBSYSTEM=="platform"''
+      ''DRIVER=="tuxedo_keyboard"''
+      ''ATTR{${attr}}="${newVal}"''
+    ];
+  optUdevRule = attr: val: lib.optional (val != null) (udevRule attr val);
 in
 {
   imports = [
@@ -26,11 +44,66 @@ in
 
       For more inforation it is best to check at the source code description: <https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers>
     '';
+    settings = {
+      charging-profile = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.enum [
+            "high_capacity"
+            "balanced"
+            "stationary"
+          ]
+        );
+        default = null;
+        description = ''
+          The maximum charge level to help reduce battery wear:
+          - `high_capacity` charges to 100% (driver default)
+          - `balanced` charges to 90%
+          - `stationary` charges to 80% (maximum lifespan)
+
+          **Note:** Regardless of the configured charging profile, the operating system will always report the battery as being charged to 100%.
+        '';
+      };
+      charging-priority = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.enum [
+            "charge_battery"
+            "performance"
+          ]
+        );
+        default = null;
+        description = ''
+          These options manage the trade-off between battery charging and CPU performance when the USB-C power supply cannot provide sufficient power for both simultaneously:
+          - `charge_battery` prioritizes battery charging (driver default)
+          - `performance` prioritizes maximum CPU performance
+        '';
+      };
+      fn-lock = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = ''
+          Enables or disables the laptop keyboard's Function (Fn) lock at boot.
+
+          When set to `true`, the Fn lock is enabled, allowing the function keys (F1–F12) to control brightness, volume etc.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     boot.kernelModules = [ "tuxedo_keyboard" ];
     boot.extraModulePackages = [ tuxedo-drivers ];
-    services.udev.packages = [ tuxedo-drivers ];
+    services.udev.packages = [
+      tuxedo-drivers
+      lib.mkIf
+      (lib.any (v: v != null) cfg.settings)
+      (pkgs.writeTextDir "etc/udev/rules.d/90-tuxedo.rules" (
+        lib.concatLines (
+          [ "# Custom rules for TUXEDO laptops" ]
+          ++ (optUdevRule "charging_profile/charging_profile" cfg.settings.charging-profile)
+          ++ (optUdevRule "charging_priority/charging_prio" cfg.settings.charging-priority)
+          ++ (optUdevRule "fn_lock" cfg.settings.fn-lock)
+        )
+      ))
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This change exposes a configuration attribute which allows for configuring some basic attributes of the `tuxedo_keyboard` driver for Tuxedo laptops, e.g.

```nix
hardware.tuxedo-drivers = {
  enable = true;

  settings = {
    charging-profile = "stationary";
    charging-priority = "performance";
    fn-lock = true;
  };
};
```

I rebuilt my system on this branch, with this change, to test it.

This change is especially relevant for tuning TUXEDO devices running NixOS as the Tuxedo Control Center, which essentially does the same changes, is not in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
