### PR TITLE
printrun: add missing platformdirs dependency

### DIFF
--- a/pkgs/by-name/pr/printrun/package.nix
+++ b/pkgs/by-name/pr/printrun/package.nix
@@ -34,6 +34,7 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     appdirs
+    platformdirs
     cython
     dbus-python
     numpy

--- a/pkgs/by-name/pr/printrun/package.nix
+++ b/pkgs/by-name/pr/printrun/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3Packages,
   fetchFromGitHub,
   glib,
@@ -9,7 +10,7 @@
 python3Packages.buildPythonApplication rec {
   pname = "printrun";
   version = "2.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kliment";
@@ -18,47 +19,41 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-INJNGAmghoPIiivQp6AV1XmhyIu8SjfKqL8PTpi/tkY=";
   };
 
-  postPatch = ''
-    sed -i -r "s|/usr(/local)?/share/|$out/share/|g" printrun/utils.py
-  '';
-
-  pythonRelaxDeps = [
-    "pyglet"
-    "cairosvg"
-  ];
-
   nativeBuildInputs = [
     glib
     wrapGAppsHook3
   ];
 
-  propagatedBuildInputs = with python3Packages; [
-    appdirs
-    platformdirs
+  build-system = with python3Packages; [
+    setuptools
     cython
-    dbus-python
-    numpy
-    six
-    wxpython
-    psutil
-    pyglet
-    pyopengl
-    pyserial
-    cffi
-    cairosvg
-    lxml
-    puremagic
   ];
+
+  dependencies =
+    with python3Packages;
+    [
+      pyserial
+      wxpython
+      numpy
+      pyglet
+      psutil
+      lxml
+      platformdirs
+      puremagic
+    ]
+    ++ lib.optional stdenv.hostPlatform.isLinux dbus-python
+    ++ lib.optional stdenv.hostPlatform.isDarwin pyobjc-framework-Cocoa;
+
+  pythonRelaxDeps = [ "pyglet" ];
 
   # pyglet.canvas.xlib.NoSuchDisplayException: Cannot connect to "None"
   doCheck = false;
 
-  setupPyBuildFlags = [ "-i" ];
-
   postInstall = ''
-    for f in $out/share/applications/*.desktop; do
-      sed -i -e "s|/usr/|$out/|g" "$f"
-    done
+    substituteInPlace $out/share/applications/*.desktop \
+      --replace-fail /usr/bin/ ""
+    substituteInPlace $out/share/applications/pronterface.desktop \
+      --replace-fail "Path=/usr/share/pronterface/" ""
   '';
 
   dontWrapGApps = true;
@@ -71,6 +66,6 @@ python3Packages.buildPythonApplication rec {
     description = "Pronterface, Pronsole, and Printcore - Pure Python 3d printing host software";
     homepage = "https://github.com/kliment/Printrun";
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    changelog = "https://github.com/kliment/Printrun/releases/tag/${src.tag}";
   };
 }


### PR DESCRIPTION
I have added the `platformdirs` dependency to the printrun package. Without it
neither pronterface nor pronsole work.

Overriding printrun like this fixed the issue for me.
```
(pkgs.printrun.overridePythonAttrs (old: {
  propagatedBuildInputs = old.propagatedBuildInputs ++ [ pkgs.python3Packages.platformdirs ];
}))
```
I applied this fix to the original package.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
