### PR TITLE
Xfce updates 2025-05-26

### DIFF
--- a/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
@@ -1,38 +1,53 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  glib,
   gtk3,
   thunar,
-  exo,
   libxfce4util,
   gettext,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "thunar-plugins";
+stdenv.mkDerivation (finalAttrs: {
   pname = "thunar-archive-plugin";
-  version = "0.5.3";
-  odd-unstable = false;
+  version = "0.6.0";
 
-  sha256 = "sha256-9EjEQml/Xdj/jCtC4ZuGdmpeNnOqUWJOqoVzLuxzG6s=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "thunar-plugins";
+    repo = "thunar-archive-plugin";
+    tag = "thunar-archive-plugin-${finalAttrs.version}";
+    hash = "sha256-/WLkEqzFAKpB7z8mWSgufo4Qbj6KP3Ax8MWVZxIwDs0=";
+  };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     gettext
+    meson
+    ninja
+    pkg-config
   ];
 
   buildInputs = [
     thunar
-    exo
+    glib
     gtk3
     libxfce4util
   ];
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  passthru.updateScript = gitUpdater { rev-prefix = "thunar-archive-plugin-"; };
 
-  meta = with lib; {
+  meta = {
     description = "Thunar plugin providing file context menus for archives";
-    teams = [ teams.xfce ];
+    homepage = "https://gitlab.xfce.org/thunar-plugins/thunar-archive-plugin";
+    license = lib.licenses.lgpl2Only;
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/desktops/xfce/thunar-plugins/media-tags/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/media-tags/default.nix
@@ -1,24 +1,48 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  fetchpatch,
+  meson,
+  ninja,
+  pkg-config,
   glib,
   gtk3,
   thunar,
   libxfce4util,
   gettext,
   taglib,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "thunar-plugins";
+stdenv.mkDerivation (finalAttrs: {
   pname = "thunar-media-tags-plugin";
-  version = "0.5.0";
-  odd-unstable = false;
+  version = "0.6.0";
 
-  sha256 = "sha256-71YBA1deR8aV8hoZ4F0TP+Q5sdcVQAB9n3B+pcpJMSQ=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "thunar-plugins";
+    repo = "thunar-media-tags-plugin";
+    tag = "thunar-media-tags-plugin-${finalAttrs.version}";
+    hash = "sha256-qEoBga+JSxpByOjqhOspjYknF0p74oXZnpoDz2MSBOA=";
+  };
+
+  patches = [
+    # meson-build: Fix typo libxfce4ui -> libxfce4util
+    # https://gitlab.xfce.org/thunar-plugins/thunar-media-tags-plugin/-/merge_requests/14
+    (fetchpatch {
+      url = "https://gitlab.xfce.org/thunar-plugins/thunar-media-tags-plugin/-/commit/4e19a56deeeefa6d913f7b15a12b30a5d99119d4.patch";
+      hash = "sha256-ASVknxEiGOWbE82hVlgEAOqE+8TknAh/ULQg55mfs9o=";
+    })
+  ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     gettext
+    meson
+    ninja
+    pkg-config
   ];
 
   buildInputs = [
@@ -29,9 +53,14 @@ mkXfceDerivation {
     taglib
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "thunar-media-tags-plugin-"; };
+
+  meta = {
     description = "Thunar plugin providing tagging and renaming features for media files";
-    maintainers = with maintainers; [ ncfavier ];
-    teams = [ teams.xfce ];
+    homepage = "https://gitlab.xfce.org/thunar-plugins/thunar-media-tags-plugin";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ncfavier ];
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/desktops/xfce/thunar-plugins/vcs/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/vcs/default.nix
@@ -1,8 +1,15 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
   thunar,
   exo,
+  libxfce4ui,
   libxfce4util,
   gtk3,
   glib,
@@ -10,19 +17,36 @@
   apr,
   aprutil,
   withSubversion ? false,
+  gitUpdater,
 }:
-mkXfceDerivation {
-  category = "thunar-plugins";
-  pname = "thunar-vcs-plugin";
-  version = "0.3.0";
-  odd-unstable = false;
 
-  sha256 = "sha256-e9t6lIsvaV/2AAL/7I4Pbcokvy7Lp2+D9sJefTZqB1g=";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "thunar-vcs-plugin";
+  version = "0.4.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "thunar-plugins";
+    repo = "thunar-vcs-plugin";
+    tag = "thunar-vcs-plugin-${finalAttrs.version}";
+    hash = "sha256-VuTTao46/3JNzCHv7phCC8DCy9rjlEcMuGmGiIOSsMM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
+  ];
 
   buildInputs =
     [
       thunar
       exo
+      libxfce4ui
       libxfce4util
       gtk3
       glib
@@ -33,9 +57,18 @@ mkXfceDerivation {
       subversion
     ];
 
+  mesonFlags = [
+    (lib.mesonEnable "svn" withSubversion)
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "thunar-vcs-plugin-"; };
+
   meta = {
     description = "Thunar plugin providing support for Subversion and Git";
+    homepage = "https://gitlab.xfce.org/thunar-plugins/thunar-vcs-plugin";
+    license = lib.licenses.lgpl2Only;
     maintainers = with lib.maintainers; [ lordmzte ];
     teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
The 5th PR for the mass autotools -> meson transition, previous:

- https://github.com/NixOS/nixpkgs/pull/409074
- https://github.com/NixOS/nixpkgs/pull/409413
- https://github.com/NixOS/nixpkgs/pull/409803
- https://github.com/NixOS/nixpkgs/pull/410534

This PR takes care of thunar plugins:

<img src="https://github.com/user-attachments/assets/7c3aeb99-e34a-4f7d-9abe-2a1d762a388c" width=30%>
<img src="https://github.com/user-attachments/assets/f0b4d42c-d127-476a-8f65-b482060d5d76" width=30%>
<img src="https://github.com/user-attachments/assets/5aca2d24-d4d5-4b1f-87d5-fe0490b95cfc" width=30%>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

