### PR TITLE
cider-2: rename to cider-3, and add darwin support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7138,6 +7138,13 @@
     githubId = 7649041;
     name = "Vlad Petrov";
   };
+  ejstrunz = {
+    email = "estrunz5@gmail.com";
+    github = "ejstrunz";
+    githubId = 180565002;
+    name = "Emily Strunz";
+    keys = [ { fingerprint = "4640 B8AD 77E2 86D2 5D4E  2398 252E A85D 6B1D 263E"; } ];
+  };
   eken = {
     email = "edvin.kallstrom@protonmail.com";
     github = "Eken-beep";

--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -45,6 +45,7 @@ appimageTools.wrapType2 rec {
     maintainers = with lib.maintainers; [
       itsvic-dev
       l0r3v
+      ejstrunz
     ];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/ci/cider-3/package.nix
+++ b/pkgs/by-name/ci/cider-3/package.nix
@@ -1,11 +1,12 @@
-{ appimageTools
-, dbus
-, lib
-, stdenv
-, stdenvNoCC
-, requireFile
-, makeWrapper
-, undmg
+{
+  appimageTools,
+  dbus,
+  lib,
+  stdenv,
+  stdenvNoCC,
+  requireFile,
+  makeWrapper,
+  undmg,
 }:
 let
   arch = if stdenv.hostPlatform.isAarch64 then "arm64" else "x64";
@@ -19,11 +20,13 @@ mkCider rec {
 
   src = requireFile {
     name = "cider-v${version}-${platform}-${arch}.${ext}";
-    sha256 = {
-      aarch64-darwin = "0mg593wc49hng6r3c24ydws9k7ysg8zp1hiwzrckqx1c516cw0d0";
-      x86_64-darwin = "1d559zwzv1f6xlq1v3f2ss7g3vshks837ianh81cl0w35q1hyy97";
-      x86_64-linux = "1rfraf1r1zmp163kn8qg833qxrxmx1m1hycw8q9hc94d0hr62l2x";
-    }.${stdenv.hostPlatform.system};
+    sha256 =
+      {
+        aarch64-darwin = "0mg593wc49hng6r3c24ydws9k7ysg8zp1hiwzrckqx1c516cw0d0";
+        x86_64-darwin = "1d559zwzv1f6xlq1v3f2ss7g3vshks837ianh81cl0w35q1hyy97";
+        x86_64-linux = "1rfraf1r1zmp163kn8qg833qxrxmx1m1hycw8q9hc94d0hr62l2x";
+      }
+      .${stdenv.hostPlatform.system};
 
     url = "https://taproom.cider.sh/downloads";
   };
@@ -81,6 +84,10 @@ mkCider rec {
       l0r3v
       ejstrunz
     ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
 }

--- a/pkgs/by-name/ci/cider-3/package.nix
+++ b/pkgs/by-name/ci/cider-3/package.nix
@@ -13,7 +13,7 @@ let
   mkCider = if stdenv.hostPlatform.isDarwin then stdenv.mkDerivation else appimageTools.wrapType2;
 in
 mkCider rec {
-  pname = "cider-2";
+  pname = "cider-3";
   version = "3.0.2";
 
   src = requireFile {
@@ -34,7 +34,7 @@ mkCider rec {
     let
       contents = appimageTools.extract {
         inherit version src;
-        # HACK: this looks for a ${pname}.desktop, where `cider-2.desktop` doesn't exist
+        # HACK: this looks for a ${pname}.desktop, where `cider-3.desktop` doesn't exist
         pname = "Cider";
       };
     in
@@ -73,7 +73,7 @@ mkCider rec {
     description = "Powerful music player that allows you listen to your favorite tracks with style";
     homepage = "https://cider.sh";
     license = lib.licenses.unfree;
-    mainProgram = "cider-2";
+    mainProgram = "cider-3";
     maintainers = with lib.maintainers; [
       itsvic-dev
       l0r3v

--- a/pkgs/by-name/ci/cider-3/package.nix
+++ b/pkgs/by-name/ci/cider-3/package.nix
@@ -1,4 +1,5 @@
 { appimageTools
+, dbus
 , lib
 , stdenv
 , stdenvNoCC
@@ -43,11 +44,12 @@ mkCider rec {
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --add-flags "--no-sandbox --disable-gpu-sandbox" # Cider 2 does not start up properly without these from my preliminary testing
 
-        install -Dm444 ${contents}/Cider.desktop $out/share/applications/${pname}.desktop
-        substituteInPlace $out/share/applications/${pname}.desktop \
-          --replace-warn 'Exec=Cider' 'Exec=${pname}'
-        install -Dm444 ${contents}/usr/share/icons/hicolor/256x256/cider.png \
-                      $out/share/icons/hicolor/256x256/apps/cider.png
+      install -Dm444 ${contents}/Cider.desktop $out/share/applications/${pname}.desktop
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace-warn 'Exec=Cider' 'Exec='$out'/bin/${pname}' \
+        --replace-warn 'Exec=dbus-send' 'Exec=${lib.getExe' dbus "dbus-send"}'
+      install -Dm444 ${contents}/usr/share/icons/hicolor/256x256/cider.png \
+                    $out/share/icons/hicolor/256x256/apps/cider.png
     '';
 
   installPhase =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I have added platform support for `aarch64-darwin` and `x86_64-darwin`. I've tested on my M2 Macbook Pro, and made sure nothing broke on my `x86_64-linux` desktop. Unfortunately (fortunately?), I don't have an x86_64 
darwin machine to test with.

As far as I can tell, the binaries for Cider 2.x don't seem to be available from official sources anymore (i.e. https://cidercollective.itch.io/cider and the new https://taproom.cider.sh/). Here's the bigger picture:
- Currently, we have `cider` for Cider 1.x and, confusingly, `cider-2` for Cider 3.x(!) as of https://github.com/NixOS/nixpkgs/commit/0022af40b966ca0d843e1a7c51c484c67d3aa37f. This is why I've renamed the package in this PR, which would leave us with `cider`  and `cider-3`.
- I don't think it makes sense to have `cider`, `cider-2` and `cider-3`, since I don't see any reason to be using Cider 2.x.
- However, Cider 1.x is more interesting because [it is open source](https://github.com/ciderapp/Cider/tree/v1.6.3), so I think `cider` should stick around in some form, but it probably shouldn't be the main package.

A naive solution would be to rename the open source Cider 1.x to `cider-1`, so that _this_ package can take over as `cider`. Naturally, this would be a breaking change, especially since `cider-2`/`cider-3` relies on `requireFile`!

I'm not exactly well-seasoned in nixpkgs procedure, how bad would this be? If it can't be backported, would this be okay for 25.11?

Alternatively we could have something like `cider-old`/`cider-free` and `cider-new`/`cider-unfree`? I'm not a big fan of that, but usage of `cider` would simply fail as a missing package, forcing the user to consciously choose what they really want.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] ~~Tested, as applicable:~~ (None applicable)
  - ~~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
  - ~~and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages~~
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking. **TODO: Waiting for feedback on the package name situation...**
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
