### PR TITLE
Revert "stalwart-mail: use system jemalloc"

### DIFF
--- a/pkgs/by-name/st/stalwart-mail/package.nix
+++ b/pkgs/by-name/st/stalwart-mail/package.nix
@@ -9,7 +9,6 @@
   sqlite,
   foundationdb,
   zstd,
-  rust-jemalloc-sys,
   stdenv,
   nix-update-script,
   nixosTests,
@@ -44,7 +43,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
     sqlite
     zstd
-    rust-jemalloc-sys
   ] ++ lib.optionals (stdenv.hostPlatform.isLinux && withFoundationdb) [ foundationdb ];
 
   # Issue: https://github.com/stalwartlabs/mail-server/issues/1104


### PR DESCRIPTION
Reverts NixOS/nixpkgs#409024

The reason is that rocksdb runs into bugs with it (#411146)