### PR TITLE
ci/check-cherry-picks: add staging-next as pickable branches

### DIFF
--- a/ci/check-cherry-picks.sh
+++ b/ci/check-cherry-picks.sh
@@ -11,7 +11,7 @@ fi
 # Make sure we are inside the nixpkgs repo, even when called from outside
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-PICKABLE_BRANCHES="master release-??.?? staging-??.?? haskell-updates python-updates"
+PICKABLE_BRANCHES="master staging release-??.?? staging-??.?? haskell-updates python-updates"
 problem=0
 
 # Not everyone calls their remote "origin"

--- a/ci/check-cherry-picks.sh
+++ b/ci/check-cherry-picks.sh
@@ -11,7 +11,7 @@ fi
 # Make sure we are inside the nixpkgs repo, even when called from outside
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-PICKABLE_BRANCHES="master staging release-??.?? staging-??.?? haskell-updates python-updates"
+PICKABLE_BRANCHES="master staging release-??.?? staging-??.?? haskell-updates python-updates staging-next staging-next-??.??"
 problem=0
 
 # Not everyone calls their remote "origin"


### PR DESCRIPTION
The first commit fixes the accidental removal of `staging` as a valid pickable branch, which I introduced in ea636d1728f25328511401c4919eec96e7426de0 as a left-over from testing. I already had this as part of https://github.com/NixOS/nixpkgs/pull/412068, but I'd like to accelerate the merge of that fix.

The second commit adds `staging-next`, because.. why not? It is a valid source, even though it might not be needed often in practice, because things will be merged into staging already (the same actually applies to master in a way).

Addresses https://github.com/NixOS/nixpkgs/pull/412295#issuecomment-2922016699.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
