### PR TITLE
formats.kdl: init

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -364,6 +364,69 @@ have a predefined type and string generator already declared under
     and returning a set with [CDN](https://github.com/dzikoysk/cdn)-specific
     attributes `type` and `generate` as specified [below](#pkgs-formats-result).
 
+`pkgs.formats.kdl` { `version` }
+
+:   A function taking a KDL version (`version == 1 || version == 2`)
+    and returning a set with [KDL](https://kdl.dev/)-specific attributes `type`,
+    `lib` and `generate` as specified [below](#pkgs-formats-result).
+
+    `generate` produces a KDL file given a list of KDL `node`s.
+
+    `lib` is a set containing the functions `node` and `typed`, which are helper
+    functions intended to facilitate generating the required structure for pkgs.formats.kdl
+    in an ergonomic way.
+
+    Their signatures are as follows:
+
+    `node`:
+
+    ```nix
+    name: type: arguments: properties: children: { inherit name type arguments properties children; };
+    ```
+
+    `typed`:
+
+    ```nix
+    type: value: { inherit type value; };
+    ```
+
+    This allows writing the KDL node
+
+    ```kdl
+    name "arg1" (special-type)"arg2" prop=1 {
+      child
+    }
+    ```
+
+    as
+
+    ```nix
+    (node "name" null [ "arg1" (typed "special-type" "arg2") ] { prop = 1; } [
+      (node "child" null [ ] { } [ ])
+    ])
+    ```
+
+    instead of
+
+    ```nix
+    {
+      name = "name";
+      arguments = [
+        "arg1"
+        {
+          type = "special-type";
+          value = "arg2";
+        }
+      ];
+      properties = { prop = 1; };
+      children = [
+        {
+          name = "child";
+        }
+      ];
+    }
+    ```
+
 `pkgs.formats.elixirConf { elixir ? pkgs.elixir }`
 
 :   A function taking an attribute set with values

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -44,10 +44,12 @@ let
     mkOptionType
     nonEmptyListOf
     nullOr
+    number
     oneOf
     path
     str
     submodule
+    submoduleWith
     ;
 
   # Attributes added accidentally in https://github.com/NixOS/nixpkgs/pull/335232 (2024-08-18)
@@ -988,4 +990,171 @@ optionalAttrs allowAliases aliases
     else
       throw "pkgs.formats.xml: Unknown format: ${format}";
 
+  # The KDL document language (https://kdl.dev/)
+  kdl =
+    {
+      version,
+    }:
+    assert version == 1 || version == 2;
+    {
+      type = (
+        let
+          # https://github.com/kdl-org/kdl/blob/main/SPEC.md#value
+          untypedKdlValue =
+            (nullOr (oneOf [
+              str
+              bool
+              number
+              path
+            ]))
+            // {
+              description = "KDL value";
+            };
+          kdlValue = coercedTo untypedKdlValue (value: { inherit value; }) (submoduleWith {
+            description = "submodule: { type = /* type annotation */; value = /* KDL value */; }";
+            modules = lib.toList {
+              options = {
+                type = lib.mkOption {
+                  type = nullOr str;
+                  default = null;
+                  description = ''
+                    [Type Annotation](https://github.com/kdl-org/kdl/blob/main/SPEC.md#type-annotation) of the value.
+                    Set to `null` to prevent generating a type annotation.
+                  '';
+                };
+                value = lib.mkOption {
+                  type = untypedKdlValue;
+                  description = ''
+                    The actual KDL value.
+                  '';
+                };
+              };
+            };
+          });
+          node = submoduleWith {
+            modules = lib.toList {
+              options = {
+                name = lib.mkOption {
+                  type = str;
+                  description = ''
+                    Name of [KDL node](https://github.com/kdl-org/kdl/blob/main/SPEC.md#node).
+                  '';
+                };
+                type = lib.mkOption {
+                  type = nullOr str;
+                  default = null;
+                  description = ''
+                    [Type Annotation](https://github.com/kdl-org/kdl/blob/main/SPEC.md#type-annotation) of [KDL node](https://github.com/kdl-org/kdl/blob/main/SPEC.md#node).
+                    Set to `null` to prevent generating a type annotation.
+                  '';
+                };
+                arguments = lib.mkOption {
+                  type = listOf kdlValue;
+                  default = [ ];
+                  description = ''
+                    [Arguments](https://github.com/kdl-org/kdl/blob/main/SPEC.md#argument) of [KDL node](https://github.com/kdl-org/kdl/blob/main/SPEC.md#node).
+                  '';
+                };
+                properties = lib.mkOption {
+                  type = attrsOf kdlValue;
+                  default = { };
+                  description = ''
+                    [Properties](https://github.com/kdl-org/kdl/blob/main/SPEC.md#property) of [KDL node](https://github.com/kdl-org/kdl/blob/main/SPEC.md#node).
+                  '';
+                };
+                children = lib.mkOption {
+                  type = listOf (
+                    node
+                    // {
+                      # Prevent Nix from trying to recurse into suboptions or submodules, as this leads to a stack overflow
+                      getSubOptions = prefix: { };
+                      getSubModules = null;
+                    }
+                  );
+                  default = [ ];
+                  description = ''
+                    [Children](https://github.com/kdl-org/kdl/blob/main/SPEC.md#children-block) of [KDL node](https://github.com/kdl-org/kdl/blob/main/SPEC.md#node).
+                  '';
+                };
+              };
+            };
+            description = "KDL node";
+          };
+          valueType = listOf node;
+        in
+        valueType
+      );
+
+      lib = {
+        /**
+          Helper function for generating attrsets expected by pkgs.formats.kdl
+
+          # Example
+
+          ```nix
+          let
+            settingsFormat = pkgs.formats.kdl { };
+            inherit (settingsFormat.lib) node;
+          in
+          settingsFormat.generate "sample.kdl" [
+            (node "foo" null [ ] { } [
+              (node "bar" null [ "baz" ] { a = 1; } [ ])
+            ])
+          ]
+          ```
+
+          # Arguments
+
+          name
+          : The name of the node, represented by a string
+
+          type
+          : The type annotation of the node, represented by a string, or null to avoid generating a type annotation
+
+          arguments
+          : The arguments of the node, represented as a list of KDL values
+
+          properties
+          : The properties of the node, represented as an attrset of KDL values
+
+          children
+          : The children of the node, represented as a list of nodes
+        */
+        node = name: type: arguments: properties: children: {
+          inherit
+            name
+            type
+            arguments
+            properties
+            children
+            ;
+        };
+
+        /**
+          Helper function for generating the format of a typed value as expected by pkgs.formats.kdl
+
+          type
+          : The type of the value, represented by a string
+
+          value
+          : The value itself
+        */
+        typed = type: value: { inherit type value; };
+      };
+
+      generate =
+        name: value:
+        pkgs.callPackage (
+          { runCommand, jsonkdl }:
+          runCommand name
+            {
+              nativeBuildInputs = [ jsonkdl ];
+              value = builtins.toJSON value;
+              passAsFile = [ "value" ];
+            }
+            ''
+              jsonkdl --kdl-v${builtins.toString version} "$valuePath" "$out"
+            ''
+        ) { };
+    };
 }

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -923,4 +923,84 @@ runBuildTests {
       </root>
     '';
   };
+
+  kdlAtomsV1 = shouldPass {
+    format = formats.kdl {
+      version = 1;
+    };
+    input = [
+      {
+        name = "foo";
+        type = "bar";
+        arguments = [
+          null
+          false
+          true
+          123
+          3.141
+          "foo"
+        ];
+        properties = {
+          null = null;
+          false = false;
+          true = true;
+          int = 10;
+          float = 3.141;
+          path = ./testfile;
+          str = "foo";
+        };
+        children = [
+          {
+            name = "nested";
+          }
+        ];
+      }
+    ];
+    expected = ''
+      (bar)foo null false true 123 3.141 "foo" false=false float=3.141 int=10 null=null path="${./testfile}" str="foo" true=true {
+          nested {
+          }
+      }
+    '';
+  };
+
+  kdlAtomsV2 = shouldPass {
+    format = formats.kdl {
+      version = 2;
+    };
+    input = [
+      {
+        name = "foo";
+        type = "bar";
+        arguments = [
+          null
+          false
+          true
+          123
+          3.141
+          "foo"
+        ];
+        properties = {
+          null = null;
+          false = false;
+          true = true;
+          int = 10;
+          float = 3.141;
+          path = ./testfile;
+          str = "foo";
+        };
+        children = [
+          {
+            name = "nested";
+          }
+        ];
+      }
+    ];
+    expected = ''
+      (bar)foo #null #false #true 123 3.141 foo false=#false float=3.141 int=10 null=#null path="${./testfile}" str=foo true=#true {
+          nested {
+          }
+      }
+    '';
+  };
 }


### PR DESCRIPTION
## Description of changes

Adds `pkgs.formats.kdl`, a Nix representation of the [KDL document language](https://kdl.dev/) using the standard `pkgs.formats` format.

Also inits `json2kdl`, a custom-built application which is required for the core functionality of `pkgs.formats.kdl`.

Closes #198655.
Superseded #295211 to incorporate feedback (/cc @feathecutie @eclairevoyant @Stunkymonkey @SuperSandro2000 @infinisil @h7x4 @sodiboo @Lyndeno).

## Things done

* Built on platform(s)
  * [x]  x86_64-linux
  * [ ]  aarch64-linux
  * [ ]  x86_64-darwin
  * [ ]  aarch64-darwin
* For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  * [ ]  `sandbox = relaxed`
  * [ ]  `sandbox = true`
* [ ]  Tested, as applicable:
  * [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  * and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  * or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  * made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
* [x]  Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
* [x]  Tested basic functionality of all binary files (usually in `./result/bin/`)
* [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  * [ ]  (Package updates) Added a release notes entry if the change is major or breaking
  * [ ]  (Module updates) Added a release notes entry if the change is significant
  * [ ]  (Module addition) Added a release notes entry if adding a new NixOS module
* [x]  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
