### PR TITLE
temporal-ui-server: init at 2.43.2

### DIFF
--- a/pkgs/by-name/te/temporal-ui-server/package.nix
+++ b/pkgs/by-name/te/temporal-ui-server/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "temporal-ui-server";
+  version = "2.43.2";
+
+  src = fetchFromGitHub {
+    owner = "temporalio";
+    repo = "ui-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z7a/21whiCjiQiqKE8aDcptSFw+op82xnqXfzVjGw6o=";
+  };
+
+  vendorHash = "sha256-HmysULH81cYOuMyW9qZRsQhv7chDobD7PnWmu3uCvJw=";
+
+  postInstall = ''
+    mv $out/bin/server $out/bin/temporal-ui-server
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/temporalio/ui-server/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/temporalio/ui-server";
+    description = "Golang Server for Temporal Web UI";
+    longDescription = ''
+      The Temporal Web UI provides users with Workflow Execution state and metadata
+      for debugging purposes. This golang server provides a binary that you can run
+      to serve the compiled temporal ui (https://github.com/temporalio/ui).
+    '';
+    mainProgram = "temporal-ui-server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ breakds ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces the `temporal-ui-server` package to nixpkgs, providing a fully self-hosted Golang service that serves the compiled Temporal Web UI assets and proxies gRPC calls to the WorkflowService API for real-time visibility into workflow executions and metadata—crucial for debugging and monitoring purposes 
 
- By pairing this package with the existing temporal server binaries already in nixpkgs, users gain a one-stop, declarative NixOS deployment (will add the service after this PR is merged)
- No other package is currently depending on this package.


Also, The UI server has been built and deployed locally with the `temporal` server, confirming compatibility and stability with a self-hosted [Temporal cluster](https://docs.temporal.io/temporal-service) 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
