### PR TITLE
smtp4dev: use finalAttrs pattern, fix updateScript, adopt

### DIFF
--- a/pkgs/by-name/sm/smtp4dev/package.nix
+++ b/pkgs/by-name/sm/smtp4dev/package.nix
@@ -57,6 +57,7 @@ buildDotnetModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       rucadi
       jchw
+      defelo
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/sm/smtp4dev/package.nix
+++ b/pkgs/by-name/sm/smtp4dev/package.nix
@@ -7,7 +7,6 @@
   npmHooks,
   fetchNpmDeps,
   dotnetCorePackages,
-  nix-update-script,
 }:
 
 buildDotnetModule (finalAttrs: {
@@ -48,9 +47,7 @@ buildDotnetModule (finalAttrs: {
     mv $out/bin/Rnwood.Smtp4dev $out/bin/smtp4dev
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version-regex=^(\\d+\\.\\d+\\.\\d+)$" ];
-  };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Fake smtp email server for development and testing";

--- a/pkgs/by-name/sm/smtp4dev/package.nix
+++ b/pkgs/by-name/sm/smtp4dev/package.nix
@@ -9,25 +9,19 @@
   dotnetCorePackages,
   nix-update-script,
 }:
-let
+
+buildDotnetModule (finalAttrs: {
+  pname = "smtp4dev";
   version = "3.8.6";
+
   src = fetchFromGitHub {
     owner = "rnwood";
     repo = "smtp4dev";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-k4nerh4cVVcFQF7a4Wvcfhefa3SstEOASk+0soN0n9k=";
   };
-  npmRoot = "Rnwood.Smtp4dev/ClientApp";
+
   patches = [ ./smtp4dev-npm-packages.patch ];
-in
-buildDotnetModule {
-  inherit
-    version
-    src
-    npmRoot
-    patches
-    ;
-  pname = "smtp4dev";
 
   nativeBuildInputs = [
     nodejs
@@ -36,10 +30,12 @@ buildDotnetModule {
     stdenv.cc # c compiler is needed for compiling npm-deps
   ];
 
+  npmRoot = "Rnwood.Smtp4dev/ClientApp";
+
   npmDeps = fetchNpmDeps {
-    inherit src patches;
+    inherit (finalAttrs) src patches;
     hash = "sha256-Uj0EnnsA+QHq5KHF2B93OG8rwxYrV6sEgMTbd43ttCA=";
-    postPatch = "cd ${npmRoot}";
+    postPatch = "cd ${finalAttrs.npmRoot}";
   };
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
@@ -67,4 +63,4 @@ buildDotnetModule {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/sm/smtp4dev/update.sh
+++ b/pkgs/by-name/sm/smtp4dev/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix-update
+
+version=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sfL "https://api.github.com/repos/rnwood/smtp4dev/releases/latest" | jq -r .tag_name)
+nix-update --version="$version" smtp4dev


### PR DESCRIPTION
`nix-update --version-regex` doesn't seem to work if there are too many versions that don't match the regex, which is the case here since upstream seems to create a new pre-release for every commit on master. Instead we just fetch the latest version directly from the GitHub API and use that with `nix-update --version`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
