### PR TITLE
nixos/limine: fix boot entry not being created properly

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -412,27 +412,42 @@ def main():
                 efi_disk = find_disk_device(efi_partition)
 
                 efibootmgr_output = subprocess.check_output([efibootmgr], stderr=subprocess.STDOUT, universal_newlines=True)
-                create_flag = '-c'
+
                 # Check the output of `efibootmgr` to find if limine is already installed and present in the boot record
-                if matches := re.findall(r'Boot[0-9a-fA-F]{4}\*? Limine', efibootmgr_output):
-                    create_flag = '-C' # if present, keep the same boot order
+                limine_boot_entry = None
+                if matches := re.findall(r'Boot([0-9a-fA-F]{4})\*? Limine', efibootmgr_output):
+                    limine_boot_entry = matches[0]
 
-                efibootmgr_output = subprocess.check_output([
-                    efibootmgr,
-                    create_flag,
-                    '-d', efi_disk,
-                    '-p', efi_partition.removeprefix(efi_disk).removeprefix('p'),
-                    '-l', f'\\efi\\limine\\{boot_file}',
-                    '-L', 'Limine',
-                ], stderr=subprocess.STDOUT, universal_newlines=True)
+                # If there's already a Limine entry, replace it
+                if limine_boot_entry:
+                    boot_order = re.findall(r'BootOrder: ((?:[0-9a-fA-F]{4},?)*)', efibootmgr_output)[0]
 
-                for line in efibootmgr_output.split('\n'):
-                    if matches := re.findall(r'Boot([0-9a-fA-F]{4}) has same label Limine', line):
-                        subprocess.run(
-                            [efibootmgr, '-b', matches[0], '-B'],
-                            stdout=subprocess.DEVNULL,
-                            stderr=subprocess.DEVNULL,
-                        )
+                    efibootmgr_output = subprocess.check_output([
+                        efibootmgr,
+                        '-b', limine_boot_entry,
+                        '-B',
+                    ], stderr=subprocess.STDOUT, universal_newlines=True)
+
+                    efibootmgr_output = subprocess.check_output([
+                        efibootmgr,
+                        '-c',
+                        '-b', limine_boot_entry,
+                        '-d', efi_disk,
+                        '-p', efi_partition.removeprefix(efi_disk).removeprefix('p'),
+                        '-l', f'\\efi\\limine\\{boot_file}',
+                        '-L', 'Limine',
+                        '-o', boot_order,
+                    ], stderr=subprocess.STDOUT, universal_newlines=True)
+                else:
+                    efibootmgr_output = subprocess.check_output([
+                        efibootmgr,
+                        '-c',
+                        '-d', efi_disk,
+                        '-p', efi_partition.removeprefix(efi_disk).removeprefix('p'),
+                        '-l', f'\\efi\\limine\\{boot_file}',
+                        '-L', 'Limine',
+                    ], stderr=subprocess.STDOUT, universal_newlines=True)
+
     if config('biosSupport'):
         if cpu_family != 'x86':
             raise Exception(f'Unsupported CPU family for BIOS install: {cpu_family}')


### PR DESCRIPTION
This fixes the issues caused by https://github.com/NixOS/nixpkgs/pull/409409

cc @JohnRTitor @joshprk

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
