### PR TITLE
buildOctavePackage: add passthru tests

### DIFF
--- a/pkgs/development/interpreters/octave/build-octave-package.nix
+++ b/pkgs/development/interpreters/octave/build-octave-package.nix
@@ -64,12 +64,19 @@ let
     writeRequiredOctavePackagesHook
   ] ++ nativeBuildInputs;
 
-  passthru' = {
-    updateScript = [
-      ../../../../maintainers/scripts/update-octave-packages
-      (builtins.unsafeGetAttrPos "pname" octave.pkgs.${attrs.pname}).file
-    ];
-  } // passthru;
+  passthru' =
+    {
+      updateScript = [
+        ../../../../maintainers/scripts/update-octave-packages
+        (builtins.unsafeGetAttrPos "pname" octave.pkgs.${attrs.pname}).file
+      ];
+    }
+    // passthru
+    // {
+      tests = {
+        testOctaveBuildEnv = octave.withPackages (ps: [ self ]);
+      } // passthru.tests or { };
+    };
 
   # This step is required because when
   # a = { test = [ "a" "b" ]; }; b = { test = [ "c" "d" ]; };
@@ -82,63 +89,64 @@ let
     "passthru"
   ];
 
+  self = stdenv.mkDerivation (
+    {
+      packageName = "${fullLibName}";
+      # The name of the octave package ends up being
+      # "octave-version-package-version"
+      name = "${octave.pname}-${octave.version}-${fullLibName}";
+
+      # This states that any package built with the function that this returns
+      # will be an octave package. This is used for ensuring other octave
+      # packages are installed into octave during the environment building phase.
+      isOctavePackage = true;
+
+      OCTAVE_HISTFILE = "/dev/null";
+
+      inherit src;
+
+      inherit dontPatch patches patchPhase;
+
+      dontConfigure = true;
+
+      enableParallelBuilding = enableParallelBuilding;
+
+      requiredOctavePackages = requiredOctavePackages';
+
+      nativeBuildInputs = nativeBuildInputs';
+
+      buildInputs = buildInputs ++ requiredOctavePackages';
+
+      propagatedBuildInputs = propagatedBuildInputs ++ [ texinfo ];
+
+      preBuild =
+        if preBuild == "" then
+          ''
+            # This trickery is needed because Octave expects a single directory inside
+            # at the top-most level of the tarball.
+            tar --transform 's,^,${fullLibName}/,' -cz * -f ${fullLibName}.tar.gz
+          ''
+        else
+          preBuild;
+
+      buildPhase = ''
+        runHook preBuild
+
+        mkdir -p $out
+        octave-cli --eval "pkg build $out ${fullLibName}.tar.gz"
+
+        runHook postBuild
+      '';
+
+      # We don't install here, because that's handled when we build the environment
+      # together with Octave.
+      dontInstall = true;
+
+      passthru = passthru';
+
+      inherit meta;
+    }
+    // attrs'
+  );
 in
-stdenv.mkDerivation (
-  {
-    packageName = "${fullLibName}";
-    # The name of the octave package ends up being
-    # "octave-version-package-version"
-    name = "${octave.pname}-${octave.version}-${fullLibName}";
-
-    # This states that any package built with the function that this returns
-    # will be an octave package. This is used for ensuring other octave
-    # packages are installed into octave during the environment building phase.
-    isOctavePackage = true;
-
-    OCTAVE_HISTFILE = "/dev/null";
-
-    inherit src;
-
-    inherit dontPatch patches patchPhase;
-
-    dontConfigure = true;
-
-    enableParallelBuilding = enableParallelBuilding;
-
-    requiredOctavePackages = requiredOctavePackages';
-
-    nativeBuildInputs = nativeBuildInputs';
-
-    buildInputs = buildInputs ++ requiredOctavePackages';
-
-    propagatedBuildInputs = propagatedBuildInputs ++ [ texinfo ];
-
-    preBuild =
-      if preBuild == "" then
-        ''
-          # This trickery is needed because Octave expects a single directory inside
-          # at the top-most level of the tarball.
-          tar --transform 's,^,${fullLibName}/,' -cz * -f ${fullLibName}.tar.gz
-        ''
-      else
-        preBuild;
-
-    buildPhase = ''
-      runHook preBuild
-
-      mkdir -p $out
-      octave-cli --eval "pkg build $out ${fullLibName}.tar.gz"
-
-      runHook postBuild
-    '';
-
-    # We don't install here, because that's handled when we build the environment
-    # together with Octave.
-    dontInstall = true;
-
-    passthru = passthru';
-
-    inherit meta;
-  }
-  // attrs'
-)
+self

