### PR TITLE
nixos/gitlab-runner: add options for privileged services

### DIFF
--- a/nixos/modules/services/continuous-integration/gitlab-runner/runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner/runner.nix
@@ -189,11 +189,15 @@ let
                         [ "--docker-image ${service.dockerImage}" ]
                         ++ optional service.dockerDisableCache "--docker-disable-cache"
                         ++ optional service.dockerPrivileged "--docker-privileged"
+                        ++ optional service.dockerServicesPrivileged "--docker-services_privileged true"
                         ++ optional (service.dockerPullPolicy != null) "--docker-pull-policy ${service.dockerPullPolicy}"
                         ++ map (v: "--docker-volumes ${escapeShellArg v}") service.dockerVolumes
                         ++ map (v: "--docker-extra-hosts ${escapeShellArg v}") service.dockerExtraHosts
                         ++ map (v: "--docker-allowed-images ${escapeShellArg v}") service.dockerAllowedImages
                         ++ map (v: "--docker-allowed-services ${escapeShellArg v}") service.dockerAllowedServices
+                        ++ map (
+                          v: "--docker-allowed-privileged-services ${escapeShellArg v}"
+                        ) service.dockerAllowedPrivilegedServices
                       )
                     )
                   )
@@ -521,6 +525,13 @@ in
                 Give extended privileges to container.
               '';
             };
+            dockerServicesPrivileged = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Give extended privileges to services.
+              '';
+            };
             dockerExtraHosts = mkOption {
               type = types.listOf types.str;
               default = [ ];
@@ -552,6 +563,19 @@ in
               ];
               description = ''
                 Whitelist allowed services.
+              '';
+            };
+            dockerAllowedPrivilegedServices = mkOption {
+              type = types.listOf types.str;
+              default = [ ];
+              example = [
+                "docker.io/library/docker:*-dind-rootless"
+                "docker.io/library/docker:dind-rootless"
+                "docker:*-dind-rootless"
+                "docker:dind-rootless"
+              ];
+              description = ''
+                Whitelist allowed privileged services.
               '';
             };
             preGetSourcesScript = mkOption {


### PR DESCRIPTION
The dockerServicesPrivileged and dockerAllowedPrivilegedServices limit which containers are allowed to run in privileged mode in the GitLab CI.

The changes have been tested on an active GitLab CI runner by disabling the nixosModule coming from nixpkgs and reimporting the module including the changes made. 

Documentation: https://docs.gitlab.com/runner/executors/docker/#use-rootless-docker-in-docker-with-restricted-privileged-mode

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
