### PR TITLE
miniaudio: export miniaudio header

### DIFF
--- a/pkgs/by-name/ja/ja2-stracciatella/package.nix
+++ b/pkgs/by-name/ja/ja2-stracciatella/package.nix
@@ -101,6 +101,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    # Fails to build on x86_64-linux as of 2025-03-16 and potentially earlier
+    broken = true;
     description = "Jagged Alliance 2, with community fixes";
     license = "SFI Source Code license agreement";
     homepage = "https://ja2-stracciatella.github.io/";

--- a/pkgs/by-name/mi/miniaudio/package.nix
+++ b/pkgs/by-name/mi/miniaudio/package.nix
@@ -2,32 +2,52 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  testers,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "miniaudio";
   version = "0.11.22";
 
   src = fetchFromGitHub {
     owner = "mackron";
     repo = "miniaudio";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-o/7sfBcrhyXEakccOAogQqm8dO4Szj1QSpaIHg6OSt4=";
   };
 
-  installPhase = ''
-    mkdir -p $out
-    cp -r $src/* $out/
+  postInstall = ''
+    mkdir -p $out/include
+    mkdir -p $out/lib/pkgconfig
+
+    cp $src/miniaudio.h $out/include
+    ln -s $out/include/miniaudio.h $out
+
+    cp -r $src/extras $out/
+
+    cat <<EOF >$out/lib/pkgconfig/miniaudio.pc
+    prefix=$out
+    includedir=$out/include
+
+    Name: miniaudio
+    Description: An audio playback and capture library in a single source file.
+    Version: $version
+    Cflags: -I$out/include
+    Libs: -lm -lpthread -latomic
+    EOF
   '';
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
   meta = with lib; {
     description = "Single header audio playback and capture library written in C";
     homepage = "https://github.com/mackron/miniaudio";
-    changelog = "https://github.com/mackron/miniaudio/blob/${src.rev}/CHANGES.md";
+    changelog = "https://github.com/mackron/miniaudio/blob/${finalAttrs.version}/CHANGES.md";
     license = with licenses; [
       unlicense # or
       mit0
     ];
     maintainers = [ maintainers.jansol ];
+    pkgConfigModules = [ "miniaudio" ];
     platforms = platforms.all;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Copying miniaudio.h to $out/include (to expose the header)
- Copying only extras to $out (to make dependencies build)
- Exported a pkg-config file for easy compiler include.

Fixes: #410998

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
