### PR TITLE
python312Packages.itables: init at 2.4.0

### DIFF
--- a/pkgs/development/python-modules/itables/default.nix
+++ b/pkgs/development/python-modules/itables/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  python,
+
+  # build-system
+  dash,
+  hatchling,
+  hatch-jupyter-builder,
+  pyyaml,
+  setuptools,
+
+  # nativeBuildInputs
+  nodejs,
+
+  # dependencies
+  ipython,
+  numpy,
+  pandas,
+}:
+
+buildPythonPackage rec {
+  pname = "itables";
+  version = "2.4.0";
+
+  # itables has 4 different node packages, each with their own
+  # package-lock.json, and partially depending on each other.
+  # Our fetchNpmDeps tooling in nixpkgs doesn't support this yet, so we fetch
+  # the source tarball from pypi, wich includes the javascript bundle already.
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-S5HASUVfqTny+Vu15MYSSrEffCaJuL7UhDOc3eudVWI=";
+  };
+
+  pyproject = true;
+
+  build-system = [
+    dash
+    hatchling
+    hatch-jupyter-builder
+    pyyaml
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    nodejs
+  ];
+
+  dependencies = [
+    ipython
+    numpy
+    pandas
+  ];
+
+  # no tests in pypi tarball
+  doCheck = false;
+
+  # don't run the hooks, as they try to invoke npm on packages/,
+  env.HATCH_BUILD_NO_HOOKS = true;
+
+  # The pyproject.toml shipped with the sources doesn't install anything,
+  # as the paths in the pypi tarball are not the same as in the repo checkout.
+  # We exclude itables_for_dash here, as it's missing the .dist-info dir
+  # plumbing to be discoverable, and should be its own package anyways.
+  postInstall = ''
+    cp -R itables $out/${python.sitePackages}
+  '';
+
+  pythonImportsCheck = [ "itables" ];
+
+  meta = {
+    description = "Pandas and Polar DataFrames as interactive DataTables";
+    homepage = "https://github.com/mwouts/itables";
+    changelog = "https://github.com/mwouts/itables/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ flokli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6983,6 +6983,8 @@ self: super: with self; {
 
   israel-rail-api = callPackage ../development/python-modules/israel-rail-api { };
 
+  itables = callPackage ../development/python-modules/itables { };
+
   itanium-demangler = callPackage ../development/python-modules/itanium-demangler { };
 
   item-synchronizer = callPackage ../development/python-modules/item-synchronizer { };


### PR DESCRIPTION
This adds [ITables](https://mwouts.github.io/itables/quick_start.html), which can render Pandas and Polar DataFrames as interactive DataTables.

Fixes #347509

![image](https://github.com/user-attachments/assets/8750f6f9-7e72-4425-a7f3-734e92adc940)



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
