### PR TITLE
python3Packages.chromadb: fixes

### DIFF
--- a/pkgs/by-name/ve/vectorcode/package.nix
+++ b/pkgs/by-name/ve/vectorcode/package.nix
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication rec {
   dependencies =
     with python3Packages;
     [
-      chromadb
+      chromadb_0
       colorlog
       httpx
       json5

--- a/pkgs/development/python-modules/chromadb/0.nix
+++ b/pkgs/development/python-modules/chromadb/0.nix
@@ -1,0 +1,220 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools-scm,
+  setuptools,
+
+  # build inputs
+  cargo,
+  pkg-config,
+  protobuf,
+  rustc,
+  rustPlatform,
+  openssl,
+
+  # dependencies
+  bcrypt,
+  build,
+  fastapi,
+  grpcio,
+  httpx,
+  importlib-resources,
+  kubernetes,
+  mmh3,
+  numpy,
+  onnxruntime,
+  opentelemetry-api,
+  opentelemetry-exporter-otlp-proto-grpc,
+  opentelemetry-instrumentation-fastapi,
+  opentelemetry-sdk,
+  orjson,
+  overrides,
+  posthog,
+  pulsar-client,
+  pydantic,
+  pypika,
+  pyyaml,
+  requests,
+  tenacity,
+  tokenizers,
+  tqdm,
+  typer,
+  typing-extensions,
+  uvicorn,
+  zstd,
+
+  # optional dependencies
+  chroma-hnswlib,
+
+  # tests
+  hypothesis,
+  psutil,
+  pytest-asyncio,
+  pytestCheckHook,
+
+  # passthru
+  nixosTests,
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "chromadb_0";
+  version = "0.6.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "chroma-core";
+    repo = "chroma";
+    tag = version;
+    hash = "sha256-yvAX8buETsdPvMQmRK5+WFz4fVaGIdNlfhSadtHwU5U=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-lHRBXJa/OFNf4x7afEJw9XcuDveTBIy3XpQ3+19JXn4=";
+  };
+
+  pythonRelaxDeps = [
+    "chroma-hnswlib"
+    "orjson"
+    "tokenizers"
+  ];
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    cargo
+    pkg-config
+    protobuf
+    rustc
+    rustPlatform.cargoSetupHook
+  ];
+
+  buildInputs = [
+    openssl
+    zstd
+  ];
+
+  dependencies = [
+    bcrypt
+    build
+    chroma-hnswlib
+    fastapi
+    grpcio
+    httpx
+    importlib-resources
+    kubernetes
+    mmh3
+    numpy
+    onnxruntime
+    opentelemetry-api
+    opentelemetry-exporter-otlp-proto-grpc
+    opentelemetry-instrumentation-fastapi
+    opentelemetry-sdk
+    orjson
+    overrides
+    posthog
+    pulsar-client
+    pydantic
+    pypika
+    pyyaml
+    requests
+    tenacity
+    tokenizers
+    tqdm
+    typer
+    typing-extensions
+    uvicorn
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    psutil
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  # Disable on aarch64-linux due to broken onnxruntime
+  # https://github.com/microsoft/onnxruntime/issues/10038
+  pythonImportsCheck = lib.optionals (stdenv.hostPlatform.system != "aarch64-linux") [ "chromadb" ];
+
+  # Test collection breaks on aarch64-linux
+  doCheck = stdenv.hostPlatform.system != "aarch64-linux";
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  pytestFlagsArray = [
+    "-x" # these are slow tests, so stop on the first failure
+    "-v"
+  ];
+
+  preCheck = ''
+    (($(ulimit -n) < 1024)) && ulimit -n 1024
+    export HOME=$(mktemp -d)
+  '';
+
+  disabledTests = [
+    # Tests are flaky / timing sensitive
+    "test_fastapi_server_token_authn_allows_when_it_should_allow"
+    "test_fastapi_server_token_authn_rejects_when_it_should_reject"
+
+    # Issue with event loop
+    "test_http_client_bw_compatibility"
+
+    # httpx ReadError
+    "test_not_existing_collection_delete"
+  ];
+
+  disabledTestPaths = [
+    # Tests require network access
+    "chromadb/test/auth/test_simple_rbac_authz.py"
+    "chromadb/test/db/test_system.py"
+    "chromadb/test/ef/test_default_ef.py"
+    "chromadb/test/property/"
+    "chromadb/test/property/test_cross_version_persist.py"
+    "chromadb/test/stress/"
+    "chromadb/test/test_api.py"
+
+    # httpx failures
+    "chromadb/test/api/test_delete_database.py"
+
+    # Cannot be loaded by pytest without path hacks (fixed in 1.0.0)
+    "chromadb/test/test_logservice.py"
+    "chromadb/test/proto/test_utils.py"
+    "chromadb/test/segment/distributed/test_protobuf_translation.py"
+
+    # Hypothesis FailedHealthCheck due to nested @given tests
+    "chromadb/test/cache/test_cache.py"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  passthru.tests = {
+    inherit (nixosTests) chromadb;
+  };
+
+  # nixpkgs-update: no auto update
+  # 0.6.3 is the last of the 0.x series
+
+  meta = {
+    description = "AI-native open-source embedding database";
+    homepage = "https://github.com/chroma-core/chroma";
+    changelog = "https://github.com/chroma-core/chroma/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      fab
+      sarahec
+    ];
+    mainProgram = "chroma";
+  };
+}

