### PR TITLE
lib.fileset: support fileFilter for file sets

### DIFF
--- a/lib/fileset/README.md
+++ b/lib/fileset/README.md
@@ -239,21 +239,6 @@ Arguments:
   And it would be unclear how the library should behave if the one file wouldn't be added to the store:
   `toSource { root = ./file.nix; fileset = <empty>; }` has no reasonable result because returning an empty store path wouldn't match the file type, and there's no way to have an empty file store path, whatever that would mean.
 
-### `fileFilter` takes a path
-
-The `fileFilter` function takes a path, and not a file set, as its second argument.
-
-- (-) Makes it harder to compose functions, since the file set type, the return value, can't be passed to the function itself like `fileFilter predicate fileset`
-  - (+) It's still possible to use `intersection` to filter on file sets: `intersection fileset (fileFilter predicate ./.)`
-    - (-) This does need an extra `./.` argument that's not obvious
-      - (+) This could always be `/.` or the project directory, `intersection` will make it lazy
-- (+) In the future this will allow `fileFilter` to support a predicate property like `subpath` and/or `components` in a reproducible way.
-  This wouldn't be possible if it took a file set, because file sets don't have a predictable absolute path.
-  - (-) What about the base path?
-    - (+) That can change depending on which files are included, so if it's used for `fileFilter`
-      it would change the `subpath`/`components` value depending on which files are included.
-- (+) If necessary, this restriction can be relaxed later, the opposite wouldn't be possible
-
 ### Strict path existence checking
 
 Coercing paths that don't exist to file sets always gives an error.

--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -767,9 +767,9 @@ in
 
       Other attributes may be added in the future.
 
-    `path`
+    `fileset`
 
-    : The path whose files to filter
+    : The file set whose files to filter
 
     # Type
 
@@ -781,7 +781,7 @@ in
         hasExt :: String -> Bool,
         ...
       } -> Bool)
-      -> Path
+      -> FileSet
       -> FileSet
     ```
 
@@ -806,20 +806,11 @@ in
     :::
   */
   fileFilter =
-    predicate: path:
+    predicate: fileset:
     if !isFunction predicate then
       throw ''lib.fileset.fileFilter: First argument is of type ${typeOf predicate}, but it should be a function instead.''
-    else if !isPath path then
-      if path._type or "" == "fileset" then
-        throw ''
-          lib.fileset.fileFilter: Second argument is a file set, but it should be a path instead.
-              If you need to filter files in a file set, use `intersection fileset (fileFilter pred ./.)` instead.''
-      else
-        throw ''lib.fileset.fileFilter: Second argument is of type ${typeOf path}, but it should be a path instead.''
-    else if !pathExists path then
-      throw ''lib.fileset.fileFilter: Second argument (${toString path}) is a path that does not exist.''
     else
-      _fileFilter predicate path;
+      _fileFilter predicate (_coerce "lib.fileset.fileFilter: Second argument" fileset);
 
   /**
     Create a file set with the same files as a `lib.sources`-based value.

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -112,7 +112,7 @@ rec {
       filesetV2:
       filesetV2
       // {
-        # All v1 file sets are not the new empty file set
+        # All v2 file sets are not the new empty file set
         _internalIsEmptyWithoutBase = false;
         _internalVersion = 3;
       }
@@ -291,7 +291,7 @@ rec {
       mapAttrs (name: value: null) (readDir path) // value;
 
   /**
-    A normalisation of a filesetTree suitable filtering with `builtins.path`:
+    A normalisation of a filesetTree suitable for filtering with `builtins.path`:
     - Replace all directories that have no files with `null`.
       This removes directories that would be empty
     - Replace all directories with all files with `"directory"`.

--- a/lib/fileset/tests.sh
+++ b/lib/fileset/tests.sh
@@ -842,9 +842,7 @@ checkFileset 'difference ./. ./b'
 expectFailure 'fileFilter null (abort "this is not needed")' 'lib.fileset.fileFilter: First argument is of type null, but it should be a function instead.'
 
 # The second argument needs to be an existing path
-expectFailure 'fileFilter (file: abort "this is not needed") _emptyWithoutBase' 'lib.fileset.fileFilter: Second argument is a file set, but it should be a path instead.
-[[:blank:]]*If you need to filter files in a file set, use `intersection fileset \(fileFilter pred \./\.\)` instead.'
-expectFailure 'fileFilter (file: abort "this is not needed") null' 'lib.fileset.fileFilter: Second argument is of type null, but it should be a path instead.'
+expectFailure 'fileFilter (file: abort "this is not needed") null' 'lib.fileset.fileFilter: Second argument is of type null, but it should be a file set or a path instead.'
 expectFailure 'fileFilter (file: abort "this is not needed") ./a' 'lib.fileset.fileFilter: Second argument \('"$work"'/a\) is a path that does not exist.'
 
 # The predicate is not called when there's no files


### PR DESCRIPTION
Not supporting file sets for fileFilter was a conscious decision when the function was introduced. The only argument in favor of that decision was future extensibility for predicate properties like `subpath` or `components`. Since those operate on the full path, not only on the filename, we could introduce a new function `pathFilter` in the future, which supports only paths, but also path-based filtering. Thus, the door is not closed for that extension.

## Things done

- [ ] Tested, as applicable:
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [x] Tested basic functionality
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
