### PR TITLE
wol: build on aarch64-darwin

### DIFF
--- a/pkgs/by-name/wo/wol/macos-10_7-getline.patch
+++ b/pkgs/by-name/wo/wol/macos-10_7-getline.patch
@@ -1,0 +1,64 @@
+From f78508f9803de42faf6e578d89ce08ea31a62b0d Mon Sep 17 00:00:00 2001
+From: Bryan Lai <bryanlais@gmail.com>
+Date: Thu, 29 May 2025 15:38:11 +0800
+Subject: [PATCH] fix: build for darwin (conflicting getline)
+
+Previously failing with:
+
+  In file included from getpass4.c:7:
+  ./getline.h:32:1: error: conflicting types for 'getline'
+     32 | getline PARAMS ((char **_lineptr, size_t *_n, FILE *_stream));
+        | ^
+  /nix/store/w41ks2baj649algkjnbh9746cprrnr1k-apple-sdk-11.3/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:355:9: note: previous declaration is here
+    355 | ssize_t getline(char ** __restrict __linep, size_t * __restrict __linecapp, FILE * __restrict __stream) __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3);
+        |         ^
+  In file included from getpass4.c:7:
+  ./getline.h:35:1: error: conflicting types for 'getdelim'
+     35 | getdelim PARAMS ((char **_lineptr, size_t *_n, int _delimiter, FILE *_stream));
+        | ^
+  /nix/store/w41ks2baj649algkjnbh9746cprrnr1k-apple-sdk-11.3/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:354:9: note: previous declaration is here
+    354 | ssize_t getdelim(char ** __restrict __linep, size_t * __restrict __linecapp, int __delimiter, FILE * __restrict __stream) __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3);
+        |         ^
+  4 warnings generated.
+  2 errors generated.
+---
+ configure.ac  | 2 +-
+ lib/getline.h | 7 +++++++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 99dc73d..fd0b0dc 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -193,7 +193,7 @@ gl_MD5 dnl for GNU md5
+ AM_FUNC_GETLINE dnl for GNU getline
+ AC_CHECK_FUNCS(usleep)
+ AC_CHECK_FUNCS(getopt_long) dnl for GNU getopt
+-AC_CHECK_FUNCS(getdelim)
++AC_CHECK_FUNCS([getline getdelim])
+ AC_CHECK_FUNC(inet_aton, [], [
+ 	dnl check libresolv for inet_aton() as seen on solaris
+ 	AC_CHECK_LIB(resolv, inet_aton,
+diff --git a/lib/getline.h b/lib/getline.h
+index 991184c..34a0247 100644
+--- a/lib/getline.h
++++ b/lib/getline.h
+@@ -28,11 +28,18 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+ # endif
+ 
+ # if __GLIBC__ < 2
++
++#include "config.h"
++#ifndef HAVE_GETLINE
+ int
+ getline PARAMS ((char **_lineptr, size_t *_n, FILE *_stream));
++#endif
+ 
++#ifndef HAVE_GETDELIM
+ int
+ getdelim PARAMS ((char **_lineptr, size_t *_n, int _delimiter, FILE *_stream));
++#endif
++
+ # endif
+ 
+ #endif /* not GETLINE_H_ */

--- a/pkgs/by-name/wo/wol/package.nix
+++ b/pkgs/by-name/wo/wol/package.nix
@@ -15,7 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "08i6l5lr14mh4n3qbmx6kyx7vjqvzdnh3j9yfvgjppqik2dnq270";
   };
 
-  patches = [ ./gcc-14.patch ];
+  patches = [
+    ./gcc-14.patch
+    ./macos-10_7-getline.patch
+  ];
 
   nativeBuildInputs = [
     perl # for pod2man in order to get a manpage
@@ -30,6 +33,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ makefu ];
     mainProgram = "wol";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Add a patch which makes it build and run on aarch64-darwin (presumably x86_64 as well but untested). Tested the WOL functionality on my home NAS.

Previously, it was failing due to conflicting `getline` implementations. The patch is straightforward: we simply do not compile the custom `getline` implementation if one is already found in stdio.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
