### PR TITLE
Added fetchTags feature to fetchgit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .nixos-test-history
 .vscode/
 .helix/
+*.vim
 outputs/
 result-*
 result

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 .nixos-test-history
 .vscode/
 .helix/
-*.vim
 outputs/
 result-*
 result

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -795,6 +795,10 @@ Additionally, the following optional arguments can be given:
 : Clone the entire repository as opposing to just creating a shallow clone.
   This implies `leaveDotGit`.
 
+*`fetchTags`* (Boolean)
+
+: Whether to fetch all tags from the remote repository. This is useful when the build process needs to run `git describe` or other commands that require tag information to be available. This parameter implies `leaveDotGit`, as tags are stored in the `.git` directory.
+
 *`sparseCheckout`* (List of String)
 
 : Prevent git from fetching unnecessary blobs from server.

--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -13,6 +13,7 @@ $SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" --name "$name" 
   ${fetchLFS:+--fetch-lfs} \
   ${deepClone:+--deepClone} \
   ${fetchSubmodules:+--fetch-submodules} \
+  ${fetchTags:+--fetch-tags} \
   ${sparseCheckout:+--sparse-checkout "$sparseCheckout"} \
   ${nonConeMode:+--non-cone-mode} \
   ${branchName:+--branch-name "$branchName"}

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -28,7 +28,7 @@ lib.makeOverridable (
       url,
       tag ? null,
       rev ? null,
-      leaveDotGit ? deepClone,
+      leaveDotGit ? deepClone || fetchTags,
       outputHash ? lib.fakeHash,
       outputHashAlgo ? null,
       fetchSubmodules ? true,
@@ -55,6 +55,8 @@ lib.makeOverridable (
       netrcImpureEnvVars ? [ ],
       meta ? { },
       allowedRequisites ? null,
+      # fetch all tags after tree (useful for git describe)
+      fetchTags ? false,
     }:
 
     /*
@@ -81,6 +83,7 @@ lib.makeOverridable (
     */
 
     assert nonConeMode -> (sparseCheckout != [ ]);
+    assert fetchTags -> leaveDotGit;
 
     let
       revWithTag =
@@ -136,6 +139,7 @@ lib.makeOverridable (
           nonConeMode
           preFetch
           postFetch
+          fetchTags
           ;
         rev = revWithTag;
 

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -11,6 +11,7 @@ leaveDotGit=$NIX_PREFETCH_GIT_LEAVE_DOT_GIT
 fetchSubmodules=
 fetchLFS=
 builder=
+fetchTags=
 branchName=$NIX_PREFETCH_GIT_BRANCH_NAME
 
 # ENV params
@@ -56,6 +57,7 @@ Options:
       --leave-dotGit  Keep the .git directories.
       --fetch-lfs     Fetch git Large File Storage (LFS) files.
       --fetch-submodules Fetch submodules.
+      --fetch-tags    Fetch all tags (useful for git describe).
       --builder       Clone as fetchgit does, but url, rev, and out option are mandatory.
       --quiet         Only print the final json summary.
 "
@@ -86,6 +88,7 @@ for arg; do
             --leave-dotGit) leaveDotGit=true;;
             --fetch-lfs) fetchLFS=true;;
             --fetch-submodules) fetchSubmodules=true;;
+            --fetch-tags) fetchTags=true;;
             --builder) builder=true;;
             -h|--help) usage; exit;;
             *)
@@ -233,6 +236,12 @@ clone(){
         echo 1>&2 "Unable to checkout $hash$ref from $url."
         exit 1
     )
+
+    # Fetch all tags if requested
+    if test -n "$fetchTags"; then
+        echo "fetching all tags..." >&2
+        clean_git fetch origin 'refs/tags/*:refs/tags/*' || echo "warning: failed to fetch some tags" >&2
+    fi
 
     # Checkout linked sources.
     if test -n "$fetchSubmodules"; then
@@ -403,6 +412,7 @@ print_results() {
   "fetchLFS": $([[ -n "$fetchLFS" ]] && echo true || echo false),
   "fetchSubmodules": $([[ -n "$fetchSubmodules" ]] && echo true || echo false),
   "deepClone": $([[ -n "$deepClone" ]] && echo true || echo false),
+  "fetchTags": $([[ -n "$fetchTags" ]] && echo true || echo false),
   "leaveDotGit": $([[ -n "$leaveDotGit" ]] && echo true || echo false)
 }
 EOF

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -83,4 +83,16 @@
     rev = "v3.0.14";
     sha256 = "sha256-bd0Lx75Gd1pcBJtwz5WGki7XoYSpqhinCT3a77wpY2c=";
   };
+
+  fetchTags = testers.invalidateFetcherByDrvHash fetchgit {
+    name = "fetchgit-fetch-tags-test";
+    url = "https://github.com/NixOS/nix";
+    rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
+    fetchTags = true;
+    leaveDotGit = true;
+    sha256 = "sha256-2vfZnYjZlnC8ODz6B6aOqAqtb1Wbjojnn/5TmzwUrmo=";
+    postFetch = ''
+      cd $out && git describe --tags --always > describe-output.txt 2>&1 || echo "git describe failed" > describe-output.txt
+    '';
+  };
 }


### PR DESCRIPTION
This adds a fetchTags parameter to fetchgit that ensures all tags
are fetched from the remote repository. Tags are sometimes required in projects, e.g. ones that call 'git describe', and since the nix store is read-only by design, it is not possible to git fetch --tags at activation- or run-time without horrendous violations of this principle. This feature may have been possible by specifying a postFetch option including calling git fetch --tags, however doing so obfuscates the solution to this very real problem, and does nothing to improve the usability of nix. 

Explicit support for fetching tags should be a first class citizen just like fetching other refs.

The parameter works by running 'git fetch origin refs/tags/*:refs/tags/*'
after the main fetch operation, ensuring all tags are available.

- fetchTags defaults to false, ensuring backwards compatibility and imposing no performance on those who do not use it
- fetchTags implies leaveDotGit, and follows the same pattern as deepClone
- Added proper validation and error handling  
- Updated relevant documentation and test cases
- Fixes issues with ESP-IDF and similar packages that need git tags
  for version detection during build or runtime.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested on x86_64, nix 25.11, and [this branch of my nix config repo](https://github.com/timblaktu/nixcfg/tree/thinky-nixos), which integrates and uses this PR source fork/branch in the context of [this corresponding branch/fork of the nixpkgs-esp-dev repo](https://github.com/timblaktu/nixpkgs-esp-dev/tree/c5), where I stumbled into this and other rakes trying to set up an esp32 dev env. This was my first foray this deep into nix packaging and process, and I learned a lot and hope to contribute more in the future.
