### PR TITLE
hyprdock: init at 0.4.3

### DIFF
--- a/pkgs/by-name/hy/hyprdock/package.nix
+++ b/pkgs/by-name/hy/hyprdock/package.nix
@@ -1,0 +1,52 @@
+{
+  cargo,
+  fetchFromGitHub,
+  gtk-layer-shell,
+  gtk3,
+  hyprdock,
+  lib,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  rustc,
+  testers,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "hyprdock";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "Xetibo";
+    repo = "hyprdock";
+    tag = "${version}";
+    hash = "sha256-ZGCzz+2++YxGFaFBV2G2j6MglW/B6+rBrvVy9H/OUJw=";
+  };
+
+  cargoHash = "sha256-LEJXqt/Cb6Bp4Gym2v2yIUjqcbTgxVwR8PqaWJE1sx0=";
+
+  buildInputs = [
+    gtk3
+    gtk-layer-shell
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cargo
+    rustc
+  ];
+
+  passthru = {
+    tests.version = testers.testVersion { package = hyprdock; };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Docking program for Hyprland with acpid socket";
+    homepage = "https://github.com/Xetibo/hyprdock";
+    changelog = "https://github.com/Xetibo/hyprdock/releases/tag/${version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ dashietm ];
+    mainProgram = "hyprdock";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Tool for docking with Hyprland or other compositors/wms that allow configuration via terminal commands.
https://github.com/Xetibo/hyprdock

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
