### PR TITLE
python3Packages.meep: cleanup

### DIFF
--- a/pkgs/development/python-modules/meep/default.nix
+++ b/pkgs/development/python-modules/meep/default.nix
@@ -28,6 +28,7 @@
   cython,
   autograd,
   mpi4py,
+  distutils,
 }:
 
 assert !blas.isILP64;
@@ -45,12 +46,6 @@ buildPythonPackage rec {
   };
 
   format = "other";
-
-  # https://github.com/NanoComp/meep/issues/2819
-  postPatch = lib.optionalString (!pythonOlder "3.12") ''
-    substituteInPlace configure.ac doc/docs/setup.py python/visualization.py \
-      --replace-fail "distutils" "setuptools._distutils"
-  '';
 
   # MPI is needed in nativeBuildInputs too, otherwise MPI libs will be missing
   # at runtime
@@ -76,9 +71,10 @@ buildPythonPackage rec {
     mpb
   ];
 
-  propagatedBuildInputs =
+  propagatedBuildInputs = [ mpi ];
+
+  dependencies =
     [
-      mpi
       numpy
       scipy
       matplotlib
@@ -89,6 +85,7 @@ buildPythonPackage rec {
     ]
     ++ lib.optionals (!pythonOlder "3.12") [
       setuptools # used in python/visualization.py
+      distutils
     ];
 
   propagatedUserEnvPkgs = [ mpi ];
@@ -100,7 +97,7 @@ buildPythonPackage rec {
 
   preConfigure = ''
     export HDF5_MPI=ON
-    export PYTHON=${python}/bin/${python.executable};
+    export PYTHON=${python.interpreter};
   '';
 
   configureFlags = [


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/410577#pullrequestreview-2866706340

- move python dependencies into `dependencies`
- add `distutils` to dependencies instead of patching them in
- use `python.interpreter` directly


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
