### PR TITLE
kagen: init at 1.1.0

### DIFF
--- a/pkgs/by-name/ka/kagen/package.nix
+++ b/pkgs/by-name/ka/kagen/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch2,
+  cmake,
+  pkg-config,
+  mpi,
+  cgal,
+  boost,
+  gmp,
+  mpfr,
+  sparsehash,
+  imagemagick,
+  gtest,
+  ctestCheckHook,
+  mpiCheckPhaseHook,
+  withExamples ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kagen";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "KarlsruheGraphGeneration";
+    repo = "kagen";
+    tag = "v${finalAttrs.version}";
+    # use vendor libmorton and xxHash
+    fetchSubmodules = true;
+    hash = "sha256-FSlTNOQgwPGOn4mIVIgFejvU0dpyydomHYJOKPz1UjU=";
+  };
+
+  patches = [
+    # replace asm by builtin function to ensure compatibility with arm64
+    (fetchpatch2 {
+      url = "https://github.com/KarlsruheGraphGeneration/KaGen/commit/cab9d5dc6cc256972e52675ad9c385524d40ecd9.patch?full_index=1";
+      hash = "sha256-DCsuwUiE98UKZMxlUI9p36/wq486uHHrUphrIVqM+Cc=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace tests/CMakeLists.txt \
+      --replace-fail "FetchContent_MakeAvailable(googletest)" "find_package(GTest REQUIRED)"\
+      --replace-fail "set_property(DIRECTORY" "#set_property(DIRECTORY"
+
+    substituteInPlace kagen/CMakeLists.txt \
+      --replace-fail "OBJECT" ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    mpi
+    cgal
+    sparsehash
+    imagemagick
+    # should be propagated by cgal
+    boost
+    gmp
+    mpfr
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "KAGEN_BUILD_EXAMPLES" withExamples)
+    (lib.cmakeBool "KAGEN_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  doCheck = true;
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeCheckInputs = [
+    gtest
+    ctestCheckHook
+    mpiCheckPhaseHook
+  ];
+
+  disabledTests = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # flaky tests on aarch64-darwin
+    "test_rgg2d.2cores"
+    "test_rgg2d.4cores"
+  ];
+
+  postInstall = ''
+    cmake --install . --component tools
+  '';
+
+  meta = {
+    description = "Communication-free Massively Distributed Graph Generators";
+    homepage = "https://github.com/KarlsruheGraphGeneration/KaGen";
+    changelog = "https://github.com/KarlsruheGraphGeneration/KaGen/releases/tag/v${finalAttrs.version}";
+    mainProgram = "KaGen";
+    license = with lib.licenses; [
+      bsd2
+      mit
+      # boost license
+      lib.licenses.boost
+    ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+})


### PR DESCRIPTION
Communication-free Massively Distributed Graph Generators https://github.com/KarlsruheGraphGeneration/KaGen
depenency of kaminpar https://github.com/NixOS/nixpkgs/pull/394871

This project does not provide standard KaGenconfig.cmake module for downstream packages to use. Downstream consumer will need to either fetch kagen src with git or manualy set the header_include_dir and link_libraray.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
