### PR TITLE
libgourou: 0.8.2 -> 0.8.7

### DIFF
--- a/pkgs/by-name/li/libgourou/package.nix
+++ b/pkgs/by-name/li/libgourou/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchzip,
+  fetchFromGitea,
   pugixml,
   updfparser,
   curl,
@@ -10,12 +10,15 @@
   installShellFiles,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libgourou";
   version = "0.8.7";
 
-  src = fetchzip {
-    url = "https://forge.soutade.fr/soutade/libgourou/archive/v${version}.tar.gz";
+  src = fetchFromGitea {
+    domain = "forge.soutade.fr";
+    owner = "soutade";
+    repo = "libgourou";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Tkft/pe3lH07pmyVibTEutIIvconUWDH1ZVN3qV4sSY=";
   };
 
@@ -46,7 +49,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
     install -Dt $out/include include/libgourou*.h
     install -Dt $out/lib libgourou.so
-    install -Dt $out/lib libgourou.so.${version}
+    install -Dt $out/lib libgourou.so.${finalAttrs.version}
     install -Dt $out/lib libgourou.a
     install -Dt $out/bin utils/acsmdownloader
     install -Dt $out/bin utils/adept_{activate,loan_mgt,remove}
@@ -62,4 +65,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/by-name/li/libgourou/package.nix
+++ b/pkgs/by-name/li/libgourou/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Implementation of Adobe's ADEPT protocol for ePub/PDF DRM";
-    homepage = "https://indefero.soutade.fr/p/libgourou";
+    homepage = "https://forge.soutade.fr/soutade/libgourou";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ autumnal ];
     platforms = platforms.all;

--- a/pkgs/by-name/li/libgourou/package.nix
+++ b/pkgs/by-name/li/libgourou/package.nix
@@ -15,9 +15,8 @@ stdenv.mkDerivation rec {
   version = "0.8.2";
 
   src = fetchzip {
-    url = "https://indefero.soutade.fr/p/libgourou/source/download/v${version}/";
     sha256 = "sha256-adkrvBCgN07Ir+J3JFCy+X9p9609lj1w8nElrlHXTxc";
-    extension = "zip";
+    url = "https://forge.soutade.fr/soutade/libgourou/archive/v${version}.tar.gz";
   };
 
   postPatch = ''

--- a/pkgs/by-name/li/libgourou/package.nix
+++ b/pkgs/by-name/li/libgourou/package.nix
@@ -12,11 +12,11 @@
 
 stdenv.mkDerivation rec {
   pname = "libgourou";
-  version = "0.8.2";
+  version = "0.8.7";
 
   src = fetchzip {
-    sha256 = "sha256-adkrvBCgN07Ir+J3JFCy+X9p9609lj1w8nElrlHXTxc";
     url = "https://forge.soutade.fr/soutade/libgourou/archive/v${version}.tar.gz";
+    hash = "sha256-Tkft/pe3lH07pmyVibTEutIIvconUWDH1ZVN3qV4sSY=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/up/updfparser/package.nix
+++ b/pkgs/by-name/up/updfparser/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Very simple PDF parser";
-    homepage = "https://indefero.soutade.fr/p/updfparser";
+    homepage = "https://forge.soutade.fr/soutade/updfparser";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ autumnal ];
     platforms = platforms.all;

--- a/pkgs/by-name/up/updfparser/package.nix
+++ b/pkgs/by-name/up/updfparser/package.nix
@@ -1,16 +1,19 @@
 {
   lib,
   stdenv,
-  fetchzip,
+  fetchFromGitea,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   name = "updfparser";
-  version = "unstable-2024-03-24";
+  version = "0-unstable-2024-03-24";
   rev = "6060d123441a06df699eb275ae5ffdd50409b8f3";
 
-  src = fetchzip {
-    url = "https://forge.soutade.fr/soutade/updfparser/archive/${rev}.tar.gz";
+  src = fetchFromGitea {
+    inherit (finalAttrs) rev;
+    domain = "forge.soutade.fr";
+    owner = "soutade";
+    repo = "updfparser";
     hash = "sha256-HD73WGZ4e/3T7vQmwU/lRADtvsInFG62uqvJmF773Rk=";
   };
 
@@ -34,4 +37,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ autumnal ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/by-name/up/updfparser/package.nix
+++ b/pkgs/by-name/up/updfparser/package.nix
@@ -6,12 +6,12 @@
 
 stdenv.mkDerivation rec {
   name = "updfparser";
-  version = "unstable-2023-08-08";
-  rev = "c5ce75b9eea8ebb2746b13eeb0f335813c615115";
+  version = "unstable-2024-03-24";
+  rev = "6060d123441a06df699eb275ae5ffdd50409b8f3";
 
   src = fetchzip {
-    hash = "sha256-RT7mvu43Izp0rHhKq4wR4kt0TDfzHvB2NGMR+fxO5UM=";
     url = "https://forge.soutade.fr/soutade/updfparser/archive/${rev}.tar.gz";
+    hash = "sha256-HD73WGZ4e/3T7vQmwU/lRADtvsInFG62uqvJmF773Rk=";
   };
 
   makeFlags = [

--- a/pkgs/by-name/up/updfparser/package.nix
+++ b/pkgs/by-name/up/updfparser/package.nix
@@ -10,9 +10,8 @@ stdenv.mkDerivation rec {
   rev = "c5ce75b9eea8ebb2746b13eeb0f335813c615115";
 
   src = fetchzip {
-    url = "https://indefero.soutade.fr/p/updfparser/source/download/${rev}/";
     hash = "sha256-RT7mvu43Izp0rHhKq4wR4kt0TDfzHvB2NGMR+fxO5UM=";
-    extension = "zip";
+    url = "https://forge.soutade.fr/soutade/updfparser/archive/${rev}.tar.gz";
   };
 
   makeFlags = [


### PR DESCRIPTION
This updates libgourou to 0.8.7 and updfparser to unstable-2024-03-24

The source URLs were also updated to reflect the author switching to another Git forge (Gitea).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