--- a/pkgs/development/interpreters/octave/run-pkg-test.nix
+++ b/pkgs/development/interpreters/octave/run-pkg-test.nix
@@ -1,0 +1,25 @@
+{
+  octave,
+  runCommand,
+}:
+package:
+
+runCommand "${package.name}-pkg-test"
+  {
+    nativeBuildInputs = [
+      (octave.withPackages (os: [ package ]))
+    ];
+  }
+  ''
+    { octave-cli --eval 'pkg test ${package.pname}' || touch FAILED_ERRCODE; } \
+      |& tee >( grep --quiet '^Failure Summary:$' && touch FAILED_OUTPUT || : ; cat >/dev/null )
+    if [[ -f FAILED_ERRCODE ]]; then
+      echo >&2 "octave-cli returned with non-zero exit code."
+      false
+    elif [[ -f FAILED_OUTPUT ]]; then
+      echo >&2 "Test failures detected in output."
+      false
+    else
+      touch $out
+    fi
+  ''


### PR DESCRIPTION
While revieweing a octavePackages PR, an ecosystem I'm not familiar with, I was puzzled to find there was no real install test.
While `buildOctavePackage` does run `octave-cli --eval "pkg build ..."`, it isn't before the user calls `octave.withPackages` that `octave-cli --eval "pkg install ..."` is run.
This PR adds a sniff test that does just that to all octave packages. This test si most often only needed when bumping and adding octave packages, although it would be nice to somehow do this during `installCheckPhase` instead.

While the `self` approach here _works_, this builder ought to be refactored to use `lib.extendMkDerivation` instead, but I leave that for the octave maintainers.

Testing:

Builds fine, albeit with some warnings here and there:

