### PR TITLE
nixos/perses: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -66,6 +66,8 @@
 
 - [Shoko](https://shokoanime.com), an anime management system. Available as [services.shoko](#opt-services.shoko.enable).
 
+- [perses](https://perses.dev/), the open dashboard tool for Prometheus and other data sources. Available as [services.perses](#opt-services.perses.enable).
+
 - [Drasl](https://github.com/unmojang/drasl), an alternative authentication server for Minecraft. Available as [services.drasl](#opt-services.drasl.enable).
 
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1038,6 +1038,7 @@
   ./services/monitoring/opentelemetry-collector.nix
   ./services/monitoring/osquery.nix
   ./services/monitoring/parsedmarc.nix
+  ./services/monitoring/perses.nix
   ./services/monitoring/pgscv.nix
   ./services/monitoring/prometheus/alertmanager-gotify-bridge.nix
   ./services/monitoring/prometheus/alertmanager-irc-relay.nix

--- a/nixos/modules/services/monitoring/perses.nix
+++ b/nixos/modules/services/monitoring/perses.nix
@@ -1,0 +1,131 @@
+{
+  pkgs,
+  lib,
+  config,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    getExe
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    mkIf
+    types
+    ;
+
+  cfg = config.services.perses;
+
+  settingsFormat = pkgs.formats.yaml { };
+
+  configPath = "/run/perses/config.yaml";
+  secretsReplacement = utils.genJqSecretsReplacement {
+    loadCredential = true;
+  } cfg.settings configPath;
+
+in
+{
+  options.services.perses = {
+    enable = mkEnableOption "perses";
+
+    package = mkPackageOption pkgs "perses" { };
+
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      description = ''
+        Perses Web interface port.
+      '';
+    };
+
+    listenAddress = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        Address to listen on. Empty string will listen on all interfaces.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+      };
+      description = ''
+        Perses settings. See <https://perses.dev/perses/docs/configuration/configuration/> for available options.
+        You can specify secret values in this configuration by setting `somevalue._secret = "/path/to/file"` instead of setting `somevalue` directly.
+      '';
+      default = { };
+    };
+
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "-web.telemetry-path=/metrics"
+      ];
+      description = "Additional options passed to perses daemon.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.perses = {
+      description = "Perses Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "networking.target" ];
+
+      preStart = secretsReplacement.script;
+
+      serviceConfig = rec {
+        ExecStart = utils.escapeSystemdExecArgs (
+          [
+            (getExe cfg.package)
+            "-config=${configPath}"
+            "-web.listen-address=${cfg.listenAddress}:${toString cfg.port}"
+          ]
+          ++ cfg.extraOptions
+        );
+
+        User = "perses";
+        DynamicUser = true;
+        Restart = "on-failure";
+        RuntimeDirectory = "perses";
+        RuntimeDirectoryMode = "0755";
+        StateDirectory = "perses";
+        WorkingDirectory = "%S/${StateDirectory}";
+
+        LoadCredential = secretsReplacement.credentials;
+
+        # Hardening
+        AmbientCapabilities = mkIf (cfg.port < 1024) [ "CAP_NET_BIND_SERVICE" ];
+        CapabilityBoundingSet = if (cfg.port < 1024) then [ "CAP_NET_BIND_SERVICE" ] else [ "" ];
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "full";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        UMask = "0027";
+      };
+    };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1249,6 +1249,7 @@ in
   peerflix = runTest ./peerflix.nix;
   peering-manager = runTest ./web-apps/peering-manager.nix;
   peertube = handleTestOn [ "x86_64-linux" ] ./web-apps/peertube.nix { };
+  perses = runTest ./perses.nix;
   pgadmin4 = runTest ./pgadmin4.nix;
   pgbackrest = import ./pgbackrest { inherit runTest; };
   pgbouncer = runTest ./pgbouncer.nix;

--- a/nixos/tests/perses.nix
+++ b/nixos/tests/perses.nix
@@ -1,0 +1,65 @@
+{ pkgs, lib, ... }:
+
+{
+  name = "perses";
+
+  meta.maintainers = with lib.maintainers; [ fooker ];
+
+  nodes.prometheus = {
+    services.prometheus.enable = true;
+    networking.firewall.allowedTCPPorts = [ 9090 ];
+  };
+
+  nodes.machine = {
+    services.perses = {
+      enable = true;
+
+      settings.provisioning.folders = [
+        (pkgs.writeTextDir "perses-test-provision-project.yaml" ''
+          kind: "Project"
+          metadata:
+            name: "my-project"
+        '')
+        (pkgs.writeTextDir "perses-test-provision-datasource.yaml" ''
+          kind: "Datasource"
+          metadata:
+            name: "my-prometheus"
+            project: "my-project"
+          spec:
+            default: true
+            plugin:
+              kind: "PrometheusDatasource"
+              spec:
+                proxy:
+                  kind: "HTTPProxy"
+                  spec:
+                    url: "http://prometheus:9090/"
+        '')
+      ];
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    prometheus.wait_for_unit("prometheus.service")
+    prometheus.wait_for_open_port(9090)
+
+    with subtest("Perses starts"):
+        machine.wait_for_unit("perses.service")
+        machine.wait_for_open_port(8080)
+        machine.succeed("percli login http://127.0.0.1:8080")
+        machine.succeed("percli version")
+        machine.succeed("percli config")
+        machine.succeed("percli plugin list | grep 'Prometheus'")
+
+    with subtest("Query resources"):
+        machine.succeed("percli get projects | grep my-project")
+        machine.succeed("percli project my-project")
+        machine.succeed("percli get datasources | grep my-prometheus")
+        machine.succeed("curl --fail -s 127.0.0.1:8080/api/v1/projects/my-project/datasources/my-prometheus")
+
+    with subtest("Datasource check"):
+        machine.succeed("curl --fail -s http://127.0.0.1:8080/proxy/projects/my-project/datasources/my-prometheus/api/v1/status/config")
+  '';
+}

--- a/pkgs/by-name/pe/perses/package.nix
+++ b/pkgs/by-name/pe/perses/package.nix
@@ -10,6 +10,7 @@
   turbo,
   linkFarm,
   installShellFiles,
+  nixosTests,
 }:
 
 let
@@ -117,6 +118,8 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     updateScript = ./update.sh;
+
+    tests.nixos = nixosTests.perses;
 
     inherit pluginsArchive;
   };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
