### PR TITLE
tribler: add StartupWMClass for .desktop file

### DIFF
--- a/pkgs/by-name/tr/tribler/package.nix
+++ b/pkgs/by-name/tr/tribler/package.nix
@@ -29,6 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-fQJOs9P4y71De/+svmD7YZ4+tm/bC3rspm7SbOHlSR4=";
   };
 
+  patches = [
+    ./startupwmclass.patch
+  ];
+
   nativeBuildInputs = [
     python3.pkgs.wrapPython
     makeWrapper

--- a/pkgs/by-name/tr/tribler/startupwmclass.patch
+++ b/pkgs/by-name/tr/tribler/startupwmclass.patch
@@ -1,0 +1,9 @@
+diff --git a/build/debian/tribler/usr/share/applications/org.tribler.Tribler.desktop b/build/debian/tribler/usr/share/applications/org.tribler.Tribler.desktop
+index b0472a18d..0e0be14f3 100644
+--- a/build/debian/tribler/usr/share/applications/org.tribler.Tribler.desktop
++++ b/build/debian/tribler/usr/share/applications/org.tribler.Tribler.desktop
+@@ -7,3 +7,4 @@ Terminal=false
+ Type=Application
+ Categories=Application;Network;P2P
+ MimeType=x-scheme-handler/ppsp;x-scheme-handler/tswift;x-scheme-handler/magnet;application/x-bittorrent
++StartupWMClass=Tribler


### PR DESCRIPTION
This PR updates - the `$out/share/applications/org.tribler.Tribler.desktop` file to add: `StartupWMClass=Tribler`

I use Gnome DE and for a while now it has bugged me that the icon for Tribler in the dash/panel when the program is running was the system default gear icon.

I poked around and found that Gnome uses the [Application ID](https://developer.gnome.org/documentation/tutorials/application-id.html) to determine what to show as the icon in this case.

I used `alt+F2` to pull up the run command window, then ran `lg` and found that gnome thinks the Tribler Application_Id is just "Tribler". 

So I tested adding the StartWMClass to the .desktop file and found that it fixes the issue.

I have attached a couple of screenshots showing how it looks on my system with and without the change.

[I put in a PR on the upstream](https://github.com/Tribler/tribler/pull/8614) to address it at that level, but I don't know what their cadence for releases are, so I figured I'd add the fix here as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`

Tested, as applicable:
- [x ] Tested basic functionality of all binary files (usually in `./result/bin/`)

- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
