### PR TITLE
perlPackages.XMLLibXML: refresh patch to fix tests

### DIFF
--- a/pkgs/development/perl-modules/XML-LibXML-fix-tests-libxml-2.13.0.patch
+++ b/pkgs/development/perl-modules/XML-LibXML-fix-tests-libxml-2.13.0.patch
@@ -1,7 +1,7 @@
 From bee8338fd1cbd7aad4bf60c2965833343b6ead6f Mon Sep 17 00:00:00 2001
 From: Nick Wellnhofer <wellnhofer@aevum.de>
 Date: Tue, 21 May 2024 15:17:30 +0200
-Subject: [PATCH] Fix test suite with libxml2 2.13.0
+Subject: [PATCH 1/3] Fix test suite with libxml2 2.13.0
 
 ---
  t/02parse.t                        | 7 ++++++-
@@ -143,3 +143,100 @@ index e48215c4..55ac0b2e 100644
  }
  
  =head1 COPYRIGHT & LICENSE
+
+From c9f9c2fe51173b0a00969f01b577399f1098aa47 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Thu, 13 Feb 2025 19:50:35 +0100
+Subject: [PATCH 2/3] Fix test suite with libxml2 2.14.0
+
+---
+ t/16docnodes.t   | 7 ++++++-
+ t/49_load_html.t | 8 +++++++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/t/16docnodes.t b/t/16docnodes.t
+index db7bc1fc..0b0ae005 100644
+--- a/t/16docnodes.t
++++ b/t/16docnodes.t
+@@ -60,7 +60,12 @@ for my $time (0 .. 2) {
+     $doc->setDocumentElement($node);
+ 
+     # TEST
+-    is( $node->serialize(), '<test contents="&#xE4;"/>', 'Node serialise works.' );
++    # libxml2 2.14 avoids unnecessary escaping of attribute values.
++    if (XML::LibXML::LIBXML_VERSION() >= 21400) {
++        is( $node->serialize(), "<test contents=\"\xE4\"/>", 'Node serialise works.' );
++    } else {
++        is( $node->serialize(), '<test contents="&#xE4;"/>', 'Node serialise works.' );
++    }
+ 
+     $doc->setEncoding('utf-8');
+     # Second output
+diff --git a/t/49_load_html.t b/t/49_load_html.t
+index 70d26607..3861edf8 100644
+--- a/t/49_load_html.t
++++ b/t/49_load_html.t
+@@ -52,7 +52,13 @@ use XML::LibXML;
+ </div>
+ EOS
+ 
+-    {
++    SKIP: {
++        # libxml2 2.14 tokenizes HTML according to HTML5 where
++        # this isn't an error, see "13.2.5.73 Named character
++        # reference state".
++        skip("libxml2 version >= 21400", 1)
++            if XML::LibXML::LIBXML_VERSION >= 21400;
++
+         my $buf = '';
+         open my $fh, '>', \$buf;
+         # redirect STDERR there
+
+From ecbebc2f33fecb66b3d5487c6e48bea353e374f9 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Fri, 16 May 2025 19:11:12 +0200
+Subject: [PATCH 3/3] Remove tests that disable line numbers
+
+Line numbers are always enabled since libxml2 2.15.0.
+---
+ t/02parse.t | 13 ++-----------
+ 1 file changed, 2 insertions(+), 11 deletions(-)
+
+diff --git a/t/02parse.t b/t/02parse.t
+index 40aa5f13..17419f8f 100644
+--- a/t/02parse.t
++++ b/t/02parse.t
+@@ -14,7 +14,7 @@ use locale;
+ 
+ POSIX::setlocale(LC_ALL, "C");
+ 
+-use Test::More tests => 533;
++use Test::More tests => 531;
+ use IO::File;
+ 
+ use XML::LibXML::Common qw(:libxml);
+@@ -25,7 +25,7 @@ use constant XML_DECL => "<?xml version=\"1.0\"?>\n";
+ 
+ use Errno qw(ENOENT);
+ 
+-# TEST*533
++# TEST*531
+ 
+ ##
+ # test values
+@@ -773,15 +773,6 @@ EOXML
+ 
+     my $newkid = $root->appendChild( $doc->createElement( "bar" ) );
+     is( $newkid->line_number(), 0, "line number is 0");
+-
+-    $parser->line_numbers(0);
+-    eval { $doc = $parser->parse_string( $goodxml ); };
+-
+-    $root = $doc->documentElement();
+-    is( $root->line_number(), 0, "line number is 0");
+-
+-    @kids = $root->childNodes();
+-    is( $kids[1]->line_number(), 0, "line number is 0");
+ }
+ 
+ SKIP: {


### PR DESCRIPTION
Fixes: e258dc4b328f ("libxml2: 2.13.8 -> 2.14.3")


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
