### PR TITLE
antifennel: init at 0.3.1

### DIFF
--- a/pkgs/by-name/an/antifennel/package.nix
+++ b/pkgs/by-name/an/antifennel/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  luajit,
+  luapkgs ? luajit.pkgs,
+  pandoc,
+  fennel-ls,
+  fetchFromSourcehut,
+}:
+stdenv.mkDerivation rec {
+  pname = "antifennel";
+  version = "0.3.1-unstable-2025-06-02";
+  src = fetchFromSourcehut {
+    owner = "~technomancy";
+    repo = "antifennel";
+    rev = "76b02c0252cfc8e2a56edea381f7f682b598ac37";
+    hash = "sha256-6gt89ZNm91JrQo/4/0CQLpkc4xux5OGQWg87cju4vCQ=";
+  };
+  nativeBuildInputs = [ pandoc ];
+  env.LUA = luapkgs.lua.interpreter;
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  checkInputs = [
+    luapkgs.luacheck
+    fennel-ls
+  ];
+  meta = {
+    mainProgram = "antifennel";
+    description = "Fennel decompiler which produces fennel code from lua code";
+    homepage = "https://git.sr.ht/~technomancy/antifennel";
+    changelog = "https://git.sr.ht/~technomancy/antifennel/tree/${src.rev}/item/changelog.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ birdee ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

init [antifennel](https://git.sr.ht/~technomancy/antifennel) at version 0.3.1

This is a fennel decompiler. It takes lua code, and turns it into fennel code.

It is mostly used when learning fennel to see what the associated fennel for a given lua file would be, or when transferring existing lua codebases to fennel.

There is a [web-based demo](https://fennel-lang.org/see) also but it is not practical for use when converting an existing codebase.

This project uses only lua and fennel, and is a pure input output style program, so there should be no system architecture issues.

You can use `.override { luapkgs = pkgs.lua.pkgs; }` to change the lua version for both the final executable and luacheck, as well as `.overrideAttrs (prev: { env = prev.env // { LUA = pkgs.lua.interpreter; }; })` to change the lua version for just the final executable, and overrideAttrs checkInputs directly if changing the luacheck version is needed. However, the lua version used is largely irrelevant. It can accept a variety of versions, and outputs fennel.

[this originally needed a git patch for the shebang but that has been resolved](https://git.sr.ht/~technomancy/antifennel/commit/3b56d0a178a202ad608cf470caff7c74c4b623ed)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
