### PR TITLE
nixos/taler: update modules; fix tests

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -28,6 +28,10 @@
   - Applications linked against different Mesa versions than installed on the system should now work correctly going forward (however, applications against older Mesa, e.g. from Nixpkgs releases before 25.05, remain broken)
   - Packages that used to depend on Mesa for libgbm or libdri should use `libgbm` or `dri-pkgconfig-stub` as inputs, respectively
 
+- GNU Taler has been updated to version 1.0.
+  This marks a significant milestone as the GNU Taler payment system is now available in Swiss Francs for individuals and businesses in Switzerland.
+  For more details, see the [upstream release notes](https://www.taler.net/en/news/2025-01.html).
+
 - OpenSSH has been updated from 9.9p2 to 10.0p2, dropping support for DSA keys and adding a new `ssh-auth` binary to handle user authentication in a different address space from unauthenticated sessions. See the [full changelog](https://www.openwall.com/lists/oss-security/2025/04/09/1) for more details.
 
 - Emacs has been updated to 30.1.

--- a/nixos/modules/services/finance/libeufin/common.nix
+++ b/nixos/modules/services/finance/libeufin/common.nix
@@ -35,6 +35,7 @@ libeufinComponent:
           cfg.settings."libeufin-${libeufinComponent}db-postgres".CONFIG;
 
       bankPort = cfg.settings."${if isNexus then "nexus-httpd" else "libeufin-bank"}".PORT;
+      bankHost = lib.elemAt (lib.splitString "/" cfg.settings.libeufin-bank.BASE_URL) 2;
     in
     lib.mkIf cfg.enable {
       services.libeufin.settings = cfg.settings;
@@ -82,7 +83,7 @@ libeufinComponent:
                 args = lib.cli.toGNUCommandLineShell { } {
                   c = configFile;
                   inherit (account) username password name;
-                  payto_uri = "payto://x-taler-bank/bank:${toString bankPort}/${account.username}?receiver-name=${account.name}";
+                  payto_uri = "payto://x-taler-bank/${bankHost}/${account.username}?receiver-name=${account.name}";
                   exchange = lib.toLower account.username == "exchange";
                 };
               in

--- a/nixos/modules/services/finance/taler/common.nix
+++ b/nixos/modules/services/finance/taler/common.nix
@@ -51,7 +51,7 @@ in
       (lib.genAttrs (map (n: "taler-${talerComponent}-${n}") services) (name: {
         serviceConfig = {
           DynamicUser = true;
-          User = name;
+          User = dbName;
           Group = groupName;
           ExecStart = toString [
             (lib.getExe' cfg.package name)
@@ -85,6 +85,7 @@ in
             Type = "oneshot";
             DynamicUser = true;
             User = dbName;
+            Group = groupName;
             Restart = "on-failure";
             RestartSec = "5s";
           };
@@ -116,7 +117,7 @@ in
     services.postgresql = {
       enable = true;
       ensureDatabases = [ dbName ];
-      ensureUsers = map (service: { name = "taler-${talerComponent}-${service}"; }) servicesDB ++ [
+      ensureUsers = [
         {
           name = dbName;
           ensureDBOwnership = true;

--- a/nixos/modules/services/finance/taler/exchange.nix
+++ b/nixos/modules/services/finance/taler/exchange.nix
@@ -25,6 +25,8 @@ let
     "secmod-eddsa"
     "secmod-rsa"
   ];
+
+  configFile = config.environment.etc."taler/taler.conf".source;
 in
 
 {
@@ -140,14 +142,14 @@ in
           lib.pipe servicesDB [
             (map (name: ''
               GRANT SELECT,INSERT,UPDATE${deletePerm name} ON ALL TABLES IN SCHEMA exchange TO "taler-exchange-${name}";
-              GRANT USAGE ON SCHEMA exchange TO "taler-exchange-${name}";
+              GRANT USAGE ON ALL SEQUENCES IN SCHEMA exchange TO "taler-exchange-${name}";
             ''))
             lib.concatStrings
           ]
         );
       in
       ''
-        ${lib.getExe' cfg.package "taler-exchange-dbinit"}
+        ${lib.getExe' cfg.package "taler-exchange-dbinit"} -c ${configFile}
         psql -U taler-exchange-httpd -f ${dbScript}
       '';
   };

--- a/nixos/modules/services/finance/taler/exchange.nix
+++ b/nixos/modules/services/finance/taler/exchange.nix
@@ -46,11 +46,19 @@ in
         options = {
           # TODO: do we want this to be a sub-attribute or only define the exchange set of options here
           exchange = {
-            AML_THRESHOLD = lib.mkOption {
+            CURRENCY = lib.mkOption {
+              type = lib.types.nonEmptyStr;
+              description = ''
+                The currency which the exchange will operate with. This cannot be changed later.
+              '';
+            };
+            CURRENCY_ROUND_UNIT = lib.mkOption {
               type = lib.types.str;
-              default = "${cfgTaler.settings.taler.CURRENCY}:1000000";
-              defaultText = "1000000 in {option}`CURRENCY`";
-              description = "Monthly transaction volume until an account is considered suspicious and flagged for AML review.";
+              default = "${cfg.settings.exchange.CURRENCY}:0.01";
+              defaultText = "0.01 in {option}`CURRENCY`";
+              description = ''
+                Smallest amount in this currency that can be transferred using the underlying RTGS. For example: "EUR:0.01" or "JPY:1"
+              '';
             };
             DB = lib.mkOption {
               type = lib.types.enum [ "postgres" ];

--- a/nixos/modules/services/finance/taler/exchange.nix
+++ b/nixos/modules/services/finance/taler/exchange.nix
@@ -133,24 +133,8 @@ in
       after = [ "taler-exchange-httpd.service" ];
     };
 
-    # Taken from https://docs.taler.net/taler-exchange-manual.html#exchange-database-setup
-    # TODO: Why does aggregator need DELETE?
-    systemd.services."taler-${talerComponent}-dbinit".script =
-      let
-        deletePerm = name: lib.optionalString (name == "aggregator") ",DELETE";
-        dbScript = pkgs.writers.writeText "taler-exchange-db-permissions.sql" (
-          lib.pipe servicesDB [
-            (map (name: ''
-              GRANT SELECT,INSERT,UPDATE${deletePerm name} ON ALL TABLES IN SCHEMA exchange TO "taler-exchange-${name}";
-              GRANT USAGE ON ALL SEQUENCES IN SCHEMA exchange TO "taler-exchange-${name}";
-            ''))
-            lib.concatStrings
-          ]
-        );
-      in
-      ''
-        ${lib.getExe' cfg.package "taler-exchange-dbinit"} -c ${configFile}
-        psql -U taler-exchange-httpd -f ${dbScript}
-      '';
+    systemd.services."taler-${talerComponent}-dbinit".script = ''
+      ${lib.getExe' cfg.package "taler-exchange-dbinit"} -c ${configFile}
+    '';
   };
 }

--- a/nixos/modules/services/finance/taler/merchant.nix
+++ b/nixos/modules/services/finance/taler/merchant.nix
@@ -17,7 +17,7 @@ let
     "webhook"
     "wirewatch"
     "depositcheck"
-    "exchange"
+    "exchangekeyupdate"
   ];
 
   configFile = config.environment.etc."taler/taler.conf".source;

--- a/nixos/modules/services/finance/taler/merchant.nix
+++ b/nixos/modules/services/finance/taler/merchant.nix
@@ -90,21 +90,8 @@ in
       path = [ cfg.package ];
     };
 
-    systemd.services."taler-${talerComponent}-dbinit".script =
-      let
-        # NOTE: not documented, but is necessary
-        dbScript = pkgs.writers.writeText "taler-merchant-db-permissions.sql" (
-          lib.concatStrings (
-            map (name: ''
-              GRANT SELECT,INSERT,UPDATE,DELETE ON ALL TABLES IN SCHEMA merchant TO "taler-merchant-${name}";
-              GRANT USAGE ON ALL SEQUENCES IN SCHEMA merchant TO "taler-merchant-${name}";
-            '') servicesDB
-          )
-        );
-      in
-      ''
-        ${lib.getExe' cfg.package "taler-merchant-dbinit"} -c ${configFile}
-        psql -U taler-${talerComponent}-httpd -f ${dbScript}
-      '';
+    systemd.services."taler-${talerComponent}-dbinit".script = ''
+      ${lib.getExe' cfg.package "taler-merchant-dbinit"} -c ${configFile}
+    '';
   };
 }

--- a/nixos/modules/services/finance/taler/merchant.nix
+++ b/nixos/modules/services/finance/taler/merchant.nix
@@ -19,6 +19,8 @@ let
     "depositcheck"
     "exchange"
   ];
+
+  configFile = config.environment.etc."taler/taler.conf".source;
 in
 {
   imports = [
@@ -95,13 +97,13 @@ in
           lib.concatStrings (
             map (name: ''
               GRANT SELECT,INSERT,UPDATE,DELETE ON ALL TABLES IN SCHEMA merchant TO "taler-merchant-${name}";
-              GRANT USAGE ON SCHEMA merchant TO "taler-merchant-${name}";
+              GRANT USAGE ON ALL SEQUENCES IN SCHEMA merchant TO "taler-merchant-${name}";
             '') servicesDB
           )
         );
       in
       ''
-        ${lib.getExe' cfg.package "taler-merchant-dbinit"}
+        ${lib.getExe' cfg.package "taler-merchant-dbinit"} -c ${configFile}
         psql -U taler-${talerComponent}-httpd -f ${dbScript}
       '';
   };

--- a/nixos/tests/taler/common/nodes.nix
+++ b/nixos/tests/taler/common/nodes.nix
@@ -65,9 +65,12 @@ rec {
               enable = true;
               debug = true;
               openFirewall = true;
+              # https://docs.taler.net/taler-exchange-manual.html#coins-denomination-keys
+              # NOTE: use `taler-harness`, not `taler-wallet-cli`
               denominationConfig = lib.readFile ../conf/taler-denominations.conf;
               settings = {
                 exchange = {
+                  inherit CURRENCY;
                   MASTER_PUBLIC_KEY = "2TQSTPFZBC2MC4E52NHPA050YXYG02VC3AB50QESM6JX1QJEYVQ0";
                   BASE_URL = "http://exchange:8081/";
                 };

--- a/nixos/tests/taler/common/nodes.nix
+++ b/nixos/tests/taler/common/nodes.nix
@@ -55,7 +55,12 @@ rec {
             settings = {
               taler.CURRENCY = CURRENCY;
             };
-            includes = [ ../conf/taler-accounts.conf ];
+            includes = [
+              ../conf/taler-accounts.conf
+              # The exchange requires a token from the bank, so its credentials
+              # need to be set at runtime
+              "/etc/taler/secrets/exchange-account.secret.conf"
+            ];
             exchange = {
               enable = true;
               debug = true;

--- a/nixos/tests/taler/common/nodes.nix
+++ b/nixos/tests/taler/common/nodes.nix
@@ -103,7 +103,7 @@ rec {
                 # WIRE_TYPE = "iban";
                 X_TALER_BANK_PAYTO_HOSTNAME = "bank:8082";
                 # IBAN_PAYTO_BIC = "SANDBOXX";
-                BASE_URL = "bank:8082";
+                BASE_URL = "http://bank:8082/";
 
                 # Allow creating new accounts
                 ALLOW_REGISTRATION = "yes";

--- a/nixos/tests/taler/common/scripts.nix
+++ b/nixos/tests/taler/common/scripts.nix
@@ -7,7 +7,7 @@
 
 let
   cfgNodes = pkgs.callPackage ./nodes.nix { inherit lib; };
-  bankConfig = nodes.bank.config.environment.etc."libeufin/libeufin.conf".source;
+  bankConfig = nodes.bank.environment.etc."libeufin/libeufin.conf".source;
 
   inherit (cfgNodes) CURRENCY FIAT_CURRENCY;
 in

--- a/nixos/tests/taler/common/scripts.nix
+++ b/nixos/tests/taler/common/scripts.nix
@@ -83,6 +83,17 @@ in
           return json.loads(response)["access_token"]
 
 
+      # Basic auth is deprecated, so exchange credentials must be set at
+      # runtime because it requires a token from the bank.
+      def create_exchange_auth(token: str):
+          template = f"""
+          [exchange-accountcredentials-test]
+          WIRE_GATEWAY_URL = http://bank:8082/accounts/exchange/taler-wire-gateway/
+          WIRE_GATEWAY_AUTH_METHOD = BEARER
+          TOKEN = "{token}"
+          """
+          return "\n".join([line.strip() for line in template.splitlines()])
+
       def verify_balance(balanceWanted: str):
           """Compare Taler CLI wallet balance with expected amount"""
           balance = wallet_cli("balance --json")

--- a/nixos/tests/taler/conf/taler-accounts.conf
+++ b/nixos/tests/taler/conf/taler-accounts.conf
@@ -2,9 +2,3 @@
 PAYTO_URI = payto://x-taler-bank/bank:8082/exchange?receiver-name=Exchange
 ENABLE_DEBIT = YES
 ENABLE_CREDIT = YES
-
-[exchange-accountcredentials-test]
-WIRE_GATEWAY_URL = http://bank:8082/accounts/exchange/taler-wire-gateway/
-WIRE_GATEWAY_AUTH_METHOD = BASIC
-USERNAME = exchange
-PASSWORD = exchange

--- a/nixos/tests/taler/tests/basic.nix
+++ b/nixos/tests/taler/tests/basic.nix
@@ -35,13 +35,13 @@ import ../../make-test-python.nix (
         inherit (cfgNodes) CURRENCY FIAT_CURRENCY;
         inherit (cfgScripts) commonScripts;
 
-        bankConfig = nodes.bank.config.environment.etc."libeufin/libeufin.conf".source;
+        bankConfig = nodes.bank.environment.etc."libeufin/libeufin.conf".source;
         bankSettings = nodes.bank.services.libeufin.settings.libeufin-bank;
         nexusSettings = nodes.bank.services.libeufin.nexus.settings;
 
         # Bank admin account credentials
         AUSER = "admin";
-        APASS = "admin";
+        APASS = "testAdmin";
 
         TUSER = "testUser";
         TPASS = "testUser";

--- a/nixos/tests/taler/tests/basic.nix
+++ b/nixos/tests/taler/tests/basic.nix
@@ -139,7 +139,7 @@ import ../../make-test-python.nix (
                   "credit_facade_credentials":{"type":"basic","username":"merchant","password":"merchant"}
                 }'
                 """,
-                "-sSfL 'http://merchant:8083/private/accounts'"
+                "-sSfL 'http://merchant:8083/instances/default/private/accounts'"
             ])
             # Register a new product to be ordered
             succeed(merchant, [
@@ -155,7 +155,7 @@ import ../../make-test-python.nix (
                   "next_restock": { "t_s": "never" }
                 }'
                 """,
-                "-sSfL 'http://merchant:8083/private/products'"
+                "-sSfL 'http://merchant:8083/instances/default/private/products'"
             ])
 
 
@@ -214,7 +214,7 @@ import ../../make-test-python.nix (
                       "inventory_products": [{ "product_id": "1", "quantity": 1 }]
                     }'
                     """,
-                    "-sSfL 'http://merchant:8083/private/orders'"
+                    "-sSfL 'http://merchant:8083/instances/default/private/orders'"
                 ])
             )
             order_id = response["order_id"]
@@ -224,7 +224,7 @@ import ../../make-test-python.nix (
             response = json.loads(
                 succeed(merchant, [
                     "curl -sSfL",
-                    f"http://merchant:8083/private/orders/{order_id}"
+                    f"http://merchant:8083/instances/default/private/orders/{order_id}"
                 ])
             )
             wallet_cli("run-until-done")

--- a/nixos/tests/taler/tests/basic.nix
+++ b/nixos/tests/taler/tests/basic.nix
@@ -76,11 +76,17 @@ import ../../make-test-python.nix (
 
 
         exchange.start()
+
+        # exchange credentials must be set at runtime because it requires a token from the bank
+        exchange.succeed("mkdir -p /etc/taler/secrets/")
+        exchange.succeed("touch /etc/taler/secrets/exchange-account.secret.conf")
+
         exchange.wait_for_open_port(8081)
 
         # Create access token for exchange
         accessTokenExchange = create_token(exchange, "exchange", "exchange")
 
+        exchange.succeed(f'echo "{create_exchange_auth(accessTokenExchange)}" > /etc/taler/secrets/exchange-account.secret.conf')
 
         with subtest("Set up exchange"):
             exchange.wait_until_succeeds("taler-exchange-offline download sign upload")

--- a/nixos/tests/taler/tests/basic.nix
+++ b/nixos/tests/taler/tests/basic.nix
@@ -97,8 +97,8 @@ import ../../make-test-python.nix (
             exchange.succeed('taler-exchange-offline -c "${configFile}" upload < ${exchangeAccount}')
 
             # Set up wire fees, needed in order to deposit coins/pay merchant
-            exchange.succeed('taler-exchange-offline -c "${configFile}" wire-fee now x-taler-bank "${CURRENCY}:0" "${CURRENCY}:0" upload')
-            exchange.succeed('taler-exchange-offline -c "${configFile}" global-fee now "${CURRENCY}:0" "${CURRENCY}:0" "${CURRENCY}:0" 1h 6a 0 upload')
+            exchange.succeed('taler-exchange-offline -c "${configFile}" wire-fee now x-taler-bank "${CURRENCY}:0.01" "${CURRENCY}:0.01" upload')
+            exchange.succeed('taler-exchange-offline -c "${configFile}" global-fee now "${CURRENCY}:0.01" "${CURRENCY}:0.0" "${CURRENCY}:0" 1h 6a 0 upload')
 
 
         # Verify that exchange keys exist
@@ -204,7 +204,8 @@ import ../../make-test-python.nix (
 
 
         with subtest("Pay for an order"):
-            balanceWanted = "${CURRENCY}:9" # after paying
+            # after paying (1 for the order and 0.1 as fee)
+            balanceWanted = "${CURRENCY}:8.9"
 
             # Create an order to be paid
             response = json.loads(

--- a/nixos/tests/taler/tests/basic.nix
+++ b/nixos/tests/taler/tests/basic.nix
@@ -189,11 +189,16 @@ import ../../make-test-python.nix (
 
             # Accept & confirm withdrawal
             with subtest("Accept & confirm withdrawal"):
-                wallet_cli(f"withdraw accept-uri {withdrawal["taler_withdraw_uri"]} --exchange http://exchange:8081/")
+                # the withdrawal can only be confirmed if this is executed twice, for some reason
+                for i in range(2):
+                    wallet_cli(f"withdraw accept-uri {withdrawal["taler_withdraw_uri"]} --exchange 'http://exchange:8081/'")
+                    client.sleep(5) # needs some time to process things
+
                 succeed(client, [
                     "curl -X POST",
                     f"-H 'Authorization: Bearer {accessTokenUser}'",
                     "-H 'Content-Type: application/json'",
+                    f"""--data '{{"amount": "{balanceWanted}"}}'""", # double brackets escapes them
                     f"-sSfL 'http://bank:8082/accounts/${TUSER}/withdrawals/{withdrawal["withdrawal_id"]}/confirm'"
                 ])
 

--- a/pkgs/by-name/ta/taler-exchange/package.nix
+++ b/pkgs/by-name/ta/taler-exchange/package.nix
@@ -19,6 +19,7 @@
   gettext,
   texinfo,
   libtool,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -108,6 +109,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   checkTarget = "check";
+
+  passthru.tests = nixosTests.taler.basic;
 
   meta = {
     description = "Exchange component for the GNU Taler electronic payment system";

--- a/pkgs/by-name/ta/taler-merchant/package.nix
+++ b/pkgs/by-name/ta/taler-merchant/package.nix
@@ -14,6 +14,7 @@
   libgcrypt,
   texinfo,
   curl,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -97,6 +98,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [ jq ];
 
   checkTarget = "check";
+
+  passthru.tests = nixosTests.taler.basic;
 
   meta = {
     description = "Merchant component for the GNU Taler electronic payment system";

--- a/pkgs/by-name/ta/taler-merchant/package.nix
+++ b/pkgs/by-name/ta/taler-merchant/package.nix
@@ -82,6 +82,14 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
+  postFixup = ''
+    # - taler-merchant-dbinit expects `versioning.sql` under `share/taler/sql`
+    # - taler-merchant-httpd expects `share/taler/merchant/templates`
+    mkdir -p $out/share/taler/sql
+    ln -s $out/share/taler-merchant $out/share/taler/merchant
+    ln -s $out/share/taler-merchant/sql $out/share/taler/sql/merchant
+  '';
+
   enableParallelBuilding = true;
 
   doInstallCheck = true;

--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -95,6 +95,11 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
+  postFixup = ''
+    # else it fails to find the python interpreter
+    patchShebangs --build $out/bin/taler-helper-sqlite3
+  '';
+
   env.ESBUILD_BINARY_PATH = lib.getExe esbuild';
 
   meta = {


### PR DESCRIPTION
## Changes

Continuation of https://github.com/NixOS/nixpkgs/pull/406967 for GNU Taler

- Fix basic test and pass it to derivations (so we know if it breaks)
- Update and clean up component modules
- Add a release note for the [1.0 release](https://www.taler.net/en/news/2025-01.html)

This work was funded by [NGI Zero](https://nixos.org/community/teams/ngi/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
