### PR TITLE
dwm-status: 1.9.0 -> 1.10.0; nixos/dwm-status: run with --quiet

### DIFF
--- a/nixos/modules/services/misc/dwm-status.nix
+++ b/nixos/modules/services/misc/dwm-status.nix
@@ -69,7 +69,7 @@ in
       wantedBy = [ "graphical-session.target" ];
       partOf = [ "graphical-session.target" ];
 
-      serviceConfig.ExecStart = "${cfg.package}/bin/dwm-status ${configFile}";
+      serviceConfig.ExecStart = "${cfg.package}/bin/dwm-status ${configFile} --quiet";
     };
 
   };

--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -38,8 +38,8 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "Gerschtli";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-982JFYZroskKppAOZjBWOFt624FfRjhXpYN57s/cM50=";
+    tag = version;
+    hash = "sha256-982JFYZroskKppAOZjBWOFt624FfRjhXpYN57s/cM50=";
   };
 
   nativeBuildInputs = [
@@ -62,13 +62,13 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Highly performant and configurable DWM status service";
     homepage = "https://github.com/Gerschtli/dwm-status";
-    changelog = "https://github.com/Gerschtli/dwm-status/blob/master/CHANGELOG.md";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ gerschtli ];
+    changelog = "https://github.com/Gerschtli/dwm-status/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gerschtli ];
     mainProgram = "dwm-status";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -15,6 +15,7 @@
   dnsutils,
   iproute2,
   wirelesstools,
+  nix-update-script,
 }:
 
 let
@@ -58,6 +59,8 @@ rustPlatform.buildRustPackage rec {
   postInstall = lib.optionalString (bins != [ ]) ''
     wrapProgram $out/bin/dwm-status --prefix "PATH" : "${lib.makeBinPath bins}"
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Highly performant and configurable DWM status service";

--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -33,13 +33,13 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "dwm-status";
-  version = "1.9.0";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "Gerschtli";
     repo = pname;
     rev = version;
-    sha256 = "sha256-OFwI4evwbXLO4ufjrh5SZia79bwbAKVoSm/IPCDku68=";
+    sha256 = "sha256-982JFYZroskKppAOZjBWOFt624FfRjhXpYN57s/cM50=";
   };
 
   nativeBuildInputs = [
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-G31p8iVRUODD4hUssXaOqEOUTW+C+GZMy/L/tgumDtA=";
+  cargoHash = "sha256-2/zzE6JzhqeBYLiRkx5ELaW150rk1bMTrpxSw/wxNes=";
 
   postInstall = lib.optionalString (bins != [ ]) ''
     wrapProgram $out/bin/dwm-status --prefix "PATH" : "${lib.makeBinPath bins}"

--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -67,7 +67,10 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Gerschtli/dwm-status";
     changelog = "https://github.com/Gerschtli/dwm-status/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gerschtli ];
+    maintainers = with lib.maintainers; [
+      gepbird
+      gerschtli
+    ];
     mainProgram = "dwm-status";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/Gerschtli/dwm-status/blob/1.9.0/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
