### PR TITLE
nebius: init at 0.12.64

### DIFF
--- a/pkgs/by-name/ne/nebius/package.nix
+++ b/pkgs/by-name/ne/nebius/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeBinaryWrapper,
+  installShellFiles,
+  buildPackages,
+  withShellCompletions ? stdenv.hostPlatform.emulatorAvailable buildPackages,
+  # tests
+  testers,
+}:
+let
+  version = "0.12.64";
+
+  sources = {
+    x86_64-linux = {
+      url = "https://storage.eu-north1.nebius.cloud/cli/release/${version}/linux/x86_64/nebius";
+      hash = "sha256-vqubl8lmRgSecLYUJyGyJuu3i61N5OJyIVUSt2G0STk=";
+    };
+    aarch64-linux = {
+      url = "https://storage.eu-north1.nebius.cloud/cli/release/${version}/linux/arm64/nebius";
+      hash = "sha256-A3w+mt5nwkIENv0ScwwVq+n0YJoMxhuQWWdcIvAfcQ8=";
+    };
+    aarch64-darwin = {
+      url = "https://storage.eu-north1.nebius.cloud/cli/release/${version}/darwin/arm64/nebius";
+      hash = "sha256-Wtc964BjFk2rQ5CNDIGbQpvHouZzXQ7KzlbdG2ovX1k=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit version;
+
+  pname = "nebius";
+
+  src = fetchurl sources.${stdenv.hostPlatform.system};
+
+  dontUnpack = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
+
+  emulator = lib.optionalString (
+    withShellCompletions && !stdenv.buildPlatform.canExecute stdenv.hostPlatform
+  ) (stdenv.hostPlatform.emulator buildPackages);
+
+  installPhase =
+    ''
+      runHook preInstall
+      mkdir -p -- "$out/bin"
+      cp -- "$src" "$out/bin/nebius"
+      chmod +x -- "$out/bin/nebius"
+    ''
+    + lib.optionalString withShellCompletions ''
+      for shell in bash zsh; do
+        ''${emulator:+"$emulator"} "$out/bin/nebius" completion $shell >nebius.$shell
+        installShellCompletion nebius.$shell
+      done
+    ''
+    + ''
+      runHook postInstall
+    '';
+
+  passthru = {
+    updateScript = ./update.sh;
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "nebius version";
+    };
+  };
+
+  meta = {
+    description = "Command line interface for Nebius cloud platform";
+    homepage = "https://nebius.com/";
+    changelog = "https://docs.nebius.com/cli/release-notes";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ jennifgcrl ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    mainProgram = "nebius";
+  };
+})

--- a/pkgs/by-name/ne/nebius/package.nix
+++ b/pkgs/by-name/ne/nebius/package.nix
@@ -10,7 +10,7 @@
   testers,
 }:
 let
-  version = "0.12.64";
+  version = "0.12.167";
 
   sources = {
     x86_64-linux = {
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
       chmod +x -- "$out/bin/nebius"
     ''
     + lib.optionalString withShellCompletions ''
-      for shell in bash zsh; do
+      for shell in bash zsh fish; do
         ''${emulator:+"$emulator"} "$out/bin/nebius" completion $shell >nebius.$shell
         installShellCompletion nebius.$shell
       done

--- a/pkgs/by-name/ne/nebius/update.sh
+++ b/pkgs/by-name/ne/nebius/update.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i bash -p bash curl jq nix-update cacert git
+set -euo pipefail
+
+new_version="$(curl -s "https://storage.eu-north1.nebius.cloud/cli/release/stable")"
+nix-update nebius --version "$new_version"
+


### PR DESCRIPTION
Command line interface for Nebius cloud platform.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
