### PR TITLE
Xfce updates 2025-05-28

### DIFF
--- a/pkgs/desktops/xfce/applications/catfish/default.nix
+++ b/pkgs/desktops/xfce/applications/catfish/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  desktop-file-utils,
   gobject-introspection,
   meson,
   ninja,
@@ -19,18 +18,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "catfish";
-  version = "4.20.0";
+  version = "4.20.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.xfce.org";
     owner = "apps";
     repo = "catfish";
     rev = "catfish-${finalAttrs.version}";
-    hash = "sha256-7ERE6R714OuqTjeNZw3K6HvQTA8OIglG6+8Kiawwzu8=";
+    hash = "sha256-mTAunc1GJLkSu+3oWD5+2sCQemWdVsUURlP09UkbVyw=";
   };
 
   nativeBuildInputs = [
-    desktop-file-utils
     gobject-introspection
     meson
     ninja

--- a/pkgs/desktops/xfce/applications/gigolo/default.nix
+++ b/pkgs/desktops/xfce/applications/gigolo/default.nix
@@ -1,27 +1,51 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
   gtk3,
   glib,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "gigolo";
-  version = "0.5.4";
-  odd-unstable = false;
+  version = "0.6.0";
 
-  sha256 = "sha256-gRv1ZQLgwwzFERnco2Dm2PkT/BNDIZU6fX+HdhiRCJk=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "gigolo";
+    tag = "gigolo-${finalAttrs.version}";
+    hash = "sha256-tyFjVvtDE25y6rnmlESdl8s/GdyHGqbn2Dn/ymIIgWs=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    glib # glib-compile-resources
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     gtk3
     glib
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "gigolo-"; };
+
+  meta = {
     description = "Frontend to easily manage connections to remote filesystems";
+    homepage = "https://gitlab.xfce.org/apps/gigolo";
+    license = lib.licenses.gpl2Plus;
     mainProgram = "gigolo";
-    license = with licenses; [ gpl2Only ];
-    teams = [ teams.xfce ];
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/desktops/xfce/applications/parole/default.nix
+++ b/pkgs/desktops/xfce/applications/parole/default.nix
@@ -1,9 +1,15 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
   dbus,
   dbus-glib,
   gst_all_1,
+  glib,
   gtk3,
   libnotify,
   libX11,
@@ -11,24 +17,40 @@
   libxfce4util,
   taglib,
   xfconf,
+  gitUpdater,
 }:
 
-# Doesn't seem to find H.264 codec even though built with gst-plugins-bad.
-
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "parole";
-  version = "4.18.2";
+  version = "4.20.0";
 
-  sha256 = "sha256-C4dGiMYn51YuASsQeQs3Cbc+KkPqcOrsCMS+dYfP+Ps=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "parole";
+    tag = "parole-${finalAttrs.version}";
+    hash = "sha256-I1wZsuZ/NM5bH6QTJpwd5WL9cIGNtkAxA2j5vhhdaTE=";
+  };
 
-  buildInputs = with gst_all_1; [
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    dbus-glib # dbus-binding-tool
+    glib # glib-genmarshal
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
     dbus
     dbus-glib
-    gst-plugins-bad
-    gst-plugins-base
-    gst-plugins-good
-    gst-plugins-ugly
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-ugly
+    glib
     gtk3
     libnotify
     libX11
@@ -38,9 +60,14 @@ mkXfceDerivation {
     xfconf
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "parole-"; };
+
+  meta = {
     description = "Modern simple media player";
+    homepage = "https://gitlab.xfce.org/apps/parole";
+    license = lib.licenses.gpl2Plus;
     mainProgram = "parole";
-    teams = [ teams.xfce ];
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/desktops/xfce/applications/xfce4-panel-profiles/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-panel-profiles/default.nix
@@ -4,10 +4,14 @@
   fetchFromGitLab,
   gettext,
   gobject-introspection,
+  meson,
+  ninja,
+  pkg-config,
   wrapGAppsHook3,
   glib,
   gtk3,
   libxfce4ui,
+  libxfce4util,
   python3,
   gitUpdater,
 }:
@@ -20,19 +24,22 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-panel-profiles";
-  version = "1.0.15";
+  version = "1.1.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.xfce.org";
     owner = "apps";
     repo = "xfce4-panel-profiles";
     rev = "xfce4-panel-profiles-${finalAttrs.version}";
-    sha256 = "sha256-UxXxj0lxJhaMv5cQoyz+glJiLwvIFfpPu27TCNDhoL0=";
+    hash = "sha256-4sUNlabWp6WpBlePVFHejq/+TXiJYSQTnZFp5B258Wc=";
   };
 
   nativeBuildInputs = [
     gettext
     gobject-introspection
+    meson
+    ninja
+    pkg-config
     wrapGAppsHook3
   ];
 
@@ -40,15 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     gtk3
     libxfce4ui
+    libxfce4util
     pythonEnv
   ];
 
-  configurePhase = ''
-    runHook preConfigure
-    # This is just a handcrafted script and does not accept additional arguments.
-    ./configure --prefix=$out
-    runHook postConfigure
-  '';
+  mesonFlags = [
+    "-Dpython-path=${lib.getExe pythonEnv}"
+  ];
 
   passthru.updateScript = gitUpdater { rev-prefix = "xfce4-panel-profiles-"; };
 


### PR DESCRIPTION
The 6th PR for the mass autotools -> meson transition, previous:

- https://github.com/NixOS/nixpkgs/pull/409074
- https://github.com/NixOS/nixpkgs/pull/409413
- https://github.com/NixOS/nixpkgs/pull/409803
- https://github.com/NixOS/nixpkgs/pull/410534
- https://github.com/NixOS/nixpkgs/pull/411149

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

