### PR TITLE
writers: add write{Ysh,Osh}[Bin]

### DIFF
--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -1347,4 +1347,162 @@ rec {
   writeFSharp = makeFSharpWriter { };
 
   writeFSharpBin = name: writeFSharp "/bin/${name}";
+
+  /**
+    Like writeScript but the first line is a shebang to YSH
+
+    Can be called with or without extra arguments.
+
+    :::{.example}
+    ## `pkgs.writers.writeYsh` without arguments
+
+    ```nix
+    writeYsh "example" ''
+      echo hello world
+    ''
+    ```
+    :::
+
+    :::{.example}
+    ## `pkgs.writers.writeYsh` with arguments
+
+    ```nix
+    writeYsh "example"
+    {
+      makeWrapperArgs = [
+        "--prefix" "PATH" ":" "${lib.makeBinPath [ pkgs.hello ]}"
+      ];
+    }
+    ''
+      hello
+    ''
+    ```
+    :::
+  */
+  writeYsh =
+    let
+      commands = rec {
+        interpreter = lib.getExe' pkgs.oils-for-unix "ysh";
+        check = "${interpreter} -n"; # syntax check only
+      };
+
+    in
+    name: argsOrScript:
+    if lib.isAttrs argsOrScript && !lib.isDerivation argsOrScript then
+      makeScriptWriter (argsOrScript // commands) name
+    else
+      makeScriptWriter commands name argsOrScript;
+
+  /**
+    Like writeScriptBin but the first line is a shebang to YSH
+
+    Can be called with or without extra arguments.
+
+    # Examples
+    :::{.example}
+    ## `pkgs.writers.writeYshBin` without arguments
+
+    ```nix
+    writeYshBin "example" ''
+      echo hello world
+    ''
+    ```
+    :::
+
+    :::{.example}
+    ## `pkgs.writers.writeYshBin` with arguments
+
+    ```nix
+    writeYshBin "example"
+    {
+      makeWrapperArgs = [
+        "--prefix" "PATH" ":" "${lib.makeBinPath [ pkgs.hello ]}"
+      ];
+    }
+    ''
+      hello
+    ''
+    ```
+    :::
+  */
+  writeYshBin = name: writeYsh "/bin/${name}";
+
+  /**
+    Like writeScript but the first line is a shebang to OSH
+
+    Can be called with or without extra arguments.
+
+    :::{.example}
+    ## `pkgs.writers.writeOsh` without arguments
+
+    ```nix
+    writeOsh "example" ''
+      echo hello world
+    ''
+    ```
+    :::
+
+    :::{.example}
+    ## `pkgs.writers.writeOsh` with arguments
+
+    ```nix
+    writeOsh "example"
+    {
+      makeWrapperArgs = [
+        "--prefix" "PATH" ":" "${lib.makeBinPath [ pkgs.hello ]}"
+      ];
+    }
+    ''
+      hello
+    ''
+    ```
+    :::
+  */
+  writeOsh =
+    let
+      commands = rec {
+        interpreter = lib.getExe' pkgs.oils-for-unix "osh";
+        check = "${interpreter} -n"; # syntax check only
+      };
+
+    in
+    name: argsOrScript:
+    if lib.isAttrs argsOrScript && !lib.isDerivation argsOrScript then
+      makeScriptWriter (argsOrScript // commands) name
+    else
+      makeScriptWriter commands name argsOrScript;
+
+  /**
+    Like writeScriptBin but the first line is a shebang to OSH
+
+    Can be called with or without extra arguments.
+
+    # Examples
+    :::{.example}
+    ## `pkgs.writers.writeOshBin` without arguments
+
+    ```nix
+    writeOshBin "example" ''
+      echo hello world
+    ''
+    ```
+    :::
+
+    :::{.example}
+    ## `pkgs.writers.writeOshBin` with arguments
+
+    ```nix
+    writeOshBin "example"
+    {
+      makeWrapperArgs = [
+        "--prefix" "PATH" ":" "${lib.makeBinPath [ pkgs.hello ]}"
+      ];
+    }
+    ''
+      hello
+    ''
+    ```
+    :::
+  */
+  writeOshBin = name: writeOsh "/bin/${name}";
 }

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -50,6 +50,10 @@ let
     writeText
     writeTOML
     writeYAML
+    writeYsh
+    writeYshBin
+    writeOsh
+    writeOshBin
     ;
 
   expectSuccess =
@@ -174,6 +178,22 @@ recurseIntoAttrs {
           - test: success
         """)
         print(y[0]['test'])
+      ''
+    );
+
+    ysh = expectSuccessBin (
+      writeYshBin "test-writers-ysh-bin" ''
+        if test "test" = "test" {
+          echo "success"
+        }
+      ''
+    );
+
+    osh = expectSuccessBin (
+      writeOshBin "test-writers-osh-bin" ''
+        if test "test" = "test"; then
+          echo "success"
+        fi
       ''
     );
 
@@ -345,6 +365,22 @@ recurseIntoAttrs {
           - test: success
         """)
         print(y[0]['test'])
+      ''
+    );
+
+    ysh = expectSuccess (
+      writeYsh "test-writers-ysh" ''
+        if test "test" = "test" {
+          echo "success"
+        }
+      ''
+    );
+
+    osh = expectSuccess (
+      writeOsh "test-writers-osh" ''
+        if test "test" = "test"; then
+          echo "success"
+        fi
       ''
     );
 


### PR DESCRIPTION
This adds writers for the two Oils shells (https://oils.pub/): YSH and OSH.

The added tests can be run with:

```ysh
for writerTest in tests.writers.{bin,simple}.{osh,ysh} {
  nix-build . -A $writerTest
}
```


## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
