### PR TITLE
[WIP] prrte/pmix: major updates

### DIFF
--- a/pkgs/by-name/op/openmpi/package.nix
+++ b/pkgs/by-name/op/openmpi/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   removeReferencesTo,
+  pkg-config,
   gfortran,
   perl,
   libnl,
@@ -114,8 +115,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature cudaSupport "mca-dso")
     (lib.enableFeature fortranSupport "mpi-fortran")
     (lib.withFeatureAs stdenv.hostPlatform.isLinux "libnl" (lib.getDev libnl))
-    "--with-pmix=${lib.getDev pmix}"
-    "--with-pmix-libdir=${lib.getLib pmix}/lib"
     # Puts a "default OMPI_PRTERUN" value to mpirun / mpiexec executables
     (lib.withFeatureAs true "prrte" (lib.getBin prrte))
     (lib.withFeature enableSGE "sge")

--- a/pkgs/by-name/pm/pmix/package.nix
+++ b/pkgs/by-name/pm/pmix/package.nix
@@ -6,6 +6,7 @@
   autoconf,
   automake,
   removeReferencesTo,
+  testers,
   libtool,
   python3,
   flex,
@@ -20,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pmix";
-  version = "5.0.8";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     repo = "openpmix";
     owner = "openpmix";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oYqDFXycNCYv0YK4VbkW5SQWLq+FTJEyY9rvH50nbYI=";
+    hash = "sha256-vnYHReG9LY2VCXUP1XS4P/yiogVKT+1QWwxMR/sSlU0=";
     fetchSubmodules = true;
   };
 
@@ -35,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs ./autogen.pl
     patchShebangs ./config
+    patchShebangs ./contrib
+    patchShebangs ./src/util/convert-help.py
   '';
 
   nativeBuildInputs = [
@@ -101,6 +104,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
   meta = {
     description = "Process Management Interface for HPC environments";
     homepage = "https://openpmix.github.io/";
@@ -109,5 +114,6 @@ stdenv.mkDerivation (finalAttrs: {
       markuskowa
       doronbehar
     ];
+    pkgConfigModules = [ "pmix" ];
   };
 })

--- a/pkgs/by-name/pr/prrte/package.nix
+++ b/pkgs/by-name/pr/prrte/package.nix
@@ -7,6 +7,7 @@
   automake,
   libtool,
   gitMinimal,
+  pkg-config,
   perl,
   python3,
   flex,
@@ -18,13 +19,13 @@
 
 stdenv.mkDerivation rec {
   pname = "prrte";
-  version = "3.0.11";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "openpmix";
     repo = "prrte";
     tag = "v${version}";
-    hash = "sha256-4JEh4N/38k0Xgp0CqnFipaEZlJBQr8nyxoncyz0/7yo=";
+    hash = "sha256-gLCRTymwNsQw8GzWe8rPzwjYs604pc3/vRC465luNnc=";
     fetchSubmodules = true;
   };
 
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    patchShebangs ./autogen.pl ./config
+    patchShebangs ./autogen.pl ./config ./src/util/prte-convert-help.py
 
     # This is needed for multi-node jobs.
     # mpirun/srun/prterun does not have "prted" in its path unless
@@ -50,6 +51,8 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     moveToOutput "bin/prte_info" "''${!outputDev}"
+    moveToOutput "bin/prte-info" "''${!outputDev}"
+
     # Fix a broken symlink, created due to FHS assumptions
     rm "$out/bin/pcc"
     ln -s ${lib.getDev pmix}/bin/pmixcc "''${!outputDev}"/bin/pcc
@@ -66,6 +69,7 @@ stdenv.mkDerivation rec {
     libtool
     flex
     gitMinimal
+    pkg-config
   ];
 
   buildInputs = [
@@ -73,12 +77,6 @@ stdenv.mkDerivation rec {
     hwloc
     zlib
     pmix
-  ];
-
-  # Setting this manually, required for RiscV cross-compile
-  configureFlags = [
-    "--with-pmix=${lib.getDev pmix}"
-    "--with-pmix-libdir=${lib.getLib pmix}/lib"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/sl/slurm/package.nix
+++ b/pkgs/by-name/sl/slurm/package.nix
@@ -60,18 +60,16 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     substituteInPlace src/common/env.c \
-        --replace "/bin/echo" "${coreutils}/bin/echo"
-
+        --replace-fail "/bin/echo" "${coreutils}/bin/echo"
     # Autoconf does not support split packages for pmix (libs and headers).
     # Fix the path to the pmix libraries, so dlopen can find it.
     substituteInPlace src/plugins/mpi/pmix/mpi_pmix.c \
-        --replace 'xstrfmtcat(full_path, "%s/", PMIXP_LIBPATH)' \
+        --replace-fail 'xstrfmtcat(full_path, "%s/", PMIXP_LIBPATH)' \
                   'xstrfmtcat(full_path, "${lib.getLib pmix}/lib/")'
-
   ''
   + (lib.optionalString enableX11 ''
     substituteInPlace src/common/x11_util.c \
-        --replace '"/usr/bin/xauth"' '"${xorg.xauth}/bin/xauth"'
+        --replace-fail '"/usr/bin/xauth"' '"${xorg.xauth}/bin/xauth"'
   '');
 
   # nixos test fails to start slurmd with 'undefined symbol: slurm_job_preempt_mode'

--- a/pkgs/by-name/sl/slurm/package.nix
+++ b/pkgs/by-name/sl/slurm/package.nix
@@ -148,12 +148,12 @@ stdenv.mkDerivation rec {
 
   passthru.tests.slurm = nixosTests.slurm;
 
-  meta = with lib; {
+  meta = {
     homepage = "http://www.schedmd.com/";
     description = "Simple Linux Utility for Resource Management";
-    platforms = platforms.linux;
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [
       jagajaga
       markuskowa
     ];


### PR DESCRIPTION
Update PMIX and PRRTE.
Note both need to be updated simultaneously. 

See: 
* https://github.com/openpmix/prrte/releases
* https://github.com/openpmix/openpmix/releases/tag/v6.0.0

Putting this in draft stage, since it breaks Slurm. The current version does not support pmix-6.

@doronbehar FYI, putting this here to document ongoing progress.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
