### PR TITLE
nixos/stalwart-mail: fix incorrect config for webadmin and spam-filter

### DIFF
--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -107,21 +107,17 @@ in
       resolver.public-suffix = lib.mkDefault [
         "file://${pkgs.publicsuffix-list}/share/publicsuffix/public_suffix_list.dat"
       ];
-      config = {
-        spam-filter.resource = lib.mkDefault "file://${cfg.package}/etc/stalwart/spamfilter.toml";
-        webadmin =
-          let
-            hasHttpListener = builtins.any (listener: listener.protocol == "http") (
-              lib.attrValues cfg.settings.server.listener
-            );
-          in
-          {
-            path = "/var/cache/stalwart-mail";
-          }
-          // lib.optionalAttrs ((builtins.hasAttr "listener" cfg.settings.server) && hasHttpListener) {
-            resource = lib.mkDefault "file://${cfg.package.webadmin}/webadmin.zip";
-          };
-      };
+      spam-filter.resource = lib.mkDefault "file://${cfg.package}/etc/stalwart/spamfilter.toml";
+      webadmin =
+        let
+          hasHttpListener = builtins.any (listener: listener.protocol == "http") (
+            lib.attrValues (cfg.settings.server.listener or { })
+          );
+        in
+        {
+          path = "/var/cache/stalwart-mail";
+          resource = lib.mkIf (hasHttpListener) (lib.mkDefault "file://${cfg.package.webadmin}/webadmin.zip");
+        };
     };
 
     # This service stores a potentially large amount of data.

--- a/nixos/tests/stalwart-mail.nix
+++ b/nixos/tests/stalwart-mail.nix
@@ -42,6 +42,11 @@ in
               bind = [ "[::]:143" ];
               protocol = "imap";
             };
+
+            "http" = {
+              bind = [ "[::]:80" ];
+              protocol = "http";
+            };
           };
 
           session.auth.mechanisms = "[plain]";
@@ -114,9 +119,13 @@ in
       main.wait_for_unit("stalwart-mail.service")
       main.wait_for_open_port(587)
       main.wait_for_open_port(143)
+      main.wait_for_open_port(80)
 
       main.succeed("test-smtp-submission")
       main.succeed("test-imap-read")
+
+      main.succeed("test -d /var/cache/stalwart-mail/STALWART_WEBADMIN")
+      main.succeed("curl --fail http://localhost")
     '';
 
   meta = {


### PR DESCRIPTION
Stalwart 0.11.0 changed the `config.resource.spam-filter` and `config.resource.webadmin` keys to be `spam-filter.resource` and `webadmin.resource` respectively. The NixOS has been updated accordingly, but unfortunately it has mistakenly used `config.spam-filter.resource` and `config.webadmin.resource`, which are incorrect and do not do anything.

This commit changes the default configuration to use the correct keys.

Note that due to infinite recursion, the `optionalAttrs` has been replaced with `mkIf`.

Additionally, some tests were added to catch this regression in the future.

Fixes #411351


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
