### PR TITLE
trunk: wrap program with utils

### DIFF
--- a/pkgs/by-name/tr/trunk/package.nix
+++ b/pkgs/by-name/tr/trunk/package.nix
@@ -4,6 +4,11 @@
   fetchFromGitHub,
   pkg-config,
   openssl,
+  makeWrapper,
+  binaryen,
+  dart-sass,
+  tailwindcss,
+  wasm-bindgen-cli_0_2_108,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -17,12 +22,32 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-0T8ZkBA1Zf4z2HXYeBwJ+2EGoUpxGrqSb4fS4CnL28A=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
   buildInputs = [ openssl ];
   # requires network
   checkFlags = [ "--skip=tools::tests::download_and_install_binaries" ];
 
   cargoHash = "sha256-/5zvbSlMzZHxnAwuu0Jd6WVVjxJtIAQpRwZZHgYyPbs=";
+
+  # Add programs used in trunk to PATH.
+  # When trunk fails to find these paths, it fetches prebuilt binaries
+  # which don't work on NixOS.  These are added to the suffix so the
+  # user can easily override them.
+  postInstall = ''
+    wrapProgram $out/bin/trunk \
+      --suffix PATH : "${
+        lib.makeBinPath [
+          binaryen
+          dart-sass
+          tailwindcss
+          wasm-bindgen-cli_0_2_108
+          # tailwindcss-extra # not in nixpkgs
+        ]
+      }"
+  '';
 
   meta = {
     homepage = "https://github.com/trunk-rs/trunk";


### PR DESCRIPTION
Add utils used in trunk to PATH.
When trunk fails to find these paths, it fetches prebuilt binaries which don't work on NixOS.  These are added to the suffix so the user can easily override them.

<details>
<summary>Error log when running trunk without this patch</summary>

```shell
2025-05-28T06:11:48.435519Z  INFO 🚀 Starting trunk 0.21.14
2025-05-28T06:11:48.900125Z  INFO 📦 starting build
Could not start dynamically linked executable: /.../.cache/trunk/sass-1.69.5/src/dart
NixOS cannot run dynamically linked executables intended for generic
linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
2025-05-28T06:11:49.505730Z ERROR ❌ error
error from build pipeline

Caused by:
    0: HTML build pipeline failed (1 errors), showing first
    1: error from asset pipeline
    2: sass call to executable '/.../.cache/trunk/sass-1.69.5/sass' with args: '["--embed-source-map", "--style", "expanded", "/.../sample/index.scss", "/.../sample/dist/.stage/index.css"]' returned a bad status: exit status: 127
2025-05-28T06:11:49.505755Z ERROR error from build pipeline
2025-05-28T06:11:49.505766Z  INFO   1: HTML build pipeline failed (1 errors), showing first
2025-05-28T06:11:49.505770Z  INFO   2: error from asset pipeline
2025-05-28T06:11:49.505771Z  INFO   3: sass call to executable '/.../.cache/trunk/sass-1.69.5/sass' with args: '["--embed-source-map", "--style", "expanded", "/.../sample/index.scss", "/.../sample/dist/.stage/index.css"]' returned a bad status: exit status: 127
```
</details>

You can check if the tools are recognized by trunk by running the command below.

<details>
<summary>
command and log
</summary>

```shell
$ trunk tools
sass
    Installed Version: 1.89.0
    Default Version: 1.69.5
    Download URL: https://github.com/sass/dart-sass/releases/download/1.69.5/dart-sass-1.69.5-linux-x64.tar.gz
    Location: /nix/store/s8wh9ywgvjhcdd0nmysl7l9ngvq2xxsy-dart-sass-1.89.0/bin/sass

tailwindcss
    Installed Version: 3.4.17
    Default Version: 3.3.5
    Download URL: https://github.com/tailwindlabs/tailwindcss/releases/download/v3.3.5/tailwindcss-linux-x64
    Location: /nix/store/vvy5bx1ywdcznlfsnvcm8sgpi8mp4dbw-tailwindcss_3-3.4.17/bin/tailwindcss

tailwindcss-extra
    Installed Version: n/a
    Default Version: 1.7.25
    Download URL: https://github.com/dobicinaitis/tailwind-cli-extra/releases/download/v1.7.25/tailwindcss-extra-linux-x64
    Location: n/a

wasm-bindgen
    Installed Version: 0.2.100
    Default Version: 0.2.89
    Download URL: https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.89/wasm-bindgen-0.2.89-x86_64-unknown-linux-musl.tar.gz
    Location: /nix/store/1lv0500ic4bvpgylvkmibz2nqg71if7m-wasm-bindgen-cli-0.2.100/bin/wasm-bindgen

wasm-opt
    Installed Version: version_123
    Default Version: version_123
    Download URL: https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz
    Location: /nix/store/vbr4xv0hhzfd21yqd0mrylcyllb8r147-binaryen-123/bin/wasm-opt
```
</details>

closes #408053

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
