### PR TITLE
efibooteditor: init at 1.5.3

### DIFF
--- a/pkgs/by-name/ef/efibooteditor/package.nix
+++ b/pkgs/by-name/ef/efibooteditor/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  qt6,
+  zlib,
+  cmake,
+  efivar,
+  pkg-config,
+  fetchFromGitHub,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "efibooteditor";
+  version = "1.5.3";
+
+  src = fetchFromGitHub {
+    owner = "Neverous";
+    repo = "efibooteditor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xD40ZzkpwerDYC8nzGVqEHLV0KWbxcc0ApquQjrPJTc=";
+  };
+
+  buildInputs = [ zlib ] ++ lib.optional stdenv.hostPlatform.isLinux efivar;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.qttools
+    qt6.wrapQtAppsHook
+  ];
+
+  postPatch = ''
+    substituteInPlace misc/org.x.efibooteditor.policy \
+      --replace-fail /usr/bin $out/bin
+    substituteInPlace misc/EFIBootEditor.desktop \
+      --replace-fail "1.0" ${finalAttrs.version} \
+      --replace-fail \
+        'pkexec efibooteditor' \
+        'sh -c "pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY efibooteditor"'
+  '';
+
+  env.BUILD_VERSION = "v${finalAttrs.version}";
+  cmakeBuildType = "MinSizeRel";
+  cmakeFlags = [ "-DQT_VERSION_MAJOR=6" ];
+
+  postInstall = ''
+    install -Dm644 $src/LICENSE.txt $out/share/licenses/${finalAttrs.pname}/LICENSE
+  '';
+
+  meta = {
+    description = "Boot Editor for (U)EFI based systems";
+    homepage = "https://github.com/Neverous/efibooteditor";
+    changelog = "https://github.com/Neverous/efibooteditor/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.linux; # TODO build is broken on darwin
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    mainProgram = "efibooteditor";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
