### PR TITLE
tflint-plugins: small compatibility fixes, version update

### DIFF
--- a/pkgs/by-name/tf/tflint/package.nix
+++ b/pkgs/by-name/tf/tflint/package.nix
@@ -43,9 +43,10 @@ buildGoModule {
         paths = [ actualPlugins ];
       };
     in
-    runCommand "tflint-with-plugins"
+    runCommand "tflint-with-plugins-${version}"
       {
         nativeBuildInputs = [ makeWrapper ];
+        inherit version;
       }
       ''
         makeWrapper ${tflint}/bin/tflint $out/bin/tflint \

--- a/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-aws.nix
+++ b/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-aws.nix
@@ -23,8 +23,15 @@ buildGoModule rec {
   '';
 
   postInstall = ''
+    # allow use as a versioned dependency, i.e., with `source = ...` and
+    # `version = ...` in `.tflintrc`:
     mkdir -p $out/github.com/terraform-linters/${pname}/${version}
     mv $out/bin/${pname} $out/github.com/terraform-linters/${pname}/${version}/
+
+    # allow use as an unversioned dependency, e.g., if one wants `.tflintrc` to
+    # solely rely on Nix to pin versions:
+    ln -s $out/github.com/terraform-linters/${pname}/${version}/${pname} $out/
+
     # remove other binaries from bin
     rm -R $out/bin
   '';

--- a/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-aws.nix
+++ b/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-aws.nix
@@ -6,16 +6,21 @@
 
 buildGoModule rec {
   pname = "tflint-ruleset-aws";
-  version = "0.37.0";
+  version = "0.40.0";
 
   src = fetchFromGitHub {
     owner = "terraform-linters";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-7xS1V7Ec3eWiVjMB/4MLeKlGxNKRYeHVFc61dpoBU/8=";
+    hash = "sha256-n8o43zCZWrTmLdEuCPe9B1lqxnCbytwRUXSof2sI1Zw=";
   };
 
-  vendorHash = "sha256-XUGcRky0GMV2RSahUk6k/KWkWvxdCLi/7TpXn2MdNoM=";
+  vendorHash = "sha256-PBXObv/9QwWPmLnTReV7iuFyas1RFtvlboEjPfyIi7w=";
+
+  postPatch = ''
+    # some automation for creating new releases on GitHub, which we don't need
+    rm -rf tools/release
+  '';
 
   # upstream Makefile also does a  go test $(go list ./... | grep -v integration)
   preCheck = ''

--- a/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-google.nix
+++ b/pkgs/development/tools/analysis/tflint-plugins/tflint-ruleset-google.nix
@@ -25,8 +25,14 @@ buildGoModule rec {
   subPackages = [ "." ];
 
   postInstall = ''
+    # allow use as a versioned dependency, i.e., with `source = ...` and
+    # `version = ...` in `.tflintrc`:
     mkdir -p $out/github.com/terraform-linters/${pname}/${version}
     mv $out/bin/${pname} $out/github.com/terraform-linters/${pname}/${version}/
+
+    # allow use as an unversioned dependency, e.g., if one wants `.tflintrc` to
+    # solely rely on Nix to pin versions:
+    ln -s $out/github.com/terraform-linters/${pname}/${version}/${pname} $out/
   '';
 
   meta = with lib; {


### PR DESCRIPTION
I've made a couple of small compatibility changes:
  - symlink an additional path for each `tflint-plugin` so that when `tflint.withPlugins` is used to create a TFLINT_PLUGIN_DIR, `.tflint.hcl` can read, e.g.,
    
    ```
    plugin "aws" {
      enabled = true
    }
    ```
    as well as
    ```
    plugin "aws" {
      enabled = true
      version = "0.37.0"
      source  = "github.com/terraform-linters/tflint-ruleset-aws"
    }
    ```
  - add a `version` attribute to the result of `tflint.withPlugins` so that, like the base `tflint` package, they support version comparisons
  
Additionally, I updated `tflint-ruleset-aws` from `v0.37.0` to `v0.40.0`. Here are the breaking changes noted in the changelogs for the relevant versions:
  - `v0.38.0`:
    - Update AWS provider/module and generated content by @wata727 in https://github.com/terraform-linters/tflint-ruleset-aws/pull/837
    - Remove Amazon Chime rules
       - aws_chime_voice_connector_group_invalid_name
       - aws_chime_voice_connector_invalid_aws_region
       - aws_chime_voice_connector_invalid_name
       - aws_chime_voice_connector_logging_invalid_voice_connector_id
       - aws_chime_voice_connector_origination_invalid_voice_connector_id
       - aws_chime_voice_connector_streaming_invalid_voice_connector_id
       - aws_chime_voice_connector_termination_credentials_invalid_voice_connector_id
       - aws_chime_voice_connector_termination_invalid_default_phone_number
       - aws_chime_voice_connector_termination_invalid_voice_connector_id
 - `v0.39.0`:
   - (none)
 - `v0.40.0`:
   - (none)
    
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
