### PR TITLE
librewolf-unwrapped: 138.0.4-1 -> 139.0-1, adopt

### DIFF
--- a/pkgs/applications/networking/browsers/librewolf/default.nix
+++ b/pkgs/applications/networking/browsers/librewolf/default.nix
@@ -32,6 +32,7 @@ in
       squalus
       dwrege
       fpletz
+      grimmauld
     ];
     platforms = lib.platforms.unix;
     broken = stdenv.buildPlatform.is32bit;

--- a/pkgs/applications/networking/browsers/librewolf/librewolf.nix
+++ b/pkgs/applications/networking/browsers/librewolf/librewolf.nix
@@ -15,12 +15,8 @@ rec {
 
   extraPostPatch = ''
     while read patch_name; do
-      if [ "$patch_name" != "patches/macos-import-vector.patch" ]; then
-        echo "applying LibreWolf patch: $patch_name"
-        patch -p1 < ${source}/$patch_name
-      else
-        echo "skipping LibreWolf patch: $patch"
-      fi
+      echo "applying LibreWolf patch: $patch_name"
+      patch -p1 < ${source}/$patch_name
     done <${source}/assets/patches.txt
 
     cp -r ${source}/themes/browser .

--- a/pkgs/applications/networking/browsers/librewolf/src.json
+++ b/pkgs/applications/networking/browsers/librewolf/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "138.0.4-1",
+  "packageVersion": "139.0-1",
   "source": {
-    "rev": "138.0.4-1",
-    "hash": "sha256-KR8ZiueaEOXt2dw8T6ZvrQURV49Xu4cYe0XE8tEUmbw="
+    "rev": "139.0-1",
+    "hash": "sha256-dhi9hUgEoOFQj7IixFKz1J81zo43h4MkAMpr2OIgass="
   },
   "firefox": {
-    "version": "138.0.4",
-    "hash": "sha512-ZNgEVtqN8n1+7tfrIMNfzyE7yUjrSHObYQHixHbqmpEz2pKEd6eWg8lsFg+NU77VK+SH8BqNKeONOQcfEmdoBg=="
+    "version": "139.0",
+    "hash": "sha512-hKK0fy/3GqwiandKsKyauNmhb1YgoG96u2ZIcyIJ0CKu81qdSHPpHr1npPxJT8I4Uk4lw4+tgEbbJq/aBub5cA=="
   }
 }


### PR DESCRIPTION
Upstream release: https://codeberg.org/librewolf/source/releases/tag/139.0-1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
