### PR TITLE
treewide: fetchCargoVendor: inherit pname+version

### DIFF
--- a/pkgs/applications/graphics/gnome-decoder/default.nix
+++ b/pkgs/applications/graphics/gnome-decoder/default.nix
@@ -40,8 +40,7 @@ clangStdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-USfC7HSL1TtjP1SmBRTKkPyKE4DkSn6xeH4mzfIBQWg=";
   };
 

--- a/pkgs/applications/version-management/silver-platter/default.nix
+++ b/pkgs/applications/version-management/silver-platter/default.nix
@@ -31,8 +31,7 @@ buildPythonApplication rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-hZQfzaLvHSN/hGR5vn+/2TRH6GwDTTp+UcnePXY7JlM=";
   };
 

--- a/pkgs/by-name/co/contrast/package.nix
+++ b/pkgs/by-name/co/contrast/package.nix
@@ -33,8 +33,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-Nj5MkYDeYUzgqegCbPt/XofSCw8ULFXAD7XHNecPznc=";
   };
 

--- a/pkgs/by-name/dd/ddnet/package.nix
+++ b/pkgs/by-name/dd/ddnet/package.nix
@@ -42,8 +42,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    name = "${pname}-${version}";
-    inherit src;
+    inherit pname version src;
     hash = "sha256-VKGc4LQjt2FHbELLBKtV8rKpxjGBrzlA3m9BSdZ/6Z0=";
   };
 

--- a/pkgs/by-name/de/delfin/package.nix
+++ b/pkgs/by-name/de/delfin/package.nix
@@ -33,8 +33,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-zZc2+0oskptpWZE4fyVcR4QHxqzpj71GXMXNXMK4an0=";
   };
 

--- a/pkgs/by-name/do/done/package.nix
+++ b/pkgs/by-name/do/done/package.nix
@@ -31,8 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-yEpaQa9hKOq0k9MurihbFM4tDB//TPCJdOgKA9tyqVc=";
   };
 

--- a/pkgs/by-name/em/emblem/package.nix
+++ b/pkgs/by-name/em/emblem/package.nix
@@ -30,8 +30,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-CsISaVlRGtVVEna1jyGZo/IdWcJdwHJv6LXcXYha2UE=";
   };
 

--- a/pkgs/by-name/fo/fontfinder/package.nix
+++ b/pkgs/by-name/fo/fontfinder/package.nix
@@ -25,8 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-g6PRGHrkHA0JTekKaQs+8mtyOCj99m0zPbgP8AnP7GU=";
   };
 

--- a/pkgs/by-name/fo/footage/package.nix
+++ b/pkgs/by-name/fo/footage/package.nix
@@ -39,8 +39,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-H8sv7faI/qbmcP7ir++/vIpN+cvRQ254rXmAvGyjdsY=";
   };
 

--- a/pkgs/by-name/fr/fragments/package.nix
+++ b/pkgs/by-name/fr/fragments/package.nix
@@ -35,8 +35,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-i77LHbaAURxWrEpuR40jRkUGPk8wZR+q3DB+rzH3sEc=";
   };
 

--- a/pkgs/by-name/gl/glide-media-player/package.nix
+++ b/pkgs/by-name/gl/glide-media-player/package.nix
@@ -28,8 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-5cohhm8/QP+vYzVf8iz3hLtu0ej7lQiHpDAC9I52+ME=";
   };
 

--- a/pkgs/by-name/he/health/package.nix
+++ b/pkgs/by-name/he/health/package.nix
@@ -29,8 +29,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-eR1ZGtTZQNhofFUEjI7IX16sMKPJmAl7aIFfPJukecg=";
   };
 

--- a/pkgs/by-name/he/helvum/package.nix
+++ b/pkgs/by-name/he/helvum/package.nix
@@ -29,8 +29,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-rwhhbEaUg7IiszmJUFh4vQV7cYyyh3tqr1z4QgmwIDY=";
   };
 

--- a/pkgs/by-name/ip/iplan/package.nix
+++ b/pkgs/by-name/ip/iplan/package.nix
@@ -25,8 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-ATEm7RYfW9nYtTDAx580tvokVUIS7BL9mA65aEeJJvk=";
   };
 

--- a/pkgs/by-name/ko/kooha/package.nix
+++ b/pkgs/by-name/ko/kooha/package.nix
@@ -33,8 +33,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-3LYoNQquYbyiEd9ZXRr4UPIcl3gultsBYWCWaCYshwQ=";
   };
 

