### PR TITLE
kea: 2.6.2 -> 2.6.3

### DIFF
--- a/nixos/modules/services/networking/kea.nix
+++ b/nixos/modules/services/networking/kea.nix
@@ -265,12 +265,24 @@ in
 
   config =
     let
+      commonEnvironment = {
+        KEA_CONTROL_SOCKET_DIR = "/run/kea";
+        KEA_LOCKFILE_DIR = "/run/kea";
+        KEA_PIDFILE_DIR = "/run/kea";
+      };
+
       commonServiceConfig = {
-        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        ExecReload = toString [
+          (lib.getExe' pkgs.coreutils "kill")
+          "-HUP"
+          "$MAINPID"
+        ];
         DynamicUser = true;
         User = "kea";
         ConfigurationDirectory = "kea";
+        Restart = "on-failure";
         RuntimeDirectory = "kea";
+        RuntimeDirectoryMode = "0750";
         RuntimeDirectoryPreserve = true;
         StateDirectory = "kea";
         UMask = "0077";
@@ -280,6 +292,12 @@ in
       lib.mkMerge [
         {
           environment.systemPackages = [ package ];
+
+          users.users.kea = {
+            isSystemUser = true;
+            group = "kea";
+          };
+          users.groups.kea = { };
         }
 
         (lib.mkIf cfg.ctrl-agent.enable {
@@ -312,10 +330,7 @@ in
               "kea-dhcp-ddns-server.service"
             ];
 
-            environment = {
-              KEA_PIDFILE_DIR = "/run/kea";
-              KEA_LOCKFILE_DIR = "/run/kea";
-            };
+            environment = commonEnvironment;
 
             restartTriggers = [
               ctrlAgentConfig
@@ -358,10 +373,7 @@ in
               "multi-user.target"
             ];
 
-            environment = {
-              KEA_PIDFILE_DIR = "/run/kea";
-              KEA_LOCKFILE_DIR = "/run/kea";
-            };
+            environment = commonEnvironment;
 
             restartTriggers = [
               dhcp4Config
@@ -411,10 +423,7 @@ in
               "multi-user.target"
             ];
 
-            environment = {
-              KEA_PIDFILE_DIR = "/run/kea";
-              KEA_LOCKFILE_DIR = "/run/kea";
-            };
+            environment = commonEnvironment;
 
             restartTriggers = [
               dhcp6Config
@@ -460,10 +469,7 @@ in
               "multi-user.target"
             ];
 
-            environment = {
-              KEA_PIDFILE_DIR = "/run/kea";
-              KEA_LOCKFILE_DIR = "/run/kea";
-            };
+            environment = commonEnvironment;
 
             restartTriggers = [
               dhcpDdnsConfig

--- a/pkgs/by-name/ke/kea/dont-create-var.patch
+++ b/pkgs/by-name/ke/kea/dont-create-var.patch
@@ -1,28 +1,34 @@
 diff --git a/Makefile.am b/Makefile.am
-index 10708e7..d4efd73 100644
+index a81f4cc..5d61407 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -150,13 +150,6 @@ cppcheck:
+@@ -173,18 +173,6 @@ cppcheck:
  docs:
  	$(MAKE) -C doc/sphinx
  
 -
--# These steps are necessary during installation
+-# These steps are necessary during installation. chmod is for reinstallation/upgrade.
 -install-exec-hook:
--	mkdir -p $(DESTDIR)${localstatedir}/log/
--	mkdir -p $(DESTDIR)${localstatedir}/lib/${PACKAGE_NAME}
--	mkdir -p $(DESTDIR)${runstatedir}/${PACKAGE_NAME}
+-	mkdir -m 750 -p "$(DESTDIR)${localstatedir}/lib/${PACKAGE_NAME}"
+-	chmod 750 "$(DESTDIR)${localstatedir}/lib/${PACKAGE_NAME}"
+-	mkdir -m 750 -p "$(DESTDIR)${localstatedir}/log/${PACKAGE_NAME}"
+-	chmod 750 "$(DESTDIR)${localstatedir}/log/${PACKAGE_NAME}"
+-	mkdir -m 750 -p "$(DESTDIR)${runstatedir}/${PACKAGE_NAME}"
+-	chmod 750 "$(DESTDIR)${runstatedir}/${PACKAGE_NAME}"
+-	mkdir -m 750 -p "$(DESTDIR)${sysconfdir}/${PACKAGE_NAME}"
+-	chmod 750 "$(DESTDIR)${sysconfdir}/${PACKAGE_NAME}"
 -
  EXTRA_DIST  = tools/path_replacer.sh
  EXTRA_DIST += tools/mk_cfgrpt.sh
  
 diff --git a/src/lib/dhcpsrv/Makefile.am b/src/lib/dhcpsrv/Makefile.am
-index a0a0289..ba42f8a 100644
+index 7e0f3c4..08c53d8 100644
 --- a/src/lib/dhcpsrv/Makefile.am
 +++ b/src/lib/dhcpsrv/Makefile.am
-@@ -408,5 +408,3 @@ libkea_dhcpsrv_parsers_include_HEADERS = \
+@@ -420,6 +420,3 @@ libkea_dhcpsrv_parsers_include_HEADERS = \
+ 	parsers/shared_networks_list_parser.h \
  	parsers/simple_parser4.h \
  	parsers/simple_parser6.h
- 
+-
 -install-data-local:
 -	$(mkinstalldirs) $(DESTDIR)$(dhcp_data_dir)

--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation rec {
   pname = "kea";
-  version = "2.6.2"; # only even minor versions are stable
+  version = "2.6.3"; # only even minor versions are stable
 
   src = fetchurl {
     url = "https://ftp.isc.org/isc/${pname}/${version}/${pname}-${version}.tar.gz";
-    hash = "sha256-ilC2MQNzS1nDuGGczWdm0t/uPwLjpfnzq8HNVfcPpCQ=";
+    hash = "sha256-ACQaWVX/09IVosCYxFJ/nX9LIDGIsnb5o2JQ3T2d1hI=";
   };
 
   patches = [
@@ -36,9 +36,9 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    substituteInPlace ./src/bin/keactrl/Makefile.am --replace '@sysconfdir@' "$out/etc"
+    substituteInPlace ./src/bin/keactrl/Makefile.am --replace-fail '@sysconfdir@' "$out/etc"
     # darwin special-casing just causes trouble
-    substituteInPlace ./m4macros/ax_crypto.m4 --replace 'apple-darwin' 'nope'
+    substituteInPlace ./m4macros/ax_crypto.m4 --replace-fail 'apple-darwin' 'nope'
   '';
 
   outputs = [


### PR DESCRIPTION
https://downloads.isc.org/isc/kea/2.6.3/Kea-2.6.3-ReleaseNotes.txt

https://kb.isc.org/docs/cve-2025-32801
https://kb.isc.org/docs/cve-2025-32802
https://kb.isc.org/docs/cve-2025-32803

Fixes: CVE-2025-32801, CVE-2025-32802, CVE-2025-32803


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
