### PR TITLE
coreutils: fix CVE-2025-5278

### DIFF
--- a/pkgs/tools/misc/coreutils/CVE-2025-5278.patch
+++ b/pkgs/tools/misc/coreutils/CVE-2025-5278.patch
@@ -19,6 +19,8 @@ Fixes https://bugs.gnu.org/78507
  4 files changed, 51 insertions(+), 2 deletions(-)
  create mode 100755 tests/sort/sort-field-limit.sh
 
+The new tests is NOT added in NixOS.
+
 diff --git a/NEWS b/NEWS
 index 6ff403206..923aa72f8 100644
 --- a/NEWS
@@ -65,59 +67,3 @@ index b10183b6f..7af1a2512 100644
      }
  
    return ptr;
-diff --git a/tests/local.mk b/tests/local.mk
-index 4da6756ac..642d225fa 100644
---- a/tests/local.mk
-+++ b/tests/local.mk
-@@ -388,6 +388,7 @@ all_tests =					\
-   tests/sort/sort-debug-keys.sh			\
-   tests/sort/sort-debug-warn.sh			\
-   tests/sort/sort-discrim.sh			\
-+  tests/sort/sort-field-limit.sh		\
-   tests/sort/sort-files0-from.pl		\
-   tests/sort/sort-float.sh			\
-   tests/sort/sort-h-thousands-sep.sh		\
-diff --git a/tests/sort/sort-field-limit.sh b/tests/sort/sort-field-limit.sh
-new file mode 100755
-index 000000000..52d8e1d17
---- /dev/null
-+++ b/tests/sort/sort-field-limit.sh
-@@ -0,0 +1,35 @@
-+#!/bin/sh
-+# From 7.2-9.7, this would trigger an out of bounds mem read
-+
-+# Copyright (C) 2025 Free Software Foundation, Inc.
-+
-+# This program is free software: you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation, either version 3 of the License, or
-+# (at your option) any later version.
-+
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-+
-+. "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
-+print_ver_ sort
-+getlimits_
-+
-+# This issue triggers with valgrind or ASAN
-+valgrind --error-exitcode=1 sort --version 2>/dev/null &&
-+  VALGRIND='valgrind --error-exitcode=1'
-+
-+{ printf '%s\n' aa bb; } > in || framework_failure_
-+
-+_POSIX2_VERSION=200809 $VALGRIND sort +0.${SIZE_MAX}R in > out || fail=1
-+compare in out || fail=1
-+
-+_POSIX2_VERSION=200809 $VALGRIND sort +1 -1.${SIZE_MAX}R in > out || fail=1
-+compare in out || fail=1
-+
-+Exit $fail
--- 
-cgit v1.2.3
-

