### PR TITLE
lib/strings: init replaceString

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -309,6 +309,7 @@ let
         stringLength
         substring
         isString
+        replaceString
         replaceStrings
         intersperse
         concatStringsSep

--- a/lib/gvariant.nix
+++ b/lib/gvariant.nix
@@ -18,7 +18,7 @@ let
     concatStrings
     escape
     head
-    replaceStrings
+    replaceString
     ;
 
   mkPrimitive = t: v: {
@@ -451,7 +451,7 @@ rec {
   mkString =
     v:
     let
-      sanitize = s: replaceStrings [ "\n" ] [ "\\n" ] (escape [ "'" "\\" ] s);
+      sanitize = s: replaceString "\n" "\\n" (escape [ "'" "\\" ] s);
     in
     mkPrimitive type.string v
     // {

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1173,7 +1173,7 @@ rec {
       string = toString arg;
     in
     if match "[[:alnum:],._+:@%/-]+" string == null then
-      "'${replaceStrings [ "'" ] [ "'\\''" ] string}'"
+      "'${replaceString "'" "'\\''" string}'"
     else
       string;
 

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -333,6 +333,41 @@ rec {
   concatLines = concatMapStrings (s: s + "\n");
 
   /**
+    Given string `s`, replace every occurrence of the string `from` with the string `to`.
+
+    # Inputs
+
+    `from`
+    : The string to be replaced
+
+    `to`
+    : The string to replace with
+
+    `s`
+    : The original string where replacements will be made
+
+    # Type
+
+    ```
+    replaceString :: string -> string -> string -> string
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.replaceString` usage example
+
+    ```nix
+    replaceString "world" "Nix" "Hello, world!"
+    => "Hello, Nix!"
+    replaceString "." "_" "v1.2.3"
+    => "v1_2_3"
+    ```
+
+    :::
+  */
+  replaceString = from: to: replaceStrings [ from ] [ to ];
+
+  /**
     Repeat a string `n` times,
     and concatenate the parts into a new string.
 

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -14,7 +14,7 @@ let
     optionalAttrs
     optionalString
     removeSuffix
-    replaceStrings
+    replaceString
     toUpper
     ;
 
@@ -522,7 +522,7 @@ let
             #
             # https://github.com/rust-lang/cargo/pull/9169
             # https://github.com/rust-lang/cargo/issues/8285#issuecomment-634202431
-            cargoEnvVarTarget = replaceStrings [ "-" ] [ "_" ] (toUpper final.rust.cargoShortTarget);
+            cargoEnvVarTarget = replaceString "-" "_" (toUpper final.rust.cargoShortTarget);
 
             # True if the target is no_std
             # https://github.com/rust-lang/rust/blob/2e44c17c12cec45b6a682b1e53a04ac5b5fcc9d2/src/bootstrap/config.rs#L415-L421

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -91,6 +91,7 @@ let
     range
     recursiveUpdateUntil
     removePrefix
+    replaceString
     replicate
     runTests
     setFunctionArgs
@@ -495,6 +496,11 @@ runTests {
       ]
     );
     expected = "/usr/include:/usr/local/include";
+  };
+
+  testReplaceStringString = {
+    expr = strings.replaceString "." "_" "v1.2.3";
+    expected = "v1_2_3";
   };
 
   testReplicateString = {
@@ -1726,6 +1732,11 @@ runTests {
       2
       6
     ];
+  };
+
+  testReplaceString = {
+    expr = replaceString "world" "Nix" "Hello, world!";
+    expected = "Hello, Nix!";
   };
 
   testReplicate = {


### PR DESCRIPTION
## Motivation

When replacing strings inside a string, most of the time people use one "replacement pair". For example `lib.replaceStrings [ "." ] [ "_" ] version` has one replacement pair, and `lib.replaceStrings [ "a" "b" "c" ] [ "A" "B" "C" ] foo` has 3 replacement pairs.

<details><summary>First 50 occurrences of replaceStrings</summary>

```
nixos/tests/maddy/tls.nix:              builtins.replaceStrings
nixos/tests/lvm2/default.nix:        v' = lib.replaceStrings [ "." ] [ "_" ] version;
lib/strings.nix:    replaceStrings
lib/strings.nix:  replaceString = from: to: replaceStrings [ from ] [ to ];
lib/strings.nix:  escape = list: replaceStrings list (map (c: "\\${c}") list);
lib/strings.nix:    replaceStrings list (
lib/strings.nix:    replaceStrings (builtins.attrNames toEscape) (
lib/strings.nix:    builtins.replaceStrings
lib/strings.nix:  replaceChars = lib.warn "lib.replaceChars is a deprecated alias of lib.replaceStrings." builtins.replaceStrings;
lib/strings.nix:  toLower = replaceStrings upperChars lowerChars;
lib/strings.nix:  toUpper = replaceStrings lowerChars upperChars;
lib/default.nix:        replaceStrings
lib/generators.nix:    replaceStrings
lib/generators.nix:          escapedV = ''"${replaceStrings [ "\n" "	" ''"'' "\\" ] [ "\\n" "\\t" ''\"'' "\\\\" ] v}"'';
lib/generators.nix:            escapeMultiline = replaceStrings [ "\${" "''" ] [ "''\${" "'''" ];
nixos/tests/ssh-agent-auth.nix:          security.${lib.replaceStrings [ "_" ] [ "-" ] n} = {
nixos/tests/spacecookie.nix:    if not (fileResponse == "${builtins.replaceStrings [ "\n" ] [ "\\n" ] fileContent}"):
nixos/tests/rspamd-trainer.nix:            builtins.replaceStrings
nixos/tests/common/acme/server/default.nix:                    builtins.map (builtins.replaceStrings [ "*." ] [ "" ]) ([ domain ] ++ cfg.extraDomainNames)
nixos/tests/monetdb.nix:  onboardExpected = pkgs.lib.strings.replaceStrings [ "\n" ] [ "\\n" ] ''
nixos/modules/tasks/network-interfaces.nix:          i: nameValuePair "net.ipv4.conf.${replaceStrings [ "." ] [ "/" ] i.name}.proxy_arp" i.proxyARP
nixos/modules/tasks/network-interfaces.nix:          nameValuePair "net.ipv6.conf.${replaceStrings [ "." ] [ "/" ] i.name}.use_tempaddr" val
nixos/modules/tasks/network-interfaces.nix:                replaceStrings [ "." ] [ "/" ] i.name
nixos/modules/tasks/filesystems.nix:  escape = string: builtins.replaceStrings [ " " "\t" ] [ "\\040" "\\011" ] string;
nixos/modules/system/etc/etc.nix:                    name' = "etc-" + lib.replaceStrings [ "/" ] [ "-" ] name;
nixos/modules/system/boot/loader/grub/grub.nix:    replaceStrings
nixos/modules/system/boot/loader/grub/grub.nix:      efiSysMountPoint' = replaceStrings [ "/" ] [ "-" ] efiSysMountPoint;
doc/packages/darwin-builder.section.md:      linuxSystem = builtins.replaceStrings [ "darwin" ] [ "linux" ] system;
nixos/tests/installer.nix:        ${replaceStrings [ "\n" ] [ "\n  " ] extraConfig}
nixos/tests/prometheus-exporters.nix:    replaceStrings
nixos/tests/prometheus-exporters.nix:          postData = replaceStrings [ "\n" ] [ "" ] ''
nixos/tests/prometheus-exporters.nix:        publicKeyWithoutNewlines = replaceStrings [ "\n" ] [ "" ] snakeoil.peer1.publicKey;
nixos/modules/services/autotierfs.nix:    name: builtins.replaceStrings [ "/" ] [ "-" ] (lib.strings.removePrefix "/" name);
nixos/tests/openstack-image.nix:      SSH_HOST_ED25519_KEY:${replaceStrings [ "\n" ] [ "|" ] snakeOilPrivateKey}
nixos/modules/services/desktop-managers/lomiri.nix:          lib.strings.replaceStrings
nixos/tests/man.nix:  machineSafe = builtins.replaceStrings [ "-" ] [ "_" ];
nixos/tests/ec2.nix:      SSH_HOST_ED25519_KEY:${replaceStrings [ "\n" ] [ "|" ] snakeOilPrivateKey}
doc/doc-support/lib-function-locations.nix:  sanitizeId = builtins.replaceStrings [ "'" ] [ "-prime" ];
nixos/modules/services/web-servers/tomcat.nix:              hostElementsSedString = lib.replaceStrings [ "\n" ] [ "\\\n" ] hostElementsString;
nixos/modules/services/web-servers/caddy/vhost-options.nix:        output file ${cfg.logDir}/access-${lib.replaceStrings [ "/" " " ] [ "_" "_" ] config.hostName}.log
nixos/tests/ayatana-indicators.nix:        serviceExec = builtins.replaceStrings [ "." ] [ "-" ] service;
nixos/modules/services/web-apps/dependency-track.nix:      lib.nameValuePair (lib.toUpper (lib.replaceStrings [ "." ] [ "_" ] n)) (
nixos/modules/services/databases/postgresql.nix:      "'${lib.replaceStrings [ "'" ] [ "''" ] value}'"
nixos/modules/services/web-apps/akkoma.nix:    replaceStrings
nixos/modules/services/web-apps/akkoma.nix:  escapeSqlId = x: ''"${replaceStrings [ ''"'' ] [ ''""'' ] x}"'';
nixos/modules/services/web-apps/akkoma.nix:  escapeSqlStr = x: "'${replaceStrings [ "'" ] [ "''" ] x}'";
nixos/modules/services/databases/openldap.nix:        "${attr}: ${lib.replaceStrings [ "\n" ] [ "\n " ] value}"
nixos/tests/redis.nix:    pkg: "${pkg.pname}_${builtins.replaceStrings [ "." ] [ "" ] (lib.versions.majorMinor pkg.version)}";
nixos/modules/services/video/epgstation/default.nix:            default = "http+unix://${lib.replaceStrings [ "/" ] [ "%2F" ] sock}";
nixos/modules/services/video/epgstation/default.nix:              "http+unix://''${lib.replaceStrings ["/"] ["%2F"] config.${option}}"
```
</details>


For this reason `lib.replaceString "." "_"` is a shorter alternative, which is easier to read and write. People coming from other languages are likely already familiar with a string replacement function that uses a single replacement pair.

When I started with Nix, I was a bit confused with the following scenario:
```nix
nix-repl> builtins.replaceStrings "foo" "bar" "string with foo"
error:
       … while calling the 'replaceStrings' builtin
         at «string»:1:1:
            1| builtins.replaceStrings "foo" "bar" "string with foo"
             | ^

       … while evaluating the first argument passed to builtins.replaceStrings

       error: expected a list but found a string: "foo"
```
Why does this function expect a list instead of just a string? After reading documentation I realised that it's possible to do multiple replacements at a time, but the lack of a simpler version of this function always annoyed me.

## Implementation

This PR adds the `replaceString` function, replacing previous instances of `replaceStrings` (with one replacement pairs) all across `lib/`.

## Future work

I'm not sure if this is worth the effort and merge conflicts of switching to `replaceString` treewide.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
