### PR TITLE
pocl: 6.0-unstable-2025-01-02 -> 7.0

### DIFF
--- a/pkgs/by-name/po/pocl/package.nix
+++ b/pkgs/by-name/po/pocl/package.nix
@@ -41,13 +41,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "pocl";
-  version = "6.0-unstable-2025-01-02";
+  version = "7.0";
 
   src = fetchFromGitHub {
     owner = "pocl";
     repo = "pocl";
-    rev = "acf4ea163b7346d20b3023d41c1141f094acc755";
-    hash = "sha256-d/BD8YkdMYtu6yFlGNXrsz7PVIrzBvvYLU1JRv7ZJmc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pyolM0SR6xiwhad7K0mX9I/PKbIa8Ltin0CYoA1U/qo=";
   };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
Changelog: https://github.com/pocl/pocl/releases/tag/v7.0

Build of pocl-6.0-unstable-2025-01-02 was known to be machine dependent.
See https://github.com/NixOS/nixpkgs/pull/403091#issuecomment-2849156104

For example, i tried to build pocl-6.0-unstable-2025-01-02 offline on local intel-e5-2696v2 and amd-ryzen5-1400 platform
The generated hash (acquired via `nix hash path /nix/store/vr4akf3vc7cpxhrjhvw2x8c8pkr35a87-pocl-6.0-unstable-2025-01-02`) differs in that
1. e5-2696v2: sha256-WHh5K4CtfuKPYPd/R6x/I+ZytgGS6TkoKFhof63Rcpc=
2. ryzen5-1400: sha256-BR+hSxgvN+LmL8UTFPaG+F0MSULbVa550wY0+2hefHs=
3. hydra-cache: sha256-oTXyqiOu6DIJpUMfhlFlrtd0usCUpKgdfeR0xhvmfv4=

This machine dependent build result in an unsupported cpu instruction code when running pocl tests in an unsupported architecture.

However, this bug seem to be fixed in 7.0 release. Now both e5-2696v2 and ryzen5-1400 generated the same nar hash
```
$ nix hash path  /nix/store/sf3acvy25dcna7dqzggirrcnmd4vps7r-pocl-7.0                   
sha256-zCOKhsFLoznV0EoofESjV6U9C5QapHp7u+f3r4d6eCA=
```

Can we check this in more different build machine?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