--- a/pkgs/tools/misc/coreutils/CVE-2025-5278.patch
+++ b/pkgs/tools/misc/coreutils/CVE-2025-5278.patch
@@ -1,0 +1,123 @@
+From 8c9602e3a145e9596dc1a63c6ed67865814b6633 Mon Sep 17 00:00:00 2001
+From: Pádraig Brady <P@draigBrady.com>
+Date: Tue, 20 May 2025 16:03:44 +0100
+Subject: sort: fix buffer under-read (CWE-127)
+
+* src/sort.c (begfield): Check pointer adjustment
+to avoid Out-of-range pointer offset (CWE-823).
+(limfield): Likewise.
+* tests/sort/sort-field-limit.sh: Add a new test,
+which triggers with ASAN or Valgrind.
+* tests/local.mk: Reference the new test.
+* NEWS: Mention bug fix introduced in v7.2 (2009).
+Fixes https://bugs.gnu.org/78507
+---
+ NEWS                           |  5 +++++
+ src/sort.c                     | 12 ++++++++++--
+ tests/local.mk                 |  1 +
+ tests/sort/sort-field-limit.sh | 35 +++++++++++++++++++++++++++++++++++
+ 4 files changed, 51 insertions(+), 2 deletions(-)
+ create mode 100755 tests/sort/sort-field-limit.sh
+
+diff --git a/NEWS b/NEWS
+index 6ff403206..923aa72f8 100644
+--- a/NEWS
++++ b/NEWS
+@@ -8,6 +8,11 @@ GNU coreutils NEWS                                    -*- outline -*-
+   copying to non-NFS files from NFSv4 files with trivial ACLs.
+   [bug introduced in coreutils-9.6]
+ 
++  sort with key character offsets of SIZE_MAX, could induce
++  a read of 1 byte before an allocated heap buffer. For example:
++  'sort +0.18446744073709551615R input' on 64 bit systems.
++  [bug introduced in coreutils-7.2]
++
+ 
+ * Noteworthy changes in release 9.7 (2025-04-09) [stable]
+ 
+diff --git a/src/sort.c b/src/sort.c
+index b10183b6f..7af1a2512 100644
+--- a/src/sort.c
++++ b/src/sort.c
+@@ -1644,7 +1644,11 @@ begfield (struct line const *line, struct keyfield const *key)
+       ++ptr;
+ 
+   /* Advance PTR by SCHAR (if possible), but no further than LIM.  */
+-  ptr = MIN (lim, ptr + schar);
++  size_t remaining_bytes = lim - ptr;
++  if (schar < remaining_bytes)
++    ptr += schar;
++  else
++    ptr = lim;
+ 
+   return ptr;
+ }
+@@ -1746,7 +1750,11 @@ limfield (struct line const *line, struct keyfield const *key)
+           ++ptr;
+ 
+       /* Advance PTR by ECHAR (if possible), but no further than LIM.  */
+-      ptr = MIN (lim, ptr + echar);
++      size_t remaining_bytes = lim - ptr;
++      if (echar < remaining_bytes)
++        ptr += echar;
++      else
++        ptr = lim;
+     }
+ 
+   return ptr;
+diff --git a/tests/local.mk b/tests/local.mk
+index 4da6756ac..642d225fa 100644
+--- a/tests/local.mk
++++ b/tests/local.mk
+@@ -388,6 +388,7 @@ all_tests =					\
+   tests/sort/sort-debug-keys.sh			\
+   tests/sort/sort-debug-warn.sh			\
+   tests/sort/sort-discrim.sh			\
++  tests/sort/sort-field-limit.sh		\
+   tests/sort/sort-files0-from.pl		\
+   tests/sort/sort-float.sh			\
+   tests/sort/sort-h-thousands-sep.sh		\
+diff --git a/tests/sort/sort-field-limit.sh b/tests/sort/sort-field-limit.sh
+new file mode 100755
+index 000000000..52d8e1d17
+--- /dev/null
++++ b/tests/sort/sort-field-limit.sh
+@@ -0,0 +1,35 @@
++#!/bin/sh
++# From 7.2-9.7, this would trigger an out of bounds mem read
++
++# Copyright (C) 2025 Free Software Foundation, Inc.
++
++# This program is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <https://www.gnu.org/licenses/>.
++
++. "${srcdir=.}/tests/init.sh"; path_prepend_ ./src
++print_ver_ sort
++getlimits_
++
++# This issue triggers with valgrind or ASAN
++valgrind --error-exitcode=1 sort --version 2>/dev/null &&
++  VALGRIND='valgrind --error-exitcode=1'
++
++{ printf '%s\n' aa bb; } > in || framework_failure_
++
++_POSIX2_VERSION=200809 $VALGRIND sort +0.${SIZE_MAX}R in > out || fail=1
++compare in out || fail=1
++
++_POSIX2_VERSION=200809 $VALGRIND sort +1 -1.${SIZE_MAX}R in > out || fail=1
++compare in out || fail=1
++
++Exit $fail
+-- 
+cgit v1.2.3
+

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchurl,
+  autoconf,
+  automake,
   autoreconfHook,
   buildPackages,
   libiconv,
@@ -54,6 +56,12 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/coreutils/coreutils-${version}.tar.xz";
     hash = "sha256-6LsmrQKT+bWh/EP7QrqXDjEsZs6SwbCxZxPXUA2yUb8=";
   };
+
+  patches = [
+    # Heap buffer overflow that's been here since coreutils 7.2 in 2009:
+    # https://www.openwall.com/lists/oss-security/2025/05/27/2
+    ./CVE-2025-5278.patch
+  ];
 
   postPatch =
     ''
@@ -124,6 +132,8 @@ stdenv.mkDerivation rec {
     [
       perl
       xz.bin
+      autoconf
+      automake
     ]
     ++ optionals stdenv.hostPlatform.isCygwin [
       # due to patch

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -2,8 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  autoconf,
-  automake,
   autoreconfHook,
   buildPackages,
   libiconv,
@@ -132,8 +130,6 @@ stdenv.mkDerivation rec {
     [
       perl
       xz.bin
-      autoconf
-      automake
     ]
     ++ optionals stdenv.hostPlatform.isCygwin [
       # due to patch


### PR DESCRIPTION
This is a heap buffer overflow in `sort` that's been here since coreutils 7.2 in 2009:

https://www.openwall.com/lists/oss-security/2025/05/27/2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
