### PR TITLE
`mkDerivation`: support `__functor` functions and clean up

### DIFF
--- a/pkgs/by-name/li/libcollectdclient/package.nix
+++ b/pkgs/by-name/li/libcollectdclient/package.nix
@@ -2,7 +2,6 @@
 
 collectd.overrideAttrs (oldAttrs: {
   pname = "libcollectdclient";
-  inherit (collectd) version;
   buildInputs = [ ];
 
   configureFlags = (oldAttrs.configureFlags or [ ]) ++ [

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -439,6 +439,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               (superDarwin.binutils-unwrapped.override { enableManpages = false; }).overrideAttrs
                 (old: {
                   version = "boot";
+                  __intentionallyOverridingVersion = true; # to avoid a warning suggesting to provide src
                   passthru = (old.passthru or { }) // {
                     isFromBootstrapFiles = true;
                   };

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -95,6 +95,7 @@ let
                 thisOverlay = overlay final prev;
                 warnForBadVersionOverride = (
                   thisOverlay ? version
+                  && prev ? version
                   && !(thisOverlay ? src)
                   && !(thisOverlay.__intentionallyOverridingVersion or false)
                 );

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -136,24 +136,7 @@ let
     in
     finalPackage;
 
-  #makeDerivationExtensibleConst = attrs: makeDerivationExtensible (_: attrs);
-  # but pre-evaluated for a slight improvement in performance.
-  makeDerivationExtensibleConst =
-    attrs:
-    mkDerivationSimple (
-      f0:
-      let
-        f =
-          self: super:
-          let
-            x = f0 super;
-          in
-          if builtins.isFunction x then f0 self super else x;
-      in
-      makeDerivationExtensible (
-        self: attrs // (if builtins.isFunction f0 || f0 ? __functor then f self attrs else f0)
-      )
-    ) attrs;
+  makeDerivationExtensibleConst = attrs: makeDerivationExtensible (_: attrs);
 
   knownHardeningFlags = [
     "bindnow"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -96,6 +96,9 @@ let
                 warnForBadVersionOverride = (
                   thisOverlay ? version
                   && prev ? version
+                  # We could check that the version is actually distinct, but that
+                  # would probably just delay the inevitable, or preserve tech debt.
+                  # && prev.version != thisOverlay.version
                   && !(thisOverlay ? src)
                   && !(thisOverlay.__intentionallyOverridingVersion or false)
                 );

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -64,10 +64,12 @@ let
   */
   mkDerivation =
     fnOrAttrs:
-    if isFunction fnOrAttrs then
-      makeDerivationExtensible fnOrAttrs
-    else
-      makeDerivationExtensible (_: fnOrAttrs);
+    makeDerivationExtensible (
+      if isFunction fnOrAttrs then
+        fnOrAttrs
+      else
+        (_: fnOrAttrs)
+    );
 
   checkMeta = import ./check-meta.nix {
     inherit lib config;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -67,7 +67,7 @@ let
     if isFunction fnOrAttrs then
       makeDerivationExtensible fnOrAttrs
     else
-      makeDerivationExtensibleConst fnOrAttrs;
+      makeDerivationExtensible (_: fnOrAttrs);
 
   checkMeta = import ./check-meta.nix {
     inherit lib config;
@@ -135,8 +135,6 @@ let
 
     in
     finalPackage;
-
-  makeDerivationExtensibleConst = attrs: makeDerivationExtensible (_: attrs);
 
   knownHardeningFlags = [
     "bindnow"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -24,6 +24,7 @@ let
     isAttrs
     isBool
     isDerivation
+    isFunction
     isInt
     isList
     isString
@@ -63,7 +64,7 @@ let
   */
   mkDerivation =
     fnOrAttrs:
-    if builtins.isFunction fnOrAttrs then
+    if isFunction fnOrAttrs then
       makeDerivationExtensible fnOrAttrs
     else
       makeDerivationExtensibleConst fnOrAttrs;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -24,7 +24,6 @@ let
     isAttrs
     isBool
     isDerivation
-    isFunction
     isInt
     isList
     isString
@@ -37,6 +36,7 @@ let
     remove
     splitString
     subtractLists
+    toFunction
     unique
     zipAttrsWith
     ;
@@ -62,14 +62,7 @@ let
     Most arguments are also passed through to the underlying call of [`builtins.derivation`](https://nixos.org/manual/nix/stable/language/derivations).
     :::
   */
-  mkDerivation =
-    fnOrAttrs:
-    makeDerivationExtensible (
-      if isFunction fnOrAttrs then
-        fnOrAttrs
-      else
-        (_: fnOrAttrs)
-    );
+  mkDerivation = fnOrAttrs: makeDerivationExtensible (toFunction fnOrAttrs);
 
   checkMeta = import ./check-meta.nix {
     inherit lib config;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15900,6 +15900,7 @@ with pkgs;
     polyml = polyml.overrideAttrs {
       pname = "polyml-for-isabelle";
       version = "2025";
+      __intentionallyOverridingVersion = true; # avoid a warning, no src override
       configureFlags = [
         "--enable-intinf-as-int"
         "--with-gmp"


### PR DESCRIPTION
- Support `__functor` functions as argument (see commit message for details)
  - Found in https://github.com/NixOS/nixpkgs/pull/299542
- Clean up
- Enable `src`/`version` override warning more broadly (see commit message no. 2 for details)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
