### PR TITLE
deark: init at 1.7.0

### DIFF
--- a/pkgs/by-name/de/deark/package.nix
+++ b/pkgs/by-name/de/deark/package.nix
@@ -1,0 +1,72 @@
+{
+  fetchFromGitHub,
+  stdenv,
+  lib,
+  help2man,
+  installShellFiles,
+}:
+stdenv.mkDerivation rec {
+  pname = "deark";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "jsummers";
+    repo = "deark";
+    tag = "v${version}";
+    hash = "sha256-dyX41gWZnZ/07Vyxo1x4Y8neGHS5ev+YyBJ0cUH+gKY=";
+  };
+
+  nativeBuildInputs = [
+    help2man
+    installShellFiles
+  ];
+  postBuild = ''
+    make man
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 deark $out/bin/deark
+    installManPage deark.1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Utility for file format and metadata analysis, data extraction, decompression, and image format decoding";
+    longDescription = ''
+      Deark is a portable command-line utility that can decode certain
+      types of files, and either convert them to a more-modern or
+      more-readable format, or extract embedded files from them.
+    '';
+    homepage = "https://entropymine.com/deark/";
+    downloadPage = "https://github.com/jsummers/deark/";
+    # cf. READMEs under "foreign" folder for details
+    license = with lib.licenses; [
+      mit
+      # deark itself + modifications to foreign code, sans foreign code
+      # ozunreduce.h (dual-licensed: MIT is one option)
+      free
+      # miniz*.h (MIT-style, predates standardized licenses)
+      # ozunreduce.h (dual-licensed: public domain is one option)
+      # dskdcmps.h (public domain)
+      # uncompface.h ("Permission is given to distribute these sources, as long as the
+      #                copyright messages are not removed, and no monies are exchanged"
+      #                + waiver of liability)
+      unfreeRedistributable
+      # lzhuf.* (no copywrite notice, predates standardized licenses,
+      #          widely distributed & intent appears to be free use)
+      # "By necessity, Deark contains knowledge about how to decode various
+      # third-party file formats. This knowledge includes data structures,
+      # algorithms, tables, color palettes, etc. The author(s) of Deark
+      # make no intellectual property claims to this essential knowledge,
+      # but they cannot guarantee that no one else will attempt to do so.
+      # Deark contains VGA and CGA bitmapped fonts, which have no known
+      # copyright claims."
+    ];
+    maintainers = with lib.maintainers; [ zacharyweiss ];
+    mainProgram = "deark";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
From [deark's homepage](https://entropymine.com/deark/): "Deark is a portable command-line utility that can decode certain types of files, and either convert them to a more-modern or more-readable format, or extract embedded files from them. It also has an option (-d) to display detailed information about a file’s contents and metadata. It’s free and open source."

Seeking feedback from more experienced contributors prior to merge, most importantly on the license. The license is "MIT-like"; the MIT license preceded by `Deark is distributed under the following MIT-style license. See the "Terms of use" section of the "readme.md" file for details and exceptions.` with the [caveats in question](https://github.com/jsummers/deark/tree/master?tab=readme-ov-file#terms-of-use) being as follows:

> Starting with version 1.4.x, Deark is distributed under an MIT-style license. See the [COPYING](https://github.com/jsummers/deark/blob/master/COPYING) file for the license text.
> 
> The main Deark license does not necessarily apply to the code in the "foreign" subdirectory. Each file there may have its own licensing terms. In particular:
> 
> miniz*.h: MIT-style license, various authors. See the miniz files for details.
> 
> uncompface.h: Copyright (c) James Ashton - Sydney University - June 1990. See readme-compface.txt for details.
> 
> lzhuf.h: Based on lzhuf.c by Haruyasu Yoshizaki. See readme-lzhuf.txt for details.
> 
> By necessity, Deark contains knowledge about how to decode various third-party file formats. This knowledge includes data structures, algorithms, tables, color palettes, etc. The author(s) of Deark make no intellectual property claims to this essential knowledge, but they cannot guarantee that no one else will attempt to do so.
> 
> Deark contains VGA and CGA bitmapped fonts, which have no known copyright claims.
> 
> Be particularly wary of relying on Deark to decode archive and compression formats (tar, ar, gzip, cpio, ...). For example, to decode tar format, you really should use a battle-hardened application like GNU Tar, not Deark. Deark's support for such formats is often incomplete, and it does not always do integrity checking.

What is the appropriate way to mark the license in nixpkgs?

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
