### PR TITLE
capa: init 9.2.1

### DIFF
--- a/pkgs/by-name/ca/capa/package.nix
+++ b/pkgs/by-name/ca/capa/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  unzip,
+  buildGoModule, # for testing capa executable against binary
+  writableTmpDirAsHomeHook,
+  runCommand,
+  capa,
+  libz,
+  writeScript,
+}:
+
+let
+  version = "9.2.1";
+  darwinHash = "sha256-/sKCEF6AJinV3jAp77ZlCLT2hDCPktoCEanauXpxag8=";
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/mandiant/capa/releases/download/v${version}/capa-v${version}-linux.zip";
+      hash = "sha256-pnWf1KXSSj7oCK0JL7v21/6D+9Mt8C/EPnH5mO7PKTg=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/mandiant/capa/releases/download/v${version}/capa-v${version}-macos.zip";
+      hash = "${darwinHash}";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/mandiant/capa/releases/download/v${version}/capa-v${version}-macos.zip";
+      hash = "${darwinHash}";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  name = "capa";
+  inherit version;
+
+  src =
+    srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs =
+    [
+      unzip
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      autoPatchelfHook
+      libz
+    ];
+
+  dontUnpack = true;
+  dontFixup = stdenv.hostPlatform.isDarwin; # Fixing up causes this error: `Could not load PyInstaller's embedded PKG archive from the executable`
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    unzip $src -d $out/bin
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests = {
+      simple =
+        let
+          # Build tiny binary for testing
+          testBin = buildGoModule {
+            name = "hello-world";
+            vendorHash = null;
+            src = ./tests;
+            nativeBuildInputs = [ writableTmpDirAsHomeHook ];
+            buildPhase = ''
+              runHook preBuild
+              mkdir -p $out/bin
+              GOOS=windows GOARCH=amd64 go build -o $out/bin/hello-world.exe $src/hello-world.go
+              runHook postBuild
+            '';
+          };
+        in
+        runCommand "${finalAttrs.name}-go-test" { } ''
+          mkdir -p $out
+          HOME=/tmp/capa-test ${capa}/bin/capa --rules ${./tests/rules} ${testBin}/bin/hello-world.exe > $out/result.txt
+          grep -q "compiled with Go" $out/result.txt
+        '';
+    };
+    updateScript = writeScript "update-capa" ''
+      #! /usr/bin/env nix-shell
+      #! nix-shell -p jq common-updater-scripts -i bash
+      set -euo pipefail
+
+      version="$(curl -s https://api.github.com/repos/mandiant/capa/releases/latest | jq -r '.tag_name' | tr -d 'v')"
+
+      macosArchive="https://github.com/mandiant/capa/releases/download/v$version/capa-v$version-macos.zip"
+      linuxArchive="https://github.com/mandiant/capa/releases/download/v$version/capa-v$version-linux.zip"
+
+      darwinHash="$(nix hash convert --hash-algo sha256 --from nix32 $(nix-prefetch-url --type sha256 $macosArchive))"
+      linuxHash="$(nix hash convert --hash-algo sha256 --from nix32 $(nix-prefetch-url --type sha256 $linuxArchive))"
+
+      update-source-version capa "$version" "$darwinHash" --system=aarch64-darwin
+      update-source-version capa "$version" "$linuxHash" --system=x86_64-linux
+    '';
+  };
+
+  meta = {
+    changelog = "https://github.com/mandiant/capa/releases/tag/${version}";
+    description = "Open-source tool to identify capabilities in executable files";
+    homepage = "https://mandiant.github.io/capa/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ heywoodlh ];
+    mainProgram = "capa";
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin" # Executable is x86_64 binary, but Rosetta on Apple Silicon Macs should handle this
+    ];
+  };
+})

--- a/pkgs/by-name/ca/capa/tests/hello-world.go
+++ b/pkgs/by-name/ca/capa/tests/hello-world.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/pkgs/by-name/ca/capa/tests/rules/compiler/go/compiled-with-go.yml
+++ b/pkgs/by-name/ca/capa/tests/rules/compiler/go/compiled-with-go.yml
@@ -1,0 +1,20 @@
+rule:
+  meta:
+    name: compiled with Go
+    namespace: compiler/go
+    authors:
+      - michael.hunhoff@mandiant.com
+    scopes:
+      static: file
+      dynamic: file
+    examples:
+      - 49a34cfbeed733c24392c9217ef46bb6
+  features:
+    - or:
+        - string: /^Go build ID:/
+        - substring: "go.buildid"
+        - string: /^Go buildinf:/
+        - string: /\bgo1\.\d/
+        - substring: "runtime.main"
+        - substring: "main.main"
+        - substring: "runtime.gcWork"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added Capa: https://mandiant.github.io/capa/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