--- a/pkgs/by-name/ma/matrix-hookshot/package.nix
+++ b/pkgs/by-name/ma/matrix-hookshot/package.nix
@@ -38,8 +38,7 @@ mkYarnPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = data.cargoHash;
   };
 

--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/package.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/package.nix
@@ -28,8 +28,7 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-Gq3QvQSRfxRovzuvdboLCheNuMW58GFO9x2N2os+p38=";
   };
 

--- a/pkgs/by-name/no/notify-client/package.nix
+++ b/pkgs/by-name/no/notify-client/package.nix
@@ -30,8 +30,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-hnv4XXsx/kmhH4YUTdTvvxxjbguHBx3TnUKacGwnCTw=";
   };
 

--- a/pkgs/by-name/pa/paleta/package.nix
+++ b/pkgs/by-name/pa/paleta/package.nix
@@ -28,8 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-RuzqU06iyK+IN7aO+Lq/IaRLh2oFpWM1rz69Koiicgg=";
   };
 

--- a/pkgs/by-name/re/read-it-later/package.nix
+++ b/pkgs/by-name/re/read-it-later/package.nix
@@ -31,8 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-mn3Jl5XEHYbCCFjLd8TBqtZKEdevH95IWKdgHwAtXk0=";
   };
 

--- a/pkgs/by-name/sh/shortwave/package.nix
+++ b/pkgs/by-name/sh/shortwave/package.nix
@@ -39,8 +39,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-DBWg9Xss1ChbPyI3MiN7eTXhSUG37ZaYS/HFxou9d/w=";
   };
 

--- a/pkgs/by-name/sq/squeekboard/package.nix
+++ b/pkgs/by-name/sq/squeekboard/package.nix
@@ -36,8 +36,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "squeekboard-${version}";
+    inherit pname version src;
     hash = "sha256-3K1heokPYxYbiAGha9TrrjQXguzGv/djIB4eWa8dVjg=";
   };
 

--- a/pkgs/by-name/ta/tailor-gui/package.nix
+++ b/pkgs/by-name/ta/tailor-gui/package.nix
@@ -30,8 +30,12 @@ stdenv.mkDerivation {
     ;
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src sourceRoot;
-    name = "${pname}-${version}";
+    inherit
+      pname
+      version
+      src
+      sourceRoot
+      ;
     hash = "sha256-9jMy23VD+C87hg/TMXGbzAoqx76dhVOkWcQNudSwsYA=";
   };
 

--- a/pkgs/by-name/te/televido/package.nix
+++ b/pkgs/by-name/te/televido/package.nix
@@ -29,8 +29,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-D9gchFS5zrD1cttq/gveT7wY2Y/5hfiUrwBa7qHD9cs=";
   };
 

--- a/pkgs/by-name/va/vaults/package.nix
+++ b/pkgs/by-name/va/vaults/package.nix
@@ -32,8 +32,7 @@ stdenv.mkDerivation rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-j0A6HlApV0l7LuB7ISHp+k/bSH5Icdv+aNQ9juCCO9I=";
   };
 

--- a/pkgs/by-name/wa/waytrogen/package.nix
+++ b/pkgs/by-name/wa/waytrogen/package.nix
@@ -29,8 +29,7 @@ stdenv.mkDerivation rec {
 
   useFetchCargoVendor = true;
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-S+JW6OvmB9vj9cR9/qnw5EIECjpD8JPhxfgwDEEtlC0=";
   };
 

--- a/pkgs/development/python-modules/aardwolf/default.nix
+++ b/pkgs/development/python-modules/aardwolf/default.nix
@@ -37,9 +37,8 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
+    inherit pname version src;
     sourceRoot = "${src.name}/aardwolf/utils/rlers";
-    name = "${pname}-${version}";
     hash = "sha256-doBraJQtekrO/ZZV9KFz7BdIgBVVWtQztUS2Gz8dDdA=";
   };
 

--- a/pkgs/development/python-modules/adblock/default.nix
+++ b/pkgs/development/python-modules/adblock/default.nix
@@ -44,8 +44,7 @@ buildPythonPackage rec {
   '';
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-fetJX6HQxRZ/Az7rJeU9S+s8ttgNPnJEvTLfzGt4xjk=";
   };
 

--- a/pkgs/development/python-modules/ahocorasick-rs/default.nix
+++ b/pkgs/development/python-modules/ahocorasick-rs/default.nix
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-uB3r6+Ewpi4dVke/TsCZltfc+ZABYLOLKuNxw+Jfu/M=";
   };
 

