### PR TITLE
nixos/encrypted-dns-server: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -10,6 +10,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [encrypted-dns-server](https://github.com/dnscrypt/encrypted-dns-server), a DoH and DNSCrypt server. Available as [services.encrypted-dns-server](#opt-services.encrypted-dns-server.enable).
+
 - [gtklock](https://github.com/jovanlanik/gtklock), a GTK-based lockscreen for Wayland. Available as [programs.gtklock](#opt-programs.gtklock.enable).
 
 - [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1109,6 +1109,7 @@
   ./services/networking/doh-proxy-rust.nix
   ./services/networking/doh-server.nix
   ./services/networking/ejabberd.nix
+  ./services/networking/encrypted-dns-server.nix
   ./services/networking/envoy.nix
   ./services/networking/epmd.nix
   ./services/networking/ergo.nix

--- a/nixos/modules/services/networking/encrypted-dns-server.nix
+++ b/nixos/modules/services/networking/encrypted-dns-server.nix
@@ -1,0 +1,132 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.encrypted-dns-server;
+in
+{
+  options.services.encrypted-dns-server = {
+    enable = lib.mkEnableOption "encrypted-dns-server";
+    package = lib.mkPackageOption pkgs "encrypted-dns-server" { };
+
+    settings = lib.mkOption {
+      description = ''
+        Attrset that is converted and passed as TOML config file.
+        For available params, see: <https://github.com/DNSCrypt/encrypted-dns-server/blob/${pkgs.encrypted-dns-server.version}/example-encrypted-dns.toml>
+      '';
+      example = lib.literalExpression ''
+        {
+         upstream_addr = "127.0.0.1:53";
+         listen_addrs = [
+           {
+             local = "0.0.0.0:5443";
+             external = "0.0.0.0:5443";
+           }
+         ];
+        }
+      '';
+      type = lib.types.attrs;
+      default = { };
+    };
+
+    upstreamDefaults = lib.mkOption {
+      description = ''
+        Whether to base the config declared in {option}`services.encrypted-dns-server.settings` on the upstream example config (<https://github.com/DNSCrypt/encrypted-dns-server/blob/${pkgs.encrypted-dns-server.version}/example-encrypted-dns.toml>)
+
+        Disable this if you want to declare your dnscrypt config from scratch.
+      '';
+      type = lib.types.bool;
+      default = true;
+    };
+
+    configFile = lib.mkOption {
+      description = ''
+        Path to TOML config file. See: <https://github.com/DNSCrypt/encrypted-dns-server/blob/${pkgs.encrypted-dns-server.version}/example-encrypted-dns.toml>
+        If this option is set, it will override any configuration done in options.services.encrypted-dns-server.settings.
+      '';
+      example = "/etc/encrypted-dns-server/config.toml";
+      type = lib.types.path;
+      default =
+        pkgs.runCommand "encrypted-dns-server.toml"
+          {
+            json = builtins.toJSON cfg.settings;
+            passAsFile = [ "json" ];
+          }
+          ''
+            ${
+              if cfg.upstreamDefaults then
+                ''
+                  ${pkgs.buildPackages.remarshal}/bin/toml2json ${pkgs.encrypted-dns-server.src}/example-encrypted-dns.toml > example.json
+                  ${pkgs.buildPackages.jq}/bin/jq --slurp add example.json $jsonPath > config.json # merges the two
+                ''
+              else
+                ''
+                  cp $jsonPath config.json
+                ''
+            }
+            ${pkgs.buildPackages.remarshal}/bin/json2toml < config.json > $out
+          '';
+      defaultText = lib.literalMD "TOML file generated from {option}`services.encrypted-dns-server.settings`";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.encrypted-dns-server = {
+      description = "encrypted dns server";
+      wants = [
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      before = [ "nss-lookup.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        CacheDirectory = "encrypted-dns-server";
+        DynamicUser = true;
+        ExecStart = "${lib.getExe cfg.package} --config ${cfg.configFile}";
+        LockPersonality = true;
+        LogsDirectory = "encrypted-dns-server";
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        NonBlocking = true;
+        PrivateDevices = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        Restart = "always";
+        RestartSec = 30;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RuntimeDirectory = "encrypted-dns-server";
+        StateDirectory = "encrypted-dns-server";
+        WorkingDirectory = "/var/lib/encrypted-dns-server";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "@chown"
+          "~@aio"
+          "~@keyring"
+          "~@memlock"
+          "~@setuid"
+          "~@timer"
+        ];
+      };
+    };
+  };
+  meta = {
+    buildDocsInSandbox = false;
+    maintainers = with lib.maintainers; [ paepcke ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -424,6 +424,7 @@ in
   ejabberd = runTest ./xmpp/ejabberd.nix;
   elk = handleTestOn [ "x86_64-linux" ] ./elk.nix { };
   emacs-daemon = runTest ./emacs-daemon.nix;
+  encrypted-dns-server = runTest ./encrypted-dns-server.nix;
   endlessh = runTest ./endlessh.nix;
   endlessh-go = runTest ./endlessh-go.nix;
   engelsystem = runTest ./engelsystem.nix;

--- a/nixos/tests/encrypted-dns-server.nix
+++ b/nixos/tests/encrypted-dns-server.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  let
+    dnscryptServicePort = 5443;
+  in
+  {
+    name = "encrypted-dns-server";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [ paepcke ];
+    };
+
+    nodes = {
+      # encrypted dns server
+      server = {
+        services.encrypted-dns-server = {
+          enable = true;
+          settings = {
+            state_file = "/var/lib/encrypted-dns-server/encrypted-dns.state";
+            listen_addrs = [
+              {
+                local = "127.0.0.1:${toString dnscryptServicePort}";
+                external = "127.0.0.1:${toString dnscryptServicePort}";
+              }
+            ];
+          };
+        };
+      };
+    };
+
+    testScript = ''
+      server.wait_for_unit("encrypted-dns-server")
+      server.wait_for_open_port(dnscryptServicePort)
+    '';
+  }
+) { }

--- a/pkgs/by-name/en/encrypted-dns-server/package.nix
+++ b/pkgs/by-name/en/encrypted-dns-server/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   libsodium,
   nix-update-script,
+  nixosTests,
   versionCheckHook,
 }:
 rustPlatform.buildRustPackage rec {
@@ -29,6 +30,11 @@ rustPlatform.buildRustPackage rec {
   };
 
   passthru.updateScript = nix-update-script { };
+
+  passthru.tests = {
+    inherit (nixosTests) encrypted-dns-server;
+    service = nixosTests.encrypted-dns-server;
+  };
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;


### PR DESCRIPTION
add nixos service integration for recently (22.05) added encrypted-dns-server (#398775) 
(https://github.com/DNSCrypt/encrypted-dns-server) via hardened systemd profile.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
