### PR TITLE
bt-migrate: 0-unstable-2023-08-17 → 0-unstable-2025-05-31

### DIFF
--- a/pkgs/by-name/bt/bt-migrate/package.nix
+++ b/pkgs/by-name/bt/bt-migrate/package.nix
@@ -13,13 +13,13 @@
 }:
 stdenv.mkDerivation {
   pname = "bt-migrate";
-  version = "0-unstable-2023-08-17";
+  version = "0-unstable-2025-05-31";
 
   src = fetchFromGitHub {
     owner = "mikedld";
     repo = "bt-migrate";
-    rev = "e15a489c0c76f98355586ebbee08223af4e9bf50";
-    hash = "sha256-kA6yxhbIh3ThmgF8Zyoe3I79giLVmdNr9IIrw5Xx4s0=";
+    rev = "eb5b0ba5e0176844efde3a319595f52ffe900c2c";
+    hash = "sha256-eg7rZnqpQiOA1N7GHv14eDAmvmj6VWq/dlw2YBw6IAA=";
   };
 
   nativeBuildInputs = [
@@ -54,13 +54,12 @@ stdenv.mkDerivation {
 
   strictDeps = true;
 
-  meta = with lib; {
+  meta = {
     description = "Torrent state migration tool";
     homepage = "https://github.com/mikedld/bt-migrate?tab=readme-ov-file";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ ambroisie ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ambroisie ];
     mainProgram = "BtMigrate";
-    platforms = platforms.all;
-    broken = true; # https://github.com/mikedld/bt-migrate/issues/26
+    platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
Fix build https://github.com/mikedld/bt-migrate/issues/26

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
