### PR TITLE
Firefox: 138.0.4 -> 139.0; 128.10.1.esr -> 128.11.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,2477 +1,2477 @@
 {
-  version = "138.0.4";
+  version = "139.0";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ach/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ach/firefox-139.0.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "8a79f50942fa160efc366622cf668900eec76c0ff189b55df229034a9d028019";
+      sha256 = "23cd09ec62b0264cbc95484d168f1863e25b61e56628747e6e2c33bbbbc32917";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/af/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/af/firefox-139.0.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "9a2d9067e7e2a39b3a8283b8187872507a71eac80a7c193948d1f490f37c1eb0";
+      sha256 = "75c036fd772860241d895e35d9b30dda925a1fbfdf333ee68e895a09089c1de5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/an/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/an/firefox-139.0.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "494301f8a08bc0a0fdf20f9afbf539f7d3120803d8254d9561f317909bb4e7ee";
+      sha256 = "36a8830ee1eb8c1c0226a7e3960d3109d1e95398e2e48ad90c0c9179ffe48c45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ar/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ar/firefox-139.0.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "8438a7b8403bd614b72567c1b72d7131696adea98c5294b2d8bb382a4ee4630e";
+      sha256 = "64535a16a72ba7ad18c0d69e52d8349eeff729e4337948a290e8fa80f512081c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ast/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ast/firefox-139.0.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "2b704fbc63c97546740146b5078239aa00d9f8f3fe92882ae25b4323d32e515c";
+      sha256 = "ea6ef3a07581ab0c3af52231c772c77911f5d02b6cc5d8f017e40ff9df00258a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/az/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/az/firefox-139.0.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "aec76622b41b2a6892ab4c0983a0fb96f7089d066810b2d6d8db2d92753a3dfe";
+      sha256 = "92f14c55e60de6fa954e35d1bcc30846e080d7be13f671a1288535728d9e4ef2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/be/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/be/firefox-139.0.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "bde73f3a3c8d4ab4abe1db3dccc5c30e39b0c4242282bec36047a358ac649789";
+      sha256 = "09487b3bef2479d5e4bcde2b858e6ede04b366cb7be1df722d243c186b071493";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/bg/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/bg/firefox-139.0.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "9294751c7aa8a25b268049f81d3adf33f59d4afe4ad5ce861afe54e9867ab58d";
+      sha256 = "9bd0c77be9e0310cefd89f9438fe895d455c6242c35963cfb592ff837221c13c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/bn/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/bn/firefox-139.0.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "fa0387eaba1377190a7a4e6b799b61050f5393d0dc850073edfb7e37bd3f7b50";
+      sha256 = "231be122e74e5ad1263a879127334033b888487e0d2d2ac67b854e946a13ef26";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/br/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/br/firefox-139.0.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "e1676536b4ddebbfe75663c11877b4b6ed97c69fdcba31a66bf72a99e7f9212e";
+      sha256 = "d8788bb513967b9a47e381af6c63303cb7a642e9e47b2dff0d9e2f0f7f1c912c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/bs/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/bs/firefox-139.0.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "52ca6b8863b0d989dd867bd1f0ee6f72049d7226d714b14582f76aed2e9b16f2";
+      sha256 = "a631715732b16ef36dfdaca062a8e8a7e86a5f37d436a3fd4e3b7a39384756c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ca-valencia/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ca-valencia/firefox-139.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "dbb97403d04abd5710d31bdabeca16caca5327f6bd86a5afe2c1792f7db2e53a";
+      sha256 = "24816f5cec1597292a4e217a608150516c7c09e6af0523dea942d14edac6314e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ca/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ca/firefox-139.0.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "831d5e632fa66a0a2b2fa5e169bcdeee9fdfd68b68f89e85f3a582342d85a4c2";
+      sha256 = "17fec4ed5e2a0b53a40bbafa672c4a7fa63c1cda524a2cff3c609fd914bdf327";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/cak/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/cak/firefox-139.0.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "2273c9dfda2ef3cd8f98a86696bbe94dfb6242a047fc8b221e4a1c026d65892a";
+      sha256 = "b346bfcf32722c72e9df85255d9d11b11dc25051aefd7a80a6984a83f4a11941";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/cs/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/cs/firefox-139.0.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "2b62d55bd79f803274ce1c4b057c92ce11a74b2c91d3d125aef93bb740d677ef";
+      sha256 = "db5fb598821ec03b1112e4c5920167b48c174ae0f91f74cb06c55fbd2f92114c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/cy/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/cy/firefox-139.0.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "bb8d822fc92dc25d0cb3237550799a2cc79b798f31b78236c846a81bf5f28a95";
+      sha256 = "3be873bf2d25dee2cb8e6f86f4af597be597a8e4fbc2d0982e657670f01f97f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/da/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/da/firefox-139.0.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "f034afad97afa8a4fca00bd40e24951ba7d3ba39b781b3285b06fb22b4b2fb13";
+      sha256 = "8bd0fbf81e1070b8f321e8cae3186d1a46ef4e8ed7c657fe5449c3e8edcaf2ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/de/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/de/firefox-139.0.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "133440a87be3e0a914e431f511bf4affcd99246f731bfac8e72fa8afbad9182a";
+      sha256 = "07c1c7f2c26e104d0779072888a54ad27d3bd81b2a126d8307e01d4596f9e7e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/dsb/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/dsb/firefox-139.0.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "0c02797b683185a45f5108b5bf9e00838b3ea18b255725dd81257e579f9436f9";
+      sha256 = "3d9ad8f10efe2452ed1b091762f90b5ef3dd30a40a1beec4f2c8c841ba349378";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/el/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/el/firefox-139.0.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "cab1433d5d146c273466de601463ab607e4df026cea88d66e30279da8194afb2";
+      sha256 = "fb1edae5e61d8fa5b64041edb050cc6d02a1638f5c387ea319b09353955e96c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/en-CA/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/en-CA/firefox-139.0.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ad573c3191be965a733162cf28134da2f702df5660a6fc66a27374a848887ab9";
+      sha256 = "4ee69c7fae9d5601a31a3396ead514b14a5284cf5ca60be67eca5e7ccc4a77b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/en-GB/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/en-GB/firefox-139.0.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "02aeccd3ee42da245fcedfa6cac2ca9ea90ff025a0ee12992a3ef8f2cd214ec7";
+      sha256 = "2ac5f940aed8efc0045f39ca95175e284e8cb984a7396b19f497a2aea2d1e448";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/en-US/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/en-US/firefox-139.0.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "c27d5bf7483eda49aae544d9f8b4f064dbc7341b27d7098378108e52071bf947";
+      sha256 = "1e3eab20cb84af1510b22e663438bd31ee1473652e10eb48661dcc6f1c0bbbe8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/eo/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/eo/firefox-139.0.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "f5d9735fc71b8336db3a9d7427b4ddf21143f6692fa73b40820bb15a87bd0182";
+      sha256 = "31ac94bce2736b13180cb4f88215e834d1c44da4eae010dcfb35aab8488bf191";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/es-AR/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/es-AR/firefox-139.0.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "fb16b058c74af3243358e046cffe5d43391f188962f86365a64477f71aa643b7";
+      sha256 = "9c14237bcac40713d967f16c9bf2a6b679760c94c9968d2f63264968ea46a8d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/es-CL/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/es-CL/firefox-139.0.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "cc53da23b4192b8b1b77f9ca0462ecd5aca3dfc5011d8a6ba433b2efbdb12252";
+      sha256 = "fe770b675c84745c06500c16e3e2cfa91a796bfc9bcf5aa50a24f751fda5d3d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/es-ES/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/es-ES/firefox-139.0.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "37122bc4e577f0e5b451cd63e55f88b62d33055d13bc298ad6efcafa21b91ba6";
+      sha256 = "d5e127a0aff0501b75dfd9bda616fb9e9229e58d37c168f11fd466dd12fa10d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/es-MX/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/es-MX/firefox-139.0.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "78da90a67ababdc71a01046e6e72a0aa20661962e054b2340c1ba7163daa437f";
+      sha256 = "1c8d5d4a1d656d33bb3763d64bea64459d98db07b5268749432612839a474e0e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/et/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/et/firefox-139.0.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d2dd22adce2768e58f2565153814a9ae7c2d8d4343a88ab729336908dbb3f25d";
+      sha256 = "53710d2c5defd4efe9b1dc6b4fad727df8530ec3534c8cfb3bccc7d41667662d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/eu/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/eu/firefox-139.0.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "d1937bd1c41e49981f5ff5da77dca89d74cc404e03338310c9375bdcb2e92f79";
+      sha256 = "63b0caa1dcbea5cb27406f656c3cae519ca83f5257ca6b7c4eaa9350cd53a377";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/fa/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/fa/firefox-139.0.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "82d63319db79eb68c1d4f93e0a8a2e6f67569cd881178de6466cd0b62dea96e4";
+      sha256 = "b9f8e391c7f3d8cf6db4cf7b0d72950fd6c327361de7bc7c9997d0f5b9beeb2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ff/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ff/firefox-139.0.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "542dd6a9d43f2a7e1472a81804e01f338b4f21e9ddd14443915904ab689000dd";
+      sha256 = "ea38fe8a87c0656cc5b94c61dde0719eda2357eebc7c227ae3bb8d2ae2a81fa0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/fi/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/fi/firefox-139.0.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "2419e379b9f4a4bf69f9a81b3f114c5e4bc8461ca423cba2f19dd936a35dfd88";
+      sha256 = "24e3836763d39eb5043b3186e774200c07a322ac7c61bc1a2605e411c7a17934";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/fr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/fr/firefox-139.0.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "719d79a87cdd6dd716aa4ce1dc867e07eedd9b051fa28f500f1ba483dd5afb48";
+      sha256 = "227a88889ba71ab531422d4abc2707360bc04a2be94a35e05063602879ed2928";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/fur/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/fur/firefox-139.0.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "ffe6655da019ed4d1e2c3fdcaff32370bfad8462d61343cc1c4ad7c37dac732d";
+      sha256 = "ed353ac9a84ad974132f15e9aaf3e561ce29bcf9a9000bfcd6a66d3a841e9b61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/fy-NL/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/fy-NL/firefox-139.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "22afd1d68ae9ec2ff6119930bfd0e36074f7f01e13ad096b0be4090113310e93";
+      sha256 = "d8b216e814271b23f84e31225059a0854f7f060cb8f64ba97838e8719c5d41ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ga-IE/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ga-IE/firefox-139.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "7fa3186f0b4a632b6f4c410c938d85620e808c57e8997d955f1d88f755d76e4d";
+      sha256 = "5cd26f19d63a51fc3c9e633ba976888a33a7cd8edfaf3af65c7ae675b50d36c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/gd/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/gd/firefox-139.0.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "198f5e116e147ad882fc932cd549c2dff29cadd3c604768830716c18e2e25e79";
+      sha256 = "f91f3301f81bcc2bb09a3c6172f42f060fcd5f22026a9ead5497155bb1f3aa52";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/gl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/gl/firefox-139.0.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "2a0617ed7e81ffa46e530d68197158f96b92391ad1ff85b7a50c36f84d9190fe";
+      sha256 = "7d75c84af9b6c269936c01387fc84676cb8d42bd9a4ef8f78fc3fcac7d9f4458";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/gn/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/gn/firefox-139.0.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "a64e0d51f7940560d311f3d8a38e2315e7a43d4bee72d7d8a16555d7998ac982";
+      sha256 = "2f5323f6a1dca8dc7f384d0e94d7cdd07856e7cae893adbec2e6588bf69dcc94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/gu-IN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/gu-IN/firefox-139.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "cb6611e4fa978abdef3749c260b063995b1c107a1851352303770c041c57e937";
+      sha256 = "a1b29a69e222ab789b7e46945d217aeed4c2654e978a5cc76590378f60618fff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/he/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/he/firefox-139.0.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "9d9a9bef24cbd1beabd933534ce6733de7ffaba76287971206ed822935d1efdd";
+      sha256 = "a1b2fd32771537a95aedba6cb67b424b8b75f0261fb935eb6e0a8479d28b2d87";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/hi-IN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/hi-IN/firefox-139.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "fa3e144b30eefe02d027f647a5ceb263b4a32177a226262e3e4ee8698051ec45";
+      sha256 = "78935bbe5424339d7a720d1c8afee5842be8d35033468955d08942ba741c04b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/hr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/hr/firefox-139.0.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "7355b2dcfb283ea5f0caa86f1859d97fd8d87df7742163ba2f157b90e519ee70";
+      sha256 = "4f044ba8f8a5dd4e8ac399f4a341c40db06b43796631711d7cc11409bf7403c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/hsb/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/hsb/firefox-139.0.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "337667220643980cfb334313d6790e875c9e84908fb917b2874cc62750b5ebc3";
+      sha256 = "99a52d22815c5a0e515c8e7cf2befbfad6751443ca555bd6406f5728f279bd81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/hu/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/hu/firefox-139.0.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "d7f0172ffdce474b465cbec769d5a16d696a4e350c57b2acaa5ca6b5668db613";
+      sha256 = "2f5bc74482f9e36ad6b3464eae73c3f4e0eba74468b115b980ef7ec8f455f53c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/hy-AM/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/hy-AM/firefox-139.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "16a40210e24f645685d6c9b7bb49e15ae2637bf8766980c47134e914b391d6c4";
+      sha256 = "3008150f60e7fea872947bf44548dbed432e594713281008265e8beaa33e4bcf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ia/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ia/firefox-139.0.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "1c86528c3163a1eefcd307802a203f9c978a83e8b3547bd7cf2f32a72299fc18";
+      sha256 = "0bbbdfc47a8cc84117feb5f2b45918eed8234f0bdfd23355f4471fff186266ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/id/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/id/firefox-139.0.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "4e6c513d761aa715010ecbef732f0357d62493236e5428df1df25253eaa8f17c";
+      sha256 = "5bdeb876bbf9969a9d8b388ae4a4d5dbfbfe6b960fa2ad0e0c3533e09dd23c38";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/is/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/is/firefox-139.0.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "061744d3ef7a2399c4d2c34685b995794a926d1ad6fc747619adb510b8a394b3";
+      sha256 = "2f9943fc19e7199fb4e4bed94322b16473bdb7abde7c81c2f9f30ec6b4b2f37c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/it/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/it/firefox-139.0.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "197423e145866987678da3d064f2341cf4c21c6bced709494f17f57a95d7b478";
+      sha256 = "d7d54deaa139ed6521787845c6087c6cc1eeccebaf3c1c35c5ecd93834d3b90c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ja/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ja/firefox-139.0.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "e4187d067fb167ad407bf5f88d9a0d78ff1b7cc13138d803dc240c2c1fd5b40c";
+      sha256 = "254361288515d5c6a1d673080690c00db95f9710d0146aa8949d0c45c8aa83b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ka/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ka/firefox-139.0.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "0b33daa993219264fc7b188a68f7e5db5ae29c0bd03e994e6f4bc76058fc7ee9";
+      sha256 = "430d36f331c9010e83c9a8df99d05a26b2f85c4f820a658162b2cadc06397d57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/kab/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/kab/firefox-139.0.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "1525dfc137131c1bd273fbd7feb618b81f35860659f16209e772b7ba0673a432";
+      sha256 = "6a6105863267194aac3e37752eb2e6b8b90178280145a260fc6076cc565da9ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/kk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/kk/firefox-139.0.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "964d2528f57cf645cdc42717f6d7927348fcdc64b41a97c76ed40ff938ce6b3a";
+      sha256 = "1f1c7bbbe0b7b6b5da607902e2da948a8ccdbcda7f7686163e6507fe4c388a9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/km/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/km/firefox-139.0.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "c88e49fa1e7b80dcea31e97c941db043489bf78d99bda288103178b9ef67f9f8";
+      sha256 = "89792a9db5502a70868cd75f570f08f029f159a62c3581d592a0312cb86befd2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/kn/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/kn/firefox-139.0.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "515b23f015bf9515071096dabe6460bbd574cb1cd236a38685b033ce9f17b591";
+      sha256 = "89faec53c260ff3e1fbb88b828a8b4c12bc1fa7a411a62ceef0d20b99c941679";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ko/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ko/firefox-139.0.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "1e14f897d809c541e66b2ed6d7d99ec40c6fc5b205129dbbba020f0ddfc20238";
+      sha256 = "d5f2c00cc56f7fd106d15b8cab4462164458359ad85eb0e2e049670b357238d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/lij/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/lij/firefox-139.0.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "2e512ed16b6f6417d0ce1526b227dd1db65574e7fbf77d44207e5f119d58cd9f";
+      sha256 = "7f6f6c74a8db597de876b2ba185007b56bd95bf1102fe736f05108892186f611";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/lt/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/lt/firefox-139.0.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "9ebed7889b0d21bd1a8888346f7e7e8f695cf1d63f1f419ba5365097865b8e08";
+      sha256 = "347fd3cb125c83a116cc27fb06078e2f189f56460bf215932c30adf3b99db278";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/lv/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/lv/firefox-139.0.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "ea6fba7fabbdf5985ea39dbcf13af668a535111f63bcefb637839971ad8679c1";
+      sha256 = "9142c42fc24e621524e689e2065bb56048320c7fb5488c5ba41283276f141df2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/mk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/mk/firefox-139.0.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "a73977acd9b93c91cb822e022d31d7e1e6b82a67534f6e3318b8ec22ae981f88";
+      sha256 = "d9e78f50252aa930d8f0cf4c8c716c44ff5b6bb2a8f57e7fcdb31c3a0e1b3115";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/mr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/mr/firefox-139.0.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "0e9e22920bf6532245d05fc8b59701837c08e194f55de9d9c2ec87df75e5b786";
+      sha256 = "10ab25e76f277fcb286f69aac82b66dd012cc2a5564f5c8fd799f87845241ddb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ms/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ms/firefox-139.0.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "a2998dbfcc31ba1a27e250ef82e338d777847d721fe2736d51c3da42aa8fc1da";
+      sha256 = "b2cf5ce2f683556e9aaa976d8a95641758274df94db8a6aedc7002b6c88535c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/my/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/my/firefox-139.0.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "6aa0cbe3b830a09c42f6e5047cb7532bcff4e7461ef2b4cdf66fc9da712d2a28";
+      sha256 = "f1c54b2641e28d9a44ad1f0df9bca599fd00b9644c8655f6d52552f821fd3a5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/nb-NO/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/nb-NO/firefox-139.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "6983681bec0c0cf843dda0f6854f1024bf78b0ade236e0798ff310461bb6cbff";
+      sha256 = "4ad13b8fc48d6ad5a248cdf2a17543490c4c2c4419bf009aaf6149d18158e0dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ne-NP/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ne-NP/firefox-139.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "887832f25352196eae4b6eb647533b7850df63f2d588186993843f71141bce87";
+      sha256 = "daf48cc5f1aa49ea2981d3ef525734a0ecab6dc9472c48ab4cb37595edf12f22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/nl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/nl/firefox-139.0.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "23cf469fc5cc8760eec4191938d1c9c62ee250e4535b7b9e9af6790e30bf4694";
+      sha256 = "84d6f492526e7d50d820a30e46506a4fba7d974e0ebcf32121d22ace9c31061b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/nn-NO/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/nn-NO/firefox-139.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "fa1a0e46dbdd3b3fe9a55cec7a909616c3bb7fdac7c31989241bde576352c4bd";
+      sha256 = "a8dd9fcd7a095f8f6c4ef34f80d6d4e89c8d79709bf7af1978a20fe62bb00777";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/oc/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/oc/firefox-139.0.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "3267e3c66eb04d82090e59600afe5f7d63965a35a23a1fd821239e7e2f281abb";
+      sha256 = "ced183e9cc067b4fde0c81082a78ceea7ac8bf9d5491b8fe6ede0142fedff8d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/pa-IN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/pa-IN/firefox-139.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "c554ac5c4229d65903451596463bdfa3406c3422cbe451658fb09945b00ab9a1";
+      sha256 = "fbeeabef8d421e03e7f10e60a03f2fff29f8d432c0385c4f49c63f3c0c168191";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/pl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/pl/firefox-139.0.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "ba6ac7e79b2baa3a134d84179604dd95f375a529f79524f35376a249e4aaef18";
+      sha256 = "889d87d15237b582db0bd5117d3eec2adef8e6b06d59b7098e696e8e19ea8e2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/pt-BR/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/pt-BR/firefox-139.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "98fe932eb1fa04eb40e0bfac8d6600368cb095a00c0d5594ae89b31da29c4317";
+      sha256 = "e008a36e1884fcbeec4e6075918bcf351a4d8c20da4287572c5042b7b7b48068";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/pt-PT/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/pt-PT/firefox-139.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "d2b0635cd7d64c38dbcaab489aaf706706d6a3818ce4c5fe12d46867970837fe";
+      sha256 = "08c0ff51e0d72fe591593f6de779f1ce49983835a2901d5eb27bfd1aa6ad766a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/rm/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/rm/firefox-139.0.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "2f17eaf677a89f0641ddd5bd272adfa7d2404a10ce36588e4101cb16f4d1c06a";
+      sha256 = "d60a79ebbbbb8c4102373aada622c666f5fe64e4cfd768495e58615017ae20eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ro/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ro/firefox-139.0.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "5c3fdebd6966a63a2b149061ac9e7a313ad045403a958e16f8d721875983ceb9";
+      sha256 = "c64b48d6186b5ebddcc33e298bb32e0a066c2250c62bec6272e63a247120b0ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ru/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ru/firefox-139.0.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "a90635f3a73f440763594d87e3496c4a3d510fc35c35c71d6984f65558205fe6";
+      sha256 = "67147d216a06fafb6788a3401e14e4faeb7fad65142708ca9e1a66d47ff58108";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/sat/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/sat/firefox-139.0.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "79f3594ef58d26fe396e1d5254b944b8f84a68a1c2ef7bcef76b15658af29071";
+      sha256 = "fef644903c31ac92d0321bf8bc535302dffa9aa6ed53d87c4acb7ad1ab7eb64f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/sc/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/sc/firefox-139.0.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "99d5875677fd16c90b7ed0adf17a6d03cebc0056c0f63fa9a6ed21b2d3b87427";
+      sha256 = "8549b061f88d772f7264f532467b3020cecc9dbdcf42c0523d700aff3cedfc1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/sco/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/sco/firefox-139.0.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "0f1a8173288e5efc5d49f6d7dc09f68a2f8f9afabc74acf523f3f3d57ff32465";
+      sha256 = "7a8a4d91b0a50b94a7d3131a62d5f7182b72322fdabe87b64404384ec6ec231c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/si/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/si/firefox-139.0.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "e985191a49387bda29d8b0afe6a0d395e1151b28a5b6f9ed1ea6c7910452a5e5";
+      sha256 = "be98d369abd1ce4142ca7546fa6e4693cf8f117365312ff7e6b5769c36516c42";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/sk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/sk/firefox-139.0.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "4b5251b43442056746574c3875a2d72c5684255e6fe335f3c28aeca0cdd2a5df";
+      sha256 = "34a578971ae81a3d674aeb879acc264ba5f21476272223b6c71876cdbb684231";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/skr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/skr/firefox-139.0.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "2c1598a8dff78558835f07eeedee009b0d7f023ef475b981fe88d51edddc8acd";
+      sha256 = "51ad118f8c0be27bdbb27fabfd17ba3fc1c0aca91b742cbab93a4277e0f60ad7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/sl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/sl/firefox-139.0.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "a569d658d08994b83e7b4da35d402ce096609aa70d4d863f700b9384ef9fb29b";
+      sha256 = "f228535fbb29ebc43e422ecfdb505c908df65cd7b15a1f86c6c85353c313494a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/son/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/son/firefox-139.0.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "c2861f1086902791d8958b4c93728c23ac562db16fc9a751fadca17ebb8b56b6";
+      sha256 = "05b5574bf2d4311bdd0d8757ed73871709a5b125aa7f2ea67676e60483c30ff3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/sq/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/sq/firefox-139.0.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "83488c68cb5ee1e9705eb91a7bcbaaf9fcf0321f2cd2864110cae421c102113f";
+      sha256 = "89b9d0f8f521f8408bd9f020693b99617f9f86945783c054b23c321640a7f6e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/sr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/sr/firefox-139.0.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "57bc4bebaf51204f586a35af80e29bce76d18e6ecb496ebb6c3f7d5ee6edfb21";
+      sha256 = "c258a0b6e528c9d10d9cf5f7bc88e95be3b1182c71c95b06576d0b4b17286a88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/sv-SE/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/sv-SE/firefox-139.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "ddc79581cb750104d2b3ca950ebc08926ae169aedff9de0097820a8609756386";
+      sha256 = "4a1dd6dfd020c55ec36f1d76a1c71d47a1f8c11cbddcf99acf66f7fdbca8d318";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/szl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/szl/firefox-139.0.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "4d3b281f70e73c97d6333aa0b93efc8b744e63b66d54e3f819b1e0cd44d48edf";
+      sha256 = "bb0f418f80e04e7ed6bd8fa51356667bd095a105b273615e13d957f50ba603b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ta/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ta/firefox-139.0.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "3e3cd2018a8c1dded25dcaa567d4718a8fb2b97306e94328b1287ca0bd823416";
+      sha256 = "bbd26b2659a375ed9810139a618181f1a5658b6a9a44f79c7575e290a75efca9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/te/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/te/firefox-139.0.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "3b7927bccae8823ed3350eea6230a1597c87edd4ef03d2545aa54b790b433500";
+      sha256 = "991665af81bfea372295d0bc053c9569544a0942e5dee1c812b802573af34dea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/tg/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/tg/firefox-139.0.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "6eb55acda161ef168ffe6b8b7ccf338d1393b809451bdc2466108276c8ed6493";
+      sha256 = "d815dd158de68813e7ff3f6f100ac81f0094d91ef437c69bc4ba54fda60a3755";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/th/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/th/firefox-139.0.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "5a0798ea59cdfa393a142ed782e1229147da7332fca84607d2ddc8086cc831cf";
+      sha256 = "7427760fadee60078e2d85047c4863579dece7ccc8a6bae2a52f4b15715e367c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/tl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/tl/firefox-139.0.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "2785030fa1641d6058d8f65012479348bbbffd458bf5266c83deb30f6f1f3553";
+      sha256 = "d0600d497dc6a5f6c798f7467e781468eff3aff74307bfccbddb398a4a75c291";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/tr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/tr/firefox-139.0.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c08252777473eb856df9eb417b01f2442e9d55421f0e2ac7924b48be10178709";
+      sha256 = "83336619a14bd6b0e4aae723c251db8002516b1cc69573d6954d5c9484dac501";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/trs/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/trs/firefox-139.0.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "4f79d48886ec1b6ad87a4e635a9b90d22a076556a35dc9245c08c1df6444c99e";
+      sha256 = "6523751118776e7311a2bf63a64669ba4eb115d216f55ce353d5ff3148fa8b3c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/uk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/uk/firefox-139.0.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "92427d29b07e6712ca3807271b2ed26cdbe99424e6bb09acc5dcd92c229f86bc";
+      sha256 = "936aa7e292b3ce731499ece4245f39e7dc53a9072852f0a9fa2d7fee84bca433";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/ur/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/ur/firefox-139.0.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "339dfe725ef1f4e788d0787149dfc03f8c219edea80c09a9f9ccef12883f23f4";
+      sha256 = "0b63faf81f96a044ad643d4d2339b7fb5667106413967cb85e262a9af12d9a24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/uz/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/uz/firefox-139.0.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "2d8a591224fb5ee93fa4927dba5c76836cca0a25585418de5fb6f9072ae56e9e";
+      sha256 = "912f907d13b186c6ef73f71768136494c86488351207327ea87f36b4b302d5ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/vi/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/vi/firefox-139.0.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "38ff692acb9f0237ff989dc80c7d67c25286fda25070e8fd65e1b217d4400f15";
+      sha256 = "997afe984f40e39114445b94e60dad299a302faaf55c2f05b074c35910445e81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/xh/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/xh/firefox-139.0.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "1c2d47df6876ab96c670562575cc9dbf8ec1ba183c6ea97035be74212786f64c";
+      sha256 = "747890f9780ae3fbaf7573495f89a01aaf341bb9bbc1201dbd972cf64747ecda";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/zh-CN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/zh-CN/firefox-139.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "f3c0e21a9d0e8875bf81bd75371cca8069308b3b89b6209dbe4fad9bebd75e44";
+      sha256 = "d03edc3d98b766fe605ccd70d875f4fe69bfbf50eb0669dd106e3bf48a6a57e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-x86_64/zh-TW/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-x86_64/zh-TW/firefox-139.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "6f4e54f67799f703422c290347aeb769687486586da55e152c2b9130206f57f5";
+      sha256 = "799bb8895b5f4c1910c9e22fbeccb395387060e67e34d99e5e8c0d722e215393";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ach/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ach/firefox-139.0.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "5dd3ba89132f9f8c7ee68e67af48d78c024c287d0a33b8c2f9ba4b55d1ad9f74";
+      sha256 = "27178256d93f9a843891a16592d62cdfbe6687825f08e67cd908bb8c72a1f602";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/af/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/af/firefox-139.0.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "f03189eed2f414ceece4d863002565f86665f359b863cf2a20a0307150ebe2cb";
+      sha256 = "292aa67b9e8e7a4b3716f70c82af78ff81e8301f6ccc130865d1573edf2ce7d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/an/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/an/firefox-139.0.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "fa601b188bbd69d0f449371c00d836d377ba313f017d05695939743037b8d3c2";
+      sha256 = "b07a21ff873eef36722b3d79e77edb5fc112fd63013fe96fa2e55e4a38240055";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ar/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ar/firefox-139.0.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "0024c9a16e7f9b797fc03c3409d7867f67fba30152d1ba2da0cc8d31590169b2";
+      sha256 = "7d4b96f67348ca1f40407e7a8ee98d7ec5d10291c90b6ac969b38b6cb5a92838";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ast/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ast/firefox-139.0.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "9f9f45ec3c8b3d1041fd01366de8a7d7e4c5cfa139ee362ba749d27b10b63ad4";
+      sha256 = "089c7a8133cc2f5fb04091916bbc984f74df22787989cea994cdc5264c410fc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/az/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/az/firefox-139.0.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "db7b0bf68da87abaa98148a0eeef7e1190905385dd42e18c752fce65d50894fb";
+      sha256 = "55ad66bdc51127a2a2c765afce28add1dd40a902ef52dffe04b55a4f8fea37de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/be/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/be/firefox-139.0.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "26e860fc1a8fc14d7711f1b7da85ef8c9514eaa902ba21621b0347def6c5d55b";
+      sha256 = "7d44dfbd5e22762be96ab4c9c6db184678ee353afb3fc0c59e777be49bc1d1ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/bg/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/bg/firefox-139.0.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "624cbda3f271329bf645f1ef43d1aeea9d8fbdb36076965f3b9db5a1b6ff4f5e";
+      sha256 = "832de0a74891240375d4c9aaf2e4f682393cc843b62aae1c7f6a12f06e569fe2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/bn/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/bn/firefox-139.0.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "597ccdce124bec7dca2e6072d34b11a5d920cf5056b13424729e159a8783b495";
+      sha256 = "e2f841caa1cf76bdb4befe94f4295e7a8c949b8b3e541df0bdfba6e18775bf88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/br/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/br/firefox-139.0.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "b13c74d9f699454554c32d67eda818634ffb7b9e83e215b7909f564702721ca8";
+      sha256 = "4f69d55359a55d57ac154b69d596ab6332d1ec59d181ee8b5354b1a1bfdca2b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/bs/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/bs/firefox-139.0.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "acdbf7f530ce672e03a0c04ed7689695d33a28e584822bde566f5a7cc002edbd";
+      sha256 = "83736a88a39d42847e4666f5f820a56ab67965a9e7ab6f98d30384a6f82c8dca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ca-valencia/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ca-valencia/firefox-139.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "0166f2f05e40690709f172ed356908fdb1743065306322c450560300a99d54d2";
+      sha256 = "7d700106989216a0f04cd44c9512788314867d522ae0fd065a92a61f3ebcfe7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ca/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ca/firefox-139.0.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "85278d898c3c9ed00355965b3eba133bb83458e67e8c05fd93cfa4679d63fa5e";
+      sha256 = "e25b39229a1efb7ff778d435725ca2faf8d42911889888690832acb6aacc136c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/cak/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/cak/firefox-139.0.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "5904a61687f1e43bcd3781781c11dee050c0a85158858097ea3aab12f2b3411f";
+      sha256 = "de677e0978e072476cac48ba7bdaa0aca5ac2b16d0df111837cf2a73f4318fe5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/cs/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/cs/firefox-139.0.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "db2592b7c11979796ca264cf5784cfe216fce30543fca3382aab9dfdcfc86b46";
+      sha256 = "42557f13736303be6b71b683d8a7f211901795c9e66c358ec07a3ee84dd26c29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/cy/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/cy/firefox-139.0.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "af3eb1ea06ff7e6c18753c6cf3d70d70aed4764d6ddb0804754fa65fab706337";
+      sha256 = "d425a6348c74b897e0e160c7de25ce54eac130983d245d0fbdb7e238f6784534";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/da/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/da/firefox-139.0.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "797c4aede76d16ea193a664bebb1a39911a84cc2725930f3f5f472105c226af7";
+      sha256 = "b8a1f2d0e93a82ddd862ff14cd0ecf8f3ca0471b02e13c60a3a911464de010ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/de/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/de/firefox-139.0.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "10d20fbf478278b7839e2eb90b42ceb54665a32de7337a62829127c40d4cb3e6";
+      sha256 = "225b2912384163aaf3e9d499a40b17488ef8e217a052657586fc99238887334c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/dsb/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/dsb/firefox-139.0.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "f3251a83c59efe8dca6003a2249c322a3fbd6ad36f1db709fea3ea0b11d47af1";
+      sha256 = "de325a64c55317017ceeccca944d4dde695492960236b1c0d8084efd14e05745";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/el/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/el/firefox-139.0.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "611c1d7d26801f491049fc09cafacb8bcd6552bb5e84ee5a96847e04416e206f";
+      sha256 = "8bb71398aaa2d0c129d405672858f7b1df42ba4fef9a65501858fb95e1dcaef3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/en-CA/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/en-CA/firefox-139.0.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "9248fff165cdddf83473eefcb044c21aea74e8163486de9c7472dc81c5568c38";
+      sha256 = "fa295f3cea1a951e96ef8bf292af2c0f169506e0950a4f4b5a43bb38e2aa35f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/en-GB/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/en-GB/firefox-139.0.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "168c1d5b3221e3de90b5e22b52e072527385898f24f4eca40327975f126e6a7b";
+      sha256 = "86ed94699031d7ad9f124b65c6515c46c70aa00410d5c525cc8c13828c2bda49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/en-US/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/en-US/firefox-139.0.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "ee449eeb513f9e02731d1281a2575c18a803789d925312d08dbe77acfd42db53";
+      sha256 = "113e3b3db499c3b7e294cd71d643fb53009c97a442a4a167275f4e6fc259ecc4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/eo/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/eo/firefox-139.0.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "a47996ea9b5370f46dec43f681fa02175eb9afd0b7c6a1c213de2c8221da394c";
+      sha256 = "a2b781b872d24f714b253c28824382e1c3617ee2c6d6bfe65f3e6953f9abad7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/es-AR/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/es-AR/firefox-139.0.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "8853b6e57a1bf6f1af9df93f18b54a3803c1c281ea62d7ebdd8a9c4752e3875b";
+      sha256 = "41285cf13315ab627829e21e8ac0f72f8673f2b8911cf4ead7c3e4a2304d7902";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/es-CL/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/es-CL/firefox-139.0.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "fcf2534647fc003d28c65f5125efc855a2acfa40ccfd1808a9ea5ca66a06f93f";
+      sha256 = "76b7cfccd87174c6db22876d9796f24fb3f66d5b7b0555fe8929d171c2421cc4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/es-ES/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/es-ES/firefox-139.0.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "afc9828ca74ebbf52f163585462c8f4536cb6c4d526a2264e7b77428699dc8ed";
+      sha256 = "8553a85b9fbb7edee2147c4ffa2d54609340dc6f3fa8bd1ee1c83e84406e5c29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/es-MX/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/es-MX/firefox-139.0.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "e30d7471cbf609d4c59aa3fbc80f93e8c61f3467641c163bd285e4388dfe2d5f";
+      sha256 = "89fdfdc2a809cc5af37a349fce6e855ec946412bf5674c0d2f9e4260bc0e5c69";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/et/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/et/firefox-139.0.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "2b27650300b9bba378caf83c58894f2c149962f1f8a957f7301ba624875533e4";
+      sha256 = "ecc3ba28eb856b1a39bde2a06c2ea2ada7d8ba766496780e23e9d02f316d3d34";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/eu/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/eu/firefox-139.0.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "47ba871013aaff2c05b56d6e75e95d5131cc27885d76d4eb67c1cdbd452d82f6";
+      sha256 = "e8ccc11316569fc104741d15263bb2c462defb1650ff1683156e4aaeeca79f8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/fa/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/fa/firefox-139.0.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "7f1bcdd745ce25852951cabbe3aa1771e9adb054211ebd66376aa1551715ad24";
+      sha256 = "3cc643e62871712605ed28b4bf0165071874c759a98c231cb7b785578ffccbdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ff/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ff/firefox-139.0.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "b4a18327ea9d084cdea3fdeae6ab4e250a618551cecc4f5579146dbb78b1b7b8";
+      sha256 = "475aa8baf8784eee752848aab728cdda23b8989b72758edb7c7e366b9267de44";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/fi/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/fi/firefox-139.0.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "70ad3a0ad598ae03bb82fa0d018fb67a3379c2fe290f8ca6db7c41547b936ee9";
+      sha256 = "fec06cb2c8390e8399557c5aa028919f24568f3aec877529ee2ff4928bb1ded2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/fr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/fr/firefox-139.0.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "6b2b8e24a3d47d9278af8cdf950a6acd8e02f41dc8d2eed6959e9e9c22b43c38";
+      sha256 = "bb296a432f4ad5e5d7919e69077ba1e49fc16672f7c93ad38e652aec0b878b4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/fur/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/fur/firefox-139.0.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "1f71f40a7b7613fce5db1ac90334c892f7942eb318c56366b0a8a9ebcdd573c3";
+      sha256 = "81bbdca701d27e97bac47d6d57546fb20da804bfaaf7412cc28db413707c2b8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/fy-NL/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/fy-NL/firefox-139.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "c6c855030055902068fa6b1494b4bd8051107f9cc551270a763483fd73baf8d3";
+      sha256 = "f4e4adb40ac7ef19e3cba1adbc5849f56f0a8f794b8afbacaf43272a7d339f23";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ga-IE/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ga-IE/firefox-139.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "5a0ee4954443dc0a9c72b141ba7c27ee4691f47203b41f871a26532d66608942";
+      sha256 = "6e3ebf0c79b0da60f23b89ab724fa25026e81ac94d4858b5c0d5b33337827303";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/gd/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/gd/firefox-139.0.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "ca2527427edb8086f8451a3bd82a6b301bf2a96bac331bfffb57b4f51f91f3fd";
+      sha256 = "62322bee24bfdebf51e15fa010049294ec4ad786349752a38dc4ba2825593675";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/gl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/gl/firefox-139.0.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "03a267074834c2b27d344d05cc2dcf00f29efb396ff9512bff0669a6f8bebbdf";
+      sha256 = "56e6e9a1dfe3b1847a2b827ea84770896d8b88156aa7225503428ac9b39a20a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/gn/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/gn/firefox-139.0.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "cfe27a3e05b961904b1597c8d4fc0b0e99b7e33227520e43e8263f9c9cfe0b4a";
+      sha256 = "724211b410224b4d62f8389df1935ad146facc517027dc456ba6f78d629a2480";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/gu-IN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/gu-IN/firefox-139.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "4cae698f4e15e43ce9cffdefaca39599adbba39175f50d65a46966fda45715f5";
+      sha256 = "6bc9a0c4b3c6fe90d12a18b14fa7d91ecf03450af9b1abf6091bdc007b620e72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/he/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/he/firefox-139.0.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "15740234c63502aebbfe37ada70c52d8d14233f9f44235a76ca2d81a28e4bcc4";
+      sha256 = "a0d04c8a83a801213087f1ec04c72664e5604a10dffcaf0c221ae58bc4619836";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/hi-IN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/hi-IN/firefox-139.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "16ca487354ae6c278e2ea46809be206da5bf406374b2778423b901466321d7a9";
+      sha256 = "e6951e1e637b23def9b64e144d65cabbc31182537efc4482a04fa0a08c216366";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/hr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/hr/firefox-139.0.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "f010c61e690aa48be7b5e1b8d2ca9f10cfa38d450738dad408901b22c9caaeaf";
+      sha256 = "9d213fc5feddff990c24cff8e65355f50cc434bdda8faac8d63647ee40c52216";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/hsb/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/hsb/firefox-139.0.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "880ef92add1adb0d1638d5bd7db94d1a3d2e753d9575fd5dc904b5efd1b6b646";
+      sha256 = "c4c10ed836ea227193bd781b92a9210f9e3820962b939998036ad736ae7d46a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/hu/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/hu/firefox-139.0.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "a8495cf15efd6cec8655df3ac160c9b4991ab58c13c832c350829835cb4350e7";
+      sha256 = "7cf59a45bfa65a6435119be5fc2c66d666e8a8cc43218eb7157c84969195484f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/hy-AM/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/hy-AM/firefox-139.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "89fc7f96ae391fcda0322c752c9f6d279cbf6f274c06c65ab1168d472ca7f8bc";
+      sha256 = "c0b389096254d07a2d17ce561677f7cf493cc72ca27a01e4305e3952e0ffc5b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ia/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ia/firefox-139.0.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "b22e860dda57ec4c2874ff4962a5c43912cc59dcb12f9c577d20cca4a35b0700";
+      sha256 = "0f9c6529ebe65476a334430bf197127357eb2fdc9cffe0f3de02e43e06bcfb2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/id/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/id/firefox-139.0.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "a1fa0cc30aef3f5aa2d59f4ff472985c1de6d86f394d94517bab39387d7362cd";
+      sha256 = "e0b0b6d7b2f741b362d53850cefec40d6e17fe1dc2d2d8c2752203c286151374";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/is/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/is/firefox-139.0.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "580cdc317a53fdeaa83127a4bf5ce47224ab6757b985254001ac36e2bb0b5db8";
+      sha256 = "531924faa51c6a66a3f86c66770ce501df0b3206c8b3c6d7bfc147ba30811460";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/it/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/it/firefox-139.0.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "8431a4a808e7cb7e8f44d3f39f75c39de327d1a51e5297dd1f62ee0a4aa1d263";
+      sha256 = "b96e5a42f0ca99bd356ec751a859ded06e3d818aa6b8157c081040d538ca099f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ja/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ja/firefox-139.0.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "f6ded939f6ca9ecdf75e7b756b7bca5302cb3c9b9e311c716aecfa665969d6c2";
+      sha256 = "d5aada2aefae34d8cad587c851a7173958da3a67d183f0d2f110954e3a729222";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ka/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ka/firefox-139.0.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "ba010ae9f3d60d3493d57b2cd149511ecbdef37c6b4e777e061f68ce53926573";
+      sha256 = "23115ba4339cdcf3e452771e56f2a593f3f516b76b7b902d902cb4336addecc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/kab/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/kab/firefox-139.0.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "e63d49d6c4323404e936c1e4db07f1b1e9178c7e2fe6fdf3feea0e27b16ba7a7";
+      sha256 = "a12121b1c8a4e1fcab2e3d2cb52bbdcf078adf68383686559869ba1ff7c7632c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/kk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/kk/firefox-139.0.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "ca2c604cd04d1cded67e68573c8258757e347cadadc7a471f20224ba72125a80";
+      sha256 = "3d26df70272ac8d5c7e7ecafb00569c1feb4531e10796da8a0a562b84dc1617b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/km/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/km/firefox-139.0.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "34cc683a8ff5d05c48eeeaf976a02088c90c30c282be284ed5d605a987bac2c7";
+      sha256 = "d8ff5e4643bedd415736bf2ffcc0d7950d5d0d915b229a8a3fb029ebee8aec94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/kn/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/kn/firefox-139.0.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "2e02074d9e35d3b7fb98c98780dd76be88eac05577753051862c051d8bca83e2";
+      sha256 = "31b2623a9a065dcb474c32132ec5404b65b6af87cb9e07b33d4cfc043a20360d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ko/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ko/firefox-139.0.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "ae8fc03e0d4f0933f9916060e057e9ddd1078d84913a184c1dc29b147bc11807";
+      sha256 = "1fc7ab78f3b137fc5fdb11223f731621a5bf2d8c17381e4a3e015a62ab57a263";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/lij/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/lij/firefox-139.0.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "dd43f573183b283e73833952de1467575a6363f9b051729e2f47379ea2ce5b37";
+      sha256 = "f6cc02dbbbdae414b69d4c68fc4b44b3591c4a6892577a05e5d026331a151fc1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/lt/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/lt/firefox-139.0.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "67490ea27fd204de0531c4a3cd7104fffbcdb5112e6c3f81e0f18ed22b8b5b40";
+      sha256 = "ce102ae92d0a05cf34caae04509625d9bcfaa0b679875574d4e3dd925a9290a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/lv/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/lv/firefox-139.0.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "ffa8d823643f2bb33c207c9ae73eb893dd538f8df6e86ba73c6af04f8f66b44c";
+      sha256 = "a6fef21f556ec9004c2016b9dc6a52130a60e1409b9929e723ffc5353ba8cade";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/mk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/mk/firefox-139.0.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "f98f20c83a1f5e4cfd27b13dc440305982f1da069b71c2002763727f2186d3f6";
+      sha256 = "c27aad6eea5ec583ba7482f0d089e8c71998d0887abf170d4bd72fe2c68ecc59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/mr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/mr/firefox-139.0.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "73d55f3dfeb925a639a6425290ed5a5684c2796e8903d5c001ac45322b6e795f";
+      sha256 = "a5bb4364b1a9fd99d429d77d704f66ac99752512512a4a25730a912b319441b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ms/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ms/firefox-139.0.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "786383fe8e227318213e18a41d665e601d52994d7bdcb73b3d61381b1d757508";
+      sha256 = "3e184d856adbdacbee368cca373ded81c2f6a86be05bcd8a95028f76e7c0bc4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/my/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/my/firefox-139.0.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "1abf6c05f1683b71bc4578a575ec066a244ac52071e1eee9e0cc1396f0e07581";
+      sha256 = "0b64672a5134976b1996fe2f5f3990463da8b80389916c99810f0624d4bf2db3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/nb-NO/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/nb-NO/firefox-139.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "92c23443656cf3e87d7acea3f81da7282a41e27d647b11c3cec23d2c1a370372";
+      sha256 = "16ae245c094af6b4a2edd7306cafd4145a989316160094f983dacec0afec7463";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ne-NP/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ne-NP/firefox-139.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "c539a8690ecef7dab5fcff0166722c4b88e7aff2bfae94c6a4ce34cb54a55a78";
+      sha256 = "c9ee9e2c787ee38843f87506a0db9a6c941d694d1db693f7affd0e391a5c0ace";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/nl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/nl/firefox-139.0.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "839d1f1b17553309725efaa4810cdc5ac7890c0fb9d7d8bbb113633753529599";
+      sha256 = "e3c2b9ddbad64352fac37c584990619e23e49bfb7911d47fbacccccd2aab3643";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/nn-NO/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/nn-NO/firefox-139.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "4a556f61f1a6f9e5e7c69a5ba6d09315ea2c8874d7456b1ef9b52c4673755e58";
+      sha256 = "b19c3d0599427a8f0b82560bdf6ea5ab1aaa88f7331cf58f607d8c96a2f378ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/oc/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/oc/firefox-139.0.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "97f6e2ed1e9062a5128cc418e14204d7d72decb6b2d5e855b24d6179a235338d";
+      sha256 = "ac3f1415611ad35cf95ca84c10c8ad790bf593aff0ee31c15e54b27e2f9f6197";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/pa-IN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/pa-IN/firefox-139.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "f4e21991f94a6796ed072e1b77bdfa0479dccc6c54ffd3982c2d83284e9bdb01";
+      sha256 = "9a8481a54a1e227ed1c98da6e01215ca9e4607e48279de38a5f717e9e1604fb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/pl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/pl/firefox-139.0.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "41e7d80bfbf56d968e4384a733736f4d1d640861efab71704b5a58803a153bcf";
+      sha256 = "b8375428099c2a00e236f71ac46b23f7bd3c2883c4f6f1299f696137eff6daed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/pt-BR/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/pt-BR/firefox-139.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2c553fa94b85f507201ca1464ebb2f9093244b73c982416b3166a878d7e7f6c1";
+      sha256 = "67f00dd3801f44d18855ffcdde89c5aee259cb4281e0e58d72b6c4d5091d4ea5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/pt-PT/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/pt-PT/firefox-139.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "ddffcb37d0d6c2edb894011a77e1f84fadc07c3ab7e3ed4a5a869884ff67c3d2";
+      sha256 = "a6b4375a075470ff48f9cceccc06f4feb3e914e713650701054b7c1e6059f932";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/rm/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/rm/firefox-139.0.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "02cf7a8d47ff3d4b60198e4827bfbc93d35c7271a11bbc48d1f7384aadce51a3";
+      sha256 = "5cc3e5232ea108a3e9903ef9c7ee90a2806b9f606f91f0c72daa8f10b7dab1dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ro/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ro/firefox-139.0.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "4381396f00da6c4f4455d10d83809721320e1562c7642305ed31aaa876eb5a47";
+      sha256 = "56d5da85761ac9ac499eab7e83e82110ed87be91594f3fe90f9fdda503676f60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ru/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ru/firefox-139.0.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "3e4b3fd1bccc7700626e02c3d1837848dbf1ebfa27a40f4c0ae6c67078911958";
+      sha256 = "d99a486e9e7200e7bef2f094be048f93effead02730e76d7cf0760681a2f5c22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/sat/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/sat/firefox-139.0.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "8761d5cec27747ea0ed8c99c21702a847dd4eb86d88c6a9faad3b5e3942543e2";
+      sha256 = "2e7d57610c746755bd690b70c8e85dbc093bc9a6a08076007a3e7ce0964d5ad0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/sc/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/sc/firefox-139.0.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "75f5f760be1a943b6e6d9bc9ff63148d4e364b6bd50c7ed7202d825536873d4b";
+      sha256 = "57f723b2611f4bb5f3fa2807e81df14513248e9ec4fd30e1a6439f54d8808ab8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/sco/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/sco/firefox-139.0.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "ad880343a9847d6e2f5ed7ed575812b075ee7e6979533bd386db0b680721c565";
+      sha256 = "d12d924dfe72c8a4f12bdde6810e4b50142824af490f23afe4bf300bed244321";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/si/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/si/firefox-139.0.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "212b68913e2311ec1012c27b28716cf51bae2f677883a1a9ce8b1c4fd0eb181c";
+      sha256 = "192520a046131e65f2cd93de2779c318162ac645dddce8b8651f601b2ac3e3c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/sk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/sk/firefox-139.0.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "3013f3fb358103a8dc434064af8042b9c1e2aa0055f63d2047953b21828c13b8";
+      sha256 = "d14bd657e88404749834c65fc836dcc5248c67607e5a54cee658d4c6263f529a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/skr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/skr/firefox-139.0.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "168a2a2bbb60b4d45af2422f077725941ca4faee077a4f1887ae955450d9c411";
+      sha256 = "b67bb1138e44092fb11836d7ea18125ac24e1034f0e5d5c8309487a7d1123ebf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/sl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/sl/firefox-139.0.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "fa40a7ada98c400fce7b7b1912a891bc62e7dd5612d9b5832d4497be0b7f30a0";
+      sha256 = "713c48bcd3e1f9af0b4b21e751aee573b96e4b0ca15874d8e0e778abf1ac3214";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/son/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/son/firefox-139.0.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "4bb9b1d05796294bc5723e9f16b8f310803211de0ed5a3d20ee4611cdaaa2cce";
+      sha256 = "cfedb2a50fd92618705b6f6a23df69c8b77ff3eb416c9767c276f4ad1f94acd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/sq/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/sq/firefox-139.0.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "4ae8d8cb80a8ee95112c493d2a155c0fc58c43edd3317cf8cf2524c07ec4a521";
+      sha256 = "10133319526d11d010b101db0fbdfd58b16088bb455e8dc06e10df81a8aa2d6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/sr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/sr/firefox-139.0.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "7a47f4872301fe2e2e63f66dbd65c347862bc6bcbbd8b073a0951dee4a744a15";
+      sha256 = "47520c7247656ba6e64e3c41e16eae8e55fbd9e834b903563b0cfbe292e0e5df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/sv-SE/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/sv-SE/firefox-139.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "9952e86cd726904ab1e934ca8bddb639619c7941f03a731453906a995bb1ce1a";
+      sha256 = "d65523a0f795e72101bbdf23e11274f0780507f5d22b5f2070532026ba1c5609";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/szl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/szl/firefox-139.0.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "5f09d2b854c2aed96cdcd0ba22ecaf7c11df84030daba04a92242640b92b14a7";
+      sha256 = "442f68feb02d60bf51a2efe8ce87789247c1c04faca007a9304c17b8441cda37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ta/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ta/firefox-139.0.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "326bffa86932b908054324020814d2a79451cf8051711d6f6160eca4757c4459";
+      sha256 = "b1f5110a5c237c7100d85df0d8709c4034020e7d23e46ee22a60984dde13f2c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/te/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/te/firefox-139.0.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "ecbbdc8b49018802e4a4248b867e6ffee723432d693933db17f62221b75c8a35";
+      sha256 = "80eada0ebcb9a58b50867ccf8f884ff29b277c75d61fccf4990f80f666eda4ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/tg/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/tg/firefox-139.0.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "5d93f9edd8668f1580b526e432806ec51581438f2001fc5778b6daf532ba23ab";
+      sha256 = "5fe16ab368d7f6e9461cced09f46e7574ae08a3ac0137f495e86212b155cd4e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/th/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/th/firefox-139.0.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "3237d2946036174cde63d4344577dabfe36768f1f005d4758607ca8ab6654a0c";
+      sha256 = "e0e17dca00d65a8aa8630d28f0c23eecd7ca89d80f6a9fc6e694ac4237dcd56d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/tl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/tl/firefox-139.0.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "ef810bb5828e21bba6822c0d563c70c62c36a167b71ebfd450c92ed673987610";
+      sha256 = "75b787fa04ef07c7d16e8e054d6ef659ef93a3d63eaaf1087d1e5996160b89f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/tr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/tr/firefox-139.0.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "ac26b876e63990c71d1e1a96819b5733579d407c4deb50ac0efc502a531b36e2";
+      sha256 = "6262f78224e1e0dd5080d9ecd057ba3a8201b6c31d073d8e4a50b6efa16ed0b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/trs/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/trs/firefox-139.0.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "42043be9e61e24817e9bcbc727939310d7db06735db976fd277b3669977c8a5f";
+      sha256 = "de7260267515a566cace0f344a8c994e697eb60269f16c32e927a245dd745a79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/uk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/uk/firefox-139.0.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "6c75f5613d266e7ac2ffd832db99749d84c20df3001adfcf0f825b14ee7df9c1";
+      sha256 = "3fa85a3f5d1da2d6d0fe496bc35d33b4ccd981418b9e2bc9558b725dc0d14dcf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/ur/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/ur/firefox-139.0.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "0c6e8025ea003bfab16850fcc7efa398822bf368d3bba54e442a0d815a1dfff0";
+      sha256 = "e22fabed99afacad618508e9c17dc718038889e724a5575070aaa9b03e52a97e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/uz/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/uz/firefox-139.0.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "34e66785d199e1a94a0c8a4c4f1339dfc55bcb0be05c56091cdae8dbd56beb7f";
+      sha256 = "af3a985129a202de96e235b201c77de50bbce0fe4672d76af47565a7421b7f24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/vi/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/vi/firefox-139.0.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "721a88a3dafc272e2a730e4e9b811af7de54e088e724c1b5c7ef0f3e6cb257fd";
+      sha256 = "bd1d57ccf01ac1c4f12b32f5fd33e41d9846e351d5434fa8c74a0cc99ad04590";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/xh/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/xh/firefox-139.0.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "3ddca5e0f0128433daefd3572dcf776e723e7bb2c81d97191ad6c33a5e9f6b9e";
+      sha256 = "3e0bba27873729db135e4ecc4ae5f46ed0378048dded183ecb7ac35a4f1da01a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/zh-CN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/zh-CN/firefox-139.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "c21f102a63d80af9f6fee9b3a182dbc55b156a1438e2981ef81f076f1237adb9";
+      sha256 = "f39684e2dee41a74d71a887202a8b003a466d5e0d3d1736fe6531d9839c60a59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-i686/zh-TW/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-i686/zh-TW/firefox-139.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "a58dc610118c03fdb0d1ecc372f3cf8be538cb225c0268ee33454e42f1f9c570";
+      sha256 = "dfb7043ec41f195c29509145acb2708ba55a42855f33b83a2df2cf4aa43dbd3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ach/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ach/firefox-139.0.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "e7800054ce0aab6fe0963cb1487ebe4fbf68e22c87e2cce5ffd92797156d81f2";
+      sha256 = "822e473d8c7013996f80e076f60b4eeeba36fb3af214c44123eb5e349f58c9cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/af/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/af/firefox-139.0.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "bca03a4e4ae4631b474137319bf42b8182512efa6adad891de449cb7170f6c24";
+      sha256 = "3d096467313bbcdd6b2cccd46812efcc4ad8de79707a91f71cc373940f8bceb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/an/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/an/firefox-139.0.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "7d70b461f98c404207ff1e9a70761975202ff5e4898f40793e0db5b33b91eb54";
+      sha256 = "7f970b417fc10c1921740dc5a1cbe3bbc83fd8747ee1512f8904519aaf659502";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ar/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ar/firefox-139.0.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "3496b952dcf8957b11da512d2c030fd5e64bc3dd8ce106cc4dfa65f4f06bc1f9";
+      sha256 = "5b92e9bbb90eaf9d8081b2b961e1173003325d48387dd7303d9f80eae9f829b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ast/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ast/firefox-139.0.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "a966ed39a1bc79b8a2b8078dd9619c7b152319844f0882e493a1e9a209bb28b2";
+      sha256 = "cea619430d325eeaddfdfd8cd02b6c479cabaf6a728490bdc98326981de3c9d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/az/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/az/firefox-139.0.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "024007bc7479294f0b8f971502f1845f72b38cb310c37946b3e2da9d95abea59";
+      sha256 = "bd177cf2d1b12c846e031fcf9a1c14564104d6b1e9e1eb05b8f4e3258b99fd2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/be/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/be/firefox-139.0.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "073c76a06185f3d3e9a6138132b03997b9b7acf6a00c7e3134a1fb72b3e89a52";
+      sha256 = "24932777ae00c24c90381273aa30ff02161f0c70940a589ca843f22e07b73f8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/bg/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/bg/firefox-139.0.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "061e7f3a2fade4016fd0dd5ab5af4c4620be75be22c935dd4669240a9091d510";
+      sha256 = "5070881f77a2fb1389bca50e32a8153e4b6e2c221c6616a40214bd527d442086";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/bn/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/bn/firefox-139.0.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "0de9ff6278f19ec15d438659eb35473a7dab7500fc7e5f0f183ffeac9e1dc21c";
+      sha256 = "b04742c34f6aae04a8a7c5859cb98371d4e4ba7f865e4e6ac3e449770334e07f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/br/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/br/firefox-139.0.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "07fc489b1ef7cc85d863a3d6ee844b363d17a618abd86fa6d7631d5afc351185";
+      sha256 = "6a3408e83ce48384324796f3441b75567d086d2ea247138ccd39c66e9da2b559";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/bs/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/bs/firefox-139.0.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "bc4fe22d0fe0630fe666fc4acad616e1345be17f57044259f4f7e5430ac45943";
+      sha256 = "ede68ddf5fdd741b934339b52979bddd3762454bb694e2d5fa128cb1bddbd528";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ca-valencia/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ca-valencia/firefox-139.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "88901e2aa2ce2fb17f25519c59c70968e8a0f1c5fe8fd76a9d82b0d21c8a7ae3";
+      sha256 = "a08143476c1ae3aaeb4ca4b8469ab02443b651125b01e96040168d17847cdc0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ca/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ca/firefox-139.0.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "32ebc6c10aacd9978c4d6bb1cb885367c460cae7b78a7b6d47abbb002486f7da";
+      sha256 = "cf4f8b2373dec3b1fadfd39fd08e65a1ed980105dcb0852ae1285d9b35fdb6af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/cak/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/cak/firefox-139.0.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "2299aa3d0a432f624293009a0bd246ab366ee054ce7feb4c13c5d0db136f4def";
+      sha256 = "d094caf15f1fa4d9aba7b908087265baaffc097b3c8abe66685384eebcd9a5b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/cs/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/cs/firefox-139.0.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "b6fafa10d291597a0cb438db3acad82c6ce6c08e5f509f1e4219a8bfba465d08";
+      sha256 = "ddcd0f00f20de7f78810429b4728174cdb553851dc0767c4f18270000e43779e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/cy/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/cy/firefox-139.0.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "7fca55c9fdfb3f4e0009abf66bf94dc3463cf8ddf610c630acfd8b42537e6762";
+      sha256 = "b2b498076c22ae7c396041a81c430be9a8ebf8ca2760bd09870cb57538d2aa35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/da/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/da/firefox-139.0.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "c715bec710edd77a9b920b4dc1e258afceee2791686fd33e0084ed98c731e819";
+      sha256 = "dcc469748f91a5b0adc439d95059c8965dd7529aa3ade2624c8b2f42dc14cd3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/de/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/de/firefox-139.0.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "de92ec72d7d0a3740c6f8fbfac506b4b4ef07852282148e216da8cdd8c25f42f";
+      sha256 = "ffa75afe9cf0f5912228c6d6b02c435138dbc8fdb7babda5ab550ddd82304a74";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/dsb/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/dsb/firefox-139.0.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "7918fffd4fd176caa159351a4b69e525cb814beeaed470cbedd342c49f27a234";
+      sha256 = "622586f39047ae0d9c3bac212dc06980b974ff8cdf0ce983a57b4d9c27bc2ce0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/el/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/el/firefox-139.0.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "bf16dd99da6347af35c37a1867ab519f81a4559a594fc5758b850d769dd4ba68";
+      sha256 = "6be3465585d4dabed75b9fab9e230aa1125bf0eefe7a3700c10285eb16e01298";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/en-CA/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/en-CA/firefox-139.0.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "45f8b0c7260cefde9fe3a872fa847c702e2962afba71264b4aed24205dfb7ac3";
+      sha256 = "8e0e8afa17d922730424014303e44bbdef3632338a942aaf2cc88cebcb089de6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/en-GB/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/en-GB/firefox-139.0.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "8da28e689b5a955804226fa65214a81d6e293df6fbedc24cc76f368d88cad106";
+      sha256 = "2ee31d1eec8c76a5de8ad880f4d8c5cd4ec918331cd2a8aa7e76c864de248617";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/en-US/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/en-US/firefox-139.0.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "6e078b2b61965b8b5525ae0da3216f7fc6a0460d4e0870e09addcb5a93a60a90";
+      sha256 = "bd9b0a7a0f0faa47cb053f7df0c2c38766d7e481d697f6cfa60c01425eb81786";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/eo/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/eo/firefox-139.0.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "412040a9acdf879d6ba2d3fe158729e0b4ddf1309467ace033de526d06dc5259";
+      sha256 = "9eb95eb1a5a7a4e0ef3fdca261fd622643b64066e8122278a4579431b9ee8a09";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/es-AR/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/es-AR/firefox-139.0.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "e1eb49ce025cd47742561930fbf83408a1afb1a163fc2f7af66a52c10715580a";
+      sha256 = "19ba5aa9e8403ca998f58038cbf4bde5dcdacf209624747c138f14c91f0e9494";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/es-CL/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/es-CL/firefox-139.0.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "413e7b2aff3a1aa43bfda19cde71b54251ce45269f73f01ce8b04311d7ca94f9";
+      sha256 = "ebdb1743b4f51d45e00831635b88f923c682a028136b249b51742b815c5f01f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/es-ES/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/es-ES/firefox-139.0.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "8935573908089eaea694d5287cab5540f580146ca135cf38b6ca61a8981da0f2";
+      sha256 = "fdc85dc2241b79cd49a40cb35e8d98b14ca1e44c5209af9a12242037fc4fc1f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/es-MX/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/es-MX/firefox-139.0.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "bbe96b11b84988efa968ec436a95057d6ce66b14b120a2d7e6ad7b91a841c5c1";
+      sha256 = "62bdcf567ab4b0d803bbecc31b820f26af4df099e661d9692f92465eacb7835e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/et/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/et/firefox-139.0.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "82f655438383306a152fdde0c11c479983d4f9a14f34c84b1ea9520e9054e14c";
+      sha256 = "e23db44ad0445015a506646a1647d6906e4563797465b1ab8292126b0b5dce54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/eu/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/eu/firefox-139.0.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "be0ed3f8e057e61e073d2be63dfb28b9fb2d0472233d0f464c28979c3a3a2084";
+      sha256 = "fcb03ba40a41f1693c069258fc9ca5f5f87d50e83c3cd06a6848cdb996901d84";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/fa/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/fa/firefox-139.0.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "ba19e14955b72223f4180e2af4df52388ed5bbc4eb231ced0fe973cdbac86005";
+      sha256 = "4544e53bb7a3c81c645cb84772b4c1afe9b579d9cf271fdd6d410c6c8b2d3786";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ff/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ff/firefox-139.0.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "ae59688241a44042d7dc99333d988ead81416dabbca130d6ce842afe7464e341";
+      sha256 = "700d7a2f91b330cbf4cf8a84e98880117c8a0515de1bd96648477f6ce31b9065";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/fi/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/fi/firefox-139.0.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "81aa6a6ed063d4a4e90355e884b15be92a1ce2a75dd6561b4036efc796ee3cae";
+      sha256 = "8940f12b55124ec64f308baa748443926317824f410fb2045911d059918327cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/fr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/fr/firefox-139.0.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "34d2cb4fb7a49c693c185e59627b3e73cd26be854145bc251aca397b515da954";
+      sha256 = "d6ff6fc283d602f914389b366b34a33810b4351ce2dfca0aeef950f9fcd7cb04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/fur/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/fur/firefox-139.0.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "ea1f8c4885b634821bb6d34c5804149170414c8802a664b7398df46ade9a9bf0";
+      sha256 = "a7ad52a74a917dcb489be7e63562d2fb1d44b9337c0a488bfc5eb76073caa179";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/fy-NL/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/fy-NL/firefox-139.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "3bb5474d6e0308ac0851e0258cf973646e7df83d1b399817f05850ddebc49eab";
+      sha256 = "f3ff60d260bc282497f12d49fd243547acdbd6c98091639cf2d2b57e6dd56fa5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ga-IE/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ga-IE/firefox-139.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "48565934c5f274d91c3c7d01188dee0c4b7db04bb5c5aaa7b19d6098f8017511";
+      sha256 = "e6941b734db7406e553ffbc26ebb521fab1a0723b6b95670e2ffb3f338f4ca6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/gd/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/gd/firefox-139.0.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "9027a7addc56ef8937a1a79cc3b1d76ae8c349ec5fccb6423244b727bda1926f";
+      sha256 = "587ffc8788f663836bf03003ff16741465cba59d3fffb5a01d446c1e9c735557";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/gl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/gl/firefox-139.0.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "374162c5b2daef4eac897ef541c4a35029388927c9a1c08556896271a455e52d";
+      sha256 = "0e69c74a5b53c9deb73455422eebbcb35cad47f5fa379182d6ba42a19629b0e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/gn/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/gn/firefox-139.0.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "ed2a6c221d9bfed5eb99ac61b0eac02fadb69ee8c66a429b60f4dce6f9b33b33";
+      sha256 = "fbb747f462e11d77bde427af564901e4667d0a7b9b355f2b717092fc1bdbf2f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/gu-IN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/gu-IN/firefox-139.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "02513fefcc276ea98a598a2c788f0cf501fc9a4878bcf8f3f71801c3975c0863";
+      sha256 = "adc5aa4a467151a8b0b7607cdd4f6703117f41a42ea129b4989e85b105256ea5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/he/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/he/firefox-139.0.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "82862c9d5f420a34ccbe74fe5904348b205327e924865a6b6b59ebbbedf41a90";
+      sha256 = "923cea94b7deab925455bd0a560d7488dd061eae0fc536d9a97f6fad6cfc0a37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/hi-IN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/hi-IN/firefox-139.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "59b1bde64273879724fa980fcb235649a0cbfc491984200bb6bc585811d70132";
+      sha256 = "84ab46281b99b948c9f08bc6b9ab847d08861b2319e34d10ff457956744adfee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/hr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/hr/firefox-139.0.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "80f4101e96ba9677a0018e1d153a95608a2b508cdd3cb2f044dfa86252d9be06";
+      sha256 = "efe5970fb389cbbd269d04f5e640b736bd4fc3f6c74339dc37fd53cac216809d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/hsb/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/hsb/firefox-139.0.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "b766e3e1a435359af2ecbd5e5afb6daef94e624210b68c4a34320687e1c63897";
+      sha256 = "cc1faaeb5f0d604b093959677c3c8747f633a9072d64463013797133a2fbc985";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/hu/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/hu/firefox-139.0.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "9f974d5a025881cfa74b19ed97a2bf4507925450eeb99f3dd1061288fd86d492";
+      sha256 = "e57a0925ceedbabaefbef1c86e3dde24df6eef672bfb273c6dab01de8341eed7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/hy-AM/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/hy-AM/firefox-139.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "1e6a40a2ab8ab7cde9ebb31a9b4552b1f4c38e3b3dc1d97d591565b5d2816969";
+      sha256 = "d33ebf0262496bba4e79b11a31675a3d07de350e358a80b794162d894e5d5827";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ia/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ia/firefox-139.0.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "6816fcf9105516ba115f70882152bdae6ac0c3083d84551d4973e28cc38538f4";
+      sha256 = "7af0f1dfde0b2eb9459d3ac9f1cf451c64839e8a0833c713500bcb4f316ce0d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/id/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/id/firefox-139.0.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "507d3be3b06ce9d22d62d565983fc53475883ae4b0ed6ed1fa3c4b2afaa8b9ec";
+      sha256 = "2b8d4814c2b863aace687e444afb57e9918f979304248e2abc28b1824b3d38fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/is/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/is/firefox-139.0.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "c1f58fef708ad94faba30dabc8a3f14ea9d60af7927a2e029c15bb1027b453a4";
+      sha256 = "bf8fb09c630eff43c77f403e6a60d9ede22aee8ac8c85a2ade7a56a34b7be4c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/it/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/it/firefox-139.0.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "b80c16b2e23dc208b4465b244b046f885ddcf8a2876d47232c256401c27d8805";
+      sha256 = "7978f4855fe1fda982c098e7de0b14f5f75dbb1c109b6b14358e4aeb4b8800e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ja/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ja/firefox-139.0.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "646444dd4c28c81cbe19796e2f13724a41cc57ee3af1ff65f26defac94f9fe40";
+      sha256 = "1840d1cd38e2864b690ac8a358c7b9dd32d4bf5c0b74d2c8d22c25122b60cd46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ka/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ka/firefox-139.0.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "5cbc44241330de896255614e7bdc2fc49287f5580611b5640d7763caa111889d";
+      sha256 = "dbdd0ce33b6462597e5e5e2e6ec89a058c6f5efdf6e33179d4a03fc65b432c8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/kab/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/kab/firefox-139.0.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "75d33229198c12a7aa7c390f74ef534a62c8eacf8b176cf6bbfb213b9fd253c7";
+      sha256 = "bac6a5dd0a8e259a2756958449df5ee17d07ed7ad4f89e5a279ba071e690554e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/kk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/kk/firefox-139.0.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "a623bb9c429f531e9d00f74cb5f8936522104b43c3d31c4a6b9c1d8c60070105";
+      sha256 = "29ad437d21914ef87d0d6394cfc212f7cd889ba38c08e3578fa3aa6f6a41ace9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/km/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/km/firefox-139.0.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "10f4d8b97803f6d9d32d44873decbd9e994ea3ead6ff3a66a80af47e0a595f92";
+      sha256 = "cc50cf76840e07dccd618d7f9b67a46ab9295d55e20d9c1f2d673fe6c80131e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/kn/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/kn/firefox-139.0.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "54dfee8ce36b2bb5841750730369f9bf15b4e784cb080c232f9d3461ecd5d42a";
+      sha256 = "c13cf7ce0b1359c0fdd13885f3bf41a9fdde01f8a565aa6e477d094f5d226f81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ko/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ko/firefox-139.0.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "8ef3d1cf0781b0a016750060fc3692439b6ad0d71260adf2cd4a4d83b659eb62";
+      sha256 = "0e7fd0cc4972012321c587044249476adf1e2d28b8124e4e3db7f0ab8f2cfe05";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/lij/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/lij/firefox-139.0.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "d820aa2fee3c0dfa3b2e927df6a807338a6ad28bb565189bf96564d5e9c464eb";
+      sha256 = "3667f5b56d763a53b2223a962713628b4ae566cd476cc965795c0309a0091738";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/lt/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/lt/firefox-139.0.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "3f86f10e0e212d78c015c082d0d80ba836b0bcb6107b9b42d2df22cdaecc9c56";
+      sha256 = "c2a63b27d8110b970c9d009e7b42651580122bdd4824b1d5057143402f52907e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/lv/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/lv/firefox-139.0.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "62d046ebb70ed46d173327d16f984aedc672c6cf561c73d92ae9dab40c64c20f";
+      sha256 = "3ac5a4a02d5eb87042ad6d583d3789fb50d5ecc88e57d158ef6ca3314ba5051b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/mk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/mk/firefox-139.0.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "d4f8a525c8f24e38558253d954b3c81e08d189e6e80d925334aba7387e1d2573";
+      sha256 = "032dcc7795e07b3a2f1426d380464bda749adadb9eec1bab93675051bb0acbdb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/mr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/mr/firefox-139.0.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "fbe4d8d6189044458c9901080343d8e40334cd1b633a6b4087c60d064ecec34d";
+      sha256 = "5814e633c4eb787d4aa7c482d4e7946d087c240746abb4c5afb65cfa258846c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ms/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ms/firefox-139.0.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "bc811fb3e907ea2aaef4e229312b2b8b3190ed3ed136641adb5f445a57f64f8f";
+      sha256 = "44f21e35684d1c0863526b5e77df67ff2949566c97b1abda64a9a38abce01dc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/my/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/my/firefox-139.0.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "f482b811c216f2b2c653976445ede9a8e5125da802354d93ded5d67ba412fdca";
+      sha256 = "b82533e4435662079703eb472ccaa3d0ac6512e35f03efb1048cde5bc9ca7ed5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/nb-NO/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/nb-NO/firefox-139.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "f37e5af711466a1c282703341fb8f61bb4f1a14ecb42cfb80b64b28a9068e051";
+      sha256 = "a0042565267bd7afbb9ea51dac8c56a1fe391faabcdd634f729d676006869910";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ne-NP/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ne-NP/firefox-139.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "bf0ae7c8a4f8248e08e0631086d0fc7dc432beed375398ece06daa7d253a6a01";
+      sha256 = "b8e89c35f97d0c10bd9207b774454177a6e103fc88e0962fcafabe47654e5a7a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/nl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/nl/firefox-139.0.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "a1513e2ff3d804ba98ba23f2c1763c2f1153f5d1971faa7f5de51081e4760741";
+      sha256 = "9252125e5ef11a0115c5e6c608ad82f4eef60633b4adbc783ad0cdb9b59b9920";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/nn-NO/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/nn-NO/firefox-139.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "b95717b63871fa8989e870b8a679d139b2bddbad846df29a1ff9de72ee83b250";
+      sha256 = "8a00da9c6fe1f57ef9d6bee2849f85a1ff2a1649e8f5b321d8c99222ce20aca1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/oc/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/oc/firefox-139.0.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "fd5bf5d5a6c354ea561321c815dbb878ea77bd3472905df04fee28ee5f5da40f";
+      sha256 = "b0ba8c1a18ed33eab972222fb6448064d2e1319b9c1f0fe50df9b488e3a21405";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/pa-IN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/pa-IN/firefox-139.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "60c60e90b7775e062b519eb83bf7102426442ec3dbbc0bc1ae173615fe6ac097";
+      sha256 = "4f5344e069d4adf6cbd77ddce9e5a5bf78ed53f2a840ea2d3e777892a8dcd90a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/pl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/pl/firefox-139.0.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "4dd7dfe2ba9443e6a00f7c84c35e909770e4702bb6f0d7ce04441770a703166d";
+      sha256 = "6b0327fa92fb4527856e8e5056632dc8b5017d8e7171648bb0b333a952a29057";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/pt-BR/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/pt-BR/firefox-139.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "3bcfa4433ffbeeb006d62e4f5e9369804bb29cc1d1c148cf5567a4d4e0b55841";
+      sha256 = "031807bbcc5c2a1d562724dea27dbad17aa0c2147f023886ec71a6c87950c5fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/pt-PT/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/pt-PT/firefox-139.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "65198fdcd506cdce1ebebc62aed478963c6a76fcffc4192bdb8ff9ebb76cec09";
+      sha256 = "361b17fa3126b538306275e3d5db4960f39b03b14d5523bc5f2e94b4499338a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/rm/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/rm/firefox-139.0.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "62ba3142235cb406f7f578e4965a474f3d444571b7be68fd2df83ac12c02051a";
+      sha256 = "44fd5cb9c28e1f9b47a53f93a48cc0cbf7170f1bc7ed6df0a525dacce21d2359";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ro/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ro/firefox-139.0.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "dbd17c28ffc6a25fb19f949d42cd53f03821ad33d2c5d84a03951fd67247cf14";
+      sha256 = "7f6ddb020d87e822c77bbb05032fa91e06d3bd1e498ec85ca0ac1a85f05c5230";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ru/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ru/firefox-139.0.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "5db4f48b841b99398d7b5a047c4a0a6554294beede94cc72e34b65ff064f809a";
+      sha256 = "245f4fc3e84275f860067c38812988b50cb23532b363b3b1d7e29ec5eafe47e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/sat/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/sat/firefox-139.0.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "e7ae475b021caf8089d2d3515bdfc09aa7585f3f4b979f12642e10470e5503b6";
+      sha256 = "fa5eab80ee9ebe49c1bad208251559c3177b96e27f7423cf6d5aa4a4fa15c833";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/sc/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/sc/firefox-139.0.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "00da6275dfa4fb2f72d863c78ccf79db0a57517ce89d722a8e8f1fc8df36febc";
+      sha256 = "7804b0b4dab0968c7cd718ebda9b4330ba4e962bb98e33859ef7ddeb0129a219";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/sco/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/sco/firefox-139.0.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "5f9d55ccc869dbaf8c95b2fc7f3626899772d8449cdfd43745d884e629b80212";
+      sha256 = "213dd83bcbd93e4b7d81c954fd8593af7a375b545b33301fa68ff25413fb896a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/si/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/si/firefox-139.0.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "1c1ade479ca81755af6111d1f2b3a80d512e765b474d2b6bb1c600b8ea04be6f";
+      sha256 = "0b19480a1b87ee3826923b2f5efb1db1c0bfd934c3c7b8a0c3609ac4787c015f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/sk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/sk/firefox-139.0.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "80853a3259dbe712369833ff0855f38d80e3c26a37d7141220457fea783cb22a";
+      sha256 = "af68908ce81f1d6731ed534ea1784de1027186263dea8c6af440397a723a7369";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/skr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/skr/firefox-139.0.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "50db394442325c6f81e59fe7ab12c802dea74422f3ff83cb9f5c16151a3e1fec";
+      sha256 = "81c29aaf0c119301d63b33e85576db660f42bc700ba10c844d9000595c1300ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/sl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/sl/firefox-139.0.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "ec8e374d1966bb4d9d4e6494c021628ee0480ae67cfa5aa9fed627acb75794e0";
+      sha256 = "8966075d8d55201a2fd4f928e91585c47263472fd1fa4bc70ec272fbb0e65035";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/son/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/son/firefox-139.0.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "be76829cd68c41a4596890931041c29456672c12332b6e632efc1ee569195792";
+      sha256 = "7d4bbcd59a7a8f6d4a9cd85675892b576e89fc99216bac4b1a98b928839cd84c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/sq/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/sq/firefox-139.0.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "d0879f857e49c55f706263ec6e9404dbae33de3f75ffa85f639bad82ce27b5a5";
+      sha256 = "0805ea05e33aa3c01549bca1b0397cae3517744d82ffa6ae17f3707165e69dd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/sr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/sr/firefox-139.0.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "7d56046b0f581531ec3069f60b76fe18ba449699e35f8fed8da46a0f771139d5";
+      sha256 = "e6ab3c4571f8893ad91b5bd7fbf011bc00be7a10c326214c795ebcef8dfd35f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/sv-SE/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/sv-SE/firefox-139.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "fb84d18e0bdd0ded9333f1341c7f9f61cef941f633a12bdc4f0b6d00232b2004";
+      sha256 = "c02a1c78d3614d25414f5994369adaba10f458842c602db683bc143f99a11411";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/szl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/szl/firefox-139.0.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "cbe04b1d56bf8110ae66e14737b5858b4be28908cfccee775dbe3c90f9f7681f";
+      sha256 = "a74fb56af8d736a7a6b389d3ca4c216bbc6c6524b6a10b8d18b525044300bf97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ta/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ta/firefox-139.0.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "1d422d42c8583aa59d39969bf6ae46bc67fb278c5089f2c33a5a06021f23be18";
+      sha256 = "9eac04fe94386ac4d74f62fe53f857b18041ce51ac31081a50610fc64f827093";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/te/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/te/firefox-139.0.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "b38747300f986e5883376fe04392adfb4abea4bc727f4099c171d37d5d82b262";
+      sha256 = "fe24906668acbb6aacedcc3897fd3575fae9903d94fc89ea1cecfbdde1236f6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/tg/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/tg/firefox-139.0.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "9c10bb44c65ea59078e619f0d4ef13c70b434aced9339ce245a4af1d3600db26";
+      sha256 = "a5c33f74b40f337dee9aaf993151dd57c8a63eab73e555ad79733baf86a1d1c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/th/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/th/firefox-139.0.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "173ca4156591bd9c931e7fed09ee7d58594732eebae07caaf702a4cbfc4c3687";
+      sha256 = "cb2d32ca4d730349b39d41c9b4f38cd6c99998f1a14f8eb96fd0fefdcd2cf47c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/tl/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/tl/firefox-139.0.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "04930b05b36942c0fa90d276eb95adc4f45712055f256e36b6cb690b9d456cd5";
+      sha256 = "9e16fed4c1609325834c82e1f8db882fe234cced384baaaf7722b87671d19388";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/tr/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/tr/firefox-139.0.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "8a15df5f7c66afca6b21d414f0fd08e39b8ac9bf7f7737607a0bde4e65948ee5";
+      sha256 = "c29e52a35d014c23318290e01cf441750cdff11b31c6f350a3f4294fded7adbf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/trs/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/trs/firefox-139.0.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "b1adf0b5166da1126adfdf3073c41ad236357b36d617082baecfa0a0c3a4626f";
+      sha256 = "8aef1a5c4d726a49b7b301e1f0d19a9a751979838f6a722d0dc28a995340e8d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/uk/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/uk/firefox-139.0.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "3129acd8165b32acab6f753e85e8ff24776738f98db4a7a72f5036911204178a";
+      sha256 = "4d4c5206faf932386c1f83c3dc1517b850bb8b8146666fef383cae5467546a2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/ur/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/ur/firefox-139.0.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "63a965fbcc1f371b32daf0eb7e1c8064bad5ecbf93376ad9e7517a5c8b9d72c2";
+      sha256 = "ebdcf15f02bf66ad3654f9898f6d0b7f0f0b485e75b484f44deac122d2b42872";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/uz/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/uz/firefox-139.0.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "61b0a1fd5b4698c9b5a5ddcd86a22f865882ae56eb57f7db373a01bda1952ef6";
+      sha256 = "738bb8b3bbbf6252142e01f3db74e8aa271e409eaa9dc7852f6e58a7c407656f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/vi/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/vi/firefox-139.0.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "2432d574e0d5cf8272c545bfaeaf24e2c7ef4edb5b9442b7fe0af88e0f6f6cd9";
+      sha256 = "387e2698224d4878bfcc510c95a34c9ea6303196bdc95f45bbe57aebda108507";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/xh/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/xh/firefox-139.0.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "631a41c20c3644ed3b196d75a76cf241a7394d715c14a125eab0bc31fe0901a2";
+      sha256 = "a78be308305262a0248913ba7b21ed65fec39ff457fb88d0fa7d7bd67ef774df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/zh-CN/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/zh-CN/firefox-139.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "1ffbb5d6af142590895c0101c89c29da6b9036bed3b410230cd98c855e947628";
+      sha256 = "e7ed9716c78e3e2c8c2f72363bcc9adc954b244b8c25a100085aa085869ee9de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/linux-aarch64/zh-TW/firefox-138.0.4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/linux-aarch64/zh-TW/firefox-139.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "0fadff63ab9283345cac653b4892340037569a76226a54e1f7bbdf42f072a957";
+      sha256 = "d21c44a3fa0b566e91624bcb0e6b124a51e6c86fb53dccd6846aba86e187d585";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ach/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ach/Firefox%20139.0.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "3ac136a08c6b33b3e693a97933e77c8348fd5db8b36488b2f6602d609cc69cb0";
+      sha256 = "a6357f4080c8a98faf11e621897c3cb3c749f505a0bec523bf3b5bbefb8b46b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/af/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/af/Firefox%20139.0.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "d1672c1830c3d8d33637ff4586cc52bddd638847063360510146366b99c9d470";
+      sha256 = "1b100c791b6628086956327ecf1c623a6bdf2fa1a701c92ab7d2c8a8765cc1e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/an/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/an/Firefox%20139.0.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "712bfaeb51f59fd4c69d4e725fa8008d4ea75483b7d1c828ce297d3b53e3d3d2";
+      sha256 = "caa82a61738d36021993eda6c312fa9fb943cb7a3c7e0dba1e5df6e4f4a3b03a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ar/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ar/Firefox%20139.0.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "77209765a44b93a7a1cf2a535a5c2e73e04e23210ea5fe5d24a3d74104e6b19a";
+      sha256 = "46963b2e2b8ad1e906fc989447e0514d65763e9b346e13fd8b7c9c8f8173c1ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ast/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ast/Firefox%20139.0.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "a275d903df9cd40e1a83c6613004c462ac39974d9b750789e27956702c9948ba";
+      sha256 = "e7ff169426f6104a26485d0488235f7f42b113fd6667a1c82e6c5e5b5e789b49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/az/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/az/Firefox%20139.0.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "51466148b09bf7055dcea0b8071c0f0499157475a97ffdfcb594d6bae09ef1d0";
+      sha256 = "c68978f5170e3107a508b302345bc5bcc3f510c2a838de96aabb6f8927b2c7f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/be/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/be/Firefox%20139.0.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "248e58e209f20af13d872e8b9b7345a325a7b5ade4660cea9562ca78f30b1ef9";
+      sha256 = "cfca77b6d7a053672eea8aa5dde841a9019579d6ecf7411d4da465a4c60da491";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/bg/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/bg/Firefox%20139.0.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "77f4828962223882f62948869ab54bee4fa645b93ad485d1057a4fc3fea80997";
+      sha256 = "2915812717cedc40501c3a17eb0b09ca7ba312d2cf8c92776edf783f02136b79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/bn/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/bn/Firefox%20139.0.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "d21174441d39618697ec7b83de3d04d6a2df29cb416949417652234c86659b98";
+      sha256 = "d4a1fc8df72b8ff77a62eaa0c3f916ca0b25f6bc4b51ff836f360cadc125f2af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/br/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/br/Firefox%20139.0.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "9f7cddfd91dc21d66ef6cddd90d84ffe51cf7c52950d9bf9352e5df867e314a2";
+      sha256 = "d391dc4fa735a71b9da271e8cc2b7ec3f89b403c02261868fbdf661e5c64a601";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/bs/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/bs/Firefox%20139.0.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "6f6655cd28b1b023e4d28237938fd5c71bb9010374026d645a68f30bef237594";
+      sha256 = "a477e30275ed45e1e8c555b7eb76d1416b91f125db3aa6001f140d6ec1a3f7d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ca-valencia/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ca-valencia/Firefox%20139.0.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "c9f59ecff31ac8e704209db62bc8d1c7863500f09c4643bf0648c738649f2af6";
+      sha256 = "2f29777e9295dd1b5e82201a1198a03993f406541b4584d314792f728b4be15c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ca/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ca/Firefox%20139.0.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "890f9404bf3a706b6cc814cf5ee24c6b1620882bf901b4f6e4bf01b0894afa47";
+      sha256 = "1cf4153f990de971b1bda9e8c4bd94ddd0dbc4861f4c0b87f865f4d98c4eb67d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/cak/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/cak/Firefox%20139.0.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "3a36b2c6866fb71b5603b1c9390ea0ec77d557569c86dcc3af8e290b8fe6956e";
+      sha256 = "34b3919d74ba1c39267a81ba30f86aafb47759bb0ed497a30bf5dfc6aea36db9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/cs/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/cs/Firefox%20139.0.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "7800f81448c466855025fac3b76f117137aa0992653893964e5d460cfd05e4e6";
+      sha256 = "2aea07c09067f4a2fec5e98580d24121f1581a55098bd37d0f8e9129e1f7239e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/cy/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/cy/Firefox%20139.0.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "2a451b589fc0f89e4739d17ff671cae547ca8d4fecf3bb9b7313a68e3c4b3b41";
+      sha256 = "327645c59b42c7e0ac6678ff4d78fe5f3cc33cd8cb01ace3377157eb8eaec999";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/da/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/da/Firefox%20139.0.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "f244f0155c3bd4b900962b900443a94baef1df4792ed900cbe4e8266af22b768";
+      sha256 = "82234dc856c0626c497a2e34b9a624d46e501d288c59f0b39abc5b9aa7cda4eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/de/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/de/Firefox%20139.0.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "55a4651a2ef01c88bb89319ac0b8a532b66ac435f821f206bda1171335858243";
+      sha256 = "c242aee361b4dcccc0614139b1213873fdbab65750181faf166a082110a023df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/dsb/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/dsb/Firefox%20139.0.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "a174edf43ab09f1548478782fe64fa961b0ebdfc6089078220a23740127077d2";
+      sha256 = "36e6a5369619ab2812345f4c8293d2a7ede6006e8b83fa662519a3d93b30faff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/el/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/el/Firefox%20139.0.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "9664a7020b5ad197ef7965796512ece13fc839009d6b7115460f43308fa77178";
+      sha256 = "c8e8a3f8c2ceefe4c8928cf15df83415f78c5566d1fa3e259806c3d41db61633";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/en-CA/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/en-CA/Firefox%20139.0.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "ea78c01cc2bf3a39f597098eb81b2a8c101c384b1be02addb7d7e54218eefd44";
+      sha256 = "01242a9c0bf1848c4c9eb1c974008fca69b01927ac4ee939b8e7711b0ca26f44";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/en-GB/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/en-GB/Firefox%20139.0.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "5f732b8a0b7ae98612b347ecd5e3dfb31a025b79dfc8a72ee49cebaa09ceebc1";
+      sha256 = "9d72c3d1c9072e2a83a1e19c5ce48720e21cec66d9a38bcd2d566bef02b1e99e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/en-US/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/en-US/Firefox%20139.0.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "6842663f38b8b12b08b67239f0cc2118e93fa0b5b57e856c21f384fb501fb430";
+      sha256 = "03f1066b70b6e502c4f1a732a63f9f93146c6ea23d0af5e2e3a57d030e255353";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/eo/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/eo/Firefox%20139.0.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "2b8d00b7bf0db729c2d2175e7f80d3f8d672bc801ffe2500166a634a3f7e1083";
+      sha256 = "95d041e3c5294e8566eb7fda6b8560cea7d5d508ec1344736cc8bdcc3e60ba6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/es-AR/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/es-AR/Firefox%20139.0.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "98ffd41b5ff746df9ac64c6926b3c49b3cfac17a2dc1bd65d5f9141a4a62c9d2";
+      sha256 = "86dca1d4399e066258bf7cba393f8202a93f722c80623f72399066048fc1fdb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/es-CL/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/es-CL/Firefox%20139.0.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "5479fcaaf105665413ed706681a87c7ba0194bae9f2b56a9d8470c5ed479788b";
+      sha256 = "d816055a61e9b5c121e090bf27541f1020f4fdeed6e0114327c51ae96c44eeb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/es-ES/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/es-ES/Firefox%20139.0.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "d579e6f2ba06ee6baa118a7d30bd7478112bb15a2221f440ef61463ffabd337e";
+      sha256 = "08dc73a704063559cc1670884e17522f9d413b04d48dc5a08e4fb5e894ee3b02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/es-MX/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/es-MX/Firefox%20139.0.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "079211e592d4f881dab4a9c0b8d89a6645347a6e02c23a58f2ec688adc56b766";
+      sha256 = "4b51b375d7043bc98878afa4068e233ddae3d9a373113a6b9e96ef6fa493461e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/et/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/et/Firefox%20139.0.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "4bbcd47c07e4295514dda68b93426aab4b9c867bb490ecbeb805484f56dc3643";
+      sha256 = "3b9b60cf5b60c87346302bafb22efd1d2e1411b45a9208ff98d5cb4157bf8482";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/eu/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/eu/Firefox%20139.0.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "b037b07509886a2c07c6b03b68bf2d6a7471a2c42c5ee4158fa018afbd145ca7";
+      sha256 = "0fcf4d2d9301d5e38229ffe74b0b81d8461f0aa5d396b814e353ef72e746182e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/fa/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/fa/Firefox%20139.0.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "8fe8c884d344fe9d5793636f1be2618c155b55a91dacc2108a19433f08c87fe3";
+      sha256 = "2c2ba07b86446ec5dea7c736dc10b4b10cfc4025825380b2a1b2bfdde5e6910e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ff/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ff/Firefox%20139.0.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "513850aac0a99a6e7d966eb28e07e83d18047122621dddab592dfe90bb61ccd9";
+      sha256 = "1617e0c5592a08423d66a90ff69f0014b69a764cec8e675304cf07bacfbaa36c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/fi/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/fi/Firefox%20139.0.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "80b5265d9ff548c19ff213ca8d26cd8764ed2e9eab42481dc0ced21c17f6b78e";
+      sha256 = "eadf8925c991ecaea5a3733cf9856d2fc1c9e5a963b7e84f5394d149c0c22578";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/fr/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/fr/Firefox%20139.0.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "ead8029cff0572adaddba2472ec2d13bfc4e82c7a96b689337aeb71d162a299e";
+      sha256 = "2fa6b62f790f1abc573847696067fa9e0b31256ce6979a75679f30901769f708";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/fur/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/fur/Firefox%20139.0.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "b921ba3ff041e5fe4c17f21438dbd7ee7a9a4e7a508249df3a13f798cc01167b";
+      sha256 = "316c8274d604466fcf0e02b9aaea1de376a1afbaa553d5bfe32ef6ab1293a8d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/fy-NL/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/fy-NL/Firefox%20139.0.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "e706bf05ce049b193b7546d585aaeca4136d0773e9e9a9899022278b4b0f9bc8";
+      sha256 = "8052eb740c2edac508659d1cf7299475927910901af1dd8204fec947693ea330";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ga-IE/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ga-IE/Firefox%20139.0.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "f6ea386594e457f4368a18a8c69f05a2a3b5df96b0cc0a688d2563ced9d8fb0d";
+      sha256 = "9dcd61c091b45aacd2e69dded14bec79754e5814ea12bfcfdf079867a2d38148";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/gd/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/gd/Firefox%20139.0.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "8d4adaf0dedf1506ac1965524ca0a835f737a1a2fd07bf9a3f21fb0ec602e755";
+      sha256 = "a2827d1b42f580b44a92f7c23dd7fdad3688f57cf2471ec81b9c4fdc20c600a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/gl/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/gl/Firefox%20139.0.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "11e5e063dbd173f0508706d9f0922e7217899615b2dde19e6eac07495fe0e620";
+      sha256 = "dabfa9f91e052ffdb1e63ccaecf7439ef3620143df264b572fc8d7ee4642dd4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/gn/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/gn/Firefox%20139.0.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "d44cb013ecff1732cf428805db9b0acc0248b8791cf5c35fefdfffa721cc29f8";
+      sha256 = "f1ac8faee33d915c2b0d39b84d50189f3e1126fff746fb4cb236ac2423f1ea57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/gu-IN/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/gu-IN/Firefox%20139.0.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "82932e549f0086e926c76894233efb652f99e7790abaec5e52f4c37d2cbad55a";
+      sha256 = "c5795c00a63ccfbff807dd03111f6776c20c401ef2d14816128b29f698a0d12f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/he/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/he/Firefox%20139.0.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "51c239717885d2d965a5b8112428273f14e7aa78eda39245376a265a932ff125";
+      sha256 = "85cee9ad457c5a51854b0b468ece5e32f8b47f781c0baa7ebb5654839f49b2bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/hi-IN/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/hi-IN/Firefox%20139.0.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "1db6ced3ed13a8fa9aff5edf01797fcbdc0dee7a9be69d98cd41583e4ddd95f0";
+      sha256 = "a34fbd24a64a47b10d54fcce6904a916320e51236d4975759774135fc9921f03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/hr/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/hr/Firefox%20139.0.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "b69b8c140c2ddba2bb0ac6a3690bc2d3c54203944c9000eaabd6f4b912841f60";
+      sha256 = "f46e02f392276e675a3b1dc534d8c19e5563cd2e7a0f52e2aa8f2078074dae60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/hsb/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/hsb/Firefox%20139.0.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "5ab9b0b9be7c0555b3e44e51bed022bdc0cb18f0b7017141dabb1daa9dfd6ec6";
+      sha256 = "542516cbf91295954824ef36ce7d142ee5c58d5f0c0473d0b26d481a205ead43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/hu/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/hu/Firefox%20139.0.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "7204e18d32f9ae90272cb9ed5c8112077be90bbd236249ceefc5f551b2fd8696";
+      sha256 = "9e40f771c0fc905b6c163937e9da3eeb3f33b1b635b5f58cd6d4720b0983bdb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/hy-AM/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/hy-AM/Firefox%20139.0.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "304e5eec4595dca6c32a9cda36a5deed3e338ed7643e78d9f7496f6ddc2e8326";
+      sha256 = "ee6d307a28344db52cb03bc3a304c461bce80217d4532cceecbaef2a4dcbcb28";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ia/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ia/Firefox%20139.0.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "93c0e7cf689538877240845fff75bba1d1a69957e30bf8dcf131ebf3fd03bce7";
+      sha256 = "c6c94ba1fc652d8690c8c7d2582c17b6383d5a39ba948f681a5d470e5de241f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/id/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/id/Firefox%20139.0.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "d88a4f33294da0f9950e573a6dcfbc2ad40a58246c5d69d24f8cfb0ae83bdf0a";
+      sha256 = "b081f67c96df26f70b5caf034766b4474c6443db34a07925e300a41a10631362";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/is/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/is/Firefox%20139.0.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "8245bab00dc3d81ae9cb661980eb169694c6799429ea9e849deb6bcdb293547c";
+      sha256 = "a2f891520464146113a73edff78b0750a3bcefe5ed4792a8e61cdb5f9828a6ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/it/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/it/Firefox%20139.0.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "9b95138d400aa6708a60505694ef75effe891dcd30f3e88a44c4af70eca8415f";
+      sha256 = "b120bb4bda4276f1c730e8cf7e2342d818f69250850b61101b1f6e14ff84be3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ja-JP-mac/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ja-JP-mac/Firefox%20139.0.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "09da37434dd08332cb08d2738e67cb68724277b9e6f263cb41f18759e84e4d30";
+      sha256 = "f6c4e6fee37ceb88f3bb1eaee4420b82a30acf2b9247ec41a122b07e04404b3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ka/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ka/Firefox%20139.0.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "0c22e56604ca5724647a7aa0666337cec48875f6f2fb31cc6947f7904ed79fe6";
+      sha256 = "804e0baf508308487e37a58710305494c4f433ec38575b24eeea743ce5733332";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/kab/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/kab/Firefox%20139.0.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "38bac8f6e2e5f0d4c43851d80205db73652ea17c225fd3ca4254cc2b53ac84ad";
+      sha256 = "40927915810ed8f134067961ace5a84df0fd347c6edb9766f488835be34ddd43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/kk/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/kk/Firefox%20139.0.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "12a4dda4a028a4833e1f7187ab783a3c26ccddfaec700cf5284c83ac18b05bce";
+      sha256 = "c1ad2dfadca570f2667f4c81b5808e3a69618901df4191aba1cb85f1a06465f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/km/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/km/Firefox%20139.0.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "39f1e761b5f13ef50e763c7705da904812dafaa92ae1d72a28345f92d8f4e467";
+      sha256 = "6f0c4b73abb84e77a715935beb86f3f619d93a341bdd650837b977a0657e80b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/kn/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/kn/Firefox%20139.0.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "8ad05e2ea6c80085ad206091a75b9bd722f11ab98e6f3be64cf52dd72f2d57d1";
+      sha256 = "d1246c42f91a5e9128ac1be7347ef62cf24ce6ffaaa3050ef3c2e3664025bac8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ko/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ko/Firefox%20139.0.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "1657df3c4fcc329f59cf53008b50b391e4df0eee92e31848e3e691f54393bcea";
+      sha256 = "e0e32e9601bed5b0e059c385a51773abdba99b2ae64f3f1cb9b8e8767903fad5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/lij/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/lij/Firefox%20139.0.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "6b86fbf8b659134f37b8402170aaf7dcbaf156143366c031784585bc498b5ea1";
+      sha256 = "62b606a40994180b765d67513f80d3caeeb49de5149afdb92ecc94544f37acb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/lt/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/lt/Firefox%20139.0.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "028155ad139df1b9fb5900031781f9ba99142dcb2e27f47b84213089c8b4d434";
+      sha256 = "bbe7863f6cbb1d670f18548e3b85ba9310f4ec9a1d78302f9d02c7014f4d3203";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/lv/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/lv/Firefox%20139.0.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "4b3cbe9fafd4cb84480acbba79cee6db9c7344ee3cffda5bb296779052911f41";
+      sha256 = "47a2c4fee31e42537d1ec255173c4c99eb62ecfed8c67471e9c5edc67b5a7284";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/mk/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/mk/Firefox%20139.0.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "1a61c2c47b59c0191289b847f6106d715c33576c7969a10fb95bffbeb746c487";
+      sha256 = "700797bd32ec321842a041e5ca1a38789c04b01f7e3c3ec88625b8624b8fc8cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/mr/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/mr/Firefox%20139.0.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "1a7acea842602d83233a302213ea7c2c5fac066847ba5f0afe7c5f50927c50bb";
+      sha256 = "de02666dc70dccc36c5af6f2c9f47652cbcbd816b2ceb9e51c022f983fb21473";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ms/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ms/Firefox%20139.0.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "933cc3aec4d39ead31539c3420a1596973b038c5fefd6fb8070c0e44dbe650d3";
+      sha256 = "9bfcd2214067ec17982e7f0b2beb5371de96884e6531bd035e020a6a82e3c04b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/my/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/my/Firefox%20139.0.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "83e60548c42201a197e1972e05ac8ff2afa2b022a0960eeb4855a9cedd8984df";
+      sha256 = "5def75eb9c0bd50f14d315df706cf69971147d8f14ff9e49b295f3b26ee887df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/nb-NO/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/nb-NO/Firefox%20139.0.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "43d0550b0e87444447734a19239e26841873ff6e2a0d6d77f697950897d45fbb";
+      sha256 = "947f244c67f16bb8004e9d3efe2aa06ff9c29fcdc189ec453f5e86130dda5972";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ne-NP/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ne-NP/Firefox%20139.0.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "c0d6936ae1fabe0e09700328297e7fcf3b55ff4fb774c9ee32a4af7e60099f40";
+      sha256 = "75b8387722f0ba37eee8fd5a527ce231cc7ebea1a5526fb48e27fba7f72230cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/nl/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/nl/Firefox%20139.0.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "6837520e293872fbaf512e9944ac9f516071cc4b6753998a4bc7043324182cd7";
+      sha256 = "d0419657503711cb0ca01de226dde6791145cd8ff0ea83ebffd0b0d821967e68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/nn-NO/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/nn-NO/Firefox%20139.0.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "cfd0abd9ee0826812c06543610e7c5ca2e03c57f9adfc1c104333b993aa1a9a2";
+      sha256 = "8135b43ca05af1e24f9eb35304ed86636ce81c772d2aceb4e624da59362e69ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/oc/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/oc/Firefox%20139.0.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "3cb83720ec60c9a6190121852038513af7ef7ab2670e9b95ef0f9e3301dbbb67";
+      sha256 = "3da585c574722fd9a74b9a2b17e23572f50088dbd770d14ddbee73961712283c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/pa-IN/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/pa-IN/Firefox%20139.0.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "7e8a867c6128aa9b729510cdf886a25405db8a0d5afff48f654114e9d85c2c2b";
+      sha256 = "21ae4e57c5dd6c66e3d915f80c727f444babc93d4b7dde65e9b9ac3724abeb78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/pl/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/pl/Firefox%20139.0.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "8e283532101bc97cb4331919f0ca8e7145d3b0f4d6fb98a5a8c756ddc04e86b9";
+      sha256 = "f8cd4292c2ba782c51de55cc15c1856cde86b0ad496d194ce18f7ebd09cbad9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/pt-BR/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/pt-BR/Firefox%20139.0.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "56faedc7770936eb5d20f94f76326a206539eefd15375978326b4322ad759e3a";
+      sha256 = "848230440791e68c5118e79b981b054abf3a52e6081bfbd4665f7a69277940b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/pt-PT/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/pt-PT/Firefox%20139.0.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "c06c016f3729be765d5b0acf64b4e69db7fee87efb0ed76e9ff363051a7d55d6";
+      sha256 = "051494b2b7dd1546ca23ac920b139450061401b0d6e8422f4cfab4c6eb7c6494";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/rm/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/rm/Firefox%20139.0.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "9e7c6615e78e5f044d1223e4517d66a6e58895e096932f7f0a5668a20cb91089";
+      sha256 = "fcf073ff8ec12006dc52595731c09e15f89ac0cda499f9d5191c529dc2fa868e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ro/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ro/Firefox%20139.0.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "4a523f91a76d9c9ca1d52b649e8818ae011c4f23aa1835580f5b1157d5c36070";
+      sha256 = "03edb86e01520b84bec2b0cb134c08d2b5225501eb4946d94b3f7d854fe34d73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ru/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ru/Firefox%20139.0.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "b5d8eb92706329e5022c985dba7ab79dff79ef64dfc26be2285d0fdb57ec58fb";
+      sha256 = "22987ce482f23a6d42b5c51518109bbfb53f981a46575bef4ed5c8f66f05328d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/sat/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/sat/Firefox%20139.0.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "fec418bae73b3e5a276efd003a54ea9735256c4cfcf8f1ce5c763d18f8bb9511";
+      sha256 = "ba9c3fa3db5c8685883a6ef5703bf63c3c07afbe5ac3ee53501abad9774a0af0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/sc/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/sc/Firefox%20139.0.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "5736c0efa3115d5b74440b70ab8df22d45d8c78599c409bde09f7a21383fcbf6";
+      sha256 = "b18ca09e991273c0302312d4363b0691f216227f4274f3b7cdfbc65d5e3f8135";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/sco/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/sco/Firefox%20139.0.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "ad72c689c81579ad0cf92debd543e6413ac347b62d3c8cffbf2eee0c63667b6a";
+      sha256 = "681631c6cc1e8ff71d37d358cafc4c06c1f1cc92f5873cf8f036a0d45fdf4782";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/si/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/si/Firefox%20139.0.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "ecab64a3bd7b619fefb95ccf4d6ba12b155d907c3b2036eec3188b13bf459b28";
+      sha256 = "35eb7248a08659e8db8d0b2f80aea83cf14153e3d4050ae930049847fbe3cf31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/sk/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/sk/Firefox%20139.0.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "5b0a58392ef50cbefcc94f48945c81b0f5977da493a7fb4b6a7d3e96fa95766d";
+      sha256 = "70ab7893fdf29e8f05cb68403c5d5699596380fec2830d9cb9ed5b76b3fc089b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/skr/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/skr/Firefox%20139.0.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "6d6f6ff8a0a81d3f1b4ffbcbc508dcdc4d29c6913fda9e8f7ba3b9911b4e9849";
+      sha256 = "608091713e068e799746e6bcdf9a0f355a510e6194a667bfab0ad3624977c778";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/sl/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/sl/Firefox%20139.0.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "fef9a3a6e32002b16f2bfa9089740d2118fd0b7321bbec975bc33bbee76127f8";
+      sha256 = "fb53a2e2b6fa8863e75210098f64b70d03b65765b34aff59e0624b62845f76db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/son/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/son/Firefox%20139.0.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "a16daca62f9f187c138cc9512091ca27fbb68341aca333373b1aa4064d1995b2";
+      sha256 = "fcdf5c03ed3a3a9eaa0af5e02b32d89a15fdefd698637164c50ddd89b29c669c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/sq/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/sq/Firefox%20139.0.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "7895ca4c7cb7ae469a8177fe3bd7e79935a81a41cb8ba8da27d1d693dc838518";
+      sha256 = "7f04c9dc75e384a336fa7aada83e7c61f9905ca87df49209fb0b559340c3b4d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/sr/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/sr/Firefox%20139.0.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "2d0bcc75c964b73c79eaaf268c90d09ee4973f5297a704c505e5c94652b37e67";
+      sha256 = "fc29468dec29395f8600850948835cd8e85ab8164a6b802987149e71e0e99691";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/sv-SE/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/sv-SE/Firefox%20139.0.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "d7c64f165852fb7b4b441879ab1006be6385e35cb9f5e1584b3a3469c1cafd58";
+      sha256 = "5e4ad98555697f92cb1d89e6a7be70a6a1a6ef5e9ed3cde6fd188026af5d4a70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/szl/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/szl/Firefox%20139.0.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "585a3cc4df211fc936ce6041e004ab3e801706919a398592c380481c9dd05bae";
+      sha256 = "69be90a6e941cec038efb7986f45b19789ccf71794a51e7c48cb1ce2e53ece0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ta/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ta/Firefox%20139.0.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "4b27162bb2589162bdb26e18db7b4b14165ce64bd5b423280da2efbf9ff01cb1";
+      sha256 = "19fb8d49b12bdcdcc37b5d3311a4ad4e0958df31d1ee2fb7afed6657d9d3103e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/te/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/te/Firefox%20139.0.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "dbbc126272a8bff19fe2c2479b2a2d0284d30d15d45427ff2562969d6ec65b79";
+      sha256 = "a6b1b940261f4df5260b91c6161189e7a917fa6cc2882a40a5fc62e64f0a7c6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/tg/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/tg/Firefox%20139.0.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "e3de69f295a5c8e00d3adb017e14c8766574a5461134852fa52447795caf6f47";
+      sha256 = "44cea3664a4507d90f51e54b5a6132f6efb5a8f45786e861dfec478f69956a94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/th/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/th/Firefox%20139.0.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "75471c7a4a3ab6b81eb1ec4f03f54a245f93e78cfa4cd5b980497236aedbdbd8";
+      sha256 = "e66eb76895e9c5f43310ade5219d36cd3467278e66745f1267f591337293f687";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/tl/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/tl/Firefox%20139.0.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "48df7d11308fc8d55f53c8df0aa013d5d0aacdd09fbd2c7fe43a418c724bbd77";
+      sha256 = "1f0e36fe95e97e2048acd43cd7ac85400e4720ceea3f83f744729751ad4f3881";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/tr/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/tr/Firefox%20139.0.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "6e51b9520f999d1d436cd4d65c526106c2d49fd67d8f5f435e2ccb8aed07d499";
+      sha256 = "8e760c6751680f941e1b2a59970d0c43cd2df24a414ba52cbbc0cbc427ea7a94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/trs/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/trs/Firefox%20139.0.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "38e5f9d1392c64cf53e3263d599f3ca2deead8f507ab89a8b13305185af8123d";
+      sha256 = "595d1e4973263348535c50f5c6eaa0cdd74d0db1b4e2b78ec8c2a2ace9ca828d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/uk/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/uk/Firefox%20139.0.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "cf75cb71b63b31252fb5e605d3f86f889a19a8aaf680e7058859843c289ececa";
+      sha256 = "d2708ae447d70c3d931b4b7d63dba5d75969b7e0579a7adec90cc916276d0749";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/ur/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/ur/Firefox%20139.0.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "c3ecbafe9be4063d9a1dc944fafe5c9286525cf60e96890390d40092e1513e3a";
+      sha256 = "53e1f218129ba29019bc2bc6085bc0d66221af03f17c12e688cd67908226ca79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/uz/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/uz/Firefox%20139.0.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "60780aed5504b50d1cdba188480937335bfa810925478061cc146416fe76ab15";
+      sha256 = "daf46d0a45e156d379c3bfb65b405db825d248a1112491cc8b4116b742b2108b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/vi/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/vi/Firefox%20139.0.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "3ffc36e2d19298cecf659e208b6f4298c4b871c8f579c92478d0df6f7d75d797";
+      sha256 = "b14577d72f748f9afd811366b2a0ddeea6543cd63ff01b9294335d26d0632073";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/xh/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/xh/Firefox%20139.0.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "2b5342eccf9e0be7afd820abe5e8f1ac9c67c5814dd1b7e09714e13f183887cf";
+      sha256 = "d8ba0b0ef4e3e8c15c88498a5ecd45e43018980a64b6ef5c5cfd8680e6b9f828";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/zh-CN/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/zh-CN/Firefox%20139.0.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "d78e66267a70dbbba17cb4992114d39594cf0562540c81d00749382a50f95ddd";
+      sha256 = "9c8d97170ef8b9868e84844f7bc4b968fa4303b0cae8b4820ebe5f49778d9853";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0.4/mac/zh-TW/Firefox%20138.0.4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0/mac/zh-TW/Firefox%20139.0.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "6e4141e78b4593d7d9bee2eacaec14ce0eac7b555ebf787d3dd858c7d373afc2";
+      sha256 = "3cee288e2a060de82a3d795622c5d754cb2d9d96529c3c15b6e6fef89c7b7806";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/139-relax-apple-sdk.patch
+++ b/pkgs/applications/networking/browsers/firefox/139-relax-apple-sdk.patch
@@ -1,0 +1,13 @@
+diff --git a/build/moz.configure/toolchain.configure b/build/moz.configure/toolchain.configure
+index 769ac0379045..160734dd386d 100644
+--- a/build/moz.configure/toolchain.configure
++++ b/build/moz.configure/toolchain.configure
+@@ -233,7 +233,7 @@ with only_when(host_is_osx | target_is_osx):
+     )
+ 
+     def mac_sdk_min_version():
+-        return "15.4"
++        return "15.2"
+ 
+     @depends(
+         "--with-macos-sdk",

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -310,12 +310,14 @@ buildStdenv.mkDerivation {
       ./no-buildconfig-ffx121.patch
     ]
     ++ lib.optionals (lib.versionAtLeast version "136") [ ./no-buildconfig-ffx136.patch ]
-    ++ [
+    ++ lib.optionals (lib.versionAtLeast version "139") [ ./139-relax-apple-sdk.patch ]
+    ++ lib.optionals (lib.versionOlder version "139") [
       # Fix for missing vector header on macOS
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1959377
       # Fixed on Firefox 139
       ./firefox-mac-missing-vector-header.patch
-
+    ]
+    ++ lib.optionals (lib.versionOlder version "140") [
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1962497
       # https://phabricator.services.mozilla.com/D246545
       # Fixed on Firefox 140

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-128.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-128.nix
@@ -9,11 +9,11 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "128.10.1esr";
+  version = "128.11.0esr";
   applicationName = "Firefox ESR";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "6e7363d8cbecda1cedaf534ac10dc046b5f515399ec754492357e8a558c61ee3389f7bb90aa929dbcb4d6eba041ae1e778a0a8f90aa1e1f939eea517333b6c45";
+    sha512 = "80af64c1dce6d7a25111480567a3251cc2d1edce00acc4d85bbaa44590f5bbf4c0716f9490c3ab8ef1e6fc2bbabb2379029c2dee51ce477933c7a5935092d279";
   };
 
   meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,10 +9,10 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "138.0.4";
+  version = "139.0";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "64d80456da8df27d7eeed7eb20c35fcf213bc948eb48739b6101e2c476ea9a9133da928477a79683c96c160f8d53bed52be487f01a8d29e38d39071f12676806";
+    sha512 = "84a2b47f2ff71aac226a774ab0ac9ab8d9a16f5620a06f7abb6648732209d022aef35a9d4873e91ebd67a4fc494fc238524e25c38fad8046db26afda06e6f970";
   };
 
   meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/139.0/releasenotes/
https://www.mozilla.org/en-US/firefox/128.11.0/releasenotes/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
