### PR TITLE
odin: raylib patch

### DIFF
--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./darwin-remove-impure-links.patch
+    ./vendored.patch
   ];
   postPatch = ''
     patchShebangs --build build_odin.sh

--- a/pkgs/by-name/od/odin/vendored.patch
+++ b/pkgs/by-name/od/odin/vendored.patch
@@ -1,0 +1,43 @@
+--- a/vendor/raylib/raylib.odin
++++ b/vendor/raylib/raylib.odin
+@@ -102,39 +102,7 @@ MAX_TEXT_BUFFER_LENGTH :: #config(RAYLIB_MAX_TEXT_BUFFER_LENGTH, 1024)
+ RAYLIB_SHARED :: #config(RAYLIB_SHARED, false)
+ RAYLIB_WASM_LIB :: #config(RAYLIB_WASM_LIB, "wasm/libraylib.a")
+ 
+-when ODIN_OS == .Windows {
+-	@(extra_linker_flags="/NODEFAULTLIB:" + ("msvcrt" when RAYLIB_SHARED else "libcmt"))
+-	foreign import lib {
+-		"windows/raylibdll.lib" when RAYLIB_SHARED else "windows/raylib.lib" ,
+-		"system:Winmm.lib",
+-		"system:Gdi32.lib",
+-		"system:User32.lib",
+-		"system:Shell32.lib",
+-	}
+-} else when ODIN_OS == .Linux  {
+-	foreign import lib {
+-		// Note(bumbread): I'm not sure why in `linux/` folder there are
+-		// multiple copies of raylib.so, but since these bindings are for
+-		// particular version of the library, I better specify it. Ideally,
+-		// though, it's best specified in terms of major (.so.4)
+-		"linux/libraylib.so.550" when RAYLIB_SHARED else "linux/libraylib.a",
+-		"system:dl",
+-		"system:pthread",
+-	}
+-} else when ODIN_OS == .Darwin {
+-	foreign import lib {
+-		"macos/libraylib.550.dylib" when RAYLIB_SHARED else "macos/libraylib.a",
+-		"system:Cocoa.framework",
+-		"system:OpenGL.framework",
+-		"system:IOKit.framework",
+-	} 
+-} else when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 {
+-	foreign import lib {
+-		RAYLIB_WASM_LIB,
+-	}
+-} else {
+-	foreign import lib "system:raylib"
+-}
++foreign import lib "system:raylib"
+ 
+ VERSION_MAJOR :: 5
+ VERSION_MINOR :: 5


### PR DESCRIPTION
Closes #348498. I added a patch to fix since odin bundles vendored libraries by default.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
