### PR TITLE
nixos/amdgpu: add overdrive and ppfeaturemask option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -27,3 +27,6 @@
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - `services.clamsmtp` is unmaintained and was removed from Nixpkgs.
+
+- `amdgpu` kernel driver overdrive mode can now be enabled by setting [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable) and customized through [hardware.amdgpu.overdrive.ppfeaturemask](#opt-hardware.amdgpu.overdrive.ppfeaturemask).
+  This allows for fine-grained control over the GPU's performance and maybe required by overclocking softwares like Corectrl and Lact. These new options replace old options such as {option}`programs.corectrl.gpuOverclock.enable` and {option}`programs.tuxclocker.enableAMD`.

--- a/nixos/modules/services/hardware/amdgpu.nix
+++ b/nixos/modules/services/hardware/amdgpu.nix
@@ -16,21 +16,44 @@ in
       series cards. Note: this removes support for analog video outputs,
       which is only available in the `radeon` driver
     '';
+
     initrd.enable = lib.mkEnableOption ''
       loading `amdgpu` kernelModule in stage 1.
       Can fix lower resolution in boot screen during initramfs phase
     '';
+
+    overdrive = {
+      enable = lib.mkEnableOption ''`amdgpu` overdrive mode for overclocking'';
+
+      ppfeaturemask = lib.mkOption {
+        type = lib.types.str;
+        default = "0xfffd7fff";
+        example = "0xffffffff";
+        description = ''
+          Sets the `amdgpu.ppfeaturemask` kernel option. It can be used to enable the overdrive bit.
+          Default is `0xfffd7fff` as it is less likely to cause flicker issues. Setting it to
+          `0xffffffff` enables all features, but also can be unstable. See
+          [the kernel documentation](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/gpu/drm/amd/include/amd_shared.h#n169)
+          for more information.
+        '';
+      };
+    };
+
     opencl.enable = lib.mkEnableOption ''OpenCL support using ROCM runtime library'';
     # cfg.amdvlk option is defined in ./amdvlk.nix module
   };
 
   config = {
-    boot.kernelParams = lib.optionals cfg.legacySupport.enable [
-      "amdgpu.si_support=1"
-      "amdgpu.cik_support=1"
-      "radeon.si_support=0"
-      "radeon.cik_support=0"
-    ];
+    boot.kernelParams =
+      lib.optionals cfg.legacySupport.enable [
+        "amdgpu.si_support=1"
+        "amdgpu.cik_support=1"
+        "radeon.si_support=0"
+        "radeon.cik_support=0"
+      ]
+      ++ lib.optionals cfg.overdrive.enable [
+        "amdgpu.ppfeaturemask=${cfg.overdrive.ppfeaturemask}"
+      ];
 
     boot.initrd.kernelModules = lib.optionals cfg.initrd.enable [ "amdgpu" ];
 

--- a/nixos/modules/services/misc/tuxclocker.nix
+++ b/nixos/modules/services/misc/tuxclocker.nix
@@ -8,14 +8,16 @@ let
   cfg = config.programs.tuxclocker;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "tuxclocker" "enableAMD" ]
+      [ "hardware" "amdgpu" "overdrive" "enable" ]
+    )
+  ];
+
   options.programs.tuxclocker = {
     enable = lib.mkEnableOption ''
       TuxClocker, a hardware control and monitoring program
-    '';
-
-    enableAMD = lib.mkEnableOption ''
-      AMD GPU controls.
-      Sets the `amdgpu.ppfeaturemask` kernel parameter to 0xfffd7fff to enable all TuxClocker controls
     '';
 
     enabledNVIDIADevices = lib.mkOption {
@@ -72,9 +74,5 @@ in
           );
         in
         lib.concatStrings (map configSection cfg.enabledNVIDIADevices);
-
-      # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/gpu/drm/amd/include/amd_shared.h#n207
-      # Enable everything modifiable in TuxClocker
-      boot.kernelParams = lib.mkIf cfg.enableAMD [ "amdgpu.ppfeaturemask=0xfffd7fff" ];
     };
 }


### PR DESCRIPTION
This PR moves options from corectrl and tuxclocker module to amdgpu module.

This allows other modules to make use of these options, ie, a future LACT module. (https://github.com/NixOS/nixpkgs/pull/338059)

- `programs.corectrl.gpuOverclock.enable` -> `hardware.amdgpu.overdrive.enable`
- `programs.corectrl.gpuOverclock.ppfeaturemask` -> `hardware.amdgpu.overdrive.ppfeaturemask`
- `programs.tuxclocker.enableAMD` -> `hardware.amdgpu.overdrive.enable`

## Things done

- Built on platform(s)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
