### PR TITLE
nixos/wyoming-satellite: fix override to use dependencies

### DIFF
--- a/nixos/modules/services/home-automation/wyoming/satellite.nix
+++ b/nixos/modules/services/home-automation/wyoming/satellite.nix
@@ -23,8 +23,8 @@ let
     ;
 
   finalPackage = cfg.package.overridePythonAttrs (oldAttrs: {
-    propagatedBuildInputs =
-      oldAttrs.propagatedBuildInputs
+    dependencies =
+      oldAttrs.dependencies
       # for audio enhancements like auto-gain, noise suppression
       ++ cfg.package.optional-dependencies.webrtc
       # vad is currently optional, because it is broken on aarch64-linux


### PR DESCRIPTION
this fixes an error seen when using the `wyoming-satellite` module in 25.05 and unstable:
```
       … while evaluating definitions from `/nix/store/2d4cws3k4ypb9kvln8qh8ikpd5j5r89l-source/nixos/modules/services/home-automation/wyoming/satellite.nix':
                                                                                                                                                                                                                     
       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
                                                                                                                                                                                                                     
       error: attribute 'propagatedBuildInputs' missing
       at /nix/store/2d4cws3k4ypb9kvln8qh8ikpd5j5r89l-source/nixos/modules/services/home-automation/wyoming/satellite.nix:27:7:
           26|     propagatedBuildInputs =
           27|       oldAttrs.propagatedBuildInputs
             |       ^
           28|       # for audio enhancements like auto-gain, noise suppression
```

the error was also reported in https://github.com/NixOS/nixpkgs/issues/393505, but was incorrectly attrbuted to the `pysilero-vad` optional dependency. I have an overlay which fixes `pysilero-vad` on `aarch64-linux` ( it's a test issue only ), however it does not resolve the issue originally reported.
```
diff --git a/flake.nix b/flake.nix
index 06d41be..cae3225 100644
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,14 @@
+        (final: prev: {
+          python312 = prev.python312.override {
+            packageOverrides = python-final: python-prev: {
+              pysilero-vad = python-prev.pysilero-vad.overridePythonAttrs (_: {
+                doCheck = prev.stdenv.buildPlatform.system != "aarch64-linux";
+                dontUsePythonImportsCheck = prev.stdenv.buildPlatform.system == "aarch64-linux";
+              });
+            };
+          };
+        })
```

I believe the issue was introduced via incomplete renaming done here:
https://github.com/NixOS/nixpkgs/commit/0a44f98cf32e87df7476106db163eea3b2a54248#diff-77e4dee6bfdf2346d2c52daae7231c0d6f31a5f8e310381e317b088ea41636efL28

## Things done

tested by applying this as a patch to nixpkgs in my flake and using `import "${nixpkgs'}/nixos/lib/eval-config.nix" {` instead of `nixpkgs.lib.nixosSystem` in order to use the corrected module.

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
