### PR TITLE
nixos/zwave-js: allow non-world-readable secrets

### DIFF
--- a/nixos/modules/services/home-automation/zwave-js.nix
+++ b/nixos/modules/services/home-automation/zwave-js.nix
@@ -108,8 +108,9 @@ in
         description = "Z-Wave JS Server";
         serviceConfig = {
           ExecStartPre = ''
-            /bin/sh -c "${pkgs.jq}/bin/jq -s '.[0] * .[1]' ${configFile} ${cfg.secretsConfigFile} > ${mergedConfigFile}"
+            /bin/sh -c "${pkgs.jq}/bin/jq -s '.[0] * .[1]' ${configFile} %d/secrets.json > ${mergedConfigFile}"
           '';
+          LoadCredential = "secrets.json:${cfg.secretsConfigFile}";
           ExecStart = lib.concatStringsSep " " [
             "${cfg.package}/bin/zwave-server"
             "--config ${mergedConfigFile}"

--- a/nixos/tests/zwave-js.nix
+++ b/nixos/tests/zwave-js.nix
@@ -1,25 +1,24 @@
-{ pkgs, lib, ... }:
+{ lib, ... }:
 
-let
-  secretsConfigFile = pkgs.writeText "secrets.json" (
-    builtins.toJSON {
-      securityKeys = {
-        "S0_Legacy" = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-      };
-    }
-  );
-in
 {
   name = "zwave-js";
   meta.maintainers = with lib.maintainers; [ graham33 ];
 
   nodes = {
     machine = {
+      # show that 0400 secrets can be used by the DynamicUser; ideally
+      # this would be an out-of-store file, e.g. /run/secrets/jwavejs/secrets.json
+      environment.etc."zwavejs/secrets.json" = {
+        mode = "0400";
+        text = builtins.toJSON {
+          securityKeys.S0_Legacy = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        };
+      };
       services.zwave-js = {
         enable = true;
         serialPort = "/dev/null";
         extraFlags = [ "--mock-driver" ];
-        inherit secretsConfigFile;
+        secretsConfigFile = "/etc/zwavejs/secrets.json";
       };
     };
   };


### PR DESCRIPTION
Currently the module's `DynamicUser` does not exist at build time and therefore this module's secrets file can't be assigned appropriate (e.g. 0400) permissions without additional configuration.
This change uses `LoadCredential` to read the secrets file with elevated privileges and place then into the service-specific credentials directory, where the dynamic user can access them.

This will allow using standard approaches to nix secrets (such as sops, agenix), which by default provide an out-of-store `0400 root:root` file.

Also updates the nixos test using an `0400 root:root` secrets file to help protect against regression.

Fixes https://github.com/NixOS/nixpkgs/issues/408780


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
