### PR TITLE
_cuda: missed fixups

### DIFF
--- a/pkgs/development/cuda-modules/README.md
+++ b/pkgs/development/cuda-modules/README.md
@@ -29,8 +29,6 @@ package set by [cuda-packages.nix](../../top-level/cuda-packages.nix).
       short, the Multiplex builder adds multiple versions of a single package to
       single instance of the CUDA Packages package set. It is used primarily for
       packages like `cudnn` and `cutensor`.
-- `lib`: A library of functions and data used by and for the CUDA package set.
-    This library is exposed at the top-level as `pkgs.cudaLib`.
 - `modules`: Nixpkgs modules to check the shape and content of CUDA
     redistributable and feature manifests. These modules additionally use shims
     provided by some CUDA packages to allow them to re-use the

--- a/pkgs/development/cuda-modules/_cuda/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/default.nix
@@ -1,8 +1,8 @@
 # The _cuda attribute set is a fixed-point which contains the static functionality required to construct CUDA package
-# sets. For example, `_cuda.cudaData` includes information about NVIDIA's redistributables (such as the names NVIDIA
-# uses for different systems), `_cuda.cudaLib` contains utility functions like `formatCapabilities` (which generate
-# common arguments passed to NVCC and `cmakeFlags`), and `_cuda.cudaFixups` contains `callPackage`-able functions
-# which are provided to the corresponding package's `overrideAttrs` attribute to provide package-specific fixups
+# sets. For example, `_cuda.bootstrapData` includes information about NVIDIA's redistributables (such as the names
+# NVIDIA uses for different systems), `_cuda.lib` contains utility functions like `formatCapabilities` (which generate
+# common arguments passed to NVCC and `cmakeFlags`), and `_cuda.fixups` contains `callPackage`-able functions which
+# are provided to the corresponding package's `overrideAttrs` attribute to provide package-specific fixups
 # out of scope of the generic redistributable builder.
 #
 # Since this attribute set is used to construct the CUDA package sets, it must exist outside the fixed point of the

--- a/pkgs/development/cuda-modules/tests/flags.nix
+++ b/pkgs/development/cuda-modules/tests/flags.nix
@@ -1,14 +1,13 @@
 {
-  cudaData,
-  cudaLib,
+  _cuda,
   cudaNamePrefix,
   lib,
   runCommand,
 }:
 let
   inherit (builtins) deepSeq toJSON tryEval;
-  inherit (cudaData) cudaCapabilityToInfo;
-  inherit (cudaLib) formatCapabilities;
+  inherit (_cuda.bootstrapData) cudaCapabilityToInfo;
+  inherit (_cuda.lib) formatCapabilities;
   inherit (lib.asserts) assertMsg;
 in
 # When changing names or formats: pause, validate, and update the assert
@@ -62,6 +61,7 @@ assert
         "7.5"
         "8.6"
       ];
+      cudaForwardCompat = true;
     };
     actualWrapped = (tryEval (deepSeq actual actual)).value;
   in

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -14,7 +14,7 @@
 
 let
   lib = import ../../lib;
-  inherit (import ../development/cuda-modules/_cuda) cudaLib;
+  cudaLib = (import ../development/cuda-modules/_cuda).lib;
 in
 
 {


### PR DESCRIPTION
A number of fixups missed during the rename near the end of #406531.

Thanks @mweinelt for making me aware of the failures on the community Hydra: https://hydra.nix-community.org/eval/448541.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
