### PR TITLE
wasm4: init at 2.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13292,6 +13292,13 @@
     github = "JollyDevelopment";
     githubId = 6932224;
   };
+  jomarm = {
+    name = "Jomar Milan";
+    email = "jomarm@pyrodax.com";
+    github = "MacaylaMarvelous81";
+    githubId = 29156241;
+    keys = [ { fingerprint = "F954 C5C9 5AE7 A312 183D  A76C 6AC4 6A6F 9A56 18D8"; } ];
+  };
   jonaenz = {
     name = "Jona Enzinger";
     email = "5xt3zyy5l@mozmail.com";

--- a/pkgs/by-name/wa/wasm4/0001-vendor-web-devtools-elsewhere.patch
+++ b/pkgs/by-name/wa/wasm4/0001-vendor-web-devtools-elsewhere.patch
@@ -1,0 +1,11 @@
+diff -ura web.a/package.json web.b/package.json
+--- web.a/package.json	2025-05-25 19:44:59.060428306 -0700
++++ web.b/package.json	2025-05-25 19:44:52.834495715 -0700
+@@ -16,7 +16,6 @@
+     "lint": "eslint src --fix"
+   },
+   "dependencies": {
+-    "@wasm4/web-devtools": "file:../../devtools/web",
+     "lit": "^3.1.2"
+   },
+   "devDependencies": {

--- a/pkgs/by-name/wa/wasm4/0002-fix-build-wasm3-by-disabling-debug.patch
+++ b/pkgs/by-name/wa/wasm4/0002-fix-build-wasm3-by-disabling-debug.patch
@@ -1,0 +1,31 @@
+diff -ura native.a/vendor/wasm3/CMakeLists.txt native.b/vendor/wasm3/CMakeLists.txt
+--- native.a/vendor/wasm3/CMakeLists.txt	2025-12-06 14:49:28.961968261 -0800
++++ native.b/vendor/wasm3/CMakeLists.txt	2025-12-06 15:00:16.322022055 -0800
+@@ -99,7 +99,7 @@
+ 
+ #-fno-optimize-sibling-calls
+ 
+-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG=1")
++#set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG=1")
+ 
+ if(EMSCRIPTEN OR EMSCRIPTEN_LIB)
+ 
+diff -ura native.a/vendor/wasm3/source/m3_config_platforms.h native.b/vendor/wasm3/source/m3_config_platforms.h
+--- native.a/vendor/wasm3/source/m3_config_platforms.h	2025-12-06 14:49:04.189291630 -0800
++++ native.b/vendor/wasm3/source/m3_config_platforms.h	2025-12-06 15:09:41.626372007 -0800
+@@ -118,6 +118,7 @@
+  * Apply settings
+  */
+ 
++/*
+ # if defined (M3_COMPILER_MSVC)
+ #   define vectorcall   // For MSVC, better not to specify any call convention
+ # elif defined(__x86_64__)
+@@ -141,6 +142,7 @@
+ # elif defined (FOMU)
+ #   define vectorcall   __attribute__((section(".ramtext")))
+ # endif
++*/
+ 
+ #ifndef vectorcall
+ #define vectorcall

--- a/pkgs/by-name/wa/wasm4/package.nix
+++ b/pkgs/by-name/wa/wasm4/package.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  stdenv,
+  cmake,
+  libxrandr,
+  libxinerama,
+  libxcursor,
+  libxi,
+  libxext,
+  libxkbcommon,
+  alsa-lib,
+  libpulseaudio,
+  makeWrapper,
+  nix-update-script,
+}:
+let
+  version = "2.7.1";
+  src = fetchFromGitHub {
+    owner = "aduros";
+    repo = "wasm4";
+    tag = "v${version}";
+    hash = "sha256-QmSqQh+8w8pxoQcgHrsTfv/lIb5Xh7LkATnSMDUwjKo=";
+    # native runtime has submodule-vendored dependencies
+    fetchSubmodules = true;
+  };
+  webDevtools = buildNpmPackage (finalAttrs: {
+    pname = "web-devtools";
+    inherit version;
+
+    inherit src;
+    sourceRoot = "${src.name}/devtools/web";
+
+    npmDepsHash = "sha256-XPSnhQLdzIKY2qCiIfTIXQ8rOm7Tg5nPW7XEE1gmxRo=";
+    # dontNpmBuild = true;
+  });
+  webRuntime = buildNpmPackage (finalAttrs: {
+    pname = "wasm4-runtime";
+    inherit version;
+
+    inherit src;
+    sourceRoot = "${src.name}/runtimes/web";
+
+    patches = [ ./0001-vendor-web-devtools-elsewhere.patch ];
+    preBuildPhases = [ "provideWebDevtoolsPhase" ];
+    provideWebDevtoolsPhase = ''
+      mkdir -p node_modules/@wasm4
+      ln -s ${webDevtools}/lib/node_modules/@wasm4/web-devtools node_modules/@wasm4/web-devtools
+    '';
+    installPhase = ''
+      cp -r dist $out
+    '';
+
+    npmDepsHash = "sha256-LHyfNk0bCsWOB3uAIDqxyN7mpQJ6IsM5Oqx8V3/iNzc=";
+  });
+  nativeRuntime = stdenv.mkDerivation (finalAttrs: {
+    pname = "wasm4-runtime-native";
+    inherit version;
+
+    inherit src;
+    sourceRoot = "${finalAttrs.src.name}/runtimes/native";
+
+    # Without this patch, the vendored dependency wasm3 fails to build on newer clang versions.
+    patches = [ ./0002-fix-build-wasm3-by-disabling-debug.patch ];
+    cmakeFlags = [ "-DWASM_BACKEND=wasm3" ];
+    installPhase = ''
+      # this fails... but it does so on upstream ci too, and it just ignores it
+      # and uses the partial install.
+      cmake --install . --prefix $out --config Release --strip || true
+    '';
+    preFixupPhases = lib.optionals stdenv.hostPlatform.isLinux [ "wrapRuntimePhase" ];
+    wrapRuntimePhase = ''
+      wrapProgram $out/bin/wasm4 --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libpulseaudio ]}
+    '';
+
+    nativeBuildInputs = [
+      cmake
+      makeWrapper
+    ];
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+      libxrandr
+      libxinerama
+      libxcursor
+      libxi
+      libxext
+      libxkbcommon
+      alsa-lib
+      libpulseaudio
+    ];
+  });
+in
+buildNpmPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "wasm4";
+  inherit version;
+
+  inherit src;
+  sourceRoot = "${src.name}/cli";
+
+  preBuildPhases = [
+    "provideWebRuntimePhase"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ "provideNativeLinuxRuntimePhase" ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ "provideNativeDarwinRuntimePhase" ];
+  provideWebRuntimePhase = ''
+    rm assets/runtime
+    cp -r ${webRuntime} assets/runtime
+  '';
+  provideNativeLinuxRuntimePhase = ''
+    mkdir -p assets/natives
+    cp ${nativeRuntime}/bin/wasm4 assets/natives/wasm4-linux
+  '';
+  provideNativeDarwinRuntimePhase = ''
+    mkdir -p assets/natives
+    cp ${nativeRuntime}/bin/wasm4 assets/natives/wasm4-mac
+  '';
+
+  npmDepsHash = "sha256-p+sh1BHHmOY9mvUDOA/9KgoWTXwBfrlK2tqhXLQSeXk=";
+  dontNpmBuild = true;
+
+  meta = {
+    description = "Build retro games using WebAssembly for a fantasy console";
+    homepage = "https://wasm4.org";
+    downloadPage = "https://wasm4.org/docs/getting-started/setup";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ MacaylaMarvelous81 ];
+    mainProgram = "w4";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Packages the CLI for [WASM-4](https://wasm4.org), a fantasy game console. It has previously been submitted but unmerged as an addition to nodePackages at #196215.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
