### PR TITLE
python3Packages.google-cloud-spanner: 3.54.0 -> 3.55.0

### DIFF
--- a/pkgs/development/python-modules/google-cloud-spanner/default.nix
+++ b/pkgs/development/python-modules/google-cloud-spanner/default.nix
@@ -33,14 +33,14 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-spanner";
-  version = "3.54.0";
+  version = "3.55.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "python-spanner";
     tag = "v${version}";
-    hash = "sha256-uJKUgY7fV+AK/2HQyjQRFypcL+mPZ/M5ZtAU+f73ezM=";
+    hash = "sha256-0+mTBqgy8SaHjoYhQjCaypipVsJTrN2DdhcfPY3PxSc=";
   };
 
   build-system = [ setuptools ];
@@ -92,6 +92,8 @@ buildPythonPackage rec {
     "test_list_instance"
     # can't import mmh3
     "test_generate_client_hash"
+    # Flaky, compares to execution time
+    "test_snapshot_read_concurrent"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/google-cloud-spanner/default.nix
+++ b/pkgs/development/python-modules/google-cloud-spanner/default.nix
@@ -19,14 +19,14 @@
 
   # optional dependencies
   libcst,
-
-  # testing
-  google-cloud-monitoring,
-  mmh3,
-  mock,
   opentelemetry-api,
   opentelemetry-sdk,
   opentelemetry-semantic-conventions,
+  google-cloud-monitoring,
+  mmh3,
+
+  # testing
+  mock,
   pytest-asyncio,
   pytestCheckHook,
 }:
@@ -54,10 +54,18 @@ buildPythonPackage rec {
     proto-plus
     protobuf
     sqlparse
-  ] ++ google-api-core.optional-dependencies.grpc;
+  ];
 
   optional-dependencies = {
     libcst = [ libcst ];
+    tracing = [
+      opentelemetry-api
+      opentelemetry-sdk
+      opentelemetry-semantic-conventions
+      # opentelemetry-resourcedetector-gcp # Not available in nixpkgs
+      google-cloud-monitoring
+      mmh3
+    ];
   };
 
   nativeCheckInputs = [
@@ -70,7 +78,7 @@ buildPythonPackage rec {
     opentelemetry-semantic-conventions
     pytest-asyncio
     pytestCheckHook
-  ];
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   preCheck = ''
     # prevent google directory from shadowing google imports
@@ -117,7 +125,7 @@ buildPythonPackage rec {
   meta = {
     description = "Cloud Spanner API client library";
     homepage = "https://github.com/googleapis/python-spanner";
-    changelog = "https://github.com/googleapis/python-spanner/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/googleapis/python-spanner/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.sarahec ];
   };


### PR DESCRIPTION
1. Added optional `tracing` imports (less `opentelemetry-resourcedetector-gcp` which is unavailable)
2. Version bump
3. Disabled flaky test that compares execution time to a constant

Supersedes #412104 to disable flaky test

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