--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -63,25 +63,26 @@
 
 buildPythonPackage rec {
   pname = "chromadb";
-  version = "0.5.20";
+  version = "0.6.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "chroma-core";
     repo = "chroma";
     tag = version;
-    hash = "sha256-DQHkgCHtrn9xi7Kp7TZ5NP1EtFtTH5QOvne9PUvxsWc=";
+    hash = "sha256-yvAX8buETsdPvMQmRK5+WFz4fVaGIdNlfhSadtHwU5U=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    name = "${pname}-${version}-vendor";
-    hash = "sha256-ZtCTg8qNCiqlH7RsZxaWUNAoazdgmXP2GtpjDpRdvbk=";
+    name = "${pname}-${version}";
+    hash = "sha256-lHRBXJa/OFNf4x7afEJw9XcuDveTBIy3XpQ3+19JXn4=";
   };
 
   pythonRelaxDeps = [
     "chroma-hnswlib"
     "orjson"
+    "tokenizers"
   ];
 
   build-system = [
@@ -166,9 +167,11 @@ buildPythonPackage rec {
     # Tests are flaky / timing sensitive
     "test_fastapi_server_token_authn_allows_when_it_should_allow"
     "test_fastapi_server_token_authn_rejects_when_it_should_reject"
+
     # Issue with event loop
     "test_http_client_bw_compatibility"
-    # Issue with httpx
+
+    # httpx ReadError
     "test_not_existing_collection_delete"
   ];
 
@@ -181,6 +184,17 @@ buildPythonPackage rec {
     "chromadb/test/property/test_cross_version_persist.py"
     "chromadb/test/stress/"
     "chromadb/test/test_api.py"
+
+    # httpx failures
+    "chromadb/test/api/test_delete_database.py"
+
+    # Cannot be loaded by pytest without path hacks (fixed in 1.0.0)
+    "chromadb/test/test_logservice.py"
+    "chromadb/test/proto/test_utils.py"
+    "chromadb/test/segment/distributed/test_protobuf_translation.py"
+
+    # Hypothesis FailedHealthCheck due to nested @given tests
+    "chromadb/test/cache/test_cache.py"
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -198,17 +212,17 @@ buildPythonPackage rec {
         "([0-9].+)"
       ];
     };
-  };
 
-  meta = {
-    description = "AI-native open-source embedding database";
-    homepage = "https://github.com/chroma-core/chroma";
-    changelog = "https://github.com/chroma-core/chroma/releases/tag/${version}";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      fab
-      sarahec
-    ];
-    mainProgram = "chroma";
+    meta = {
+      description = "AI-native open-source embedding database";
+      homepage = "https://github.com/chroma-core/chroma";
+      changelog = "https://github.com/chroma-core/chroma/releases/tag/${version}";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [
+        fab
+        sarahec
+      ];
+      mainProgram = "chroma";
+    };
   };
 }

--- a/pkgs/development/python-modules/chromadb/disable-fastapi-fixtures.patch
+++ b/pkgs/development/python-modules/chromadb/disable-fastapi-fixtures.patch
@@ -1,0 +1,14 @@
+diff --git a/chromadb/test/conftest.py b/chromadb/test/conftest.py
+index efde1c382..163f55c57 100644
+--- a/chromadb/test/conftest.py
++++ b/chromadb/test/conftest.py
+@@ -678,9 +678,6 @@ def sqlite_persistent(request: pytest.FixtureRequest) -> Generator[System, None,
+ 
+ def system_fixtures() -> List[Callable[[], Generator[System, None, None]]]:
+     fixtures = [
+-        fastapi,
+-        async_fastapi,
+-        fastapi_persistent,
+         sqlite_fixture,
+         sqlite_persistent_fixture,
+     ]

--- a/pkgs/development/python-modules/langchain-chroma/default.nix
+++ b/pkgs/development/python-modules/langchain-chroma/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-chroma";
-  version = "0.2.3";
+  version = "0.2.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-chroma==${version}";
-    hash = "sha256-6WOViBKXZ844g2M6pYohHsXnzJiWbTNgj9EjN+z+B+4=";
+    hash = "sha256-w4xvPPLYkPiQA34bimVHLe+vghMI9Pq36CHoE/EMnr8=";
   };
 
   sourceRoot = "${src.name}/libs/partners/chroma";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2458,6 +2458,8 @@ self: super: with self; {
 
   chromadb = callPackage ../development/python-modules/chromadb { };
 
+  chromadb_0 = callPackage ../development/python-modules/chromadb/0.nix { };
+
   chromaprint = callPackage ../development/python-modules/chromaprint { };
 
   ci-info = callPackage ../development/python-modules/ci-info { };


### PR DESCRIPTION
### chromadb: updates and backwards compatibility

1. Cleanup: Organize imports, fix `with lib` in meta block
2. Add self as maintainer
3. Update chromadb to 0.6.3 and package as `python3Packages.chromadb_0`. Many packages in the AI ecosystem aren't ready for 1.0 and can use `chromadb_0`.
5. Update to version 1.0.12. release notes: https://github.com/chroma-core/chroma/releases/tag/1.0.12

### Dependents

1. Update `python3Packages.langchain-chroma` to 0.2.4 which needs chromadb >= 1.0.9
2. Update `vectorcode` to use `chroma_0`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
