### PR TITLE
python3Packages.pymupdf: propagate mupdf better

### DIFF
--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   fetchpatch,
   python,
+  toPythonModule,
 
   # build-system
   libclang,
@@ -39,6 +40,8 @@ let
     enablePython = true;
     python3 = python;
   };
+  mupdf-cxx-lib = toPythonModule (lib.getLib mupdf-cxx);
+  mupdf-cxx-dev = lib.getDev mupdf-cxx;
 in
 buildPythonPackage rec {
   pname = "pymupdf";
@@ -87,7 +90,7 @@ buildPythonPackage rec {
     gumbo
   ];
 
-  propagatedBuildInputs = [ mupdf-cxx ];
+  propagatedBuildInputs = [ mupdf-cxx-lib ];
 
   env = {
     # force using system MuPDF (must be defined in environment and empty)
@@ -95,14 +98,14 @@ buildPythonPackage rec {
     # Setup the name of the package away from the default 'libclang'
     PYMUPDF_SETUP_LIBCLANG = "clang";
     # provide MuPDF paths
-    PYMUPDF_MUPDF_LIB = "${lib.getLib mupdf-cxx}/lib";
-    PYMUPDF_MUPDF_INCLUDE = "${lib.getDev mupdf-cxx}/include";
+    PYMUPDF_MUPDF_LIB = "${mupdf-cxx-lib}/lib";
+    PYMUPDF_MUPDF_INCLUDE = "${mupdf-cxx-dev}/include";
   };
 
   # TODO: manually add mupdf rpath until upstream fixes it
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     for lib in */*.so $out/${python.sitePackages}/*/*.so; do
-      install_name_tool -add_rpath ${lib.getLib mupdf-cxx}/lib "$lib"
+      install_name_tool -add_rpath ${mupdf-cxx-lib}/lib "$lib"
     done
   '';
 


### PR DESCRIPTION
Otherwise, we end up in this situation where this derivation works:

```nix
{ pkgs ? import ./. { } }:

pkgs.runCommand "driver" { buildInputs = [ pkgs.python3Packages.pymupdf ]; } ''
  python -c 'import pymupdf;' > $out
''
```

... but this ostensibly identical derivation fails.

```nix
{ pkgs ? import ./. { } }:

pkgs.runCommand "driver" { buildInputs = [ pkgs.python3.withPackages (ps: [ ps.pymupdf ]; } ''
  python -c 'import pymupdf;' > $out
''
```

What's happening is that the propagated input `mupdf-cxx` doesn't pass the filter check in `requiredPythonModules` as it does not have a Python module as defined in that function.

Now, it does.

Huge thanks to hexa (@mweinelt) who debugged this with me on Matrix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).