### PR TITLE
linuxKernel.packages.new-lg4ff: 0-unstable-2024-11-25 -> 0.5.0

### DIFF
--- a/pkgs/os-specific/linux/new-lg4ff/default.nix
+++ b/pkgs/os-specific/linux/new-lg4ff/default.nix
@@ -25,19 +25,20 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = [
-    "KVERSION=${kernel.modDirVersion}"
-    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    # Fake the CONFIG_LOGIWHEELS_FF config option, so it builds for 6.15
-    "KCFLAGS=-DCONFIG_LOGIWHEELS_FF"
-  ];
+  preConfigure = ''
+    makeFlagsArray+=(
+      KVERSION="${kernel.modDirVersion}"
+      KDIR="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      KCFLAGS="-DCONFIG_LOGIWHEELS_FF -DCONFIG_LEDS_CLASS"
+    )
+  '';
 
-  meta = with lib; {
+  meta = {
     description = "Experimental Logitech force feedback module for Linux";
     homepage = "https://github.com/berarma/new-lg4ff";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ matthiasbenaets ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ matthiasbenaets ];
+    platforms = lib.platforms.linux;
     broken = stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/os-specific/linux/new-lg4ff/default.nix
+++ b/pkgs/os-specific/linux/new-lg4ff/default.nix
@@ -37,7 +37,10 @@ stdenv.mkDerivation rec {
     description = "Experimental Logitech force feedback module for Linux";
     homepage = "https://github.com/berarma/new-lg4ff";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ matthiasbenaets ];
+    maintainers = with lib.maintainers; [
+      amadejkastelic
+      matthiasbenaets
+    ];
     platforms = lib.platforms.linux;
     broken = stdenv.hostPlatform.isAarch64;
   };

--- a/pkgs/os-specific/linux/new-lg4ff/default.nix
+++ b/pkgs/os-specific/linux/new-lg4ff/default.nix
@@ -5,15 +5,15 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "new-lg4ff";
-  version = "0-unstable-2024-11-25";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "berarma";
     repo = "new-lg4ff";
-    rev = "6100a34c182536c607af80e119d54a66c6fb2a23";
-    sha256 = "sha256-90PnQDGwp94ELvWx6p8QiZucYmTbH3N0GiZbj3fo25g=";
+    tag = "v${version}";
+    sha256 = "sha256-nh5J89S3z0odzh2fDsAVVY1X6lr4ZUwoyu3UVOYQiq8=";
   };
 
   preBuild = ''
@@ -28,6 +28,8 @@ stdenv.mkDerivation {
   makeFlags = [
     "KVERSION=${kernel.modDirVersion}"
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    # Fake the CONFIG_LOGIWHEELS_FF config option, so it builds for 6.15
+    "KCFLAGS=-DCONFIG_LOGIWHEELS_FF"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Closes #413170

CONFIG_LOGIWHEELS_FF seems to be unset in 6.15, which results in build failure of new-lg4ff module:
```bash
› nix build .#linuxKernel.packages.linux_6_14.kernel.configfile
› cp ./result config-6.14
› nix build .#linuxKernel.packages.linux_6_15.kernel.configfile
› cp ./result config-6.15
› diff -u config-6.14 config-6.15 | grep LOGIWHEELS_FF
-CONFIG_LOGIWHEELS_FF=y
+# CONFIG_LOGIWHEELS_FF is not set
```

Also updated the module, so it includes the upstream patch to work on 6.15.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
