### PR TITLE
shaperglot-cli: init at 0-unstable-2025-05-27

### DIFF
--- a/pkgs/by-name/sh/shaperglot-cli/package.nix
+++ b/pkgs/by-name/sh/shaperglot-cli/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  _experimental-update-script-combinators,
+  unstableGitUpdater,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "shaperglot-cli";
+  version = "0-unstable-2025-05-27";
+
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "shaperglot";
+    rev = "0d934110dfdf315761255e34040f207f7d7868b5";
+    hash = "sha256-5Bgvx4Yv74nQLd037L5uBj6oySqqp947LI/6yGwYSKY=";
+  };
+
+  cargoHash = "sha256-UMPoPNpyM/+1rq4U6xQ1DF4W+51p5YjQXr/8zLiPvEI=";
+
+  cargoBuildFlags = [
+    "--package=shaperglot-cli"
+  ];
+
+  cargoTestFlags = [
+    "--package=shaperglot-cli"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    describe_output="$("$out/bin/shaperglot" describe English)"
+    [[ "$describe_output" == *'support'* ]]
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    updateScript = _experimental-update-script-combinators.sequence [
+      (unstableGitUpdater {
+        branch = "main";
+        # Git tag differs from CLI version: https://github.com/googlefonts/shaperglot/issues/138
+        hardcodeZeroVersion = true;
+      })
+      (nix-update-script {
+        # Updating `cargoHash`
+        extraArgs = [ "--version=skip" ];
+      })
+    ];
+  };
+
+  meta = {
+    description = "Test font files for language support";
+    homepage = "https://github.com/googlefonts/shaperglot";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "shaperglot";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Introducing [shaperglot-cli](https://github.com/googlefonts/shaperglot/blob/0d934110dfdf315761255e34040f207f7d7868b5/README.md?plain=1#L83-L101), a new command-line tool that expands the shaperglot family.
It helps you test font and language support. [shaperglot-py is already in nixpkgs](https://github.com/NixOS/nixpkgs/blob/e2063a97142c5bb616414ed93596a77bad272c26/pkgs/development/python-modules/shaperglot/default.nix)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
