### PR TITLE
python312Packages.weasyprint: cleanup, mark as broken on darwin

### DIFF
--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -111,5 +111,10 @@ buildPythonPackage rec {
     homepage = "https://weasyprint.org/";
     license = lib.licenses.bsd3;
     teams = [ lib.teams.apm ];
+    badPlatforms = [
+      # Fatal Python error: Segmentation fault
+      # "...weasyprint/pdf/fonts.py", line 221 in _harfbuzz_subset
+      lib.systems.inspect.patterns.isDarwin
+    ];
   };
 }

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -26,6 +26,7 @@
   pytest-cov-stub,
   pytestCheckHook,
   replaceVars,
+  versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
 
@@ -69,8 +70,10 @@ buildPythonPackage rec {
     pkgs.ghostscript
     pytest-cov-stub
     pytestCheckHook
+    versionCheckHook
     writableTmpDirAsHomeHook
   ];
+  versionCheckProgramArg = "--version";
 
   disabledTests = [
     # needs the Ahem font (fails on macOS)

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -1,26 +1,32 @@
 {
-  stdenv,
   lib,
+  stdenv,
   pkgs,
   buildPythonPackage,
-  cffi,
-  cssselect2,
-  fetchPypi,
-  flit-core,
+  fetchFromGitHub,
   fontconfig,
-  fonttools,
   glib,
   harfbuzz,
   pango,
+
+  # build-system
+  flit-core,
+
+  # dependencies
+  cffi,
+  cssselect2,
+  fonttools,
   pillow,
   pydyf,
   pyphen,
-  pytest-cov-stub,
-  pytestCheckHook,
-  pythonOlder,
-  replaceVars,
   tinycss2,
   tinyhtml5,
+
+  # tests
+  pytest-cov-stub,
+  pytestCheckHook,
+  replaceVars,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -28,12 +34,11 @@ buildPythonPackage rec {
   version = "65.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.9";
-
-  src = fetchPypi {
-    inherit version;
-    pname = "weasyprint";
-    hash = "sha256-EgKBvb1C/6p9flztvjGCos7zbqWtl/6fNX5DvmoeWOo=";
+  src = fetchFromGitHub {
+    owner = "Kozea";
+    repo = "WeasyPrint";
+    tag = "v${version}";
+    hash = "sha256-iSeuRX1dnnrGZbcb1yTxOJPD5kgIWY6oz/0v02QJqSs=";
   };
 
   patches = [
@@ -64,6 +69,7 @@ buildPythonPackage rec {
     pkgs.ghostscript
     pytest-cov-stub
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
   disabledTests = [
@@ -92,11 +98,6 @@ buildPythonPackage rec {
 
   # Set env variable explicitly for Darwin, but allow overriding when invoking directly
   makeWrapperArgs = [ "--set-default FONTCONFIG_FILE ${FONTCONFIG_FILE}" ];
-
-  preCheck = ''
-    # Fontconfig wants to create a cache.
-    export HOME=$TMPDIR
-  '';
 
   pythonImportsCheck = [ "weasyprint" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- **python312Packages.weasyprint: cleanup**
- **python312Packages.weasyprint: add versionCheckHook**
- **python312Packages.weasyprint: mark as broken on darwin**

---

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
