### PR TITLE
gpredict-unstable: 2.4.0-unstable-2024-09-17 -> 2.2.1-unstable-2024-09-17

### DIFF
--- a/pkgs/by-name/gp/gpredict-unstable/package.nix
+++ b/pkgs/by-name/gp/gpredict-unstable/package.nix
@@ -11,7 +11,7 @@
 }).overrideAttrs
   (finalAttrs: {
     # Next version is 2.4.0
-    version = "2.4.0-unstable-2024-09-17";
+    version = "2.2.1-unstable-2024-09-17";
 
     src = fetchFromGitHub {
       owner = "csete";

--- a/pkgs/by-name/gp/gpredict-unstable/package.nix
+++ b/pkgs/by-name/gp/gpredict-unstable/package.nix
@@ -10,7 +10,6 @@
   goocanvas2 = goocanvas3;
 }).overrideAttrs
   (finalAttrs: {
-    # Next version is 2.4.0
     version = "2.2.1-unstable-2024-09-17";
 
     src = fetchFromGitHub {


### PR DESCRIPTION

### Automatic Update for `gpredict-unstable`
- **Old version**: `2.4.0-unstable-2024-09-17`
- **New version**: `2.2.1-unstable-2024-09-17`
- This PR was generated by a GitHub Actions workflow.
