### PR TITLE
zsh: migrate to PCRE2

### DIFF
--- a/pkgs/by-name/zs/zsh/package.nix
+++ b/pkgs/by-name/zs/zsh/package.nix
@@ -10,7 +10,7 @@
   util-linux,
   texinfo,
   ncurses,
-  pcre,
+  pcre2,
   pkg-config,
   buildPackages,
   nixosTests,
@@ -52,6 +52,22 @@ stdenv.mkDerivation {
         hash = "sha256-oA8GC8LmuqNKGuPqGfiQVhL5nWb7ArLWGUI6wjpsIW8=";
         excludes = [ "ChangeLog" ];
       })
+      # PCRE 2.x support
+      (fetchpatch {
+        url = "https://github.com/zsh-users/zsh/commit/1b421e4978440234fb73117c8505dad1ccc68d46.patch";
+        hash = "sha256-jqTXnz56L3X21e3kXtzrT1jKEq+K7ittFjL7GdHVq94=";
+        excludes = [ "ChangeLog" ];
+      })
+      (fetchpatch {
+        url = "https://github.com/zsh-users/zsh/commit/b62e911341c8ec7446378b477c47da4256053dc0.patch";
+        hash = "sha256-MfyiLucaSNNfdCLutgv/kL/oi/EVoxZVUd1KjGzN9XI=";
+        excludes = [ "ChangeLog" ];
+      })
+      (fetchpatch {
+        url = "https://github.com/zsh-users/zsh/commit/10bdbd8b5b0b43445aff23dcd412f25cf6aa328a.patch";
+        hash = "sha256-bl1PG9Zk1wK+2mfbCBhD3OEpP8HQboqEO8sLFqX8DmA=";
+        excludes = [ "ChangeLog" ];
+      })
     ]
     ++ lib.optionals stdenv.cc.isGNU [
       # Fixes compilation with gcc >= 14.
@@ -78,8 +94,10 @@ stdenv.mkDerivation {
 
   buildInputs = [
     ncurses
-    pcre
+    pcre2
   ];
+
+  env.PCRE_CONFIG = lib.getExe' (lib.getDev pcre2) "pcre2-config";
 
   configureFlags =
     [
@@ -102,16 +120,6 @@ stdenv.mkDerivation {
       "zsh_cv_sys_dynamic_strip_exe=yes"
       "zsh_cv_sys_dynamic_strip_lib=yes"
     ];
-
-  postPatch = ''
-    substituteInPlace Src/Modules/pcre.mdd \
-      --replace 'pcre-config' 'true'
-  '';
-
-  preConfigure = ''
-    # use pkg-config instead of pcre-config
-    configureFlagsArray+=("PCRECONF=''${PKG_CONFIG} libpcre")
-  '';
 
   # the zsh/zpty module is not available on hydra
   # so skip groups Y Z


### PR DESCRIPTION
Fixes #411056

## Things done

- Built on platform(s)
  - [x] x86_64-linux: but no manual testing done
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).