### PR TITLE
python312Packages.ossapi: init at 5.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27115,6 +27115,13 @@
     githubId = 13378502;
     name = "Wulfsta";
   };
+  wulpine = {
+    name = "Wulpey";
+    email = "wulpine@proton.me";
+    matrix = "@wulpine:matrix.org";
+    github = "wulpine";
+    githubId = 59339992;
+  };
   wunderbrick = {
     name = "Andrew Phipps";
     email = "lambdafuzz@tutanota.com";

--- a/pkgs/development/python-modules/osrparse/default.nix
+++ b/pkgs/development/python-modules/osrparse/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hypothesis,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "osrparse";
+  version = "7.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kszlim";
+    repo = "osu-replay-parser";
+    tag = "v${version}";
+    hash = "sha256-MBE4z1SDkr0YA5ommF+WZyR2N67Y1/xmDhxrTrUhQJk=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "osrparse" ];
+
+  meta = {
+    description = "Parser for osr (osu! replays) file format";
+    homepage = "https://github.com/kszlim/osu-replay-parser";
+    changelog = "https://github.com/kszlim/osu-replay-parser/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wulpine ];
+  };
+}

--- a/pkgs/development/python-modules/ossapi/default.nix
+++ b/pkgs/development/python-modules/ossapi/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  aiohttp,
+  osrparse,
+  requests,
+  requests-oauthlib,
+  setuptools,
+  typing-utils,
+}:
+
+buildPythonPackage rec {
+  pname = "ossapi";
+  version = "5.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tybug";
+    repo = "ossapi";
+    tag = "v${version}";
+    hash = "sha256-eCq+NbDYoJ5y1ZC4RfVJUTYcT9AOLU1mtgpZkcSYZG8=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRelaxDeps = [ "osrparse" ];
+
+  dependencies = [
+    osrparse
+    requests
+    requests-oauthlib
+    typing-utils
+  ];
+
+  optional-dependencies = {
+    async = [ aiohttp ];
+  };
+
+  # Tests require Internet access and an osu! API key
+  doCheck = false;
+
+  pythonImportsCheck = [ "ossapi" ];
+
+  meta = {
+    description = "Python wrapper for the osu! API";
+    homepage = "https://github.com/tybug/ossapi";
+    changelog = "https://github.com/tybug/ossapi/releases/tag/${src.tag}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ wulpine ];
+  };
+}

--- a/pkgs/development/python-modules/typing-utils/default.nix
+++ b/pkgs/development/python-modules/typing-utils/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "typing-utils";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bojiang";
+    repo = "typing_utils";
+    tag = "v${version}";
+    hash = "sha256-eXVGpe1wCH1JG+7ZP0evlxhw189GrrRzTwNDCALn3JI=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "typing_utils" ];
+
+  meta = {
+    description = "Utils to inspect Python type annotations";
+    homepage = "https://github.com/bojiang/typing_utils";
+    changelog = "https://github.com/bojiang/typing_utils/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ wulpine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10895,6 +10895,8 @@ self: super: with self; {
 
   oss2 = callPackage ../development/python-modules/oss2 { };
 
+  ossapi = callPackage ../development/python-modules/ossapi { };
+
   ossfs = callPackage ../development/python-modules/ossfs { };
 
   osxphotos = callPackage ../development/python-modules/osxphotos { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18637,6 +18637,8 @@ self: super: with self; {
 
   typing-inspection = callPackage ../development/python-modules/typing-inspection { };
 
+  typing-utils = callPackage ../development/python-modules/typing-utils { };
+
   typing-validation = callPackage ../development/python-modules/typing-validation { };
 
   typish = callPackage ../development/python-modules/typish { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10891,6 +10891,8 @@ self: super: with self; {
 
   osqp = callPackage ../development/python-modules/osqp { };
 
+  osrparse = callPackage ../development/python-modules/osrparse { };
+
   oss2 = callPackage ../development/python-modules/oss2 { };
 
   ossfs = callPackage ../development/python-modules/ossfs { };


### PR DESCRIPTION
Add [ossapi](https://github.com/tybug/ossapi), an osu! API wrapper, and its dependencies.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