--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -33,9 +33,8 @@ buildPythonPackage rec {
 
   cargoRoot = "src/_bcrypt";
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
+    inherit pname version src;
     sourceRoot = "${pname}-${version}/${cargoRoot}";
-    name = "${pname}-${version}";
     hash = "sha256-HgHvfMBspPsSYhllnKBg5XZB6zxFIqJj+4//xKG8HwA=";
   };
 

--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -64,8 +64,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-ZtCTg8qNCiqlH7RsZxaWUNAoazdgmXP2GtpjDpRdvbk=";
   };
 

--- a/pkgs/development/python-modules/clarabel/default.nix
+++ b/pkgs/development/python-modules/clarabel/default.nix
@@ -21,8 +21,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-Ohbeavkayl6vMyYX9kVVLRddvVB9gWOxfzdWAOg+gac=";
   };
 

--- a/pkgs/development/python-modules/css-inline/default.nix
+++ b/pkgs/development/python-modules/css-inline/default.nix
@@ -35,12 +35,11 @@ buildPythonPackage rec {
   # call `cargo build --release` in bindings/python and copy the
   # resulting lock file
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
+    inherit pname version src;
     postPatch = ''
       cd bindings/python
       ln -s ${./Cargo.lock} Cargo.lock
     '';
-    name = "${pname}-${version}";
     hash = "sha256-4zi29ZdALummwcWxYqDDEPAjKptmLqyYUJzWMrEK4os=";
   };
 

--- a/pkgs/development/python-modules/etebase/default.nix
+++ b/pkgs/development/python-modules/etebase/default.nix
@@ -40,8 +40,7 @@ buildPythonPackage rec {
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-tFOZJFrNge3N+ux2Hp4Mlm9K/AXYxuuBzEQdQYGGDjg=";
     inherit patches;
   };

--- a/pkgs/development/python-modules/evtx/default.nix
+++ b/pkgs/development/python-modules/evtx/default.nix
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-IqV4BsLE+5Dk3ey4M+h5wxR/SToZTLf8vU0BlWU5e8c=";
   };
 

--- a/pkgs/development/python-modules/fastcrc/default.nix
+++ b/pkgs/development/python-modules/fastcrc/default.nix
@@ -31,8 +31,7 @@ buildPythonPackage {
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-9Vap8E71TkBIf4eIB2lapUqcMukdsHX4LR7U8AD77SU=";
   };
 

--- a/pkgs/development/python-modules/gb-io/default.nix
+++ b/pkgs/development/python-modules/gb-io/default.nix
@@ -21,8 +21,12 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src sourceRoot;
-    name = "${pname}-${version}";
+    inherit
+      pname
+      version
+      src
+      sourceRoot
+      ;
     hash = "sha256-97aEuXdq9oEqYJs6sgQU5a0vAMJmWJzu2WGjOqzxZ4c=";
   };
 

--- a/pkgs/development/python-modules/gilknocker/default.nix
+++ b/pkgs/development/python-modules/gilknocker/default.nix
@@ -28,9 +28,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-cUv0CT8d6Nxjzh/S/hY9jcpeFX/5KvBxSkqOkt4htyU=";
   };
 

--- a/pkgs/development/python-modules/glean-sdk/default.nix
+++ b/pkgs/development/python-modules/glean-sdk/default.nix
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-Ppc+6ex3yLC4xuhbZGZDKLqxDjSdGpgrLDpbbbqMgPY=";
   };
 

--- a/pkgs/development/python-modules/hf-transfer/default.nix
+++ b/pkgs/development/python-modules/hf-transfer/default.nix
@@ -28,8 +28,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-O4aKqVSShFpt8mdZkY3WV55j9CIczRSRkIMC7dJoGv0=";
   };
 

--- a/pkgs/development/python-modules/jh2/default.nix
+++ b/pkgs/development/python-modules/jh2/default.nix
@@ -26,8 +26,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-CW95omstpWm76TTSKsb04iChU0EW1Vl+OA3QXxfZAX0=";
   };
 

--- a/pkgs/development/python-modules/johnnycanencrypt/default.nix
+++ b/pkgs/development/python-modules/johnnycanencrypt/default.nix
@@ -29,8 +29,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-V1z16GKaSQVjp+stWir7kAO2wsnOYPdhKi4KzIKmKx8=";
   };
 

