### PR TITLE
ccextractor: 0.94-unstable-2024-08-12 -> 0.94-unstable-2025-05-20

### DIFF
--- a/pkgs/by-name/cc/ccextractor/package.nix
+++ b/pkgs/by-name/cc/ccextractor/package.nix
@@ -30,13 +30,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ccextractor";
-  version = "0.94-unstable-2024-08-12";
+  version = "0.94-unstable-2025-05-20";
 
   src = fetchFromGitHub {
     owner = "CCExtractor";
     repo = "ccextractor";
-    rev = "92f2ce0fa026b01fb07db6751210e6bd8c8944d3";
-    hash = "sha256-bp7T9uJK4bauR2Co4lKqqnM6oGa3WZ+1toEKmzOx4mI=";
+    rev = "407d0f4e93611c5b0ceb14b7fc01d4a4c2e90433";
+    hash = "sha256-BfsQmCNB4HRafqJ3pC2ECiwhOgwKuIqiLjr2/bvHr7Q=";
   };
 
   patches = [
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src cargoRoot;
     patches = [ ./use-rsmpeg-0.15.patch ];
-    hash = "sha256-7v3gQghByUDWZLJRRGa/7X2ivUumirq6BbexNQcCXCk=";
+    hash = "sha256-68Y8nzPHxhVIRHoPXOy9tc71177lCBuOf//z3cqyDGQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cc/ccextractor/use-rsmpeg-0.15.patch
+++ b/pkgs/by-name/cc/ccextractor/use-rsmpeg-0.15.patch
@@ -34,10 +34,9 @@ index 4c1e73dcf0..68502915dc 100644
 +++ b/src/rust/Cargo.toml
 @@ -15,7 +15,7 @@
  env_logger = "0.8.4"
- iconv = "0.1.1"
- palette = "0.6.0"
--rsmpeg = { version = "0.14.1", optional = true, features = [
+ palette = "0.6.1"
+-rsmpeg = { version = "0.14.2", optional = true, features = [
 +rsmpeg = { version = "0.15.1", optional = true, features = [
      "link_system_ffmpeg",
  ] }
- tesseract-sys = { version = "0.5.14", optional = true, default-features = false }
+ tesseract-sys = { version = "0.5.15", optional = true, default-features = false }


### PR DESCRIPTION
Update to newest commit. Should fix build errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
