### PR TITLE
treewide: unpin python311

### DIFF
--- a/pkgs/by-name/do/dooit-extras/package.nix
+++ b/pkgs/by-name/do/dooit-extras/package.nix
@@ -1,13 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  python311,
+  python3,
   dooit,
   nix-update-script,
 }:
-let
-  python3 = python311;
-in
 python3.pkgs.buildPythonPackage rec {
   pname = "dooit-extras";
   version = "0.2.0";

--- a/pkgs/by-name/do/dooit/package.nix
+++ b/pkgs/by-name/do/dooit/package.nix
@@ -2,14 +2,11 @@
   lib,
   fetchFromGitHub,
   dooit,
-  python311,
+  python3,
   testers,
   nix-update-script,
   extraPackages ? [ ],
 }:
-let
-  python3 = python311;
-in
 python3.pkgs.buildPythonApplication rec {
   pname = "dooit";
   version = "3.2.2";

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -23,7 +23,7 @@
   opencascade-occt_7_6,
   opencascade-occt,
   pkg-config,
-  python311Packages,
+  python3Packages,
   spaceNavSupport ? stdenv.hostPlatform.isLinux,
   ifcSupport ? false,
   stdenv,
@@ -40,7 +40,7 @@
   nix-update-script,
 }:
 let
-  inherit (python311Packages)
+  inherit (python3Packages)
     boost
     gitpython
     ifcopenshell

--- a/pkgs/by-name/fr/frescobaldi/package.nix
+++ b/pkgs/by-name/fr/frescobaldi/package.nix
@@ -2,11 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python311Packages,
+  python3Packages,
   lilypond,
 }:
 
-python311Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "frescobaldi";
   version = "3.3.0";
 
@@ -17,7 +17,7 @@ python311Packages.buildPythonApplication rec {
     sha256 = "sha256-Q6ruthNcpjLlYydUetkuTECiCIzu055bw40O8BPGq/A=";
   };
 
