### PR TITLE
pencil2d: add ffmpeg dependency; fix build id

### DIFF
--- a/pkgs/by-name/pe/pencil2d/git-inherit.patch
+++ b/pkgs/by-name/pe/pencil2d/git-inherit.patch
@@ -1,0 +1,13 @@
+--- a/app/app.pro    
++++ b/app/app.pro
+@@ -208,8 +208,8 @@
+
+ GIT {
+     DEFINES += GIT_EXISTS \
+-    "GIT_CURRENT_SHA1=$$system(git --git-dir=.git --work-tree=. -C $$_PRO_FILE_PWD_/../ rev-parse HEAD)" \
+-    "GIT_TIMESTAMP=$$system(git --git-dir=.git --work-tree=. -C $$_PRO_FILE_PWD_/../ log -n 1 --pretty=format:"%cd" --date=format:"%Y-%m-%d_%H:%M:%S")"
++    "GIT_CURRENT_SHA1=$$cat($$_PRO_FILE_PWD_/../COMMIT)" \
++    "GIT_TIMESTAMP=$$cat($$_PRO_FILE_PWD_/../SOURCE_TIMESTAMP_EPOCH)"
+ }
+
+ macx {

--- a/pkgs/by-name/pe/pencil2d/package.nix
+++ b/pkgs/by-name/pe/pencil2d/package.nix
@@ -3,30 +3,56 @@
   stdenv,
   fetchFromGitHub,
   qt5,
+  git,
+  ffmpeg_6,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation (FinalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pencil2d";
   version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "pencil2d";
     repo = "pencil";
-    tag = "v${FinalAttrs.version}";
-    hash = "sha256-OuZpKgX2BgfuQdnjk/RTBww/blO1CIrYWr7KytqcIbQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-l+iW0k3WdNXDwXtt958JJWSe3zNhQVul4FUcPPMrVxE=";
+    leaveDotGit = true;
+    postFetch = ''
+      # Obtain the last commit ID and its timestamp, then zap .git for reproducibility
+      cd $out
+      git rev-parse HEAD > $out/COMMIT
+      # 0000-00-00T00:00:00Z
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%d_%H:%M:%S" > $out/SOURCE_TIMESTAMP_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
+
+  patches = [ ./git-inherit.patch ];
 
   nativeBuildInputs = with qt5; [
     qmake
     wrapQtAppsHook
     qttools
+    git
   ];
+
+  qmakeFlags = [
+    "pencil2d.pro"
+    "CONFIG+=release"
+    "CONFIG+=PENCIL2D_RELEASE"
+    "CONFIG+=GIT"
+    "VERSION=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
 
   buildInputs = with qt5; [
     qtbase
     qtmultimedia
     qtsvg
     qtwayland
+    ffmpeg_6
   ];
 
   meta = {


### PR DESCRIPTION
Pencil2D uses a custom build name in qmake, added that. Added ffmpeg dependency
fixes #411051

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
