### PR TITLE
dependabot: 1.64.0 -> 1.65.0, add update script

### DIFF
--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -11,34 +11,20 @@
 }:
 let
   pname = "dependabot-cli";
-  version = "1.64.0";
+  version = "1.65.0";
 
-  # vv Also update this vv
+  # `tag` is what `dependabot` uses to find the relevant docker images.
   tag = "nixpkgs-dependabot-cli-${version}";
 
-  updateJobProxy = dockerTools.pullImage {
-    imageName = "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy";
-    # Get these hashes from
-    # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy --image-tag latest --final-image-name dependabot-update-job-proxy --final-image-tag ${tag}
-    imageDigest = "sha256:3030ba5ff8f556e47016fca94d81c677b5c6abde99fef228341e1537588e503a";
-    hash = "sha256-RiXUae5ONScoDu85L6BEf3T4JodBYha6v+d9kWl8oWc=";
+  # Get these hashes from
+  # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy --image-tag latest --final-image-name dependabot-update-job-proxy --final-image-tag ${tag}
+  updateJobProxy.imageDigest = "sha256:ef245bd38aaa3cf89cafcffe0630d3ad3cff840488a2051a48517454e7f42368";
+  updateJobProxy.hash = "sha256-yndoGLpyV2MiIs0QXbF/W0xJ6jtmnw/ezL54VM80/CI=";
 
-    # Don't update this, it's used to refer to the imported image later
-    finalImageName = "dependabot-update-job-proxy";
-    finalImageTag = tag;
-  };
-
-  updaterGitHubActions = dockerTools.pullImage {
-    imageName = "ghcr.io/dependabot/dependabot-updater-github-actions";
-    # Get these hashes from
-    # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/dependabot/dependabot-updater-github-actions --image-tag latest --final-image-name dependabot-updater-github-actions --final-image-tag ${tag}
-    imageDigest = "sha256:a356576adbec11bc34b142b6ef69a5856a09dc3654bdc9f9b046c08ee2d73ff8";
-    hash = "sha256-zqydb2v39xiSBT5ayWEacD0NIH6LoFX8lkRcCKppH08=";
-
-    # Don't update this, it's used to refer to the imported image later
-    finalImageName = "dependabot-updater-github-actions";
-    finalImageTag = tag;
-  };
+  # Get these hashes from
+  # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/dependabot/dependabot-updater-github-actions --image-tag latest --final-image-name dependabot-updater-github-actions --final-image-tag ${tag}
+  updaterGitHubActions.imageDigest = "sha256:adeaa00b4ae49e942adccec76d4487a393eebd0dec27cd75a3cdf6cc46d801d7";
+  updaterGitHubActions.hash = "sha256-ni9rSEpeo0gIdYy2CIIpnIWg0kttoTnvRwbZ71QwmIg=";
 in
 buildGoModule {
   inherit pname version;
@@ -47,7 +33,7 @@ buildGoModule {
     owner = "dependabot";
     repo = "cli";
     rev = "v${version}";
-    hash = "sha256-NcmDYCXdhMY1KFz3if0XlX4EisQFr0YhJItllXnOfaA=";
+    hash = "sha256-A7CPn0YDeyr+d1OUde2TGfSt3eCfrK4k3S7NWsvCGx0=";
   };
 
   vendorHash = "sha256-pnB1SkuEGm0KfkDfjnoff5fZRsAgD5w2H4UwsD3Jlbo=";
@@ -85,14 +71,30 @@ buildGoModule {
     name = "dependabot-cli-with-docker-images";
     paths = [ dependabot-cli ];
     buildInputs = [ makeWrapper ];
-    postBuild = ''
-      # Create a wrapper that pins the docker images that are depended upon
-      wrapProgram $out/bin/dependabot \
-        --run "docker load --input ${updateJobProxy} >&2" \
-        --add-flags "--proxy-image=dependabot-update-job-proxy:${tag}" \
-        --run "docker load --input ${updaterGitHubActions} >&2" \
-        --add-flags "--updater-image=dependabot-updater-github-actions:${tag}"
-    '';
+    postBuild =
+      let
+        updateJobProxyImage = dockerTools.pullImage {
+          imageName = "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy";
+          finalImageName = "dependabot-update-job-proxy";
+          finalImageTag = tag;
+          inherit (updateJobProxy) imageDigest hash;
+        };
+
+        updaterGitHubActionsImage = dockerTools.pullImage {
+          imageName = "ghcr.io/dependabot/dependabot-updater-github-actions";
+          finalImageName = "dependabot-updater-github-actions";
+          finalImageTag = tag;
+          inherit (updaterGitHubActions) imageDigest hash;
+        };
+      in
+      ''
+        # Create a wrapper that pins the docker images that `dependabot` uses.
+        wrapProgram $out/bin/dependabot \
+          --run "docker load --input ${updateJobProxyImage} >&2" \
+          --add-flags "--proxy-image=dependabot-update-job-proxy:${tag}" \
+          --run "docker load --input ${updaterGitHubActionsImage} >&2" \
+          --add-flags "--updater-image=dependabot-updater-github-actions:${tag}"
+      '';
   };
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -1,10 +1,11 @@
 {
+  lib,
+  stdenv,
   buildGoModule,
   dependabot-cli,
   dockerTools,
   fetchFromGitHub,
   installShellFiles,
-  lib,
   makeWrapper,
   symlinkJoin,
   testers,
@@ -49,7 +50,7 @@ buildGoModule {
     installShellFiles
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd dependabot \
       --bash <($out/bin/dependabot completion bash) \
       --fish <($out/bin/dependabot completion fish) \

--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -79,6 +79,8 @@ buildGoModule {
     $out/bin/dependabot --help
   '';
 
+  passthru.updateScript = ./update.sh;
+
   passthru.withDockerImages = symlinkJoin {
     name = "dependabot-cli-with-docker-images";
     paths = [ dependabot-cli ];

--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -104,14 +104,15 @@ buildGoModule {
     version = "v${version}";
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/dependabot/cli/releases/tag/v${version}";
     description = "Tool for testing and debugging Dependabot update jobs";
     mainProgram = "dependabot";
     homepage = "https://github.com/dependabot/cli";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       infinisil
+      philiptaron
     ];
   };
 }

--- a/pkgs/by-name/de/dependabot-cli/update.sh
+++ b/pkgs/by-name/de/dependabot-cli/update.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq gh nix-prefetch-docker nix gitMinimal
+
+set -x -eu -o pipefail
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+NIXPKGS_PATH="$(git rev-parse --show-toplevel)"
+
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+gh api repos/dependabot/cli/releases/latest > "$temp_dir/latest.json"
+
+VERSION="$(jq -r .tag_name "$temp_dir/latest.json" | sed 's/^v//')"
+OLD_VERSION="$(grep -m1 'version = "' ./package.nix | cut -d'"' -f2)"
+
+if [ "$OLD_VERSION" = "$VERSION" ]; then
+  echo "dependabot is already up-to-date at $OLD_VERSION"
+  exit 0
+fi
+
+SHA256="$(nix-prefetch-url --quiet --unpack https://github.com/dependabot/cli/archive/refs/tags/v${VERSION}.tar.gz)"
+HASH="$(nix hash convert --hash-algo sha256 --to sri "$SHA256")"
+
+nix-prefetch-docker --json --quiet --final-image-name dependabot-update-job-proxy --final-image-tag "nixpkgs-dependabot-cli-$VERSION" ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy latest > "$temp_dir/dependabot-update-job-proxy.json"
+
+nix-prefetch-docker --json --quiet --final-image-name dependabot-updater-github-actions --final-image-tag "nixpkgs-dependabot-cli-$VERSION" ghcr.io/dependabot/dependabot-updater-github-actions latest > "$temp_dir/dependabot-updater-github-actions.json"
+
+setKV () {
+    sed -i "s,$1 = \"[^v].*\",$1 = \"${2:-}\"," ./package.nix
+}
+
+setKV version "${VERSION}"
+setKV hash "${HASH}"
+setKV updateJobProxy.imageDigest "$(jq -r .imageDigest "$temp_dir/dependabot-update-job-proxy.json")"
+setKV updateJobProxy.hash "$(jq -r .hash "$temp_dir/dependabot-update-job-proxy.json")"
+setKV updaterGitHubActions.imageDigest "$(jq -r .imageDigest "$temp_dir/dependabot-updater-github-actions.json")"
+setKV updaterGitHubActions.hash "$(jq -r .hash "$temp_dir/dependabot-updater-github-actions.json")"
+
+# We need to figure out the vendorHash for this new version, so we initially set it to `lib.fakeHash`
+FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+setKV vendorHash "$FAKE_HASH"
+
+set +e
+VENDOR_HASH="$(nix-build --no-out-link --log-format internal-json -A dependabot-cli "$NIXPKGS_PATH" 2>&1 >/dev/null | grep "$FAKE_HASH" | grep -o "sha256-[^\\]*" | tail -1)"
+set -e
+setKV vendorHash "$VENDOR_HASH"


### PR DESCRIPTION
1. Added update script (per https://github.com/NixOS/nixpkgs/pull/405991#pullrequestreview-2831073803 and cribbed from around the tree)
2. Update the various docker hashes at the same time
3. Update to the latest release

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).