### PR TITLE
qutebrowser: fix on darwin

### DIFF
--- a/pkgs/by-name/qu/qutebrowser/package.nix
+++ b/pkgs/by-name/qu/qutebrowser/package.nix
@@ -8,6 +8,7 @@
   asciidoc,
   docbook_xml_dtd_45,
   docbook_xsl,
+  desktopToDarwinBundle,
   libxml2,
   libxslt,
   withPdfReader ? true,
@@ -69,7 +70,7 @@ python3.pkgs.buildPythonApplication {
     docbook_xsl
     libxml2
     libxslt
-  ];
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
 
   dependencies = with python3.pkgs; [
     colorama
@@ -131,6 +132,11 @@ python3.pkgs.buildPythonApplication {
   preFixup =
     let
       libPath = lib.makeLibraryPath [ pipewire ];
+      resourcesPath =
+        if (isQt6 && stdenv.hostPlatform.isDarwin) then
+          "${qt6Packages.qtwebengine}/lib/QtWebEngineCore.framework/Resources"
+        else
+          "${qt6Packages.qtwebengine}/resources";
     in
     ''
       makeWrapperArgs+=(
@@ -145,7 +151,7 @@ python3.pkgs.buildPythonApplication {
           --set-default QSG_RHI_BACKEND vulkan
         ''}
         ${lib.optionalString enableWideVine ''--add-flags "--qt-flag widevine-path=${widevine-cdm}/share/google/chrome/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so"''}
-        --set QTWEBENGINE_RESOURCES_PATH "${qt6Packages.qtwebengine}/resources"
+        --set QTWEBENGINE_RESOURCES_PATH "${resourcesPath}"
       )
     '';
 


### PR DESCRIPTION
```sh
$ qutebrowser
17:50:23 INFO: Run :adblock-update to get adblock lists.
17:50:24 CRITICAL: The following paths were searched for Qt WebEngine resources:
  /nix/store/b0rnn35pm662fsc0xvyc15sgwfqx095p-qtwebengine-6.9.0/resources
but could not find any.

fish: Job 1, 'qutebrowser' terminated by signal SIGABRT (Abort)
```
Caused by switching to Qt6 in #398471.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
