### PR TITLE
rust: 1.86.0 -> 1.87.0

### DIFF
--- a/pkgs/development/compilers/rust/1_87.nix
+++ b/pkgs/development/compilers/rust/1_87.nix
@@ -45,18 +45,8 @@ let
 in
 import ./default.nix
   {
-    rustcVersion = "1.86.0";
-    rustcSha256 = "sha256-AionKG32eQCgRNIn2dtp1HMuw9gz5P/CWcRCXtce7YA=";
-
-    rustcPatches = [
-      # Fix for including no_std targets by default, shipping in Rust 1.87
-      # https://github.com/rust-lang/rust/pull/137073
-      (fetchpatch {
-        name = "bootstrap-skip-nostd-docs";
-        url = "https://github.com/rust-lang/rust/commit/97962d7643300b91c102496ba3ab6d9279d2c536.patch";
-        hash = "sha256-DKl9PWqJP3mX4B1pFeRLQ8/sO6mx1JhbmVLTOOMLZI4=";
-      })
-    ];
+    rustcVersion = "1.87.0";
+    rustcSha256 = "sha256-FJu5/Sm+WS2k6HkA/GjwYpo3v2hQtGM53URDTAT9jnY=";
 
     llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
     llvmSharedForHost = llvmSharedFor pkgsBuildHost;
@@ -114,28 +104,28 @@ import ./default.nix
     # Note: the version MUST be the same version that we are building. Upstream
     # ensures that each released compiler can compile itself:
     # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
-    bootstrapVersion = "1.86.0";
+    bootstrapVersion = "1.87.0";
 
     # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
     bootstrapHashes = {
-      i686-unknown-linux-gnu = "6d39b7599f872fe330e64800ca2ebfd58624d78e135c491226f44f5ff68b900d";
-      x86_64-unknown-linux-gnu = "f6a8c0d8b8a8a737c40eee78abe286a3cbe984d96b63de9ae83443360e3264bf";
-      x86_64-unknown-linux-musl = "2d399a43e1e4a2dea0e16f83cd0a1dd53f7f32250ba25970ea5d9c31a16df611";
-      arm-unknown-linux-gnueabihf = "d7af8bdf97c76b2c2df50486597dd0ad8af36b9213549f3e0d15384d36bc0a37";
-      armv7-unknown-linux-gnueabihf = "fbddb4d24d701362c65201dc0905f7445eb9dfa3a5d767ff29a5d3f676957253";
-      aarch64-unknown-linux-gnu = "460058cd78f06875721427a42a5ce6a8b8ef2c0c3225fccfae149d9345572ff4";
-      aarch64-unknown-linux-musl = "fcfc61f571b25c13f89545f0ab2fe1950751d8d50bcdc2d40c136e0df533d5a4";
-      x86_64-apple-darwin = "bf8121850b2f6a46566f6c2bbe9fa889b915b1039febf36853ea9d9c4256c67d";
-      aarch64-apple-darwin = "01271f83549c3b5191334a566289aa41615ea8f8f530f49548733585f21c7e5a";
-      powerpc64le-unknown-linux-gnu = "9b104428e2b0377dbdb9dc094eb4d9f4893ada0b80d2b315f0c4ea2135ed9007";
-      riscv64gc-unknown-linux-gnu = "b74cd0bf5ddeb759cd75fb4d7f3f90972dbab6e77569484491ab7ecf073558a8";
-      s390x-unknown-linux-gnu = "721121bcb8f96b98942289f627f9054ded92215c391d48f459527d4b0c63114f";
-      loongarch64-unknown-linux-gnu = "0e7827b14c77ce3ede5ba414de9806b52c655940f95fddd3e07873b8fe46c8bf";
-      loongarch64-unknown-linux-musl = "d769fb639a9116c77d5b35cb0abe4fd3bc85b6d578fe7e4440c218530e32e1cf";
-      x86_64-unknown-freebsd = "fc424d582cd45df010f3b3ff76768f6c87942002421f8896daf7e3989a8f72b4";
+      i686-unknown-linux-gnu = "53138ed9a47d520e4734fb73224925e84c8a90d391db388dcfc03a1b38dac530";
+      x86_64-unknown-linux-gnu = "1f6f18ce19387c42968a474cf175e67f99280614ded9c752d5d2e37af3204bcd";
+      x86_64-unknown-linux-musl = "ab3951f30b08104de8b578df4776645a81939d7d918000ce231a35389ae59df8";
+      arm-unknown-linux-gnueabihf = "9e62054e809534c1b2f62036d8331423a113ab3b8265bca08a715f339dec89c5";
+      armv7-unknown-linux-gnueabihf = "9c9133e8a88dede2036d240ed3b792b93a1bbf444b6b2b6998df58b0c7bcdd83";
+      aarch64-unknown-linux-gnu = "2c66e31d774a0dcd4422db74584ebc6362ff3ae90c452caff9d2fb912c821e8d";
+      aarch64-unknown-linux-musl = "6f301f0ee7d3be2fdd245432c01543a4c61413b5d0a62493e5b0d57d9756b0b6";
+      x86_64-apple-darwin = "867a84a93c6ba0b468b78b52004a6307d6f5e2e5598e64f65726c6810b6f7c82";
+      aarch64-apple-darwin = "249496972e6f845f052036b9d7e73f816418412de2b266ec717b9050c1810dc3";
+      powerpc64le-unknown-linux-gnu = "3f8f68d79460475396a52b5ae70eee73d6fb194fff1c4ff4286b64fbebee4429";
+      riscv64gc-unknown-linux-gnu = "ea25b048bad7737188345392d1a0dfa92aa3ed6c00834b0974bdba52cb2398c4";
+      s390x-unknown-linux-gnu = "198d3bda0daef12f86b8171025c62fee0a3caa59fa82c22c364d1a69305d8f46";
+      loongarch64-unknown-linux-gnu = "61eee03a25a51a74b057d661c3be6c4052e781adcb118b555cb41e0b108cabf4";
+      loongarch64-unknown-linux-musl = "b002ed82c1b7ccec039d18c5ee131e953a350c535b710d56ae204935810eb11e";
+      x86_64-unknown-freebsd = "b675d11e521e50a45506001479e77a65b9d89cf4caf588381264a511a3c1c49a";
     };
 
-    selectRustPackage = pkgs: pkgs.rust_1_86;
+    selectRustPackage = pkgs: pkgs.rust_1_87;
   }
 
   (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6015,10 +6015,10 @@ with pkgs;
   wrapRustcWith = { rustc-unwrapped, ... }@args: callPackage ../build-support/rust/rustc-wrapper args;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
-  rust_1_86 = callPackage ../development/compilers/rust/1_86.nix {
+  rust_1_87 = callPackage ../development/compilers/rust/1_87.nix {
     llvm_19 = llvmPackages_19.libllvm;
   };
-  rust = rust_1_86;
+  rust = rust_1_87;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
@@ -6026,8 +6026,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
-  rustPackages_1_86 = rust_1_86.packages.stable;
-  rustPackages = rustPackages_1_86;
+  rustPackages_1_87 = rust_1_87.packages.stable;
+  rustPackages = rustPackages_1_87;
 
   inherit (rustPackages)
     cargo


### PR DESCRIPTION
This PR updates Rust from 1.86.0 to 1.87.0.

Rust 1.87.0 release notes: https://doc.rust-lang.org/stable/releases.html#version-1870-2025-05-15

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
