### PR TITLE
melange-json: init at version 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/melange-json/default.nix
+++ b/pkgs/development/ocaml-modules/melange-json/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  yojson,
+  melange,
+  ppxlib,
+}:
+
+buildDunePackage rec {
+  pname = "melange-json";
+  version = "2.0.0";
+  src = fetchFromGitHub {
+    owner = "melange-community";
+    repo = "melange-json";
+    tag = version;
+    hash = "sha256-vgcvPRc2vEHE1AtHyttvs1T0LcoeTOFfmPUCz95goT0=";
+  };
+
+  nativeBuildInputs = [ melange ];
+  buildInputs = [
+    melange
+    yojson
+    ppxlib
+  ];
+  meta = {
+    description = "Compositional JSON encode/decode library and PPX for Melange and OCaml";
+    homepage = "https://github.com/melange-community/melange-json";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.GirardR1006 ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1194,6 +1194,8 @@ let
 
         melange = callPackage ../development/tools/ocaml/melange { };
 
+        melange-json = callPackage ../development/ocaml-modules/melange-json { };
+
         memprof-limits = callPackage ../development/ocaml-modules/memprof-limits { };
 
         memtrace = callPackage ../development/ocaml-modules/memtrace { };


### PR DESCRIPTION
Add melange-json, a compositional JSON encode/decode library and PPX for [Melange](https://melange.re/).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`): no binary files provided as it is only a library; local version works on a project requiring ppx_deriving 
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
