### PR TITLE
poetryPlugins.poetry-plugin-lambda-build: init at 2.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18760,6 +18760,11 @@
     githubId = 17091659;
     name = "Pablo Andres Dealbera";
   };
+  pacaroha = {
+    name = "pacaroha";
+    github = "pacaroha";
+    githubId = 187338595;
+  };
   pacman99 = {
     email = "pachum99@gmail.com";
     matrix = "@pachumicchu:myrdd.info";

--- a/pkgs/by-name/po/poetry/package.nix
+++ b/pkgs/by-name/po/poetry/package.nix
@@ -41,6 +41,7 @@ let
       poetry-plugin-up = callPackage ./plugins/poetry-plugin-up.nix { };
       poetry-plugin-poeblix = callPackage ./plugins/poetry-plugin-poeblix.nix { };
       poetry-plugin-shell = callPackage ./plugins/poetry-plugin-shell.nix { };
+      poetry-plugin-lambda-build = callPackage ./plugins/poetry-plugin-lambda-build.nix { };
     };
 
   # selector is a function mapping pythonPackages to a list of plugins

--- a/pkgs/by-name/po/poetry/plugins/poetry-plugin-lambda-build.nix
+++ b/pkgs/by-name/po/poetry/plugins/poetry-plugin-lambda-build.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  docker,
+  poetry-core,
+  pytest-cov,
+  pytestCheckHook,
+  poetry,
+  pip,
+}:
+
+buildPythonPackage rec {
+  pname = "poetry-plugin-lambda-build";
+  version = "2.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "micmurawski";
+    repo = "poetry-plugin-lambda-build";
+    tag = version;
+    hash = "sha256-i9vFLiuEXTsNhdvSPQQUh2EYwSjlmgRepplf24eddeA=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    docker
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov
+    pytestCheckHook
+    poetry
+    pip
+  ];
+
+  preCheck = ''
+    export POETRY_CACHE_DIR=$TMPDIR/.cache/pypoetry
+    export POETRY_VIRTUALENVS_PATH=$TMPDIR/.cache/pypoetry/virtualenvs
+  '';
+
+  # it's kinda stupid to include this here, but maybe upstream would be open to
+  # including it.
+  postPatch = ''
+    substituteInPlace tests/test_builds.py \
+      --replace 'if platform.system() == "Darwin":' \
+                'if platform.system() == "Darwin" and "USER" in os.environ:'
+  '';
+
+  # I don't know how do get this escaping/quoting stuff to work right with the
+  # newer `pytestFlags` attribute, but this works with pytestFlagsArray:
+  pytestFlagsArray = [
+    "-k 'not container and not docker'"
+  ];
+
+  meta = {
+    description = "Poetry plugin for building packages for serverless functions deployments";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/micmurawski/poetry-plugin-lambda-build/";
+    maintainers = with lib.maintainers; [ pacaroha ];
+  };
+}


### PR DESCRIPTION
I added a package for a poetry plugin that builds images for AWS Lambda [poetry plugin lambda build](https://github.com/micmurawski/poetry-plugin-lambda-build). My team has been using this on `x86_64-linux` and `aarch64-darwin` to build lambda layer ZIP packages for `x86_64-linux` for several months, and it works nicely.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
