### PR TITLE
sandsifter: init at 1.0.0-unstable-2024-12-13

### DIFF
--- a/pkgs/by-name/sa/sandsifter/package.nix
+++ b/pkgs/by-name/sa/sandsifter/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  capstone,
+  python3,
+}:
+
+let
+  pythonEnv = python3.withPackages (ps: with ps; [ ps.capstone ]);
+in
+
+stdenv.mkDerivation {
+  pname = "sandsifter";
+  version = "1.0.0-unstable-2024-12-13";
+
+  src = fetchFromGitHub {
+    owner = "jakiki6";
+    repo = "sandsifter";
+    rev = "2dcaf26282a1fa451006d6aaebb9a657a5bce8e8";
+    hash = "sha256-7cREZMXR4m7F2u+6ADwjP4GEADu6oYQISgHl/N5UtMs=";
+  };
+
+  nativeBuildInputs = [
+    capstone
+    pythonEnv
+  ];
+
+  env.NIX_HARDENING_ENABLE = "format stackprotector strictoverflow";
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CC -Wall -O0 -no-pie -pthread -o injector injector.c -lcapstone
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -Dm755 injector $out/opt/sandsifter/bin/injector
+    install -Dm755 sifter.py $out/opt/sandsifter/bin/sifter.py
+    install -Dm755 summarize.py $out/opt/sandsifter/bin/summarize.py
+    ln -s $out/opt/sandsifter/bin/injector $out/bin/injector
+    substituteInPlace $out/opt/sandsifter/bin/sifter.py \
+      --replace-fail "#!/usr/bin/python3" "#!${lib.getExe pythonEnv}" \
+      --replace-fail 'INJECTOR = "./injector"' "INJECTOR = \"$out/bin/injector\""
+    substituteInPlace $out/opt/sandsifter/bin/summarize.py \
+      --replace-fail "#!/usr/bin/python3" "#!${lib.getExe pythonEnv}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "x86 processor fuzzer";
+    homepage = "https://github.com/jakiki6/sandsifter";
+    license = lib.licenses.bsd3;
+    platforms = with lib.platforms; [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ mikehorn ];
+    mainProgram = "sifter.py";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add [sandsifter](https://github.com/jakiki6/sandsifter). The x86 processor fuzzer presented at [BlackHat 2017](https://www.youtube.com/watch?v=KrksBdWcZgQ).  
The package is build from an updated fork, original repository is [sandsifter](https://github.com/xoreaxeaxeax/sandsifter).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
