### PR TITLE
biz-ud-gothic: init at 1.051

### DIFF
--- a/pkgs/by-name/bi/biz-ud-gothic/package.nix
+++ b/pkgs/by-name/bi/biz-ud-gothic/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "biz-ud-gothic";
+  version = "1.051";
+
+  src = fetchzip {
+    # Sticking with this assets file due to ongoing discussions.
+    # We may switch to a different asset once the issue is resolved or clarifications are provided.
+    # ref: https://github.com/googlefonts/morisawa-biz-ud-gothic/issues/47
+    url = "https://github.com/googlefonts/morisawa-biz-ud-gothic/releases/download/v${finalAttrs.version}/morisawa-biz-ud-gothic-fonts.zip";
+    hash = "sha256-7PlIrQX1fnFHXm7mjfoOCVp3GSnLT2GlVZdSoZbh/s4=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 fonts/ttf/*.ttf -t "$out/share/fonts/truetype/"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Universal Design Japanese font";
+    homepage = "https://github.com/googlefonts/morisawa-biz-ud-gothic";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[BIZ UDGothic](https://github.com/googlefonts/morisawa-biz-ud-gothic) is a popular Japanese font that's great for presentations and documents.
I often find myself wanting it when creating PDFs with Typst.

- It's the original font for [udev-gothic](https://github.com/NixOS/nixpkgs/pull/259843)
- It's been [included by default in Windows 10](https://www.morisawa.co.jp/about/news/4010)

Reason for choosing this asset file: https://github.com/googlefonts/morisawa-biz-ud-gothic/issues/47

```console
> tree -h result/
[4.0K]  result/
└── [4.0K]  share
    └── [4.0K]  fonts
        └── [4.0K]  truetype
            ├── [4.4M]  BIZUDGothic-Bold.ttf
            ├── [4.5M]  BIZUDGothic-Regular.ttf
            ├── [4.4M]  BIZUDPGothic-Bold.ttf
            └── [4.5M]  BIZUDPGothic-Regular.ttf
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
