### PR TITLE
firefox-{devedition,beta}{,-bin}-unwrapped: {138.0b9,138.0b4,139.0b4,139.0b3} -> 140.0b2

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,2477 +1,2477 @@
 {
-  version = "139.0b4";
+  version = "140.0b2";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ach/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "709fe8a024c4531f515eb01a6b267a56029a03166ac5d6de413019fe0a8ba45e";
+      sha256 = "9772122fe9b864f2247c7fdb6e5d11813b25af4e86120959581ef8d1e4d43522";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/af/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "a62c1d62f6e2dfce5225df31b215f1227c7eabb220dc12043c8a5ad4c8f417f5";
+      sha256 = "dd758bbab164e46f9484b1a271b94d95dff15788998e137ba4ea6a4adc325625";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/an/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "63cc13f04ea6f0c77a6855cfad11f4f6f35bdaa3d5fc06edcf030a8ffcad7a6e";
+      sha256 = "e10bf7cb75a4b9c395aa2c0adf1f5406daaab1ed2148a6c8cad034376e79380c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ar/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "0298c9c247c673847b8154d19b35b7379345409dfb9a5d80f2a6239e972e7cdc";
+      sha256 = "09d6db922f63c3a0b9fa080050820f9a83c517c6faa0848bd104a669336789b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ast/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "f48ab573fdad0eeb69b4c70a99e8cf7af87783f6698c591d01739ed3ea870723";
+      sha256 = "5e2bed35394f61519b2cc67e341e14002e692edbf7c52b5a5aca329403ff36ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/az/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "add78dfa402bf925f4834c4e0b698b5dbe01d99e1838de9c03272f819404b8d8";
+      sha256 = "7f56c3afe0cb2a899411496e5f989b44834bafb0febda20bed7495ec5dfcd8d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/be/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "0500f7ce071b2867a712f32a830ae65a98cfd7b4beb28ea9623361affca11e62";
+      sha256 = "202cde7a9402777c80ce654b264007d13baf7e573ecb6ada8ac21a58ff80c6c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a32e773d73f2a10cf17292c65f21e0e3fc1516dd4093111ddbe54d4fd553a26b";
+      sha256 = "58d17e006afc3a024d843ad196b09a5ed19b29ab40318be8d0682b4a21e73117";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "dc1386c1677b429980463325db93c9a96c1a4178bd2604adf3e943ae6a5890a1";
+      sha256 = "8f21073aaa86facd7e5828857f3581e67949be14a359c1a99967e02ebc888a03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/br/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "26ec0871ac96b3ce28d7953d4ead1df0d2826b5c2650fe1db2af238753edfc9c";
+      sha256 = "ee8f892efd0dd4a9bb2d45609f54c7ca06e1e803c7a1abbed7bc3a80ac03cd3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "6a2ab79e63632932b673e7d22a98767b7e923094ead8ecd48511444b46be6dcc";
+      sha256 = "11308e30b1a7bb4c26779048b5cf6c36ed6f1092c6aebb19c5413379b000c245";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ca-valencia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "fb19289c0f3d03d5f66467ad740d753f43e6fc2601f87d130209ec0c836fe718";
+      sha256 = "e99bb572c923e86dab8ca768dd7016553a166bff9479ed568e0c0cf823058b8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ca/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "6380ca078dfec8f821f537a685b2b5f7b4ff9e328ef0a5acbf6257069c0b27e5";
+      sha256 = "b0cce2c03c5a3b5741cfa158f8cf294c51b881ba101695e00c91b1bd14f897e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cak/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "4947e4d6c8433efa7379115eb0523f75ec3c00bcdfa8179f97ae97ef662bd8a4";
+      sha256 = "bc26e0bd9336906decce9e79bc4501335d1144bfe4acad0e34d604982a99e799";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "49b157447c444099afa5177aa7179d98f71171fee8a89f0ce14c65fd9af58214";
+      sha256 = "d94e4fdd4aa4c2cc57c8dd5cc3f28c9287d916ac98d803048f9c254b7036b32c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cy/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "f440960100c6685444e6507a4e0f072871b410784967e2f00c04ef9427609a78";
+      sha256 = "f6e8adfabb271dc3275af1c0123a050a9acea8cb20d69da53c06b1f8b93abcb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/da/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "ea2cefb990e4bd8f283c45a14bbf7a5ca420b69542692d2bb86093c885a1f627";
+      sha256 = "a0c7e0fd4daa6f83ea721bddcb67b0dcaebfa971964d5eb8b30421c6ccf9afb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/de/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "5bacffc6c87f049f865c2a6ad00e5d26a4b4ba879092902165db0a345daaf77e";
+      sha256 = "a41061a13e540377854c68bac1e0ead0e43fb6eb398cedd1c7d072fbd1aa7d2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/dsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "f93de9c31f9d63d41fbe7635103500a81144888518bc8c2f698e39d4b0357028";
+      sha256 = "a4ee38be8dc35f327c7e10178f5d589234ece7fa82799748e51c10b9b2a03e57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/el/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "201f51c2f4f30618d8e9f614cf27b3e07e899f852504becdf46f6a15220309c7";
+      sha256 = "76c892f181579b8d86468789df62e2f61b87be550235884419966dcdf5f159b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-CA/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ef5403be996abf97e9c58c5ebcd0c74fe9a14122119c33266e30428a60c4c944";
+      sha256 = "57cf1cb329540eb612f2b2392ade585b4505a89ad32dc4bbc6adb199ec179b31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-GB/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "64b2ce817ac1cfb314a9f22456716f9e1e5d7893bf46fd6b55d203c718df6c9a";
+      sha256 = "62b77a005adc751657d1c40c8f744c7d1c0ab341a6bd3ee0e7864f69ed2759f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-US/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "21bfb99fe445e64ad8fb86822fd6d77c9c0d387530b787f3c3fc99b97723d664";
+      sha256 = "828cac8a8d7e83fd82c13c979fce4a77262be2d8bf6639612664ca1f10c96ec1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/eo/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "531b94cf1b0a20de877bbe1cc9e3ab3ae9b7dd8729586a70a43f04576909c99e";
+      sha256 = "91f3b063d16c364419ec2ccdd152c05b19a0bb38eededdd2461d79952a760753";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-AR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "f80d18dca3009011d97bb89726d9b09c548e239383412615c4a341537e157165";
+      sha256 = "b2edc4c81a5910901a6e2e9b90b2fc3c625f67e74f746cbc3ca4a32dc9115611";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-CL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f2144b0b492eff30dbd95ab92ef9523d3d7d48dbad2efc52e8401a4e4f85d561";
+      sha256 = "f35abf87c2ac7afe6f75861bf99595a06f7216de0003f91cde3c719f3a2b0124";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-ES/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "895b92176b7dc1a492574bb625e6264548377adabd1655c6ba07eb24a786c1a6";
+      sha256 = "575e9368ff7bbac6c168441d1095472bd29eeaf8dbb271bf7c1ef14d0e0c69ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-MX/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "b770be36d7b93925baf0c85fcccecb73f1c1b8845615e7631f3d83e8fafe10ce";
+      sha256 = "5ce0c62e79621a15c533768282344b523b96c478d463de58754e3808bccf4d0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/et/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e88a52d747dc3d6c5a449c5449fb2b412441f41da64c496da22f5880ba5c4752";
+      sha256 = "b8493cd786ec0beb918cd7bbe5009d039ec6e5b8fa2f8cdd80309a3325947015";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/eu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "4d7d7fe2f695c79418a746c875cfd9357cb290ad8b6d253774a3ab92fe235210";
+      sha256 = "5573776ed1d9b4dda2d0bd566b2b4c8a83906193005f2db7f953d1eb57079335";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fa/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8cb53568f15e61491f0b3c03a1e71599cac3ce278f145f638830b9d22b789ff4";
+      sha256 = "59a775986c659bf12ef00f2f13de480b69279d1881358827244eae0ba6631976";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ff/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "2f229d6811bbc2bde175dc9b6fea0b1fdf4221f9f8042cf50d67513074a45a5e";
+      sha256 = "2e5bec3ebf2b31d9a3eac67f03f9fadf249956df08529fccfb1fe6d305c99e31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "316ac34c897feb1b98f677436d4dbac7b4a5c5fc29cf07bb55341736b156ae0a";
+      sha256 = "f31288ef2e48ac0cb3fdff3395346927fd866878d22bcc9be6a70fb1c86cb441";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2b1e4ab91f25e9b95fb894231709d086d9645eb76a64e0db194dd386e8f362ac";
+      sha256 = "4d011e05781ad8cf93d704e7455e28a0325c07d0b3bd12ade2f315b918e9fe65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "1a2c3b4e20c5cbbd6531c53516bcd97478cd86f6bc8b2761fd7074cc9e0429d0";
+      sha256 = "042c4f0d7fa4a638db9dec99fd30d7af490fd11097b4adfa9f7d474bccabb4a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fy-NL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "ca55a18278f39416d4982834357d8ee4e9dbb47e129feb3d45b4912f411dcfc6";
+      sha256 = "7c44584b9bc19d943191385cc8c56420f77fba6e4f9712a229797b3cf6588639";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ga-IE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "34594aded12da96b71053623e9bdc09367d8d28281f6ea31be81dc1eab4d76f1";
+      sha256 = "33ee655e264ed6b96a3aa75e7f1d7cd6c188fa55eb6c07c633cd7a388d04ce03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gd/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "a6dffbb23c3b61f25a913933d700ace50954ae6e879a9d7d4b73c1a864954523";
+      sha256 = "24a8becd37c3836af08e14e010914563ab4a205380b8a7ebeb856afe552f6c17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "a629a7d61624ade963df689fbee4add6f3eca0f603bd8fcc75563480642e7e97";
+      sha256 = "a0be7754c2e9b50429b62decb89123da0818530ffdecfae333b2c94342d23975";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "fb827103cafe3179b1b17f8fdc21e2008a5ff24f4502b923c7426ae91fc26c91";
+      sha256 = "ad5844d9720a0847aa8ccd06fe2fb948cbebc2b1adfe0fc871d18b0461ad4591";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gu-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "e9f4437d6f8959aa9270e6cc8eb7070165a8418f4ed28c2a31e1b955948c7837";
+      sha256 = "7a32e73b96af77fbcb4a14fb6098d270a73484054ea9d8a47319247f2ba2db0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/he/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "5eedd55e647c494461a013912eaac5b1d40b20acef64a0810e74fdd72083e5df";
+      sha256 = "50a1e0ea0c17140525584a1cbb7de67801af5be12765d4d610cd70dea4ad1bfc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hi-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "3a1e543d88f0103776397decc1ae9fa2b5a96b68fddadea56c60e1d76b1120d5";
+      sha256 = "9871be936ad26228905a9bbabc94f8b027b066af8b4a27c0895fbb927dfea723";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "4dbfbb04729a97c82b4eb123d1a6623867b6ece4f26777ed12c81a9bc5f4b88e";
+      sha256 = "f950a486143e3658168f7caed53f546679d5af41994398ccd3578222c4f6c513";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "1cca8fe6f46c797b8e03923d9b4a317cab0e011c34a44feabcaea6767a4054b8";
+      sha256 = "1885e8881aa7bc06a993fd350c0368f85101d007583eb3b9145e9fc777ba2012";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "ddbb8a9b6fd89f496c47398f09cb2a56ecf51299138cdf1dff659d027f1f8055";
+      sha256 = "3efa843d3a3c1b8ca7454959ea2838ff436cb5820725b98599a99f57db4f21fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hy-AM/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "e819ccd80cfe1446cd60398e788931d12060766fbd23539932efc6e16a0a59a0";
+      sha256 = "4566fba506a4ee45d1152a5ebb716ec264e1cccfa84b011cb6bbccc1d58e5ffc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "bb5dc9c1a4cb919a2f6207fe171fe0e2c9345d038cf7a7d969fc72f6c0d9aa94";
+      sha256 = "e599c11c636a7912a5d64df4c4f642c6b23b8ac8917602319c7d1aadf2c6e15a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/id/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "04f8e8f738dad42e6c0daca2ada66ea01f7d994c2ef4f2ec329070f740a2bd0d";
+      sha256 = "788e2874ea4d845a742eb4f5ef9e02c79ad3ce156a09e1b7db19e83ed661b650";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/is/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "140e3f7a50a57f415913465372b3c0cb026f648d587eab2e2406361430c1d81e";
+      sha256 = "280b95ffa32b43aa893b0df87fdda0adb14826b8a2b195c8a8a6f21174894412";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/it/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "81eaf1ea39d5792ce31388a3936cc9597f7873eddbb6ab34ed78acf688598272";
+      sha256 = "5bf7718acb53c53244cb9979ed72c132b14b66b53caf51d554b01e601dfc116d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ja/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "5eb2dad48c1fdd9b869c89009f83433c7c43ecfbb85c6489a46bde89e935b534";
+      sha256 = "67cffcb3c101d24c384056b9ed5285f78a5a00421753524a8a4936d2ac3727c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ka/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "16cd1d3352195a758bb256d9f201d50934c016f772c4ae01133f7ff25f86f2fd";
+      sha256 = "e868d7da325cb38a4a6360aaeec5d34d2e7aa545da2682226b319b4f3aca2d53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kab/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "e9390977f31c11d995d3748329da38c45300aa43ac5639c11cc90db9cd5b8d4f";
+      sha256 = "0de027c78af9346e30d4d64595ea81d5c522bb3a44e33e380b45e0d9fcfd0f28";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "7d13ee5bf4718468f8ea20a5fc6aceff58ac0be84fa7659932e85dbbaeed867d";
+      sha256 = "411e311bac40c12392aca73a5a4315fc015ba413526d20a19c620f74a66a8200";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/km/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "999eff92897c3cb7597abef1e2c86eb962204dfa4ebd0d86842b3f2cbc7fe957";
+      sha256 = "6575b0b44caa29ba2d2ce4f69ccd0ac09c2d89b86eb9a541632a0e155e8108f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "a2d45d1ffe1a46c8178f460ac30c394a7f4177ecc8cdb4c130bf3e5c49bc2ad7";
+      sha256 = "a1757ad5a847e430271d2cc99a3ef45ea409d0f8df52d8df38012e618ddb90fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ko/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "f847db77a08952229d6ef998c7157f0c75850f06cc96953ad66fd3a024ad1713";
+      sha256 = "6aa52561db8818725fe013bc7940b81c07e38c2678ef427675d0fc58c6741da6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lij/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "5e82c700fc49d454496199107a8fcb752847cd46981754a8413af64777ba9d5f";
+      sha256 = "c07084a6bc9324dd71dc442fe24934bf29873b6e7e5158ae68eb4323507a5b0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lt/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "5d60fd80069d73d12e285b65da1e3af0eca6824c27cb80e946c856f5c3028879";
+      sha256 = "5b088e25ded761cd501be0f5617349a2126c9eec6839e3ec6bcdc0b19ec9db02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lv/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "28e9eba64a0662004171f87e2ccf23308d259bc78b2184ffdfec398ef08f89f6";
+      sha256 = "2bfe6a0bb5522305f577608ca6759013be5a947fd3e5e253191dc25376d2ab12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/mk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "83df7f0457e3ecc36c1a6376ec595f3df04543ba36d80d896cd7d68fdf6d9de5";
+      sha256 = "441e386a2c4c0f3602907f48438b390a19e1f6a00831f8160b3212724d7da07d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/mr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "879ae358c38367b634154936a9e8d093813ac8e410f8f533f7c32227845d3bb4";
+      sha256 = "c9f51bf2d9ebf2e76c80d2911f15f1ebb0272011c39059ea9a4e1c1bf83bf190";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ms/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "ec20aeaf31cd2f4b16b94ab16c62a0ebde70b738b86c739dd4deca7b50feb95b";
+      sha256 = "261acca048d14496d15c2ebd56fa069346b194c652f0f6f2cd9afbe8ffad02f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/my/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "90468dd5c6db813612f69f2b646be26db909dcaa92e66b3c3250823baea81de6";
+      sha256 = "58ba0821d03e4f362bc506b420427c02ca69ae43eb5bf241caa481ee791f1c13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nb-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "904f3f3760506b6feb246397caab176e6dd884e982dcb07274605bc067113d95";
+      sha256 = "5792c3f26540c20ba966fe7d587a1874452eb4346d72c24ede6a8bdaeaf704cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ne-NP/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "0181214f14fd5e88381952ad07df7a37efa293e8fbe903db0029e773ff1e50f9";
+      sha256 = "2f0656c6a7ae21a07a506b4293afcd85f6d3376961a71d5b45af698d67496d17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "cd1f662dcc64190d00c84b0c02d67558626246470c5cdac78fdee1408ec88cac";
+      sha256 = "e135d0459ba83b78cbd606e2fb033f8fc945ff628959103ef65747123bee7cae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nn-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "c20d2ea023e5eb1a60863cadd085db28f616dfa79c79652dc1f38c2efd2e4f49";
+      sha256 = "24ae203327f886d34d71d1820292fea86cbd39bb68400a317e1185c291739eb8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/oc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "6f387a7892a61b623ec1696adec24f5836dce98a4157c59cc47a987f11e8dfec";
+      sha256 = "fe061945a5fab1a73a03f424e02db5e90f490b3dbab11af978bf2bca27abd44c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pa-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "1973852bbe05fc0207834a6271858a8b6585254635854cc2302b45d0a10f8b07";
+      sha256 = "16e22303ce33d37a5462fe1f9cc09959a7f8efe77133d3d87b6a6b3d5fedf0d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "9919cc6421b35798c2df90729d2d25e200e24d1450003ce30794124fb88ac21d";
+      sha256 = "9e1d841a5e5457f62f20cee241e538b1336edffe42a893fcbcf616a5989044e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pt-BR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "0ca06936133a86645d2975acb69fd01d3b80fdfcbc1ab003561ecd9fc85d4467";
+      sha256 = "e7da00d2172e5ce485957061bf3b8869f7437de3e3324dc9251f095e48ae26cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pt-PT/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "48dfb1081c2bee39a5bb2729d4aa83860d29435c818bef4b80c53e02efafb807";
+      sha256 = "b44a97bb059b2c4d11fd4786be517b22db28eb61bec88dab6335fdc5820cfbfc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/rm/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "4cb0f6115a83a9e30d5800f2d7c4709431c3617fba9fa43073bfd169c7a61266";
+      sha256 = "eecf8793a52e4f64391b3f424530b2ba9fe3474ad24ef16e3388272bb0cd1839";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ro/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "cf18a73a2170ab3fc5934adab6ef6142779f8f3c1fd949b1a1051bf2ea9795b8";
+      sha256 = "b1d69873414e221ffbe2b5c7175487c5dcd97ae2b7da17011d14f0e6e1342e1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ru/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "85ea9ba70d407d009aced7ab3d1b8552b0cf1a44cb0df5d3cae35bbefec3bc8a";
+      sha256 = "823e6ec4c9a1326cc08ef9afaa50f33e892517fb94b8cf135c5df2ad0b39af49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sat/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "693a3a17e376381dba4439a35eb8b7cf03ea59dbd6c8030b4da15466475f23b1";
+      sha256 = "2c24a66abdbe63b8537c1d1eb457e1078f4768fa4e1c628ec91c801fa4e29863";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "0d031bb02cef10ec8ee44376f384df868c20a6ae96138011adcfe577a132d788";
+      sha256 = "3f49ee23328467021066957d5c46150a2b2ed2216774d4593a2bedc8c3a116f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sco/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "e38e1b62fdbf65b5893c448a8df763da3e04436ad75db1531023a800bb2fd186";
+      sha256 = "1d1ec36ea66705cd0b0d986d7f7ceca5a0b56dd98fd51cc640b3aba03454ab72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/si/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "efaac36b3c3a6da5958563d682936413851f76134eff15652cab0260038affca";
+      sha256 = "1d2609c2d3b7ef1badb501a65644d3dcd0e376a9a95fccbc751c9420aa9144ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "e60387517f08d43b27179b08a0f9f8280d9e5e1d72ebd200f1794d37ecbb7b42";
+      sha256 = "adf327cae6a85ef120eb027a8e5477654db02f829bf673db4bdcc8c05dee86d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/skr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "834d207793100f06741459b12203ebf73750abeaffb43524564562bbb7160779";
+      sha256 = "70f8da6b2e7ef52d707a80011ae8998342fa64def483ba4717f6c7e0ea1b7ac2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "9f0f2d2d7b22a2c2eb7ba28974d41d6db63fea0e66491753eea7e009ee7dd23f";
+      sha256 = "bdd9383a3d0f8f736371956852a51583e68c0227612610b3831c6601b4cbd319";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/son/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "bb57306e0b721a99b3d916ead2ca6c813315d010f51076dd6d415d53dc1e1847";
+      sha256 = "24d2724df88cedccbceeebd89e5c8087e54049bf11f291a707adacb16f4fefff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sq/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "64e95983086221f6f01d19fe37282ebce21f93516a43905dc29d3006d59b7847";
+      sha256 = "7211cb03bc81a7eb781fd4d35c6826c70df13a29fdb4486d423c718047a76859";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "456423a6a6c0c49b643d25bb3d32866c177a7856110c3cc94494f44296a836b2";
+      sha256 = "177e7e9786e45883f84939ce5eff32dfccdc08adc5c034e22437203637a9d89e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sv-SE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "960c1aade2e27b872e648f61944ea5421cfe4f7f09205dac2693cf5d6f3840af";
+      sha256 = "700f554cdf816dc5aa91b6cfbaf8bf204264538ea9b9ae3d6ef10d256450a29c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/szl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "2966c66c503b0fbdd8cf0fb141549cac9a8f34af9eb107b65aa7ed9409a629e5";
+      sha256 = "48db54afbcc1e6840e52b0a023dd6ee1956a44ee6a96930b52d10e1640155eed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ta/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "afa115d8acfa334d69f8baf6159ffbb02165dcde6593b0b9132086bebd274714";
+      sha256 = "17074b69f77f2db0bd507e334d7b74cf290854d9fe696763223487c130629ca9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/te/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "215cf233c79f4d33e0de76e4dd11f270a908b8f1fa55c6744200e86b6c862f9c";
+      sha256 = "85f1f5bb9ab7517b0ab0700bbb94048776454cec7677216005989c0c4eec6047";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "e88ab65a2a477f5ad36ec77e334c2bbe9fc39e60fdd44b5ac705ff60f01dd8b9";
+      sha256 = "417933976c3a4b3d9e001adb8817b97830c22d2500d2bd20fb3d260d4efb58f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/th/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "ba4f17f2fc2d86486dda6acaea1acfabcf4157f23c2aa39a858c35c78be3b20b";
+      sha256 = "3ebb8a62335d1ff46df072f88244c94e7af3476efc892f2116526829f854d0e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "e123514d141c959e8f29b2dfc1c8152cb9c978267aca5cfa647ca79fcfd67563";
+      sha256 = "9751edb8943cf113a14be6bf5e1f9b06368d8ad316ab3e58b0924a62fea31749";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "73988d7cc818bfbed084a626727d1bbbbb378daf849fbaa8b23f3f5a76315f63";
+      sha256 = "428675ed3f2bb5691329628bca3a1684c4154faffaf0a99d8ac7bea1e5af2f4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/trs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "2b9022ed251f2e72bc0a7f7c319e7169eaddeec9cba230ceb9789ccd6c2a4c20";
+      sha256 = "5d41e893d50d9e39325ce571341594f247b429c7316415c7df1be2d7e67524c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/uk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "f721779da0e1c681ae7ef66e789a81a3655ed7be116357c518d4eb0401937fe1";
+      sha256 = "38e28de077f6c2e70ffd42cb08d9ebdbb33873f42ec28e3f1380675818b232c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "080b7d053124ec03e821b5db14544de1a76e0b8d1aad4cbf6a5bfe7a721debba";
+      sha256 = "1f4be2e844e19a070bd976411abf5b84b8e71b68b098ef6724c0115e3347a4e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/uz/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "7fb7b3fd94aabaa611c53c6d8b75e0908c5bb93b0bdaa73a3e6e030a204d0bbc";
+      sha256 = "3b14162e19e28f35bc616fae251180a7fdf1698a7a9ebd0f43e04215fdb6dd54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/vi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "27d15b1434b9aae896a3915eb647c1078a1663b1dfd6ce4c05d8e77bc21232f5";
+      sha256 = "34aaece124bf3a1af61dd0f6a0b7a7b924f332b04a2cb86c2e9375bb40e6e32b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/xh/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "642d2ce475f6b2662ae13a54775fb4e5a01a1d25a5cec6e95bc341e8505c4856";
+      sha256 = "1055d5e93a507660405c64d8a122617467d26894b7786e998a0226442bf2e106";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/zh-CN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "1c07356d7c142aed0c17df737aa7b3e0ad38d9d4897d7df7bfd0a79a367d8ca1";
+      sha256 = "3725c141425b3977fd3120f3a6eacfbd5e2fb413a3723834e30ac3a41e5c124c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/zh-TW/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "d20921bd3d75051a61de3890349bf65280a539824403074f51d14332cb33b3df";
+      sha256 = "7ff7baece1723aa893bed76b18117ea1ec633371018443553b7eb1af90617859";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ach/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "87a70f57297d5b0c01492da28bc80d74f290682f37b19a43fc6126efd85c6079";
+      sha256 = "b884ba50b81fe756b20f463131757dd701480fcd16133185a4fc983ca17d7c6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/af/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "c14ea82b75e114e01bad4b6e0b405c9611330105659b88bf8455857e181b4913";
+      sha256 = "60654b1bfb5c2922bb55ec75cc4c5c286e415741c0fb9b648bd53b3b2abb93d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/an/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "233822a13e7ddc7eb437a6fa48b95f57c4c1d7da7a6ca54e84015b6d6cc16f8f";
+      sha256 = "ef3be35e1124bedb22f1ec478e7f55e0436c416e5a049a7ec3d97be2b87012ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ar/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "c0cd5c0d31333a5a6ba6af3de586df838adbf7da09b2d85f8310757b3c9c8253";
+      sha256 = "67f4cda86a7e272fb194b6daaee4abe1040540014a02db93fa98e01f86748b4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ast/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "e38ac58bff96c8396df39b1fe090abd67bdf9b3e410f504f25e0d24482a2d1ed";
+      sha256 = "052afbe7da0e5f8772097e25db3019a4bf8092c3369f8617052e876b162e7d4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/az/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "2c7a74321548b4d3c3c07e2c0f1127c4f54c55d1af0dabfc6704fa7eaa02b102";
+      sha256 = "394b4a7cb760e060b75031ecaa462dbb72622565583eb0ad7d3228fa1ab8b522";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/be/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "624589d8c29240678a85b5b0978b4de1c43ea7850960bab85f7c7f7a172cb4f4";
+      sha256 = "c353fdd48caf79fa4ad02148bf80d480d7ecac400368d6e865be11f479ef794a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "84b144c5d7ae2cbc95dbb4fa262b6e0653000c645c9a604022aca70ead9282d8";
+      sha256 = "12e6f03a85147c992445ad753af7ba04c265570c103a489bca7fd9e724fc9f22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "b7273dc41403f54eff659a67c8a4b70f2a4df61f62a1dd4c562b0bc75c08f909";
+      sha256 = "fe2c94b27a658388764fe5147ff989d2915f013c3efe26a60210022ab749e877";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/br/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "0815292d40fb6ebe791d7de8d699ccc0d5096c0999fd498fe30ceb55aeb7292d";
+      sha256 = "aad228d7e751e6829e9fc48a4de4c71bfd1dbbe6cf698f0c51065baab521991e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "24de75d8e893acefc305717a2f8ba2decdb722e2505385d6cddb04ad43d7fe5b";
+      sha256 = "8931cc82c8f5a22053fe21dbb2947d5b1478348f8dd7e9ee4f727771166006af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ca-valencia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "2ba91787e8af61cb24de5c122a5ff57c6081e9680f7594d02e2b363f28e16a4b";
+      sha256 = "04a5f2a9344e369adfc40c57b719446da83ab80eea582efae5dc56ff0abb50de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ca/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "da9e7f0f9a0730b2a9c4bc467da5f5c2349f98e22f683db02b5651df4a202251";
+      sha256 = "36e14338dc3686949fc391946599b523b83c8bc9638c42ee7fa424ea4f0731f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cak/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "8e77e88d9fc94f819d450ca6c7a78c618d881a97aabae5b997f7a6d69290e29f";
+      sha256 = "511fe4e4dbb53e2df4a76aa7ce83c67405f0f177d275125570b00e909c3dd327";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "a79b45aaf0e6e8f412e21e746265c1d43e7de9046a050b670ba3667b1462c620";
+      sha256 = "56f018158aa318c1ed5d4355b7fdc2de9ab98e45a2e7a86ba330a4b7f4b5c884";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cy/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "2a436e2d6a9eba59a8bcb448cb61c5730772e204665416c4c2e04564c19ac23a";
+      sha256 = "7f4a3c45b989379066dc94eb10c609c94efb62706a0ce6238c9f652b18e11972";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/da/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "c055660cefb5fe09c71ea087de51efbd4d0b8c2a349f78f2ec5d4349116ad694";
+      sha256 = "d4cbf628409e36837cfdeb25c4815bb48d469d9c21019a87960e904ef2f2bf03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/de/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "e3d546c3a20067ea5c710e6af065bcd11e6ab49a803f730873affa229a1badc8";
+      sha256 = "3cffaf86b35b6c4fc8dafac8817c958247241e617562baab0c099159f4d8445a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/dsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "50b1be16d8856605e37078f0cb87bce59f621a76c354a8d64d2f9a68e626405a";
+      sha256 = "ae5ef7bfad006e61943aab84c6b4af62beb4e2caa2b802e5bc7cd1d8cf4ca29d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/el/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "7f85663812934905be421c0bc3bb0ebcf22c5a497db7fbcf91a21b8174bdad0b";
+      sha256 = "efdbf60eeb1f6e04aebef7ef6c35d049d4719211d90203c514984dc0f506d2c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-CA/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "e5304a3d0557d7ec259e41e989ae191c14e7aa72203eea1ea2c180ba8aec1913";
+      sha256 = "72469319463c7a378e7de8de9cd28f9a64d13ba027aea08caf6cda9db297ad9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-GB/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "393f92153a7935bc161badc7d81b23803f1d6cf9ce69651097cbc383056a30d7";
+      sha256 = "593c9812fd7296bae1388d96d8b4aaf75a2f3bfcb6c1a4cb740cb28d5e34f3d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-US/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "8d61639f9b02659fa3486e2f17af815e028e87c373a1770c69e968af3c7c0b74";
+      sha256 = "eff54312f1bfa5f4be53d200cbaea6dd85f41c5cfea83611f9a6977ecc7228f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/eo/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "dcd9df03ad825bd50f3b162ebd5bc6561d09688972d7c80af15b10d1801a3fd3";
+      sha256 = "985b855971a03440ad95a69cb0042fb103b146900a7957ac61277b46dde691e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-AR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "cbe7dff319e0cf3d67126565366bf6063536188fb5b2c830e24b2b439d5410a2";
+      sha256 = "a37df3746470d646d2c97775d1e90cec189ae3e487f508fbd84523de7f6e35b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-CL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "225c027d37ea0d6da7f9de2c784ee13db182bc76ea0398ae7dd3ec90b3146b7c";
+      sha256 = "371f39656c30e7c677bf1b57696ef135191bb1b755f152b2df77638cba27afe7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-ES/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "2b349436c1ce8d99138875f11af5d5210210eaeb39f0dbdea381dafb8c5d4404";
+      sha256 = "7446b7f231a58db5feeda635bffc148ca699a3a3e792737077c177d4b7794318";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-MX/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "016fada5c527dd9c4c95b6549e2cbb7b3616ec6256c9e30c527f995af1029ebb";
+      sha256 = "b0ffd426095764a5b67cf7757f29aca249205379d2e5505f48a442e599796436";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/et/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "57eecae03d4cb2c2e86f2909e82a8e42113f86b7f30eb8711b3a6262e1157b4e";
+      sha256 = "9d67e8f49fedffb0054f6e211f6e43eb63767a0ce9733827f5ebdbb5d501305c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/eu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "af2405d4e1db8662e7cc6f212694ab80f607c854ddc707d5322d4a0565227f04";
+      sha256 = "f7902502f184288a7a3d3c22918711e9c7b615aac7e6ee233cefd0bdfcec7cdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fa/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "1170f8ca54cc2eac1a2bdd9a63eee87b29a627d30cd2f06e91e519ac2be2b05c";
+      sha256 = "7929c783bf090082fc51cee3e45398396ade4909237e9ba951c7d07ccdaa0126";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ff/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "bdc3e84a777bba9e664f29cc3e109af18dc40253b0f9b4fba57765b604d4320f";
+      sha256 = "64260c4ba89431f4537838ac0a4ad15aca7f2e771e8f7150f42cd7790be32e39";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "db78665b7ea38f0f5f054949d3045239f6971b827e781bf740650596e7d91580";
+      sha256 = "388366eeed2c2487cbfea71ec8469c317b9b4315fe775e4aa629daf1ca6bee6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "9a41a156bf9c002d3f438c2895e3154ac483a67ebe6f80e0eee2b01b7fd7244e";
+      sha256 = "b5cd62e23ee855775e0529f849936dc0ff949605372e217b9cdb4dbcab135a3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "56220f6634ea0e7e69a29f07736120b46f2c1911e82df13a842e4101ab0e7cf0";
+      sha256 = "4fe3aee24eec68a7b88c40e23f035848030525b74cf3e17acc81bc84d5c0e086";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fy-NL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "9334756030f7495ee55780665ba0f8587331364ef4221393106194b9ab938362";
+      sha256 = "2efb11fc2c9ac5591828fa237c4f3549ac6a708cc8ddbccb5517f6408c362eb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ga-IE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "96a68363e3a6593f3657da4d5add4af443b2db60d30efdcf23485244472e59eb";
+      sha256 = "64e96b326e33d74c2fed43d45c1900d3c90593c9ef8da0ecf15c1b5a509a5f1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gd/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2a21ee5ca1acca96a81cbd1c0f6f0ce8c3a52ed88ba787d98d6059bbc097e22f";
+      sha256 = "947d98a1333460ef5d722becc2d28599425e4f877c522f2f11bc320edebb8a77";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "bd8a9e005ba534d5ab7436f78b02cc84f380bd36a4044a797085f529b23466eb";
+      sha256 = "8f3b052afdbe5371a4d2c87100f005aa1878a06ffae8cbf75dd95cc6003a7d97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "3d6aa78558ec05bfcab9872160c7ee06eda338aacdf78974022dab4fd047adaf";
+      sha256 = "c9fff849e03704d1324680eb856d01b051e8395e7dea9ee80ceba2ecb1c2c83a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gu-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "37a683ae33978ad481ef68f40b3c83f27a85b13aa1b55b905905c2d3ed1ceafb";
+      sha256 = "d1ba1fd9a19556f8d1128d3b6025cd862210d8635f35221ae96a894414c1acbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/he/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "1916e775b875911d87365bfdbbf549ae728ab674814ac222edb955853a224273";
+      sha256 = "5624f4bc7a3b700e602af22443d40da302fcb604240258c5ff1864a32040421e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hi-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "72a3b2387777f16e2b5f8232522d4080a276bf60b853a564f5e70c37d9fd2e3b";
+      sha256 = "d67706f3213f12d475250f0c1ee4d7e618b03bba9130803bf7cea24d5d46e770";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "4186afabb2595f717bda2555348fc082ea7167e6c83f03755d925ff2c084a31d";
+      sha256 = "55b89834e35ef17fb1d619a7ac949f0e662531892ea2c0d17fa5f6131e4575d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6b12f273ce7cb98e913ebe1785e2271813c351fe85203a8e96558bee3d8b802b";
+      sha256 = "1c112a4996b5c32971ba5d784379ece5bab5f9ff10d3568884f76dc2e985e47f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "f689294ca4226c898df2ebcbfcd60c4b9fb8bf529bc51df60b36896a77b3fb95";
+      sha256 = "748830a3236b3165c25cf4ceb91e99d1c082c0df507e76e49825fa7b8437320e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hy-AM/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "c1483077c18d4527053c7d979f9d8abc10710580295056f6fc14ce0034dd0711";
+      sha256 = "f836c11a40efc7cf1aecaa7719713f282d8d983c1df5d747669fde975f9173ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "11829a72579c847b78622bedf1aa6e5af500bf2eebc04bd10cbf8c7ea7790b3f";
+      sha256 = "9b814a6c15a9418f4e412cc265798d630fa2a935fa714db4db17b2916f3dc73f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/id/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "2217188bd592ca5c4cc8e2749ea31015861287c59fc14780335e42275b559cae";
+      sha256 = "d47fa1a73c96f23fa169fb0ca4dcf977e4bfe264be21620a61e91776381d09d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/is/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1ffab05f776dc59104a34baa0164d6de764dc8882f4c7ab2748b59c492823c4d";
+      sha256 = "2c431df3eac6468a456d568e5659d422abf7b529e7405c522b63ab5151011825";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/it/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "3e9965d635107eaf2607463508d0da22906bcac4db645dd43708ad885c037ddb";
+      sha256 = "67d030c97665b64ea8ce7c61e9f2f42b1e2f917debbb072887552bd2640aa031";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ja/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "1a971c6f7e1558b6a47ca204a398c5b1b9be44700726b8daf0c0298271b5562c";
+      sha256 = "28a3bdbe49900a2b290a986800665bd610aaba582ed852c7d7c16b36efff4f90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ka/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "4b7c001d19b96b0254fc3d5760feb2f473014e5ba1602d320fe179d8c8e8e1f5";
+      sha256 = "55871733f141fce7cb20244efa9cce6811e79c45f5f77177de5e9ac48bfd2c1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kab/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "4022280fc975d0fdccfe02ec6ee4159936a9de99ca2eed8d6c496f290a5a6d0a";
+      sha256 = "859ca377458e20fab592010257ab7d10552a8bb60d93d3936519c1b6cb6a82d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "06612dc7f831654df0ca60cf3c2ab4fd1e72b4cba16ec496f02528c0fd4fbfd8";
+      sha256 = "1759ea36efa1ccdb77734b0886c00c797356435994fed5747dc644ba0a18a477";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/km/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "91ed4c4b6b6f294b8d47b013393bfa48402a63c6f4d2f986947d51729c624f12";
+      sha256 = "f0f9886f6324a6fcce0e76c48457ade4a891f3c38e1a91997b5f97c34ed66e5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "a4a2e2c5759805640ae3080c563fd0e5ca127e8b5067351928b6dfd10e45a761";
+      sha256 = "7d79b905a38e09d9551e423760ec2ca4e92fa1ef07c676da822567d9e157b400";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ko/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "2e09752b2c02315d79185c86e546f66d314a5c158720e1163132c54934c06ebe";
+      sha256 = "030fc4bde9e14dd0f67c8007827f52dac7a623112b250e39c67ec4621818f2e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lij/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ebf2dd79fc7c373feaf517f3030bddec4fb22879452cc3abd6192d5868333fc2";
+      sha256 = "2042102cf667d81d62870df30e00cfb6015c7032f6367d2eee65bbc646aaa13f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lt/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "71aa1ff3f47b4be838e06bdb791bfa70b638c09dbddae37128c90ff4b4974998";
+      sha256 = "53e504395c32ae53b926505cf3fba5f3dcbae8995eec8657be085200e79bff6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lv/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "90b01be8cb7b2ebddbb2966a45f6ca29a86feb1285db233012ef85f301ca4fed";
+      sha256 = "0924feafc5ffefa07bf2d805ebb3396b8ab565f92714ad438a2077f395dfe3b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/mk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "f6fa830344486666e46113e5515e1f24a0c32943db3c6bb7f02e5ad3db6de2d9";
+      sha256 = "44c9fff89d42c44ab2eeeed8ac54e9ece3d52ca3f3c05a7cc800f5ae458861b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/mr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "2c58107d0ab0cd7c5fa0a4030e047c892808c9d6de05123cd0337ce36e54360d";
+      sha256 = "1740dd34a0d1a0f4b529535473714b016bda43c2838879b5991e43c8ff11eef4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ms/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "8afefb023e6bd415c29f075e484bd0783f5f05f10616d4f191cff8839ce372ba";
+      sha256 = "669c371e0103d0da8df990f002e1f67632de4fe01f4c4fa18c620445176de1ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/my/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a713b3d904d5590488141f331d89560b0fe3c163287861b6c709133521aeda99";
+      sha256 = "2a312674d939b1cbffdb708a36d8159c1c7d7ae18fb839952db0a99909e11692";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nb-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "40e037728d2697304965ff04db4e8d8206335a7e52866954241766182d9f150e";
+      sha256 = "a8df416206c09635d76ef4b76f194c2044bf7527b187787e46cd445361270c87";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ne-NP/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "32e752b56699102d5d0e65a5fbb2644b7d95059f12c737944a56c9807fcb5d4b";
+      sha256 = "9551f9f3a19efd9827cf8302bdd4ccffd9c84c5bcd34a874bff741a8e2f8b312";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "086f26eb82543f2f536b3546782d9531b2367c090244bb3dd7d7b3766f5e3bdb";
+      sha256 = "9766566147c5d4b1c2150258dbbb719d1f9dd971bbb8c81c0b2a1feeeb867046";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nn-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "8f7faf5cf79fece9aa05dead8931cc51829399c1e77d865fc7a2e90586ffa68d";
+      sha256 = "413bfb495237e4f7bbcfed9a2a6511c0c9e0ddd84c08c7ebe939675039969b7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/oc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "7a6743d63d6ebd2c8019e5e4431d0251eb1764e5cb4c2bcd2da43489c304e0a0";
+      sha256 = "a51718ea3fcee92b96445f592ad90c51e011dad048c00e547566929968101f2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pa-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "25c72f3a21ca5c1e09b4d6c97fe8ccda39c107ee4ac23c447cd7097d0fdd8eef";
+      sha256 = "98bdcd33a7053afe0a770818337d7cbc358c387f263a6a587065adeab091d5ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "f1adf8d5eedd479cc763fefd80306a4f400a0b8838b356d223aab85f305c0b51";
+      sha256 = "80d06c0c7d211136e715bc0d708b261da09f17e4182d302ae2c673265251452c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pt-BR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "ca70a854d9930a008fba706f839840408dfd37b7805b1fc686786c7804906c1b";
+      sha256 = "857d512372876071be9741ab69ead9641221578e66b46c08be0bd4b9ceb67ee5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pt-PT/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b81b41f9aca42e313941fe69c2a884118144640f5faa53fb16b21e0d19ffc640";
+      sha256 = "b8b555872fcd6f6dfdaa08f084ca65fbf33d58bcd8419973f2efe25b3d03e5e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/rm/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "68b07bd5a6f6adf58851980157e1a04f6a0a069d4418fbf74108eb7101e39905";
+      sha256 = "ca253108c8246320aa47376f5e6dd0663d76c7c05fcb8d156f3d4e236b1329e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ro/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "34962c09e2f96ff552733d3e70363989122e58657d85488d215b12aba6a478de";
+      sha256 = "8006f4534e48d7dd26725dd3cd7cae56aff960181f9f7a8e63648c90c3afafac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ru/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "631f44ac7908c217df544986041576f22afa37ada0b550ceb4f143b68f6f044d";
+      sha256 = "c57b4c19aae50965bd88d0fdece6b999f02885987d2fe52ce251e2cedb175c2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sat/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "f55ed94a407e02de8f519e0db3731c778ae27f53dba62a4d27dea12ee5c69d67";
+      sha256 = "a15d19aafd33c8a95b2fd7e9f35086043e08151255b7eab880918422a2c6c727";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "ecdeba036f6d3c69377b282fc11b16137ddcc97c55d49f12a6497b3ddd857758";
+      sha256 = "9843fc42dec2c3af953736915c4ba815b170276442f679c448ce094bd844d152";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sco/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "a9c5742f64b9018906b5fabd9373e5fe8805a447a001acbc3106818f081ff09b";
+      sha256 = "b6991a246b2328c04ddd385ac16438f4e73da1ed9ad2485e3ac322b26e3c3a68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/si/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "3621682261e1243d64012ae5ef4508458ef088a20c097f22d0d3889b2c0fad00";
+      sha256 = "2f93452a96fed41bfbaf5467f33372ebb6b9f6c0ba5ba40cd1f349b8c983e71e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "15ee029ae13f93060ceb44bc032e90062fbeb4e7f1cddd4acbdd8c03187441b2";
+      sha256 = "47e6d512ce895898505b8ca6b7105ddcb6017a1f3b0878dd904244c2826140a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/skr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "c61dbb39288239c7620c87d799fd745f02f1e2e4320ce8f44f92aeff38e35204";
+      sha256 = "871e23a7c187230462ebb61550c9083b2d898c5f76160e95913a0fad8f60742e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "701b3105c92bf18dc0baa508008c6a9208ba69a67babe16f7404dc50e5b5c822";
+      sha256 = "57db29bc5fd0f98b231338bb256e07953fb54867cf483de08b7b530526f8defb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/son/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "a7b5fb0c9cf055db86b411d5b4d8fe7b154dd79da1e0d23f050bb890e111584a";
+      sha256 = "72873188351e9dd5ba46fb229eff1306713944a45dfb6c96ca24bb5ab4ad61f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sq/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e88c917629b50cc933daed3134bf61bb9a7021db66d5840c00e179afd22af58b";
+      sha256 = "5acec6030e5705819159886d9a719fefc5aafad0d69b58d3cbcdcda1311264fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "c06aa97b94fee81c474784e005ea0b87fb108dbc023697caa036e0c8b394e825";
+      sha256 = "74ac1e41660b8127c701b30e616131ba46e87b47665095c0836fb70bc9525d10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sv-SE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "972103e2717945e1c7f53e6606bbc6b8939f9030a4bcb2d4fc718e230669eaff";
+      sha256 = "62676a28d5791d0bdb0ab45996313442d9ebe8e36a401f1750e3522f2148bbb8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/szl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "04adc5b6186a5af52d0e49dfb798bfd7da80553cd284763b5affc471dd1e8328";
+      sha256 = "89c2be0bfcddaa8c44bfca3ab3c91f9c257b1ecebcbeacea203673f4a4e0edb8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ta/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "44934dc8cc75f9e0d96812ad7f60de98b1fc7f2008926afa61a3ac81d3c43977";
+      sha256 = "6df705686cc62e94fff63e1eea2c962e6ac8e45c797755809f4ef7657e97f489";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/te/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "a65484fff230858c4f0ce1c8554928e469fe06c5c0eb941217ba770a15cf3762";
+      sha256 = "011478d18c5a07bee2dc417a618be95ed94b10f9e97c315c2114405219f4f633";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "78ea45f86204077dafa932bc892159ae11bf1bf8f32a86b9bb79742944115250";
+      sha256 = "bf71f9da12c8060543ebe48ebfdcc6e2e16a8b86b930a138a7a35996d6308974";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/th/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "937d5f0858d4701a739557a54df30dc20ed3dfa0c92d9c08909b64c57ee34dc9";
+      sha256 = "f8c6c9c5a8d51df500f463cab3951addd59a11eda3bc92228d9c42a56c3883a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "977abd61324f94d41a030ed8affb6d7c99a9f44cd89df35ae5e075ff746e3b45";
+      sha256 = "45c02ae216dfbff769daf7236a31d4efd7aaca3b419ed037d3250b2a5c03658d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "a9de20042a68a2afa8726b31da47e950a5fb1578a9f1c3855fe04700dd3461a5";
+      sha256 = "ff6ab57920b494349951ba85e1e604f135a6b706a89d26a93ec5945ebba7932d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/trs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "7de7776812f6188e1b88aad5293f1472975356c989bb6dd61b53d634c1595d9e";
+      sha256 = "e3999c0c31fa0c1210cbf52ae4a936ee08d1cee6a53e9f6a2b294167317bed99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/uk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "ccc2e770e91aed87bf1690dd82e52107ef49efe2062cb08ac4a4e372b097770b";
+      sha256 = "85af79aed55ab6b5f5f700540bd0a6d382195cbf0f7749e21a9705fc9cc2fc66";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "1e61bbf085a439b6a51add991499e582a58f50453c2018d15548f0ce50f95191";
+      sha256 = "8efb1afcb3555911be2816f62db5d2d2115f416804064f4a7ea016d368605bce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/uz/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "7b4120e694d31a901d7e9224ca42034db85f27f9062463f1fbe7aa8dd7afcfd6";
+      sha256 = "bbc614544c7b2272e812ea8ebd058adef37bc905bfb989e28259c270d837eda7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/vi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "9798b0741ff2e5eb5eadf5234d54fc5c2e473ef3d093079b7b6ac23518e06404";
+      sha256 = "f6d77d1d12ebcd17795be230395f42f8499ae4fd2c954d96a2fea50102141bcd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/xh/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "17e717b6a62c34d7f0e74b9c6b4af4e04e0bb9e6e0624b5691f1762c8ac734ab";
+      sha256 = "06427fbd032094695659c8aac0b7d48b8ac49207750c72a20bd96516a086e3e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/zh-CN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "a32bd1b70bfb1c5fdcf33d0c4413fc1f3d4c7c1b355e06c1e7fa571657078682";
+      sha256 = "afb4e3d700f9c67efe6ca59e1baf98dcbe014f9abcae6aa3326a94f47540556c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/zh-TW/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0ee631ecf8b7de2ffcb9a77aba4e4dd20cb62f2a1aab53650c1c12b39c5b48a2";
+      sha256 = "1eb8189e613d855bdb4da3d929fa59ae00c87c7ce4caf26e242b77dfe4ef9e46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ach/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "d754b7c77338934ad9c988af0ca76c20b9d0eeb9f63beb9423d48902cf39579c";
+      sha256 = "7cd042bf81247ca4bf869772140a28da2cac0f38336c1b21774753ef0935c252";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/af/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "9e3893fe70cff031562b1f9b6d1a8651a591d050a02733126d00d24c8d676bf2";
+      sha256 = "0b46b672ec0ba920946e8a19b66c4c15618457fa0d70f80283e9339efe919b88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/an/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "01055cd10e6bb1e963a7b7366233faf8d2951318576a02a9f1e81aa7a1c4c50b";
+      sha256 = "cc4e3757e933755b79c35946f87b88a4dd0e9fd68ad8391e2f0a1ec758707c35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ar/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "d1cd5710aee5418d9c903f195d96f2fff01bee31875877e737399c9f4479e056";
+      sha256 = "7ca7a1330d97c5c2d242dcb9b0681768cceabbe931796d78d1db4e434c555cc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ast/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "55834b6c054928aa733035366c5b45ad19503f03730001d70a41ba6510d5bd72";
+      sha256 = "67976e71bcd80adbfd9e5910708ebba978a1ec02db046b209bee54c0e9fe4e7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/az/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "41c91dba441d06e022af5e90d2d8e77e2051e09e1cb4cec1a5fcb4bbc93dc97d";
+      sha256 = "f99cdbb0b61406a82b6d31e87a5ad60cc11b654ba20199eef7e6ff6a0211e0b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/be/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "be5610c2f38693dd6a1f8c4949bb8df06e201f4e769b986df4b3e404d9a0e494";
+      sha256 = "baa9da20ff4f0cd15f67ca190982a26ab45635a83d6fb2a60a0c537cdf3f0d9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "8bd908287a0c2871839dfc027e0e6279218addfdf0de06a62b4018097375e2cd";
+      sha256 = "493851b1cdeba502582e3f311858296883637763c6b3875c4e2c8fe1832726d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "f74f9db667a9774b4c3eae709facd5a33b432cbf18fb72365c57ce0ce9e8c1da";
+      sha256 = "7ecad658638c5b4357e06043c33ede20870f50055f3840fa76e0829341e8ed2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/br/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "a00ab0024862e999d7d739722f441b2b63368ba227346fee3e9bc80c31807771";
+      sha256 = "90cb3c30c226a64ee8e04c89ba4511741b788a08c29305e4bd37f15c568c0790";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "39b8da8c52d4fa01498d9684e0f80d2431ac029e72ca39ef431533333b4318a0";
+      sha256 = "359bce9cb8555fcfd5e3782755345c74a023fd5196629993b9c7ddb4c159d29c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ca-valencia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "de6ec7c3bfffbfb4f0783ab91c708449f0f90dc21d412220044715e56f209469";
+      sha256 = "d0c0a903e7f49cdd4e7abbc010362ef7f9f94f0ddaede5c073b7d5ed492c8b4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ca/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "43a84887bc56e8e775a1fc77238a9a5b311a3922b342c0b8937a10864a58e1df";
+      sha256 = "065d8a4d120a5f6bcdc2aaf598e96950b87439b3f091c6ab45ba42c42d9dc493";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cak/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "b781db306b99c87420a371d5504505613258001326341e12d53cad1c6d22eef9";
+      sha256 = "f1e95e51e3c73a2c28632e3f23d53d3aaf1211d9db640b8c110eaed94a97ff8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "a0e7e2d60296d59eb438d67e9e6f7e7397cec1ced5b8eda1210e244fa10a0205";
+      sha256 = "1cabba2333c315ec8a8ffa64609ffdaf3664428b6f109dfbb3f9bcefe6a08326";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cy/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "c985bf38fcb61a264e3e7cefe00ba90bdb935009546533bf018d4bd173b88c60";
+      sha256 = "aeaea449bd1427315022606358eda4907a611248ee48cf94b8936c68067f93cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/da/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "31b86f8656a3c5a92439457714d2215481e175718dad2e71a0bd12cb9d8d53ab";
+      sha256 = "baccce03f5a023e9c4db5c786416108d1e9a3b34f8e224c11b0c50089b5044b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/de/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "2931c7cdfbb9113176130df3551731c1313c06168257a1e1a393a4d8c71fc648";
+      sha256 = "cc7f6ce82a0c27854cc0b2c1aded7f589c29e73741746fa3a9dcad685ddd8b62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/dsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "e4970af22566a2c423138dfc68a7d58b58e7d3284e88f4c7f3e9d00940739cf5";
+      sha256 = "0a3aba29ef00869e8a543e5196188c42ca87331df9b283d61238ba1a8a724f3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/el/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "b12bf7bbb352c7b34d9bfb11478a0ae7717325f4807c2baef04aa4f250400a90";
+      sha256 = "d87b9a60fa65911acfe8535ccb1c8d4e6cbfad290d9979692cc7899ce0ac6b38";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-CA/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "09e94e0803a321b313a740036171cb59e049a826e737a4151713f072c797953d";
+      sha256 = "026ad7b1f2b3b746c85a31860910ae1487e0871d406b63ffbdb87e374c517bb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-GB/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "cf6922dd5832202593dab94022f82e91af46685f8c16cdf92ee6fd2665ac225c";
+      sha256 = "f26d62c55973c679153ad8b2378c00a28b068748db76c38c61c9aee03aa7bf96";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-US/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "4edba8a869dfe9c906649b5e7989748490665e99599b44c653c2fbe896f268e5";
+      sha256 = "fb8905d9af83f43bb09b453a0fbd85e23adc70eefa07efcf015395a534140450";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/eo/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "8ce7a3c2d44ec47d0c76a896005cc485a5e325f5991a50833e244cf69b8a7645";
+      sha256 = "347cbb9195e8012d39d18cfd8ada8302a5f5746674bcff21c68926d93edcbc35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-AR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "d1c49d9227b3d9e27e73f9788171c718c73829c077040520b05dc9b9a02cc839";
+      sha256 = "c3e04df1298513e487072a6bb5eda83e3921f3217408cb0f86f33c6a52bcc7e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-CL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "79c5b47dc1962faec8ef4db9860698a160b2e724145dbc3520a3b179073d2aaf";
+      sha256 = "040bc8601a976587a173a5d82b4b3ed7474dc6d274e1be504fd516eacb951174";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-ES/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "c3ea8d8ca383dc7271537b5fb888ea0c155c94b0f1a7988a69359d4930b1624c";
+      sha256 = "ed4197fe2d0279979e879eda7f51a5f3bc19b161ba0e6a031f6cea2cb22b5229";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-MX/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "fe673d9624ff97fafb5e41d4bbcb0142d24051201fcdd58ddf8863b0a169010c";
+      sha256 = "290ae698fca93612144db3d7821b38a9a7708ba1bd9aacda09f9efee8e5a2fcd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/et/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "721727d911c456833e9207f35b5fa574561789eb9d5aef2cf70c07a41996604f";
+      sha256 = "7b174a91b10efbd8d5628ea29d95a4dc7dbc986ae64dc5c7709df3f7a9aeb113";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/eu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "c1d51c11fe6eb6b74a1170e93ceb910aa01b227ff67181a436abd9a272f4006a";
+      sha256 = "36ee14d1be91e8aa663439cd08f71ec6bde8e4b13f5aaf4a17f95df4080b4e00";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fa/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "d48577e912bc8d9302164ce233c02bb0d1a802bbf6923d2f6e3e40466753e7ef";
+      sha256 = "1b538780607b5fcc3a153c4198a0ea086b245c4c6f246561179d5aec98e6032d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ff/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "6397792fe1f9b6cf9e074f6dbdc620d2bb9e5a81cd9203a6b9e19d8ebe4af951";
+      sha256 = "64362226245b8694ef956f4bd3d285c45aa5f7a31830c043fe23b96071e09280";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "8f5c2ca086de1cda97c4383b0032cbe134a4af7231def94e19abdcf794d3a858";
+      sha256 = "1f810aa9a14a0f47c48d2a485397d8164c71f9a833cea682949d582ac30c4091";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "cea552b5a870c9a0842dfc56bde4d91927fbc40cef6a1f0e36d0399b65ceac7a";
+      sha256 = "2861e18226f50259f0ec8426e419c93b268c2e9113c0cae1a3d4923dd906c139";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "baa9819189ba1ff16efeeb80052f6d0afc2306a09757630e978c4a92a74147d6";
+      sha256 = "42e8d9e6582267a374246cd83cb51a71dfb24b5c54d5b8230dcab93d47e89ecc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fy-NL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "c1b1b141ced5a635383e2e0066f36c56b852e0e44842e86b684d6ceb8209aa4a";
+      sha256 = "5ed467f0a335d41d82007f39b078c60e244faa7f7614e3386991f7e687fc10dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ga-IE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "6a9348174c586c70f55d77ac9076c203287590eed6254b3d1eeed9cc8424b076";
+      sha256 = "edb53eec33ed84ead0b00d90930c9e0d93cf7f95835f003884190a6379d61664";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gd/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "c6f367eced3add25b7a51b8eb1d55b42d7cd5c674cc934c33fa9de86d6ef5c81";
+      sha256 = "dabd8721dbe812bfe349d89011317bffeb2eb8578dfd580e97fb962c6b234ccf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "30fcda0e983a655e8f0a87f40bf1f7e877569808b4b0e6710e58d446ec3913fe";
+      sha256 = "4c2cedbd7c26cbdc2869a5186ae3e766c27f059a5be4b745f91cb3b7d334c1de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "9c458bf9d63fec82a51b92391bc7d7b3030cce9e6228f14d5d5cde80c577349b";
+      sha256 = "557eb831214ae85f8954b609fc6c381c7334a6c8fe98c98f0b5ab5d6e3afd9d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gu-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "92e5e135ac587dd6b7bea7a4df4803eaabf509a55b98ec2a127af3293a10c048";
+      sha256 = "937e4455d075a52b5dc546840a7be025ab14266d36c287dbbfa415f9db5edb38";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/he/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "ec64a5e068e2223c95ac1c90531ef9d857fa72f03a5b4b200242029b661344e3";
+      sha256 = "2a660ac10700d2d0c8e223a7e7ccc641923e53001a9ed8f523126766919e3694";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hi-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "434c8bfea7979d256f40f3f3766c1230b8a403678893ad988b54c19188ca82be";
+      sha256 = "d2714b679ca967305693eb28655127e381ad7a4adf7e8dfc09c4ebb92385ac61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "59d09b703c2ed3dc3e289310503e505507b345b1c5b2133da6ce59df9f952b06";
+      sha256 = "8c42af036a26589817096562c089d62c035726be61137b04de137e72fbe0f784";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "55ac7f1a2a6b00118aae7d3acab31a563cf05a23e4f35389795cdd7afd613b6c";
+      sha256 = "8233a55b9d57fa591fb5b6ced9163c9e1ad3ac0efc16106f7900e0938b9bc505";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "75265bbd21c0c783c373f2ff57dfaebedb3baa8e8f635adb764d00ae340df15b";
+      sha256 = "e36fcfe99e3885cf8eaff441d917f8b714314688484ed31bc82061eba6cb78a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hy-AM/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "825bb3ab555455af7204fc3081d4e881bfaad7272b97c7a52d574711ac6fce43";
+      sha256 = "caa0557f2ba798d0d0d0b2e1d2b084079baf1203bade06c580062983fa53fde4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "07b43f7d3dbf12f9d8a9a4b2d393b0cc9fe3ce0d333431b9d8c694abf2948607";
+      sha256 = "66c4626de30fca547e690fbae7ef8d665f138548ed29b973630c1e5fea8cba1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/id/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "bf34449bee65bd3bf8ca7568683c111e19af99323970f6070bac75ae5d8df14e";
+      sha256 = "afeb6eb9c996a7f6bfe93c2e0606f29af90b9d46d9a35633ffd6218b76dd367b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/is/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "4b825583d13bf6f4b75cba352d1bf0eba3ab97c92f62da2c16aae79174f6f185";
+      sha256 = "ddf3e0190f6ded182ed3d9cc80cb3456d2251f5a3a5af42a4eee4d6144cb04d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/it/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "2dff0bac0c85f40cb21103c48e0489573cd12a21078b8edc5af5cfd6c1c5be9f";
+      sha256 = "cd16a0d3b70e4e746f2d5a19ce448b4c8f3761e1b4879c6fb50902e5779f73b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ja/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "7012be903c3b748178a4bdd87849251f01bc341bb1d418e43c15adb8a5236697";
+      sha256 = "2761071a3916fdaf81608d12fc7356450c4abc27fe2315d7ae1768b048751a85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ka/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "bb7b562895a31c2985e5b57dcd697ea65e0627c3ca92a7a1031de12d88f2d112";
+      sha256 = "2fa470435b4e3ecd4389639b135f840f2869ba1f997e495d5b7ca3b3b472a14e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kab/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "534d152fd21b7206fa1d781167d2d39114224e694cd6e0ce0df0c51f632be8d9";
+      sha256 = "23a15e2d7667bb0cad5069a555ce7eb5ebd647d01dcd5b5008df5dd3a25c41f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "c914ef270be6d93b244e77eae73f0b8dc81ccae98d1e5648c9f36df3534b5b83";
+      sha256 = "c9ab7d7695204eab0aaf2d395484df8331dcdd5a2d3cf7bcc2ea544e5877443f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/km/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "4c4b716afcad883b4c3d4ef98f256fd3a7383c6f6f9daf004ed57dc66c9cc1d3";
+      sha256 = "6740c9921ea366cae10b37b3c5de4076f1f1710b4169030c68be12b5070c633b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "bf36d322be0eb143d16b3266f468218e4db77edf5752d92d0527737d5699bead";
+      sha256 = "938558327b5c687bdebc00007467cc911084ed13d347b3dca50bd4064a1ed0a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ko/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "d306fe18f0afb856b5eca468cadf0661a0f296900aa213693f9dfce7ce01e693";
+      sha256 = "d610e561841fa970c6be608a25f030e7bebc0812b674c65e1f32e0f3a722f494";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lij/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "4134c5b66369b7e7baaf9ed18e686aec1f6fba8dabfcea557c8801e271099604";
+      sha256 = "3f8a986918ca0504c5f7e16996d62e52a59ae812aa10b521c93f71e5495a26f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lt/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "d02e63dc5244755d70d7c6adf8809e809ad5624b5b2cf7db5d549fe873c8e030";
+      sha256 = "41c516c24cbdb6c3953cd378272039c8cbd92c4dfcd45e807224dee8ead1edad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lv/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "49906a5a4bf59e755de8002436a431adf3a26ae70865a5c14cf2b1148d67be46";
+      sha256 = "fee89b89b07fdb6de208967bdfdf0cd09ff47ef4b382b5ff6dad823e2038f3bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/mk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "d0baccadc36ae94f9038e2c22b0a90d2084c512b71471af4e8f744548c92a79d";
+      sha256 = "fc713d3a275cb918aac2960e5d02ed55c1e53a588cd1d7b3072ce4ef1d322010";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/mr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "f8015e7594ec2b02914884f5be2d50f2cf0236bbe496fec731592ac81eeeb9a9";
+      sha256 = "9770d1c413bb780ba5734397fc44a4a750759fafbf092baa2dff9b0ca03f3778";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ms/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "fd820b03aebcfda8057f630f881c49d443f14661a6bf55ddd4b9a26b4cdb9308";
+      sha256 = "c0b6fcb678b449c2a7341fee0602591178dc3f783ad914f5e2e1fde3b3889dd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/my/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "f2286cf08af4be1daf434cfe972049f40ed68b1d59a0073c0f022c9f02dee1ca";
+      sha256 = "af5a3b599a09708b6981cb3079e3b1512ab3f271c09f506c953b39936e6e0952";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nb-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "668569c1fccef37f1398b1ecd9e9974081e6c055edd0577bc464fde69e5e7ada";
+      sha256 = "0c6dd74781697f69a8cfd7b657e8971d2272f0c2c7c37efb5476a3c6d226e8d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ne-NP/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "6ce7d8b5d852ca4abd94fd8505e52a2482b5b1ba207d48fd02dce6f585ef0fd6";
+      sha256 = "22c46f8ecc726cb41d302149b6ee4816d8e5f4afc3322ce6a38621f0edfcfc55";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "b57bac3e8a06c66f93f7c98a77accfe6a21661d6bdfc148cb2d8f3ce83bdbb80";
+      sha256 = "c19785a813e1d190ff83eae04d02c6647e5423d9e3dbfa5bbdbc124aa20c0b01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nn-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "01ee287813e78d073926bbeaab9cafae2a11e9239f8da1db3c45b5d6168a5f8b";
+      sha256 = "1f5e90790da565b4e661726b11fa2d07a006c25d6ba41557e20cd8fc53972e7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/oc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "7af2c95d9d6c9241fb98dc21a4c542f6e038098eca89a72aad53d03d834cf8d7";
+      sha256 = "8280752b38cf4e19ea5400ffe96c370888df59999be3ba73a6ff358df55eb973";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pa-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "c109cbbfc292aa3ad04656c79ee5fcd0b839032fc156499dadb60aed37d93c13";
+      sha256 = "8496cd59b2f13317622e23e3840a086f70217566bade2b749288d884f6d08326";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "ad2ee57783e372d968b9a76b4b0c5f4cf039e53f6ab8ab5169d556bc9733b04e";
+      sha256 = "466931bbf9058183abe611c927a2bf147e254c84f159a9c1c528bae40d8b62e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pt-BR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "c4b649b39622a0cdd8afaffdf531681659ae6c092221786df71ada4f8e5dc81f";
+      sha256 = "3c9cdc685156255ad8cdc5e557a3c58de63c3d3c1293c92ea816b2abcca69863";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pt-PT/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "d84337d337c87390e8ac98f43d8b1199d3b8bf640d55ddd2eda86f3c6c2f9084";
+      sha256 = "b89c7c4d38f667b70ea74e66cb052525e692829a001b0415387f806021ceaf54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/rm/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "a8d422e2ebeb5c76a27e3df7dc8ca4052be628022d3d7df38255aae4b14089d7";
+      sha256 = "47595af5bf7ad9e8ccd76abe627037bad388bb733b625cd9200414fbe385bad1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ro/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "4b222f477c9291a0ed28dd51f57588914e26efd69c0a249cd2f4a3251ef2b3cf";
+      sha256 = "48cc3b4168318447044806f63dd4ab2d84aff91ed3315846df63ad9dfdf7e0a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ru/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "caa6d2698ce1e5508f5fad2bf90563b10a8f9961042c089f2f1a5e4d61822246";
+      sha256 = "2413517aa76e06fcfb7122c949ba8acca175201ae338b8425eb28a5ffc2ad253";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sat/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "3f17440f5a67e6ac0f7f0a67eea72a4beae7c20627ba97c786f4740563adb4ff";
+      sha256 = "802f635513658ff4c9f146b7988763bf363e9676c7c3c8edaad7d15e99baf22f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "3eb57781a60c295918d7f065edc1429bcd2685f01398c3176fbfd097bf88e059";
+      sha256 = "4b88d2609d1fd79ca3ec2c0e5f6f8313953a79ff321df92a66aadc0150001635";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sco/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "a6c32b5c1d63728429ada5211857a49c056ce93b23d428f26a8d00efbb143e91";
+      sha256 = "b89f86a38a1595d8b4052b74e1f9beb741c859f4015c7dbf9b894a08eca6fdc1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/si/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "dc50c48c50cd0fa013b0754dfcecd15015392d23e0247f33b3ad15cd7aa309a6";
+      sha256 = "cf5854ec14f712d1a12502edd0026288078d81273ee260244c8d09bc45b1f704";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "35906da5afd4bf8a52ddbd2ddeeb9ce01b40d5e93968e4e1f66541d0dcfb1b88";
+      sha256 = "54f6863f9dd7ca0b48ddd5b1b46b4b3b929fd01349bc5e2933f314388972757a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/skr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "0af03523f3a0987e32c36d182d51c318f62efba1f614d2864e571837ca8eab13";
+      sha256 = "a051e36dbcec29dde148453fd95881c7073cd8ede0ef92e3c1e2263fcb5e1c94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "d7b9c75397dddb544fc4287e43f255929f04ba3e5cbd9c8c737f1f47d4d8353f";
+      sha256 = "e18c4b176463416e35438b155748b69714a965f54e87e8cc578c483a2454d30e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/son/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "7ab390ad40c8c7db2029a5ff103e523f2dce8691926e4f3f140c911a862937c3";
+      sha256 = "46461fa15f488234915e4a6f39fc0e241c1256c6ade93d584e686552fae53d49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sq/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "3fa9746d65d15ebed2d0bef82e16c26c25fe40671ea71651c3ea55f23769a5d1";
+      sha256 = "b6bb2006bff76cd6fa875e18e0717a357ddfbd09a419126f41ac1f614bf56adc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "954194b63497a3c490f819188c7353139af87a0c6ab2a0b87ce5db1a942d8b68";
+      sha256 = "f24fb9fdd5ec517efd56a5c539916a756c6ecb1686e0ec1b1437bc30b78b9168";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sv-SE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "ef30b8f7ba31857b871c4e41d139eee7ac6bfc759a461c0addec73b1e1559695";
+      sha256 = "5d25e7d100840d8259a7c9043e14d2e50daef0fe14ef766aec19ca6fe30e8db5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/szl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "ba038643ce7af49c6e16e6eece4a56b4bbe85a9a14639d534b9cf64884046154";
+      sha256 = "0ebdd8c0dc4f1d1f6567a9319688c7b71aff30a6999d4d57bb6ca3e50fb66031";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ta/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "b12d92276744680c57aeabdbd714bf5d3f2ea09030858d6d38d4aae80099989c";
+      sha256 = "e89ad50eb57568f223fc96751b6b426741826a41f1895fde4e0b1d3e3e48a0ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/te/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "eb5b186241b7fde86cc0f57fbe3712ef1d3831700d741c1955fd89efe84aed96";
+      sha256 = "e2e94525844616c4f9f3c51ae82a7c6b1cb4ca39272f76fc77c0c21bd1ef2278";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "b3f5feef512525cc09d11935cc1fb0b7086756158bd6cc6dffcd22cf3ec9497f";
+      sha256 = "bf8d5f5ea4c8ecc6e6764560966affcc969acacb0a6015153b2c46688b165574";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/th/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "2d187742b7e8a60f0a427b60f41f1d684d19360e562d2fc9d0f968cce4581b21";
+      sha256 = "23046863b1c3405f5ecd184a0ba82207f46c4489e1672e43110c47f5d6a522bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "44c490eccdae6a1c0fd08d7c3b589de398498f4ff705292ff6f72366f27dd768";
+      sha256 = "0955e3bbc514eccf2774d3e70ec94d890be12b50c555787937ab38b2b30e1eb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "b784b58007959048c3067a041950813ec8be9ae30a73dc24bd0b5f1b3d702460";
+      sha256 = "a99c19d94963709c38ab298199263643f9e5f55459648d4ce9a98ec46f087db9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/trs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "611991646e94273c6b142f2af670755fe18878f2a5c61a2e9f13a0fea99ce775";
+      sha256 = "e4f033ccdf9ff353d4de0a5fd5aaf239f95c7340a90873a35ca51ad1730f6e5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/uk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "90c25ceb18b53030e881e0f44b7d3e23c5b6c9cd380babfdcad957783d0e0c4e";
+      sha256 = "d16f97ed40b919d179a530d344a16520cf957141d3cbb68987ccffcb7a69fa62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "9be466dcebfd73ff9b5a4b0982a9421034654310ccf077fb812d652b67d6d284";
+      sha256 = "0eee3a71fdbedcdadf3ffe9025c3436a0e551e7596a0b2f386175d196d3dc73a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/uz/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "9d58ea902acb5ad35b19cd87f5423b21fb7772512156198d2fd05f84c08a778f";
+      sha256 = "b7e3707e6c76bdf87c83ca237895c651b9137b83814e8975569512c2c5c9cb10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/vi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "2cfc4c3f5d129a3041096dde196f3e887498a886dac1ab6845fb54b7eeae16d2";
+      sha256 = "2ddbdf7c755241c1400656f65a181e6c117b08743d52127943882f3f0172c405";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/xh/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "4eab0c87e4bd3f54d1e77b83a8c82b084c23beb0d0882d542e04bb19e798c98a";
+      sha256 = "b4fadd9165a04b491c81273273e894a81667de20e06479d166cf36942edd6ccc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/zh-CN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "e6094469887c77d367ca255d0b461d47f9a352b12602042caaf668846b5f295a";
+      sha256 = "0e6b7ff8960f0cbbc1b34a3a44bb7d8bef6a832d40f6d9bd85e8d8a54f03b9f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/zh-TW/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "4b5490a70185a206ad337404876cf943bd49681065d87e302a2856d2543b0329";
+      sha256 = "fbc5b78a7b6e022d8e6784c741d29d0adb6bad2afed4c5b3ff878b26f6dcdd00";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ach/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ach/Firefox%20140.0b2.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "4a42735641e22b977ec4ac31451ac8e0a17faf7e409a33f0d35a33efe5e033c0";
+      sha256 = "1c2d490bbe1ec81a70cc42fd9474f980771b64f8c8142d73001d18a5e74a2f45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/af/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/af/Firefox%20140.0b2.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "15754862b1b05ac166ae8f157655477aaf008fb7dff4ecb8847bda815dfb74fd";
+      sha256 = "d841a2fb6679761f95697ed1252c765220ca226774881153ab709f8da13339cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/an/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/an/Firefox%20140.0b2.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "ae9f4fb8eeb5d868a89c2f602d036ce71c199489d704bfbb430ceea99d21ceb9";
+      sha256 = "3ebec1ccb2d8a5050ad2920c53016c02f50dbaeb4249fbc65f72aa50463799ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ar/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ar/Firefox%20140.0b2.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "b5fa0c0e348e1aa81719979ed2348b36efb77e212e4806bb70131400ef3a3b1c";
+      sha256 = "2d40019da859a502af6d3e48112509cdc4fca031901c299dd7f0734bb6ca5de0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ast/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ast/Firefox%20140.0b2.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "97c54f7224b0baf23d2f0c775de23aa3187f7f41de4e2d406634642967fbf797";
+      sha256 = "0f69deb4c3b87c4696d34852d9e7bd956b728d3802403929ec3ba733d174635f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/az/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/az/Firefox%20140.0b2.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "0166eb8d67ec5cef8efb3c0625e8a4d3b0dd23e1a697ad1b3193e3acf3515b82";
+      sha256 = "de80d2c96e6106aff495e91dda2dc66c98b49082627fc9b73e6cb541418e01bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/be/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/be/Firefox%20140.0b2.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "995a25f2eb716ece9467a62673e1ad5938b3eca2bee1b8fc0392ecbf08d79c78";
+      sha256 = "6d1561f7858485628a4d75340d7f24e6d912703594b4c9d7bca49fd5c0b9a792";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/bg/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/bg/Firefox%20140.0b2.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "58eebc470431b310c5012ee22e21051295742cb4cdcc991bfacec025f20f16a8";
+      sha256 = "59e34ca3ced32f81b26e1a03aa9872c8a9a6247c7c660b146f787f29f53ee4a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/bn/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/bn/Firefox%20140.0b2.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "8c019e1b39c963a6c776bec5065440190afea8661a86e098d73a4139ede3438f";
+      sha256 = "3f14512645552b8fd4added4ac10995449e7e01dbfc5fb2dba8923d95298b54d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/br/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/br/Firefox%20140.0b2.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "c263c604507b44d9eceff1c6a4d88a5d03f6b72a437235902440811b5594fc4c";
+      sha256 = "7793a491f9fa9a417408685ca1d8dcf2b9a2bb1048f4ee95e4aaec3dfa6b2168";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/bs/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/bs/Firefox%20140.0b2.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "709e3edf72a4927c929eb978611553f1c9c51f4d2b65ad8316ae08e7db5727da";
+      sha256 = "8e1e58ae603650f447244b20da467a987bc5663f7805eaa87c108aea0dfe8629";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ca-valencia/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ca-valencia/Firefox%20140.0b2.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "fd21e0c49e8c89479e43a5e8e6eadcc565550ccedae11b48e534875c79858c40";
+      sha256 = "0fcc15e68a06f56e3aa8f52833652570d2e2c80386b4d468f119d9b2f5d63cc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ca/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ca/Firefox%20140.0b2.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "49945e34d0031cd6d734904449c0cc45bb43a064674ae30d249a69202aa2ffc7";
+      sha256 = "a4cd0c1f124a8997182dbdccaee61f03d688e10c2c9f4f46076ef62c88bc2ebc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/cak/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/cak/Firefox%20140.0b2.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "9716963c81d5bf84ccc5046a1cc61a3bc4e593f116b390e761f2dba1edf7d1f9";
+      sha256 = "ba76bb6afbbb6f72538d1a0b50d5f95cd2a14421a321ae013984ee880017031b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/cs/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/cs/Firefox%20140.0b2.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "239a8caba9b1a23b7c98ab9f507d8718594f353dd27c079efeb8b42bd77ae7ea";
+      sha256 = "005862a68ec16e926e9e888a73fa27314da31519e38ce0fd6656ad924b6c296c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/cy/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/cy/Firefox%20140.0b2.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "cecc8f11be8ccaa4b3d98120e86c347510b56a04c9812ba8e98852f331bfe6c5";
+      sha256 = "d71f2f3f678b5289023089482107772a448848db26e75908e8cde58087aaf1d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/da/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/da/Firefox%20140.0b2.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "6edf58c11f2d4ab1ea575bc5b5fc32cf9cdafff197e17aa47450fc940a22ae15";
+      sha256 = "a2ca0b54a7324acc16e9d2ee6831e3bf25cabf36e1f4ec69c4034795c1519185";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/de/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/de/Firefox%20140.0b2.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "0e0d6110bb40aca8498523b49e48da8fc4e7ae198191aeab5b7f0e9e9baa11f2";
+      sha256 = "24cbff457b1bdba5c44a473f7d65e247727df35a28ece5ab2b685a92f24cb4db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/dsb/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/dsb/Firefox%20140.0b2.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "8713f01cea21be9d90e917809b963aacd05d8ca5fb8d311e46c06e693a40ded7";
+      sha256 = "0af7cec5144e91bd7c42b3ac6e1bf1b73724853e0c0a67b4d1800aa5a7ef9218";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/el/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/el/Firefox%20140.0b2.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "75eb0726b6cbf7e2b5172a282b79069d1580cacfa0f9a1654853195d9976d84f";
+      sha256 = "4fe53f17a96dcaa91ae4e630222a8311c4b63c8d627ba7fecafab3cb66ae8bc8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/en-CA/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/en-CA/Firefox%20140.0b2.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "1cf3f9e0bdd4941243f11a55c3fb4a24dac024a942ad2b89d568b784f174fb1b";
+      sha256 = "5671afd041943c805d0115bb235636c656966b79b37b8ff622318b08dc66f23d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/en-GB/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/en-GB/Firefox%20140.0b2.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "b29064c4277036ebca99ea3cbbebf7ef887247e97e34778180c3381da673aae2";
+      sha256 = "27899bd86fe738877c78e9c95dfed10f84f1d99865caf1c8e377a285f7539742";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/en-US/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/en-US/Firefox%20140.0b2.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "c61d0fe161c6cb778a3e564f4cffa70cc7fb6bb5770586fa66c7db8ab9c31cf1";
+      sha256 = "e60b906321e4e8f6479d87e02314fdf804e3b461028f8d70552d88911a693a0e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/eo/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/eo/Firefox%20140.0b2.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "fdf543162489d4165d8b39e01bad6d28addcad942d90c32aa2068e74558def80";
+      sha256 = "e5513b3584e0e07ab2efbbc3b1acb531cd19fe88decc460fdef0b8bab1ba45ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/es-AR/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/es-AR/Firefox%20140.0b2.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "13641a204ea5fbce36d1c9661fc149081e90fcd03a2840300a288861bacd5925";
+      sha256 = "e70de7f34a08c75c8ca81e041033fda21f8af581f30705ccd1708666a69ed993";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/es-CL/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/es-CL/Firefox%20140.0b2.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "1fb4f9f7f01c78188b038a1116b4e19607388947067dbcad3bde3daa115e5f68";
+      sha256 = "f93f379e3953b56cf32f1e7d71df9fd6d0e898a41cb10c1af8fb0c83fd953c64";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/es-ES/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/es-ES/Firefox%20140.0b2.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "13cc2d4179bc10b58253e8a88cabb8228f9fd14fb1e237f002c7220c29c790af";
+      sha256 = "d7275c44b957fe378e949d0c47f8eba8792b5cbc0bacfaa98a4f26795c0f4bef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/es-MX/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/es-MX/Firefox%20140.0b2.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "a78061c9a63720610f1a11990199299a66e6c3f805821df80fc994bcab01d2e1";
+      sha256 = "529a01a430b6fd03e8de52f7fad75243d53fd042d39dba676b285156f7279a89";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/et/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/et/Firefox%20140.0b2.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "3623ae5b628d82224b39e5506e5f1b604355e932d7a2e320795baeb72e892323";
+      sha256 = "c4e67c20198d278dc784212f765c638f25137d3654ccb3cdb49564c599a0d074";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/eu/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/eu/Firefox%20140.0b2.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "ef038ab87151a9ec36b311ab73fab8d5444f8ac9317c94b8ade608a7387f83bb";
+      sha256 = "5a2cdbf4aef80735073adf761ca7ebeafee4ec68868c1b19580dc0a3d73d3d4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fa/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fa/Firefox%20140.0b2.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "84034c107634a08322974c899956ef02ec725970603d9f73d15833c508089984";
+      sha256 = "57e1d9990fbc724eca8b9bc3f2bd8b2b63c30d99788859d4cdf6c94104dc0713";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ff/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ff/Firefox%20140.0b2.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "2874b586b9cc2f55fe12a1dda4de3f45f702966359f62276b6009c113193e87d";
+      sha256 = "2b5bcf6057d17ef408cdcb198198d67a9f27a0bea5f3bc682a167d958b2bbf54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fi/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fi/Firefox%20140.0b2.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "dba286212463e1fcd3052dcaa8a66fa2d5a938052c74b655d634e700522041e3";
+      sha256 = "392ce242ddef92bf02dff3f7ce26f7dfc5358a259a3679ebc2333294650e91cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fr/Firefox%20140.0b2.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "d4ca7c3969f32f2af2f2ca4824d4439228a8e17386c9cf9fe849caba4c271280";
+      sha256 = "c07d5671bef18729205554a881e2055c2d4af04c1109210ba8ea5b5e33c0c553";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fur/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fur/Firefox%20140.0b2.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "4accfe0a3721b1ac5ffac33b586e778fe888210b92c4375c80aed95e3daa34db";
+      sha256 = "baeb0ab73c5b288c67fb87a57f9b3866071051e7e04e68c9f554b30640aa988f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/fy-NL/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fy-NL/Firefox%20140.0b2.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "db6751ce87b9e801a1bb72a0f04c7f909fd6aab5c4cb5591b522e798355f9eba";
+      sha256 = "57d0713b6c1eca3460bbeb1f9cc6a769db2bb01036054a5538cca93c6fbb5225";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ga-IE/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ga-IE/Firefox%20140.0b2.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "257dc1d4b56b5e633bdba46ec71469b746f175ebab0463ca3792257e7c6efdf0";
+      sha256 = "82fd3bf162cf641549c2a98fe88393d3caa1a41ebdd9fef15e3aff278b24cf5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/gd/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/gd/Firefox%20140.0b2.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "e2f8d9c9c0a494239472b760687d1bdcaf018a9a3a87882541936ab3c628f974";
+      sha256 = "b15a9124f3c4a138adaf497109467d242b7eb706f7ba904c53e9073fa5b40068";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/gl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/gl/Firefox%20140.0b2.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "f735a8db8e58deb85c1b2455db1924f3375df450890bd1e0a94990e5744bc831";
+      sha256 = "be63b8dabc4673022dd0c69577d202efea303ef3d9204bebbe86b09c80913602";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/gn/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/gn/Firefox%20140.0b2.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "4c859dcd1819e5c53a3adff48d958a8d301a37e72ed0de63abd71889aff02c0d";
+      sha256 = "0fd5f6cf33ea00c65c1e37c2b5b27e6e28b1e804f873ed2a81862639697fb6da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/gu-IN/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/gu-IN/Firefox%20140.0b2.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "ba0941058959c7cfc06cbe6cab3245499850369f7f31d8428cc1cdb88f1ff673";
+      sha256 = "a72071f5897b9de30fe23ab448751d88b0943a1ce12bbac525fc25e0d06ca824";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/he/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/he/Firefox%20140.0b2.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "75e398253677225953a07d1e9e144adc4086968899554b7d57031cc8f5b1b638";
+      sha256 = "8f5873c677ffa3bf8f3c03c1cdd56c9d532f5576b1d45e3eaddc4ca63a4c84d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hi-IN/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hi-IN/Firefox%20140.0b2.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "66872abb8f5eeacdbe8bd6f5c96c9566e72ebfa57b897dc64c46df2ab0fdfc84";
+      sha256 = "ef2a4cb4a0822afd273713265b2bd12199cd5754876205435a996af6bd08e7db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hr/Firefox%20140.0b2.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "d8d8e4aea4c86635ee536fa929e12eece775e2abab09956244776a9de308b4bc";
+      sha256 = "19f7a517502a8cf46cb802fd428688b2f9733a4b29c6bd69ffb42ead7078c823";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hsb/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hsb/Firefox%20140.0b2.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "d5c31f2a62960141813d8f0d9120fd9af14a114e418b2f71c4b61760abb0addd";
+      sha256 = "43b7bed183606c1ea212fde9cd996ec7b0c227e2e827ca7f0ac11a11a46c1f46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hu/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hu/Firefox%20140.0b2.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "aec856b42ff661f07626fe6e7c49fbc09eb09b7e3732e5a4ffd7e2152ba18fdc";
+      sha256 = "97998fce9f91f25ae8354c274cd0a8e29145935163e1b0d723818d939bfe0434";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/hy-AM/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hy-AM/Firefox%20140.0b2.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "3757bad209cde3d24c008756be1e1ba03bc86a6567c5f919221b75ca113c70c5";
+      sha256 = "26fdba87a2584afba336c3e388abf0bcaf75352694415954644b3300a482fd88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ia/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ia/Firefox%20140.0b2.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "669117617c58b1048772c519dd9796e25636703d6f1ce29ca4b41a25c9734140";
+      sha256 = "a714bf43aa173d5d4ef29ee5e406f09fe137ab1d9a311299604dbd6a63653238";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/id/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/id/Firefox%20140.0b2.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "4e7a95a805b4a870201728c6fe267a69751b8d7135210133718b48771b1efd81";
+      sha256 = "883a1081b0a0bb03fbf5ab735520b241f9f6d46f05ff7492750223ba1388bfde";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/is/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/is/Firefox%20140.0b2.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "1ab46c1a5858000683c0004dc3fdb59d2b2ded4e78b24b1d9ec0daf2945db6e3";
+      sha256 = "411ac5c44cca622d542e568ead74f6192c4dfe717ac16863554b1d6da11755c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/it/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/it/Firefox%20140.0b2.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "e7cc58da37fa5dc49d32b85c226e25214546dab7798458f18db31c3a28420691";
+      sha256 = "fb088f8cdcaf8ea9aced69ca2892fb776dcf48b746f0abef6975e99854c55a79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ja-JP-mac/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ja-JP-mac/Firefox%20140.0b2.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "26ee160188fcb0d59bb88e0ae10856b556a01a16254f59b122490714ac3a8cef";
+      sha256 = "9258d8f492c8c64695af53960fcdbeee60a6bb82a37d71abc77abe1002f98f09";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ka/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ka/Firefox%20140.0b2.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "4ceb3e350415425f05ce77abdc582d4f5a8934dae7a987cfa9ab909543f25d1a";
+      sha256 = "0f486c5bbcc0af6a9bdb4e1b706c303501284848d3fcfd4000c1bfca71bc0300";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/kab/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/kab/Firefox%20140.0b2.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "eb2cd412c94a67415664290b14a08f5bb870b3f25e7fa404dfd68272e33df4fd";
+      sha256 = "ccbda4ad3d59661a897a1b47ac77e0c48144802575f6740aec95d788227e1028";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/kk/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/kk/Firefox%20140.0b2.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "c2bbf15bd5013388c090b9ba7631ccd6ca803c262b2e3f8ac8f07a8ff22d0bcf";
+      sha256 = "e55c667813ee5b15f79c5d623cb33eebd1eec5ac4d57f2a8bb9c3466794b746d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/km/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/km/Firefox%20140.0b2.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "b75cfef561797c1b19f696234e6c5792f0835de469b71dc0736c47087ea43b02";
+      sha256 = "5774f04b93c6863b27514a2eae504bcfc1ef8ccfc068a953e4d3e270dedf7b93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/kn/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/kn/Firefox%20140.0b2.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "383e8dca3ee948a086e4a9bfb16149c443ecb5aab957564ec33e7f32b98f3c61";
+      sha256 = "7c376799a36ce1cd8f89798ebdd777f7886a99693c5f98729684252d340ba2d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ko/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ko/Firefox%20140.0b2.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "e4fd810f240a24a9fa9d7d9a3e3d52d3eb8bcd59704da3777998c4288d8d5634";
+      sha256 = "5f3d2829512178f393b9a665ebeea9cf4f18e9afa042839b7f53e2b620c5db8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/lij/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/lij/Firefox%20140.0b2.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "d803bf21f5b2fbd058319b68b86ee3a1ceefa9473fc0ed85cf549065c4040a13";
+      sha256 = "30ec59741eb1324d18f995d1b94fe5928421002bfc0d8876cfff257148eda97e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/lt/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/lt/Firefox%20140.0b2.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "3e8a7440f91d017060f4045a2bf99eeaafbffeb114de3a3afde30b71dee77f54";
+      sha256 = "0fe2982d361f6beffd4d61f55fd81843943a9fb4daeb1c2df872191cb1bc6a17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/lv/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/lv/Firefox%20140.0b2.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "cc82e24338955ea73fc488cd2bd4408783e1006d8a4644036de09c2731cc1fa2";
+      sha256 = "7914c9bcf07701a2978c0ff417e14a23078ae2cd6ec6315b4be8979ab09e9823";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/mk/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/mk/Firefox%20140.0b2.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "d12e758204660abeae700ad10b79effb2627486cda0a6123bed191e3d6ff9282";
+      sha256 = "244798bc32bd4429eb230b4aa7d7a6192c5456cb95faee5bf66f09ad8013517b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/mr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/mr/Firefox%20140.0b2.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "8ad6085ae950d89ba4754dd9ea3f9154ecf12252ee47636fd6834ba8dc7ff71f";
+      sha256 = "67a2d6ce2ac921d47d01ef7cee9543014eeb4f2db0394ba3b459114b5e65c23d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ms/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ms/Firefox%20140.0b2.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "c7f082195da9a650df72066d7f4e9004adb59fca30deaed4ecfd2e70514c02fd";
+      sha256 = "d74083626dfccd8d628ef0326ff7f2865cad8c0c32aada246d4cbd9edd6cdefa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/my/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/my/Firefox%20140.0b2.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "639b38b8c6b9e42ae89fbaea360ddfed3be74e9eb3a55456a251d9d22ede241d";
+      sha256 = "61a501809b50a3006a362eeb76f3c4d49bad778cee9fe35b6dd072c53e7be210";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/nb-NO/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/nb-NO/Firefox%20140.0b2.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "87a676d880411221b19763c9263024507d41e0c89f6fd818f8efe8563952bd09";
+      sha256 = "7b1fbd6ed0aaa7865997be627bc7c89622f872c2c5c7725393620404bb6660c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ne-NP/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ne-NP/Firefox%20140.0b2.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "b8018da6989bdb66b02dc386b608ee439718b5ba2f377dc3302710ce7854aa8d";
+      sha256 = "e16d0769328870f6b964ffc209b6c0b2cdfa015a83ef1b7744cedbaf91f7ed29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/nl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/nl/Firefox%20140.0b2.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "9037c896ea9aedd7275c8922f4a61d5ad9e4b41ecf43f808e9e996c7d702ed33";
+      sha256 = "92bade0cb93b3aa2bafee685b671f4284144f554a3910fe6c3d125a58fd1c830";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/nn-NO/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/nn-NO/Firefox%20140.0b2.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "06368696dcedd347d62ceb7a1bf3ce6f0d92eab035310aa704b0a09a495448c9";
+      sha256 = "0ee61fda7d45de9c3a85a88514aef5fa2d7ef9c33e839657257da3804c33e488";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/oc/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/oc/Firefox%20140.0b2.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "9865f0cf11e8baf3b6930617597ba807b1e06d95abc9a8a68525119a0d591e48";
+      sha256 = "9b549cec47785c84ed77694f21efa1c8a39eecb76bddfa191e43e54ebd798adf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/pa-IN/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/pa-IN/Firefox%20140.0b2.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "1bd442dfd70d0da87a4904f25a955323fa15d1551d529e710876c2c4e7cf257a";
+      sha256 = "271b013e5388416b2d0956b72d68191cd51857d0ab92595a2ff2f7a0aad95462";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/pl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/pl/Firefox%20140.0b2.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "e261443f9dd5160e941378c9c8f0aaef9159ae21172babecd0154b7481081210";
+      sha256 = "04554a10737ed4c2862a3b9e20c82de6e22b6053a55e4ef34b62bc977a8e1ef3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/pt-BR/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/pt-BR/Firefox%20140.0b2.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "4140fca76b890df5b79a7accc26bba64f43b31b3818bf5567930451666cfca43";
+      sha256 = "cf56901b76d04c7ed54827e07d11ef8556cabaf7fc9657b83fbc3d86b051a104";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/pt-PT/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/pt-PT/Firefox%20140.0b2.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "8d492cdcc1af5e98bf89039474b1af4e7e4f784e82ad2645351500a2dc22bf23";
+      sha256 = "07d160fbc743da7aff2f3501c4861abb300d509549ad46d8230a298f62e57b99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/rm/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/rm/Firefox%20140.0b2.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "c65018162dfec1f1f1a03be127fb27bbd25a604a4e5d2df53f5bbbd13f02e64c";
+      sha256 = "2bf8142a9034bd15ea15e625788d7dd2aeeb378df54b1e64330a99d6d8fb84e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ro/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ro/Firefox%20140.0b2.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "396b5d2061bb0df1fa5af0b1b77e92c230e043a853cc0df7bad529c74eec6c1f";
+      sha256 = "c739d147056f2fe970b53977e58139580c6200d414d5a07c656bd33386f8d1f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ru/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ru/Firefox%20140.0b2.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "c90e4d1bf9440ab473eeeb6ebbf57051b30d13f5586abe7adb61487f43b15423";
+      sha256 = "a52b9100ed56fdeb1d3fcb96741e379d96062a89d27a52dc3e1b56ee9d295941";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sat/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sat/Firefox%20140.0b2.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "4a02f90828c7bcd302ed8e2689dad6b9186ae230210c0a56b2a8fcfc3001880f";
+      sha256 = "593a800e5993a1d64b25de417e21b86604bf00a5a46b3bdabeda86ab04876a31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sc/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sc/Firefox%20140.0b2.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "1ce3f7cb4770771ab928006ccd0c2d855a5c69179efec9e62e8dafbdcffd54f5";
+      sha256 = "195f0e203e720b40024ccfe65e98b9c3fe485e5f27ab10aeb7f01145f129be2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sco/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sco/Firefox%20140.0b2.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "5ac1424837f62ff290017a880b9b816bc7ab79e7a4401a2e8dbab8e3b05478c0";
+      sha256 = "dfceefc189afb27e80659e38446433b9cf92fb81c92b783ff9ae1533a0ca950c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/si/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/si/Firefox%20140.0b2.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "6f0f1b88034a03b3f1c31db951f23555b2e758338b92eb7e9486b38376b0540a";
+      sha256 = "70c88ca3c07759e59add1e057020f7bc18a9b2dd582178727bd6c0c9a74ff407";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sk/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sk/Firefox%20140.0b2.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "44d0e95057c74f1e6728ed14aeeb4846f789d5c7770a327a6530c21837bd230d";
+      sha256 = "ce352af03817432c6f8da15ffa2c57ecd2fde59729140ac0f7cd59439d677185";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/skr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/skr/Firefox%20140.0b2.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "e18e95beecb16f455ff78e9eab622e6df7e80b0461c6beec5e2b68534802653e";
+      sha256 = "6205c5cc529b43747cbbb3931e828dd273cac01c1cb4413c8dccf8a3f37b075e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sl/Firefox%20140.0b2.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "065a5250d0145b713685c045280cca1bf7a2559e10d1c812fc4e1a6108b0b114";
+      sha256 = "74cb297c6f9fc2fef69bfa7f8a0f7c846e6980ef980b40b8479ca843caf20fc2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/son/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/son/Firefox%20140.0b2.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "e7d1090386a485211cb358bb757a0fa54d0953eac79347eea36dce4808d443a8";
+      sha256 = "d0972c1cf8c89153daaa8fecea950802dc3c15d93e53eb0549f33e31178dc51f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sq/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sq/Firefox%20140.0b2.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "cb5a4f74226b68fafe633f6e39af27948ffe9bfa3c866cb9f935018f0ab01fb4";
+      sha256 = "cf89a59786a888726616aae73c8b1a3ba783e64fbcfda3b383d66ec72a6b1d8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sr/Firefox%20140.0b2.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "676d0da9ee7951a46270b9f47bd33ac5135b4a439a93f61eb260c8f0af2c0d49";
+      sha256 = "91ebceddc8280c6c7fb35306abdc551ca4671944f7caceb493a5dab8f200a563";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/sv-SE/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sv-SE/Firefox%20140.0b2.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "c4f9814dab5efee3a4a67cc9f8bd703d015b51f4e59947dac56636f0a9325048";
+      sha256 = "864e8427329b950ad42ead7d0044c51a5bc5595f1f94038093b0fbc6eaeee2f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/szl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/szl/Firefox%20140.0b2.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "1d92ef8edb7bb67be228771019f2f1fc9ae72ba3f005998f9f2db60287fc81e2";
+      sha256 = "92dae8cb9b2f3388a070672cbe74e2f2399cd416374f78ac7201ac6389bf5865";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ta/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ta/Firefox%20140.0b2.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "f210471b4963521bce9aa29b4526e786cfd615a7dc3c57f6f16c92327ebaed86";
+      sha256 = "3998a4b1d8eedce4789b33fbdfe887bb6c434ef668d45d8cc12445351de18ad9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/te/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/te/Firefox%20140.0b2.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "0c22ca5d3109cd8ff222906afe4ac7023aad6e983e1c00cb21159e018a2ae52f";
+      sha256 = "b47d181b75916c505795aa612cfd44708f4fdf99e2c47d95ad8b01fd92eff35a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/tg/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/tg/Firefox%20140.0b2.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "1d9f2a44adec91d4120228640d6cf73290ca40333109b28f8c6f832e4cbd382b";
+      sha256 = "a149324442209694df3a229d00ccb2f67c7589a601dccf4a263f7e9ab5b80425";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/th/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/th/Firefox%20140.0b2.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "315c2049ab3f0905cc8e3420cddf90e00e7e0a54b65b60625c1eab2f2e560ef4";
+      sha256 = "5391f60c1322ad8ae87436317ac6b95c1c1d3d5f112d5b3d23e82af45118caf8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/tl/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/tl/Firefox%20140.0b2.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "b8ce0475f332fc463ab40763ef250ae4711591f81f60065a3d66fa39a1c06dfb";
+      sha256 = "c2a5ee86077abe59ae4acf0ce3d1d4ba2c86511fac1ec44a21bde5c1a714509e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/tr/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/tr/Firefox%20140.0b2.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "ba882caba5bec222b61c307d661caf1d2a3bbc8e58de21c6ecec9a0e48a10c64";
+      sha256 = "799ec56efb3bd5fa7e5f76f9cf7683711c79f342fbf02fd69037d8141887f682";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/trs/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/trs/Firefox%20140.0b2.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "fae309ad38fd0972148effa759d979a43c3233c424fcef036921371a5f5c4355";
+      sha256 = "9f6123302bcf9b18344260e3dfab6839087ea41a42daf9c2fed7df04e3362ff4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/uk/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/uk/Firefox%20140.0b2.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "54d8631cc02b44f286cc3716034fa854da91486ac78dae035a1206f1ac00685f";
+      sha256 = "f2e58fb4bae53bd8dc03cd5c29e9d5676dced99a2376322a0ba013eaa5154bb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/ur/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ur/Firefox%20140.0b2.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "e401903f76ef26a3b968a605776428c8b55b54503587644706c2e991f4684932";
+      sha256 = "a4db73f4a8b98557ceb77f1f491e48bd783f0f4f5941d5234309d618a0221a7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/uz/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/uz/Firefox%20140.0b2.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "f12af8f8cd8d56742dd2a780842b88649d0914aae5151edd7071643bfd96337d";
+      sha256 = "0446e4a59da6f5e3fb242c2a9e3adb781832c2729f64167a12351638f3d00d8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/vi/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/vi/Firefox%20140.0b2.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "5981392db9d826d35e2a23a0da72664883c57a2e30273912a35cc80dd5e8dba1";
+      sha256 = "e6f47ff4cc809313f928fb365ccd716f7c8de8a5e914e7afdc774c7f3fbd03f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/xh/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/xh/Firefox%20140.0b2.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "4d86249d3b3cef3b87f2974199bdc49b5f4116b76595a8c33fc261b7ca6945a8";
+      sha256 = "c4ee8e4849fa4334757c2068f9eb94341bba22b7298c767f7fffa8cde8341c6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/zh-CN/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/zh-CN/Firefox%20140.0b2.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "1c1b40f50bc92af90419cf2851e707b815dca48ffd43a550a866c3c09e212f36";
+      sha256 = "f22948993a7882ef1e244bcda91b0cd9ef4c814d17f4f54af2b9911e44f0899f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/mac/zh-TW/Firefox%20139.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/zh-TW/Firefox%20140.0b2.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "7b41474db868d1ddf74bbf96486ea51ca8f187075bff0dabed74ef47db3114a5";
+      sha256 = "c95699dca04392bf80ecd477514e74804614765d53029a9be80e9ea6b821a90c";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
@@ -1,2477 +1,2477 @@
 {
-  version = "139.0b3";
+  version = "140.0b2";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ach/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "fd57bc7e6844cedf2c85e685246c42d929d3156a77e1d0ded40b8bca1099d5a7";
+      sha256 = "6304038c471eb73b1c8581f0d0812ba328de0f8d7db7f2b17f587e194754d2a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/af/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "5fdb91b4dee48d1ca0a4191b6d4be2ea44bc2b1513efa50434b763f1fcd9d69e";
+      sha256 = "8cd9c38cce4f6672d7c1017e1309f65481af918314a4ceb43c6acd20ac1bba2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/an/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "ddb7dea1828c4906c5a6126f1d325d4eafade0a247d0f22fcc9c4e212bb79010";
+      sha256 = "2380b688d5f54edb3b0a5ec3fa7adc5f6f01513551a3d02bfed1a0ada05ddc05";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ar/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "cf581f622fb37c71e2886fd122bdc826600ab04cb8a2a5725905d29ea087157a";
+      sha256 = "fde74a9a25843aa6141c796958f9cef020b3265a9578aa63a268365cc1be8e69";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ast/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "436e4ab12e59de6b5cb5cba78d3e68db43e0408460ba46b25b81e03effd71eb0";
+      sha256 = "3112d67a4d293f672694661266791521d16e3cde918eedf65f3157e9a2b9f008";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/az/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "1d62aa36c32b2dc2f4af25ba12679436bcf79e50c2b73db1624e4fd7bf46933b";
+      sha256 = "1904894b09994f8f9ffccc32a295237ffb94779787ff04e2f427416d0912f319";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/be/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "f054bea6716d06ef8aecbbf147d3c81cb61f514e82ad57f515204aa176abc33d";
+      sha256 = "9393160070ed056e5d1568e90f68ebdd13323e894b79fd05afea64f207231131";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "ffb4c108609792de752947becc51c2e2975e90ea0fe46d44601c186f804eab49";
+      sha256 = "c521605cfd30f37dffb5b1063d18f40c35d843782480befa7b4e3a91c9960b80";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "877a26a16590cde1bcd678b0d419bec76f09cf4be230d0fc93fddf751c08b13e";
+      sha256 = "3d31bd1fbd7d9cac8ce4c4a9f1ed2595d17319dbe640aa8d07b96fce80abba28";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/br/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "55bd564631ecc2614080ce653ad5312ec5d7de98df948b1bbe8dd9e613cc77a5";
+      sha256 = "39c1e6cfca4001c63698e066753269d29328fd3188f9fd2ee8c89a35b72da079";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "f33fbced526a89acab9fc34a860e4811cb83842a583f6d7871d11152ff1fee4c";
+      sha256 = "406e850b89cf20211936221b208bc164a8a73b02fc5d6a9bf791cdf7a7e9c439";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ca-valencia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "d9c250c770914d018f596cb15ff87c0d009ef0121a040f09c1c2e8c95e415570";
+      sha256 = "0093fcdc460bc29b826f66da5711bba2b70fe584c41c830e2555f71f33111baf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ca/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "1a675352282c3fb2966287a0e763defc6f259ea396ee17c9ba4d71e79ce263ad";
+      sha256 = "9ed9e2eeb261926aa79faa89122887e7ad0a07b2dd764f05ef140e709a413779";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cak/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "3a672f2a6b1132d0cc37c9fac289c7029588d585e887a05943e01d2df0059562";
+      sha256 = "1b4b3619ef9114b3713a64aa5afec1f33861dc6335bcce5449b86676f4b6a0ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "f83bde54b11b0cb95c49a953d74f5d9dba8351e775ddb53238debeee26ab558b";
+      sha256 = "89ada949f223c2579be305656a3dcbdead12465bde6d6ee2a464bb3c92455e77";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cy/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "6876cb45e012664a3ddeeb8d833a28d97af191b3653a850393ba24c850c1c327";
+      sha256 = "4c18ce881a44473dd2e4e5ad1b7732bfafbac5519d92e036ee59f61319d2de4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/da/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "438f790a0a0c8648c9d265a4e3d487d87ffd6b41beb91bddc8b60e538e2a7d40";
+      sha256 = "d00cecaa47c94d895a6b94e155e8e24fa43abdd83d9f96aacdc34a1c70b2d6eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/de/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "70d4882852da68a7e431de93377cb7b7a1f68b906c2b3332f6b65ec705f5256b";
+      sha256 = "6039041822411f42a6757c4f53f85f1036c2094b8e8a8d8ec6a26f3c1abe521e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/dsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "7e845675e5a334b6080505f62790e6dda22aca0f07af1e1599faa9b2478ac3f0";
+      sha256 = "9845539a1db4a76ce1f31047471815f2a2ca4adef51d2b56c6fe487f7b9eafb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/el/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "07675440e77b87a0b64a83b28e59be294fc559f7fe4d5d6506cd34fe4dfa69f7";
+      sha256 = "b468c6b5ca6163aeb94ec45ef16fb856cc02a75fc55d939d2aab6181a777d8f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-CA/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "988e4e463a5e3684df5633e11e5e37dace06626bb20e04b1b69e9ef089d962cc";
+      sha256 = "ebadf4008439945b4909f0b4bc68515e89837ea871fe09c76dfd78e194469797";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-GB/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "b1c268a2c350a065e37cf259c81b6e535c0597c15e046fbac6dbcc064625bcdf";
+      sha256 = "f73ac36adeae16e5b0a383dd65ccde3946072de55094b52259cf96b5ee78d732";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-US/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "7a5f6f3816f25442272606ed5e45a9db22c507f0ceaec5858e55d02e4dc10d54";
+      sha256 = "ab17cf4f447bc681649903aca837c950f62e7fee004eaaa9fc2c894f6d001891";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/eo/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "b36ab4a47cb20b07b1c1ac77c3cd24fb850feb40261d398bc0b1f16d7e1f0e1f";
+      sha256 = "6f61eb153692e3de7bf83da4670c44d524aee1761aec5c8e54c9fef3ac843d72";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-AR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "cd03f278e58beb350683174d9614b78e41f2f0ec1552d50882dc1c405bc37ee6";
+      sha256 = "1ad06fdea8283a58544922066eedb16801d07ad7ed72cc6fc817a33f36741e69";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-CL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "1ff43a0e99f0f540944209470ae660756cd41a1b9e5fa267a78cdfa1b6ddb287";
+      sha256 = "79963ea997d12e82e245364556fd7c4deceacdaeb1e0c7e4376c7e10df6d5eca";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-ES/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "9a8abef988292db0d3e2b7d728770d6e8b397f90493acba75b2910ff348114dc";
+      sha256 = "cc966099a59e66bfddfae99a9a5874490ed5716fd5af99b9db03e3f13125dd80";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-MX/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "f76653c3b4a3d7244eef6adb61ea79903f42133deb4ec5c93715cbe06dbaa1e9";
+      sha256 = "ad8b1bf472d0a377fea8e0f5b532a144b397d1447ae85c7c14f871d9029cab19";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/et/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "3f725c9a2c84f3eb329d321ddd4b3a3ea6a21cf64fb3f18dd0fb681af378b007";
+      sha256 = "296e93456cc6e9027d187ca7b59923acd330066b36829f8140ca16d4ec423d20";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/eu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "bec67bfbfae8f1a0969c1bd083d200db25e9d7efadea0192955e2ca5be3a506d";
+      sha256 = "9269d0e584c4d004d6cb2c6f3d3859329947fada0413141b77cab3e4270e594d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fa/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "c37543777fc3c90368768c730398c1782400f94e05b26601cb6068f0b947284f";
+      sha256 = "02a5f409e51ec0010f551afde246a7b405a642fbdc9c85e8e021c7bbacc298b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ff/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "cd4af2a894a4a6f523aced106bad12f91ec41ae9409d0a5b32a1ee99f09c184a";
+      sha256 = "89a1e5d4e8d81ed4c3e2b0db3cb82acfe85f00c7875a993d9ef97a895a2c1e8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "7e9e1692e2d870375e17d8f91be4808118409088160bc61df8d2ea99fc4879b6";
+      sha256 = "feb7014dad2848a0e70bf2cb6f59fd7cbe4526566e9517ca636c7f81af1fd227";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2d1eb3ef8903cf00994a8b0b249cc806f0085b8ac4de11da66cc0611ec9ca62c";
+      sha256 = "d8c21f84f555a7ed705d7a21098151195a18a1ceeb8838a6204aa8b346e3b77e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "1b6a9f6592e3b2d35553c39b8bd59a1d0e7975c16d6e742fb748fc5071e61c8d";
+      sha256 = "df6870ff18a549566f89c864349f6e1b1be1e996af61a23f6ba8c8ebdc43ea99";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fy-NL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "9bea116bfd10e2687fd903fa533642f9380901196a4068a8d19d05176aa9b8df";
+      sha256 = "800b0a1ca94fdb9bf745c163053816152a62bfc374682fcb46920c281de24c7b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ga-IE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "fcc39ffaccfddff75c5b9dff184a7f67df03c24598910dd4d89380e29fc9fbdd";
+      sha256 = "60d3d9b322ed276db8495119171dbc822dac0720fa67d6e0e2417d5f7d903303";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gd/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "3bfc75d90fd3c4cc7a271350e7b4474ac5dab71f742aee22bd994c775906fab9";
+      sha256 = "fdc316f98f0b7c6c58e11a85df0596763276f506b224a79c17314bbcedd76b18";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "9a1008adc5c74857777bf8379bfcfd5592c987c36b9495534ae6c5cbd1be740d";
+      sha256 = "3f541084a75bfd470f9684ff0e9c64566ae1ae70ec6cab992f641d1ea711f56f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "46aa366e2df1df9365ff81214b637ab563689d53714f78c4950bca7e78334678";
+      sha256 = "403181843d5b8b0a511fb1c8526ac04938750ea19ce5bea725c6f6e67aab4cd9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gu-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "c6a34a993efa290921958cc79bf4a59a9fe66548a7684710a8eaf07f1e62d9ec";
+      sha256 = "a0a75e18c30ba231bbb8696d47f203f35800bfa945b010e4b67102e9ea995a57";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/he/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "86462bfc1e78034b69e106d1c3a728ccdd1f18ded37563fd9d7ee37d2b98fedb";
+      sha256 = "da0a1845ead82dbec393b3951ddfb050ea7b1eddf07d1dd52c6ea3941629373c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hi-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "36235be9dc59e2c093a43ad0d7ec6ae8341f8afa9fc939c6d29590acbd384e72";
+      sha256 = "9cfca47a6e5c5ce56679575657cc52da56a04cbdfeba9fdde7eed2f7dca21e01";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "20eafa0b16a86da30b39dcda17e232d69b0df3e02f1301d7c52e192768ed52f6";
+      sha256 = "e2412f9401f913fb3f78c68c242ed2bc7727e4798145f6d78e7ea7bb1e2330b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "e99331dc0ecd3f9be2dfa63dfabb71c2b3d8d84b62fbdbe67faaa6e106cfe2b6";
+      sha256 = "eef6641537eb1902fb5c80f85c028012151a864a011d87dfabdfff4860adcdea";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "1d14b5d69e230ef6ec21f2376b07230b64981e66f79c968c47ff109b34fe421a";
+      sha256 = "338ce874b6b6e7c18c805488eddbaae60cc0070dede2768e1fe8bd807efa858c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hy-AM/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "cf226323063c8d2786031a888b9001b18f282708e858247f9180a1bea3451282";
+      sha256 = "fce3954dab579911bc3f3f2daa4139b6567ec48ba209119fa7a890835abb25b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "b4d61eab8372f1cc20f28c1a3e8c1f72b21d584c0dd45266a715ac116e4e0c04";
+      sha256 = "cd252dfb69f3c202f6a10a1f94a3958474b281c5648c86fe1fd7058f1cc0daf4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/id/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "7086deb11a567fb9e15a2b301fe4234aff8ba5125cd6a9371700f10e6e89a06f";
+      sha256 = "c4110ddcbb1ffe4ef89423626887c8f2f093c26e449f109eeec04e23c8f86f82";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/is/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "f37387831ad3722a61a9bdf082e15cdcbdf6f9757be183bf2f4ff44b7e44d1e2";
+      sha256 = "27093bd2b6373dc87174473b087afa19fb9073978819157adca9afac9c1b01a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/it/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "9957340442c44bbc4ce06897545bb977a290263377ee3eae5b64616e561b1a21";
+      sha256 = "d7cd7f8f77550be23ac2f834ec892711bdfd40301eb60eb8041b6373881a8063";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ja/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "8eebb7e6d6351a8269b83fd8095b86bf8b2f4177565cd2fdd323717cef6971ef";
+      sha256 = "547d409c2fae32d519b85a0ecaa4fa798035de83a99a24b8679841450816e918";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ka/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "fafdbba964ad85b38565589118323d1551ac5021e041a00e29b8a629229e2085";
+      sha256 = "7c8283de2bd1b175da442f54374737d1c483714ff5a65614393a831d87da5587";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kab/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "ef2f0225bab971c7b6b6237cf2795e9281730b459812209f2d11656ad39e698d";
+      sha256 = "f79764adead47510e6af35e084c4bc23e550a07d700e9bf315825eaab019da2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "cdfebcd9afe5c55c6ff84543580e08108f3e362751f09b99cb703c20dc1de3fe";
+      sha256 = "efafd746dbcc752c401d19475513a567cbd334f6ea3f9d64470bb5e1f67bf443";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/km/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "ea997189f11e283f1d37e7e8a148f45ae0f7557fefc23501d2cf534a4f4d423f";
+      sha256 = "5f06885bc54c63e176f521e39030a5cc6efa850a49b1329a06332881143d9d56";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "005b89059b12d1369c338f9206e899c76c0d5a97ad94f28564778fc092694814";
+      sha256 = "2af7d765a6093ad174cfb34b89782d6c0ce17555d6b12650ac9e17f4fd383d87";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ko/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "56282aec275e94b3a556e3a9b95e107e68cf366f6d2a9dc8ce7fbcea9bc23ddd";
+      sha256 = "7ebf5fda02c87f0eeae2036ba3ef26f166cddc131ee165ae4e18c50e69ed676f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lij/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "8ff69cc72d47d3e212280b8ae004abbb9a34b6e052cfb81f6fed4b1c0d85f8cd";
+      sha256 = "c864a48999305e753d72ece78900eb7a97a3dad8eedfc8a72374c58f1d5227ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lt/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "353a5ff5baa875628c32f6a0b7cbe5234209616684641032493394c986811cdc";
+      sha256 = "04d711be33f1fae9366442584a7f2bbffd74fc3b3854728db5dcce37e50f31c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lv/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "7eb1a0e3e0441da2df5082693588135b8e7069a29c82c1331d3defdf3e68b837";
+      sha256 = "1568ed415833621077555b9c9ab1341882ec1f8f1ba17c596d51bbf40bace3bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/mk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "d7df7d215f440025117d472c7962f10b3db26536d424b633860bd0a2b8634e13";
+      sha256 = "f7fab263b90e197038ced58d845c8ff1220d4b7b10dc2afa3265ad0027856353";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/mr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "9d6b1174365423cac77f4066e174ac0e24808cb8147cb0fc4a04f526883f3038";
+      sha256 = "6e7b7b1d9977bc6d4462e08ed6e2a49ce22dcc8ae408dcc832f63d04b878e5e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ms/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "1e3eb5e62665157538768e85c30728e1b0916e9637a4d7d5f3fb390c9bba31c1";
+      sha256 = "17306a80a5bbbaa00ca9c1bb3717f25c49ed94c18c58c751c01292e8a92e8a03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/my/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "76fed1cabb2e1ec137e939d6b0318c32e23e5fa9d5602c08f6a9e56f0a469734";
+      sha256 = "eff89fa784ad8b0f039fa182ed67159aca185093402ddbf33752ef327bb4dd43";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nb-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "afb07ebb11a8e3247b8689a7809bb33a83cbe88ded223e5967d4251541f3d55b";
+      sha256 = "cddb858d97fd0206ad5b138d41d29acff16199b35cd6fcbe1c70d3ca126da3e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ne-NP/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "a877b86d57e978bb020d9a4447a96ae85f0d8c9bad117373f81561e8379ac051";
+      sha256 = "291570b761874ce5146d1282972abde6da445c7cf63be89f3d4a2abb5ae52369";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "5aead7a62bbfa6f765be274d64d6d8a6402b2dd6ee68a571600e64433a871854";
+      sha256 = "00139cb8cc6c4c5f6f478c476ffc00450d57ba239288462bd296b72aee205562";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nn-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "d35f50beb12afd6427c615f4faba025e2679289b7eed8772b9c2521c0f096130";
+      sha256 = "1c3f80cd5e39d450564a7266a58104e117f892243a5166ba6a5c79a12371cb66";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/oc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "a309df62f5d50210dab2d410ddf72cf8ce83124e49250d010a3098d45a519403";
+      sha256 = "6fafc879c80e60d49c32b7752dce41906213132e3a19e3eaef5edeccb2d6b389";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pa-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "76fa9af171ca8ef48f2d40dd357dff2f4f434ec5972934d8d5660b975d9ff14e";
+      sha256 = "c7bf8f30d961adcd6b560d855357a0503bfb5ffa0295ced4f92f6e7b6f0c63b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "441c0d7aa570ab16c13da29e1eef27bd58277b0546481dd455af687eed1c3546";
+      sha256 = "43345fd177e16fda3bead11b3e6c094ce947b4913d401c2d849b13607d8f1474";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pt-BR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "401cbd05af87d88f8351a6780a200f32d3e5521ddf8dea09f4caceb565eff554";
+      sha256 = "8d20b449e1f5dec93f7526bddcb01682478df46b7d6b647235f94d86ff47327d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pt-PT/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "1a64160ff804281709b279c0671be0a378020c3e9cbbafc21c537212af67566d";
+      sha256 = "0f9febcfb684ea28734508fa27dcbb89282174c8ab04fca0d99adb2596b1bb08";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/rm/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d05161f9d5a54db76b46be34c13bd628645f57175e237d691b4607f8bb1ad13c";
+      sha256 = "505a664aa0b5eb7fb919437655f807f87224ca346bdde982eaa6bc755e14bae1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ro/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "01813e83959f3c51d841d5d5a134b903fdd6908c77f932219f7f2976be33d151";
+      sha256 = "fe1317999e0d07e634f4da7813e25d553844339ef484d055115be201d351c94d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ru/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "60562e6b5bad99bd61b31790993b1af13d66b71888b75680ea2ff2a0a429a682";
+      sha256 = "45808d9eaff267c7aa5263291352f459e30988e00a3ec867ac0e4eb9e3fa5828";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sat/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "363eedd05b26529651905995a75d4fa7cc4a4cb0eabd71223011df8819b2c9e2";
+      sha256 = "e2ddcf9086a5aab8039b2ee40264ea5349bf27f424c8cebfd8d3f8be64b4812c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "d4893587265913d0cdab363809038afd61a0c96f8add8605f8f709d7cf6df1c2";
+      sha256 = "6c10bf086c38c7f030cd1ac37ddeee3e7900262367a26d873f1130f1b1a3fa1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sco/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "9c56abbb7208a26d8fbf1ebd3dccf42f23da60c73df628eaa44b9293e128f5d7";
+      sha256 = "fc5a205155469cdd157423b526c5ddbb8ef6619518543d0a13138e4548902c98";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/si/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "f9d59c8e43c249293c844c8e46fe001aaea050fc32a9e06dac0544319b248872";
+      sha256 = "f0165747a086b031eaed9fe6d56a6a664d48cc2cc1fcb4acf4cb2980680bbb18";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d7e396c453b86e7181a0af09f5a608b7b3120d0b2df93fbce472c4935ee1cb25";
+      sha256 = "3139af3d80de44cabe66907b1ff1a0c9abd6d4dcce7cb8f6a8a4c64cc96d0d6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/skr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "4b120fda51484bcc9e7251ffa267a42dea1328148476252dff33c22aa10da3c2";
+      sha256 = "4bfd49af3b1a4af17b4830ddad90e3d4742baf9ad3b296ad82c186e46e002c43";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c145d10b2a5ed42b1e0ec7aac49caf51468f200f361b0d3b576430f14825e0ea";
+      sha256 = "e58e08c08ce875647350c17919a247d1d959e9aa7cf090b9e1f631e3904e1c49";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/son/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "bb0a17d3089ea0fd8809fffc43258b2ea2d98e8a3ce96385ea80fd859f82ba2e";
+      sha256 = "df8df3a9d363721f5d7284c95e690938a9669bad7d1cbc659318e71807bfef61";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sq/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a013d51f7dfd0ac9da4cb6159034027ef7bc3360de3421211f5ff453912d9065";
+      sha256 = "78c45ef74932ad3264ceffa6ca2a3d5863642b8febd784016b5dbe4ad515ce3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "5388d19db672524f2a4d5975070a4e5fe09d9bddba8b9a3a54c2cb3052b3c28f";
+      sha256 = "9a3b7e25cd80c19c9ee0ebf2b9cd7fb956969b1a699348859193bb3d138a16f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sv-SE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "49600c47143f89d34657577d1175db5c415d4a4a6766e1c410db58337371004b";
+      sha256 = "864703a7933ca315ef1dcaf1e978b9fa61035a160cc3017bb6df53d50e42cfe9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/szl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "25a6cce7c972c74bb8f8f881200417765ae7deab09405a947a4010002cb5fa82";
+      sha256 = "e63cd0f41501fccf3d6da7779e6926971122b9a40509cb57719ca987417d6231";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ta/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "ca4eb3d2ffcbfdf0e70a42bc358854b99fb9d8b297959530b25db69fff8da6b1";
+      sha256 = "8d45af2c0e6cf88a02c25b7c5fb31dc844bb90ddc8aeec774ad8c700ec12919c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/te/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "a642f8335f263b9fc58ec32128ac3467c1dd2879ab72b90e74411afa723685eb";
+      sha256 = "0d0868ec91ad13430488eba13840a0fdb238a355a0b74ede0bd536c6cdc2d013";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "08636c243613e677caf9726e73e640165f90d0fb3b7f5d7a85535a9d20af06e2";
+      sha256 = "2112d847a6377c3f4b6fddc2064891f17348a0639a6341833cc6a8681aca2496";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/th/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "4586b68f7a73cbaa86eab8a2a67b904a3300ae485b85ff878f442e58f2c25a86";
+      sha256 = "a49f6e380f2ee83e08b9bce632ac9adc8863eff92f043886e6dff361af0d9fd6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "29d943a1e465b089e4b4216bff1343a3b267bc2d0e6757429dfdefe1123c87be";
+      sha256 = "a05dc7b3b86eb5c6c8e8bbd405c356ce6716ff7f57048c502a16dba1dc616778";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c0ebd1339d95eff201d85bf549f38ca93907021853a2841dbb48bb7587f84890";
+      sha256 = "be4ff7df882a6bbbb82426868abd07b3bc31328b72faab12c50f44910a04157b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/trs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "fbdd2bf864b5d2cbb0b633b733c70c71457c04cb405b0aa14c4dc83a5380f4e1";
+      sha256 = "b59cd940914a1dc6034648cb4d2eb98a27db282a63f549670112c005a4fc2c22";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/uk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "9f2af01f2187bc3dece162cd493ffa46bbb7b4af25aed176f81bc1bf99ab8f3e";
+      sha256 = "cd723b22c8bf8d857e68ba7b7101a42451fd4e0e9216898165194dba6f66600c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "4d3e57b37ea0d9f498701e768e6a1d3ebed495c83715df9b0623845b9ebf4464";
+      sha256 = "23307a580138e4f1e8de9de441c1dfa274b871daa68274510683ce02d1bc4554";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/uz/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "c9419b604b2a6e91cdf9f3c7fcc1a7213eeba095a7ca4950138d4757326a5337";
+      sha256 = "75554e0cb06a1244106e2cab513286d0a48c4b5c5c2645b373e20245d8163d5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/vi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "436b6789d5c91955affae937528b38532c09b96f80cca4ff893b593c10720138";
+      sha256 = "a502e8408f00db0089081072b813debb97bc5c60e31c632b460cdc3d1f9f3d71";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/xh/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "ad35a67010effc02db685ab1b05a534e8454a3d7d8d9eac2abb20ea3494440bb";
+      sha256 = "a87cb0aff09dfd91acac6931f5f8ff1bd000533448f8e79950dee7baa29f072b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/zh-CN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "25efcfc912e9e20d7479ec869afb471d4a4be279500e06f2609bfb5df9d65e21";
+      sha256 = "7616247e8ee73956d925b4a4d4b3ba1b269db286390250ff04ffd066c37e6323";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/zh-TW/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "a694e1461292c471cbf263f1fca962b27e5bc1dcc655cd9c0f22b6ec868b0196";
+      sha256 = "1070fc52e45b0827958fc4ebe74f4fd4643738a1d20a9647b37620066cf18896";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ach/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "8acea013f0230e45e5dfe7cb2d1495fc31fe8f62e3f0c71021faaeed56f88d90";
+      sha256 = "15dd9a2a6103f8b4e11d558aa1b5def0119929f304fe330f14fec35452ba88fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/af/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "e9cd59e8ecb6f05aa3f71fbdc898e38f5fe16e7366283a899dc918639bbfabe2";
+      sha256 = "076016952832f1f9923426ccabc14fdce0016572134be4413c323f04929d2b7a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/an/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "06f077e94b604c14d4b23b5c7ca90988a91fd77b4923762880a8ecf6d0d96549";
+      sha256 = "55e43ac6458d7be27db5aeeef0a4e25732555645faba647f379140b5b18f1cca";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ar/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d766a8ce6766609052f059d44b324cf67e872eea704095190a00099b472d1312";
+      sha256 = "1640b262104f1f637240480cb5d7727aadc003ce320f444fa7446b2345239a8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ast/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "2b4f5ea265d192b4ff27e24ccc60a1b2e70b5e19f5957ab482c6b0d36a4182eb";
+      sha256 = "726dad49420e6f8f6f48b00df01419fa1e25022e1a9034c917732f591d899ab5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/az/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "1659ad578e6b9768e3a2bd2dd2ccffcf1b8d8060c08bb2dd9f45a5a8b35ce6fc";
+      sha256 = "32f38f9452d6bfe9ed0059402286ba86b8e7d49767b84ef68a807009b3928a71";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/be/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "7959c9e95a1858961a2322ea9ff572c53d08c5f1e855d5115cf68343f1dfce63";
+      sha256 = "d205be69a64a92dd2dd4938cbe3804e41f9370bd572b0e6bde337feaacc7c80a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "74d7142554e8621b5662d322c5d1eb63a6bb4422365d037212813fc2b1ca17c4";
+      sha256 = "a6a8a3d4b40853a7bcbcae6c142896b69632720d1cd8ff0ef38944dee718110d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "5d40f8cdadf7510337271c98350a14b002462dbb58fd89c7f5a5e898d4d96522";
+      sha256 = "b1ee7cd72876760977922e48ac38cbf55f45bdd191015fd98b72b9169f88c905";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/br/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "98606dd41a554c6642b07c7012c8fc0e831cae305c77b17018abd7cf1f835126";
+      sha256 = "df82db0effa2010c5c90fb0795ba63cd8985716d68649d97e15408dc37c6c84e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "319901c06f9ae63714f5e50def341f7af82446d657a4792f6aa0dacefa6c5aa5";
+      sha256 = "87c0752bd5b5a9c2b87c6e538621c2626b4464bd585f906e305e4c5715f97c86";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ca-valencia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "bdbee33f7f53270a075e45854b42f5879eb081875310285ad4b99dfc2494c766";
+      sha256 = "632893b5ad32cc730ade803beef2b413b4df144ea80f233e2b24574092a8036c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ca/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "9b8af77f7db2bd74065f7b56823ea68db58822db1d55e1a9c98d4654d5178e42";
+      sha256 = "000cfb032ec853d10c5130b04e88da02998fd57bf70a07844390cbff55f9885f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cak/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "649a2617e215d8f3610de863ddfc29dc0c2b27fb7d642c1e0c9f2c6aa365ecbc";
+      sha256 = "009ba5baaa7d454aa9dcfde0b2b4e6940590b6fd6ad7d5a90003ebaf450a93f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "8e8c2e892caa8bc5db5804f42332ad57d1264eda034feb467d6d75827c3a7cd7";
+      sha256 = "67ebd37c779ce36133ccac10894ced3faf9d1131a6d0a71a9f35d73bf4bbae36";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cy/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "394bb39242b8631d46d42586611e91b54028fea43d78248af3bb446e6c6834e6";
+      sha256 = "baad091e481f7e3c3e7affc3261a22a5a390e3cb739875af53b4fd09f8995ec6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/da/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b42f902cab834a1a177afec0812b118280f3733adba9433d31098df63d184d83";
+      sha256 = "62315dee7ee9cbe3eef1b01359ccfd45ef7348d526fb6adf35077c74178dbacd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/de/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "420f1853b37b823edbccdb02e19669d5caca76b2ba3f607a81d11b5654f04c1e";
+      sha256 = "c32d7e2e8f07db2c92c876f835d506568d5aa5df587742aac5b5b38b1d741224";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/dsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "5987303e490b524c31619d18cdbcedff7f24d70a1652bb9bba15120d34befed6";
+      sha256 = "9bfbe5c14cc47de7c04d89fc8d753e8cb07e0722b01e694e40769578ab41f80c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/el/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "4001d4bce1fff3dba641b7c38c2b26338e40ba28ddad8554c4f7dbbebf1536d6";
+      sha256 = "b847df7a731151defb9a7195e52e5170f914df02f125474c44e3aa63c676c34a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-CA/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "35707a5d0e7df572c341da8d4ccb76f560267feeb8df785eec304e6c920da3f8";
+      sha256 = "7812b2ddeda5bc1ed121e8512ba2d019edf1596a0ebd5d1a8349613e1745d685";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-GB/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "02b5a1f051e02b949e7c8df2d4196e6e45cc02a0ae0178f8500c99b67737042d";
+      sha256 = "5b7e6a78a8d98b36cf640282e2aec5b34d9d54dc1c244d45e043de18be59ede4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-US/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "ddf19c5fd706f7d20060d009e26e5f98d15707d7ce1130a3e5209a80237c4d45";
+      sha256 = "60ca80fc4bdfbabe6810ba4ffb1b49eb02147fb05134a3c3eb19cbb2d7ef5ff3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/eo/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "75a9e8c3f3f1a11b22be4501fcc6743f6d7233591df6f1f3eee8243fea27e6a6";
+      sha256 = "61947e8887d2f0010de1b1cdd1df5ece9dcf4f9abaa17c76deb48b47a14ef79b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-AR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "5a66e9d13ae53b0e163630f1b9a20c4b68f4e7cdbf88c2d2ca702fcf9846d064";
+      sha256 = "8c0c291f1150c6cc45180dce4d94540c947791aaee2172e2f37b57b002aa1784";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-CL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "79dd1dcc771346f0aadab81fdfcbc6fe1d532001ae17793447b423b1a85a4aae";
+      sha256 = "aa1444a6092cb96637ef7dc9c44506702cb96eaf633a39302673d040f0b2a9ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-ES/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "90054b5ee7292a1df8f0e7688b35fedcb19f2a8945f0bfb440c44913bd123c4e";
+      sha256 = "0442ff731adeae06a0ea178098ef17c1d0aca3f34ab854a7807c56d2b1ace7d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-MX/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f18593686f6a02b0bfb66b364b93fbf1f868365eb96e8152ce1500d6c739b457";
+      sha256 = "b260521cef1779ccd7d6b1cbfe66ac2d5cd8ee72f282b6e81110ea40995e9b30";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/et/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "b6f65d28916d962223af04027a1b5550ef7e6326924f83115a7b86791220bf2c";
+      sha256 = "f7b752e18302aeab61df546a0423fbdc297d538c35b2038e6e9dd3f0432d55fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/eu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "410f33a12c705d8ff753b4cbb11942df9aaca3777774e7cb2db5277b7791de1f";
+      sha256 = "e0d403ce1c3fb69e692c0679c7ed65464bd28cdfcb107756bcf66b03bb20f15a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fa/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "67728e0982b672da05cf00b46a12e18539a0ce2c3cfbc3f91e0c5b62b6d01408";
+      sha256 = "75eefefa501b4e46f84672aacd3d8e5c96f4bbee41dd652436624de5bbd837e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ff/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "ea729dd3c19b979d00c25b6dfdd2f2d633055a9ca389ad5cde5b5154886d25d3";
+      sha256 = "197ccaeb27559a1dd913969a3a8dd011555c8125fcbb55a28caf4a6074b963b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "40b78a9e4cea933865f06a41c8a32d276a59bae2488601afa6d6e936669eef4e";
+      sha256 = "61ac2a275d6410f7eb8cc4f9bfd70e1e5e56fd63eaac9447a56f15920221be7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "5828e6b8ebc7b7508f363f9309554b544205479c22b9632e230340774c46e442";
+      sha256 = "9322f072928c09b3d45e9e683ef26480f404def390315f46eaad3aa76c5db4a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "bae0801fdbab156db54f0562f246a59eb5f8c24c79ba17fe2b6c98fc9ed91c58";
+      sha256 = "4ca712790eb5a98804b6b21e68cf1d875f9dccd5bd729a7f1231cd3d7b4c85a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fy-NL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "0e21ed14bcfc78650f62cffa63d1d9f1a8f21b64b0d258b0e15e346b6f497f93";
+      sha256 = "3ca2c4a2ef1de935d5a3ec0f29314596ef64611fb9025efbee2e809b8bf51da2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ga-IE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "a873d3ce455f8f8c82901d9e2b6795e59515263380443801b2e0c9fd050f03b9";
+      sha256 = "2e43d6679a844f9241110f67a785525b09124f004d697b41400686851a45811a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gd/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "13d114359f5c30759febb7bfffe79286f3261477a160a35faa3d5d2e1e236271";
+      sha256 = "a51f8e4c872a39f307bbd8c71e56a3f90d84163feed7ca79067ab0f51f7eef11";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "57c6b29e1b05a4e75224085c7a8f13a3948930e92204f882092cc71efc7d4071";
+      sha256 = "24fdfac7aa372ea38d4ce642b5e30cdd49c46428e5431b004f368c40d52a450e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "6a197a8c1b138f1eb95f85770e4734fcb400679fe18c0241352dc9d0d025dc5e";
+      sha256 = "9f81e0d531c7a9826889328afcd0e8e8c29cf00b253b0b6ef420fb798ea3d2de";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gu-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "53bb01d3b87a5a463b993e69ea9472b9b7dce818ffd41a3efc74b0def2880c10";
+      sha256 = "72ca1ecac233a4e8d51a70edc8d39d6bcbf036827e868b14c9d166c70a7140f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/he/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d2f51a83e9f625df054c75b6212c95a2ee98a6ac6912fb37f6dcce151f0d8cc5";
+      sha256 = "2cbffa2df9acd1b30b7e96b14e9dd7d9cc9658779fc24d87cf89f5a5989770df";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hi-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "72b1cb85cf3c3774befbafbec03aa95084356b955b6c86acdc2d12fad9a05d57";
+      sha256 = "301469bd1372c6153612dda25c686461d55d5140e65a8f4048d9159b7fba67d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "9d0b4cfa3f23f962e2784f9a17e8998d2a6ee1a3e54740317473e32c790fb1b4";
+      sha256 = "b00411fb0539a1de5a4d025fc938f6352cd38f2a3d586d7c5023cea8d3fc976f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6ad41bdaeaa4bba9360ea98787f0c84760f849570452425508f3dbb0472e7349";
+      sha256 = "0e9daab014b58ca0b5b065ceb8429b576765ddf692886c0b2709f9cecda54373";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "583782cc9ee0da5f8ff488643ea6a1573979653130bb6120affc1a7ba57d10c4";
+      sha256 = "d1ebe95c9ca85f7ad097a42f01728f7ca4b67e0b0325993cd7a8788bfaacf186";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hy-AM/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "bab8bcfd4374d076023b6e1fccf797fb3d83f26d0fa8df75a0d3c5f69879c5c3";
+      sha256 = "84d00b6cf98ff0a2ffc08ead1b7dc61e74f689d69a946f2ab8c0c7ce96299f3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "2bd01c27ac6e282be53d72b7993fe9b35847ef5639104924a5d45fc20a42e56e";
+      sha256 = "54fff386745c615db563a7e1344ad4c0dfedbfe9ff1b69311fb96106130eda46";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/id/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d110ba5a2d529cc020a476fcaa8781c35f1071224b33814983b83722fcad0078";
+      sha256 = "d52a44a22505daf7236e289b1653b991d640c2b2be5a9ac4effe0a819e9ef063";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/is/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1bb68a757bb2c9ec9c87522d91733fe55cf5aab0ccfec58cbee67c3a3764df85";
+      sha256 = "f01b7bc84a711c72491dffe4be999cff939ba3fd433572f693d9e3a0a97d2a6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/it/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "6eeaaa32990d457aaaf37804f54e39fee7fbcf90e024797461c76b7b1522bb84";
+      sha256 = "b885a44f52597ece4a719245709263626fefdc94702162523d0c6392e95a9817";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ja/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ad3d2dc245f06c540b7705e4c43b18477f3ef2b6cb21046f2c6aea5ec3343744";
+      sha256 = "5deaef5a05465c8bfa5f10480f0c0928a498c1b5f495e198bbf5bb187c2139dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ka/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "5d1c0a0642967fcd4646e2a615c5033634913b4e55b53669de1a27f6de18d39d";
+      sha256 = "6c8ea6cab65bae0429c9f63b906e63f40233a01dffb061b0c37d60b0c966346d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kab/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "fb3636bc0836dc5754a86f40274e3cabb1d32ea1e493cb84bdd0f61b1ce526ae";
+      sha256 = "2c1b647450c0e179548aef5794a596e2053322be9c4b36da78616cad106537b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "ff7faeccbc3977063bc69628c64320e0113a6cf0cf487fc0b6253debd7c1da04";
+      sha256 = "36349bedecc9a5d3cc4eca66232925583b82a5f9b7ec2104259f7e5ab2704041";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/km/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "fad1f93e314bde16894eb472b2cc2ea41b5227f4d916d15c536b3892fead5587";
+      sha256 = "a50643354ee4c99602b2a31c6ab79a651a6a74692eee373c988c0ccba8ae9574";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "32891d6d78f97ce1eb3f72751252e8ac15474a67ff3b69e0fe78f21efbe50aea";
+      sha256 = "bf484b8f53ce0703250f4ae0adca41b327addd29319a99087a930abaf92296d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ko/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "f4f7315ddffe3bd50d927cb29e6a29887f31601c6c062dd349e26920fa1faaa2";
+      sha256 = "4297f9355f72fbbddb7a337f0de9877c88cfe6a74b98262791d4eea48a9e8b44";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lij/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ffd066b6b01c2180e8d85ac3c91521b3c2d0a349184bd6c3a5daa220dde51942";
+      sha256 = "d1128743a077f51f9dabfc3b949a64500dbe5936bd29347e0042ce118b5621f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lt/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "6d14d17de1c256b6c2f44dc032a09b99244cf9dc81619c18cb750f9900857f94";
+      sha256 = "ca2d1ae064e99bd1cc490b8d47cac1a342419ab23a3dd39919873d102d416d7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lv/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "d9f0720f4d1b663406b14db66f739ff1d0e2dc5e849f88640d0899c3de528f4c";
+      sha256 = "cab179bfcd42b5a93311a3b0e7d298ff1130e17c5c5493b8321693b9149b5b48";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/mk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "e770c64d793af8d63bb33434f427ecc9cdffb49345ef966ee7b27232214a11ad";
+      sha256 = "ddbf2ffebf122e83bc865808782cb3d1e0700cc29467b6ad8506ee03499580bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/mr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "bf0a4fb9bec478a1fa1d48be903509b5f23c45dfa7754afb78aca3962e7fd21e";
+      sha256 = "b7635fbe1baff6f7edeb4b832aabd21d12582a7c66cd086b95b0a02aebba4f56";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ms/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "8d09acce703795b35bc04887cb26e4020af5c397fa396c2f2806548b5980b6da";
+      sha256 = "953a47f53c007d2cf02b22a787e8c476c763ebc5b15796973cc406d34301440c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/my/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "f0b894a6462f5a80c23cf83a1a011c491a0fcbf61fc04c2b0aad6a0ecf9b6a42";
+      sha256 = "a6ff85aead2ee5d55bcf055a42452d44439b9a51ae25b5336a3b22a573c0b46a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nb-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "2af8e1f308a6010c3b8523c1e9d12d0e1b5b9724ad1f444394ca58433a2298c0";
+      sha256 = "ae4dadeba15ae17d3307f09392ebb3f85f0212332f9a9a857ba5b6118452c2cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ne-NP/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "004f3b52f367a1bbd35aa06d7040035bfaf5da5524370810c789746ed78af888";
+      sha256 = "28e20f4d661bd7e95495155249faecf8fbb5e7e654298ed1fbdd62cc971476e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "eef545c2a3937500dd825e5e0ba94735246bb2e8750a3b3c2266026f5b1859b6";
+      sha256 = "dafc7696a404c8fad558b649677988c076c5eb4685fb801840710657631c5356";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nn-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "794b917cedc6dc92964665da249dd018ddf288f837ab2968794b63c2360a8cce";
+      sha256 = "992fe42be2e1521e85b9f5baed59f0e87ed71bf62c99190801bf9c2f5f5351f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/oc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "3b83f2fbbf74b91e44a7f0043940d242b1b736d75394caecbb9401e328e23da6";
+      sha256 = "accf61fd69c7e00bdd48163403b6bbacb37202a2db113983fbaf8dc1a3598b0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pa-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "72e016689aa5823d0c1023afa000780e6e60bcf752eaa7f1fd68da107f22f6e3";
+      sha256 = "6fe0de8669c63d79837ea4dc062f4550b5ee709446c24cdb54572fa9a3916469";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "263dbd2d79cbc7a2c0a0b21a3fbff69fa22383f39d7824ffdc31194f03a69327";
+      sha256 = "71d4c24b490678d5941caa81eb9206c8aef0688eb6d134766588b2ba1a4fd808";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pt-BR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2c9b08173760317cebebe8ab746b8a024db38bc7a7aaf4e9de034bfb50abe5be";
+      sha256 = "85a69113a9348f3aea241a7de7439dea2c3ce3768ddd8d4b2a3ca5c1769059fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pt-PT/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "df8fdc9ca8a2a16decff55ac6b64775ae2dc7c64d6dbdd8fc15df014a8f8a656";
+      sha256 = "4586e1e50cb48044075c4128ae7671d23daa9ea186c8d60272aed76ac5d3bc7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/rm/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "2b6f3c308e293955fd8243fa724dc969d054b7c0d086bc1a243e2c19bef27bed";
+      sha256 = "d06072037678bb49711952a3f5c7a082b0a39258bbbc951578110ab7f1314bf8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ro/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "81d6fb48b838aeb5e9fbbfaffac8936f376289b162958169a50e8a48bdb4bdbe";
+      sha256 = "cdc758063dc9dff54e5d4ca6809798e239c7e096ab7c21c91738c86bd50c4499";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ru/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "6fbcd6ea92f5e2c81c926dd407ff2523e551f388b56154a3324c1f04f66c80b7";
+      sha256 = "094f692ad849c608df35112dcaab251f3710145fd28a6426f578d984de4e2bef";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sat/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "77b8647e8702ec7dd982ec622151de4eac6e1873fd632c57bc174d4ebcadb675";
+      sha256 = "5922623b038eb20d5e600d1dfe48af7cadf9e731de85abb5fa12f6e11b59629b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "cb23ce760425c17792dfb75fe52d39f4fd377b640f69ba8bb575df6fba3f80d1";
+      sha256 = "922dd68c7737deab349f55f8c978a2408e6d405b5a6add9c9ec0728dac4d8e72";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sco/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "f1f71c42b2626d0dcfc3552a1224db422328f4f312512b3fce292b69b24b7560";
+      sha256 = "b5aa0dc79307853f86a37404d9bc42fbedbd94d94c5d65b2600e4505ff4a8553";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/si/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "7600e8c27c2e795f7cc4481badc279b461901aa516bbb0728128874791d6639b";
+      sha256 = "3b43ce4e8f2ff93ce083d4202269ca316c7f74407b30386b0cb8c290dc88b895";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "45d7b3b578ead0d40175954f9e65e124853e295a0c528dd6abde891622534e3e";
+      sha256 = "38d4002072a718b74a479e5c733a572565e761a68b906bd7f0e0bc6fd896366a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/skr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "187fbb481c64cc981b20de374913b9d17c3b117a80ab1feec58c18c965ef3e4b";
+      sha256 = "39bb8166cb65e836fa2d4462c8af2bda38ce896b918304a776f1d2cce1419f98";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "17b5faa5a116cc9ab8fa1a322bf6555450f4bcee1a2abf09709645b17bd46ecc";
+      sha256 = "6c72f3e2c35c677ef755e9dfa39ff8c9947a341b4b91d3a8906350fa9395030c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/son/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "4639c5d5d267896d07214291c468546ff26478c26c435ee4d10cb2e9dc307e65";
+      sha256 = "2d0711bdbfc89da98a0baa43ce8ef0027c86aa7db78b0a1bd18672b667ab0e30";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sq/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "a0aa72766d7cee37f9d9a4c3a28ae8b954a2d28810bf553cbf442b30edd623d1";
+      sha256 = "1435a9477d2040a926eae4161026f7d343c15dd154af39c785fd0c69a60ccb10";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "607d5e9a73671eb99735e619a2ee701f31ed6dc55ba016a237618de6fe159933";
+      sha256 = "ce3002b8360b73d0ad16175dc65ced8a6a5051b01947ef747bf7aa4bbd2c9ac1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sv-SE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "dada2e913de21d7ecf323d302fe2b9263ef6820450622b3b06e73963a6d48f9a";
+      sha256 = "56dbd4190064e6f4e34d85c25771b30decdf97c7050336badb6875137780c70b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/szl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "12526451c0f4c8a8446b0638be2e3c24a52cbd8277928a45e9dafb2c65eb2d03";
+      sha256 = "a3f255842ba2050b100d26ee84a6afb31665f8dbe701db7557449b14672a3c12";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ta/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "d3153deeb5951fc6dbff2fac07a51e587d98559042cf1cfea70a55c4c8ad25c7";
+      sha256 = "73f008cf652c7a4453d710674d9d8c635e1feb3187f615a087b3ec87b4b16035";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/te/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "21377ea235bb38c01aa1a21516722e2a91ce679ef7d1b32487c8813f1cdd2aea";
+      sha256 = "4307336f634d2bd01aacaeeab52bc995cbc127bc8fd5d9503dbec7c24a4d2f0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "a428becb1a20753379791ae6538b0b1bf0ebad0d55f98d7d8c19af0a7294f7e0";
+      sha256 = "97b28078ce5f731948c1e12f0920fa4a307a03d2ed65efe12019ec29b23ab7a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/th/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "28a30d8cda25aa1e63fbbcd1bbcdda5a3ae990e1d973f10d4744499a27f13ef8";
+      sha256 = "c159df215ddea3e0372cc738d13897a89470031d4302a0d28612ace823ce1398";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "80bd0de1021edfe3178abc43017669dbcfe1885c66b71729372bcdb27d381ab5";
+      sha256 = "bd888218d668794483dc75778fbe4afd83443a655b9eaf2c9b367cf32c95d7c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "f9bc32e243c091be454fc5b4356b986cbbd87bb76135e7cb9f9dd44115af2f5d";
+      sha256 = "88b9244ee99bdd1ffd602df92cd25d02b240ff4aa3a45cd931c0bd9f5d4c9893";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/trs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "fc7e927f0ed152dea1940b6965c79c3f2a21d22c117d52d9f32568d5f80bd48f";
+      sha256 = "14278135b7debd30d31853d9189ec21f400c2d32cc8a390f1e01675f26aec36c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/uk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "f529c85cd2f12c7b2fb66b1f79268af7ba889c8a6c4cc1accc5b19b74f77301f";
+      sha256 = "93b22572fdbd3095d8e30deea395625b788fb9a778ac2229cb195ce63bfcfe46";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "e677de49b31054981a22dfa36d9b29339cdc2dc230077b48a381edefa1a17271";
+      sha256 = "f3917596f5f0ca2afd8faa99e916ee272e99bb969c0532775b4b250492e80065";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/uz/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "46d1fa8b789e3c4adb313883a438a8dc051b67b3f005541a31967921b4cf280f";
+      sha256 = "cd5eba259c10496a1febcb3e45af097fef27a1988b46d3da92f41acd2f0ae523";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/vi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "65e242430ce65fa104fbb0bdaff6cc53a5c0dc60b2094362f2dcebc9aecabb3a";
+      sha256 = "f40f814223621311d4e61330aba019463bce28b238176ee241b5182dcd23fd5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/xh/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "979438f443e8c0ab980af19e9bead77f3039c955c46a2c450db7265bbcf6259e";
+      sha256 = "194e2abca87a28bc6fac3fd8a2e81c2948d82bb02e9a21d77ebbb852d4d3323d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/zh-CN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "c79ad34593f9ef472d0231fe57082a1d4ec62bb4c7cc870c4e510cee5ba3ff44";
+      sha256 = "19d5bd43ee524ec3a7b4bf7d743c382ab21ad8738f821359fa5b076e38dc71a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/zh-TW/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0e169aa02e3102b396e0d721b15138fe39277e4d84935fe6c8931ef69117b4fe";
+      sha256 = "aae9ed93330ba2097ea3b3281ea5c91dcd21f4577acdc87b368a5b2a30f8e46c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ach/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "bd3e5c69934115d423aa111c257520f9cc5219a29588843ee1c5b61b1a3e3da5";
+      sha256 = "8e333cc92651318838354682396e621d91346f82515106a44645db9d58a3af4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/af/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "f3b63934c1632d71f49d9a401dc8bf6073936dcd656fb0462a3d34e352075352";
+      sha256 = "b73650f86928fb676d4a1b4ad13abd48a99b3a87c69099f4e67891f2f16b8916";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/an/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "313da7d73bf645cea5125e3909c310f3aa81b1713297fb7b66493b79f16d34cf";
+      sha256 = "0087d94bccd33bf7cd38e5272b4722fc6ce0654c86329e5fa400212ba2deae5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ar/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "9bd0294aec83fb9bdb4164eb8eeeeda22fc3b2d26e8cb8b1a5e036251be3bcdd";
+      sha256 = "ea37bd6670ac8c1074db798729b2b6372ddc081546f05f5ab492e45edf491280";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ast/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "2a3229c50482cd3b86ba9892985680b6cffe4259503d3efcee1ecd6fad4a6005";
+      sha256 = "048e5268852cbb2882daa7e768b661b0168feadd538068724b771564addafd32";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/az/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "b64a348dab5618276f0102c23d7e74b4e1bc2af38b36e678b3db53fac08e3125";
+      sha256 = "69be7ed2489c62f4d4aabe0b6e0e356ae0708fd963243a43843f098624883218";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/be/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "6e19e16df133ea7b7b796a92c470ddec4ad9db281361210dc249851dd9c05e3b";
+      sha256 = "831ac7b7469b7a94a63f8687f8c8d1a6626d0555f084602b341b7875100ec6e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "c691fcf4ff5aa896b51e12c01b5faddf1ab8d3e990fcb5a37c89450511647335";
+      sha256 = "071125d022f167f209c6b5fa6099a1eb4819ac095e44e28c72835af09dfc857d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "b88a34520fbc6cfa328e879478857b10a738dd5ed6c99d6db16d380e1b80b71a";
+      sha256 = "05bdb1c8f3bb8d673b2956471a60b616565d9acdc3ab673004c5fe30d4dd8b03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/br/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "d2a051c03154c151367d01d887dd22d9c029c948c7ff406e5ba975a981e3270d";
+      sha256 = "cce32f7d6985778559a2559f9dd2d27acee239823176676732869f99fd114ac8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "b7ba2f914aacea218596d2118c001961c1151b9df842b5afb498d7729f4c7efc";
+      sha256 = "22b677d215dfc64350e9cc08cf77facdf56f2248d0be32136310014fcb8bc4c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ca-valencia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "3d9cb24a0d049de007c4125efa869119aef50263f70bad64fb8ce328cce6abb0";
+      sha256 = "070138cb5c1576458df1acf2d7c735aeee45fd831cf6a5c058f705a555f08074";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ca/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "40288f778e9706bb3c2bccd641b7f79a9b96f5129bfb282a88fe891f95d20e9d";
+      sha256 = "3397ef999dabaef0f21e9c94597e5c1da632a525aac547635fc39ecdc4f7f8de";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cak/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "79a734a1a83b350d123b7c76dd991e9139d14c84b795486587bac3e001e43fdf";
+      sha256 = "f4bdcf93142b268ad5ece77deff6684197acc671c39ec3408269a5636761e9c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "3fbf932baa5ecb2c4ba06c6f8f29251d8c33c173df96ceef38250decdef6d73a";
+      sha256 = "f93563b2f365be59e77b205cd582fbab900aef88aa954c1bece23a6ee8d01a2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cy/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "4bf4c523a593907dba5ef4ed211d721ce89ca13af52852b61a8a812f7da6473f";
+      sha256 = "6ffa2b32e82102eec535998ee3593f9c6bae6290546425ad3d19f6038be42d7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/da/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "f459937cbe98b49931130dc0ff35741600d919afc84226a0907f6b373496090d";
+      sha256 = "4cb2c407cf89df1a1add90caa9aaae5947ae389a322666ac5fc3f4534ab9f3be";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/de/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "c1cbb2e1a978612c0fa60ba060fcd00f45ab0610a49f42f3ea59a0032c1fdc5c";
+      sha256 = "25e3d5ff4e13d7b716d664f92bb60bedc0b695700c743cc27badba490df4cc2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/dsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "94288aba032c65e197001b10641ae42ea05a9a6c87f8ca6d98b48f5924ccb314";
+      sha256 = "a85a8c6d39afb495e1b34a896b3cc1aa930334fa8e720a06ba86620ebcb64641";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/el/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "143f849d261a87f066952914b466e6737a337cbd412117add91e7731b088c89e";
+      sha256 = "9a2abda0113c66b95d1bade25336432618e0123c3e344b97ed27f59a03257b13";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-CA/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "a08ab6a5968ebf60d9c4c082475e1c7cfd840d90e8dc1265d999eab45d0bb26f";
+      sha256 = "05b6af15963426fbd845b2b43dc45499d366d476ad59cc80a1558009bd1d63a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-GB/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "a14d387031ea588bddc104982f11480983a45f2d4e08c814ae91a6f9e8bdc4be";
+      sha256 = "b1babf23c66ddf5ac23188b272cbc61d0c9821c8d2ce4924b15d7231aaca96cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-US/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "a8b95ece65cf5ebc5d5ae2144943c66135a2a32d64d7ca1c2424a621b8ffc152";
+      sha256 = "b6b38968b00781bbc144065f0294947bdcd1f23bfa641f57efb6e88f5905cb40";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/eo/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "0bf932cdb5b2b672bad8875e4bd59da43fda2fc8293b14f5b6fa5cf58c11dee1";
+      sha256 = "195e8ad6973822bd5f1919a82bdf2206cf9d12baa7ed38e467eb360dc5dd2c42";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-AR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "991cd0e2894a4293fe8d8bb78dadc51b7c0527a1d64b1bbad6328e553b65ec7d";
+      sha256 = "b4c3d0c5fe505ac5e7c9a38584683ce3c8236ecd497f055c7ffcd7b08604fc3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-CL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "15f27bd91d2d9f1833a3dff0ebf957bff6ab740bd5de214482e348240968259c";
+      sha256 = "42fdd9a3dc09de733adb19bc07eb40448390a4ae9a32039f695564915fca8537";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-ES/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "0abd7d09a96262f226564b01633ddf9912ab190e448b57422c965d7ab544bdaa";
+      sha256 = "8946e80d10fbf064eb6fe4565afbf4b7c320d3e224871c33fd45a4c22c53554d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-MX/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "651f09eb5e0818805219e57f9e9567fde5ea538e62b0970270547349cdd6bf09";
+      sha256 = "2e04c6985567aaec38c91f7d45da067153b12d6d800ff6653356af6a39bde95e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/et/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "3f970da97eba78efcb840aaa9e7812fc07340ead7b8939648fb8839c743298cd";
+      sha256 = "a331657da8a21a447d94ccf778b766abf845f73f2350fd75b4066a1a97cb7255";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/eu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "eb5464b8618eeda6aa507d09e403528ac991f883e4ea6070c01ecf7ccb34a2f9";
+      sha256 = "1b10be47d311454b148558de6e6a98947286d66b32627fe9da586f6e764b3846";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fa/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "6f78eb8b602d2b349d564d08e1797f7dd381a818b4f5fc4916e5e2d80a6890d1";
+      sha256 = "61ec0edc1639d7c69f258b4860135955addb730c382cd693faccd07acc9ee59e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ff/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "dd74dfd1b55dc2005764ee2237f4bd0cd841a90dcca88f97f4d7ea1cda57be28";
+      sha256 = "97a5d77fd30cf21502b8b9c8005112180396f26d24dce88f6086671b3711d710";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "108304dedc88ed30195dc443a62df7f1d579a8540fef911e7ebecc544aeebd2c";
+      sha256 = "180a4a853a9f03cb5c4b6467b8476edeee17ea5cf324ea4415648dcf3d85b228";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "c02dfe50d5b405f8fb90868ad317f1020c85d6bd15c6167d4bb8af152af29f29";
+      sha256 = "6490b20b7cdb731df9d8e0df8ca46bc834b362c577c235d5397665a617b271ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "c110494b901de0d5cf4623bab3fb7aa523c2c8afe14ce1339207a07715c24e0c";
+      sha256 = "6d7c83bb94c905b02365b0502cb5d1ed7924eff2ffac575994598d7382aa4635";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fy-NL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "09fefbf594c1c840dc18611d303c8aeae70eb7126e17b5d0e41e96868601acbb";
+      sha256 = "9b11642f4ebd8e27f12d3c244ee467a668976a17edfb12b71e94238eb2a98d6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ga-IE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "51e4f9ad18f29f46875ce2e146a4300afb0f3b860f0bc9bbab2cd6be9c20a564";
+      sha256 = "2fea6d116c6be60aa0a0a46278fe29e29f0ea2d6b48396211d500fdfe5669d29";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gd/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "cab4cdd9d7b1af933f53863be982d427f59435522f24bdef27a302b9221dac7f";
+      sha256 = "22832b70b7504b7bea490b45a70ed88488951d4b9f4e50cec6869cedf5fdf916";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "48b3771b813b62c8ade64e55ca5ea2e39671f2556e6057c49374b089adfbd2c7";
+      sha256 = "0fefa4add517fbd4a49ef4305c0a37dab58d5cd1cc579ac9dc4db005fd434e9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "63e40c6ee16180e62fa6ef06f0bf1bf04fc9b368940013f2442e034229bbe586";
+      sha256 = "0dd0a13c53de0ff825cb563381ad0fd2956cc1b485f270cd9fd07fb791d7da79";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gu-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "3c3c3847fc36800336e000c7a5ca479edf4832f80b44ca7b4f79151a67119a16";
+      sha256 = "0afc4e0cf35f8668cd41026532b05070f5bfb116213d7f195a9e2458a2538c33";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/he/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "b77b031493a228f911f29ad93d55d9895005c31ba90a99a5b1b4e2d7d7034cbc";
+      sha256 = "f53438739efa25fb3bf2e76ea57105005c048ee8f87e3fdbaddb6987bd8b41f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hi-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "a0ada0fe2c28f6e0bf6abdfcdf60ceb5cdab896ff1c86a58d33c9bfb4faedeec";
+      sha256 = "e82d7805936223b363613138e1641e7ef042ca6229896b1f261cf9db85095921";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "56fdf616a68d2701b4c505da83e70c14a6c08541ec826c7a187c23a30323c8a2";
+      sha256 = "5ccbd439a15849ab7cf33899e52190d7823042c05ad119e54d968284fd95cbc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "dc133236dcd7500e46b2bb806212a41b11e906cf66a744dad2ab6aef663ab482";
+      sha256 = "6671d4973471337ff156fb0aa8d8a89026ea001a82a3c39151236e450ba83d11";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "d2c85ea926529b2caea6f3d5a07a954eac9fcb1feb1cd1780a7115fb38f7d03b";
+      sha256 = "f2b96cd0724c64b2bb946d03fbe4f689e06aeacfe25546521a85fc823df19190";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hy-AM/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "b7e324693725687422ec9ffad3bec53e559fc755d9eb169783a0737edd9b173e";
+      sha256 = "9b57ab8d9dc9cf31b1e8c5983085ca6380b4edabc78c823cc5957862011c14d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "1016c382f3add7c82860d4a7f980770ca8d2332e182b1b14a958012378f272f0";
+      sha256 = "188793a0c4619be9fafb870583c716f2f71026505312050b38c90ba69a7ecba3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/id/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "331b1885e004f602ebc004460ad4780725dbb3829ed04714b21df919e4972661";
+      sha256 = "69601bbff0fe4b1719d9f76326ff363aed11404d0cc3b1babd6de85f174beae9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/is/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "4ec80ba6afb69479b2cbc942551cc129aa0d8887ee32a2803b07ae14de800744";
+      sha256 = "a446c41c5055ab8b81d28394aa0c3a204012a7409028a610269d6b8c31cab303";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/it/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "9d04dfe6d24db792b2091f6726f8ba5edf0ab2d9373f2e0957c951f1a055dce4";
+      sha256 = "68ec8352f64a031b2e12f43104822a2fbcd80b4061d8cd8ce87498112fd7e5a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ja/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "7d2b0709f649b8a6b2edb124a2a501f2309b2570b1807efb038c5400cb0216b2";
+      sha256 = "a21480a969ac74e85749a6e2904af86dcbee8a85b799b45e09b23c9e7553b783";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ka/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "06eef2411c405e2a17267bddd6d958c7fb55497478b6213fe259e40fb273dcff";
+      sha256 = "279672ac2c1b8d7f0e0d942f027a7fdfa7245c9676a406889f420e6b55131ae7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kab/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "eaafc34c8c596602091810cbc2af966e003d870c66a647c0cdd2a2a343f4a068";
+      sha256 = "502c7aefb553e3dd95dd66ee5c20f3314996e0a9551c6da66b3210a2af3268b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "dfef47c7d3255b1a711b611afd9adbb53be80eebefdac763da04af2157faece1";
+      sha256 = "71b29a6a4b5d8520c74b4321da341fd7d249396d898535f5ddcabdcb63c3fd05";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/km/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "9074c6ee90c6582c1202582d35d81f97b43789ebc3f9019261130dabcb01fd46";
+      sha256 = "dd9e94f1c57b55e16cbeaffa85ad406a9a845b7f67c2675b7f0cce97837b389c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "f8badc895b36bdcb7666510faf5f775470ab90733ac31201f147f3b45dc4ad9e";
+      sha256 = "9ef46633c7abf9862442181598534019b5da16d64cb0150bfa82a06c85a3410f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ko/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "9d8739e1e382c5b96240a6564219c7b0ce161524386539141f4dcc020cbb5fee";
+      sha256 = "bcfa77af5b291c24b0c60e730c39dd0217a6ff54818e2728ccbf84e04d20d2f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lij/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "c36fd45434f81e1c20c8793bd52cb85637999206b06ea9b094b2d1b0442f95cb";
+      sha256 = "2ab2cd1914eb0cf2429d9f02e95f5752a5284e12f85e29c54fbfde1ba95bff55";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lt/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "24d94d2ef16561bb3750d607fda39f4b39060efb83fd4d435cbef7383bf8f76d";
+      sha256 = "21854475ae62c250dd11e3265b109ccc755cfe4b7827c6911dd4246f26987318";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lv/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "6eb7553cd275cbf11b387088e52d9f508486d3f737b2482d1f53af1a2c1e0dbb";
+      sha256 = "1fb6f3e717bd7f285f1d084fea8be957eb7959c29035c4c1de3b116a21f9af67";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/mk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "8a1b20b6be53d68dd1effedc3522fec9b2d8c64a4d8e30c7a7113bf0fdb2317c";
+      sha256 = "9f52a7a077d6578820ae9011936ba436eb121814aeeae80e3c5aae097fc3af28";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/mr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "4dc0347a86f3e4f784ae32e2324f3d134ce5b4fdec4eec34572f51c13763889b";
+      sha256 = "3f2b240659b7354b2d3cbdd8175f33a2a5884c90133fa394cd15b4f6e86ba4a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ms/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "7b3fbd663639fe8575eaadf01d3a9299f0c132a4b2fbbf25ddc2d18378102cf4";
+      sha256 = "73a18b565e742dbf56c406f2f1cf729a0dd0cbbb3c8660c8c01b2081cc924fba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/my/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "8a039ed198a5b338fd32dd632f05c4de8a9dd61cb09247d5f37a1ffbc640e0fa";
+      sha256 = "e5e43ede829a329c553e786659e980d5e6e94f5228c42c2a44eb34b399210bb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nb-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "70404a9fe3361dff890f344eebb61001bdcb6a3d4356cc06386783d70a163857";
+      sha256 = "bd5feca0d1a34e6ba4cc4839ba50d89bf0beda61ba975a2ef76f1a053d725605";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ne-NP/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "e148000a58bd8b834985ad9dee1eb6724ed2550fc70279ab915c06fea148afe1";
+      sha256 = "864e1ede94813108b75fbd870884f93f77628e6cce0449b76018b9118a2c4b0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "b15ebbf39c475a53fc5b01d1c5c6559f74c42e35c1d7b7bbd4cda37366359fee";
+      sha256 = "4bba7f1feaa30adc2bfcc769469eb03361b6193260424d3af0092047c6e777a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nn-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "90221ff410eca0d1aed97186e45106b7ab826029965e2b4fb54d93c74f743ee0";
+      sha256 = "968d80dbeb5418f968d584ce0c51bfd322b1189c2122a1205f64c0ade22b66f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/oc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "7cbad01d0adb697bcae6c072bb69cb151e83920f39b67df2a340f7c1dc4faaf2";
+      sha256 = "66f45ad09dd4a90a3b0c6d66a73b8833a1f1f62f58719a98905ae57c60805b9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pa-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "1601a8192da0564af21b4cb7e63d87b6015d5533c08e96187a0d895e32bb03fd";
+      sha256 = "05f4b146691ca748e27b524c7e1889bee07290d417b8bab59c0582d48019f61e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "f62fa06e9e651e7db14cfdbd0af5acac3d6f282a2842e41bed7b6ea323342ff7";
+      sha256 = "da9d5833e75feba4034b9b708ff0d17dd93364f0d2f0b5bcb2fcfa5b70717fba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pt-BR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "493c505bc795451989d58049e0a16397eb32c6d26f3ff5c285b845b35cf63a53";
+      sha256 = "680f083f8dcae74b053214b8a20ff2e253829b3b811212356847f99a108438d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pt-PT/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "ce1caab07d4ca3f93e5be33580e09c1109f3a19176144d7cfa06e97ab04fe7fd";
+      sha256 = "0a5eb3f4a0c9f0c47fd157a26bc8ea6b70007f912f5e50d38d6ea1487c23f7c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/rm/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "d580649d6aa0f7fc519dbbc7c72943b36a437806020f6a56fb7659befb9dea7a";
+      sha256 = "33f73c88fd97ac68c415c9bb55db59c68cc7f482d381ca1a96b235ba2854b9d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ro/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "a78d357d761f72d5795608199701c429f2016ad618e2899c10d13b9f7ee8e3ef";
+      sha256 = "77c641e73af901a2986661790890dbd831e586b579ae398433ce98117e310b8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ru/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "8892c5688612eda284319c1df7c366d529be0d0c96a55d89958d7185a78ab30e";
+      sha256 = "cc6994ffc7d98817352c390db1d06cd215acb5459121d657862c15a95f27ce4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sat/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "c6d9eec9c8ebe83c966c904611d6d865328b5a7f401b42b06d72dae32174fec3";
+      sha256 = "f2ca87b4c371399e211874e60e25abbcc320eae84993c066ae9c491d6eece514";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "d504d52b43598ec3fdcf02949868fa65d6e6a72f78f131c53fce804817de4ee2";
+      sha256 = "3703ff4a67d1c503fe90726aa63dfa4cb266350aa4c0b5f29723a57ce677fda1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sco/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "89962ba5d9de002d3f03b4527eb9ef84235d59c19abb46165dfa9c52a085ad2a";
+      sha256 = "963234677f4cd4c3beb7299541700f865132646b39df9e12e89d0f99d2d9e8df";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/si/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "247261439dc9594b9ad95fa066431ce1629537b8cfc01df7716c491044a7c72a";
+      sha256 = "3632f156201c1c86b9497e09b45707f3126cb02b0cd93a936f9fbcea47af57e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "29cb232a5339abc4890b306a12b0f55cd2700cfe2521fa745491903ee87a26ad";
+      sha256 = "e5b6158136204fc90b960d1650e5c7f0f8b74ecaa46529f3f48c9a9bf7a9cbe6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/skr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "f606442e9a6f87616a77d2fd392412a8dd61e596ddc8c067e38846331cbfca0f";
+      sha256 = "ee71bf891c728250978a0d19290ddad63e893a68362f73e47249c8600e496c58";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "43cc2db32879fce3424c1a3ff2f862cca4835b0a4c5df5c3e28def64812ce73c";
+      sha256 = "1b38a650fd3e2c41e4e20e19468483b4001719741bc2de99ab555784baea34f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/son/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "cfec396b94bcc091927c0884ccddd3969f69acba8c09467609319c54c0bef55e";
+      sha256 = "5b0ee6db02cb38b7f340f074d4e454c29babf2bab55282aa29bc51174cebe9fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sq/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "ec827f911bb4553cd7caefbdf2aa3aa6b4521059beab32b23e65e80f9858181c";
+      sha256 = "14fcb51691a9a4addb2b4d01c0bfff630359c7e1c94181a1b1f41a0bc64f9a9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "284b34324291ba29a1d1d7b36cff68fff0f00213a7e12fa7f48536fc5a80990a";
+      sha256 = "9297b97dd92c4a9b848a0b59f6490014c323d54c63965512719cb766b5ec98b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sv-SE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "07e48d548cfbc4c4ab3fb3b4ec630385a125d3c5cbe30526be95d0476b4d8f87";
+      sha256 = "36c4d22521d6515ef705d59b42cbc86ea385b6713049bac544db89cbe79929f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/szl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "84cfbf70da99b4f544193d6d167a2280142f8ae37d8de1e9b4093f7ca6671fea";
+      sha256 = "47cef94cb8d05f1e67fa3c805761bc556181769778d86f91014b01e722da0a95";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ta/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "dca3f4fd1b468cae66bdb6ef3817860760a2527b94928359c302e789ca2c04c3";
+      sha256 = "eb1ba963923ff35be8d85e2e432db2eea1815e23245006c153616fa643a923af";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/te/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "bfa4f775d02a2b2cf0dfcfbf4ed3d2342f7db943256c2e73bddd7f9a8077484c";
+      sha256 = "f20e07229cd5cb062b1ce2c07bce7eace439dee11c1de11b956a2ed3dbbde26b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "1515a00b6d53e074bfb60b1bc7e37ac60fd977131a6ac6e772433b1daaaa4efa";
+      sha256 = "b25eac2f5a213045980536b4d5ca04f802f083c0467c56dd02680370ea3c7329";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/th/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "507d9c041c8874095a52f57e5a46adf8db6d4116d5ccdca0b100d831c41c0422";
+      sha256 = "d2242d267cfa67a147becb147b6ce9540d24049d601a4f00776c0eceac02849b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "cba3d10cee0a09ed530f6e8ec71e1da36fc29c972136bcf6beacd7ccf91bd162";
+      sha256 = "74891370d6b308e15b200355152ba34a31a23fcccee53ad2472a4be17a38667f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "f5e68e280db29872b7570484dbc841756693b3d00eda2cc0840a77e5600628af";
+      sha256 = "6ffa80dc70a4b37da1a0dd45ee26512b60352f5f0a7d7753ae0f786dc3ecc120";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/trs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "028e3728920e5978501773da88c2eb1d5d86927d83e5f51e910692fd4482d9f4";
+      sha256 = "c34973c0d13355f79461880372fed959c4a5872a72b22f570c8480cee4e403ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/uk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "9e63e86af01787ceec6b4776b78cd98db74230287f1c065eeda6b5e5f6133b42";
+      sha256 = "f0c0b73f4dddc526b058954b4ad3c6757388646dcad0c1fd694947f7f06bb479";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "964b123de671b9f763861d626a444c86d48516cdefe9ab71f866dc564428d119";
+      sha256 = "7cfa2930a547d9b0b15e6ebc571ec8447c42b6a845fd228ccc023df7ddbce914";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/uz/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "e603da60f6be77a60584bd361f773a5e12612e8fad84f0aecaf33756fa13d9a5";
+      sha256 = "1d86c24fcac2d62b946d9bc957a9dfeeebc7d519b4662f5a973beb509b946cdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/vi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "c8ce7aa8546ecaa76af778e29de3bfb12490c2e9e4f667888449939ac424f122";
+      sha256 = "126e1f815c3e57cade53f92fdb57f0f2c8f93436523f5947df4e1bc64ad32263";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/xh/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "dc9071c3a8553cee661223eadaccb949944d11f4631cef76775e6b3d93f89eaa";
+      sha256 = "e3cf2284986f716bb80eac9bc258af4ad089fcb9f24e20dedbc718da3324370e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/zh-CN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "f8561851a5acce3ba9ea763855464592777d2371d1918d70cce0a01d833ee77c";
+      sha256 = "4b4d6d3dbf2fff5efea5c659d5d95c45b55fbc68d0767f7cbd8c052bfdcc5a0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/zh-TW/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "180c46473119cdbe027f13a26a53234e63e1f2dfd291925b0af2edf68ff05650";
+      sha256 = "7725257c301afb843517120dbd5f28d2af0e394aa838d56e208680e8a51183ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ach/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ach/Firefox%20140.0b2.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "e0a518e46e2f11edca8e5e0ac47449947c3c2777505ef4da832cadcadd093a23";
+      sha256 = "4ed0131e4684690e82a3365020d901921255096dcf3a9d59c9ea6845dad75373";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/af/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/af/Firefox%20140.0b2.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "680fd32905798aed50dd4a0bb0bb88817581ac246bf12ad7db49c90809619424";
+      sha256 = "b880748c005d6036dd89d9d303976393f3d9ac2a91c185c641ccd647ed056ab8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/an/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/an/Firefox%20140.0b2.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "bff5ee309b3f73e65b5de3f40f1a7025a4137e806399c703d20c492ca925585c";
+      sha256 = "6b35af1d4cf4965bae7bfa7ed4df969a81f24b490033c59a9e41eea21fc3e730";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ar/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ar/Firefox%20140.0b2.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "71f47f400126a2729f37bf8947c8577cb012a787b9c37f8dda516f4e765e5b2f";
+      sha256 = "866cfb8c17c8e2382c6ea691187507db00157aaaaf53448d49b95407e18e5c85";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ast/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ast/Firefox%20140.0b2.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "a614feb3d06e2cf3430bcfc3daa02d53bbff1dca8a5433d43745efa03f0c7e73";
+      sha256 = "7f6aa9adad62d9991e693775e91ed6826594405f17cdebccb99cb8dcc39bf095";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/az/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/az/Firefox%20140.0b2.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "07482d9ffdbc3629e9c7c4fe419cbe2824b947cf93b4cc7fa371bf9c1083198a";
+      sha256 = "6fe3f217f783eb93cd8d84b903a9453893b9f1de3f48f68e5484b351b93ef711";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/be/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/be/Firefox%20140.0b2.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "6163ec17db5b8bbe2e897ee3820334928f18fae85055262561cedf1a1ee8918d";
+      sha256 = "aae7e9683edee898fd2c665eb1e11572ac4ba61a4960daaa09c19675fa1a19c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/bg/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/bg/Firefox%20140.0b2.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "575f9b58298f0981566ba826294f80edc45dfd9de69d79e6c82d28d0c884c58c";
+      sha256 = "45cdf56dd70258d1c20ed870adfe2772b7a1b30cf834409edf397d0dca6f395f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/bn/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/bn/Firefox%20140.0b2.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "076b89297184b520cce7ffc362b7bca90c4ebade5d64dccf0f7315bd2584f678";
+      sha256 = "51e9862caf96e94224efee1300fd54eefdafb03cae20d15b40b02bc9d44ed731";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/br/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/br/Firefox%20140.0b2.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "1a29076fab57e50c45cd6fcc8f25cbfbd9d6a962705b88a607935c6184ebe2df";
+      sha256 = "be935dc3369b54d1cdb61ce4662b45839d4bd97ab7e2e66edf2693c9b6716b56";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/bs/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/bs/Firefox%20140.0b2.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "267526f268fc1deec51cfd16fce9c24fbf7fa9789e1d3d82c42df7bef754787e";
+      sha256 = "2cbe8ca8c678cb81385e657660bd92346dafbebf58b6c73d1f6f77e48f52aa6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ca-valencia/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ca-valencia/Firefox%20140.0b2.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "713b6a6a73f06e3a6f09bf1ec06fd9914bf0672b5569b51d4a8fce689fa02c67";
+      sha256 = "3a2312c808f9342b7fac383b075ca13b272861f79f49015fb51ae4d9a01c92f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ca/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ca/Firefox%20140.0b2.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "1537068f9e353f37f69d39acb852fd25bfee7c9bc6f83af2b2dab2da21737ca9";
+      sha256 = "367bfe9dc9f53f783eb59a2e345a3cf8e65dc4b15f535d8f25be9f2c0ab3ca68";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/cak/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/cak/Firefox%20140.0b2.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "726df556a936dbfd4cf756c7736abbe406c7c774986a745eba460a82f79a2f50";
+      sha256 = "055b667349f3962d352bc29a69e2ce67ff19893d2520e1c70043bbb1248d8c53";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/cs/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/cs/Firefox%20140.0b2.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "ef6701cb85dbc9af3f2e0013c2813e4cc140307b2c7ddf77ed18307b2a3583a9";
+      sha256 = "c424df549e13c0a6041b212d9e7e49d09bedd634ad0a35daf5ff8b7f08b705fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/cy/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/cy/Firefox%20140.0b2.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "911406e16a06a37be909b298d84fbca827b74a771e13ad7d1921f62c11e8b9dd";
+      sha256 = "4cb05bb577e421bc3004831bf878267edb6f6c98b5d776522acd57600b7813ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/da/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/da/Firefox%20140.0b2.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "4080196890c2a15ef88a55a97e5f4ddbe03cfafb80f536894b3a9c25fb0ee8b1";
+      sha256 = "793fa4ff34f9f04d83a6f316b8cfa0099f2228648d6fd8e2f066ed381affe5aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/de/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/de/Firefox%20140.0b2.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "40eae4dc5ab677b214dc13afd066444b892bd444f6ab09922a73ceb9ea00d4b3";
+      sha256 = "9284ff990ecbc6260d82aed6e0ffb3608348c5c084c0ca50d59cd75c84e5f4da";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/dsb/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/dsb/Firefox%20140.0b2.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "3ee17df8b247301f376652f938f24464d0809b7fb6b402b9f5083ce2cee9bf34";
+      sha256 = "e433105013e8b543ad239f0ca7a0007e40541056c8a3bd57adc6136b0fe1d117";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/el/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/el/Firefox%20140.0b2.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "11fafe77ea6929eff1dcc1da0df306c0f8520d7f522c316518889ef6b4bdd273";
+      sha256 = "b9b8a5f25aebdc89e672793436e3d1f1c35aa6af0ef13f080c89ec23d66ccdd2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/en-CA/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/en-CA/Firefox%20140.0b2.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "a15fcbf8b20e47ec62f8a0421d21f67ae091a3fb29aced137a52ba05247762d6";
+      sha256 = "3f6db147fc75e6d2c3efe2dee4e889ead1b3d46909bfa555da8012d48fc7f418";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/en-GB/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/en-GB/Firefox%20140.0b2.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "cdf313854d38f48bc31f30fa4e546d2ea8867f49872b7398005b574d26362548";
+      sha256 = "8328b5267b092e75a646da81563461b6d660cfd1000a2da26ca404acb516badf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/en-US/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/en-US/Firefox%20140.0b2.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "bb516b07c4519ae946b79a6fc34e911221e5d83851aab2bafdff87c3e5b74b3c";
+      sha256 = "880d44a98e9232eabf61ed9949047c235d4fc68145a97cf3f3569c8557ac848b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/eo/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/eo/Firefox%20140.0b2.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "00c505dc9fd5c7e10e424022ce7807a886567b9ef01817e0d86ebd7bcb51e38a";
+      sha256 = "ae306283229c379bfc29cf47b3dfc1fcb5a71d038e4e851781206f619fd19023";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/es-AR/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/es-AR/Firefox%20140.0b2.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "cb8cd92f3762979b88dfc445bf5d71d83fc7eccd138995b1f6f8662a00c06751";
+      sha256 = "e9d3b45ad4454c8b3ae7b04ad9976b46c9d2b5b96271a58fee55dff00f7044ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/es-CL/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/es-CL/Firefox%20140.0b2.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "4d54031158a87e46f4dd79a2f3835fa2ecafe059160fece167a3eccb213d4ded";
+      sha256 = "1e1fc107c05a73888155a9eb89287a5eb4dd9c4eb61fa54afc096a53b4283fd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/es-ES/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/es-ES/Firefox%20140.0b2.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "2e150d79a2ba9e065128963097289a4ed340473de8a6b5f73a6435ca3bc8ae88";
+      sha256 = "639b027643f251dc168d3b93530d8bd3fcd394f3ff62a3eab964b00f9904a175";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/es-MX/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/es-MX/Firefox%20140.0b2.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "4e22a347506019c216f3d8f3b363677f9677a44816de1b1cb42a11fb3beb62b7";
+      sha256 = "f9f13f56e74d999c13b17c565087bdc62d38228c49bdebacd2ffe5d972172131";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/et/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/et/Firefox%20140.0b2.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "f887cf78873cce42ec474a9bf7e2de793b39087b5d71a86a00ace6543d5f06ed";
+      sha256 = "c05c637c4e1e3f5ac941ed86f3eb35a25e910eefd08901322aca5aaef1aa9c3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/eu/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/eu/Firefox%20140.0b2.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "832d8dc7d0d7d011967825e747ffca5697c6a8bbcd0592b60f77bcb602e64b3e";
+      sha256 = "38ed25cbd21e84d73408fd4b2a934b0e4a975cd9b67050b2f584f462f6175cc2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fa/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fa/Firefox%20140.0b2.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "bd2fd21b2efddcbad65057b06059c93e4a3ed4535966f71f59b213b9dddcf110";
+      sha256 = "781e74251240e31bc03c6453cd912c6b8c1399bde374d9218ed0b4a4fa3be374";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ff/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ff/Firefox%20140.0b2.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "2268a7857090100091254d57e47d72826965e94d3d2922ae0713d8331c0c3fa7";
+      sha256 = "1e02316b5877b8ac781edb9c97b3341d923d02b04eb0a625cc48220f3fa595dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fi/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fi/Firefox%20140.0b2.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "72c7f214ac536cddd3bdd12e14f8e18e82d91e2341622e340691dc119b44b459";
+      sha256 = "444db967472e296569612d6686ac31bd0d13d16c58fa87a05edce7a04d8aa8c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fr/Firefox%20140.0b2.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "1392ee9e9ece7c3c0a1034ea3460ce18d4dc09695a6c3872f75b44e2083dd6cf";
+      sha256 = "4b8b893500b27eaa571b87f5a02fb2259cc8e0be6dfa11bbbc43635b9656233b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fur/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fur/Firefox%20140.0b2.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "6b37a09f9e0d05747bf71f6bf33bfee5405900a6486b0e327af7958c4848b889";
+      sha256 = "1e049b0c7b303bb59425280c838f5855329b523e092e151323c5f3e4b14b1446";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/fy-NL/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fy-NL/Firefox%20140.0b2.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "c1ba5e0babab78374c0644917a985bd016fc84383e848c0c08e424ae229f33ee";
+      sha256 = "a66abc76de786b262bf98b903ec78509d4bdd760ec4b7664befaf7a34c29ba9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ga-IE/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ga-IE/Firefox%20140.0b2.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "ab89350cad0a76f3aa3b7958f5e41af7b3f0362ae5716ed764019d86cd55830a";
+      sha256 = "f3d3846347c1295cdd2ce5f9eedb7924ca3eb58b1dfb62cb941b09166dd5d5fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/gd/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/gd/Firefox%20140.0b2.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "4e36e3ca3e6f2336c10bb1c78db21449b0e893b56f8e0220ad783a0481676e2b";
+      sha256 = "31ffc94d1dd8dd5fe8586cdaf62289f3dfeadb13f98a7253463ad1e31d3b01c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/gl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/gl/Firefox%20140.0b2.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "8834cb809f19bbe04bcb97fa0d231049fb0636d701ed04c2eb5c29cf2bb938cd";
+      sha256 = "a35e82b0ea8b3dda94af2250e88fbabe73d1e80c3107a0858510797564e508dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/gn/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/gn/Firefox%20140.0b2.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "d14cd07d0fd5b9b0f805b327bcb76966ca52ea1790145e47ae770f6361245727";
+      sha256 = "027723af70d814b569ed34f3aac20f88b3f240f385c74938cd17c4f51a5d821f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/gu-IN/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/gu-IN/Firefox%20140.0b2.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "c2c14a42f72894d17751c324b5a372a2141c5f3228e8c2055e302ce5a619b795";
+      sha256 = "fd90192e423f2ebd31b2fc3cf5489203c64cec7a32e407eefa67d9f855ea9e01";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/he/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/he/Firefox%20140.0b2.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "36499814455eea5f4b625c332739530bcbe67b884fb3634086c51841043ab861";
+      sha256 = "cf93ebd15ad94671080e7e1cedb89b62269ffea14eb577b6fe0e2bf07850207e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hi-IN/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hi-IN/Firefox%20140.0b2.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "6aaae4c73c81bbff984c8b94dbbc51c403161ce0658e713215167c62b9bd5a26";
+      sha256 = "e31224609e571576e63fbc976ef5d19f829cc4f3651079f31da4e2121dccdf4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hr/Firefox%20140.0b2.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "1d05037ef618476b485a1ee5f54fd379978caac33aed2601da1196b531ff9251";
+      sha256 = "db90c833900707d4f4a5774fc63481883ba49dc5fe64a8f6356b3d050d62124e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hsb/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hsb/Firefox%20140.0b2.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "c5dc2bea7cc3035da37e6adbbb7ff5e4c9c8dadb18a0f284aa6480ba0523fa27";
+      sha256 = "062a1815118ab0b8504f1fe68ef15e989f228ff8cfde50df0ec0cb23bb64edb9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hu/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hu/Firefox%20140.0b2.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "98747da364f017149e792d392c3799f5817960f84ef0fb291c2dc76bd2acff93";
+      sha256 = "0d58e286af8a98faebe766da043523ec6ed558c65284d791e82efc5a1defdad1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/hy-AM/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hy-AM/Firefox%20140.0b2.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "caf0feb89b4d2830699d9e6beb4f799269a291a8de1c7792b9ae7ea59cf33c4b";
+      sha256 = "b3129366bab54573c690bece87689f971c33f0255865b57f836d87583241054a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ia/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ia/Firefox%20140.0b2.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "e07aac3d382089f3b2739427a687f77ba1b4e366988c64dfca24fa7aa154ff41";
+      sha256 = "af5c9f132655b2a5a64faad3bc5f4334108d5cfbb860313fdbb5959c67f4846f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/id/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/id/Firefox%20140.0b2.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "b080f0e359a540b588f44388fdeb340e73e00eca8183e75d3df34eb0c94e6adc";
+      sha256 = "159eef1610be0923f99b77ad48ab2bbaf451bb0d8b1e6651ca164ba993e25611";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/is/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/is/Firefox%20140.0b2.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "14ea2fdb726247ff132736ee16abf640a50e2c4626d4128cabf29c92868b9c64";
+      sha256 = "08569f11b397506b4376ccd634fcdf3c548a78b1ccfb1bbff43704cd73d4fded";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/it/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/it/Firefox%20140.0b2.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "896c2b89b0e74550ffee1b2b64cbabba41a5e966f0a606b1cd1109c82fa7b839";
+      sha256 = "d7469d7f3117ea3ea013df5dec0003a9890504d2f3d70550217dc80b290bf93d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ja-JP-mac/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ja-JP-mac/Firefox%20140.0b2.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "bce36ac2f32606f1ee92fd9bda765bb7a3956efb4b87827b94ea246779caff51";
+      sha256 = "2991001790e31d97bd5e7378dc3fd6f78bf496db091dcb7e5e8929980a3ca8c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ka/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ka/Firefox%20140.0b2.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "15c2a3a3f1b4d4b3602afd3e25774b1ea073b6cc1394c623ebde0d5cb2196d59";
+      sha256 = "053c5217774c857a6dc15007e447dea36dc76d403cd1024938987bd6e15ca8af";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/kab/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/kab/Firefox%20140.0b2.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "3647fb09d5c77bb90788aab0329da3e7e562cb455483289d5152bd845162aaef";
+      sha256 = "57a6e16519fa59c2dd902d26308ce1f9bd1e28ab7d20ca55736cfa275192e951";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/kk/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/kk/Firefox%20140.0b2.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "bc253d2686952356ae7b6ee8429fc30b3b67b9c99ce1f8372b7a280172bc340a";
+      sha256 = "bc6974ccea65432855aa31f5183578ada6562efce971588c3fc6bfe1b841986a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/km/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/km/Firefox%20140.0b2.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "62ffcffd64359b8cae0138819e4783678f2a50f9359a4d71a883731117cfc5c1";
+      sha256 = "893979330f94c241f95188b479628e6a3c20f771e778459bdd95cf6e9b6abdc4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/kn/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/kn/Firefox%20140.0b2.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "c213cbd3f6d7267f39be082f93dd5d46ead2df09878f31f2c2b472e3c795c718";
+      sha256 = "12cd26e5fc8dc9355ac7e75964cff9553ce300949fe0c9646c901b4b31ea8e97";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ko/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ko/Firefox%20140.0b2.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "257a6db2f9324b4f983ab0bd655096391dc193733ab0a4c3fcd8525f8e0d2e8b";
+      sha256 = "f81b961491a67e97ed738a49f1a09dbf42654df0921ee0a7b8b711b72ac906c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/lij/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/lij/Firefox%20140.0b2.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "13ab3253431ca8903376986973944f50930d81ba5265b20063819e425ccf03be";
+      sha256 = "3ebcf3cf0fa5bfcc742f915aa5c35bf83cd51e9da0e196bc2d8ba66e9692cd9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/lt/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/lt/Firefox%20140.0b2.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "eaf604655b8851623523e07adeb17d3c491a6446483f8ae08a0e3b26ac00537b";
+      sha256 = "49f53843360a4b9b5ac9464a5d2a94d795f5dae355d590127e8804229b4e55a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/lv/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/lv/Firefox%20140.0b2.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "68a8759f7b87d60a5888bc3e411ff1d96c8fbe2d777d955405c7175a26785947";
+      sha256 = "33506586c4e1672039cf32e62c0558d06ee96d3f0172565f9bd1ecee7ea38f65";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/mk/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/mk/Firefox%20140.0b2.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "dfaf7648103b53050f8e6bfd9d15a16c91b5c8097ae66dbf29b4816c98585f8d";
+      sha256 = "0798de1794c577af5e0545f4682baa4e72cb700bc153ce23d597fbb58882a32e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/mr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/mr/Firefox%20140.0b2.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "98b55e60b28c26f2d4b64ccc6c2a168eb3778b3eb7f30338c7fe65b93c4947aa";
+      sha256 = "a73d3ae4ebd2e80e4fb7280ca335ad99146d71faabf6dbb0c114f98f088d89f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ms/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ms/Firefox%20140.0b2.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "0f4dfebfe6a49408c9e6f86f08fbeeba1752e2338547414d3f951b54301a0190";
+      sha256 = "73c3351e7e63bbd50b7b9c79c3a604fd31efcf381d1a9c023f9c7bdc6f0f5303";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/my/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/my/Firefox%20140.0b2.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "69a6343204688fb6917ae3bc8246dbf05aa0d33ba1e3ab1dd63bff15517927eb";
+      sha256 = "631e0ece9a4af6e8ae1bc447ee433c95cdae9a9c18ae75c49022655ace95395a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/nb-NO/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/nb-NO/Firefox%20140.0b2.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "e53432862824641c579b83b0390c5266fd9acd775774e675b92c85dd0a1f283b";
+      sha256 = "632a6cafabc4fb5bb579d00938a727e169453bca23727c4f981bc6af49487958";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ne-NP/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ne-NP/Firefox%20140.0b2.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "1ec4db3a6a73d9c89c1abac64c3f21f203a312d03239c634aab1b5fc1e1978f7";
+      sha256 = "5fc19a06fdb469fa27246f5541887fb36a5f05826f645fd4dd5941d37ac46ad8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/nl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/nl/Firefox%20140.0b2.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "c4d22c9a149fc3b9fe1026e12463e95e96dd684dba1d6087d295d83b214ee419";
+      sha256 = "68c88cac72f77231dd4e26a6e1790f13facb0bc37cfc04eb5e17020ad1c6521d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/nn-NO/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/nn-NO/Firefox%20140.0b2.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "8ed77e09b7f21288f0afab5eeaa3f37d516d65c98937e6651362d1655be35b27";
+      sha256 = "25cd5de92e437b848c83d049380a10d9dce7f26456c20fb3da1e29d7adb98b6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/oc/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/oc/Firefox%20140.0b2.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "228a5983879f3d71ed5c3f0e3147814889e647a495083a18b99ec0a352620138";
+      sha256 = "6a8a2d6a6f85d8583d14abb61b7aba1dadb5830f5d33b80ad1b7ef5ed010341a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/pa-IN/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/pa-IN/Firefox%20140.0b2.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "8b2c24e4396863b73b514035ef1bd950bbdce38a891bfd157e8dce2b47be0ce9";
+      sha256 = "72d017a1115c861d89ba13ffaa673d1a33b459426cf2be7434ac526473e458b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/pl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/pl/Firefox%20140.0b2.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "54dbd4a9a0ff77c603108afda46ad70d492795dfd1de37e0baa61fc1a1892839";
+      sha256 = "868b42e0a9752172fe8871a5e74a6ee6d1e6ace89480a2b8f937f57187581d17";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/pt-BR/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/pt-BR/Firefox%20140.0b2.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "67a1c150bf04edc8d4cc15fdb864828feeb3329cdd454be8b25bf455cd64b863";
+      sha256 = "edf314c2893d2a07ae3c0e98fd4faa01a8c70afa1c42bf96f4b908e987d65d30";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/pt-PT/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/pt-PT/Firefox%20140.0b2.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "8f64369b64b5bdecfd25eabd0efc4ddc1b2ca724e0532f1a79c4d1875217aba8";
+      sha256 = "7c23718aae1119db08e6225104c3748e7b175eb6c96eb21ff7e098f3b3b457bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/rm/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/rm/Firefox%20140.0b2.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "2f2f00063d3bf05c486734567e26cbc9563d699208b180ee969bda9a3e990872";
+      sha256 = "0dee6e7eabfb1d2727ae10ffe3efde28e87574573271793f27f4696cc6ed4735";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ro/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ro/Firefox%20140.0b2.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "8c4f64ff21c0fc81559d29958a9f3419680272a8fe3a309e07b2848b3a0756b2";
+      sha256 = "258337f48e73793368e35586b22ab61f441eeb5c884fb1fae2a19fe750dee283";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ru/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ru/Firefox%20140.0b2.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "c0976a0c47d82613fbcbd3054cc92f1239ec8af017b79f9cc3c7e2a46058b085";
+      sha256 = "0d94677e22915b79deddfbfdb80c8be4699fbb47fda59b5e54ea26ab80064210";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sat/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sat/Firefox%20140.0b2.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "ca292c59e2845540369343d79572523e1e4cf383ab27b079e5503ca9b336db40";
+      sha256 = "78f600da1286888e95132da917f0881e2fb480cdaab5f339914f7a3509b5cb12";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sc/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sc/Firefox%20140.0b2.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "bef03d37448cd88fd7d455e263673ad057e51e5e375766c79dc96d10c807904c";
+      sha256 = "567c98cf0a6d6c789dce738546e02a8c31574b718e997a9e287abc3eedec8c39";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sco/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sco/Firefox%20140.0b2.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "6d303464a114597524152610c4e431a81fae3b9282764874f2a0548bc5d20974";
+      sha256 = "d71db15059d870d0dfb7492403342df38f7ec0942f72363914153357141b780b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/si/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/si/Firefox%20140.0b2.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "4f4c76296bc4f04ad97cbd35a02987d99ef9c05a3a02b06e8d48860087adbf8d";
+      sha256 = "894c1f664aacb2dd66ba0428d27bb07918c50fbf5529243591f93447c4a21811";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sk/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sk/Firefox%20140.0b2.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "07d0440034e2c92c183682ebc9778f32f7549e9e3668a9a012faebf64b66d1b3";
+      sha256 = "29bbcf6c57010f28cbba52d2fffa909387c3660d0fdda5a53486e05a872adf9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/skr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/skr/Firefox%20140.0b2.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "f8ceb672752e27a354ff54250a182465a718e1d83ccc6d7f3716c36d343b8ff7";
+      sha256 = "3d65a2d0b7ae8546feee7720261cbcde1f100adb31305c4f2ffcc26206b475db";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sl/Firefox%20140.0b2.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "76a258adaadc52b24f596495766cab8ce4344db2d06d291afcc20029627d9ea9";
+      sha256 = "60f74c2dfaac5b049ffc480ed6fd77280ed839caaa8872d3a30eaf5698f5273a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/son/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/son/Firefox%20140.0b2.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "6356d093eafd677b78e76fe1fa7247ec723df4432fe69024fc80de6ebd98a146";
+      sha256 = "513be0645fa2800fdc4f228727fbb9b4f93364caba511673265a8993850100bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sq/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sq/Firefox%20140.0b2.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "b57ecf837b0930f369a87bac330854dc952ea8fd664bc4d9367a1bc602884543";
+      sha256 = "29e2b1ea31394dc37021433220e8962dfa24e146491280a93b97b4bc5a0a4bb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sr/Firefox%20140.0b2.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "608a72824910e43dc62d6c6e856edf886e280fa1499eda3fb15df01aa58475ae";
+      sha256 = "df4ecb60378e381c578952e0f3be3adcf7453b21c43a4c2015a596b118c7d683";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/sv-SE/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sv-SE/Firefox%20140.0b2.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "64c79d0c96810221692d65cf3830a4dc68c0123e93c15b4e6425825f2a485bc6";
+      sha256 = "b0f0d77d48cd31bc6b61253ecec6a99c7b4e5ae79659dad34b937790118e64e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/szl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/szl/Firefox%20140.0b2.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "598d0cedf0037f92e579917de539a72d2bf89963cc09e182dc298912724adc7b";
+      sha256 = "460465dc52fb1d8c4776d20b275fa31dd6a6b3c959ae29a17ac0a57570deaeeb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ta/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ta/Firefox%20140.0b2.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "5046f6a144780b890bd13599b5043b95989838ae021180c08479755411de60a3";
+      sha256 = "aa67060f3c84e4691b24e6673e8320031422f4443038fa6534a963c63a60e37c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/te/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/te/Firefox%20140.0b2.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "e5dd35d5878bf0b397c6b55e4bf03405068e188c655f426160f00a2dee4eda87";
+      sha256 = "35df147c9ef6d765889ff758c3c5214bc5dc5eff7f9eb0080724bf70d2192a25";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/tg/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/tg/Firefox%20140.0b2.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "245f224cb73ea1337c04d839cd10b5d5d67e9d1d278696cc408c7e7d71154124";
+      sha256 = "dac6ebb25fe418ffc29811398bdbd2b5ec2c5ac522b1baacc8b0ed15923e18a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/th/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/th/Firefox%20140.0b2.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "056638b388bd20f14c6c41662aa0a495600a40ec9393e5d157fa9fcb0649ec78";
+      sha256 = "d055912dca60a974f7301ce63599cd685c24a375df4622c28ccbeff67eb1df50";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/tl/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/tl/Firefox%20140.0b2.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "32d4699b72e0e0adbca59d84fc63a3ce5a3780976545d1a3d150cabf0856b78b";
+      sha256 = "c7f9cb0e805776940e0f33849ff9f321f53b93e21470057432e45ad2638cce43";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/tr/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/tr/Firefox%20140.0b2.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "a8a3028435311d2c4124254372a5d6008ced3fae5cbcadbf25b02d74509c0c7d";
+      sha256 = "97d25c6dc788e64f1857f0c1fec8745a0f3a16cd802dd5af3d3c167d9158e1dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/trs/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/trs/Firefox%20140.0b2.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "f1d8039af76a04dca82979c42971d1096456e196f4a1124ec4beed727f2185d3";
+      sha256 = "aed82548580fef5dda24a7b48f301ff7fb23041f9e00f651392e38ef92dc7a80";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/uk/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/uk/Firefox%20140.0b2.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "838a1942ea4ca9e163b06df9bc72970e128af87e4a35376f912623ef73b5b52b";
+      sha256 = "792e2b27880a62f5eef7b93c36a35d89404b964cd17b879bd14e567e846d55c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/ur/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ur/Firefox%20140.0b2.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "306d04d7c9965e1c3c5ce1f45574b82437c32316dd5857c066c228d2a22606d2";
+      sha256 = "1e9c8922a7cf00a080b9e69186136dee0f84d44ab61cb8ac8390f77dfb5d7982";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/uz/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/uz/Firefox%20140.0b2.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "93c61ed4ffb6875756b366f1ffe01682303bdb6ed20c6d2d7e44979305d31254";
+      sha256 = "674551891bbe01db98fbc843ce035c473a19bb6ea7f9b50cfca6a57d281f4345";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/vi/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/vi/Firefox%20140.0b2.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "60fad61144cfdeeaad641b714e4e63ca184079d58091dc555975543657d54fcc";
+      sha256 = "14d97055a0487c9a7f82959ff4e0978bc67867c5f969ea90cedf1d18a976a344";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/xh/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/xh/Firefox%20140.0b2.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "00f599dfacd33bb98f67e05fab0d9588456de666f9bb78eb52e22d96a4f1e323";
+      sha256 = "e91833e99b4e8b04f690c1e041e2db288d5f64412e04f34bbc3d8b00123a32b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/zh-CN/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/zh-CN/Firefox%20140.0b2.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "0ab249304b86ca7ae055291353a4627e507d2699b6346b9ff3dbeba3766ba044";
+      sha256 = "721f621b057bcfea7397b16f8e5da98e0059a742809c8b0d3fd54d3b459ac1bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/mac/zh-TW/Firefox%20139.0b3.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/zh-TW/Firefox%20140.0b2.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "b9c4765a5aed85cece38efa50fed10fa361ba9ba56d9c40925661885680d8165";
+      sha256 = "0f0dc4ebad9ff5c09a4c015cff5e76a7ca271dbadf185a23034806976a6dd1e5";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-beta.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-beta.nix
@@ -10,11 +10,11 @@
 buildMozillaMach rec {
   pname = "firefox-beta";
   binaryName = pname;
-  version = "138.0b4";
+  version = "140.0b2";
   applicationName = "Firefox Beta";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "a8f9e645c80d9c40b0435ee00261aa9fcac801efcfcbf42b10e6af9390290b9f643358aca6a01d9465eab3b64f46b2b71b4a3ea4c7e0a8f96bdfce15bf817f92";
+    sha512 = "c8010b6cdf90f52d5105971d726139460a0194ca7e84ed57184897f4f258957ff64117ef14a38a6dba4cab3074f3a92aee0eaf221ecf22218f6408636ab9c960";
   };
 
   meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
@@ -10,13 +10,13 @@
 buildMozillaMach rec {
   pname = "firefox-devedition";
   binaryName = pname;
-  version = "138.0b9";
+  version = "140.0b2";
   applicationName = "Firefox Developer Edition";
   requireSigning = false;
   branding = "browser/branding/aurora";
   src = fetchurl {
     url = "mirror://mozilla/devedition/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "cf737b8c394150430cda512a84ebdf04426db0c413863eb37a327c44fc952db7de1be07956aaded3ddb769480fb307a102c1f4f7dab4ba8a38f2371fdd35a961";
+    sha512 = "4a369638dab1202f21f071a1eb48552888adf01e49ee4e029dfe7b42919312719004099b203a066057fd4d9ef9a684e5f95b0aa06ecf82cc88df0025f33f6368";
   };
 
   meta = {


### PR DESCRIPTION
Closes #411537
Closes #409162
Closes #406916

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
