### PR TITLE
[Backport release-24.11] nixos/mediagoblin: fix gmg argument parsing and media reprocessing

### DIFF
--- a/nixos/modules/services/web-apps/mediagoblin.nix
+++ b/nixos/modules/services/web-apps/mediagoblin.nix
@@ -25,22 +25,32 @@ let
 
   iniFormat = pkgs.formats.ini { };
 
-  # we need to build our own GI_TYPELIB_PATH because celery and paster need this information, too and cannot easily be re-wrapped
-  GI_TYPELIB_PATH =
+  # we need to build our own GI_TYPELIB_PATH and GST_PLUGIN_PATH because celery, paster and gmg need this information and it cannot easily be re-wrapped
+  gst =
     let
       needsGst =
         (cfg.settings.mediagoblin.plugins ? "mediagoblin.media_types.audio")
         || (cfg.settings.mediagoblin.plugins ? "mediagoblin.media_types.video");
     in
-    lib.makeSearchPathOutput "out" "lib/girepository-1.0" (
-      with pkgs.gst_all_1;
+    with pkgs.gst_all_1;
+    [
+      pkgs.glib
+      gst-plugins-base
+      gstreamer
+    ]
+    # audio and video share most dependencies, so we can just take audio
+    ++ lib.optionals needsGst cfg.package.optional-dependencies.audio;
+  GI_TYPELIB_PATH = lib.makeSearchPathOutput "out" "lib/girepository-1.0" gst;
+  GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" gst;
+
+  path =
+    lib.optionals (cfg.settings.mediagoblin.plugins ? "mediagoblin.media_types.stl") [ pkgs.blender ]
+    ++ lib.optionals (cfg.settings.mediagoblin.plugins ? "mediagoblin.media_types.pdf") (
+      with pkgs;
       [
-        pkgs.glib
-        gst-plugins-base
-        gstreamer
+        poppler_utils
+        unoconv
       ]
-      # audio and video share most dependencies, so we can just take audio
-      ++ lib.optionals needsGst cfg.package.optional-dependencies.audio
     );
 
   finalPackage = cfg.package.python.buildEnv.override {
@@ -189,7 +199,7 @@ in
         if [[ "$USER" != mediagoblin ]]; then
          sudo='exec /run/wrappers/bin/sudo -u mediagoblin'
         fi
-        $sudo sh -c "cd /var/lib/mediagoblin; env GI_TYPELIB_PATH=${GI_TYPELIB_PATH} ${lib.getExe' finalPackage "gmg"} $*"
+        $sudo sh -c "cd /var/lib/mediagoblin; env GI_TYPELIB_PATH=${GI_TYPELIB_PATH} GST_PLUGIN_PATH=${GST_PLUGIN_PATH} PATH=$PATH:${lib.makeBinPath path} ${lib.getExe' finalPackage "gmg"} $*"
       '')
     ];
 
@@ -248,15 +258,7 @@ in
       let
         serviceDefaults = {
           wantedBy = [ "multi-user.target" ];
-          path =
-            lib.optionals (cfg.settings.mediagoblin.plugins ? "mediagoblin.media_types.stl") [ pkgs.blender ]
-            ++ lib.optionals (cfg.settings.mediagoblin.plugins ? "mediagoblin.media_types.pdf") (
-              with pkgs;
-              [
-                poppler_utils
-                unoconv
-              ]
-            );
+          inherit path;
           serviceConfig = {
             AmbientCapabilities = "";
             CapabilityBoundingSet = [ "" ];
@@ -325,6 +327,7 @@ in
             Environment = [
               "CELERY_CONFIG_MODULE=mediagoblin.init.celery.from_celery"
               "GI_TYPELIB_PATH=${GI_TYPELIB_PATH}"
+              "GST_PLUGIN_PATH=${GST_PLUGIN_PATH}"
               "MEDIAGOBLIN_CONFIG=/var/lib/mediagoblin/mediagoblin.ini"
               "PASTE_CONFIG=${pasteConfig}"
             ];
@@ -350,6 +353,7 @@ in
             Environment = [
               "CELERY_ALWAYS_EAGER=false"
               "GI_TYPELIB_PATH=${GI_TYPELIB_PATH}"
+              "GST_PLUGIN_PATH=${GST_PLUGIN_PATH}"
             ];
             ExecStart = "${lib.getExe' finalPackage "paster"} serve /var/lib/mediagoblin/paste.ini";
           };

--- a/nixos/modules/services/web-apps/mediagoblin.nix
+++ b/nixos/modules/services/web-apps/mediagoblin.nix
@@ -189,7 +189,7 @@ in
         if [[ "$USER" != mediagoblin ]]; then
          sudo='exec /run/wrappers/bin/sudo -u mediagoblin'
         fi
-        $sudo sh -c "cd /var/lib/mediagoblin; env GI_TYPELIB_PATH=${GI_TYPELIB_PATH} ${lib.getExe' finalPackage "gmg"} $@"
+        $sudo sh -c "cd /var/lib/mediagoblin; env GI_TYPELIB_PATH=${GI_TYPELIB_PATH} ${lib.getExe' finalPackage "gmg"} $*"
       '')
     ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
