### PR TITLE
nixos/seafile: update outdated https links in package metadata

### DIFF
--- a/nixos/modules/services/networking/seafile.nix
+++ b/nixos/modules/services/networking/seafile.nix
@@ -84,7 +84,7 @@ in
       default = { };
       description = ''
         Configuration for ccnet, see
-        <https://manual.seafile.com/config/ccnet-conf/>
+        <https://manual.seafile.com/11.0/config/ccnet-conf/>
         for supported values.
       '';
     };
@@ -122,7 +122,7 @@ in
       default = { };
       description = ''
         Configuration for seafile-server, see
-        <https://manual.seafile.com/config/seafile-conf/>
+        <https://manual.seafile.com/11.0/config/seafile-conf/>
         for supported values.
       '';
     };
@@ -235,7 +235,7 @@ in
       type = types.lines;
       description = ''
         Extra config to append to `seahub_settings.py` file.
-        Refer to <https://manual.seafile.com/config/seahub_settings_py/>
+        Refer to <https://manual.seafile.com/11.0/config/seahub_settings_py/>
         for all available options.
       '';
     };

--- a/pkgs/by-name/se/seafile-server/package.nix
+++ b/pkgs/by-name/se/seafile-server/package.nix
@@ -39,8 +39,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "seafile-server";
-  version = "11.0.12";
-
+  version = "11.0.12"; # Doc links match Seafile 11.0 in seafile.nix – update if version changes.
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seafile-server";


### PR DESCRIPTION
This PR updates outdated or broken Seafile documentation links in the package metadata (`description`, `longDescription`, etc.).

The previous links pointed to deprecated or missing pages. These have been replaced with the current Seafile manual URLs at `https://manual.seafile.com/`.

This improves the accuracy of the metadata and helps users find relevant documentation more easily.

## Things done

- [x] Updated metadata only (no package rebuild required)
- [x] Verified that all new links are correct and accessible
- [ ] Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` (not required for meta-only changes)

No release notes or functional testing required for this type of change.