### PR TITLE
Fix typo in name of postgrest configuration options.

### DIFF
--- a/nixos/modules/services/databases/postgrest.nix
+++ b/nixos/modules/services/databases/postgrest.nix
@@ -247,7 +247,7 @@ in
 
     # Since we're using DynamicUser, we can't add the e.g. nginx user to
     # a postgrest group, so the unix socket must be world-readable to make it useful.
-    services.postgrest.settings.service-unix-socket-mode = "666";
+    services.postgrest.settings.server-unix-socket-mode = "666";
 
     systemd.services.postgrest = {
       description = "PostgREST";


### PR DESCRIPTION
This PR fixes a typo in the module definition for the postgrest service.
The config-file key is 'server-unix-socket-mode' not 'service-unix-socket-mode'.
