### PR TITLE
hfsutils: init at 3.2.6-unstable-2018-01-17

### DIFF
--- a/pkgs/by-name/hf/hfsutils/package.nix
+++ b/pkgs/by-name/hf/hfsutils/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+}:
+stdenv.mkDerivation rec {
+  pname = "hfsutils";
+  version = "3.2.6-unstable-2018-01-17";
+
+  src = fetchFromGitHub {
+    owner = "JotaRandom";
+    repo = "hfsutils";
+    rev = "263327c7cd0e788282c949fbcb03791009c9943c";
+    hash = "sha256-P4VixeG4rMerXvBXHKcjqF2vbsJRsblYfLeMD5fNW74=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  # fix makefile trying to touch files in .stamp w/o dir created
+  preConfigure = ''
+    mkdir -p .stamp
+  '';
+
+  # ignore implicit strcmp declaration in hpwd.c's function hpwd_main
+  # patch source to include <string.h>?
+  NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
+
+  meta = {
+    description = "Tools for reading and writing Macintosh HFS volumes";
+    homepage = "http://www.mars.org/home/rob/proj/hfs/";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
[hfsutils](http://www.mars.org/home/rob/proj/hfs/) "is the name of a comprehensive software package being developed to permit manipulation of HFS volumes from UNIX and other systems." [HFS](https://en.wikipedia.org/wiki/Hierarchical_File_System_(Apple)) is one of the original Macintosh file systems, introduced in 1985.

Here, I've packaged the CLI tools from a "fork" of the code — where they imported to GitHub, and added a few minor commits atop the last version of the original project (3.2.6).

Few questions for folks reviewing:
- Should the package be titled to correspond with the "fork" author, eg `hfsutils-jotarandom` or is it kosher to keep as `hfsutils`?
- Should the missing <string.h> be patched in? Or kosher to ignore with "-Wno-implicit-function-declaration"? Functions happily as currently packaged.
- Should the manpage be patched to omit the unpackaged/unbuilt GUI apps?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
