### PR TITLE
bitwuzla: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/by-name/bi/bitwuzla/package.nix
+++ b/pkgs/by-name/bi/bitwuzla/package.nix
@@ -16,17 +16,18 @@
   zlib,
   pkg-config,
   cmake,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bitwuzla";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "bitwuzla";
     repo = "bitwuzla";
     rev = finalAttrs.version;
-    hash = "sha256-S8CtK8WEehUdOoqOmu5KnoqHFpCGrYWjZKv1st4M7bo=";
+    hash = "sha256-Th2YkynOzxcZB4xqyH8D3QqcuQzkWYAd+hYfZ5OmrJ0=";
   };
 
   strictDeps = true;
@@ -86,6 +87,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstallCheck
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "SMT solver for fixed-size bit-vectors, floating-point arithmetic, arrays, and uninterpreted functions";


### PR DESCRIPTION
Fixes #412357

And add an update script.

Unfortunately two tests fail:

```
Summary of Failures:

  28/3927 bitwuzla:unit+api / api_capi                                             FAIL            0.37s   exit status 1
 416/3927 bitwuzla:unit+lib_ls_bv / lib_ls_bv_bvnodeselpath                        FAIL            2.55s   exit status 1

Ok:                 3925
Expected Fail:      0
Fail:               2
Unexpected Pass:    0
Skipped:            0
Timeout:            0

[ RUN      ] TestBvNodeSelPath.urem
../test/unit/lib/ls/bv/test_bvnodeselpath.cpp:150: Failure
Value of: (is_essential0 && is_essential1) || !is_essential0 || is_val0 || pos_x == 0
  Actual: false
Expected: true

[  FAILED  ] TestBvNodeSelPath.urem (12 ms)

bitwuzla: error:  invalid call to 'bitwuzla::Term bitwuzla::TermManager::mk_term(bitwuzla::Kind, const std::vector<bitwuzla::Term>&, const std::vector<long unsigned int>&)', Unsupported experimental floating-point format (non-experimenta
l: Float16, Float32, Float64, Float128), enable experimental FP formats with build configuration option --fpexp.
Note that there are known issues with experimental formats in SymFPU, use at your own risk.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).