### PR TITLE
[24.11] curl: patch CVE-2025-4947 for WolfSSL backend

### DIFF
--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -98,6 +98,23 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-A0Hx7ZeibIEauuvTfWK4M5VnkrdgfqPxXQAWE8dt4gI=";
   };
 
+  patches = lib.optionals wolfsslSupport [
+    (fetchpatch {
+      # https://curl.se/docs/CVE-2025-4947.html backported to 8.13. Remove when version is bumped to 8.14.
+      # Note that this works since fetchpatch uses curl, but does not use WolfSSL.
+      name = "curl-CVE-2025-4947.patch";
+      url = "https://github.com/curl/curl/commit/a85f1df4803bbd272905c9e7125.diff";
+      hash = "sha256-zxwcboJwHjpcVciJXoCiSLrkAi0V9GtSEBf14V6cfvQ=";
+
+      # All the test patches fail to apply (seemingly, they were added for 8.14)
+      includes = [ "lib/vquic/vquic-tls.c" ];
+
+      postFetch = ''
+        substituteInPlace $out --replace-fail "ctx->wssl.ssl" "ctx->wssl.handle"
+      '';
+    })
+  ];
+
   # this could be accomplished by updateAutotoolsGnuConfigScriptsHook, but that causes infinite recursion
   # necessary for FreeBSD code path in configure
   postPatch = ''
@@ -299,6 +316,11 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     # Fails to link against static brotli or gss
     broken = stdenv.hostPlatform.isStatic && (brotliSupport || gssSupport);
+    knownVulnerabilities = lib.optionals wolfsslSupport [
+      # wolfssl.c has been refactored in between 8.12.1 and this patch:
+      # https://github.com/curl/curl/commit/e1f65937a96a451292e92313396.diff
+      "CVE-2025-5025"
+    ];
     pkgConfigModules = [ "libcurl" ];
     mainProgram = "curl";
   };


### PR DESCRIPTION
Manual backport of #411667 for 24.11.

- https://curl.se/docs/CVE-2025-4947.html
- https://www.openwall.com/lists/oss-security/2025/05/28/4

Note that the patch for CVE-2025-5025 fails to apply and will take some refactoring to fix:

- https://curl.se/docs/CVE-2025-5025.html
- https://www.openwall.com/lists/oss-security/2025/05/28/5

Marked insecure in the meantime, if people really care about using WolfSSL with curl they probably should use unstable. 

----

Build: `NIXPKGS_ALLOW_INSECURE=1 nix-build -E 'with import ./. {}; curlFull.override { opensslSupport = false; wolfsslSupport = true; }'`
Test: `./result-bin/bin/curl --cacert /etc/ssl/certs/ca-bundle.crt https://tls.browserleaks.com/`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