-  propagatedBuildInputs = with python311Packages; [
+  propagatedBuildInputs = with python3Packages; [
     qpageview
     lilypond
     pygame
@@ -28,7 +28,7 @@ python311Packages.buildPythonApplication rec {
     pyqtwebengine
   ];
 
-  nativeBuildInputs = [ python311Packages.pyqtwebengine.wrapQtAppsHook ];
+  nativeBuildInputs = [ python3Packages.pyqtwebengine.wrapQtAppsHook ];
 
   # Needed because source is fetched from git
   preBuild = ''

--- a/pkgs/by-name/gp/gpodder/package.nix
+++ b/pkgs/by-name/gp/gpodder/package.nix
@@ -6,12 +6,12 @@
   gobject-introspection,
   gtk3,
   intltool,
-  python311Packages,
+  python3Packages,
   wrapGAppsHook3,
   xdg-utils,
 }:
 
-python311Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "gpodder";
   version = "3.11.4";
   format = "other";
@@ -35,6 +35,7 @@ python311Packages.buildPythonApplication rec {
     intltool
     wrapGAppsHook3
     gobject-introspection
+    python3Packages.distutils
   ];
 
   buildInputs = [
@@ -42,7 +43,7 @@ python311Packages.buildPythonApplication rec {
     adwaita-icon-theme
   ];
 
-  nativeCheckInputs = with python311Packages; [
+  nativeCheckInputs = with python3Packages; [
     minimock
     pytest
     pytest-httpserver
@@ -51,7 +52,7 @@ python311Packages.buildPythonApplication rec {
 
   doCheck = true;
 
-  propagatedBuildInputs = with python311Packages; [
+  propagatedBuildInputs = with python3Packages; [
     feedparser
     dbus-python
     mygpoclient

--- a/pkgs/by-name/py/py3c/package.nix
+++ b/pkgs/by-name/py/py3c/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python311,
+  python3,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,8 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   nativeCheckInputs = [
-    python311
+    python3
+    python3.pkgs.distutils
   ];
 
   checkTarget = "test-python";

--- a/pkgs/by-name/py/pysolfc/package.nix
+++ b/pkgs/by-name/py/pysolfc/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchzip,
-  python311Packages,
+  python3Packages,
   desktop-file-utils,
   freecell-solver,
   black-hole-solver,
@@ -10,7 +10,7 @@
   gitUpdater,
 }:
 
-python311Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "pysolfc";
   version = "3.2.0";
 
@@ -51,7 +51,7 @@ python311Packages.buildPythonApplication rec {
     '';
   };
 
-  propagatedBuildInputs = with python311Packages; [
+  propagatedBuildInputs = with python3Packages; [
     tkinter
     six
     random2

--- a/pkgs/by-name/re/renderdoc/package.nix
+++ b/pkgs/by-name/re/renderdoc/package.nix
@@ -13,7 +13,7 @@
   nix-update-script,
   pcre,
   pkg-config,
-  python311Packages,
+  python3Packages,
   qt5,
   stdenv,
   vulkan-loader,
@@ -51,9 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
     [
       libXdmcp
       libpthreadstubs
-      python311Packages.pyside2
-      python311Packages.pyside2-tools
-      python311Packages.shiboken2
+      python3Packages.pyside2
+      python3Packages.pyside2-tools
+      python3Packages.shiboken2
       qt5.qtbase
       qt5.qtsvg
       vulkan-loader
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     pcre
     pkg-config
-    python311Packages.python
+    python3Packages.python
     qt5.qtx11extras
     qt5.wrapQtAppsHook
   ];

--- a/pkgs/by-name/sm/smassh/package.nix
+++ b/pkgs/by-name/sm/smassh/package.nix
@@ -2,13 +2,10 @@
   lib,
   fetchFromGitHub,
   smassh,
-  python311,
+  python3,
   testers,
 }:
 
-let
-  python3 = python311;
-in
 python3.pkgs.buildPythonApplication rec {
   pname = "smassh";
   version = "3.1.6";

--- a/pkgs/by-name/th/thelounge/package.nix
+++ b/pkgs/by-name/th/thelounge/package.nix
@@ -6,7 +6,7 @@
   nodejs,
   yarn,
   fixup-yarn-lock,
-  python311,
+  python3,
   npmHooks,
   cctools,
   sqlite,
@@ -39,13 +39,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-csVrgsEy9HjSBXxtgNG0hcBrR9COlcadhMQrw6BWPc4=";
   };
 
-  # Distutils was deprecated in 3.10, and removed in 3.12. This build needs it. An alternative could be adding
-  # setuptools, but testing with that and 3.12 still fails.
   nativeBuildInputs = [
     nodejs
     yarn
     fixup-yarn-lock
-    python311
+    python3
+    python3.pkgs.distutils
     npmHooks.npmInstallHook
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ];
   buildInputs = [ sqlite ];

--- a/pkgs/by-name/to/toolong/package.nix
+++ b/pkgs/by-name/to/toolong/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  python311Packages,
+  python3Packages,
   fetchFromGitHub,
   testers,
   toolong,
 }:
 
-python311Packages.buildPythonApplication {
+python3Packages.buildPythonApplication {
   pname = "toolong";
   version = "1.4.0";
   pyproject = true;
@@ -18,8 +18,8 @@ python311Packages.buildPythonApplication {
     hash = "sha256-HrmU7HxWKYrbV25Y5CHLw7/7tX8Y5mTsTL1aXGGTSIo=";
   };
 
-  build-system = [ python311Packages.poetry-core ];
-  dependencies = with python311Packages; [
+  build-system = [ python3Packages.poetry-core ];
+  dependencies = with python3Packages; [
     click
     textual
     typing-extensions

--- a/pkgs/by-name/vo/volk_2/package.nix
+++ b/pkgs/by-name/vo/volk_2/package.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitHub,
   cmake,
-  python311,
+  python3,
   enableModTool ? true,
   removeReferencesTo,
   fetchpatch,
@@ -49,10 +49,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    # This version of the project wasn't updated to use Python 3.12 which
-    # doesn't include the deprecated distutils module.
-    python311
-    python311.pkgs.mako
+    python3
+    python3.pkgs.mako
+    python3.pkgs.distutils
     removeReferencesTo
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12645,9 +12645,7 @@ with pkgs;
     }
   );
 
-  manuskript = libsForQt5.callPackage ../applications/editors/manuskript {
-    python3Packages = python311Packages;
-  };
+  manuskript = libsForQt5.callPackage ../applications/editors/manuskript { };
 
   minari = python3Packages.toPythonApplication python3Packages.minari;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15297,7 +15297,7 @@ with pkgs;
 
   steam-run-free = steam-fhsenv-without-steam.run;
 
-  steamback = python311.pkgs.callPackage ../tools/games/steamback { };
+  steamback = python3.pkgs.callPackage ../tools/games/steamback { };
 
   protontricks = python3Packages.callPackage ../tools/package-management/protontricks {
     steam-run = steam-run-free;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2253,7 +2253,7 @@ with pkgs;
     stdenv = gcc14Stdenv;
   };
 
-  hyprshade = python311Packages.callPackage ../applications/window-managers/hyprwm/hyprshade { };
+  hyprshade = python3Packages.callPackage ../applications/window-managers/hyprwm/hyprshade { };
 
   hyprlandPlugins = recurseIntoAttrs (
     callPackage ../applications/window-managers/hyprwm/hyprland-plugins { }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15577,9 +15577,7 @@ with pkgs;
 
   deepdiff = with python3Packages; toPythonApplication deepdiff;
 
-  deepsecrets = callPackage ../tools/security/deepsecrets {
-    python3 = python311;
-  };
+  deepsecrets = callPackage ../tools/security/deepsecrets { };
 
   deep-translator = with python3Packages; toPythonApplication deep-translator;
 


### PR DESCRIPTION
Approach was simple: unpin python311 and see if it builds, if it didn't it try and fix it

- **freecad: unpin python311**
- **frescobaldi: unpin python311**
- **gpodder: unpin python311**
- ~~guake: unpin python311~~
- **pysolfc: unpin python311**
- **renderdoc: unpin python311**
- ~~sapling: unpin python311~~
- **toolong: unpin python311**
- **dooit-extras: unpin python311**
- **dooit: unpin python311**
- **py3c: unpin python311**
- **smassh: unpin python311**
- **thelounge: unpin python311**
- **volk_2: unpin python311**
- **hyprshade: unpin python311**
- **manuskript: unping python311**
- **steamback: unpin python311**
- **deepsecrets: unpin python311**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
