### PR TITLE
python3Packages.cloudflare: fix meta.changelog URL

### DIFF
--- a/pkgs/development/python-modules/cloudflare/default.nix
+++ b/pkgs/development/python-modules/cloudflare/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   meta = {
     description = "Official Python library for the Cloudflare API";
     homepage = "https://github.com/cloudflare/cloudflare-python";
-    changelog = "https://github.com/cloudflare/cloudflare-python/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/cloudflare/cloudflare-python/blob/v${version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [
       marie
       jemand771


### PR DESCRIPTION
I'm hoping this isn't one of the cases where r-ryantm will just rewrite to the previous (broken) version, when the next version is released.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).