### PR TITLE
open-webui: 0.6.10 -> 0.6.11

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -2,7 +2,6 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  fetchpatch2,
   python3Packages,
   nixosTests,
   fetchurl,
@@ -10,27 +9,18 @@
 }:
 let
   pname = "open-webui";
-  version = "0.6.10";
+  version = "0.6.11";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-OZPZlF6tXzfuFU8/ZavE67E8+XdRu+7oCA1eD0EA9fg=";
+    hash = "sha256-G5rbSClztrphQwVYoBvfFTZ/dPHCuxL1PdZZhSy2RbQ=";
   };
 
   frontend = buildNpmPackage rec {
     pname = "open-webui-frontend";
     inherit version src;
-
-    patches = [
-      # Git is not available in the sandbox
-      # Remove this patch at the next release
-      (fetchpatch2 {
-        url = "https://github.com/open-webui/open-webui/commit/ed0659aca60eedadadba4362b309015b4a8368c6.patch";
-        hash = "sha256-lTzCdAk9gagIfN5Ld1tCS3gp/oVm4+CRy/lD42702WM=";
-      })
-    ];
 
     # the backend for run-on-client-browser python execution
     # must match lock file in open-webui
@@ -42,7 +32,7 @@ let
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 
-    npmDepsHash = "sha256-F/xum76SHFwX/77kPHTFayJ00wv6ZWE09hw8taUbMMQ=";
+    npmDepsHash = "sha256-qQzAehIXMWyXmz7jT0aU6zsSXi3WVcOjchcA+3M7tAU=";
 
     # Disabling `pyodide:fetch` as it downloads packages during `buildPhase`
     # Until this is solved, running python packages from the browser will not work.
@@ -197,6 +187,7 @@ python3Packages.buildPythonApplication rec {
       sentence-transformers
       sentencepiece
       soundfile
+      starlette-compress
       tencentcloud-sdk-python
       tiktoken
       transformers

--- a/pkgs/development/python-modules/starlette-compress/default.nix
+++ b/pkgs/development/python-modules/starlette-compress/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  brotli,
+  brotlicffi,
+  starlette,
+  zstandard,
+  pytestCheckHook,
+  httpx,
+  trio,
+}:
+
+buildPythonPackage rec {
+  pname = "starlette-compress";
+  version = "1.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Zaczero";
+    repo = "starlette-compress";
+    tag = version;
+    hash = "sha256-VEVPbCGE4BQo/0t/P785TyMHZGSKCicV6H0LbBsv8uo=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    brotli
+    brotlicffi
+    starlette
+    zstandard
+  ];
+
+  checkInputs = [
+    httpx
+    trio
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "starlette_compress" ];
+
+  meta = {
+    description = "Compression middleware for Starlette - supporting ZStd, Brotli, and GZip";
+    homepage = "https://pypi.org/p/starlette-compress";
+    license = lib.licenses.bsd0;
+    maintainers = with lib.maintainers; [ wrvsrx ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16726,6 +16726,8 @@ self: super: with self; {
 
   starlette-admin = callPackage ../development/python-modules/starlette-admin { };
 
+  starlette-compress = callPackage ../development/python-modules/starlette-compress { };
+
   starlette-context = callPackage ../development/python-modules/starlette-context { };
 
   starlette-wtf = callPackage ../development/python-modules/starlette-wtf { };


### PR DESCRIPTION
Update open-webui from 0.6.10 to 0.6.11.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
