### PR TITLE
lazpaint: 7.2.2-unstable-2024-01-23 → 7.3

### DIFF
--- a/pkgs/by-name/la/lazpaint/package.nix
+++ b/pkgs/by-name/la/lazpaint/package.nix
@@ -10,29 +10,27 @@
   python3,
 }:
 
-let
-  bgrabitmap = fetchFromGitHub {
-    owner = "bgrabitmap";
-    repo = "bgrabitmap";
-    rev = "2814b069d55f726b9f3b4774d85d00dd72be9c05";
-    hash = "sha256-YibwdhlgjgI30gqYsKchgDPlOSpBiDBDJNlUDFMygGs=";
-  };
-  bgracontrols = fetchFromGitHub {
-    owner = "bgrabitmap";
-    repo = "bgracontrols";
-    rev = "v8.0";
-    hash = "sha256-5L05eGVN+xncd0/0XLFN6EL2ux4aAOsiU0BMoy0dKgg=";
-  };
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lazpaint";
-  version = "7.2.2-unstable-2024-01-23";
+  version = "7.3";
 
   src = fetchFromGitHub {
     owner = "bgrabitmap";
     repo = "lazpaint";
-    rev = "45a7a471d531d6adb5ee557ff917a99af76e92f1";
-    hash = "sha256-KgCxSK72Ow29T58mlcYCJiS4D0Ov2/p37c1FSNgKZew=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yT1HyvJcYEJgMkQxzCSD8s7/ttemxZaur9T+As8WdIo=";
+  };
+  bgrabitmap = fetchFromGitHub {
+    owner = "bgrabitmap";
+    repo = "bgrabitmap";
+    tag = "v11.6.6";
+    hash = "sha256-bA8tvo7Srm5kIZTVWEA2+gjqHab7LByyL/zqdQxeFlA=";
+  };
+  bgracontrols = fetchFromGitHub {
+    owner = "bgrabitmap";
+    repo = "bgracontrols";
+    tag = "v9.0.2";
+    hash = "sha256-HqX9n4VpOyMwTz3fTweTTqzW+jA2BU62mm/X7Iwjd/8=";
   };
 
   nativeBuildInputs = [
@@ -59,8 +57,8 @@ stdenv.mkDerivation {
     runHook preBuild
 
     export HOME=$(mktemp -d)
-    cp -r --no-preserve=mode ${bgrabitmap} bgrabitmap
-    cp -r --no-preserve=mode ${bgracontrols} bgracontrols
+    cp -r --no-preserve=mode ${finalAttrs.bgrabitmap} bgrabitmap
+    cp -r --no-preserve=mode ${finalAttrs.bgracontrols} bgracontrols
 
     lazbuild --lazarusdir=${lazarus-qt5}/share/lazarus \
       --build-mode=ReleaseQt5 \
@@ -86,4 +84,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ aleksana ];
     mainProgram = "lazpaint";
   };
-}
+})


### PR DESCRIPTION
https://github.com/bgrabitmap/lazpaint/releases/tag/v7.3

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
