### PR TITLE
hotdoc: patch libclang and clangd for runtime access

### DIFF
--- a/pkgs/development/tools/hotdoc/clang.patch
+++ b/pkgs/development/tools/hotdoc/clang.patch
@@ -1,0 +1,52 @@
+diff --git a/hotdoc/extensions/c/c_extension.py b/hotdoc/extensions/c/c_extension.py
+index 1cfd5b3..cff20c8 100644
+--- a/hotdoc/extensions/c/c_extension.py
++++ b/hotdoc/extensions/c/c_extension.py
+@@ -89,7 +89,7 @@ def get_clang_headers():
+     try:
+         # Clang 5.0+ can tell us directly
+         resource_dir = subprocess.check_output(
+-            ['clang', '--print-resource-dir']).strip().decode()
++            ['@clang@', '--print-resource-dir']).strip().decode()
+         if len(resource_dir) > 0:
+             include_dir = os.path.join(resource_dir, 'include')
+             if os.path.exists(include_dir):
+diff --git a/hotdoc/extensions/c/clang/cindex.py b/hotdoc/extensions/c/clang/cindex.py
+index fc93fda..2eb8eaf 100644
+--- a/hotdoc/extensions/c/clang/cindex.py
++++ b/hotdoc/extensions/c/clang/cindex.py
+@@ -3937,20 +3937,23 @@ class Config:
+         if Config.library_file:
+             return Config.library_file
+ 
+-        import platform
+-        name = platform.system()
++        if Config.library_path:
++            import platform
++            name = platform.system()
+ 
+-        if name == 'Darwin':
+-            file = 'libclang.dylib'
+-        elif name == 'Windows':
+-            file = 'libclang.dll'
+-        else:
+-            file = 'libclang.so'
++            if name == 'Darwin':
++                file = 'libclang.dylib'
++            elif name == 'Windows':
++                file = 'libclang.dll'
++            else:
++                file = 'libclang.so'
+ 
+-        if Config.library_path:
+-            file = Config.library_path + '/' + file
++            if Config.library_path:
++                file = Config.library_path + '/' + file
++
++            return file
+ 
+-        return file
++        return "@libclang@"
+ 
+     def get_cindex_library(self):
+         try:

--- a/pkgs/development/tools/hotdoc/default.nix
+++ b/pkgs/development/tools/hotdoc/default.nix
@@ -3,10 +3,12 @@
   stdenv,
   buildPythonApplication,
   fetchPypi,
+  replaceVars,
+  clang,
+  libclang,
   pytestCheckHook,
   pkg-config,
   cmake,
-  clang,
   flex,
   glib,
   json-glib,
@@ -38,6 +40,13 @@ buildPythonApplication rec {
     hash = "sha256-xNXf9kfwOqh6HS0GA10oGe3QmbkWNeOy7jkIKTV66fw=";
   };
 
+  patches = [
+    (replaceVars ./clang.patch {
+      clang = lib.getExe clang;
+      libclang = "${lib.getLib libclang}/lib/libclang${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
   build-system = [ setuptools ];
 
   nativeBuildInputs = [
@@ -68,10 +77,7 @@ buildPythonApplication rec {
     wheezy-template
   ];
 
-  nativeCheckInputs = [
-    clang
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   # CMake is used to build CMARK, but the build system is still python
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
```
$ ./result/bin/hotdoc --list-extensions
Extensions:
 - c-extension 
 - check-missing-since-markers 
 - comment-on-github 
 - core-tags 
 - dbus-extension 
 - devhelp-extension 
 - edit-on-github 
 - feedgen 
 - gi-extension 
 - git-upload 
 - gst-extension 
 - license-extension 
 - search 
 - syntax-highlighting-extension 
```

cc @trofi

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
