### PR TITLE
nixos/systemd-stage-1: Mount /sysroot/run with rbind

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -642,7 +642,7 @@ in
         {
           where = "/sysroot/run";
           what = "/run";
-          options = "bind";
+          options = "rbind";
           unitConfig = {
             # See the comment on the mount unit for /run/etc-metadata
             DefaultDependencies = false;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1291,6 +1291,7 @@ in
   systemd-confinement = handleTest ./systemd-confinement { };
   systemd-coredump = runTest ./systemd-coredump.nix;
   systemd-cryptenroll = runTest ./systemd-cryptenroll.nix;
+  systemd-credentials-cmdline = runTest ./systemd-credentials-cmdline.nix;
   systemd-credentials-tpm2 = runTest ./systemd-credentials-tpm2.nix;
   systemd-escaping = runTest ./systemd-escaping.nix;
   systemd-initrd-bridge = runTest ./systemd-initrd-bridge.nix;

--- a/nixos/tests/systemd-credentials-cmdline.nix
+++ b/nixos/tests/systemd-credentials-cmdline.nix
@@ -1,0 +1,24 @@
+{ ... }:
+{
+  name = "systemd-credentials-cmdline";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      boot.kernelParams = [ "systemd.set_credential=foo.bar:baz" ];
+      boot.initrd.systemd.enable = true;
+      systemd.services.read-credential = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ImportCredential = "foo.bar";
+          ExecStart = [ "${pkgs.coreutils}/bin/cat \${CREDENTIALS_DIRECTORY}/foo.bar" ];
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("read-credential.service")
+  '';
+}

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -938,6 +938,7 @@ stdenv.mkDerivation (finalAttrs: {
             systemd-confinement
             systemd-coredump
             systemd-cryptenroll
+            systemd-credentials-cmdline
             systemd-credentials-tpm2
             systemd-escaping
             systemd-initrd-btrfs-raid


### PR DESCRIPTION
When systemd transitions to stage 2, it will move the API file systems
(/run, /dev/, etc.) into /sysroot recursively, but not for any that
are already mounted. So the fact that we already mounted /run prevents
systemd from recursively moving the other file systems underneath
/run, including /run/credentials (which is where systemd stores the
cmdline credentials). This is why cmdline credentials don't work.

TODO: Realistically, I'd like to do this stuff differently. I don't
like that we have our own /sysroot/run mount unit. I'd like to just
run activation with RootDirectory= and MountAPIVFS= but that has
proved more challenging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ x x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
