### PR TITLE
miunlocktool: init at 1.5.9

### DIFF
--- a/pkgs/by-name/mi/miunlocktool/package.nix
+++ b/pkgs/by-name/mi/miunlocktool/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  android-tools,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "miunlocktool";
+  version = "1.5.9-unstable-2025-05-30";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "offici5l";
+    repo = "MiUnlockTool";
+    rev = "3f4581341bc380e66b14ebd80f596ea6fd34a32c";
+    hash = "sha256-uXYWYzn5zwzX6yXQjQWV95t9YmEnZqxPRPYoy8M+7Fk=";
+  };
+
+  nativeBuildInputs = with python3Packages; [ setuptools ];
+  dependencies =
+    [ android-tools ]
+    ++ (with python3Packages; [
+      requests
+      colorama
+      pycryptodomex
+    ]);
+
+  installPhase = ''
+    install -Dm0755 MiUnlockTool.py $out/bin/miunlocktool
+    patchShebangs $out/bin/miunlocktool
+
+    wrapProgram $out/bin/miunlocktool \
+      --prefix PATH : ${lib.makeBinPath [ android-tools ]}
+  '';
+
+  meta = {
+    description = "Mi Account Unlock Tool";
+    homepage = "https://github.com/offici5l/MiUnlockTool";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ phodina ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
CLI tool to unlock the bootloader on Xiaomi phones.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
