### PR TITLE
Revert "stellarsolver: 2.6 -> 2.7"

### DIFF
--- a/pkgs/by-name/st/stellarsolver/package.nix
+++ b/pkgs/by-name/st/stellarsolver/package.nix
@@ -11,13 +11,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "stellarsolver";
-  version = "2.7";
+  version = "2.6";
 
   src = fetchFromGitHub {
     owner = "rlancaste";
     repo = "stellarsolver";
     rev = finalAttrs.version;
-    sha256 = "sha256-eGyqJX9TZzIDBCrAlrblhUy4G49hpE5r4q89+/1pnfM=";
+    sha256 = "sha256-6WDiHaBhi9POtXynGU/eTeuqZSK81JJeuZv4SxOeVoE=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#410696

I accidentally merged this although the PR did not build. I am sorry. 