--- a/pkgs/development/python-modules/jsonschema-rs/default.nix
+++ b/pkgs/development/python-modules/jsonschema-rs/default.nix
@@ -25,8 +25,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-LNT2wQnOaVMBrI+fW6wbIRaTYPvw3ESinI5KY8wjp1o=";
   };
 

--- a/pkgs/development/python-modules/kurbopy/default.nix
+++ b/pkgs/development/python-modules/kurbopy/default.nix
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-51qJAcJvolYCW3XWeymc2xd2QHiKLd7MdRdDedEH8QY=";
   };
 

--- a/pkgs/development/python-modules/lzallright/default.nix
+++ b/pkgs/development/python-modules/lzallright/default.nix
@@ -20,8 +20,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-2AR9slC/vWv5Ump1DLE2em8LLSTXHVkI/PBW5PxCXXg=";
   };
 

--- a/pkgs/development/python-modules/minify-html/default.nix
+++ b/pkgs/development/python-modules/minify-html/default.nix
@@ -19,8 +19,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-NLPei6ajR55mLyFhsjzUpXB/TsqqeDvP8yKE74t0ufk=";
   };
 

--- a/pkgs/development/python-modules/nh3/default.nix
+++ b/pkgs/development/python-modules/nh3/default.nix
@@ -23,8 +23,7 @@ buildPythonPackage {
   disabled = pythonOlder "3.8";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-1Ytca/GiHidR8JOcz+DydN6N/iguLchbP8Wnrd/0NTk=";
   };
 

--- a/pkgs/development/python-modules/nutils-poly/default.nix
+++ b/pkgs/development/python-modules/nutils-poly/default.nix
@@ -25,8 +25,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    name = "${pname}-${version}";
-    inherit src;
+    inherit pname version src;
     hash = "sha256-3UBQJfMPVo37V7mJnN9loF1+vKh3JxFJWgynwsOnAg4=";
   };
 

--- a/pkgs/development/python-modules/nutpie/default.nix
+++ b/pkgs/development/python-modules/nutpie/default.nix
@@ -42,8 +42,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-ZUBrZqdesy0qKaxuD5gSlq7qOoXWn0aZNOidUb0grMM=";
   };
 

--- a/pkgs/development/python-modules/pcodec/default.nix
+++ b/pkgs/development/python-modules/pcodec/default.nix
@@ -21,8 +21,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-91p0eoVRzc9S8pHRhAlRey4k4jW9IMttiH+9Joh91IQ=";
   };
 

--- a/pkgs/development/python-modules/primp/default.nix
+++ b/pkgs/development/python-modules/primp/default.nix
@@ -72,8 +72,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-iPf25DMGNHrWYByNTylB6bPpLfzs0ADwgkjfhVxiiXA=";
   };
 

--- a/pkgs/development/python-modules/py-sr25519-bindings/default.nix
+++ b/pkgs/development/python-modules/py-sr25519-bindings/default.nix
@@ -22,8 +22,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-OSnPGRZwuAzcvu80GgTXdc740SfhDIsXrQZq9a/BCdE=";
   };
 

--- a/pkgs/development/python-modules/pycddl/default.nix
+++ b/pkgs/development/python-modules/pycddl/default.nix
@@ -40,8 +40,7 @@ buildPythonPackage rec {
   '';
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-Qep5YD4LQ+r118L5H+hUqeS00SibyvsbtLWDrJJBNc0=";
   };
 

--- a/pkgs/development/python-modules/pyperscan/default.nix
+++ b/pkgs/development/python-modules/pyperscan/default.nix
@@ -22,8 +22,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-9kKHLYD0tXMGJFhsCBgO/NpWB4J5QZh0qKIuI3PFn2c=";
   };
 

--- a/pkgs/development/python-modules/pysequoia/default.nix
+++ b/pkgs/development/python-modules/pysequoia/default.nix
@@ -17,8 +17,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-cq55j3wNcV8CRbnqZPV8zrRzvUud5RXJDX1oh7WZoiU=";
   };
 

--- a/pkgs/development/python-modules/python-bidi/default.nix
+++ b/pkgs/development/python-modules/python-bidi/default.nix
@@ -20,8 +20,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-Oqtva9cTHAcuOXr/uPbqZczDbPVr0zeIEr5p6PoJ610=";
   };
 

--- a/pkgs/development/python-modules/regress/default.nix
+++ b/pkgs/development/python-modules/regress/default.nix
@@ -26,8 +26,7 @@ buildPythonPackage rec {
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-B652Bfanw51e+U6rHukWtfdr7bjoWDUx/nUczDwyzZk=";
   };
 

