### PR TITLE
jpeg2png: init at 1.02

### DIFF
--- a/pkgs/by-name/jp/jpeg2png/package.nix
+++ b/pkgs/by-name/jp/jpeg2png/package.nix
@@ -1,0 +1,70 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  libjpeg,
+  libpng,
+  nix-update-script,
+  llvmPackages,
+  versionCheckHook,
+  zlib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jpeg2png";
+  version = "1.02";
+
+  src = fetchFromGitHub {
+    owner = "ThioJoe";
+    repo = "jpeg2png";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GTc2r9w87PUKQqhPPOD26smpqt6fIH4QyM14hmfYB1Q=";
+  };
+
+  postPatch = ''
+    ${lib.optionalString (!stdenv.hostPlatform.isx86_64) ''
+      substituteInPlace Makefile \
+        --replace-fail "CFLAGS+=-msse2 -mfpmath=sse" ""
+    ''}
+    ${lib.optionalString (!stdenv.hostPlatform.isWindows) ''
+      substituteInPlace Makefile \
+        --replace-fail "LIBS += -ljpeg -lpng -lm -lz -lpsapi" "LIBS += -ljpeg -lpng -lm -lz"
+    ''}
+  '';
+
+  buildInputs = [
+    libjpeg
+    libpng
+    zlib
+  ] ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
+
+  makeFlags =
+    lib.optionals (!stdenv.hostPlatform.isx86_64) [
+      "SIMD=0"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isWindows [
+      "WINDOWS=1"
+    ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm0755 --target-directory=$out/bin jpeg2png
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Silky smooth JPEG decoding";
+    homepage = "https://github.com/ThioJoe/jpeg2png";
+    changelog = "https://github.com/ThioJoe/jpeg2png/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ jwillikers ];
+    mainProgram = "jpeg2png";
+  };
+})


### PR DESCRIPTION
[jpeg2png](https://github.com/ThioJoe/jpeg2png) is a silky smooth JPEG decoding. This is the ThioJoe fork of the original project. The [original project](https://github.com/victorvde/jpeg2png) has been inactive for some time. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
