### PR TITLE
workflows/manual-nixpkgs: build nixpkgs on staging and stable branches

### DIFF
--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - .github/workflows/manual-nixpkgs-v2.yml
   pull_request_target:
-    branches:
-      - master
     paths:
       - 'doc/**'
       - 'lib/**'
@@ -38,4 +36,4 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Building Nixpkgs manual
-        run: NIX_PATH=nixpkgs=$(pwd)/untrusted nix-build --option restrict-eval true untrusted/ci -A manual-nixpkgs -A manual-nixpkgs-tests
+        run: nix-build untrusted/ci -A manual-nixpkgs -A manual-nixpkgs-tests

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -82,8 +82,8 @@ in
   # CI jobs
   lib-tests = import ../lib/tests/release.nix { inherit pkgs; };
   manual-nixos = (import ../nixos/release.nix { }).manual.${system} or null;
-  manual-nixpkgs = (import ../pkgs/top-level/release.nix { }).manual;
-  manual-nixpkgs-tests = (import ../pkgs/top-level/release.nix { }).manual.tests;
+  manual-nixpkgs = (import ../doc { });
+  manual-nixpkgs-tests = (import ../doc { }).tests;
   nixpkgs-vet = pkgs.callPackage ./nixpkgs-vet.nix { };
   parse = pkgs.lib.recurseIntoAttrs {
     latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };

--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "eaeed9530c76ce5f1d2d8232e08bec5e26f18ec1",
-  "sha256": "132nimgi1g88fbhddk4b8b1qk68jly494x2mnphyk3xa1d2wy9q7"
+  "rev": "3d1f29646e4b57ed468d60f9d286cde23a8d1707",
+  "sha256": "1wzvc9h9a6l9wyhzh892xb5x88kxmbzxb1k8s7fizyyw2q4nqw07"
 }

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,6 +1,6 @@
 {
-  pkgs ? (import ./.. { }),
+  pkgs ? (import ../ci { }).pkgs,
   nixpkgs ? { },
 }:
 
-pkgs.nixpkgs-manual.override { inherit nixpkgs; }
+pkgs.callPackage ./doc-support/package.nix { inherit nixpkgs; }

--- a/doc/shell.nix
+++ b/doc/shell.nix
@@ -1,7 +1,1 @@
-let
-  pkgs = import ../. {
-    config = { };
-    overlays = [ ];
-  };
-in
-pkgs.nixpkgs-manual.shell
+(import ./default.nix { }).shell


### PR DESCRIPTION
Currently, we only build both the manuals on PRs targeting master. This leaves a gap for all PRs targeting release or any of the staging branches. While we could simply enable the build for release branches (we should!), we explicitly opted out of building it on staging: That's because it would need to possibly build the whole stdenv. This just never finishes in a CI runner and times out after 6 hours - a waste of (our) resources.

Unfortunately, running this only on PRs targeting master won't help in every case: Sometimes, we open PRs to master only to then realize, that this causes a mass-rebuild and should go to staging instead. The manual job will then be started and run for 6 hours. Going through the runner logs, we can see that this happens from time to time. This can be partly fixed by cancelling previous jobs on a new push to the PR, which is something that we still don't do (I have a branch for that, but am waiting on #411160 to avoid conflicts). Still, this doesn't cover the case where we only realize this after a few hours and the job has already run for 6 hours and timed out.

Also, more importantly: We don't build the docs on PRs to staging, so we are missing CI feedback there. Which is the same locally, while working on a staging-based branch, you can't just spin up `devmode`, but need to do that on master first. Annoying.

Down the road, it would also prevent us from implementing *required status checks / workflows*, because those only work (well), when the jobs for them run unconditionally.

To fix all of that, I propose to build the docs based on the pinned nixpkgs instance from `ci/pinned-nixpkgs.json` for both CI and the local dev shell. The release / hydra jobs would *not* change, they'd still build the docs against the same nixpkgs checkout as before. Of course, this pin should only affect the tooling to build the docs, not the contents.

While this would solve all of the above mentioned issues, I think, it would come with some challenges on its own:
- Some changes to the docs must be implemented in steps: Tooling first, wait for it to get to the channel, then update the pinned nixpkgs instance. Then adjust the docs. An example PR, which would have been affected: #408871.
- Since we're not testing the exact thing that hydra builds in GitHub CI, there is a chance that CI passes, but hydra breaks. I'd argue, that by building on staging we are overall lowering the number of things that break this way, though.

Of course, we'd want to do the same for the NixOS manual, because it has exactly the same problems. I didn't look into that, yet, couldn't figure out on the spot how I'd hook into that process the same way as I did here.

First, I'd like to get some feedback from others - is this something that we want to do?

## Things done

- [x] Tested locally
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