--- a/pkgs/development/python-modules/rtoml/default.nix
+++ b/pkgs/development/python-modules/rtoml/default.nix
@@ -25,8 +25,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-/elui0Rf3XwvD2jX+NGoJgf9S3XSp16qzdwkGZbKaZg=";
   };
 

--- a/pkgs/development/python-modules/skytemple-rust/default.nix
+++ b/pkgs/development/python-modules/skytemple-rust/default.nix
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-9OgUuuMuo2l4YsZMhBZJBqKqbNwj1W4yidoogjcNgm8=";
   };
 

--- a/pkgs/development/python-modules/sourmash/default.nix
+++ b/pkgs/development/python-modules/sourmash/default.nix
@@ -31,8 +31,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-DnJ0RFc03+rBg7yNdezgb/YuoQr3RKj+NeMyin/kSRk=";
   };
 

--- a/pkgs/development/python-modules/spacy-alignments/default.nix
+++ b/pkgs/development/python-modules/spacy-alignments/default.nix
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-0U1ELUMh4YV6M+zrrZGuzvY8SdgyN66F7bJ6sMhOdXs=";
   };
 

--- a/pkgs/development/python-modules/tiktoken/default.nix
+++ b/pkgs/development/python-modules/tiktoken/default.nix
@@ -42,8 +42,12 @@ buildPythonPackage {
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src postPatch;
-    name = "${pname}-${version}";
+    inherit
+      pname
+      version
+      src
+      postPatch
+      ;
     hash = "sha256-MfTTRbSM+KgrYrWHYlJkGDc1qn3oulalDJM+huTaJ0g=";
   };
 

--- a/pkgs/development/python-modules/tree-sitter-make/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-make/default.nix
@@ -21,8 +21,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-75jtur5rmG4zpNXSE3OpPVR+/lf4SICsh+kgzIKfbd4=";
   };
 

--- a/pkgs/development/python-modules/typst/default.nix
+++ b/pkgs/development/python-modules/typst/default.nix
@@ -26,8 +26,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-bcO+irLT4Sy8IZ/YQZFD2jVjZAUCO0j+TitigHo4xbM=";
   };
 

--- a/pkgs/development/python-modules/wasmer/default.nix
+++ b/pkgs/development/python-modules/wasmer/default.nix
@@ -38,8 +38,7 @@ let
       };
 
       cargoDeps = rustPlatform.fetchCargoVendor {
-        inherit src;
-        name = "${pname}-${version}";
+        inherit pname version src;
         hash = cargoHash;
       };
 

--- a/pkgs/development/python-modules/y-py/default.nix
+++ b/pkgs/development/python-modules/y-py/default.nix
@@ -22,8 +22,7 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit pname version src;
     hash = "sha256-Wh25tLOVhAYFLqjOrKSu4klB1hGSOMconC1xZG31Dbw=";
   };
 

--- a/pkgs/development/python-modules/zxcvbn-rs-py/default.nix
+++ b/pkgs/development/python-modules/zxcvbn-rs-py/default.nix
@@ -27,8 +27,7 @@ buildPythonPackage rec {
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    name = "${pname}-${version}";
-    inherit src;
+    inherit pname version src;
     hash = "sha256-WkaTEoVQVOwxcTyOIG5oHEvcv65fBEpokl3/6SxqiUw=";
   };
 

