### PR TITLE
openmw-tes3mp: add missing stl includes

### DIFF
--- a/pkgs/games/openmw/tes3mp.patch
+++ b/pkgs/games/openmw/tes3mp.patch
@@ -11,3 +11,42 @@ index be365cfb8..204dcdc7b 100644
  #else
      template<typename R, typename... Types>
      constexpr ScriptFunctionPointer(Function<R, Types...> addr) : ScriptIdentity(addr), addr(addr) {}
+diff --git a/apps/openmw/mwstate/charactermanager.hpp b/apps/openmw/mwstate/charactermanager.hpp
+index 2daf73401..ad36d2f06 100644
+--- a/apps/openmw/mwstate/charactermanager.hpp
++++ b/apps/openmw/mwstate/charactermanager.hpp
+@@ -5,6 +5,8 @@
+ 
+ #include "character.hpp"
+ 
++#include <list>
++
+ namespace MWState
+ {
+     class CharacterManager
+diff --git a/components/myguiplatform/myguidatamanager.cpp b/components/myguiplatform/myguidatamanager.cpp
+index 0310e996b..3c4aeffa3 100644
+--- a/components/myguiplatform/myguidatamanager.cpp
++++ b/components/myguiplatform/myguidatamanager.cpp
+@@ -7,6 +7,8 @@
+ 
+ #include <components/debug/debuglog.hpp>
+ 
++#include <memory>
++
+ namespace osgMyGUI
+ {
+ 
+diff --git a/components/vfs/filesystemarchive.cpp b/components/vfs/filesystemarchive.cpp
+index 6eef4b93a..f0d172aa6 100644
+--- a/components/vfs/filesystemarchive.cpp
++++ b/components/vfs/filesystemarchive.cpp
+@@ -4,6 +4,8 @@
+ 
+ #include <components/debug/debuglog.hpp>
+ 
++#include <algorithm>
++
+ namespace VFS
+ {
+ 


### PR DESCRIPTION
This patch includes some missing C++ STL headers that were preventing `openmw-tes3mp` from building on NixOS unstable/25.05. I think that until recently these headers may have been included indirectly through a previous version of Boost.

Given that we already have a `tes3mp.patch` file from #402905, it seems to be common knowledge that the development state of the TES3MP project is indeterminate, else I would have more hope of an upstream patch like the still-unmerged TES3MP/TES3MP#691.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