* `octavePackages.audio.tests` -> `/nix/store/gfsfcffvg139g1mxvb0klwlyx2gdjix7-octave-10.1.0-env`
* `octavePackages.bim.tests` -> `/nix/store/5qnxx078760j600wj5j934pg1qi6vnjp-octave-10.1.0-env`
* `octavePackages.bsltl.tests` -> `/nix/store/di46mpwws75v9limprr669ap1kdcqg6p-octave-10.1.0-env`
* `octavePackages.cgi.tests` -> `/nix/store/ydmv60i8sw1ka6blgbb7i0b00jpa06ba-octave-10.1.0-env`
* `octavePackages.communications.tests` -> `/nix/store/fgyvys3llwga8dffkbmvvfd4j2bmgir7-octave-10.1.0-env`
* `octavePackages.control.tests` -> `/nix/store/jmsx2h17py4if2sxks90kzxk8yva179y-octave-10.1.0-env`
* `octavePackages.database.tests` -> `/nix/store/n7750sl8ycq80jddjsk7jfhrynshk7hh-octave-10.1.0-env`
* `octavePackages.dataframe.tests` -> `/nix/store/n47kcw9akf3g1rrvkg43qvhdspypgqxz-octave-10.1.0-env`
* `octavePackages.dicom.tests` -> `/nix/store/mgkbc1bgn54y5lzv152x0zrkmv5g8n3g-octave-10.1.0-env`
* `octavePackages.divand.tests` -> `/nix/store/dxpmqirr60qcj810n89lq4q6fylwbrvz-octave-10.1.0-env`
* `octavePackages.doctest.tests` -> `/nix/store/wh5nhndxlfg8ahf2dhsi4k7s4q24kn4x-octave-10.1.0-env`
* `octavePackages.fpl.tests` -> `/nix/store/3mx9s9dbvcx20m0m4hm8mgfrvl2f8c4j-octave-10.1.0-env`
* `octavePackages.fuzzy-logic-toolkit.tests` -> `/nix/store/ysx68g7wpy4fbz21q9x9zdgb4yj9li13-octave-10.1.0-env`
* `octavePackages.ga.tests` -> `/nix/store/9p6mgsv3166il24s4bfpxbaqy7pr3np3-octave-10.1.0-env`
* `octavePackages.general.tests` -> `/nix/store/bhjm2ar1n379c2dg4k7wmby721qi3w9b-octave-10.1.0-env`
* `octavePackages.generate_html.tests` -> `/nix/store/r33k2qna874ncyf0rzfvmxwbkl3sal4k-octave-10.1.0-env`
* `octavePackages.geometry.tests` -> `/nix/store/3pxrh2wb9wlv69kvrrg6jjpgwxy2rjqr-octave-10.1.0-env`
* `octavePackages.image-acquisition.tests` -> `/nix/store/r0ywp3kq967ay64y6hhmpxkqjy8n69q9-octave-10.1.0-env`
* `octavePackages.image.tests` -> `/nix/store/pssi79pdvp0k14z1lbvsnlh46ygq78ya-octave-10.1.0-env`
* `octavePackages.instrument-control.tests` -> `/nix/store/61m4n8ii3qsnbgbd0zzc8x0bk72cx5vv-octave-10.1.0-env`
* `octavePackages.interval.tests` -> `/nix/store/g78z6ah6xxjrnvz2fafn5nx9fm2pgnyv-octave-10.1.0-env`
* `octavePackages.io.tests` -> `/nix/store/dw8lav38xn5wp4h88q926b3krxvfczdn-octave-10.1.0-env`
* `octavePackages.linear-algebra.tests` -> `/nix/store/wriqa38xf9vfnrhhv6slfpc6k5arv5cm-octave-10.1.0-env`
* `octavePackages.lssa.tests` -> `/nix/store/wwhj069fgnazbmwyakqkrhbrfdkfvwhc-octave-10.1.0-env`
* `octavePackages.matgeom.tests` -> `/nix/store/di1dp02ds6lvlm8ifwmsmxafki0my5j3-octave-10.1.0-env`
* `octavePackages.miscellaneous.tests` -> `/nix/store/pbh2khwbs3asxr98ww3dadynyp4w5gjl-octave-10.1.0-env`
* `octavePackages.msh.tests` -> `/nix/store/g609r2iy0skgcv2kginkxqpp6kcvk8nb-octave-10.1.0-env`
* `octavePackages.mvn.tests` -> `/nix/store/y84dhsf3h4kz0vs729lvncjbs75rlls3-octave-10.1.0-env`
* `octavePackages.nan.tests` -> `/nix/store/gm7ma33w5v67379wjvghx6lmpk39r4a4-octave-10.1.0-env`
* `octavePackages.ncarray.tests` -> `/nix/store/xdqn7cd3a7q0aj0f42l2ifskhn1k9c4m-octave-10.1.0-env`
* `octavePackages.netcdf.tests` -> `/nix/store/4rzqbs8i1hkhsgl9q67laf5srz25gwh5-octave-10.1.0-env`
* `octavePackages.nurbs.tests` -> `/nix/store/gnsx5i5c6ky8y5s5j8izlgjz74prp1ys-octave-10.1.0-env`
* `octavePackages.octclip.tests` -> `/nix/store/bd723m3w1ffig5a1cnvaf1wkhnc66hfv-octave-10.1.0-env`
* `octavePackages.octproj.tests` -> `/nix/store/pi19581cqja36m3zlh09l6mpk4yynq34-octave-10.1.0-env`
* `octavePackages.optics.tests` -> `/nix/store/ig9f7adp173c2qngkclp01iv388ivxsk-octave-10.1.0-env`
* `octavePackages.optiminterp.tests` -> `/nix/store/249dq2sadln4bgknylaxzc13yg4lcbbp-octave-10.1.0-env`
* `octavePackages.quaternion.tests` -> `/nix/store/amw45jgwqqf7bw55qwc8bsjzx9khlbyj-octave-10.1.0-env`
* `octavePackages.signal.tests` -> `/nix/store/q8banm7pkgzka9ygpzqivn44gn88iqpd-octave-10.1.0-env`
* `octavePackages.sockets.tests` -> `/nix/store/74xb0m3ykpxny8grbz2a0c84bp5x8qk2-octave-10.1.0-env`
* `octavePackages.splines.tests` -> `/nix/store/1yk0p5yxl46b2bl1mlmiw32s2d0a5vxm-octave-10.1.0-env`
* `octavePackages.statistics.tests` -> `/nix/store/r161lfb3cg4ajk3ky06gnlr94y1g7n1l-octave-10.1.0-env`
* `octavePackages.stk.tests` -> `/nix/store/djf5x4jsi0yx2jsw3jrs3cnzn8mc7v44-octave-10.1.0-env`
* `octavePackages.strings.tests` -> `/nix/store/f8hhf2p6ykrchjnc8nngsbbscagkhiyl-octave-10.1.0-env`
* `octavePackages.struct.tests` -> `/nix/store/y8svqkjsfxv75s7nxim9wk1qba72xrvm-octave-10.1.0-env`
* `octavePackages.symbolic.tests` -> `/nix/store/f3r2brimsfymqk28fl44cf9ddsw34w3x-octave-10.1.0-env`
* `octavePackages.tsa.tests` -> `/nix/store/rvga4qc13dcrf913mjrmq4nr4gb6rk54-octave-10.1.0-env`
* `octavePackages.video.tests` -> `/nix/store/h6m2d90qjviq3qv89mnrysbasmg55zbi-octave-10.1.0-env`
* `octavePackages.windows.tests` -> `/nix/store/qx79vshxqm1hr5d7chqzzc751iqcq75x-octave-10.1.0-env`
* `octavePackages.zeromq.tests` -> `/nix/store/ws42x3gpqvfrqm7bvbffcphf0snb994i-octave-10.1.0-env`

Build failure:

* `octavePackages.arduino.tests`
* `octavePackages.financial.tests`
* `octavePackages.gsl.tests`
* `octavePackages.mapping.tests`
  * fixed by https://github.com/NixOS/nixpkgs/pull/406300
* `octavePackages.queueing.tests`

No eval (the majority because they're marked broken):

* `octavePackages.data-smoothing.tests`
* `octavePackages.econometrics.tests`
* `octavePackages.fem-fenics.tests`
* `octavePackages.fits.tests`
* `octavePackages.level-set.tests`
* `octavePackages.ltfat.tests`
* `octavePackages.ocl.tests`
* `octavePackages.optim.tests`
* `octavePackages.parallel.tests`
* `octavePackages.sparsersb.tests`
* `octavePackages.tisean.tests`
* `octavePackages.vibes.tests`
* `octavePackages.vrml.tests`
* `octavePackages.writeRequiredOctavePackagesHook.tests`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
