### PR TITLE
[24.11] mongodb-6_0: 6.0.17 -> 6.0.23

### DIFF
--- a/pkgs/servers/nosql/mongodb/6.0.nix
+++ b/pkgs/servers/nosql/mongodb/6.0.nix
@@ -24,8 +24,8 @@ let
 in
 buildMongoDB {
   inherit avxSupport;
-  version = "6.0.17";
-  sha256 = "sha256-rGGAu2B0gAAE/n0NSdVm7Me2YeChZhDGWehvzcBJTi8=";
+  version = "6.0.18";
+  sha256 = "sha256-Nq3xwR/z11HsZs8cC9Yr0Xkjg0l1MLb0YRFHsAeQKTM=";
   patches = [
     # Patches a bug that it couldn't build MongoDB 6.0 on gcc 13 because a include in ctype.h was missing
     ./fix-gcc-13-ctype-6_0.patch

--- a/pkgs/servers/nosql/mongodb/6.0.nix
+++ b/pkgs/servers/nosql/mongodb/6.0.nix
@@ -24,8 +24,8 @@ let
 in
 buildMongoDB {
   inherit avxSupport;
-  version = "6.0.19";
-  sha256 = "sha256-qcf+6hMg0LASeOoZJPoRCQ9ajCJBqSsBDg2Wp+2SMKY=";
+  version = "6.0.23";
+  sha256 = "sha256-E87l73bA2i/wEPkzYBX70UptX7tWqBRyhb4fIyrwHZk=";
   patches = [
     # Patches a bug that it couldn't build MongoDB 6.0 on gcc 13 because a include in ctype.h was missing
     ./fix-gcc-13-ctype-6_0.patch

--- a/pkgs/servers/nosql/mongodb/6.0.nix
+++ b/pkgs/servers/nosql/mongodb/6.0.nix
@@ -24,8 +24,8 @@ let
 in
 buildMongoDB {
   inherit avxSupport;
-  version = "6.0.18";
-  sha256 = "sha256-Nq3xwR/z11HsZs8cC9Yr0Xkjg0l1MLb0YRFHsAeQKTM=";
+  version = "6.0.19";
+  sha256 = "sha256-qcf+6hMg0LASeOoZJPoRCQ9ajCJBqSsBDg2Wp+2SMKY=";
   patches = [
     # Patches a bug that it couldn't build MongoDB 6.0 on gcc 13 because a include in ctype.h was missing
     ./fix-gcc-13-ctype-6_0.patch


### PR DESCRIPTION
Backports of #342099, #360829 and #399593

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
