### PR TITLE
bochs: rely on upstream defaults for experimental options

### DIFF
--- a/pkgs/by-name/bo/bochs/fix-darwin-build.patch
+++ b/pkgs/by-name/bo/bochs/fix-darwin-build.patch
@@ -1,0 +1,15 @@
+diff --git a/gui/keymap.cc b/gui/keymap.cc
+index 3426b6b..7bf76d8 100644
+--- a/gui/keymap.cc
++++ b/gui/keymap.cc
+@@ -30,6 +30,10 @@
+ #include "gui.h"
+ #include "keymap.h"
+
++#if defined(__APPLE__)
++#include <libgen.h>
++#endif
++
+ // Table of bochs "BX_KEY_*" symbols
+ // the table must be in BX_KEY_* order
+ const char *bx_key_symbol[BX_KEY_NBKEYS] = {

--- a/pkgs/by-name/bo/bochs/package.nix
+++ b/pkgs/by-name/bo/bochs/package.nix
@@ -32,6 +32,9 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://sourceforge/project/bochs/bochs/${finalAttrs.version}/bochs-${finalAttrs.version}.tar.gz";
     hash = "sha256-y29UK1HzWizJIGsqmA21YCt80bfPLk7U8Ras1VB3gao=";
   };
+  # Fix build on darwin, remove on next version
+  # https://sourceforge.net/p/bochs/bugs/1466/
+  patches = lib.optional stdenv.hostPlatform.isDarwin ./fix-darwin-build.patch;
 
   nativeBuildInputs = [
     docbook_xml_dtd_45

--- a/pkgs/by-name/bo/bochs/package.nix
+++ b/pkgs/by-name/bo/bochs/package.nix
@@ -148,7 +148,7 @@ stdenv.mkDerivation (finalAttrs: {
       Intel x86 CPU, common I/O devices, and a custom BIOS.
     '';
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ patrickdag ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/bo/bochs/package.nix
+++ b/pkgs/by-name/bo/bochs/package.nix
@@ -82,11 +82,6 @@ stdenv.mkDerivation (finalAttrs: {
 
       (lib.enableFeature false "docbook") # Broken - it requires docbook2html
 
-      # Dangerous options - they are marked as "incomplete/experimental" on Bochs documentation
-      (lib.enableFeature false "3dnow")
-      (lib.enableFeature false "monitor-mwait")
-      (lib.enableFeature false "raw-serial")
-
       # These are completely configurable, and they don't depend of external tools
       (lib.enableFeature true "a20-pin")
       (lib.enableFeature true "avx")


### PR DESCRIPTION
These options are called experimental but contrary to the upstream documentation at least `enable-mwait` is already default enabled for newer architectures. This is needed as some things depend on it, mainly `kvm_intel` does not work without monitor support.

The other two options are still default disabled, but if they ever get default enabled we don't have to worry about it.

I don't think there are nixos specific reason to disable them at this point.

Other package repositories, eg. debian and arch already enable these options anyway, so I we could even do that, I seems bochs really likes to keep the experimental flag on options, even if they've been in use for years at this point.

Also added a patch to fix the darwin build errors. The patch is already merged upstream just not yet in a released version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
