### PR TITLE
doc: point manual contributing guides to devmode's README

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -56,11 +56,7 @@ Make sure that your local files aren't added to Git history by adding the follow
 
 #### `devmode`
 
-The shell in the manual source directory makes available a command, `devmode`.
-It is a daemon, that:
-1. watches the manual's source for changes and when they occur — rebuilds
-2. HTTP serves the manual, injecting a script that triggers reload on changes
-3. opens the manual in the default browser
+Use [`devmode`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/de/devmode/README.md) for a live preview when editing the manual.
 
 ### Testing redirects
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -56,7 +56,7 @@ Make sure that your local files aren't added to Git history by adding the follow
 
 #### `devmode`
 
-Use [`devmode`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/de/devmode/README.md) for a live preview when editing the manual.
+Use [`devmode`](../pkgs/by-name/de/devmode/README.md) for a live preview when editing the manual.
 
 ### Testing redirects
 

--- a/nixos/doc/manual/contributing-to-this-manual.chapter.md
+++ b/nixos/doc/manual/contributing-to-this-manual.chapter.md
@@ -37,7 +37,9 @@ Make sure that your local files aren't added to Git history by adding the follow
 /**/.direnv
 ```
 
-You might want to also use [`devmode`](https://github.com/NixOS/nixpkgs/blob/master/doc/README.md#devmode) while editing the manual.
+### `devmode` {#sec-contributing-devmode}
+
+Use [`devmode`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/de/devmode/README.md) to hot reload updates to the manual.
 
 ## Testing redirects {#sec-contributing-redirects}
 

--- a/nixos/doc/manual/contributing-to-this-manual.chapter.md
+++ b/nixos/doc/manual/contributing-to-this-manual.chapter.md
@@ -39,7 +39,7 @@ Make sure that your local files aren't added to Git history by adding the follow
 
 ### `devmode` {#sec-contributing-devmode}
 
-Use [`devmode`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/de/devmode/README.md) to hot reload updates to the manual.
+Use [`devmode`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/de/devmode/README.md) for a live preview when editing the manual.
 
 ## Testing redirects {#sec-contributing-redirects}
 

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -86,6 +86,9 @@
   "sec-contributing-development-env": [
     "index.html#sec-contributing-development-env"
   ],
+  "sec-contributing-devmode": [
+    "index.html#sec-contributing-devmode"
+  ],
   "sec-mattermost": [
     "index.html#sec-mattermost"
   ],

--- a/pkgs/by-name/de/devmode/README.md
+++ b/pkgs/by-name/de/devmode/README.md
@@ -1,0 +1,6 @@
+# `devmode`
+
+`devmode` is a daemon, that:
+1. watches the manual's source for changes and when they occur — rebuilds
+2. HTTP serves the manual, injecting a script that triggers reload on changes
+3. opens the manual in the default browser


### PR DESCRIPTION
There's quite a bit of pingpong redirection with Nixpkgs and NixOS manual utilities. Since devmode was lacking a README, the descriptive text is moved there and it's referenced by both manuals.
