### PR TITLE
positron: add aarch64-linux and update to 2025.06.0-146

### DIFF
--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -33,6 +33,11 @@ stdenv.mkDerivation {
         url = "https://cdn.posit.co/positron/dailies/mac/universal/Positron-${version}.dmg";
         hash = "sha256-dmRYKysQJYrNWyGvH9DsNIC0tIHYNix7QWagVtuGx1g=";
       }
+    else if stdenv.hostPlatform.system == "aarch64-linux" then
+      fetchurl {
+        url = "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${version}-arm64.deb";
+        hash = "sha256-RPSQONl6Oj9UgFD2EIqGcbiCtuNJug1I+xaKiWeOyls=";
+      }
     else
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${version}-x64.deb";
@@ -133,6 +138,9 @@ stdenv.mkDerivation {
       detroyejr
     ];
     mainProgram = "positron";
-    platforms = [ "x86_64-linux" ] ++ platforms.darwin;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ] ++ platforms.darwin;
   };
 }

--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -22,7 +22,7 @@
 }:
 let
   pname = "positron-bin";
-  version = "2025.05.0-75";
+  version = "2025.06.0-146";
 in
 stdenv.mkDerivation {
   inherit version pname;
@@ -31,17 +31,17 @@ stdenv.mkDerivation {
     if stdenv.hostPlatform.isDarwin then
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/mac/universal/Positron-${version}.dmg";
-        hash = "sha256-dmRYKysQJYrNWyGvH9DsNIC0tIHYNix7QWagVtuGx1g=";
+        hash = "sha256-V9ADtOskxEbGZryXD/6aiUDeTvqPzoY372f/Vo5195s=";
       }
     else if stdenv.hostPlatform.system == "aarch64-linux" then
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${version}-arm64.deb";
-        hash = "sha256-RPSQONl6Oj9UgFD2EIqGcbiCtuNJug1I+xaKiWeOyls=";
+        hash = "sha256-FiCTF5Bmfp4id9HXuB4luSGT9A7OoquaRW/QIh0A3ZY=";
       }
     else
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${version}-x64.deb";
-        hash = "sha256-dmJrDE3g44aoCsVBvSDDFLt38uIqxzaXPBhcmu/U5Oo=";
+        hash = "sha256-FnNoLV9uqgUeumYpHtRJuHrFA6mL65KI4jru7Ebq0/o=";
       };
 
   buildInputs =

--- a/pkgs/by-name/po/positron-bin/update.sh
+++ b/pkgs/by-name/po/positron-bin/update.sh
@@ -27,7 +27,7 @@ new_hash=$(nix store prefetch-file --json --hash-type sha256 \
 
 sed -i "s|$current_hash|$new_hash|g" $positron_nix
 
-# Update Linux hash.
+# Update Linux x86_64 hash.
 current_hash=$(nix store prefetch-file --json --hash-type sha256 \
     "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${current_version}-x64.deb" \
     | jq -r .hash)
@@ -38,17 +38,16 @@ new_hash=$(nix store prefetch-file --json --hash-type sha256 \
 
 sed -i "s|$current_hash|$new_hash|g" $positron_nix
 
+# Update Linux aarch64 hash.
+current_hash=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${current_version}-arm64.deb" \
+    | jq -r .hash)
+
+new_hash=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${new_version}-arm64.deb" \
+    | jq -r .hash)
+
+sed -i "s|$current_hash|$new_hash|g" $positron_nix
+
 # Update version
 sed -i "s|$current_version|$new_version|g" $positron_nix
-
-# Attempt to build.
-export NIXPKGS_ALLOW_UNFREE=1
-
-if ! nix-build -A positron-bin "$nixpkgs"; then
-  echo "The updated positron-bin failed to build."
-  exit 1
-fi
-
-# Commit changes
-git add "$positron_nix"
-git commit -m "positron-bin: ${current_version} -> ${new_version}"


### PR DESCRIPTION
This PR adds:

- aarch64-linux as an available platform. Tested and working on Ubuntu 24.04 on raspberry pi 5. In the specific case of Ubuntu an apparmor profile needs to be configured to make Positron work as described here: https://github.com/NixOS/nixpkgs/issues/121694#issuecomment-2159420924
- updated to last release of Positron

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
