### PR TITLE
nixos/tinyproxy: fix config generation handling of strings

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -156,6 +156,8 @@
 
 - Plugins for the JetBrains IDEs have been removed from Nixpkgs.
 
+- `services.tinyproxy` changed its handling of config values to more directly match upstream. As a result, some string values may now require manual double-quoting.
+
 - `spacetimedb` has been updated from 1.12.0 to [2.0.3](https://github.com/clockworklabs/SpacetimeDB/releases/tag/v2.0.3). Breaking changes and migration notes from 1.0 to 2.0 can be found [here](https://spacetimedb.com/docs/upgrade/).
 
 - `jetbrains.plugins.addPlugins` no longer supports plugin names or ID strings.

--- a/nixos/modules/services/networking/tinyproxy.nix
+++ b/nixos/modules/services/networking/tinyproxy.nix
@@ -46,12 +46,12 @@ in
         default = { };
         example = lib.literalExpression ''
           {
-            Port 8888;
-            Listen 127.0.0.1;
-            Timeout 600;
-            Allow 127.0.0.1;
-            Anonymous = ['"Host"' '"Authorization"'];
-            ReversePath = '"/example/" "http://www.example.com/"';
+            Port = 8888;
+            Listen = "127.0.0.1";
+            Timeout = 600;
+            Allow = "127.0.0.1";
+            Anonymous = ["\"Host\"" "\"Authorization\""];
+            ReversePath = "\"/example/\"" "\"http://www.example.com/\"";
           }
         '';
         type = lib.types.submodule (

--- a/nixos/modules/services/networking/tinyproxy.nix
+++ b/nixos/modules/services/networking/tinyproxy.nix
@@ -7,32 +7,28 @@
 
 let
   cfg = config.services.tinyproxy;
+
   mkValueStringTinyproxy =
     v:
     if true == v then
       "yes"
     else if false == v then
       "no"
-    else if lib.types.path.check v then
-      ''"${v}"''
     else
       lib.generators.mkValueStringDefault { } v;
-  mkKeyValueTinyproxy =
-    {
-      mkValueString ? lib.mkValueStringDefault { },
-    }:
-    sep: k: v:
-    if null == v then "" else "${lib.strings.escape [ sep ] k}${sep}${mkValueString v}";
 
   settingsFormat = (
     pkgs.formats.keyValue {
-      mkKeyValue = mkKeyValueTinyproxy {
+      mkKeyValue = lib.generators.mkKeyValueDefault {
         mkValueString = mkValueStringTinyproxy;
       } " ";
       listsAsDuplicateKeys = true;
     }
   );
-  configFile = settingsFormat.generate "tinyproxy.conf" cfg.settings;
+
+  configFile = settingsFormat.generate "tinyproxy.conf" (
+    lib.filterAttrs (k: v: v != null) cfg.settings
+  );
 
 in
 {
@@ -42,7 +38,13 @@ in
       enable = lib.mkEnableOption "Tinyproxy daemon";
       package = lib.mkPackageOption pkgs "tinyproxy" { };
       settings = lib.mkOption {
-        description = "Configuration for [tinyproxy](https://tinyproxy.github.io/).";
+        description = ''
+          Configuration for [tinyproxy](https://tinyproxy.github.io/).
+
+          Note that whether a string-like value needs to double-quoted varies for
+          each configuration option, and, unless specified explicitly here needs
+          to be manually wrapped.
+        '';
         default = { };
         example = lib.literalExpression ''
           {
@@ -83,8 +85,11 @@ in
               Filter = lib.mkOption {
                 type = lib.types.nullOr lib.types.path;
                 default = null;
+                apply = val: if val != null then "\"${val}\"" else val;
                 description = ''
-                  Tinyproxy supports filtering of web sites based on URLs or domains. This option specifies the location of the file containing the filter rules, one rule per line.
+                  Tinyproxy supports filtering of web sites based on URLs or domains.
+                  This option specifies the location of the file containing the filter rules, one rule per line.
+                  The filename will be quoted.
                 '';
               };
             };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
