### PR TITLE
 stalwart-mail: build against system jemalloc [second try]

### DIFF
--- a/nixos/tests/stalwart-mail.nix
+++ b/nixos/tests/stalwart-mail.nix
@@ -48,8 +48,19 @@ in
           session.auth.directory = "'in-memory'";
           storage.directory = "in-memory";
 
+          storage.data = "rocksdb";
+          storage.fts = "rocksdb";
+          storage.blob = "rocksdb";
+          storage.lookup = "rocksdb";
+
           session.rcpt.directory = "'in-memory'";
           queue.outbound.next-hop = "'local'";
+
+          store."rocksdb" = {
+            type = "rocksdb";
+            path = "/var/lib/stalwart-mail/data";
+            compression = "lz4";
+          };
 
           directory."in-memory" = {
             type = "memory";
@@ -116,6 +127,12 @@ in
       main.wait_for_open_port(143)
 
       main.succeed("test-smtp-submission")
+
+      # restart stalwart to test rocksdb compaction of existing database
+      main.succeed("systemctl restart stalwart-mail.service")
+      main.wait_for_open_port(587)
+      main.wait_for_open_port(143)
+
       main.succeed("test-imap-read")
     '';
 


### PR DESCRIPTION
The reason we want to build against our own prebuilt jemalloc is that we can centrally manage all the required parameters to build a working jemalloc for many different platforms (e.g. set a fixed max-supported pagesize instead of auto-detecting it) and also it's good practise to unvendor dependencies in distro packaging.
This has previously caused problems: #411146 

Stalwart sets the Rust allocator to jemalloc via the jemallocator crate.
But rocksdb does not properly distinguish between pointers it has allocated itself, and pointers which were passed in and might be registered with a different allocator.

Thus, rocksdb with jemalloc can only work properly when the malloc library is globally overridden (as can be obtained by setting the `unprefixed_malloc_on_supported_platforms` feature of jemalloc-sys, [as rust-rocksdb does](https://github.com/rust-rocksdb/rust-rocksdb/blob/master/librocksdb-sys/Cargo.toml#L37)), but because stalwart never enables the jemalloc feature of the rocksdb crate, this never happens.

I attached a patch to fix this by enabling the jemalloc feature of the rocksdb crate, which also required changing stalwart to the more maintained tikv-jemallocator to match what rust-rocksdb uses, since we can't have two crates attempting to link jemalloc at the same time.

I suggest doing this only on NixOS master/unstable, and implementing a less invasive workaround for the aarch64 pagesize issue on 25.05 stable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
