### PR TITLE
oxigraph: add tnias to maintainers, cleanup

### DIFF
--- a/pkgs/by-name/ox/oxigraph/package.nix
+++ b/pkgs/by-name/ox/oxigraph/package.nix
@@ -5,14 +5,20 @@
   installShellFiles,
 }:
 
-rustPlatform.buildRustPackage rec {
+let
+  features = [
+    "rustls-webpki"
+    "geosparql"
+  ];
+in
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "oxigraph";
   version = "0.4.9";
 
   src = fetchFromGitHub {
     owner = "oxigraph";
     repo = "oxigraph";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-sv9LpAoPQ4oFrGI6j6NgVZwEwpM1wt93lHkUwnvmhIY=";
     fetchSubmodules = true;
   };
@@ -27,10 +33,7 @@ rustPlatform.buildRustPackage rec {
 
   buildAndTestSubdir = "cli";
   buildNoDefaultFeatures = true;
-  buildFeatures = [
-    "rustls-webpki"
-    "geosparql"
-  ];
+  buildFeatures = features;
 
   # Man pages and autocompletion
   postInstall = ''
@@ -43,9 +46,9 @@ rustPlatform.buildRustPackage rec {
   '';
 
   cargoCheckNoDefaultFeatures = true;
-  cargoCheckFeatures = buildFeatures;
+  cargoCheckFeatures = features;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/oxigraph/oxigraph";
     description = "SPARQL graph database";
     platforms = [
@@ -53,14 +56,14 @@ rustPlatform.buildRustPackage rec {
       "aarch64-linux"
       "aarch64-darwin"
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       astro
       tnias
     ];
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20
       mit
     ];
     mainProgram = "oxigraph";
   };
-}
+})

--- a/pkgs/by-name/ox/oxigraph/package.nix
+++ b/pkgs/by-name/ox/oxigraph/package.nix
@@ -53,7 +53,10 @@ rustPlatform.buildRustPackage rec {
       "aarch64-linux"
       "aarch64-darwin"
     ];
-    maintainers = with maintainers; [ astro ];
+    maintainers = with maintainers; [
+      astro
+      tnias
+    ];
     license = with licenses; [
       asl20
       mit


### PR DESCRIPTION
I want to be maintainer so I can review and merge @r-ryantm version bumps like https://github.com/NixOS/nixpkgs/pull/407506 in the future.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
