### PR TITLE
waydroid-helper: fix dependencies and `WrapperArgs` issues

### DIFF
--- a/pkgs/by-name/wa/waydroid-helper/package.nix
+++ b/pkgs/by-name/wa/waydroid-helper/package.nix
@@ -16,6 +16,7 @@
   dbus,
   systemd,
   bash,
+  fakeroot,
   gobject-introspection,
 }:
 
@@ -54,6 +55,7 @@ python3Packages.buildPythonApplication rec {
     pkg-config
     wrapGAppsHook4
     desktop-file-utils
+    fakeroot
     gobject-introspection
   ];
 

--- a/pkgs/by-name/wa/waydroid-helper/package.nix
+++ b/pkgs/by-name/wa/waydroid-helper/package.nix
@@ -42,8 +42,6 @@ python3Packages.buildPythonApplication rec {
     # com.jaoushingan.WaydroidHelper.desktop: component-name-missing, description-first-para-too-short
     # url-homepage-missing, desktop-app-launchable-omitted, content-rating-missing, developer-info-missing
     sed -i '/test(/{N;/Validate appstream file/!b;:a;N;/)/!ba;d}' data/meson.build
-    substituteInPlace waydroid_helper/waydroid-cli.in \
-      --replace-fail "/bin/bash" "${bash}/bin/bash"
   '';
 
   nativeBuildInputs = [
@@ -55,7 +53,6 @@ python3Packages.buildPythonApplication rec {
     pkg-config
     wrapGAppsHook4
     desktop-file-utils
-    bash
     gobject-introspection
   ];
 

--- a/pkgs/by-name/wa/waydroid-helper/package.nix
+++ b/pkgs/by-name/wa/waydroid-helper/package.nix
@@ -63,6 +63,7 @@ python3Packages.buildPythonApplication rec {
     libxml2
     libadwaita
     dbus
+    bash
     systemd
   ];
 

--- a/pkgs/by-name/wa/waydroid-helper/package.nix
+++ b/pkgs/by-name/wa/waydroid-helper/package.nix
@@ -56,7 +56,6 @@ python3Packages.buildPythonApplication rec {
     wrapGAppsHook4
     desktop-file-utils
     bash
-    fakeroot
     gobject-introspection
   ];
 

--- a/pkgs/by-name/wa/waydroid-helper/package.nix
+++ b/pkgs/by-name/wa/waydroid-helper/package.nix
@@ -55,6 +55,7 @@ python3Packages.buildPythonApplication rec {
     pkg-config
     wrapGAppsHook4
     desktop-file-utils
+    bash
     fakeroot
     gobject-introspection
   ];
@@ -81,7 +82,10 @@ python3Packages.buildPythonApplication rec {
 
   dontWrapGApps = true;
 
-  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+  makeWrapperArgs = [
+    "\${gappsWrapperArgs[@]}"
+    "--prefix PATH : ${lib.makeBinPath [ fakeroot ]}"
+  ];
 
   postInstallCheck = ''
     mesonCheckPhase


### PR DESCRIPTION
**Changes done as of 21-Jun-25 02:46 PM (GMT +6):**

- Added `fakeroot` as dependency.
- Added `bash` to `buildInputs`.
- Updated `makeWrapperArgs` to fix issues with `waydroid-cli` portion of the program.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
