### PR TITLE
workflows/check-cherry-picks: fix silent failure

### DIFF
--- a/maintainers/scripts/check-cherry-picks.sh
+++ b/maintainers/scripts/check-cherry-picks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Find alleged cherry-picks
 
-set -e
+set -eo pipefail
 
 if [ $# != "2" ] ; then
   echo "usage: check-cherry-picks.sh base_rev head_rev"
@@ -10,6 +10,10 @@ fi
 
 PICKABLE_BRANCHES=${PICKABLE_BRANCHES:-master staging release-??.?? staging-??.??}
 problem=0
+
+commits="$(git rev-list \
+  -E -i --grep="cherry.*[0-9a-f]{40}" --reverse \
+  "$1..$2")"
 
 while read new_commit_sha ; do
   if [ -z "$new_commit_sha" ] ; then
@@ -88,10 +92,6 @@ while read new_commit_sha ; do
   echo "$original_commit_sha not found in any pickable branch"
 
   problem=1
-done <<< "$(
-  git rev-list \
-    -E -i --grep="cherry.*[0-9a-f]{40}" --reverse \
-    "$1..$2"
-)"
+done <<< "$commits"
 
 exit $problem

--- a/maintainers/scripts/check-cherry-picks.sh
+++ b/maintainers/scripts/check-cherry-picks.sh
@@ -8,6 +8,9 @@ if [ $# != "2" ] ; then
   exit 2
 fi
 
+# Make sure we are inside the nixpkgs repo, even when called from outside
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 PICKABLE_BRANCHES=${PICKABLE_BRANCHES:-master staging release-??.?? staging-??.??}
 problem=0
 


### PR DESCRIPTION
Regression caused in #410791.

## Things done

- [x] Tested the script locally from outside the checkout.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
