### PR TITLE
archlinux-logout: init at 24.04-01

### DIFF
--- a/pkgs/by-name/ar/archlinux-logout/package.nix
+++ b/pkgs/by-name/ar/archlinux-logout/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  wrapGAppsHook3,
+  betterlockscreen,
+  gobject-introspection,
+  libwnck,
+  bash,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "archlinux-logout";
+  version = "24.04-01";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "arcolinux";
+    repo = "archlinux-logout";
+    tag = version;
+    hash = "sha256-zSsZsI6mPK7zzfHi00jahO4sAZ4bO2z13DjIom0ouQA=";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    bash
+    libwnck
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    distro
+    psutil
+    pycairo
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 usr/bin/archlinux-logout $out/bin/archlinux-logout
+    install -Dm755 usr/bin/archlinux-betterlockscreen $out/bin/archlinux-betterlockscreen
+    cp -r usr/share $out/share
+    chmod +x  $out/share/archlinux-betterlockscreen/archlinux-betterlockscreen.py
+    chmod +x  $out/share/archlinux-logout/archlinux-logout.py
+    sed -i '1i #!/usr/bin/env python3' $out/share/archlinux-logout/archlinux-logout.py
+    install -Dm644 etc/archlinux-logout.conf $out/etc/archlinux-logout.conf
+    substituteInPlace $out/bin/archlinux-betterlockscreen \
+      --replace-fail "python3 /usr/share/archlinux-betterlockscreen/archlinux-betterlockscreen.py" '${placeholder "out"}/share/archlinux-betterlockscreen/archlinux-betterlockscreen.py $@'
+    substituteInPlace $out/bin/archlinux-logout \
+      --replace-fail "python3 /usr/share/archlinux-logout/archlinux-logout.py" '${placeholder "out"}/share/archlinux-logout/archlinux-logout.py $@' \
+      --replace-fail " sh" " bash"
+    substituteInPlace $out/share/applications/archlinux-betterlockscreen.desktop \
+      --replace-fail "/usr/bin/" ""
+    substituteInPlace $out/share/archlinux-logout/Functions.py \
+      --replace-fail "parents[3]" "parents[2]" \
+      --replace-fail '"/usr/bin/betterlockscreen"' "True"
+    patchShebangs $out/bin
+
+    runHook postInstall
+  '';
+
+  dontWrapGApps = true;
+
+  makeWrapperArgs = [
+    "\${gappsWrapperArgs[@]}"
+    "--prefix PATH : ${lib.makeBinPath [ betterlockscreen ]}"
+  ];
+
+  postFixup = ''
+    wrapPythonProgramsIn $out/share/archlinux-logout "$out $pythonPath"
+    wrapPythonProgramsIn $out/share/archlinux-betterlockscreen "$out $pythonPath"
+  '';
+
+  meta = {
+    description = "Widget displaying a transparent window allowing quick access to various power features";
+    homepage = "https://github.com/arcolinux/archlinux-logout";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "archlinux-logout";
+    maintainers = with lib.maintainers; [ powwu ];
+  };
+}


### PR DESCRIPTION
Add archlinux-logout, a logout screen originally used in Arco Linux (as arcolinux-logout). When Arco Linux became defunct, they renamed the package to archlinux-logout, hence the strange name. It technically has nothing to do with Arch Linux.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
