### PR TITLE
nix-your-shell: Add generate-config script

### DIFF
--- a/pkgs/by-name/ni/nix-your-shell/package.nix
+++ b/pkgs/by-name/ni/nix-your-shell/package.nix
@@ -3,6 +3,8 @@
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
+  runCommand,
+  nix-your-shell,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "nix-your-shell";
@@ -11,12 +13,21 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "MercuryTechnologies";
     repo = "nix-your-shell";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-FjGjLq/4qeZz9foA7pfz1hiXvsdmbnzB3BpiTESLE1c=";
   };
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-zQpK13iudyWDZbpAN8zm9kKmz8qy3yt8JxT4lwq4YF0=";
+
+  passthru = {
+    generate-config =
+      shell:
+      runCommand "nix-your-shell-config" { } ''
+        ${lib.getExe nix-your-shell} ${lib.escapeShellArg shell} >> "$out"
+      '';
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     mainProgram = "nix-your-shell";
@@ -26,6 +37,4 @@ rustPlatform.buildRustPackage rec {
     license = [ lib.licenses.mit ];
     maintainers = with lib.maintainers; [ _9999years ];
   };
-
-  passthru.updateScript = nix-update-script { };
 }


### PR DESCRIPTION
This lets users generate a shell configuration file from Nix, for use with `home-manager` and similar:

```nix
{ config, pkgs, ... }: {
  home.file."${config.xdg.configHome}/nushell/nix-your-shell.nu".source =
    pkgs.nix-your-shell.generate-config "nu";
}
```

This increases parity with the upstream packaging.

See: https://github.com/MercuryTechnologies/nix-your-shell/issues/81

Incorporates suggestion https://github.com/NixOS/nixpkgs/pull/383164#pullrequestreview-2716332709 to reduce merge conflicts.
Supersedes #383164 (/cc @9999years @drupol @isabelroses).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