--- a/pkgs/kde/gear/akonadi-search/default.nix
+++ b/pkgs/kde/gear/akonadi-search/default.nix
@@ -14,8 +14,7 @@ mkKdeDerivation rec {
   cargoRoot = "agent/rs/htmlparser";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    # include version in the name so we invalidate the FOD
-    name = "${pname}-${version}";
+    inherit pname version;
     src = sources.${pname};
     sourceRoot = "${pname}-${version}/${cargoRoot}";
     hash = "sha256-hdm4LfQcs4TTfBLzlZYJ0uzqfLxMXuYQExLGJg81W2U=";

--- a/pkgs/kde/gear/angelfish/default.nix
+++ b/pkgs/kde/gear/angelfish/default.nix
@@ -14,8 +14,7 @@ mkKdeDerivation rec {
   inherit (sources.${pname}) version;
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    # include version in the name so we invalidate the FOD
-    name = "${pname}-${version}";
+    inherit pname version;
     src = sources.${pname};
     hash = "sha256-FgzmWw8FZb+DNSf2n6H14Rq07+x1LzG9hX4hFetuqDw=";
   };

--- a/pkgs/kde/gear/kdepim-addons/default.nix
+++ b/pkgs/kde/gear/kdepim-addons/default.nix
@@ -17,8 +17,7 @@ mkKdeDerivation rec {
   cargoRoot = "plugins/webengineurlinterceptor/adblock";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    # include version in the name so we invalidate the FOD
-    name = "${pname}-${version}";
+    inherit pname version;
     src = sources.${pname};
     sourceRoot = "${pname}-${version}/${cargoRoot}";
     hash = "sha256-66FqoD3JoPbtg6zc32uaPYaTo4zHxywiN8wPI2jtcjc=";


### PR DESCRIPTION
candidate for https://github.com/NixOS/nixpkgs/issues/346453, but may not need repeating.

Should be zero rebuilds. Made with:

```shell
#!/usr/bin/env nix-shell
#!nix-shell -I nixpkgs=. --pure -i bash -p ripgrep sd jq git git-wait lix util-linux diffutils delta

export NIX_PATH= # no nixpkgs-overlays plz
export NIXPKGS_CONFIG= # no surprises plz

export NIXPKGS_ALLOW_UNFREE=1
export NIXPKGS_ALLOW_INSECURE=1
export NIXPKGS_ALLOW_BROKEN=1

git-wait restore .

mk_packages_json() (
  set -x
  time nix-env  \
    --extra-experimental-features no-url-literals  \
    --option system x86_64-linux  \
    -f ./.  \
    -qaP  \
    --json \
    --meta \
    --drv-path \
    --out-path \
    --show-trace \
    --no-allow-import-from-derivation  \
    --arg config '{ allowAliases = false; }'
)

test -s packages.json || {
   mk_packages_json > packages.json
}

list_attrpath_fname_column() {
    jq <packages.json 'to_entries[] | select(.value.meta.position==null|not) | "\(.key)\t\(.value.meta.position)"' -r |
        sed -e "s#\t$(realpath .)/#\t#" |
        sed -e 's#:\([0-9]*\)$#\t\1#' |
        grep . |
        grep -iv haskell |
        grep -iv /top-level/ |
        grep -iv chicken |
        grep -iv build |
        grep -E '/(package|default)\.nix'
}

eval_package_outputs() {
  local attrpath="$1"
  nix eval \
    --log-format raw \
    --impure \
    --json \
    --expr '
      with import ./. {};
      let
        fixup = attrs: lib.attrsets.mapAttrs'"'"' (k: v: lib.nameValuePair (if k != "outPath" then k else "outPath_") v) attrs;
      in
        lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) (fixup {
          inherit ('"${attrpath}"') pname version drvPath outPath passthru meta;
          src = fixup { inherit ('"${attrpath}"'.src) name drvPath outPath; };
          cargoDeps = fixup { inherit ('"${attrpath}"'.cargoDeps) name drvPath outPath; };
        })
      ' |
    sd '.nix:[0-9]+"' '.nix:XX"' |
    sd '"line":[0-9]+,' '"line":"XX",' |
    sd '"line":[0-9]+}' '"line":"XX"}'
}

while read attrpath fname column; do
    grep -qF 'name = "${pname}-${version}";' "$fname" || continue
    grep -qF 'cargoDeps = '                  "$fname" || continue

    echo | (
        echo "$attrpath"

        pkgdata="$(eval_package_outputs "$attrpath")" || exit
        test -n "$pkgdata" || exit

        (set -x
            sd -F 'name = "${pname}-${version}";' 'inherit pname version;' "$fname"
            sd 'inherit src;'$'\n'' *inherit pname version;' 'inherit pname version src;' "$fname"
            sd 'inherit pname version;'$'\n'' *inherit src;' 'inherit pname version src;' "$fname"
        )

        pkgdata2="$(eval_package_outputs "$attrpath")"
        if [[ "$pkgdata" = "$pkgdata2" ]]; then
            (set -x; git-wait add "$fname")
        else
            diff -u <(cat <<<"$pkgdata") <(cat <<<"$pkgdata2") | delta
            (set -x; git-wait restore "$fname")
        fi

    )

done < <( list_attrpath_fname_column )

git restore .

mk_packages_json > packages2.json
```

With manual modifications to join the remaining `inherit` statements that the script could not.

The script checks that the `drvPath` of `cargoDeps` is unchanged (FODs only lock `outPath`), which ensures that this code change makes no difference to the cargo crate fetchers.

I compared packages.json and packages2.json to ensure there are no eval errors introduced.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
