### PR TITLE
microsoft-edge: re-init at 137.0.3296.68

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14907,6 +14907,13 @@
     name = "Mæve";
     keys = [ { fingerprint = "96C9 D086 CC9D 7BD7 EF24  80E2 9168 796A 1CC3 AEA2"; } ];
   };
+  maeve-oake = {
+    email = "maeve@oa.ke";
+    matrix = "@maeve:oa.ke";
+    github = "maeve-oake";
+    githubId = 38541651;
+    name = "maeve";
+  };
   mafo = {
     email = "Marc.Fontaine@gmx.de";
     github = "MarcFontaine";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13904,6 +13904,12 @@
     githubId = 567634;
     name = "Daniel Kuehn";
   };
+  leleuvilela = {
+    email = "viniciusvilela19@gmail.com";
+    github = "leleuvilela";
+    githubId = 19839085;
+    name = "Vinicius Vilela";
+  };
   lelgenio = {
     email = "lelgenio@lelgenio.com";
     github = "lelgenio";

--- a/pkgs/by-name/mi/microsoft-edge/package.nix
+++ b/pkgs/by-name/mi/microsoft-edge/package.nix
@@ -1,0 +1,293 @@
+{
+  fetchurl,
+  lib,
+  makeWrapper,
+  patchelf,
+  stdenv,
+
+  # Linked dynamic libraries.
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gcc-unwrapped,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  gtk4,
+  libdrm,
+  libglvnd,
+  libkrb5,
+  libX11,
+  libxcb,
+  libXcomposite,
+  libXcursor,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXi,
+  libxkbcommon,
+  libXrandr,
+  libXrender,
+  libXScrnSaver,
+  libxshmfence,
+  libXtst,
+  libgbm,
+  nspr,
+  nss,
+  pango,
+  pipewire,
+  vulkan-loader,
+  wayland, # ozone/wayland
+
+  # Command line programs
+  coreutils,
+
+  # command line arguments which are always set e.g "--disable-gpu"
+  commandLineArgs ? "",
+
+  # Will crash without.
+  systemd,
+
+  # Loaded at runtime.
+  libexif,
+  pciutils,
+
+  # Additional dependencies according to other distros.
+  ## Ubuntu
+  curl,
+  liberation_ttf,
+  util-linux,
+  wget,
+  xdg-utils,
+  ## Arch Linux.
+  flac,
+  harfbuzz,
+  icu,
+  libopus,
+  libpng,
+  snappy,
+  speechd-minimal,
+  ## Gentoo
+  bzip2,
+  libcap,
+
+  # Necessary for USB audio devices.
+  libpulseaudio,
+  pulseSupport ? true,
+
+  adwaita-icon-theme,
+  gsettings-desktop-schemas,
+
+  # For video acceleration via VA-API (--enable-features=VaapiVideoDecoder)
+  libva,
+  libvaSupport ? true,
+
+  # For Vulkan support (--enable-features=Vulkan)
+  addDriverRunpath,
+
+  # Edge AAD sync
+  cacert,
+  libsecret,
+
+  # Edge Specific
+  libuuid,
+}:
+
+let
+
+  opusWithCustomModes = libopus.override { withCustomModes = true; };
+
+  deps =
+    [
+      alsa-lib
+      at-spi2-atk
+      at-spi2-core
+      atk
+      bzip2
+      cacert
+      cairo
+      coreutils
+      cups
+      curl
+      dbus
+      expat
+      flac
+      fontconfig
+      freetype
+      gcc-unwrapped.lib
+      gdk-pixbuf
+      glib
+      harfbuzz
+      icu
+      libcap
+      libdrm
+      liberation_ttf
+      libexif
+      libglvnd
+      libkrb5
+      libpng
+      libX11
+      libxcb
+      libXcomposite
+      libXcursor
+      libXdamage
+      libXext
+      libXfixes
+      libXi
+      libxkbcommon
+      libXrandr
+      libXrender
+      libXScrnSaver
+      libxshmfence
+      libXtst
+      libgbm
+      nspr
+      nss
+      opusWithCustomModes
+      pango
+      pciutils
+      pipewire
+      snappy
+      speechd-minimal
+      systemd
+      util-linux
+      vulkan-loader
+      wayland
+      wget
+      libsecret
+      libuuid
+    ]
+    ++ lib.optional pulseSupport libpulseaudio
+    ++ lib.optional libvaSupport libva
+    ++ [
+      gtk3
+      gtk4
+    ];
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "microsoft-edge";
+  version = "137.0.3296.68";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_${finalAttrs.version}-1_amd64.deb";
+    hash = "sha256-dgmQF6zpd8dAYKoTSiidk8VU6dZ/ZWEDlYD91IPaDEE=";
+  };
+
+  # With strictDeps on, some shebangs were not being patched correctly
+  # ie, $out/share/microsoft/msedge/microsoft-edge
+  strictDeps = false;
+
+  nativeBuildInputs = [
+    makeWrapper
+    patchelf
+  ];
+
+  buildInputs = [
+    # needed for XDG_ICON_DIRS
+    adwaita-icon-theme
+    glib
+    gtk3
+    gtk4
+    # needed for GSETTINGS_SCHEMAS_PATH
+    gsettings-desktop-schemas
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    ar x $src
+    tar xf data.tar.xz
+    runHook postUnpack
+  '';
+
+  rpath = lib.makeLibraryPath deps + ":" + lib.makeSearchPathOutput "lib" "lib64" deps;
+  binpath = lib.makeBinPath deps;
+
+  installPhase = ''
+    runHook preInstall
+
+    appname=msedge
+    dist=stable
+
+    exe=$out/bin/microsoft-edge
+
+    mkdir -p $out/bin $out/share
+    cp -v -a opt/* $out/share
+    cp -v -a usr/share/* $out/share
+
+    # replace bundled vulkan-loader
+    rm -v $out/share/microsoft/$appname/libvulkan.so.1
+    ln -v -s -t "$out/share/microsoft/$appname" "${lib.getLib vulkan-loader}/lib/libvulkan.so.1"
+
+    substituteInPlace $out/share/microsoft/$appname/microsoft-edge \
+      --replace-fail 'CHROME_WRAPPER' 'WRAPPER'
+    substituteInPlace $out/share/applications/microsoft-edge.desktop \
+      --replace-fail /usr/bin/microsoft-edge-$dist $exe
+    substituteInPlace $out/share/gnome-control-center/default-apps/microsoft-edge.xml \
+      --replace-fail /opt/microsoft/msedge $exe
+    substituteInPlace $out/share/menu/microsoft-edge.menu \
+      --replace-fail /opt $out/share \
+      --replace-fail $out/share/microsoft/$appname/microsoft-edge $exe
+
+    for icon_file in $out/share/microsoft/msedge/product_logo_[0-9]*.png; do
+      num_and_suffix="''${icon_file##*logo_}"
+      if [ $dist = "stable" ]; then
+        icon_size="''${num_and_suffix%.*}"
+      else
+        icon_size="''${num_and_suffix%_*}"
+      fi
+      logo_output_prefix="$out/share/icons/hicolor"
+      logo_output_path="$logo_output_prefix/''${icon_size}x''${icon_size}/apps"
+      mkdir -p "$logo_output_path"
+      mv "$icon_file" "$logo_output_path/microsoft-edge.png"
+    done
+
+    # "--simulate-outdated-no-au" disables auto updates and browser outdated popup
+    makeWrapper "$out/share/microsoft/$appname/microsoft-edge" "$exe" \
+      --prefix LD_LIBRARY_PATH : "$rpath" \
+      --prefix PATH            : "$binpath" \
+      --suffix PATH            : "${lib.makeBinPath [ xdg-utils ]}" \
+      --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addDriverRunpath.driverLink}/share" \
+      --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" \
+      --set CHROME_WRAPPER  "microsoft-edge-$dist" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --add-flags "--simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT'" \
+      --add-flags ${lib.escapeShellArg commandLineArgs}
+
+    # Make sure that libGL and libvulkan are found by ANGLE libGLESv2.so
+    patchelf --set-rpath $rpath $out/share/microsoft/$appname/lib*GL*
+
+    # Edge specific set liboneauth
+    patchelf --set-rpath $rpath $out/share/microsoft/$appname/liboneauth.so
+
+    for elf in $out/share/microsoft/$appname/{msedge,msedge-sandbox,msedge_crashpad_handler}; do
+      patchelf --set-rpath $rpath $elf
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $elf
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.py;
+
+  meta = {
+    changelog = "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel";
+    description = "Web browser from Microsoft";
+    homepage = "https://www.microsoft.com/en-us/edge";
+    license = lib.licenses.unfree;
+    mainProgram = "microsoft-edge";
+    maintainers = with lib.maintainers; [
+      cholli
+      ulrikstrid
+    ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/mi/microsoft-edge/package.nix
+++ b/pkgs/by-name/mi/microsoft-edge/package.nix
@@ -1,9 +1,10 @@
 {
-  fetchurl,
   lib,
+  stdenv,
+  fetchurl,
   makeWrapper,
   patchelf,
-  stdenv,
+  dpkg,
 
   # Linked dynamic libraries.
   alsa-lib,
@@ -92,6 +93,9 @@
   # For Vulkan support (--enable-features=Vulkan)
   addDriverRunpath,
 
+  # For QT support
+  qt6,
+
   # Edge AAD sync
   cacert,
   libsecret,
@@ -163,13 +167,13 @@ let
       wget
       libsecret
       libuuid
-    ]
-    ++ lib.optional pulseSupport libpulseaudio
-    ++ lib.optional libvaSupport libva
-    ++ [
       gtk3
       gtk4
-    ];
+      qt6.qtbase
+      qt6.qtwayland
+    ]
+    ++ lib.optionals pulseSupport [ libpulseaudio ]
+    ++ lib.optionals libvaSupport [ libva ];
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -188,6 +192,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     patchelf
+    dpkg
   ];
 
   buildInputs = [
@@ -200,13 +205,6 @@ stdenv.mkDerivation (finalAttrs: {
     gsettings-desktop-schemas
   ];
 
-  unpackPhase = ''
-    runHook preUnpack
-    ar x $src
-    tar xf data.tar.xz
-    runHook postUnpack
-  '';
-
   rpath = lib.makeLibraryPath deps + ":" + lib.makeSearchPathOutput "lib" "lib64" deps;
   binpath = lib.makeBinPath deps;
 
@@ -218,9 +216,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     exe=$out/bin/microsoft-edge
 
-    mkdir -p $out/bin $out/share
-    cp -v -a opt/* $out/share
-    cp -v -a usr/share/* $out/share
+    mkdir -p $out/bin
+    cp -v -a usr/share $out/share
+    cp -v -a opt/microsoft $out/share/microsoft
 
     # replace bundled vulkan-loader
     rm -v $out/share/microsoft/$appname/libvulkan.so.1
@@ -229,6 +227,8 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/share/microsoft/$appname/microsoft-edge \
       --replace-fail 'CHROME_WRAPPER' 'WRAPPER'
     substituteInPlace $out/share/applications/microsoft-edge.desktop \
+      --replace-fail /usr/bin/microsoft-edge-$dist $exe
+    substituteInPlace $out/share/applications/com.microsoft.Edge.desktop \
       --replace-fail /usr/bin/microsoft-edge-$dist $exe
     substituteInPlace $out/share/gnome-control-center/default-apps/microsoft-edge.xml \
       --replace-fail /opt/microsoft/msedge $exe
@@ -251,13 +251,16 @@ stdenv.mkDerivation (finalAttrs: {
 
     # "--simulate-outdated-no-au" disables auto updates and browser outdated popup
     makeWrapper "$out/share/microsoft/$appname/microsoft-edge" "$exe" \
+      --prefix QT_PLUGIN_PATH  : "${qt6.qtbase}/lib/qt-6/plugins" \
+      --prefix QT_PLUGIN_PATH  : "${qt6.qtwayland}/lib/qt-6/plugins" \
+      --prefix NIXPKGS_QT6_QML_IMPORT_PATH : "${qt6.qtwayland}/lib/qt-6/qml" \
       --prefix LD_LIBRARY_PATH : "$rpath" \
       --prefix PATH            : "$binpath" \
       --suffix PATH            : "${lib.makeBinPath [ xdg-utils ]}" \
       --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addDriverRunpath.driverLink}/share" \
       --set SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt" \
       --set CHROME_WRAPPER  "microsoft-edge-$dist" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
       --add-flags "--simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT'" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
@@ -286,6 +289,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       cholli
       ulrikstrid
+      emaryn
     ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/mi/microsoft-edge/package.nix
+++ b/pkgs/by-name/mi/microsoft-edge/package.nix
@@ -290,6 +290,7 @@ stdenv.mkDerivation (finalAttrs: {
       cholli
       ulrikstrid
       emaryn
+      maeve-oake
     ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/mi/microsoft-edge/package.nix
+++ b/pkgs/by-name/mi/microsoft-edge/package.nix
@@ -291,6 +291,7 @@ stdenv.mkDerivation (finalAttrs: {
       ulrikstrid
       emaryn
       maeve-oake
+      leleuvilela
     ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/mi/microsoft-edge/update.py
+++ b/pkgs/by-name/mi/microsoft-edge/update.py
@@ -1,0 +1,44 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3Packages.packaging python3Packages.python-debian common-updater-scripts
+
+import base64
+import textwrap
+import os
+from urllib import request
+
+from collections import OrderedDict
+from debian.deb822 import Packages
+from debian.debian_support import Version
+from os.path import abspath, dirname
+
+PIN_PATH = dirname(abspath(__file__)) + '/default.nix'
+
+def packages():
+    packages_url = 'https://packages.microsoft.com/repos/edge/dists/stable/main/binary-amd64/Packages'
+    handle = request.urlopen(packages_url)
+    return handle
+
+
+def latest_packages(packages: bytes):
+    latest_packages: OrderedDict[str, Packages] = {}
+    for package in Packages.iter_paragraphs(packages, use_apt_pkg=False):
+        name: str = package['Package']
+        if not name.startswith('microsoft-edge-stable'):
+            continue
+        channel = name.replace('microsoft-edge-', '')
+        if channel not in latest_packages:
+            latest_packages[channel] = package
+        else:
+            old_package = latest_packages[channel]
+            if old_package.get_version() < package.get_version():  # type: ignore
+                latest_packages[channel] = package
+    return OrderedDict(sorted(latest_packages.items(), key=lambda x:x[0]))
+
+
+def write_expression():
+    latest = latest_packages(packages())
+    version = Version.re_valid_version.match(latest['stable']['Version']).group('upstream_version')
+    os.system(f'update-source-version microsoft-edge "{version}"')
+
+
+write_expression()

--- a/pkgs/by-name/mi/microsoft-edge/update.py
+++ b/pkgs/by-name/mi/microsoft-edge/update.py
@@ -1,20 +1,19 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i python3 -p python3Packages.packaging python3Packages.python-debian common-updater-scripts
 
-import base64
-import textwrap
 import os
+from collections import OrderedDict
+from os.path import abspath, dirname
 from urllib import request
 
-from collections import OrderedDict
 from debian.deb822 import Packages
 from debian.debian_support import Version
-from os.path import abspath, dirname
 
-PIN_PATH = dirname(abspath(__file__)) + '/default.nix'
+PIN_PATH = dirname(abspath(__file__)) + "/default.nix"
+
 
 def packages():
-    packages_url = 'https://packages.microsoft.com/repos/edge/dists/stable/main/binary-amd64/Packages'
+    packages_url = "https://packages.microsoft.com/repos/edge/dists/stable/main/binary-amd64/Packages"
     handle = request.urlopen(packages_url)
     return handle
 
@@ -22,22 +21,24 @@ def packages():
 def latest_packages(packages: bytes):
     latest_packages: OrderedDict[str, Packages] = {}
     for package in Packages.iter_paragraphs(packages, use_apt_pkg=False):
-        name: str = package['Package']
-        if not name.startswith('microsoft-edge-stable'):
+        name: str = package["Package"]
+        if not name.startswith("microsoft-edge-stable"):
             continue
-        channel = name.replace('microsoft-edge-', '')
+        channel = name.replace("microsoft-edge-", "")
         if channel not in latest_packages:
             latest_packages[channel] = package
         else:
             old_package = latest_packages[channel]
             if old_package.get_version() < package.get_version():  # type: ignore
                 latest_packages[channel] = package
-    return OrderedDict(sorted(latest_packages.items(), key=lambda x:x[0]))
+    return OrderedDict(sorted(latest_packages.items(), key=lambda x: x[0]))
 
 
 def write_expression():
     latest = latest_packages(packages())
-    version = Version.re_valid_version.match(latest['stable']['Version']).group('upstream_version')
+    version = Version.re_valid_version.match(latest["stable"]["Version"]).group(
+        "upstream_version"
+    )
     os.system(f'update-source-version microsoft-edge "{version}"')
 
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1226,7 +1226,6 @@ mapAliases {
   microcodeAmd = microcode-amd; # Added 2024-09-08
   microcodeIntel = microcode-intel; # Added 2024-09-08
   micropad = throw "micropad has been removed, since it was unmaintained and blocked the Electron 27 removal."; # Added 2025-02-24
-  microsoft-edge = throw "microsoft-edge has been removed due to lack of maintenance in nixpkgs"; # Added 2025-05-19
   microsoft_gsl = microsoft-gsl; # Added 2023-05-26
   midori = throw "'midori' original project has been abandonned upstream and the package was broken for a while in nixpkgs"; # Added 2025-05-19
   midori-unwrapped = midori; # Added 2025-05-19


### PR DESCRIPTION
As discussed in  #407617 this PR reintroduces microsoft-edge with me as a maintainer and updated to the latest stable version

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
