### PR TITLE
aider-chat: fix aider-chat's flake8 lint invocation for python

### DIFF
--- a/pkgs/development/python-modules/aider-chat/default.nix
+++ b/pkgs/development/python-modules/aider-chat/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  replaceVars,
   gitMinimal,
   portaudio,
   playwright-driver,
@@ -254,9 +255,11 @@ let
       gitMinimal
     ];
 
-    postPatch = ''
-      substituteInPlace aider/linter.py --replace-fail "\"flake8\"" "\"${flake8}\""
-    '';
+    patches = [
+      (replaceVars ./fix-flake8-invoke.patch {
+        flake8 = lib.getExe flake8;
+      })
+    ];
 
     disabledTestPaths = [
       # Tests require network access

--- a/pkgs/development/python-modules/aider-chat/fix-flake8-invoke.patch
+++ b/pkgs/development/python-modules/aider-chat/fix-flake8-invoke.patch
@@ -1,0 +1,13 @@
+--- a/aider/linter.py	2025-05-28 17:12:07.177786621 +0000
++++ b/aider/linter.py	2025-05-28 17:12:45.834897524 +0000
+@@ -136,9 +136,7 @@
+     def flake8_lint(self, rel_fname):
+         fatal = "E9,F821,F823,F831,F406,F407,F701,F702,F704,F706"
+         flake8_cmd = [
+-            sys.executable,
+-            "-m",
+-            "flake8",
++            "@flake8@",
+             f"--select={fatal}",
+             "--show-source",
+             "--isolated",


### PR DESCRIPTION
The previous flake8-invocation-fix should not work anymore given linter.py currently uses "python -m flake8" pattern and "python -m path" is not valid? @happysalada 