### PR TITLE
Add meta.mainProgram to crane/go-containerregistry

### DIFF
--- a/pkgs/by-name/go/go-containerregistry/package.nix
+++ b/pkgs/by-name/go/go-containerregistry/package.nix
@@ -68,6 +68,7 @@ buildGoModule rec {
     description = "Tools for interacting with remote images and registries including crane and gcrane";
     homepage = "https://github.com/google/go-containerregistry";
     license = licenses.asl20;
+    mainProgram = "crane";
     maintainers = with maintainers; [ yurrriq ];
   };
 }


### PR DESCRIPTION
so `lib.getExe pkgs.crane` works
