### PR TITLE
uudeview: 0.5.20 -> 0.5.20-unstable-2025-03-20, update repo, fixes build

### DIFF
--- a/pkgs/by-name/uu/uudeview/package.nix
+++ b/pkgs/by-name/uu/uudeview/package.nix
@@ -1,19 +1,21 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchFromGitHub,
   tcl,
   tk,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation rec {
   pname = "uudeview";
-  version = "0.5.20";
+  version = "0.5.20-unstable-2025-03-20";
 
-  src = fetchurl {
-    url = "http://www.fpx.de/fp/Software/UUDeview/download/uudeview-${version}.tar.gz";
-    sha256 = "0dg4v888fxhmf51vxq1z1gd57fslsidn15jf42pj4817vw6m36p4";
+  src = fetchFromGitHub {
+    owner = "hannob";
+    repo = "uudeview";
+    rev = "7640bc56aa5016cdc9c139eb1ab3ec874e47c744";
+    hash = "sha256-IdHxkrXe+2I+aJpZ0bhimXq4xEXE9HDXrL5DtCs7MKk=";
   };
 
   buildInputs = [
@@ -21,20 +23,11 @@ stdenv.mkDerivation rec {
     tk
   ];
 
+  nativeBuildInputs = [ autoreconfHook ];
+
   configureFlags = [
     "--enable-tk=${tk.dev}"
     "--enable-tcl=${tcl}"
-  ];
-
-  patches = [
-    # https://wiki.tcl.tk/3577
-    ./matherr.patch
-    # format hardening
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/OpenMandrivaAssociation/uudeview/master/uudeview-0.5.20-fix-str-fmt.patch";
-      sha256 = "1biipck60mhpd0j6jwizaisvqa8alisw1dpfqm6zf7ic5b93hmfw";
-      extraPrefix = "";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
- Upstream moved to github, updated by @hannob
- fixes build

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
