### PR TITLE
{,nixos/}pocket-id: 0.53.0 -> 1.1.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -20,6 +20,8 @@
 
 - The `services.polipo` module has been removed as `polipo` is unmaintained and archived upstream.
 
+- The Pocket ID module ([`services.pocket-id`][#opt-services.pocket-id.enable]) and package (`pocket-id`) has been updated to 1.0.0. Some environment variables have been changed or removed, see the [migration guide](https://pocket-id.org/docs/setup/migrate-to-v1/).
+
 - `renovate` was updated to v40. See the [upstream release notes](https://github.com/renovatebot/renovate/releases/tag/40.0.0) for breaking changes.
 
 ## Other Notable Changes {#sec-release-25.11-notable-changes}

--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -75,6 +75,16 @@ in
             '';
             default = false;
           };
+
+          ANALYTICS_DISABLED = mkOption {
+            type = bool;
+            description = ''
+              Whether to disable analytics.
+
+              See [docs page](https://pocket-id.org/docs/configuration/analytics/).
+            '';
+            default = false;
+          };
         };
       };
 

--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -7,13 +7,16 @@
 
 let
   inherit (lib)
+    concatMap
+    concatStringsSep
+    getExe
+    maintainers
     mkEnableOption
     mkIf
     mkOption
-    optionalAttrs
-    optional
     mkPackageOption
-    concatMap
+    optional
+    optionalAttrs
     ;
   inherit (lib.types)
     bool
@@ -28,7 +31,7 @@ let
   settingsFile = format.generate "pocket-id-env-vars" cfg.settings;
 in
 {
-  meta.maintainers = with lib.maintainers; [
+  meta.maintainers = with maintainers; [
     gepbird
     ymstnt
   ];
@@ -149,7 +152,7 @@ in
           User = cfg.user;
           Group = cfg.group;
           WorkingDirectory = cfg.dataDir;
-          ExecStart = "${cfg.package}/bin/pocket-id";
+          ExecStart = getExe cfg.package;
           Restart = "always";
           EnvironmentFile = [
             cfg.environmentFile
@@ -188,7 +191,7 @@ in
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
           SystemCallArchitectures = "native";
-          SystemCallFilter = lib.concatStringsSep " " [
+          SystemCallFilter = concatStringsSep " " [
             "~"
             "@clock"
             "@cpu-emulation"

--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -134,8 +134,8 @@ in
     ];
 
     systemd.services = {
-      pocket-id-backend = {
-        description = "Pocket ID backend";
+      pocket-id = {
+        description = "Pocket ID";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         restartTriggers = [
@@ -149,7 +149,7 @@ in
           User = cfg.user;
           Group = cfg.group;
           WorkingDirectory = cfg.dataDir;
-          ExecStart = "${cfg.package}/bin/pocket-id-backend";
+          ExecStart = "${cfg.package}/bin/pocket-id";
           Restart = "always";
           EnvironmentFile = [
             cfg.environmentFile

--- a/nixos/tests/pocket-id.nix
+++ b/nixos/tests/pocket-id.nix
@@ -15,8 +15,6 @@
           enable = true;
           settings = {
             PORT = 10001;
-            INTERNAL_BACKEND_URL = "http://localhost:10002";
-            BACKEND_PORT = 10002;
           };
         };
       };
@@ -30,16 +28,13 @@
     in
     ''
       machine.wait_for_unit("pocket-id-backend.service")
-      machine.wait_for_open_port(${toString settings.BACKEND_PORT})
-      machine.wait_for_unit("pocket-id-frontend.service")
       machine.wait_for_open_port(${toString settings.PORT})
 
-      backend_status = machine.succeed("curl -L -o /tmp/backend-output -w '%{http_code}' http://localhost:${toString settings.BACKEND_PORT}/api/users/me")
+      backend_status = machine.succeed("curl -L -o /tmp/backend-output -w '%{http_code}' http://localhost:${toString settings.PORT}/api/users/me")
       assert backend_status == "401"
       machine.succeed("grep 'You are not signed in' /tmp/backend-output")
 
       frontend_status = machine.succeed("curl -L -o /tmp/frontend-output -w '%{http_code}' http://localhost:${toString settings.PORT}")
       assert frontend_status == "200"
-      machine.succeed("grep 'Sign in to Pocket ID' /tmp/frontend-output")
     '';
 }

--- a/nixos/tests/pocket-id.nix
+++ b/nixos/tests/pocket-id.nix
@@ -27,7 +27,7 @@
       inherit (builtins) toString;
     in
     ''
-      machine.wait_for_unit("pocket-id-backend.service")
+      machine.wait_for_unit("pocket-id.service")
       machine.wait_for_open_port(${toString settings.PORT})
 
       backend_status = machine.succeed("curl -L -o /tmp/backend-output -w '%{http_code}' http://localhost:${toString settings.PORT}/api/users/me")

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -9,18 +9,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "pocket-id";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "pocket-id";
     repo = "pocket-id";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cHPG4KZgfLuEDzLJ9dV4PRUlqWjd7Ji3480lrFwK6Ds=";
+    hash = "sha256-J/s8wpKAU7w8Djtd7rtamCzg/7176W0ybSoAB/vHOjs=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/backend";
 
-  vendorHash = "sha256-82kdx9ihJgqMCiUjZTONGa1nCZoxKltw8mpF0KoOdT8=";
+  vendorHash = "sha256-jLwuBYiFZhUDIvG5uk78vXmo+wuqkFmyC5lAUZ3vUxU=";
 
   env.CGO_ENABLED = 0;
   ldflags = [

--- a/pkgs/by-name/po/pocket-id/package.nix
+++ b/pkgs/by-name/po/pocket-id/package.nix
@@ -22,6 +22,12 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-82kdx9ihJgqMCiUjZTONGa1nCZoxKltw8mpF0KoOdT8=";
 
+  env.CGO_ENABLED = 0;
+  ldflags = [
+    "-X github.com/pocket-id/pocket-id/backend/internal/common.Version=${finalAttrs.version}"
+    "-buildid=${finalAttrs.version}"
+  ];
+
   preBuild = ''
     cp -r ${finalAttrs.frontend}/lib/pocket-id-frontend/dist frontend/dist
   '';


### PR DESCRIPTION
Continuation of https://github.com/NixOS/nixpkgs/pull/410768

## https://github.com/pocket-id/pocket-id/releases/tag/v1.0.0

This contains breaking changes, see https://pocket-id.org/docs/setup/migrate-to-v1/.

The frontend now generates only static files and no longer includes a
binary for serving them. The backend has taken over the responsibility
of serving the static assets.

## https://github.com/pocket-id/pocket-id/releases/tag/v1.1.0

This introduces some lightweight analytics, I added an option for the NixOS module for discoverability.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
