### PR TITLE
amp-cli: 0.0.1748404992-ga3f78f -> 0.0.1748865683-g71e54e

### DIFF
--- a/pkgs/by-name/am/amp-cli/package-lock.json
+++ b/pkgs/by-name/am/amp-cli/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@sourcegraph/amp": "^0.0.1748404992-ga3f78f"
+        "@sourcegraph/amp": "^0.0.1748865683-g71e54e"
       }
     },
     "node_modules/@colors/colors": {
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@sourcegraph/amp": {
-      "version": "0.0.1748404992-ga3f78f",
-      "resolved": "https://registry.npmjs.org/@sourcegraph/amp/-/amp-0.0.1748404992-ga3f78f.tgz",
-      "integrity": "sha512-+BvCW8zrbO7ENRzMg0LdAeKigjzL+ASIDBjJ/m2uL2CVT8WPk1h34FTNCbvnO6kssimEtdP8FcxR/2O4AHwUbA==",
+      "version": "0.0.1748865683-g71e54e",
+      "resolved": "https://registry.npmjs.org/@sourcegraph/amp/-/amp-0.0.1748865683-g71e54e.tgz",
+      "integrity": "sha512-ZiNbIbgCb/l7Q7wRT0sva6Ju7VDtq7+lijMWK8jotPorTq1DYUy3h7XJIOjyJEdvqlQkEfwrnbOfREmsnwlPyg==",
       "dependencies": {
         "@types/runes": "^0.4.3",
         "@vscode/ripgrep": "1.15.11",

--- a/pkgs/by-name/am/amp-cli/package.nix
+++ b/pkgs/by-name/am/amp-cli/package.nix
@@ -9,11 +9,11 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "amp-cli";
-  version = "0.0.1748404992-ga3f78f";
+  version = "0.0.1748865683-g71e54e";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@sourcegraph/amp/-/amp-${finalAttrs.version}.tgz";
-    hash = "sha256-axd5VP7afa4ptAl/y8CEVguqoRKVRhWfRDSI0sgyXqA=";
+    hash = "sha256-kkQKjw1SzDjV8/206i+NUyxeDhZ/35My9gyXRe/U7I8=";
   };
 
   postPatch = ''
@@ -45,7 +45,7 @@ buildNpmPackage (finalAttrs: {
     chmod +x bin/amp-wrapper.js
   '';
 
-  npmDepsHash = "sha256-05+hBr+eX3I92U9TsqPQrYcJCmKXTvz3n6ZTxR1XvC8=";
+  npmDepsHash = "sha256-yeZ5UCVUCbVjpYTYYN5mI6eCkShtnCKxumjpb5GRCws=";
 
   propagatedBuildInputs = [
     ripgrep

--- a/pkgs/by-name/am/amp-cli/package.nix
+++ b/pkgs/by-name/am/amp-cli/package.nix
@@ -4,14 +4,15 @@
   fetchzip,
   ripgrep,
   makeWrapper,
+  testers,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "amp-cli";
   version = "0.0.1748404992-ga3f78f";
 
   src = fetchzip {
-    url = "https://registry.npmjs.org/@sourcegraph/amp/-/amp-${version}.tgz";
+    url = "https://registry.npmjs.org/@sourcegraph/amp/-/amp-${finalAttrs.version}.tgz";
     hash = "sha256-axd5VP7afa4ptAl/y8CEVguqoRKVRhWfRDSI0sgyXqA=";
   };
 
@@ -25,7 +26,7 @@ buildNpmPackage rec {
       "version": "0.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sourcegraph/amp": "${version}"
+        "@sourcegraph/amp": "${finalAttrs.version}"
       },
       "bin": {
         "amp": "./bin/amp-wrapper.js"
@@ -69,6 +70,10 @@ buildNpmPackage rec {
   '';
 
   passthru.updateScript = ./update.sh;
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "HOME=$(mktemp -d) amp --version";
+  };
 
   meta = {
     description = "CLI for Amp, an agentic coding agent in research preview from Sourcegraph";
@@ -81,4 +86,4 @@ buildNpmPackage rec {
     ];
     mainProgram = "amp";
   };
-}
+})


### PR DESCRIPTION
We additionally add a smoke test which just runs --version. Amp will try create a log directory in your
homedir, so we need to give it a homedir it can write to.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
