### PR TITLE
foonathan-memory: 0.7-3 -> 0.7-4

### DIFF
--- a/pkgs/by-name/fo/foonathan-memory/0001-Use-system-doctest.patch.patch
+++ b/pkgs/by-name/fo/foonathan-memory/0001-Use-system-doctest.patch.patch
@@ -1,0 +1,26 @@
+From: =?utf-8?q?Timo_R=C3=B6hling?= <timo@gaussglocke.de>
+Date: Wed, 2 Dec 2020 15:59:22 +0100
+Subject: Use system doctest
+
+Forwarded: not-needed
+---
+ test/CMakeLists.txt | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 37359ea..f269cfb 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -8,11 +8,7 @@ target_link_libraries(foonathan_memory_profiling foonathan_memory)
+ target_include_directories(foonathan_memory_profiling PRIVATE
+                             ${FOONATHAN_MEMORY_SOURCE_DIR}/include/foonathan/memory)
+ 
+-# Fetch doctest.
+-message(STATUS "Fetching doctest")
+-include(FetchContent)
+-FetchContent_Declare(doctest URL https://github.com/doctest/doctest/archive/refs/tags/v2.4.12.zip)
+-FetchContent_MakeAvailable(doctest)
++find_package(doctest REQUIRED)
+ 
+ set(tests
+     test_allocator.hpp

--- a/pkgs/by-name/fo/foonathan-memory/package.nix
+++ b/pkgs/by-name/fo/foonathan-memory/package.nix
@@ -2,28 +2,25 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   doctest,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "foonathan-memory";
-  version = "0.7-3";
+  version = "0.7-4";
 
   src = fetchFromGitHub {
     owner = "foonathan";
     repo = "memory";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-nLBnxPbPKiLCFF2TJgD/eJKJJfzktVBW3SRW2m3WK/s=";
+    hash = "sha256-qGbI7SL6lDbJzn2hkqaYw35QAyvSPxcZTb0ltDkPUSo=";
   };
 
   patches = [
     # do not download doctest, use the system doctest instead
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/f/foonathan-memory/0.7.3-2/debian/patches/0001-Use-system-doctest.patch";
-      hash = "sha256-/MuDeeIh+7osz11VfsAsQzm9HMZuifff+MDU3bDDxRE=";
-    })
+    # originally from: https://sources.debian.org/data/main/f/foonathan-memory/0.7.3-2/debian/patches/0001-Use-system-doctest.patch
+    ./0001-Use-system-doctest.patch.patch
   ];
 
   outputs = [
@@ -44,12 +41,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   # fix a circular dependency between "out" and "dev" outputs
   postInstall = ''
-    mkdir -p $dev/lib
-    mv $out/lib/foonathan_memory $dev/lib/
+    mkdir -p $out/lib/cmake
+    mv $out/lib/foonathan_memory/cmake $out/lib/cmake/foonathan_memory
+    rmdir $out/lib/foonathan_memory
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/foonathan/memory";
+    homepage = "https://memory.foonathan.net/";
     changelog = "https://github.com/foonathan/memory/releases/tag/${finalAttrs.src.rev}";
     description = "STL compatible C++ memory allocator library";
     mainProgram = "nodesize_dbg";


### PR DESCRIPTION
https://github.com/foonathan/memory/releases/tag/v0.7-4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>foonathan-memory</li>
    <li>foonathan-memory.dev</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
