### PR TITLE
nixos-render-docs/redirects: implement mass move of identifiers

### DIFF
--- a/pkgs/by-name/ni/nixos-render-docs-redirects/src/tests/test_redirects.py
+++ b/pkgs/by-name/ni/nixos-render-docs-redirects/src/tests/test_redirects.py
@@ -1,7 +1,11 @@
 import unittest
+from unittest.mock import patch
+from io import StringIO
+import json
 from nixos_render_docs_redirects import (
     add_content,
     move_content,
+    mass_move_content,
     rename_identifier,
     remove_and_redirect,
     IdentifierExists,
@@ -43,6 +47,44 @@ class RedirectsTestCase(unittest.TestCase):
 
         with self.assertRaises(IdentifierNotFound):
             move_content(result, "baz", "path.html")
+
+    @patch('sys.stdin', new_callable=StringIO)
+    def test_mass_move_content(self, mock_stdin):
+        initial_redirects = {
+            "foo": ["path/to/foo.html#foo"],
+            "bar": ["path/to/bar.html#bar"],
+            "baz": ["path/to/baz.html#baz"],
+        }
+        final_redirects = {
+            "foo": ["new/path.html#foo", "path/to/foo.html#foo"],
+            "bar": ["new/path.html#bar", "path/to/bar.html#bar"],
+            "baz": ["new/path.html#baz", "path/to/baz.html#baz"],
+        }
+
+        mock_stdin.write(f"""
+        A line
+        Another line
+        NRD_E_OUTPATH:{json.dumps(["foo", "bar", "baz"])}
+        More lines
+        """)
+        mock_stdin.seek(0)
+
+        result, count = mass_move_content(initial_redirects, "new/path.html")
+        self.assertEqual(count, 3)
+        self.assertEqual(list(result.items()), list(final_redirects.items()))
+
+    @patch('sys.stdin', new_callable=StringIO)
+    def test_mass_move_content_wrong_format(self, mock_stdin):
+        mock_stdin.write(f"""
+        A line
+        Another line
+        NRD_E_OUTPATH:"foo", "bar", "baz"
+        More lines
+        """)
+        mock_stdin.seek(0)
+
+        with self.assertRaises(json.decoder.JSONDecodeError):
+            result, count = mass_move_content({}, "")
 
 
     def test_rename_identifier(self):

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -703,6 +703,7 @@ def _build_cli_html(p: argparse.ArgumentParser) -> None:
     p.add_argument('--section-toc-depth', default=0, type=int)
     p.add_argument('--media-dir', default="media", type=Path)
     p.add_argument('--redirects', type=Path)
+    p.add_argument('--redirects-pipe-missing-outpath', default=True)
     p.add_argument('infile', type=Path)
     p.add_argument('outfile', type=Path)
 
@@ -711,13 +712,14 @@ def _run_cli_html(args: argparse.Namespace) -> None:
         redirects = None
         if args.redirects:
             with open(args.redirects) as raw_redirects:
-                redirects = Redirects(json.load(raw_redirects), redirects_script.read())
+                redirects = Redirects(json.load(raw_redirects), redirects_script.read(), 
+                                      args.redirects_pipe_missing_outpath)
 
         md = HTMLConverter(
             args.revision,
             HTMLParameters(args.generator, args.stylesheet, args.script, args.toc_depth,
                            args.chunk_toc_depth, args.section_toc_depth, args.media_dir),
-            json.load(manpage_urls), redirects)
+                           json.load(manpage_urls), redirects)
         md.convert(args.infile, args.outfile)
 
 def build_cli(p: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
This is a crude first attempt at piping erronous identifiers from nrd to the redirects utility. Ideally, nrd could be more modular to simplify reusing its parsing for these purposes, but this does the trick for the time being.

Example:
nix-build ./nixos/release.nix -A manual.x86_64-linux 2>&1 | redirects mass-move-content "new-path.html"

