### PR TITLE
[Backport release-24.11] Firefox (beta, devedition): update to 140.b2

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "138.0b8";
+  version = "138.0b9";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ach/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ach/firefox-138.0b9.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "80989a964e38730d2fe4319235806764520b5a0650192799ae13bfe441940279";
+      sha256 = "b3ffb3ddcd92974bb68092b0f192e709f8c6ea4dd04a53cdd01ae3e1265e4ce1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/af/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/af/firefox-138.0b9.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "421a4d6cc45c4d64c95ad7783362350cb64aadf66a44895550247d1ec7f3ece0";
+      sha256 = "873329379f2ebc5423e088baad11bc8e9e1dd9f86ad28dbaf9bff78e85a9cd9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/an/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/an/firefox-138.0b9.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "797657def82cfd6ee70084af60d5f09ad1f66d6325b9e08ffb88ecdccd62ec02";
+      sha256 = "6b664107a382ad84cfb4bf88f614f7a551daed5f09e52125cf4b9963288af052";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ar/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ar/firefox-138.0b9.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "919ad1d11421fcae4b05f2a0eec8724d8bce40865e4efaf71bb362451acd748c";
+      sha256 = "2157430396d0e622b5bb3432b6c2da4d98355f07bcab57f768ffa4f961c7422c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ast/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ast/firefox-138.0b9.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "147c7bb0b40dbf5653447861f16b8515fe39ae7f1c13533cfbb08526be9c1dfd";
+      sha256 = "5f4041933b0788a94982d5abe82c2bd320562c42e3bf5e9ee11439ac31bd0657";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/az/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/az/firefox-138.0b9.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "37dd7aeb3c2f88a451f5e623bc2575bd71d529dcc31f5a4c072e0ae25010ca2d";
+      sha256 = "b60de8fe2b27f47cec99b0fda40355b6dd0aba9f13af9b0369ea6c0149426491";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/be/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/be/firefox-138.0b9.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "099eab295d39cb2044774a097040eb5d4ae9595f26ae76421a48f741e37a4b97";
+      sha256 = "6472c3c7ea0316d54a10fc48c8648446c270c97b3605b3e84517e556a42fbafb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/bg/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/bg/firefox-138.0b9.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "22be921854a33169b7d8ae8f72187f4928c8d02d52a0db626f8d25ea79f6ba0a";
+      sha256 = "a5c59d142b5d09047f1a9bca0a6f5b02d64a1a78768ad7d2845dcb52c2e108d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/bn/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/bn/firefox-138.0b9.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "8c33ec8119293d8351159e8ca1741f6a4a06a858373dc41b02a340017fe5af21";
+      sha256 = "1645b8c44d52a7fe9f06de75877c845cd5e48e1cfe72323b76d9d14c274a91fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/br/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/br/firefox-138.0b9.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "6816dc30f54105995cc29f28ab75abfb7b9b14ecbe963f0fa493e3f845c86dc2";
+      sha256 = "c22c1d557970a63cbe6f215b9432755514db1d491379ba948a5f5b03c4cfcbdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/bs/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/bs/firefox-138.0b9.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "259dd175006d8eb98b62bf3d4126f790e57d7b05c15fc3eeba3badf3eebacf24";
+      sha256 = "56040544746128cbb94a5064266c366b6e15d1d4e7c4ca83e146a911cc0f4a2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ca-valencia/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ca-valencia/firefox-138.0b9.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "92f7e70f2f9a552dd558ff3c3f4d6633624b373d0d74dff1c5fb40e90418a48d";
+      sha256 = "05ff5e1862b32b8cd1f298bc7cb33b10fcc23e96c9fdf9d0c6a6bbeda0555710";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ca/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ca/firefox-138.0b9.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "f61026c82d71b9925a3573bdd6c1e9e6f7de8868d07944544c9854a8929c8d01";
+      sha256 = "168cd1cf9c6d44a579d0d6aac0ec94e70264346c6d0a7d1b27c794454c5917c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/cak/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/cak/firefox-138.0b9.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "d90f8af5129110899a818224eac03e34690ffc21df1ec1258c7d3f919ed976c1";
+      sha256 = "052649cd769e1cb1c39fd9ec17d936402890af702f1e727744e16ecae0bdc1e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/cs/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/cs/firefox-138.0b9.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "866c297ac37839400ef3eb13ddc616d35b376b64c19be83faf093d8b4104d5e0";
+      sha256 = "7f216ca4ce4914abd5c1bea28a9e70e73053a6ab3f4e88954f5c6f57dd13aa6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/cy/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/cy/firefox-138.0b9.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "631eef205844faa2b305cfb0b5294cb8c480e9338c6c069b48ac7ba482388d60";
+      sha256 = "7797275f345510fd867ef8f70f26df1352f2a96b8cccd0e05a8335013f81a33a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/da/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/da/firefox-138.0b9.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "2cffffd9edafdd60f7c2c2a38d2cf9da14d91b6c1315e82273f58a2487914e06";
+      sha256 = "b38d4e85485e147ade0ac5b7fab531f04853923bedab7a5cb749985ac3a60ea4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/de/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/de/firefox-138.0b9.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "1a8a7c232c4611108a47afcb98d433e9fbd4dcbeae84cc7263931b619c54b85a";
+      sha256 = "1a537b14a9182b0544d36c1bccf6b7e3036d50112f2502b36e42ea6de963e55c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/dsb/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/dsb/firefox-138.0b9.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "1ed273febd64e31eb2ea76513b968cad099a2aa8c3e93005fff60ff6835254a4";
+      sha256 = "41299aef70f687ea7d6311ce2c5c00fbabac1b7b2303dab693168ec677977fdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/el/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/el/firefox-138.0b9.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "53e5a38a785b5ec57c7d5cc72cf0cc63971d618804e908e36734b4cd848dd780";
+      sha256 = "5f0aad046a2b534f08eab6d15a8e8646f6ecbdb6384916feec72b23e56f17d59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/en-CA/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/en-CA/firefox-138.0b9.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "58bd81c3b7df16bd8674749b9fcdce124a580203013df4904d5e6c22328939ca";
+      sha256 = "02d1ea886eac8dbe58d8797c8a9be6910bc8940dbc67b4dc99077f64cff73e8f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/en-GB/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/en-GB/firefox-138.0b9.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "79f98e187a8506cb41e54538b932e835615dfe244f1e9b33d6c8b695e109627d";
+      sha256 = "d0e216f4e50b266e407bfdd7017711459cf5c50507a1750f9fc3d366dbd0ef0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/en-US/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/en-US/firefox-138.0b9.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "1201eebc10e1a6d8e02ab9daae3bea5795ae9e6f9cd289f7244557fbd10c2fc6";
+      sha256 = "ca4f673d6abd3b2b4adc971097057664ad1a097ffd67b99257e08ea50ad5fed5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/eo/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/eo/firefox-138.0b9.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "65107fb2691ce2f54805d544968ebc50a19fa627264ced0ff22392b13ce547ad";
+      sha256 = "3403de04ae3603a88748a290b50dbae659e03dbeaf2b5d53dea22b6192c2b141";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/es-AR/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/es-AR/firefox-138.0b9.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "8eeeb37caa5ac429b5814b0a242f3515e09a9064f38f31d64a7f19b5654fe0e7";
+      sha256 = "2d7908dc8106b20c98edd6853acee8c9227a0c4c9cf7dae885f7c3ecb8f84f8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/es-CL/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/es-CL/firefox-138.0b9.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "625d302661d8ebd31d23c64b84a305d458312244c817dfdf5cd571afab6510d8";
+      sha256 = "90b98d20b4b59ce0b5267ef629fa902ffb80d3f7f0d16497a4c669cd2504b7fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/es-ES/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/es-ES/firefox-138.0b9.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "4daff44ef46d32046c729f029f9b0ea9d86ea501bd17ac45ba9c0c0e4c718453";
+      sha256 = "26bcf7dac7ddb3d91a657414c6773eca8a4f7188dd2a53a55b01bec1922e3356";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/es-MX/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/es-MX/firefox-138.0b9.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "38f282b0386287a7a2b6729b07d2c22b4961d948983bf650de88b8d794a00ad9";
+      sha256 = "a2c1b2dfa990ac22dca8d2e84a44edd1d7f5c7364a5c923cbfcf71f60020ca67";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/et/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/et/firefox-138.0b9.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "74bed5f9d6316740b4bccbee3089e83500280df3d0656cf5a9699c7ebb383a8c";
+      sha256 = "d5fe2ce37d7d372f9509607016ef06c941dc5a090b260b1745975af377bcbe56";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/eu/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/eu/firefox-138.0b9.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "04113f82f4ff1e9620b3ebf80aeb67671580d5e7a67ae0eac74ff7317e9c74d1";
+      sha256 = "b081e24e03eccb7e0c6ce5fd9b692902dee0939d18673378323230680662bbdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fa/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fa/firefox-138.0b9.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "cebcf7d923f02a5d30a4b73f11dd3cac73d64473ae9f525c82e4a15fb8a23470";
+      sha256 = "0bb48d3c9d84e5f894bd741d507b4a854b9ad20c3152bfca41e1c4178d6f558d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ff/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ff/firefox-138.0b9.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "8853de176648d95a2407dc77627d433d5f2278c82e7c5f98a461b5a95a8f897f";
+      sha256 = "bb17a6d3cfccd4cf08ee169f0b5395c21fd5195f76b4814011743319403392da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fi/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fi/firefox-138.0b9.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "9cd51d0cbd5a4d2f32e7553cab24ea28a44834e5e9e94259980e17b4e32d75d9";
+      sha256 = "070758f58f545ad51645f50bff333b3ccbf5743a41ce32da3758b1bd0ade188b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fr/firefox-138.0b9.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "e29729ae855e9995e5c2c5548b5af0580851bdc264b93c3e1ced4a29ba5c4813";
+      sha256 = "586d5cd79456e96e9303d3fa3061cd53e7400138a36e44dbb1ec36f7af1e727d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fur/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fur/firefox-138.0b9.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "008a4410171cd5dc57d71d3970d461a9de88ddf684047240935ed34c436129d6";
+      sha256 = "835e029784412037746780450e6cf4b359c55a8424a5449f0df3c40eba480b47";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fy-NL/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fy-NL/firefox-138.0b9.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "574252eba950aa2adbaa69e43710d4300efdf609beb574c1348e0fc7320e72e1";
+      sha256 = "1e5990cfbbfed896480276c49220a5a01c079fcd67b93a622a6176bd85d2f657";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ga-IE/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ga-IE/firefox-138.0b9.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "ad425b945f93f64a5eeff7fc7299cdb8858341f79704d7d5123121ca3cac907f";
+      sha256 = "88d99fbd512d6069f233c54fe8979c14de8e4f80df75b6a3ed25c9ae7bf82eb9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/gd/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/gd/firefox-138.0b9.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "dc4c549e67bca41686cab05a70778d251bec7f04393c2ffdd1839fd2dc5aee6a";
+      sha256 = "e709f3a79328849e8eed16c763a99e75ea98301262b7b7e2696d364e9bd09f22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/gl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/gl/firefox-138.0b9.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "0b257b3fad952202deb5efb8c9c16827cc736bc30294dbb75c8e7b5e3da9d0fd";
+      sha256 = "4bb992cc7899db5f287fb308e5cf46e6a0de88ba3f309dfaa7572849bffe3631";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/gn/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/gn/firefox-138.0b9.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "c3bcd3278666a66c14ae86eeca705a89e43bd40121408c52a877188676768ec1";
+      sha256 = "394dfc68789fb34a9660cded12d0c068b6bbabf32752df26c5d0ce17054ac15f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/gu-IN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/gu-IN/firefox-138.0b9.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "57f77ad57a0195fffad63fc84204d4d47df35b4c1c207b5ac747743ddc2f68b3";
+      sha256 = "3bd178b93097d42a1e1889370f9ebb2e694b838126bae3d3499a1cfd74f76bc4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/he/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/he/firefox-138.0b9.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "5ba38e979772b2c37dd95cb8b9e4ab4cb0c07a8e18288b7adaec4b89c2ed738d";
+      sha256 = "55eabfc77a302c7c3c563aaaf9e6166dc8ca69bf8ba6cc7d6f4436dbb3bbc618";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hi-IN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hi-IN/firefox-138.0b9.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "7322e060be05bbcffab7392b9d937ac17a8d60c3af0bdb43b45a0dcfc182fb94";
+      sha256 = "1ce9e995742d6adb6354983e4dfa59a5ae137dd44a0fd4f7d109e1535cf5e16a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hr/firefox-138.0b9.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "f4a16125374c9aa466d5213c565e694a4668fa92e875814ac5fb44994685b9d4";
+      sha256 = "b443f56294322beeeaa49b1d56b55d583071cebca3f1ebbcad935dade5863dd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hsb/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hsb/firefox-138.0b9.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "ce961cca196da998192b8f24344e34b476a19d5142db800d0fee153efcb77ce6";
+      sha256 = "4feac595468c1b186b83acaf4caa350e07467adea1a5072559427cd2a26bc1bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hu/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hu/firefox-138.0b9.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "69ca37e072084ec23eeee0a7ab0243c3b7749f9e6b37ea48f16fb17c626b76b5";
+      sha256 = "2ba338240f527f390e0a2b1b4cb87a3c2d2a6c2f3074f202c26d893f06b84227";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hy-AM/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hy-AM/firefox-138.0b9.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "3da107e96a56ba4a5ab175571088793610f8b8efe61c4e180173b100d4b305d8";
+      sha256 = "340f077ec7ec896d012497227261427a083313ab968a1ddb7ed946e86f1efec8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ia/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ia/firefox-138.0b9.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "32c3042feb9808d33897b2a1b21a6e96d61b0b2b563064d72b2ac4579c401835";
+      sha256 = "4799ba81ad1e9dced07bd4455b74614513b9dc0e35278cf5e3314519375abece";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/id/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/id/firefox-138.0b9.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "42d9c7eb1328f76f846102fde392123843efc6dce95163b23695485698b28f24";
+      sha256 = "1a0b703975abbefaf41b0aa680f7363961f00cbfd976ee0dfc61d859abe2c6a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/is/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/is/firefox-138.0b9.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "17e477d1f96d273bd4c8b51dd6112e9d623c79793acf8c350c3c8d589e23fd57";
+      sha256 = "f773b68f7d330150cae95fee13e04bd6ed64acaf492a1765f8e2bcf38e2088a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/it/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/it/firefox-138.0b9.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "97bf236f9dfef9cc366408d65fce9ce7a0d34a80b2b9661211767bdc064c1b1d";
+      sha256 = "9d5bd4ed52733d584ae38dfd1ab740524bca0288779936b0e14828fa3010cb97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ja/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ja/firefox-138.0b9.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "17f0e2326114fe84e29d43862c97d86851eb298fe9b8f63ed256564c5eed0cbb";
+      sha256 = "833364c8524891fefee36123c27beef3117e28e807cda7392f8aba58e817a5c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ka/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ka/firefox-138.0b9.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "49cd63a3d178bee3a16d4621e3636065a6ff2c0e156161cd3c8ae9f946c89982";
+      sha256 = "90056e9ec3bd80f1c54c640360334b25a333de3a81622a5acaded9dd09a8f244";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/kab/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/kab/firefox-138.0b9.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "586d36bbf978f3b8a67c969fa6cfb795a1f55e412d20afb881f69b6b4e8a8c43";
+      sha256 = "1ff4af65294c6bb720b0d37ca78ce28dec5cf8391fc73e9854ee595f9a214807";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/kk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/kk/firefox-138.0b9.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "67d2d58a7e70cf536b88d4c0f8dde991716a9daafdda837eb3cfd4f2493dd201";
+      sha256 = "add96c9ee56fa8c01ab79dfb28bea67ffe4aae659b766802d164d47c821567e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/km/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/km/firefox-138.0b9.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "4d1a054d9ff827415fc330d6d142d51bdabdde327d80d9f0fde43da660a44261";
+      sha256 = "a7c05b16e60e878af35441d7fa76bf0f1c3230a12f870ba68926d6366b5c29ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/kn/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/kn/firefox-138.0b9.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "89bf39d54a0265e83d1b6b0ae5585b50ecf5e77a07285eb75ea7c5df96e4935e";
+      sha256 = "bb3378b00e4587b338edd0a757c6c2b33400ab60cb187ea08d154b78bec8166d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ko/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ko/firefox-138.0b9.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "b53a59317398e513afcfc577fe7680cc0923f0c1b17858d0afc0d35840830808";
+      sha256 = "07156a96ff4de2c7caa722acc9054545d7e754ca66071749fc82e5b40b08b753";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/lij/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/lij/firefox-138.0b9.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "e2e0eeafebc9f8a287bee6a8774a0fd31519d573b7c0a61ca9d69db525434656";
+      sha256 = "8d42b8110e3d405aeb59662c2893c9683757913787d813e67f7095ed98c41404";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/lt/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/lt/firefox-138.0b9.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "5ac4031cbf7a29ddb99495dc839bcc5a726943f6737e35a899527e93c05b53be";
+      sha256 = "9b0f537416a21ba0924ec129cb674f972957800c00ce4da928bdf69b6f54f02a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/lv/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/lv/firefox-138.0b9.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "dd786a35101a5d8145fe45f81f0bb63e26853c4b1683a870a2f6708cc46826c7";
+      sha256 = "f52a391a83ef35e9cdb9477a1fd79f02e3bc57efb3c96dce4dd6500588b64b2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/mk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/mk/firefox-138.0b9.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "7fbceffe26dca9560a41812f9080661a9d95f9447c2d942124280b607c68a90d";
+      sha256 = "f795a11e9f59b57c94f2ae68c30de75bce11ae615871c829b4a1b335cc7cfc4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/mr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/mr/firefox-138.0b9.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "9c01a5c0e09bbc4a2f6e9140daed81459f415e5e95f92111509e71fa00170ab1";
+      sha256 = "03a7b2e164c6a6f7d261671382f267667864e67f5f138468a636bc2424f1ab51";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ms/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ms/firefox-138.0b9.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "d38f1953eeba0321b20f089ad10a37644ecc39ec422c3b1ea580432bdc42ba58";
+      sha256 = "b58d49b20d7d180b6544f8e0e247e4e03c2dcf116ac7ecfc39bc4bded19df6a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/my/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/my/firefox-138.0b9.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "09d0b529b37c94886fa1665cad9c420d7306865d4df0ef1313129b0c6c41bc32";
+      sha256 = "5bff0e7a50047b9adad4ca7bea17367143e8d77c1f837e992bf9a4c886e1e370";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/nb-NO/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/nb-NO/firefox-138.0b9.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "0287b916add04fa8f23178384fe5ff832392cbdbe84116d19600fe4b3571ff8f";
+      sha256 = "55f8264e3a2fc66d27a9244b4d44f005df38a6df07ef887a496faf9a403bd5dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ne-NP/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ne-NP/firefox-138.0b9.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "05dd8ebe1986c76a86c62b870ed6964dfa0b813edc440042138a6908ea174408";
+      sha256 = "22f21bdcbdc27e2bc030f04e3af51236a1115d90b9c60f0dbef1c55842dfded6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/nl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/nl/firefox-138.0b9.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "5b4dfb153877e573a9b0b4a81ea07253cb4e2c583b0788ae39527dfcb68ddab8";
+      sha256 = "473638a89dd5d60dc516064739d7a1267b3c3c1f0d16ab1a685361eb27c11cbd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/nn-NO/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/nn-NO/firefox-138.0b9.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "a50b32883392a405daa6e7bafc3161fd2d5fbadc183500126b41eb54b4961470";
+      sha256 = "3bdb958681516c6bbb38bae154527fac7daf5516ba4141085fa7aa7746ef2d27";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/oc/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/oc/firefox-138.0b9.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "083e6bdcceba2079ceaee7113c6f5a526affe2283820d2e6ad9abeedabe664c7";
+      sha256 = "a5fb11472289e634e367b9cf2eeefa642b7acc56836db219a8d8d7e74bcc78a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/pa-IN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/pa-IN/firefox-138.0b9.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "acdb216ba73dcd18bc05d1e848e241a251dd9dfcf51d7fc07107f8f9275273a3";
+      sha256 = "4fb2ed5330fa4fe6cbd63eafc2f4509c4e9e8874a547798ad67ff45c85aa4f72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/pl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/pl/firefox-138.0b9.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "051a4cc7a27a6f0657930a3bac4feb801034066ac5c1f597eb864d62b8398507";
+      sha256 = "99d726eca2197ed9403487f92da9551d2f43ebff80782f6a176556f72d2a3af7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/pt-BR/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/pt-BR/firefox-138.0b9.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "81ad860db9d5195d20697e9c952069cfa823b16335b526ba5594de341cf94b97";
+      sha256 = "3d87b053809abc2cc7e4bb89d449952f4d6ddd08335bc9a7336b4fb97783149e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/pt-PT/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/pt-PT/firefox-138.0b9.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "767c02235a8c5f053ea686ab52bd4ae5e89185958aaca42474ea6f8aff361c5f";
+      sha256 = "595b743edb3704645c6ff28ffe3a0a657d8ee8150e2c8c2f0cf9b8498049a1d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/rm/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/rm/firefox-138.0b9.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "266505f3dfd3587721d8c9aa70015c319f92bb6292d6a3a2af9903193add23f5";
+      sha256 = "f61220acc62f3d02113f8f05cb480340aa0e409ed15a9cc132f527ead602d748";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ro/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ro/firefox-138.0b9.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "1e973a8e4d22ecb6c99d0017080ef376d1c755c4aed1db4c17f3d5ba937ef32b";
+      sha256 = "b9f36eebe2b1ef701234191aac9af5a9a1095e51efcd6657e39385e9310820bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ru/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ru/firefox-138.0b9.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "54ee7d43166ea9728d16d42f9afa9f1ef2ee9f77f7dc39396724563f5045f57f";
+      sha256 = "4d16a70498e872c802fa8a131a4efde2fde2a6517a2fcebaddc9fe9b155f86e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sat/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sat/firefox-138.0b9.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "6c6dc76fe09ac48a86697547a11226412591183cc25c955a49be86095ce099ac";
+      sha256 = "3bbc7f387ab8433be069dac9ef7f54ac04a29953291e554c77c3f0df8f701285";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sc/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sc/firefox-138.0b9.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "ad776ef072469ec87f37f10e0a6f3b0ed94dd0a0c33bc630675009a86a933a3c";
+      sha256 = "7d91a6dbd6532344b9283a77443ec67613f56d1dc0655b923a2f416d9ef3d861";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sco/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sco/firefox-138.0b9.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "0e5fc72f533778248e9b2364ee00452840828e9a6f22a77a63d3f853037f5b49";
+      sha256 = "5ded3b7312c290de1688443e29a215ab88c5b2df07afda9009aeb525b05d3e9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/si/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/si/firefox-138.0b9.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "bf243cae6fe9b3da2f3efa3acd3e4390e15fcfff26795770e658aa62fa841a14";
+      sha256 = "4bb65aced228724c99efdf333e7187e135c363de2724911a51483ae16af1d211";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sk/firefox-138.0b9.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "25809b89943527a092655f77259302b848cded4135ea84ae43a85cf52618a0d2";
+      sha256 = "6fe12385a2ccbbaccc0f3cd7af00b214a7cc62358979d8a323b341bba0c0fe9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/skr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/skr/firefox-138.0b9.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "1866ef50dc4b0122078825ed2f540b537a807300795eeb92b363d00fd288e76b";
+      sha256 = "d6281da91df61ad271b3728fa537853afb23ac1d5b9c5f197daee9d0f69ddb83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sl/firefox-138.0b9.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "d99bc7d841864846359fb7953e2bc8768dd70d10f5f2e96e2620b0d3dbed9be7";
+      sha256 = "1fd528f21c3428a8354e0441968002845a3191741aa4d273863345316a0edf58";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/son/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/son/firefox-138.0b9.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "b6e3a9a889c54656c986b8062cc959641c746fb5b72d99fc3a6f706448612124";
+      sha256 = "c09191f749e15748de1d64c5258271bef58922fd52ad73e6a2958f4af22840c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sq/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sq/firefox-138.0b9.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "722e657909aa48eb3d4795e609e6fad435aecaaaf0fd43c29125aa8355d6b342";
+      sha256 = "cbb55d0e073e06531aaad1ae2237e18c8e7e89e2f564f4405e64b6bbe5001c87";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sr/firefox-138.0b9.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "54006212032d6aeb187ec1ae5682e08e17161bb1c246b9631b08261d915cdb3c";
+      sha256 = "7a4ea65224574e81385b60f5eb960d3c9252427d7602727483441204e96c4f8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sv-SE/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sv-SE/firefox-138.0b9.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "85eef0439aff665442f12900c55eb6c86b11f5e31c92120b252da90e9ac09853";
+      sha256 = "e014bb87ed0bd09f514a2d89a58ab3d0e3c94c10a86a0c6cf391732e186fe39f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/szl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/szl/firefox-138.0b9.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "28695dc87161eb34244659579d67cc908a4bafe4b88e6c6a8d01a74826e57cb4";
+      sha256 = "0097c9696d4c7cac646360afe6c0620e4378fecec285f8e8514ecd1391393076";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ta/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ta/firefox-138.0b9.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "ec03c79225cdae737171d402885725e6ea2a46d7b2a88169f2a81f93f09f27d5";
+      sha256 = "1072f19ee7f6c0b0a9ce927907f891bc0a4aaa61e8d72f355ba455a6c81ac12b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/te/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/te/firefox-138.0b9.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "bcff0f09f256a8ca561a98be6d38a2d8e4b8f3077fdca1ddcc8b8ef1225b3a36";
+      sha256 = "c49a4e9ca7a52a524cd5a6e8e90124e964cae0529f9a08a449349939cd4d3a94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/tg/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/tg/firefox-138.0b9.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "b14b42e6792b234146921471a420c2a8533ef8281d85fc21d482838aeab73b27";
+      sha256 = "07b0eac74d886c8e9b4f3d40bd9013895dd968e8e0dbf84062137427e5f4041a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/th/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/th/firefox-138.0b9.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "ee6a01b836c079eda1ca4c98949491860153dfe0a4a28183df163ab2b2737bb6";
+      sha256 = "c372a1bbb565c0f7f1b47506d72cb549bdfc74f6fc8a38227255b08dc6bce84f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/tl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/tl/firefox-138.0b9.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "f83e81dea8da021371db0968a94577a1c6c3d4a3f74edc7b46fdedc47a473366";
+      sha256 = "0dcba23318509f033f5d080108f26fb546674e1f672cc4c6f60bdb7ebb3bcc22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/tr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/tr/firefox-138.0b9.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "03ed4ab6015aefc21dbe35190734260643caf7f36467c56f8cf720d8ffa72968";
+      sha256 = "ebf9f41cc25946c0eb12dbb1238d7740a8ddf76159f8df6167415a9afc2032dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/trs/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/trs/firefox-138.0b9.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "b8b2290dc1fd69480cc14b25639a347d493948dfc25e7816d1963907a4f33d9e";
+      sha256 = "64d9d779bd9eac33d0fd8945598a4a2168440dcc4396316fe7a3b16fed9e7ff2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/uk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/uk/firefox-138.0b9.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "8016a28eb52336b369bdff7146af4e83442b7263191b36367ee0bdf2f3c33c2d";
+      sha256 = "fe8999f25346cb39bf18e13cc13fdbe2e0add0b70dd6a62f633623e7fc108f65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ur/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ur/firefox-138.0b9.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "a107906c9e22713bf338b67c51b8c50a0dbed92549211097b0358e343a79b6f3";
+      sha256 = "62e031e5ba00b90cdde5d8c5c6a232e2f02799dab6a645b2836b5d497fb4e138";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/uz/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/uz/firefox-138.0b9.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "15f2726658d3cbd9444716ab6aa0b393d29df37e9db96fc72fec5545865d05ba";
+      sha256 = "22a7748c964ec5bec57caa2312fcef75538fab00fdb3880355d7abe967f7aed4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/vi/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/vi/firefox-138.0b9.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "67c961a25713221353c6fc422ca267cdb73bef6fba198e4ebf7cdc44eee9e015";
+      sha256 = "3a4cd26ace63c2e9b9a2267a3f799d34d3cb4bff301413b5a30fb38cf84f7f22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/xh/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/xh/firefox-138.0b9.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "1ebf8bc0a3a94fecfbe50a5eeed4942998f83e047983da1ba9317c7e3c5a726e";
+      sha256 = "2088e63127590fef556dbfd0b8f2badceb82565a67758f32a3f9a4b5be1f9ef4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/zh-CN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/zh-CN/firefox-138.0b9.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "6458482532f7f0483aa0fb32fffa0082f775855d3bfafa75e989a615d5066766";
+      sha256 = "d5999efb8f70e8170117292aabc9fedf0ff69b0ecae6833352c636f3e2d743be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/zh-TW/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/zh-TW/firefox-138.0b9.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "3d104c31729925ef76c7436343a776f3b33678d95c5b15e182939adf2a782ad3";
+      sha256 = "fc9c4fc99157dfc6885202296e7bfbfd8d7757c135f3863179db219849a208cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ach/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ach/firefox-138.0b9.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "7479dc6122632f2cc38394263af9e5c83204e091530f3a1f6fde3895a144bb9e";
+      sha256 = "7ce28f002755dcbfb1fe21a415c0852a1fbcb20e4667d7c8e9561f1bacd8ae5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/af/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/af/firefox-138.0b9.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "9079967eea0a8c06d70ab710699056aa44389cd0db80abc7246d166d29161405";
+      sha256 = "2e6c6e55d30ab8376e0abe0e347bc8f54e668066af222658e24750fcd54b96d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/an/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/an/firefox-138.0b9.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "5b4aa10813bebba6f2a3f854539771d90b88111d7a33464dc5bc44e6e3d2a271";
+      sha256 = "5768efea60392994777b11e8fae1081522343b15e9943ce26a1feba0a01e471e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ar/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ar/firefox-138.0b9.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "27b331312e6e312658290c15b4f643d74a79ece02be99369adbb0f3595f80f1b";
+      sha256 = "14bc94bcdc76cc220064deb656b2b38f891048366d2f801f822757b6ee326217";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ast/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ast/firefox-138.0b9.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "d763f646a358ce3486301eec5dd049d47d236600d91032a9fab8c116e194b8fa";
+      sha256 = "af00bb8c1b4ae9522dd3f08f83f4d98f69537dbe016e5f70882176354beb67e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/az/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/az/firefox-138.0b9.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "559e7881155e0e1e328622685f51a9dc355bc11b228ef50a84e6a4dd68570674";
+      sha256 = "b4b44fdd925df1316a086757f207b569345c6121a29a24703a5260e3226d7c60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/be/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/be/firefox-138.0b9.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "bca0a29c7662740d053975cd5659849e09d1b29e694c51ebe3db6889bbdbc4c4";
+      sha256 = "9c81aac5cc32a640f83cc550444654e70a96cb170079ceeacdacb63ba47e6909";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/bg/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/bg/firefox-138.0b9.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "f707c2aba8387f2c53b9a9f54b22b5ba263a348546625616957709b3ebfcd9d5";
+      sha256 = "d479c27b0d8ede199fced85de653eb655470290fe34b7fa9835c3a849195a8f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/bn/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/bn/firefox-138.0b9.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "f4f12f428781608cf480e2b35b24f4570f93ec3e04a5d2a9708c77df2b061c92";
+      sha256 = "6ccebe56abc1d453eb87d28b3bf9956fe2c0339bb1f3da50b9b22d42b147ec97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/br/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/br/firefox-138.0b9.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "8ba3248074e7870d650e0a4435c0cf8a6a74c8a34516c04ac3cdbd0417c0fc3d";
+      sha256 = "af48d70e9dda8ba429a0e9e56c55ca296f4fd8cbd11954fa90bd43335301ab94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/bs/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/bs/firefox-138.0b9.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "f1693020c29737622a97143ca82cd2dc93b0f41c25b75ebe5432a0b522f54367";
+      sha256 = "bcb9bb9c923e6d7911e9c4a6498f473227608eb5d52aec3bc0bac029a847cecc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ca-valencia/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ca-valencia/firefox-138.0b9.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "5acbbf7244b59673eb3a308d1e3b9ffd2735ee532780ddb97dfbf23ed3022e2b";
+      sha256 = "5f17bb1126de1442bc2c47c494b3e7bd23018c3cf813d4f69a0858454c244322";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ca/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ca/firefox-138.0b9.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "bb711a740bba862cdbedf18c23b54cf0873879bed2f97e2b0eeaad03f5890a2a";
+      sha256 = "2ed1124e2518525121b44ec3a7ce536559d5b48826e1a5bed3f2ac4080aec48e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/cak/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/cak/firefox-138.0b9.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "876521aaad356d8637c411d5e522840c7f49dbce0af601b96bfb4a24c8b4379f";
+      sha256 = "d4da5d3d237ea1125d579ef37154b3812c0dc3bbf0eebaff44c2f8b962542ef9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/cs/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/cs/firefox-138.0b9.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "eb442833658fb203ebfe1444a67528c17fc06c59737ccf4f034b0d256d79932b";
+      sha256 = "0c26a5b6424a8e75105afb35357348e61609bfea05e8e5edabc2cb3dfe0d28fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/cy/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/cy/firefox-138.0b9.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "73f40e17cc4084b86c242b4d8124fded5c084c2ab936021bdadaf7be7e92e9a3";
+      sha256 = "1016ca93fec5c4a62665d9d5db84d374ca589611963744e7e1ece7188fd8cf62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/da/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/da/firefox-138.0b9.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "15c92c6d2d7b6f391ecbd4a9f949b3df56a942c1d4615bd0d3ba9ea5534fd660";
+      sha256 = "7b73f8a206a2f1a2c78600cdda2add1d06a052230cb0404b6c1376e3fef1715a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/de/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/de/firefox-138.0b9.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "3a8c4c10841424ea86ffea7c351421f738328a393b950f6e2262bccd447de0f4";
+      sha256 = "6e43a1c86555426646fecbbbae6b06e471766818f88ed62fbbeec82047247ac2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/dsb/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/dsb/firefox-138.0b9.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "c5b9d2b803ad0b886314d3ddaad23d9629887d82354e26c07d82ec868753b9b2";
+      sha256 = "6e61c2cfad4397d9203ea0ecca7f77520ebe8281218d3ab543080b11de5bfac4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/el/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/el/firefox-138.0b9.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "99fde56a01a16ab1e09d009aa0e36697b5cbf9fb5b8b0b970dc88f4e281bf46a";
+      sha256 = "9eb70baf74e6211020905a81d8bb85606448e16b1fe5542dca2b9e153b1ed9a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/en-CA/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/en-CA/firefox-138.0b9.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "004f8db95896a2366343f7d00fbb30c0689a2910b53abe786a280d5f7f6781f5";
+      sha256 = "74280be6ef4d49607bcea1fa913543e96408895aad19a4e214c85d35f857e1aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/en-GB/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/en-GB/firefox-138.0b9.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "9a2c3371a2cad437e135412043863ecc769f941a9fcf741a5e88f57bf91971e7";
+      sha256 = "02c2fe632d98fe4d8505ef53de2cb2e6e6da6090326ca230d12fc042ab229c18";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/en-US/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/en-US/firefox-138.0b9.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "d16fae37e6042ea23c5d7ffd3f5817730b5489bc1acff60de17bd4e64e6349ed";
+      sha256 = "0a549086503c09cca2c9d7f89e586c5d110b341a500610c3f4a2d3e9ed25a409";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/eo/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/eo/firefox-138.0b9.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "9dac38d1121ccdb5ce2124cf5ea10f12a417dca50385715ff4ee0d530b4eba95";
+      sha256 = "f93d71d5e38e301e5f7232734aa54639ca4dba844a4a056c593f79bb517529c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/es-AR/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/es-AR/firefox-138.0b9.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "85c96f509d0fafa7f2a2e744e483e7ffea4fb559cd7f918639023be358b41c6b";
+      sha256 = "beb858411f25c11cbeae0de8603820b723313ff1c50d62545f844037030aaecc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/es-CL/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/es-CL/firefox-138.0b9.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "27f083d3d7cac7c5b153e01f3890f493b48a7931a1d3158139c9f0670a89bf84";
+      sha256 = "dcc809b75597e3ee0c9d320fe895169fd55b02fd0b5083ac974ba23251499f06";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/es-ES/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/es-ES/firefox-138.0b9.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "f4af98251961ae0f93f8b444bf8558dd26a02e467236fda34cf15bf54e2dbf36";
+      sha256 = "67c62f317a1e6b8d8e054fb41feb2891886f2a2322da6eba6caf2449c3b5f122";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/es-MX/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/es-MX/firefox-138.0b9.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "3fcf3e01b81c53541429e089173740144027c2441f0e6a269919f8f6f4cff38d";
+      sha256 = "e82a9713de44ab3a65b5d6a2479e302b755882b0f1a9e7bda8a729d0f9f5800a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/et/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/et/firefox-138.0b9.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "8c7d0a6c67917234ba3b8054a6ff30ebf42b746f74fc4b92434e958c4a4f66db";
+      sha256 = "cf9c51d12336f421de096354de51964d1f1c167a71e1ddf42b942365f36bcff3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/eu/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/eu/firefox-138.0b9.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "c2b5bdb5b6ed4cd17c0a16cb8a909a406038398c128b4409b7b2cf500cee510a";
+      sha256 = "19db396937697d20534d4b277e305a88fa58aefd53622b30f62dca15d2248315";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fa/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fa/firefox-138.0b9.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "1affa59a71f9d47ed01b7c2a4f704346b10029c84fa04a8fbab5377819587b94";
+      sha256 = "88644cade82ed0e852bee544b031bc7eb9c9d3cf5e81d70d620c7e24525e0dee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ff/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ff/firefox-138.0b9.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "8609c462b25c386474fafe63614addafa66589857388ab94834b54c814db5ec8";
+      sha256 = "1f89e5c3bdc3612c9dcc7e50246acf7afb46451c09f2411d788b8c85a7e7c3ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fi/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fi/firefox-138.0b9.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "cbd0467316432d860e8ac154b4725c4301dff8e6a4943dd3d4294d54bb1839de";
+      sha256 = "32fc8b17a67d35332ef39e575d35384dc152f999cf985ae787b88b8ee70da1b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fr/firefox-138.0b9.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "3042106b307cf18c646b6a36a527e1981e731e8fd8e8c7f4f78008c5bd864416";
+      sha256 = "c8a27b7c343e542712281c20c77403e982ddbf2ae5c1bde8cc0a1ca4feb6494b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fur/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fur/firefox-138.0b9.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "f0a6afaea91f2e9c5c12393f960ad2a4041062262377bc5877d13f7c1ed93711";
+      sha256 = "c21eb646929dcda7e4c5b079159ab60636d3f4cf5b4e1ebf1c169df1ed6a2692";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fy-NL/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fy-NL/firefox-138.0b9.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "661041ec4465bc3040dacd2dadaad9f9253568deb18e988712300e86cd158bd1";
+      sha256 = "ee6f585f8e1bab66422c43a214de40b4c964102f6f8443312511134300f7718d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ga-IE/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ga-IE/firefox-138.0b9.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "eaeabd3bff721aa8281f4a5cda884ab6823544d528ad5e3ea036433053a77793";
+      sha256 = "fd8c8f859675ff8a23c3923f88fe96e67cf6fca84011de64ace8febf1dc1974f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/gd/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/gd/firefox-138.0b9.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "78de6bb428a013479925616db118e9d8e8062ecde75c1bef1de4cff24d08b39a";
+      sha256 = "f3c69b4ef87dabd047b51780f8dbbbd3bb5102138ba67b5792418923faaee3a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/gl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/gl/firefox-138.0b9.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "0b931e1b7367b9e529766b33e7f9b33539638f0c8ebcdebe9803aa3102e4b51d";
+      sha256 = "f8412a360248f60eedaf98b5bb973c17f0f586f02a700d58fb15de0a8dc30751";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/gn/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/gn/firefox-138.0b9.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "c2703d7bf7827e6ceb5d5380321b0ff07705c3b0e5c7c5eef9b814e58c212111";
+      sha256 = "475058f84ce6c87022d24782476ab300776e99f2c941e0a2c37c43ce4b16743c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/gu-IN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/gu-IN/firefox-138.0b9.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "d500719429666e63b2343e83c8c0b2ed87994dbe313f48961baaa45414739c5b";
+      sha256 = "326b7c5a12ecdef9879b09af9dee007be2c8d962173cc03d28dc06e904d9259b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/he/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/he/firefox-138.0b9.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "225fe65494f8a2ea36f618c2b2bc8f22cd055e2c2142d243a9c74f067ba39a33";
+      sha256 = "67a0961a17ab0ed020d6f0599e27bb76f205cd6b6f601c7dcb41c8241da529a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hi-IN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hi-IN/firefox-138.0b9.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "8cda527dacaafbf33921e4630754ddbacd587d9f03aa7f4c4b27f8f9826b4b44";
+      sha256 = "8c62141bab666ea189ec431bbe1246bb31df639fcbd19e1841441da8addae021";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hr/firefox-138.0b9.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "7b21066ee72f55b50d8e32d30d74b297fd3a04514b02ece928871a21b7845749";
+      sha256 = "63cd4ad08842e62b8df6dda22183e30f93fd2528e5b4013cf83eeb92e50d256e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hsb/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hsb/firefox-138.0b9.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "33ea54c36ce97402c3f38eb70f7c3036a29383d2a786b91c0923faae890ecc13";
+      sha256 = "889f9366ff2251e4228be3165171b582ce5c29d7ce3587ca3ffef0d35a4070ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hu/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hu/firefox-138.0b9.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "7eacde8665ca348ea0108c9434193aac632d7543002c2a84fd643cab8cb1da72";
+      sha256 = "552b9c7e629dd2dc51f5aa3bc554ce575da71e07a8038fc6bb52d7fc375d8698";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hy-AM/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hy-AM/firefox-138.0b9.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "2b979961fc4cf15ab839fc011d1007f57256244e0369e672bacf370fc7a586fd";
+      sha256 = "15f0aa48bacc5faa3e70d5aa1273f9f366440bc7e59827a1a77a2954eda3062e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ia/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ia/firefox-138.0b9.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "a6ebd0c8299a56e09e0251a78957693b44a7dd636540981f80e502d0ef7f6dc5";
+      sha256 = "3d0649f01e2c0ecfd22a593aadec114b6d1d005157dfea0e1f8ec0dc2c2b5503";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/id/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/id/firefox-138.0b9.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "8e6e96dff1046f38febcd342ad383e72310c71cbf816da8f536d93c656d26319";
+      sha256 = "a80ef0db6a0723a41a270f83e39fef4bc18103a66ead7dff209d800e2e785189";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/is/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/is/firefox-138.0b9.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "8bc09e75e17ce60c4d250aa673c41a92d9308743b425b3fe81ab5feffcfa331c";
+      sha256 = "38e9415aee3673604144fca76825352e6f2cfc87aa3b43ca9a2f56af22542dab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/it/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/it/firefox-138.0b9.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "b979aafd747007759f9658db5cf49545b7fc6c4dd7a8516bc682b54013d96fb0";
+      sha256 = "eb75d8b9ae3afc769cb65f512f0cd0c4809ae089c39f073d61095969bea9297f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ja/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ja/firefox-138.0b9.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "6b7b43ab0e602b19cd966fdaadc6733536b0e61f7e23b8633c230ee941446740";
+      sha256 = "3015c6d1fa6680403314f0c793f4cd702dc3d591234d5a948457aa10b8541810";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ka/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ka/firefox-138.0b9.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "620a990d91302c743acd9e2ed0d15af2ef7c9c95cbfcbd13abe31f37db667b20";
+      sha256 = "513d1d6d81ef85f93516ca07e22c667f56d8c74c5b7dd97085eae9c3201e0227";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/kab/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/kab/firefox-138.0b9.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "c549e9d8be66da2c60621deaf3c03c365b578ad026a8fbb18163f44a2edde8ff";
+      sha256 = "77cc93beefce3542b29c9ee6cc9268f74b805a06b2a11f25ec6e0e3248d1ed48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/kk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/kk/firefox-138.0b9.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "319992af03c691622fd4e028dee9f68ff681b201c829c8fac94b6ac1b2444880";
+      sha256 = "839056e0bf61a4f639b4e790bbc66314aef173cbf7b09e5f80a20c78099fc0db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/km/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/km/firefox-138.0b9.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "f62bfee8800237128d7ae727564bda9060eb41d7d27f2b7eb1140c52b62e86f1";
+      sha256 = "743ac6c946cc7d9a52e1c97fc5c0dbe26412fbe302247d55113815ecfa9f9c2d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/kn/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/kn/firefox-138.0b9.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "818823253da880800026ae6e08739e615ee9aad15246e2579b4e96ee7e40f3ca";
+      sha256 = "d4a2a27c7b4707218b72e7ea65c22ea68d9aaf53e3af8b7e1479f053373481fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ko/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ko/firefox-138.0b9.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "0fb41dc322ddd629311d6bcb8d6eb78a7127cf70cf6389f928c7cd7007b574bc";
+      sha256 = "c57ea249d8470d9fd59aacf877574ed7710e8b4b67937bc991ba214269dbd11e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/lij/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/lij/firefox-138.0b9.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "a87b35d5068ecabf1541d552e09518e6871751c35bde78e50bf67b2bbb0f9124";
+      sha256 = "f79206346a6eee3c582bee7dcdb1442e230f0dba4ffa4af221199108cc31fb9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/lt/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/lt/firefox-138.0b9.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "89190fdf49f74bd65f09850432bb60ae457887480365d3edac3dc1eca76a30df";
+      sha256 = "72cbbb299ae282f20eac44f00c42e41a8ec59bb02b35135cabb3689820b1d2b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/lv/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/lv/firefox-138.0b9.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "3d51fecaf98018f8d6fdad6402e635b42b16da88150867fc9c74f2cf900378ee";
+      sha256 = "26da34db3ed639b3ec7931d78ad5bc541b056a3fe0c08e6c9612e30a10c8f878";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/mk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/mk/firefox-138.0b9.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "fcd0107b68139c9585693efdbe52e4a67669a721bb0bb719b7375331fd081c11";
+      sha256 = "1d49cd2a297bd97f1c4fb2852064959b70ce2a22fbdf9aadb9b0f8a702aa236c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/mr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/mr/firefox-138.0b9.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "a6fa9a09d4de8a458913f9fcc5103bf098c0d49ff51e2d233e146411320c61a0";
+      sha256 = "d0c0f33616bc6cec80af9480d9498ac5b1908938c6adf099e542e4e890c6d3d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ms/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ms/firefox-138.0b9.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "b3f3a2133d92ce08e8b77e6051f7c2109e8f210e11ade78e1dfdaec5c107c091";
+      sha256 = "5fe8361933deebfed59b871af864da3402954179c7185d153d513718059e0c48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/my/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/my/firefox-138.0b9.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "998882322ea526f81ae367025eddd7bb38c5f0da8d88ebfefbf78ae47c06b77e";
+      sha256 = "bf4c16418ff1c09f0f32cd75701734a89323bd4b58f45d29b54d85e3ca46502d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/nb-NO/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/nb-NO/firefox-138.0b9.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "8a7b1e32d6895b7120f6de59614136c3fa6788d419afacd3aa3031b147a44b29";
+      sha256 = "f6cd1229d9909ab4082dbb27305ea4c4568b910d19a3bb71bcede6ca62c61d47";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ne-NP/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ne-NP/firefox-138.0b9.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "2d764038f27072b9048b5ceea925160a577f655be63db9fbb10dcc313a0ecf19";
+      sha256 = "373e6dfbdd023eafb0604346bbc29f70f9be5bc354cc861244c68040557cf0e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/nl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/nl/firefox-138.0b9.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "9f36b90b2e781872218598472b4351713976210f94544b284db420a902d90d5c";
+      sha256 = "0a93d10dd9800759ced99444ec5628f48914f8c10f900bed3fb72dbd2e45a69a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/nn-NO/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/nn-NO/firefox-138.0b9.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "d717f8e3d80f21fdca92a39b0c85bb8d4d9279d42a471c8130f841e0a1a6092c";
+      sha256 = "4525142f8879b8b4dbac13af7eeaf7c6551aaeaa4c8c1d9f0868cc0d5822ca8f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/oc/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/oc/firefox-138.0b9.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "8b861eb3f4bf31caa19648d5d56b8fc4f3f6982e5bb66849b56e13240d2eef4f";
+      sha256 = "f65837831aa178b4c11b7dfb6300539238bc86c201ba01507594118119888810";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/pa-IN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/pa-IN/firefox-138.0b9.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "883bcbd17478958b7051a4831ae4c4cae6eb317fa0ad57d7dc3e5ee5a07744f0";
+      sha256 = "bb3cb018cfb3a3ce9f2da7d84abc547124f88940e03d15ba13cbdb4c41c996c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/pl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/pl/firefox-138.0b9.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "94179577c1acfb8ce027e2abf828cb29025d7419bf110eb33f998ca69f8e44a3";
+      sha256 = "dd99387cb9df41d09939532c3e44b5718eb927a8062816ea38ef9340e5268bfc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/pt-BR/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/pt-BR/firefox-138.0b9.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "3b18635c5ccab1a3fb31fddd5ec73a5bcafd217d91b392b4bfdb152c8e60888c";
+      sha256 = "9b8d90f71be0959bcc5a0f55d5df3b34054426e2c7ee39443cdf531bd24c3290";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/pt-PT/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/pt-PT/firefox-138.0b9.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "e6c0d92e26f3c793654269f0ac041492f1a61efade8c21a8f1f5d9f5c7a462f6";
+      sha256 = "7fcb4b787f79200699315a2991acfedf0fcff022dd1816953d5b441717cfa27e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/rm/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/rm/firefox-138.0b9.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "896fa4341255ad6edd05747b1d9b7862746649f5a17d1771e52e4d3ecfcb0f8d";
+      sha256 = "0d5fe4fd2b1d8fa8fc828cae26410e5dc306528fd26cb1b2f0e9407e684a067a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ro/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ro/firefox-138.0b9.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "1453aa68ab6f1473ea6f2bd74b3d1bbf7867a3f874f5ac4a006f711c7f2606e0";
+      sha256 = "80639cd1d6d35da3ffdf9879857841cd1f5e457248c3d74827b0185c80ef78dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ru/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ru/firefox-138.0b9.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "f66e1fe7ad4be8c611a4086e2c274315761040f8a703501b88569dfc4a47cd35";
+      sha256 = "20de91eb62d677a3b38e9af038f73c83ff29703d82bdbfcda4d0bde5d289f604";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sat/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sat/firefox-138.0b9.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "9348c28b1407b57a2498eeaa8928e9b2df482414a4ce842e0fd5d32a15ef960b";
+      sha256 = "14f1492ba249fedf9b3d64192a3ffe033c053ad412efdecc9a9c5e6fb188b148";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sc/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sc/firefox-138.0b9.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "5f1e203b0bc54bef4d26b799c9f0b36135a10e52a11432442a993c422009777d";
+      sha256 = "149ae0e4e41f7e3d45b80e905b1ed21b4559af34d4082f6a37dd0cc29acb1aad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sco/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sco/firefox-138.0b9.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "9d5aa39bea903a6c64798b57208a37a429a48188fc90f85e07d439a8b4d4c982";
+      sha256 = "5dcb0ed695c0a0c5b8ed0702e035881c1ae0d2339fd8efdf667c7e0e153f09c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/si/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/si/firefox-138.0b9.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "c976b9445a68b630c6b8092c3f9cf1809759d3541d9db3edd791a2c8a2c58431";
+      sha256 = "4550b500d57c250eb81842562643f9f590102fcda1ff22f9495fde5b0f710fea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sk/firefox-138.0b9.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "528cfc6405d82e49ce1d3f50b982778e0666e6f2a6db2581cb85d0c32fcfb958";
+      sha256 = "2805569e2503c28584871f16e5793d5ae21d0e886a2fc06a71fb5b2e445b025f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/skr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/skr/firefox-138.0b9.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "5888fba7e084bd38d72fb4d3b9ec8515c78f60a07e7297a02c86611f9d854645";
+      sha256 = "67c457cfb2d5259859380312876f446b67b12f1f90c10d2af5265dc7f268ef1e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sl/firefox-138.0b9.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "05713c10164b52bd8d8e0713fba0c983b3b1eb8c7aa36192e967b808ca99f3ae";
+      sha256 = "d727b93beb813e17596dad9255b8268a036ae206047119125caca31011f91079";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/son/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/son/firefox-138.0b9.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "0ba74b43e2a4c41730fba7ee8b67c3b545fc580d3f891d5498c2d2ee5d2305a6";
+      sha256 = "2316c93c31ca52db0683decc256116a1c1195013f92a98b554fce2e5fcef22a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sq/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sq/firefox-138.0b9.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "d14cba8c3d12875ae5899e48a94eeaf2405f1877df587508b59bf3268fa92b0e";
+      sha256 = "14eb34f915c76c6d156739581f4a0dd5c184c6b3a5dea1e5609febd288d6ff9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sr/firefox-138.0b9.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "7990c1a1fdd683dc42746eb062fb8c7dae0f1de5d15a6d78c1d798eb1be71f89";
+      sha256 = "b1ee34d1db9d61695a01e2bca1d020064a927a97cbe731bcc61413549221f7dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sv-SE/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sv-SE/firefox-138.0b9.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "132a876e9bb9acd950646bd8b39a098f46c5c6ebafd07cb86da8b85407758d29";
+      sha256 = "da1d0e004484fef9637b42971ab8863d3fa9e27d8d079aa75609a46c745eb94b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/szl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/szl/firefox-138.0b9.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "fbf778fe846332616090640a2545ffbc4c536e7769137758d22b0aa33e3534d1";
+      sha256 = "1a9cc76e14217ac4b41e78b0838763c6bee4117994cf79bdd23bedd28f557efe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ta/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ta/firefox-138.0b9.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "49ed6296edbce85d364427a730bfb74e536dbbc92b1887a6d23878d1dffb4d65";
+      sha256 = "1d307fc31ccb8567d6a118835f9233bd3880403275b466f2c7289ebba4c667d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/te/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/te/firefox-138.0b9.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "df9eabaec213bdb9df7c3fb487048f5d0e03ef9e1b36edd5a508c3699409a33f";
+      sha256 = "15aa89919b9d96d1a338122cdc1cc29a83643b63d5a761b7e8a819c33be009f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/tg/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/tg/firefox-138.0b9.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "976fb89f5111994de51ffc51d6a18e5c96aea5bc6a80c57690fb843a453eca18";
+      sha256 = "82c69afd7dd65e3efc9ed8df2f269e9ea0b9a26ca8c03a215ecefe971925bee2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/th/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/th/firefox-138.0b9.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "509845c33718e4d66c50507a919a7eeffa65aa62795edc37bf03374056025cec";
+      sha256 = "aee29d229015401c5f5e619df494ab687997c77c7f177e52e8c027b1240e5b5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/tl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/tl/firefox-138.0b9.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "ce97e79ee1f295bfb92a26126efa3366681655806014e38b0218621745159dfc";
+      sha256 = "d8de7515395316fa30d58d0b0dc3b684e9f5d2e3aa46a65142ff82731c0eb488";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/tr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/tr/firefox-138.0b9.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "4d044aebd3893b607626ffb53b57ff962b3bc12770f5be7da42f12f5c03eebb6";
+      sha256 = "dedf256fef420ea2d8e5231ad02c681064cf00bb978d97bf07c4a5624ddc883d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/trs/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/trs/firefox-138.0b9.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "f7c6cdb6b7d29a66b9f5477bd8ad6e2f90d2c9c51c0ba454305fc47bdd0222fb";
+      sha256 = "547dfa2d5e3b6bc3cfa536b2e29a925be1b8001ef23db9f91681bf946ea72cd0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/uk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/uk/firefox-138.0b9.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "544abc2450e681b0ca8ec833a13bd02ddf94bb8dab370126b190eb3d46b35548";
+      sha256 = "536e095a95c64dff9ed40f60748af048b935d0bf2cf7b94def0e6b5bd9567a3c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ur/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ur/firefox-138.0b9.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "0dd23e0b02a3d25131ccada64e1ca735ec97702b8c5bd8904f04cfd93701004b";
+      sha256 = "2a4feeef97879302c6a64dc60f8a81f200eba292b23292cec5cfeddb5d0481d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/uz/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/uz/firefox-138.0b9.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "44f51fe9a06fef663ae75d5e045ad7ffabd0b111ec3a312b1d427c272719ade4";
+      sha256 = "38ec2a3424b6c2a587c720c5d4a73bcc0fc54459e1e36e7bc8ae7f97256253a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/vi/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/vi/firefox-138.0b9.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "0e1514cd3dceffc592703a44afcc456d0ebb01528c3215ede19c97c86cf50937";
+      sha256 = "8f66051904bd6675a8e6eb0a08747f076509d1e0fce8b77fabe43b2b9d15c034";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/xh/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/xh/firefox-138.0b9.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "b4ac60687f69fc7d697bf6cbd3d34cf17c0135aef0044148da9bc930926a4d21";
+      sha256 = "f113652ecf2ea05717079c75c86a56edadb04660c5de4bbd1bec42dff9f302b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/zh-CN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/zh-CN/firefox-138.0b9.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "feca67d43e8cac981830b46c826c7739ed79051c51008622d5900b8184e64486";
+      sha256 = "2cf9172ff5665370b5bf1dc96b482cbe1fd61dbcac2b28cc8c07c7a9d3d88707";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/zh-TW/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/zh-TW/firefox-138.0b9.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "787b75e92cd96ae3808ad38dcd7300360d017ac234f3fb3fff7f11874ae3f7d6";
+      sha256 = "09da69ee59a9c8c9896d64c83e45e9bec02510cfbc899bab7743573459e4eb22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ach/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ach/firefox-138.0b9.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "4dba4de14bf320c5e71a133b183b60b7d04d83a76d86cf77ac507c45bea9fb8e";
+      sha256 = "5e3a47e49853d2f50247538cadfb55d0b9090657ad529fea54718d06267a806d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/af/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/af/firefox-138.0b9.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "f429dd76944239dfe5d55242e1a194aad714ec352e8b0f2b10bf5dfc322c92d9";
+      sha256 = "81116a42585f5055e59380b553a824a5cafa9db59c55368368f7cff925b5cfa9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/an/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/an/firefox-138.0b9.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "6a74e60087a3c6d75d805c320c6b2920ed14a5d0354b3e6cd7573fe2954cbdab";
+      sha256 = "e03b451a6c36d82e693b0e7e91d16df8c3ec44a3df6575a9e43ae85642aa21a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ar/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ar/firefox-138.0b9.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "59cf79704987223a349c033c00f323b4f85897f3879fac905c8b217e9f41ebdd";
+      sha256 = "d0fec6cda884d47ef9cb7d59b4601e2804a6fab505b1a4105d35ca6f3c7511a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ast/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ast/firefox-138.0b9.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "e172f60107ffb37fa364f2401a63818216083e907b25dd4b8142248b999b6589";
+      sha256 = "858524559c1d4c8dfc08e78da932c46dbef4eacb3d3a14c8504f116c9345a80e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/az/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/az/firefox-138.0b9.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "70c01c89cbeab938b3d09fbd609d20393853e7b7cf9370f7d8111567477dde57";
+      sha256 = "5f52c31274a50c978f29614d33e41fd2bb75b4753b0f5a7f1ba99ef12296594c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/be/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/be/firefox-138.0b9.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "a1b5371d5c0f533fffe78b193e38945bc1ecefc13e6d41dc75ea6fe7a0012b8b";
+      sha256 = "cb7d7f7af9949e2fab6ec9ea506167b32deeaf623a597a480f832118b90e1d20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/bg/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/bg/firefox-138.0b9.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "f546a566fc02cd611b54da162e01eca1591c05950faa283619ff462f311e46c7";
+      sha256 = "9e6eab8a7d726360a7111e0a33d7d293d782eb0708de5325696f6324942d6a91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/bn/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/bn/firefox-138.0b9.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "83493f8396f07c94297e4d3f140b64286d5dc0aa9fabebf011640f7a31a5174e";
+      sha256 = "c9c9c27437e507d65956ffa1e6f7d72cd518a80e8246ac3468305b83f9e14fd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/br/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/br/firefox-138.0b9.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "e8f9348a03dbbb95dc54669295263412c6770ba8092668776205325c4d66c498";
+      sha256 = "88328aeef69c610e176cf13f0505a498da6ece55acc7918bf93385775d103333";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/bs/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/bs/firefox-138.0b9.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "1e8f291cc4869139abf7fe4cc0aa34bde2cd6ddd65b1de88122c190eb1fd9f41";
+      sha256 = "e0ed2d31920ddeaaa253efc5ce6a88b0d410c393e43a528304928db60bc571bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ca-valencia/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ca-valencia/firefox-138.0b9.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "d70218ffd6bb42aead9e52656bec4f78ff5d71e43a6a4ad74f5687e171af530c";
+      sha256 = "e19a51c97579ee162255869d4dae6c5be99955a1f0aa3af39d42ecadfc4c949b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ca/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ca/firefox-138.0b9.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "92549a05b092a511ee061144204195f44a12db4e69a91962a678dd98b456e59a";
+      sha256 = "bfb1a6818fe98a2f514d1c7a6bd2c4421158443b7e7845c866dcb005db1b7d41";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/cak/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/cak/firefox-138.0b9.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "2b45886b54ef0e35605d76871c93df2773077bd63a19edb940fcf46e7769cdfb";
+      sha256 = "1177513167534f2893b8d5e40da2d9240c8171514b3206fcd21ff480a610fad2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/cs/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/cs/firefox-138.0b9.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "13bc0c007f6cb8fdc1dd2110dcf4a688315bd72e3b5abafad0cc1143695459c1";
+      sha256 = "0227f210716065e251e3c3b69feea728d689cbfa6cea637e114c675fee3510be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/cy/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/cy/firefox-138.0b9.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "c3a60745e0a01dcc024fb5f1a669b2ca64a44f0d3ccfd2ba55a8c54656115417";
+      sha256 = "bead0d7876df8c62cf66c9f1b497547b7374affb325a7c3817df69554a3a7690";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/da/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/da/firefox-138.0b9.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "455d9e99a3c6b40b1b043b9cfbcbbb1a1c591ea48f5d516255241eb393e2b574";
+      sha256 = "c6e30d23b71facbbebf2123603d5043af13bf77428c24bf4e82f8998dccaa8a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/de/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/de/firefox-138.0b9.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "7955b14e88187ba18ca1cc548406932639d8aef074c2b95016d92d4f1d16b695";
+      sha256 = "0b44715056d449255557bd1d79b6b342ebf87f218a5764010f27b0acc80a7919";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/dsb/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/dsb/firefox-138.0b9.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "45ff9f1fd0ca8a5a2292dcde5e3a13e9aa0021f97cf9321f281003a3ed360fbe";
+      sha256 = "9b3ce960970fea55ebc905af93e86cf08130249cb761ed7845d4b9d949e22db5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/el/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/el/firefox-138.0b9.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "8c72c30ceb3a44b79b3a7c48234744c47cd726592131c71b8abc27b1c769254d";
+      sha256 = "83b8fa1155fbb5a4fe47713dd954d05d365faf1e94f76b6bf69f258ac0cda546";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/en-CA/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/en-CA/firefox-138.0b9.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "3c030eeb676ec244a66bc049abc2f7c41c4b9af648a8bea243682fdb4af400aa";
+      sha256 = "8b1faddb955b3f6f66816ccaed1224d0ecc2d558c34e9fa9a2ae11ec1337757f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/en-GB/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/en-GB/firefox-138.0b9.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "2e729717b9cc8029784cd2e00767552ee68b08796c20a4ccf0197076b7e2c281";
+      sha256 = "d309c99711904629a5f2f28256f39489966bcabc13c93b477b9129a73de90822";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/en-US/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/en-US/firefox-138.0b9.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "c9246a995979a13b142deddff467e899954c327ec8a945cc0b22a7e20663c001";
+      sha256 = "e30ba28b3d4cd0122edac0185c9948af1bf46d99dceafbd7549bc560e6fca824";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/eo/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/eo/firefox-138.0b9.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "6faf6b3db45088f3c7c826a6a0c866c5b16fa5a7ecd6080ab448eefe056a67f2";
+      sha256 = "8b62f77cd305122bdc8434128bda39ed5a5b719d09e5019697a47ed7c3cf06b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/es-AR/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/es-AR/firefox-138.0b9.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "d354bd8afe79bc10eee44e71ca1f0d71a0295e393fab7dfc80b58d82fe8dc0e0";
+      sha256 = "a2fd10d9ae8854581939f1fc1b17de5d3849b49e35073e2b8e51fda98ae435e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/es-CL/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/es-CL/firefox-138.0b9.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "36a553b846c8e2fd5880574a88a0113132634e0e049de5c712d20e6897c1c176";
+      sha256 = "e22a22a4c12f1fd3127898848b11183a0e3256700e747aabc0bbba03f8b7e3a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/es-ES/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/es-ES/firefox-138.0b9.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "3a09f6aab43b37c65585c4352e8df347d0505c84bf8d7a5c510b0e540873c23d";
+      sha256 = "3daff8ee93b00a5f45908f4271fdfb32d4f46ffb7c3309a283ab9c1668985ff2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/es-MX/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/es-MX/firefox-138.0b9.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "218d3547916fb90d9fbf3f43eb2e17473807429bd7f82cd98469f3f49c33b119";
+      sha256 = "0b93af4b976bfb4381422b26c20f82cdbd751ea1027a34e53e385dc27bd9730c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/et/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/et/firefox-138.0b9.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "6522bf6eab8e7dc2856ed36f5e8a34a5a2c7938e35df288261d9bb21fb08188e";
+      sha256 = "f944396258f6d7b15241cb54a8e299eea0116c314093fb66ad35be36c2273059";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/eu/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/eu/firefox-138.0b9.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "8030d323e062a1173eda9e9ca2d29ed7a77155f202eb990b71aae790bb62fabc";
+      sha256 = "0cf77645cea356217270228d70458f450075260b90e00287d5613a3ef0dade24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fa/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fa/firefox-138.0b9.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "7ef0bb05281b92a6b74e856fda0941c3390e5dccc3cf9a5a2d927a640ef9d1cd";
+      sha256 = "b2898e4c79921744d7536c2ea49669158044b25aa4d52c812d15d2428e24f3b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ff/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ff/firefox-138.0b9.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "002f289c4ca6b7ff049e9e527a914d8725015f5072fafff463f9b573097a5008";
+      sha256 = "e208fd92fee2998746840149ba8db5f57be571dc77681bce374d3092510eefaa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fi/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fi/firefox-138.0b9.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "96c014b4d4c3de54d2f78b9d74d1ff138410261cd09600e0fce4892c415f8de7";
+      sha256 = "74be727c6a4c6e7f0900d00d0fefab5dc47bf3b1fec9c755c7a4cd01ac059340";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fr/firefox-138.0b9.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "e0e597b512754cc7426a75655d4fda26eed5c219afd195bf50f81849f07a3ce6";
+      sha256 = "b272e4764673d06d9aff452bfb008e121a161c14d1f181a078b480f530e0a5d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fur/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fur/firefox-138.0b9.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "ec7bd02d2f83959143ac47889a7bef5bcfd7082b7858c276aea7513f9503d32e";
+      sha256 = "d465858108df841e2f2f6f58a89f9312390044132ddbb20aea32dac1c1d4e618";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fy-NL/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fy-NL/firefox-138.0b9.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "9c0315fb65755fd68e646a3735ba7e7ace5a43b8664c3cb0131a35300e7672fc";
+      sha256 = "498808abd06f0d076d0753a0bb4489634b3d462982a4549fe3af4471c6b49db5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ga-IE/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ga-IE/firefox-138.0b9.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "484828425dad1a8ee77b35ec531a2144df77b5bcb0f9620aad11a994409d41c4";
+      sha256 = "cfa34d2677bc39e3122c5598dae7fd203f5e9b1d25807dd4ba9de0f669e7f3e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/gd/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/gd/firefox-138.0b9.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "b831c4d80580ba2aecf7e724816ea26075c952c7de28c8cb78496d75af533cdf";
+      sha256 = "17721331129c81f92eb62391dbf304518defe8b44caa45336dfcaff68e19843b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/gl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/gl/firefox-138.0b9.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "cbdd00d04fb1a9728123becc83f0279a96bfe283a27dc044898dc87a7ccb5440";
+      sha256 = "1c42e35bd71b2757c5dab64f76112f7364e5a3c20a64127279943435f452f663";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/gn/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/gn/firefox-138.0b9.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "389dcb60e0e20e2ea19b751cf9cba2160175e7c297b838ccb3a11e0bc78d259a";
+      sha256 = "2d867826ff6a89331107921d095b8f1b4fce4bd42e84be759822a625c99362a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/gu-IN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/gu-IN/firefox-138.0b9.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "de31fafb532f86565ec03c939250fc32537f672ed09cb3eea21272fae962eefc";
+      sha256 = "84e2b7d754a5ac24a9abf31fb1686200d15a95c72b19f758df314f55a129cdc7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/he/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/he/firefox-138.0b9.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "cce0cc8fa93f6318688ef2a664159199e4c6e1a2d3aa984ec46bfbc2536fc0ba";
+      sha256 = "5bb6ec9c4223a87615290a35a5cdaddc5ff0800d85a807ab3daef0f3dd4665e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hi-IN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hi-IN/firefox-138.0b9.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "3dc345ff030c1ba64e95f06b6ba3e6c9a2aa175ad7464fb7bcea28d4225f175a";
+      sha256 = "4aa787d3a09962e752c6e727ca07b3221a35954f49644407ab0aac22b920a339";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hr/firefox-138.0b9.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "bed89b538d187722de5e18a3d6e2aef568c3a5bf1be7c2f9b418c263dac0f11d";
+      sha256 = "41c46b1269ef9ca0972dea37a17701a428bd0c7ce64f19c94d838cadefc2a231";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hsb/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hsb/firefox-138.0b9.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "143ca5f040c5274775b40c3a7f6a9756ab04160423eaf7338f75b0f03629dadf";
+      sha256 = "f359c2f20e3ee863a617419c6020818395c136a4b10991c930adbbc41087fa9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hu/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hu/firefox-138.0b9.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "aa979034b6fdd14f3e948eddc0f4bca691a213279f4351dadefef6d2e7bcf7b8";
+      sha256 = "8b5ac5424dc438b4e10673a3f6019d85134b0045259c1407355c2df1768e5643";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hy-AM/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hy-AM/firefox-138.0b9.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "6345b24a6ee4d5a63340c7673dac3afc729ce001e37e9019d6ca74e8606bf298";
+      sha256 = "718c98bcdbb5aaffb0dd1647a632159554cbf215d4a33824212f578d1b2837d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ia/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ia/firefox-138.0b9.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "d9875bf61c807750f626237c55dbb6b9c0544fda8ad4d6f60e0c8b98293bca1b";
+      sha256 = "cb77e02f475bac87767a91fc6448070aea9e13ea36513a510c36ceb64910d895";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/id/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/id/firefox-138.0b9.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "b8fbad9f4bd52096ebcef09da94271a2b22914b034b0aa3dde30763061003f2a";
+      sha256 = "9f3be1d02453213115639060ac02cc5d154aeb30eafffee5a258cee6c41a1187";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/is/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/is/firefox-138.0b9.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "5905f09f368c0b8165eecd8fd896c082d4b6ad7a288e2de96223b00fae4f380a";
+      sha256 = "c360c3a27aa8b174e38d05c9a4dd40a72d3b9968b3efb705fba97433aaeaa66c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/it/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/it/firefox-138.0b9.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "4d0051391fc367fa2f9de69ad761fa8832aa5b4aedaf4dbbc09b4668cb7c6ee7";
+      sha256 = "fbbe8510405a558eb15d1ec6e99f7e307743220f2a5886c85fc6600e36048cc0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ja/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ja/firefox-138.0b9.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "c56d46da0be7190bc1112420080a1ab34e161576b53165cc189e03d2c5174e63";
+      sha256 = "8d16338d16eaae1a065afe8d34477eeb3a246679cc8f65e79725450735d40d0c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ka/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ka/firefox-138.0b9.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "83149973b83d8405d1cfd3d02ee382ec79e606bf852398abf0960d7f13b100a9";
+      sha256 = "fc08a082a89d3edca2bcf61f295fd624cd86e93cb9a1615638c8212f526a4b4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/kab/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/kab/firefox-138.0b9.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "4086a97e0341648b4784b8e3cec4029f4fed00ebaab536b655230123349ec24d";
+      sha256 = "4bea9b3c151c7521b0bef38a21bfe7685e4a24c29c645765f42604cbb55ba854";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/kk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/kk/firefox-138.0b9.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "9232a3cb15b541e6b0375f1eb2ec7ad60c32e4a6aff255d373e3895ecfa01ed0";
+      sha256 = "b54663b35c23513ffd45bdce3e0baff2d0f4539ecedea99d3a2ec31ee0d954b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/km/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/km/firefox-138.0b9.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "777e0d9beab3480e0556a10caca424cdc8d51a2e19751e8bbcd47ba536a4a0a4";
+      sha256 = "240df5bc306c8eb09fbc707592f92e3a8a50026491b01120aeceea835204d007";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/kn/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/kn/firefox-138.0b9.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "c15468a0a703020e1fc518b0752fdc522e047b7138b485a8b72133e4622a7d12";
+      sha256 = "2eb01ed15c38fbf823310f0500046fec193ffce8e260674e48e9940545362fb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ko/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ko/firefox-138.0b9.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "1c49f3125f5b71e5ba2b7e5bb4331f4f1d561b0a12d8a21488bfe9a6c11d0f72";
+      sha256 = "3443871e1e0b6f332379cbfd4bc9b4ba4902973644c091d91304cb9197519ce8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/lij/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/lij/firefox-138.0b9.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "919caa0bd18b0d7baaa393c0682aa250d980a045dcf4303df5d4076cd212ff07";
+      sha256 = "24be60be0493df639d1fdcec1067c331dace4067d9caf6fddd8833c706edb937";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/lt/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/lt/firefox-138.0b9.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "7cca85b0f5cb687c4a58cb3ed8440850cad102ce8b9410978f51e42e3f3ce732";
+      sha256 = "1c4db0a32b53ebfa0868d743dd61b6578655db2559902b834a6e3c878e546831";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/lv/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/lv/firefox-138.0b9.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "3404a967cee8b521da2aa2e44de6e1fff492266f11d4e16b6130889530c4bae6";
+      sha256 = "6902fe65dfa7d5ff8761835b4ae5c3a545b5fda885ef59c69bfcc102f8caeeb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/mk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/mk/firefox-138.0b9.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "3764c46ad2eaeeb18692cb23399ccb958fc855a1776096252e1362c8d6b7746d";
+      sha256 = "7e6c17647447da936ba569bf2e1773b3b56de0f2703f47104b53d4e69e78dafd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/mr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/mr/firefox-138.0b9.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "b953a8be0c927e09e8a32b607a2e405be0d343e2856f31d4727edd3cc21c72f3";
+      sha256 = "4e0aca0d5e4d994ea9c1b223afc6a5c5b31b48c130c57be8db5d28a4886a6260";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ms/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ms/firefox-138.0b9.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "2c2654b5b7288f1b03c340a58b6cff5bb2fd28188e3a60dc36732ffc9a5d3548";
+      sha256 = "8cee31a6791556810ac791ebcef8ac5d30fc1cb72678cb2935e0555f62651ad4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/my/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/my/firefox-138.0b9.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "93a8cea90b538beff516fe946a9b6bf96fc1e8edbcf30c90bf3b311bb662340a";
+      sha256 = "c8a7d8b72da9930d9e8a013c01e028ead5c5525cc46c5043180fbbc924ce38ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/nb-NO/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/nb-NO/firefox-138.0b9.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "da4e75f2f00f535908141a3ae633f4391f6d181a7b8072cd3ff1ee36a0783a68";
+      sha256 = "7e53fb62a519456519531e4e279bdd004a626b4de690e9524eb2bcba16457224";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ne-NP/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ne-NP/firefox-138.0b9.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "c1b57522b6628e23d74d889958fe43ed88e236d612fcd2d1b124307f9ce2a1d9";
+      sha256 = "e503ff023e51e5c772bb4460b74534be7539083803491eb6901559c41fa93d25";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/nl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/nl/firefox-138.0b9.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "f08d7801a35502d87ba79536d0852046db3ad086559c0f355633b24e915bc18a";
+      sha256 = "a6f442c5cbeada795d317e3245e1c28d865b302a1b01e484009cb34130067576";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/nn-NO/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/nn-NO/firefox-138.0b9.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "3caf0db9687ae89a5a4e226eefd9739179a7889ec81c2ca26186f2eedba8bcdc";
+      sha256 = "24bb3d9bba4549696ae339edefaa3d3f231ca1cc5672d2d52909c1cd09f8439d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/oc/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/oc/firefox-138.0b9.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "46799eb3d065f4a16100afaab696827b156474d9d83b4e95ef0678c7981f52e1";
+      sha256 = "502ec34f615bee8b3bdfa9cb95960f9518e3ec90d4db802bd9b68f1a9efe1a60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/pa-IN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/pa-IN/firefox-138.0b9.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "889931181631832037cbcbbb2c883a22a154ee4161309d9bb3f87721eb97e191";
+      sha256 = "2ffcf30b6ba7373b232bbf82f6bf33704a85bb0be7f498f42d505c47bc6dd620";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/pl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/pl/firefox-138.0b9.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "9ee7fa9407d5ba68483f1383e453cfaa6598e26b8e8800d9fd5b1246579d8e13";
+      sha256 = "51d5b980a1b086f8a4ab728a357ca705c8b4fd495c77ad233f08ef7b84c7ae73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/pt-BR/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/pt-BR/firefox-138.0b9.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "26948401239bed611427dd907bf8c16ec8aa7fabe901817eca4b404a56dc0a13";
+      sha256 = "77bca34213ea30dce4f105f0322832ced7ca2f52d4d6fa07345069a8af6be4fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/pt-PT/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/pt-PT/firefox-138.0b9.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "9b61c3bc750c01a97e063533bc383cbc37b8a756685fa51fbdf0d37aca0c4a3e";
+      sha256 = "8e6ce8af8690284c764bcfa6588ca52997c2e6e31dadec887a063b3652a2e45a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/rm/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/rm/firefox-138.0b9.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "1090ee036cf5ccc6e54c8d027c3dfc4b48d0b551b5d1e5445af9df8df3773b6a";
+      sha256 = "7e69cb160def7fa4dc050cbd442635b94f2700c93aaf35cef02b0bc81834f07d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ro/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ro/firefox-138.0b9.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "4c5ec76aa87d68d23136f8b6493cf49de7e1f4626ef6591bf7f56ba2a05e9848";
+      sha256 = "af8a4e1bbd653f5e81e0e2b53e7ead8397327cb0aa6bc12dd57de051b22ac6ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ru/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ru/firefox-138.0b9.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "0d689b56d5ac9feab771f71af7b5fdac84c493fa53d6df84107a97982b4816b2";
+      sha256 = "1b4f515de80b1ed1783644d22b61cc9f9e120831b55e354d67a95d47cb8915de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sat/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sat/firefox-138.0b9.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "9f7b24a649199891e9df80f418a7ac446dfa5c788654e865f5a345495912787b";
+      sha256 = "f95bef736c704afcef3c1a04cfaa85f06d5b44d7e7cc9dc16a7e953281efad08";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sc/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sc/firefox-138.0b9.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "c6ad52380b870f26799bb06b98864aab86f25b33c41666c5f2d759d51eba6ef1";
+      sha256 = "8a376905176ea8e58b761cba3fd844c3995db46e1784215e197944babe498dbe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sco/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sco/firefox-138.0b9.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "2936d6257caa14ac7143fb2e2b94a461bb843503580906f8135210cbca57dfbb";
+      sha256 = "ecadf0d2b59f3c3ca78cda22a305cfc29943690769303e4402457002f1ad5668";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/si/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/si/firefox-138.0b9.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "81822c077d0970599d5eb3e5c189c8d9c2c8f7e6c81e21d2150a3448450a9859";
+      sha256 = "ef2f594a5582765bd6f32c1089182a3e5c6bdd5f42d68e6984501190a9f524cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sk/firefox-138.0b9.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "0c6478b5031dcd15a2e33a5c90be75f284eb5f6e6986681d5d47f2a6c0c77331";
+      sha256 = "b4b6faecd8bb2c21fef94b2ac1dd2cd05031f04ce07bba5b0e69fabb68a2f9bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/skr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/skr/firefox-138.0b9.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "6215e72dd7d3632b7fbc6931a9a0419063ba1530ab0ab1d75b86da3a7f84af97";
+      sha256 = "0c2d8fd72ca6c597092ff5e24be16a17a3a4600428b2acc8ed98ea3a0c6732a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sl/firefox-138.0b9.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "a516ff966fccccd21a7372bd657dde36140197ca2ac0f9fc2ff5a138abd74189";
+      sha256 = "7edce37cad96c5c5555f63d804ec2fb61dea416e231a8d39725e835dda35133a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/son/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/son/firefox-138.0b9.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "fbec94c4d3d4418c06d8d6efe93d42afdbc9b7de0c2cd438db14b32e65243618";
+      sha256 = "c11063194e36ee19681d777aa415565dca2ee736648c34cf37cb30b52f2ba700";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sq/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sq/firefox-138.0b9.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "cdc237a4a886e5b529b8f71d23e29d8a275bd2c804e2299db2d2a5da75a34a7e";
+      sha256 = "4f4c1bddcad1e0483da836f75aa93f2bc8282ee0d9861e9c1bf27df60793c4f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sr/firefox-138.0b9.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "d69d4bd632eb6fc9b116449c4da3324bede43e403184b45aca638a1d1df4bafa";
+      sha256 = "a0faf86b492539e7def08c4b90ecb279e3b006e14a043dc48534746206d7e555";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sv-SE/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sv-SE/firefox-138.0b9.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "3c113a2404605870064f1f8b792025fc23a84dac4414c422a264a316ba88af63";
+      sha256 = "63f3cd89b64671e31bf1cbff9112d80b95199e12e6df9e516069c1d86d5a34c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/szl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/szl/firefox-138.0b9.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "d035ef26694caac8f64cd71c2633e3309d5d8d9ad1a88884edaf9b79dfacbf6c";
+      sha256 = "1ad7b45cbe71bf50ae0837993a359ca81a4841e59d6b537a72475c28df79612c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ta/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ta/firefox-138.0b9.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "5c9d1e685c27dbec4beed6c134f925c18ecfc55e1f338eaf0961f45a8aaca82a";
+      sha256 = "b75104161d68cbb513aa6c1f0bf5215997de73345b9ca7c7899061bef2cd5d78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/te/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/te/firefox-138.0b9.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "766c287ab620c1656c6a9f9f015d164b0d3d5a9aae15e528c0441a890cd4a661";
+      sha256 = "a6836538ff1c2a98ee049af9ed6bb6bb5d50d7a852c7d5566a7334f7ed7c3ca2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/tg/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/tg/firefox-138.0b9.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "50ef2e5781a433b7805c977889a34a202f3a17d1bd931a923b76c9f9bfef5d05";
+      sha256 = "9f731f33297fa4061047b7c40d331eeacd5debc8162140de8736ed50676ef563";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/th/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/th/firefox-138.0b9.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "a26724d9359df4ebca36a0b7ac7e48dfc882e53e0624b939302a899511371061";
+      sha256 = "0143fd3b0899b6e93188290c486cceb96066627c1c39a1aa446d4fe1bba17bb9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/tl/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/tl/firefox-138.0b9.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "cec6563c1836c69ef503f2307cf8a2671db43fea2968eb80fbe63141c6d0c48a";
+      sha256 = "c8411db1ee1aa0180fd354f4571d299edb962e3b8ef60951f9fc08c886b11fea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/tr/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/tr/firefox-138.0b9.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "3ade583446f7858772af48080fcadad55254d97851389e3fff02dffcd74e988c";
+      sha256 = "448201c4e9f0d6952d838de9ff6bcfe69a4769c2714228949d0148f56d9330a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/trs/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/trs/firefox-138.0b9.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "853baacdb7ea6470764de05f64fffe6eaef7563c25b4ece73fba1e1cd52eaa59";
+      sha256 = "f725dee6d30b294e83f75942834f51705bf34b67c77cf4ffeaf196dda137b75d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/uk/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/uk/firefox-138.0b9.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "b083cae062edc44eead68adb030b5c885fd004b4c9aab63d451151c8f0a95ea7";
+      sha256 = "6953218f8567be687af1d53a50ca9f725248877ef662b4e0ef008063c763e8d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ur/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ur/firefox-138.0b9.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "7fcd0c36294c345eaa39b889364f919fcb35a07749009548cfb041ec6d0faf50";
+      sha256 = "aeefe7e4096ac1af3f7ec767606306ffc73d1040d09f43f54f201b451a23b401";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/uz/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/uz/firefox-138.0b9.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "8cdca4b49f7b61e6dce0303af91ab171ba19bc68ef26c31709cb549faf802ed0";
+      sha256 = "f4589f2e3a49c207b90875dbd01d358d519bd2f5105f6d6045a1364d89a44d65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/vi/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/vi/firefox-138.0b9.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "f333e144c031925e1fb2016a9c1bac1bfca794feb8f68d32798b95c7470bbf22";
+      sha256 = "5d768acd15e31d66445a7548324e4d782ccf88922a5bfa56c0a4d3caf75a0db7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/xh/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/xh/firefox-138.0b9.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "3d04450587c1a914c9494d48f8330b131346675a5050304b59e4639a0d7d5699";
+      sha256 = "798a0636308acde4888372e94d6e3f993fbe906c089613e96b4e626273783f87";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/zh-CN/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/zh-CN/firefox-138.0b9.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "61ac04cad80424a04cffe63009d1f491fe83bf9aaa37fd9f53b32b6bf44045f1";
+      sha256 = "8fa3a3be5c1db35edea30715d7d2bfa0a6435d88b4e17d400a57be323df77d62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/zh-TW/firefox-138.0b8.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/zh-TW/firefox-138.0b9.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "c887b4b68d10263a65423ccf7f7367733d9d19cc4de9ff52c6b2402ca2fc3ba5";
+      sha256 = "8bca45e1549d5dedb8e3ff67a6df7b3f212e82de1f6e21dbe1bb3cc355db03b4";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "137.0b10";
+  version = "138.0b8";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ach/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ach/firefox-138.0b8.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "d0f0da12027c6e9b798fc8420785809ed5f7208984e585d791846d32ffd1c085";
+      sha256 = "80989a964e38730d2fe4319235806764520b5a0650192799ae13bfe441940279";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/af/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/af/firefox-138.0b8.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "6e4620ecb89169e9b1e60dd23969c7649d62d4cac614e7c6a83308402cb67f7a";
+      sha256 = "421a4d6cc45c4d64c95ad7783362350cb64aadf66a44895550247d1ec7f3ece0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/an/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/an/firefox-138.0b8.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "fe2d385e510ee289d174c00349a6429b0b985fd0fabec111a50a58c59471b769";
+      sha256 = "797657def82cfd6ee70084af60d5f09ad1f66d6325b9e08ffb88ecdccd62ec02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ar/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ar/firefox-138.0b8.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "f87eb7054f34a2c09409c68bfc27f69dda1d6ae01c16347edf3f44e86c9d9862";
+      sha256 = "919ad1d11421fcae4b05f2a0eec8724d8bce40865e4efaf71bb362451acd748c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ast/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ast/firefox-138.0b8.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "356e3dab406a768b54ec641bfc32b30c503b9608e4b446218243cadc61863b3f";
+      sha256 = "147c7bb0b40dbf5653447861f16b8515fe39ae7f1c13533cfbb08526be9c1dfd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/az/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/az/firefox-138.0b8.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "fdf66de1bb5799d725377e9a2039deee49867f5d799a878db75812fe72c5cbe6";
+      sha256 = "37dd7aeb3c2f88a451f5e623bc2575bd71d529dcc31f5a4c072e0ae25010ca2d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/be/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/be/firefox-138.0b8.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "4570956b5a82505ee705c4ee0615c98755a2e7e827e741a633387a452ff723f1";
+      sha256 = "099eab295d39cb2044774a097040eb5d4ae9595f26ae76421a48f741e37a4b97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/bg/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/bg/firefox-138.0b8.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "14e37e5a57af4ea698fb554e410c366821af7c26e007123fb66373e63641135f";
+      sha256 = "22be921854a33169b7d8ae8f72187f4928c8d02d52a0db626f8d25ea79f6ba0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/bn/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/bn/firefox-138.0b8.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "63b78127c286e955a9221a38390c31d9413f92c5c4894952282359cddc91c438";
+      sha256 = "8c33ec8119293d8351159e8ca1741f6a4a06a858373dc41b02a340017fe5af21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/br/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/br/firefox-138.0b8.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "2e63841530a8c265e81a1e34e43f279c34f4f13928a5592931172956db7ba6f5";
+      sha256 = "6816dc30f54105995cc29f28ab75abfb7b9b14ecbe963f0fa493e3f845c86dc2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/bs/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/bs/firefox-138.0b8.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "40c0bd4064c84d0197f2dfee5c77a4a5a0f6bd0eb5505c325091b23ee282174a";
+      sha256 = "259dd175006d8eb98b62bf3d4126f790e57d7b05c15fc3eeba3badf3eebacf24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ca-valencia/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ca-valencia/firefox-138.0b8.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "beba161453814dc95f53074b19218abecfda9bf2d1b4571e8cd1af4376be9b9e";
+      sha256 = "92f7e70f2f9a552dd558ff3c3f4d6633624b373d0d74dff1c5fb40e90418a48d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ca/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ca/firefox-138.0b8.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "148cfe273854edd64a0841f5a4eed8c08c4e06abaf0198d0617c1b840743fd1c";
+      sha256 = "f61026c82d71b9925a3573bdd6c1e9e6f7de8868d07944544c9854a8929c8d01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/cak/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/cak/firefox-138.0b8.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "a3250d57ab8d434a71fa48054870df3934dede3ca87ab6227654daa2c478febb";
+      sha256 = "d90f8af5129110899a818224eac03e34690ffc21df1ec1258c7d3f919ed976c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/cs/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/cs/firefox-138.0b8.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "a72f95cf2dd349a01769ba8b1f7c73c6553e9de9d406470e40563d302cb2f38e";
+      sha256 = "866c297ac37839400ef3eb13ddc616d35b376b64c19be83faf093d8b4104d5e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/cy/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/cy/firefox-138.0b8.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "a7fc2e0893d921ce6c6bb5d9fb47183b8ea14772cb31b9333bffd48ca7a79eb6";
+      sha256 = "631eef205844faa2b305cfb0b5294cb8c480e9338c6c069b48ac7ba482388d60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/da/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/da/firefox-138.0b8.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "18cf5d0c1da42d49ce885e993a64b1fa39fb124f76627b3d389093efff9e429d";
+      sha256 = "2cffffd9edafdd60f7c2c2a38d2cf9da14d91b6c1315e82273f58a2487914e06";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/de/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/de/firefox-138.0b8.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "78ce80c62a025c6850bb362e026406043a246d99b33096e5449f67f09c19ed60";
+      sha256 = "1a8a7c232c4611108a47afcb98d433e9fbd4dcbeae84cc7263931b619c54b85a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/dsb/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/dsb/firefox-138.0b8.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "b2a0c9b51715afae4e5f6014561abaf1022c9e5e1911e9e147760458542be365";
+      sha256 = "1ed273febd64e31eb2ea76513b968cad099a2aa8c3e93005fff60ff6835254a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/el/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/el/firefox-138.0b8.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "9bf8a3fa1d05c46c377d7fecb9d1ae4857fa5ab19160f81c0921f5d3721d3baf";
+      sha256 = "53e5a38a785b5ec57c7d5cc72cf0cc63971d618804e908e36734b4cd848dd780";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/en-CA/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/en-CA/firefox-138.0b8.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "7c74368a8aeeac88ad4587428d6dd86de51fa1c4ecab76953e41aad9bb0ccabb";
+      sha256 = "58bd81c3b7df16bd8674749b9fcdce124a580203013df4904d5e6c22328939ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/en-GB/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/en-GB/firefox-138.0b8.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "6b8f0732d30af5eda5fed8eda112d08fc5500a1c3e02117a22db967546107036";
+      sha256 = "79f98e187a8506cb41e54538b932e835615dfe244f1e9b33d6c8b695e109627d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/en-US/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/en-US/firefox-138.0b8.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "319af71913886726333110cc2f365b39cdaa120d90938869985f8967e8f4f4af";
+      sha256 = "1201eebc10e1a6d8e02ab9daae3bea5795ae9e6f9cd289f7244557fbd10c2fc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/eo/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/eo/firefox-138.0b8.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "fcb0face5526bba1bad5fdf6fc7eba2bb96b7f5ab64df78674ed4c081c8f94a0";
+      sha256 = "65107fb2691ce2f54805d544968ebc50a19fa627264ced0ff22392b13ce547ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/es-AR/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/es-AR/firefox-138.0b8.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "90b7fdcc676399b320e9a068d34e00959042286e3ebb40b709c9cde9b8dfbc72";
+      sha256 = "8eeeb37caa5ac429b5814b0a242f3515e09a9064f38f31d64a7f19b5654fe0e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/es-CL/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/es-CL/firefox-138.0b8.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "eb43c4d52d87873fc58a26d935ef95d9915cb8c14851fc2ea62b5110a2ae5819";
+      sha256 = "625d302661d8ebd31d23c64b84a305d458312244c817dfdf5cd571afab6510d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/es-ES/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/es-ES/firefox-138.0b8.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "1daa83de45da55f9f2ca238ed3f0a1ec23df7ec74105ecfdddc4cfabc12980e7";
+      sha256 = "4daff44ef46d32046c729f029f9b0ea9d86ea501bd17ac45ba9c0c0e4c718453";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/es-MX/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/es-MX/firefox-138.0b8.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "83ab68086711114b20f9849efaebd081e19e4e7c33a5dd73d1502cd1228b20f5";
+      sha256 = "38f282b0386287a7a2b6729b07d2c22b4961d948983bf650de88b8d794a00ad9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/et/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/et/firefox-138.0b8.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "ec34b966424b586f5e384c81d10aab9b29fd684f3560ca449abdc3254add8cc6";
+      sha256 = "74bed5f9d6316740b4bccbee3089e83500280df3d0656cf5a9699c7ebb383a8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/eu/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/eu/firefox-138.0b8.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "70e64c904b0a65ac0be8ae2bac04ed1af85c4fb1169a0898941e1b956713329d";
+      sha256 = "04113f82f4ff1e9620b3ebf80aeb67671580d5e7a67ae0eac74ff7317e9c74d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fa/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fa/firefox-138.0b8.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8750c4aff9537b89e76938817dd4f98b3b31c21634f954752b0bf49724672454";
+      sha256 = "cebcf7d923f02a5d30a4b73f11dd3cac73d64473ae9f525c82e4a15fb8a23470";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ff/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ff/firefox-138.0b8.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "ef428591168086a6b6d2344394aa5fcd4551b119a85f7258d1f35bb8f28232ea";
+      sha256 = "8853de176648d95a2407dc77627d433d5f2278c82e7c5f98a461b5a95a8f897f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fi/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fi/firefox-138.0b8.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "fc43b3cb736b040790e92b2b4e23bc59360a58d533b167118590cbe102db521a";
+      sha256 = "9cd51d0cbd5a4d2f32e7553cab24ea28a44834e5e9e94259980e17b4e32d75d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fr/firefox-138.0b8.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2361aa0991e71f2242e1d6fce3c97beee9dac61d0c02b0f9265cc9da199d502a";
+      sha256 = "e29729ae855e9995e5c2c5548b5af0580851bdc264b93c3e1ced4a29ba5c4813";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fur/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fur/firefox-138.0b8.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "f32bd5c0c3ae17cd7893139ec20c608ba0e058744e155284a9dc6baf433b3604";
+      sha256 = "008a4410171cd5dc57d71d3970d461a9de88ddf684047240935ed34c436129d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fy-NL/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/fy-NL/firefox-138.0b8.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "bf3354e2e772e827df7bd344bd7e56f958b04cab43f03de229eb724700102870";
+      sha256 = "574252eba950aa2adbaa69e43710d4300efdf609beb574c1348e0fc7320e72e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ga-IE/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ga-IE/firefox-138.0b8.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "468751b8fad4eac1b1ac308319912672f8f9fbf4571f8134e734b0d09303b640";
+      sha256 = "ad425b945f93f64a5eeff7fc7299cdb8858341f79704d7d5123121ca3cac907f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/gd/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/gd/firefox-138.0b8.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "ce7e20daa5f1f5b6818f55569a1f68fd5582e971b0e88b2b6bb929838dde7eef";
+      sha256 = "dc4c549e67bca41686cab05a70778d251bec7f04393c2ffdd1839fd2dc5aee6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/gl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/gl/firefox-138.0b8.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "a472ef1726220f89dca3507e22b8c779f49944c38eae90ee67996b4647956403";
+      sha256 = "0b257b3fad952202deb5efb8c9c16827cc736bc30294dbb75c8e7b5e3da9d0fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/gn/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/gn/firefox-138.0b8.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "ad10b1dae8bf121e9a29a5aa52bd2f1dc59b5ec7519e119bccc7f8fe21065568";
+      sha256 = "c3bcd3278666a66c14ae86eeca705a89e43bd40121408c52a877188676768ec1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/gu-IN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/gu-IN/firefox-138.0b8.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "f18813f2ca4e9febeaeb26eb87705f8d7c3ba0092e07035dc381e72a31537c5e";
+      sha256 = "57f77ad57a0195fffad63fc84204d4d47df35b4c1c207b5ac747743ddc2f68b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/he/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/he/firefox-138.0b8.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "85ae9fec9c97e72bf164b7c0d39b7d6c56243e720e500ced87aae51a92fbbb8a";
+      sha256 = "5ba38e979772b2c37dd95cb8b9e4ab4cb0c07a8e18288b7adaec4b89c2ed738d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hi-IN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hi-IN/firefox-138.0b8.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "370a23bc3d57b2c2af5835bac73cbc3ddfae78bd63b1a3e2a4e68267a3853c50";
+      sha256 = "7322e060be05bbcffab7392b9d937ac17a8d60c3af0bdb43b45a0dcfc182fb94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hr/firefox-138.0b8.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "9fc278c697d363b8210b828bcd7688babbdfacc250c15c69c5101dcee9219434";
+      sha256 = "f4a16125374c9aa466d5213c565e694a4668fa92e875814ac5fb44994685b9d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hsb/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hsb/firefox-138.0b8.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "5094b85a8c87181a9aaa18ccfdf2410a910a3b01912c3f29b5735cac009ed475";
+      sha256 = "ce961cca196da998192b8f24344e34b476a19d5142db800d0fee153efcb77ce6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hu/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hu/firefox-138.0b8.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "ca43990b646a281aa3a081f2a0ad29084fa8063d060eb3205c759bce64c65cfd";
+      sha256 = "69ca37e072084ec23eeee0a7ab0243c3b7749f9e6b37ea48f16fb17c626b76b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hy-AM/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/hy-AM/firefox-138.0b8.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "443e28421a588229742e0c0cb354e2dc4a4d4a6a34b02849137902c34d4aa7ad";
+      sha256 = "3da107e96a56ba4a5ab175571088793610f8b8efe61c4e180173b100d4b305d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ia/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ia/firefox-138.0b8.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "909554909e4ca042879e46421abbe22c7a1a697bad5b7429c73f24fa83d55352";
+      sha256 = "32c3042feb9808d33897b2a1b21a6e96d61b0b2b563064d72b2ac4579c401835";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/id/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/id/firefox-138.0b8.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "68252135e463181f7769cba5529dcdbddd42f694a3bcb4f77d8813cd54a4cda9";
+      sha256 = "42d9c7eb1328f76f846102fde392123843efc6dce95163b23695485698b28f24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/is/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/is/firefox-138.0b8.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "531ccc2cfcc1d405064b6dfd793443be992f3b1d12635da826805cef2627bd15";
+      sha256 = "17e477d1f96d273bd4c8b51dd6112e9d623c79793acf8c350c3c8d589e23fd57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/it/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/it/firefox-138.0b8.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "7e43713ef319fb08680fc1ccda216be9d6c0c2fb413630574d321cb28c3d4a3a";
+      sha256 = "97bf236f9dfef9cc366408d65fce9ce7a0d34a80b2b9661211767bdc064c1b1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ja/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ja/firefox-138.0b8.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "07b7a5613e9a36ed773aa400de1fac7b44e180d89b85de9c56583a7a7f3bba28";
+      sha256 = "17f0e2326114fe84e29d43862c97d86851eb298fe9b8f63ed256564c5eed0cbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ka/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ka/firefox-138.0b8.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "0f6e5f1c126816863c34654e2226a672be34dd31cd0c8567435d7c3d7563a56e";
+      sha256 = "49cd63a3d178bee3a16d4621e3636065a6ff2c0e156161cd3c8ae9f946c89982";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/kab/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/kab/firefox-138.0b8.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "5dd613b222a00d6bc4294e4ac190adcbd8d1af7ea20092716d26ad0002a24673";
+      sha256 = "586d36bbf978f3b8a67c969fa6cfb795a1f55e412d20afb881f69b6b4e8a8c43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/kk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/kk/firefox-138.0b8.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "3e94f8b72384e119500a6ddc1d750bc28507bee04bc1604de9a5618b274d3552";
+      sha256 = "67d2d58a7e70cf536b88d4c0f8dde991716a9daafdda837eb3cfd4f2493dd201";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/km/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/km/firefox-138.0b8.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "3639933713c2291c5771fd21068a4d2fa0770fd6c7764f3e11e58c11c16ccc8c";
+      sha256 = "4d1a054d9ff827415fc330d6d142d51bdabdde327d80d9f0fde43da660a44261";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/kn/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/kn/firefox-138.0b8.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "9260368ea1474d6611c9f5dbdeb9a7b398a1d465b8a42aed90989b929fb879ca";
+      sha256 = "89bf39d54a0265e83d1b6b0ae5585b50ecf5e77a07285eb75ea7c5df96e4935e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ko/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ko/firefox-138.0b8.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "abafa1b3f6de01f1a05af169c6c6b599cef374f9827aa73fbb0ee0bed2f8bd7c";
+      sha256 = "b53a59317398e513afcfc577fe7680cc0923f0c1b17858d0afc0d35840830808";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/lij/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/lij/firefox-138.0b8.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "98a004987887a49fe244bf3ebb1b6bce5ed97d45a093e81126eb9ed66279f411";
+      sha256 = "e2e0eeafebc9f8a287bee6a8774a0fd31519d573b7c0a61ca9d69db525434656";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/lt/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/lt/firefox-138.0b8.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "201855ba80fe1c88eed7eb43ac46ccc29d8db82a563381f9743c1ea798d044b7";
+      sha256 = "5ac4031cbf7a29ddb99495dc839bcc5a726943f6737e35a899527e93c05b53be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/lv/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/lv/firefox-138.0b8.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "a36ce7dfa47918d5b963fcaf1d5e9b44aa75c4fc86e46467c64f030d84ef72e1";
+      sha256 = "dd786a35101a5d8145fe45f81f0bb63e26853c4b1683a870a2f6708cc46826c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/mk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/mk/firefox-138.0b8.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "ba434cb6eb5e9c64eab8fc19ed6b63b37babee8a545823b703cd750a6d24ee75";
+      sha256 = "7fbceffe26dca9560a41812f9080661a9d95f9447c2d942124280b607c68a90d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/mr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/mr/firefox-138.0b8.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "576e06215f4c8522924e48f7fdb7078d79cc2cb1b71e8d7bb015c760faf024c1";
+      sha256 = "9c01a5c0e09bbc4a2f6e9140daed81459f415e5e95f92111509e71fa00170ab1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ms/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ms/firefox-138.0b8.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "3e3e54688b7e8a9b464d9c23e7925b47a6b6f171f816f805bb520e05e3e2f79f";
+      sha256 = "d38f1953eeba0321b20f089ad10a37644ecc39ec422c3b1ea580432bdc42ba58";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/my/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/my/firefox-138.0b8.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "79138b0eaa972d1c7df403028f53c4b4d6d222f11cf5ecf9468565f1518c6390";
+      sha256 = "09d0b529b37c94886fa1665cad9c420d7306865d4df0ef1313129b0c6c41bc32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/nb-NO/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/nb-NO/firefox-138.0b8.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "d33ca66814433c8971b6d37d2812ef3a0e9e9b569afd94031f98762d9f98086e";
+      sha256 = "0287b916add04fa8f23178384fe5ff832392cbdbe84116d19600fe4b3571ff8f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ne-NP/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ne-NP/firefox-138.0b8.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "f6aac9719ec68474b4abb58b9aacdb6122007c95df5b421752e38f124e41f1ca";
+      sha256 = "05dd8ebe1986c76a86c62b870ed6964dfa0b813edc440042138a6908ea174408";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/nl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/nl/firefox-138.0b8.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "5b8d31d21d06cc4b19ff9bb05d07d53d180820dd1cd86a95ee5c1e7403a1981a";
+      sha256 = "5b4dfb153877e573a9b0b4a81ea07253cb4e2c583b0788ae39527dfcb68ddab8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/nn-NO/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/nn-NO/firefox-138.0b8.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "757cef127d50b804479e136ebc58ea5c000254a32f2c09f92f2d43e4a47bd999";
+      sha256 = "a50b32883392a405daa6e7bafc3161fd2d5fbadc183500126b41eb54b4961470";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/oc/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/oc/firefox-138.0b8.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "965405d799f1440ac0a33bb12efcf0b9511dd80849b7ca0f2cc89ad0c77e932f";
+      sha256 = "083e6bdcceba2079ceaee7113c6f5a526affe2283820d2e6ad9abeedabe664c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/pa-IN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/pa-IN/firefox-138.0b8.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "9aeafc8fae330a3e09ceaaf122dfee8f581f054e5c0e91e10bc308b435a3ada8";
+      sha256 = "acdb216ba73dcd18bc05d1e848e241a251dd9dfcf51d7fc07107f8f9275273a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/pl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/pl/firefox-138.0b8.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "5dc8d09f27776f0f96c0302a81fc2027843a915fee40b09855d80f2692a108f5";
+      sha256 = "051a4cc7a27a6f0657930a3bac4feb801034066ac5c1f597eb864d62b8398507";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/pt-BR/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/pt-BR/firefox-138.0b8.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "fd95ca5be74c5ee2a9ee117e6f08def52b9003d80ca552b5535a6f3272f8a51b";
+      sha256 = "81ad860db9d5195d20697e9c952069cfa823b16335b526ba5594de341cf94b97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/pt-PT/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/pt-PT/firefox-138.0b8.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "1892b62ab2721d8716220c5e88af9c90fec5beb420374c3e603707ff44bc47d1";
+      sha256 = "767c02235a8c5f053ea686ab52bd4ae5e89185958aaca42474ea6f8aff361c5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/rm/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/rm/firefox-138.0b8.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "51d581629f587de3a2055d8c6799359ecfb7fe5fd13c11b77935f8041c2a295e";
+      sha256 = "266505f3dfd3587721d8c9aa70015c319f92bb6292d6a3a2af9903193add23f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ro/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ro/firefox-138.0b8.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "ea978843d609281f73d545e85bd0ba9c57adc91e4645b1f0e8b022dd92f9998b";
+      sha256 = "1e973a8e4d22ecb6c99d0017080ef376d1c755c4aed1db4c17f3d5ba937ef32b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ru/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ru/firefox-138.0b8.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "e4ab2d28171a701d63d62cd65d0cad78ff4506b7a497485b06f808037ca7ea21";
+      sha256 = "54ee7d43166ea9728d16d42f9afa9f1ef2ee9f77f7dc39396724563f5045f57f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sat/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sat/firefox-138.0b8.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "b160fab29f0fdde16c5ebf99769a7dc4bf00c4ac09f3f7d726a47cd9d69cc936";
+      sha256 = "6c6dc76fe09ac48a86697547a11226412591183cc25c955a49be86095ce099ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sc/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sc/firefox-138.0b8.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "d8213839c9e3b35db2f743d4a2789ee1ec91759f344879bccc9187c4a5acef5d";
+      sha256 = "ad776ef072469ec87f37f10e0a6f3b0ed94dd0a0c33bc630675009a86a933a3c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sco/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sco/firefox-138.0b8.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "3916653026146b6f13a98bd3559dfdf38ea2645f93b24b85cc663dee67f1c0d6";
+      sha256 = "0e5fc72f533778248e9b2364ee00452840828e9a6f22a77a63d3f853037f5b49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/si/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/si/firefox-138.0b8.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "d1fc184b57cf24b6041731d5f9ab2fa73ae0549a27cb695d8558491e44901210";
+      sha256 = "bf243cae6fe9b3da2f3efa3acd3e4390e15fcfff26795770e658aa62fa841a14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sk/firefox-138.0b8.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "243da2b019aca664e445a6cf486ee78a399b89da1ca1e67d560c82a9e2e1c13d";
+      sha256 = "25809b89943527a092655f77259302b848cded4135ea84ae43a85cf52618a0d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/skr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/skr/firefox-138.0b8.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "2156ab1d3c5185511c909f8072152649583a45c3f6e43b08ba91b7402b41d1a2";
+      sha256 = "1866ef50dc4b0122078825ed2f540b537a807300795eeb92b363d00fd288e76b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sl/firefox-138.0b8.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "6f5a698c5498603250e91c877c4e1bf021ead850ffb25d707a9fdef45f4bf560";
+      sha256 = "d99bc7d841864846359fb7953e2bc8768dd70d10f5f2e96e2620b0d3dbed9be7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/son/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/son/firefox-138.0b8.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "ba839673b1adb6630233c1daf1ddcc3e905528f60076ceb390b9bf977b86c6da";
+      sha256 = "b6e3a9a889c54656c986b8062cc959641c746fb5b72d99fc3a6f706448612124";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sq/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sq/firefox-138.0b8.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "36f06ea635d64e5fc0497e020def2304651a6fd385fe67844d2878c94ffca122";
+      sha256 = "722e657909aa48eb3d4795e609e6fad435aecaaaf0fd43c29125aa8355d6b342";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sr/firefox-138.0b8.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "9bb4a103678e526e0797ce4ce6c68e27637917436c431e33f48a06b4a7d5b73a";
+      sha256 = "54006212032d6aeb187ec1ae5682e08e17161bb1c246b9631b08261d915cdb3c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sv-SE/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/sv-SE/firefox-138.0b8.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "99b873da9b8bf0a729f3eadee176b3bf5ebbc095ca59f119b8f7775cc96434f2";
+      sha256 = "85eef0439aff665442f12900c55eb6c86b11f5e31c92120b252da90e9ac09853";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/szl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/szl/firefox-138.0b8.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "b1eb754a9421ef53d1873480938e0d26c9bc4431bc24f21f020e1d0a6ba5038b";
+      sha256 = "28695dc87161eb34244659579d67cc908a4bafe4b88e6c6a8d01a74826e57cb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ta/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ta/firefox-138.0b8.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "df7acdf49fb510f12fce7ec99f00119a29e0254dd270ae1c1b52da899d7e23b4";
+      sha256 = "ec03c79225cdae737171d402885725e6ea2a46d7b2a88169f2a81f93f09f27d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/te/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/te/firefox-138.0b8.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "4d9309859577e18c3b707283ab68112fec2ab61e66ae57ec68dd389be6235519";
+      sha256 = "bcff0f09f256a8ca561a98be6d38a2d8e4b8f3077fdca1ddcc8b8ef1225b3a36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/tg/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/tg/firefox-138.0b8.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "36044388faa92f1d2d06c18aa0fd32cd5311d8a11f5bb0f16cddda5128b0888a";
+      sha256 = "b14b42e6792b234146921471a420c2a8533ef8281d85fc21d482838aeab73b27";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/th/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/th/firefox-138.0b8.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "1818a5657f524194b08644ff1fa2444a4d18e224774ce1a0a4d84e2dda8cfa8a";
+      sha256 = "ee6a01b836c079eda1ca4c98949491860153dfe0a4a28183df163ab2b2737bb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/tl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/tl/firefox-138.0b8.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "7f821360c515bb180d5f4de778bc76e96fc32b1ddf3dd7533f79c39c866d6e61";
+      sha256 = "f83e81dea8da021371db0968a94577a1c6c3d4a3f74edc7b46fdedc47a473366";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/tr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/tr/firefox-138.0b8.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "788fad9f6ff62df7257095d0ff7f0026e651f5cfa03ca3d72976978be686465f";
+      sha256 = "03ed4ab6015aefc21dbe35190734260643caf7f36467c56f8cf720d8ffa72968";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/trs/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/trs/firefox-138.0b8.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "51e5ffbaf0c77708323fad6c82658ebe84f16eb26401b8b252538f49841e2503";
+      sha256 = "b8b2290dc1fd69480cc14b25639a347d493948dfc25e7816d1963907a4f33d9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/uk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/uk/firefox-138.0b8.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "b3ea841a43f4d226580dfc9613a457fa7c945b2a638e58906ecfe5da8661f042";
+      sha256 = "8016a28eb52336b369bdff7146af4e83442b7263191b36367ee0bdf2f3c33c2d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ur/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/ur/firefox-138.0b8.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "ee2303f9d69089f292bdc28ac67adaad40a27654e21854c93c6e493f157ea210";
+      sha256 = "a107906c9e22713bf338b67c51b8c50a0dbed92549211097b0358e343a79b6f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/uz/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/uz/firefox-138.0b8.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "2a2b1bddb030346c7b229153784cfc64d0b9619002cba1ad13d5530cbaecf8c7";
+      sha256 = "15f2726658d3cbd9444716ab6aa0b393d29df37e9db96fc72fec5545865d05ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/vi/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/vi/firefox-138.0b8.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "fb0a54a9c393d1e62ffed1e7864444274ae9e22a3f2f027b225f3f4cdc9952e9";
+      sha256 = "67c961a25713221353c6fc422ca267cdb73bef6fba198e4ebf7cdc44eee9e015";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/xh/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/xh/firefox-138.0b8.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "74298cd379e0d2bfcd9cd3beeb10c1bad040cba292a09669db0861b88f3f1ef2";
+      sha256 = "1ebf8bc0a3a94fecfbe50a5eeed4942998f83e047983da1ba9317c7e3c5a726e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/zh-CN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/zh-CN/firefox-138.0b8.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "adb07f9499ab8e1b09a6e546653192dc86b7af3878d8f6c9e1a4b94a72c891bc";
+      sha256 = "6458482532f7f0483aa0fb32fffa0082f775855d3bfafa75e989a615d5066766";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/zh-TW/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-x86_64/zh-TW/firefox-138.0b8.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "81274c3d1fe8d0cd833821947225637b544cd64973b4456088f18b6d1dfb7cfa";
+      sha256 = "3d104c31729925ef76c7436343a776f3b33678d95c5b15e182939adf2a782ad3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ach/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ach/firefox-138.0b8.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "9df21b1ff9945ff4a8b8152e4bf4a3519e98174a29c2af5ce23e8f67b3abb7bb";
+      sha256 = "7479dc6122632f2cc38394263af9e5c83204e091530f3a1f6fde3895a144bb9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/af/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/af/firefox-138.0b8.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "01ba75d77f73b589e44e8bf5367700d6241d32e0ed562da4489af9f8e1ee2a65";
+      sha256 = "9079967eea0a8c06d70ab710699056aa44389cd0db80abc7246d166d29161405";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/an/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/an/firefox-138.0b8.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "f75442c5fad7155bf3e339b612a1b3b024d0ceaf1f7c81e9217998a055a85bc9";
+      sha256 = "5b4aa10813bebba6f2a3f854539771d90b88111d7a33464dc5bc44e6e3d2a271";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ar/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ar/firefox-138.0b8.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "aa4a2889b3baa03ceaa18cd53f3601540abe2261277d0650489bc6ac3ab5a060";
+      sha256 = "27b331312e6e312658290c15b4f643d74a79ece02be99369adbb0f3595f80f1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ast/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ast/firefox-138.0b8.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "56c39b1c083063f74819655ff1929e1e3c9c2dc4bb9a1bed43859f2780ef0d72";
+      sha256 = "d763f646a358ce3486301eec5dd049d47d236600d91032a9fab8c116e194b8fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/az/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/az/firefox-138.0b8.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "877596d4171746dd7cdffe3c073c4634b610c396d99cbe5aaee6794a923bf96e";
+      sha256 = "559e7881155e0e1e328622685f51a9dc355bc11b228ef50a84e6a4dd68570674";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/be/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/be/firefox-138.0b8.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "66b4cb0e25fb263614775548c85479fe17d1b98b875d320cf366e8854921b2ca";
+      sha256 = "bca0a29c7662740d053975cd5659849e09d1b29e694c51ebe3db6889bbdbc4c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/bg/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/bg/firefox-138.0b8.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "0a885b0ebef3041360694ab89737dcc9c98b9d749888db1d778a88bb671b587b";
+      sha256 = "f707c2aba8387f2c53b9a9f54b22b5ba263a348546625616957709b3ebfcd9d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/bn/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/bn/firefox-138.0b8.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "af0559b15d9ff6125207d39c4e4c7be1d9127eec85c4844b2ebba56d3b9580bb";
+      sha256 = "f4f12f428781608cf480e2b35b24f4570f93ec3e04a5d2a9708c77df2b061c92";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/br/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/br/firefox-138.0b8.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "fd8ed6377e263f69b258a994c0b6a3c58da9664031be265a0eceb48a1afb73d5";
+      sha256 = "8ba3248074e7870d650e0a4435c0cf8a6a74c8a34516c04ac3cdbd0417c0fc3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/bs/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/bs/firefox-138.0b8.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "02ee80372fd1b2994e6b8fca3ad7749f14270bd19f30e0130b1c0bf72a90cb0f";
+      sha256 = "f1693020c29737622a97143ca82cd2dc93b0f41c25b75ebe5432a0b522f54367";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ca-valencia/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ca-valencia/firefox-138.0b8.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "4e0882dc24784f0fa990d9eca6fa7e41497de82bba12b0685c412b25e6c6563a";
+      sha256 = "5acbbf7244b59673eb3a308d1e3b9ffd2735ee532780ddb97dfbf23ed3022e2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ca/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ca/firefox-138.0b8.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "d36a4d9fe0a8a45d75228b10133427a8e7de10470764624849b0c753e4baa48c";
+      sha256 = "bb711a740bba862cdbedf18c23b54cf0873879bed2f97e2b0eeaad03f5890a2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/cak/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/cak/firefox-138.0b8.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "c0e952accd97cf53d0ac8dcc309fe3645d265c681e20fcf7ddb18d8b0bf29e56";
+      sha256 = "876521aaad356d8637c411d5e522840c7f49dbce0af601b96bfb4a24c8b4379f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/cs/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/cs/firefox-138.0b8.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "1fa69b2eb220a6abe2e014357160817f805b223ede4cebc69a786a6c253c3354";
+      sha256 = "eb442833658fb203ebfe1444a67528c17fc06c59737ccf4f034b0d256d79932b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/cy/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/cy/firefox-138.0b8.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "6f3d484a3a1e883e0866e5847a94c107a355c6f38350413f9c8e054c82987418";
+      sha256 = "73f40e17cc4084b86c242b4d8124fded5c084c2ab936021bdadaf7be7e92e9a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/da/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/da/firefox-138.0b8.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "3618ba5f56c810e1a087ffc9cba9f39a9e9682a530b9f65420441c86d6d5fda3";
+      sha256 = "15c92c6d2d7b6f391ecbd4a9f949b3df56a942c1d4615bd0d3ba9ea5534fd660";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/de/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/de/firefox-138.0b8.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "7929672a9f2631c78a0a1309a7d8c06ae2e0cd16a4133d64a998a57bdd2402f3";
+      sha256 = "3a8c4c10841424ea86ffea7c351421f738328a393b950f6e2262bccd447de0f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/dsb/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/dsb/firefox-138.0b8.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "c3bab0d523d7657c6be39a21d048a83d070cd4c5ae33d01e5f0cca8733a6c30b";
+      sha256 = "c5b9d2b803ad0b886314d3ddaad23d9629887d82354e26c07d82ec868753b9b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/el/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/el/firefox-138.0b8.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "5433ff937adae7f0c6559c37d6934114b170f71e84c3c2c2e9a3338370139fe5";
+      sha256 = "99fde56a01a16ab1e09d009aa0e36697b5cbf9fb5b8b0b970dc88f4e281bf46a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/en-CA/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/en-CA/firefox-138.0b8.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "c45ad41936fc1e9bfa9d59cf737d0e029e08328ac026673b27daf90a0fc8a39a";
+      sha256 = "004f8db95896a2366343f7d00fbb30c0689a2910b53abe786a280d5f7f6781f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/en-GB/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/en-GB/firefox-138.0b8.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "52ea4415837b9c3791d04a5563b9acc7caa6012a295c6880f461303abb65a542";
+      sha256 = "9a2c3371a2cad437e135412043863ecc769f941a9fcf741a5e88f57bf91971e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/en-US/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/en-US/firefox-138.0b8.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "e428129f2d3cf9cbbf2701317fd222b2ee8c94b76aaf6a54f3a86de540aa3af2";
+      sha256 = "d16fae37e6042ea23c5d7ffd3f5817730b5489bc1acff60de17bd4e64e6349ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/eo/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/eo/firefox-138.0b8.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "bc2dee43a7f7d4ccb04dcc233ff1359eb3f45dc272d01e92039fb3bcd0534fc2";
+      sha256 = "9dac38d1121ccdb5ce2124cf5ea10f12a417dca50385715ff4ee0d530b4eba95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/es-AR/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/es-AR/firefox-138.0b8.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "99c747b138a8481829711c63afe7f5e5eb1b45442203c4eff8e09afb2673d00e";
+      sha256 = "85c96f509d0fafa7f2a2e744e483e7ffea4fb559cd7f918639023be358b41c6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/es-CL/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/es-CL/firefox-138.0b8.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "eb81bd1bad7debf0a332afbed4eecfdd5765fca6fa05ed9e75ab8c8dd05b5de7";
+      sha256 = "27f083d3d7cac7c5b153e01f3890f493b48a7931a1d3158139c9f0670a89bf84";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/es-ES/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/es-ES/firefox-138.0b8.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "446d7d956bb878a28869a57256d2a08c090c6893276f4ea09cf2116515aaeb48";
+      sha256 = "f4af98251961ae0f93f8b444bf8558dd26a02e467236fda34cf15bf54e2dbf36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/es-MX/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/es-MX/firefox-138.0b8.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "e2f4db1178e11a43e1d62f21eed61c5e25d4bd75edf91f63401ba384d29080f7";
+      sha256 = "3fcf3e01b81c53541429e089173740144027c2441f0e6a269919f8f6f4cff38d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/et/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/et/firefox-138.0b8.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "3d47570c5de25da080f2e9e7ca20641d06878b421147f4ccdbadeccde9bff61e";
+      sha256 = "8c7d0a6c67917234ba3b8054a6ff30ebf42b746f74fc4b92434e958c4a4f66db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/eu/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/eu/firefox-138.0b8.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "f8631ded866eaea8ef7812ecba52958242c95b8e39e69d892f38f1c1a0ea03db";
+      sha256 = "c2b5bdb5b6ed4cd17c0a16cb8a909a406038398c128b4409b7b2cf500cee510a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fa/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fa/firefox-138.0b8.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "d55346559f9cc01070bae44b1f53513f2897cbb3deef0fd5a51d692fbda6b4be";
+      sha256 = "1affa59a71f9d47ed01b7c2a4f704346b10029c84fa04a8fbab5377819587b94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ff/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ff/firefox-138.0b8.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "05588e3f4b121ff1f042abe8ed9c0a011f0db6cd035d049b9c765ecf107b5bcd";
+      sha256 = "8609c462b25c386474fafe63614addafa66589857388ab94834b54c814db5ec8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fi/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fi/firefox-138.0b8.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "3cdb70af6f7720e263c4eb9353ea1dffdbe881203227666a589e215318698e1f";
+      sha256 = "cbd0467316432d860e8ac154b4725c4301dff8e6a4943dd3d4294d54bb1839de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fr/firefox-138.0b8.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "4c92f507c46acc5bb90849bcedf0a763068fce151cfe3e7b3c886e1a2de45c03";
+      sha256 = "3042106b307cf18c646b6a36a527e1981e731e8fd8e8c7f4f78008c5bd864416";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fur/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fur/firefox-138.0b8.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "9acba01f31b0f61cecfd99432f2e7b9fe7bdce0a8a3b2a1bb3416b5b1b7b81f6";
+      sha256 = "f0a6afaea91f2e9c5c12393f960ad2a4041062262377bc5877d13f7c1ed93711";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fy-NL/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/fy-NL/firefox-138.0b8.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "3a3955cc52c5f6b9c14b82cc18ac3668cf5c6afa01c27a037fcad4db82275cb8";
+      sha256 = "661041ec4465bc3040dacd2dadaad9f9253568deb18e988712300e86cd158bd1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ga-IE/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ga-IE/firefox-138.0b8.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "375281860f95bd4c80d9668c1e277540cb7f81d0ebe01fbfc5b207760d706c20";
+      sha256 = "eaeabd3bff721aa8281f4a5cda884ab6823544d528ad5e3ea036433053a77793";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/gd/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/gd/firefox-138.0b8.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "e07c785c5c9873062d9b761c212dac14bdfe88737a8df93a3fe928190b6c28d2";
+      sha256 = "78de6bb428a013479925616db118e9d8e8062ecde75c1bef1de4cff24d08b39a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/gl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/gl/firefox-138.0b8.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "ced8304e694cb5a33c1fc4004debddb6a5ab001717e0fa7e70d0635680c1df12";
+      sha256 = "0b931e1b7367b9e529766b33e7f9b33539638f0c8ebcdebe9803aa3102e4b51d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/gn/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/gn/firefox-138.0b8.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "cfa35eb30a9d4dd075dba1dc83dc1941689c40988839e761919b417b9b1e4555";
+      sha256 = "c2703d7bf7827e6ceb5d5380321b0ff07705c3b0e5c7c5eef9b814e58c212111";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/gu-IN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/gu-IN/firefox-138.0b8.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "f5efc09dc204f7872f6cda19db0f66733dc536b823f6bbb223beafb5900005d9";
+      sha256 = "d500719429666e63b2343e83c8c0b2ed87994dbe313f48961baaa45414739c5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/he/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/he/firefox-138.0b8.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "b4bf8b6bb71f713850da46ca1df1f4aaf7278174c48cbc4f4ebaeca65d9863c0";
+      sha256 = "225fe65494f8a2ea36f618c2b2bc8f22cd055e2c2142d243a9c74f067ba39a33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hi-IN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hi-IN/firefox-138.0b8.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "0f1c4f1f75517c393198cfb944ace2159e3d3f12fb9170eb532ef5edbe241d95";
+      sha256 = "8cda527dacaafbf33921e4630754ddbacd587d9f03aa7f4c4b27f8f9826b4b44";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hr/firefox-138.0b8.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "4bfbe567206a9c37dcd1dfedd430c6c5cbee015ae11723f654108b1ad1dd07e9";
+      sha256 = "7b21066ee72f55b50d8e32d30d74b297fd3a04514b02ece928871a21b7845749";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hsb/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hsb/firefox-138.0b8.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "92cf0ae541ccc4b7609dd70bfbb37f7dc066a926e8c9f14e94d85dd2b2847638";
+      sha256 = "33ea54c36ce97402c3f38eb70f7c3036a29383d2a786b91c0923faae890ecc13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hu/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hu/firefox-138.0b8.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "05bae7f6e502256d1b7a9da81a207bdf01d529a6bd2ca85fa557062452aee498";
+      sha256 = "7eacde8665ca348ea0108c9434193aac632d7543002c2a84fd643cab8cb1da72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hy-AM/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/hy-AM/firefox-138.0b8.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "4fbe110d0c790e317c3d052b46550ea1cfbf3d04e836cbd48b6b43c11bdd2ec2";
+      sha256 = "2b979961fc4cf15ab839fc011d1007f57256244e0369e672bacf370fc7a586fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ia/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ia/firefox-138.0b8.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "dcfe829ba81b743e6835b2b8712650f45a9e6ef51e1b5b89fbcc6a8458a6d775";
+      sha256 = "a6ebd0c8299a56e09e0251a78957693b44a7dd636540981f80e502d0ef7f6dc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/id/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/id/firefox-138.0b8.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d434c3c92da14dd3a75f61e1793f0e81cbaf4271bdb0a2a31db5aa2aadcecdcb";
+      sha256 = "8e6e96dff1046f38febcd342ad383e72310c71cbf816da8f536d93c656d26319";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/is/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/is/firefox-138.0b8.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "f08a607f20e20f41d0644a80e0e916a37085d37627dd0e04828a4fd22988e8e2";
+      sha256 = "8bc09e75e17ce60c4d250aa673c41a92d9308743b425b3fe81ab5feffcfa331c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/it/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/it/firefox-138.0b8.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "65d258db99319900e8ffb23614d70f3f54423399cd822682359bf0f3c7e5abe2";
+      sha256 = "b979aafd747007759f9658db5cf49545b7fc6c4dd7a8516bc682b54013d96fb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ja/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ja/firefox-138.0b8.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "4ad16c31e3be0c8e9e449c93fc201f2fc093abababdfab2d863115881533d2bd";
+      sha256 = "6b7b43ab0e602b19cd966fdaadc6733536b0e61f7e23b8633c230ee941446740";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ka/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ka/firefox-138.0b8.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "2361559e34ddd3bdb002f898bb3b5923c4958114992fa6334b057f22f33a5b5a";
+      sha256 = "620a990d91302c743acd9e2ed0d15af2ef7c9c95cbfcbd13abe31f37db667b20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/kab/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/kab/firefox-138.0b8.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "aafcd78122be357a6fa4c7fbe027f45fed98f0bf3d4eacf06fa8aa24d593c2dd";
+      sha256 = "c549e9d8be66da2c60621deaf3c03c365b578ad026a8fbb18163f44a2edde8ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/kk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/kk/firefox-138.0b8.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "e44b1992c70e356c0c5118f2eb31f63ddd98c98ebbd8c5c872118584eb71c400";
+      sha256 = "319992af03c691622fd4e028dee9f68ff681b201c829c8fac94b6ac1b2444880";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/km/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/km/firefox-138.0b8.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "0905dc9e42430fb8299ce8a0eae722b5ec7d24b8db5260612c082415f0979f14";
+      sha256 = "f62bfee8800237128d7ae727564bda9060eb41d7d27f2b7eb1140c52b62e86f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/kn/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/kn/firefox-138.0b8.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "a592fff8c6a6076bc6e4e3631f923c3ac04af775142546e42d580ae5fdc9cead";
+      sha256 = "818823253da880800026ae6e08739e615ee9aad15246e2579b4e96ee7e40f3ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ko/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ko/firefox-138.0b8.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "bb7bc9712d8f672f30dfafbff4901ebd2c23c68b66bb3800b5a5a9d145ff9202";
+      sha256 = "0fb41dc322ddd629311d6bcb8d6eb78a7127cf70cf6389f928c7cd7007b574bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/lij/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/lij/firefox-138.0b8.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "505d9ec5d3c110593da450ac6b8ae57740f2474fb92e26bfd7e372d168997973";
+      sha256 = "a87b35d5068ecabf1541d552e09518e6871751c35bde78e50bf67b2bbb0f9124";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/lt/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/lt/firefox-138.0b8.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "eca8790d0866a8d694f74db9ceb7f2f913cf1a6ecadd3df77eed217de686b8fc";
+      sha256 = "89190fdf49f74bd65f09850432bb60ae457887480365d3edac3dc1eca76a30df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/lv/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/lv/firefox-138.0b8.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "4d81e0900bb7d552a61ccfcab80c68495bbf883047f8d0e928f6ff2c582ad360";
+      sha256 = "3d51fecaf98018f8d6fdad6402e635b42b16da88150867fc9c74f2cf900378ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/mk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/mk/firefox-138.0b8.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "851b8db8097c0f872208ba92ac628b66ab85572f16412351b36faef18f733037";
+      sha256 = "fcd0107b68139c9585693efdbe52e4a67669a721bb0bb719b7375331fd081c11";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/mr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/mr/firefox-138.0b8.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "8fdb01d7a9299d4f46b8d4fc2622eea7d343fffb8d02139b696a5125a0f525d3";
+      sha256 = "a6fa9a09d4de8a458913f9fcc5103bf098c0d49ff51e2d233e146411320c61a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ms/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ms/firefox-138.0b8.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "eb9104fea4231c5096c23b4769ceee5cbfda2d06c43e6248476e5559f415c019";
+      sha256 = "b3f3a2133d92ce08e8b77e6051f7c2109e8f210e11ade78e1dfdaec5c107c091";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/my/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/my/firefox-138.0b8.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "0363c1bba70dd20e047784ee7aee50b97512fa01a498de8611fdcbc424b489ef";
+      sha256 = "998882322ea526f81ae367025eddd7bb38c5f0da8d88ebfefbf78ae47c06b77e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/nb-NO/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/nb-NO/firefox-138.0b8.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "1d7421306ccfb6afb43649895bc71eccb9a2ae8da95c941ed5a0538add4c08b7";
+      sha256 = "8a7b1e32d6895b7120f6de59614136c3fa6788d419afacd3aa3031b147a44b29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ne-NP/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ne-NP/firefox-138.0b8.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "a3005348908f842726eebebfd8ed21763cb893e5416021e963b80733df1c2ad1";
+      sha256 = "2d764038f27072b9048b5ceea925160a577f655be63db9fbb10dcc313a0ecf19";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/nl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/nl/firefox-138.0b8.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "8a1b2dc5c61ac95e38de823186e886531482ba75e837e9df6c8bb0b0c3ccf208";
+      sha256 = "9f36b90b2e781872218598472b4351713976210f94544b284db420a902d90d5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/nn-NO/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/nn-NO/firefox-138.0b8.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "351341647bde6c40e0ba8112e98ca80be4f7af8b74da08892f82b43284a4c9e9";
+      sha256 = "d717f8e3d80f21fdca92a39b0c85bb8d4d9279d42a471c8130f841e0a1a6092c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/oc/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/oc/firefox-138.0b8.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "d8fb3dd34388204543e4e4bb8aed424df10b77e2cd2b51f7549f091d3c7ec6c2";
+      sha256 = "8b861eb3f4bf31caa19648d5d56b8fc4f3f6982e5bb66849b56e13240d2eef4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/pa-IN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/pa-IN/firefox-138.0b8.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "839dea66654c3efba3d733bbfba365214189eeb4a61dbbf020daa115eaa7a304";
+      sha256 = "883bcbd17478958b7051a4831ae4c4cae6eb317fa0ad57d7dc3e5ee5a07744f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/pl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/pl/firefox-138.0b8.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "20edbddca204268e30efeb2ee20995cbba5f26fdd706ab260ab4e7ae2f1b9ef5";
+      sha256 = "94179577c1acfb8ce027e2abf828cb29025d7419bf110eb33f998ca69f8e44a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/pt-BR/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/pt-BR/firefox-138.0b8.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "4cf9ab194610b2405e34de6e456993b70fe31f9b04962a9a344250ecf16500aa";
+      sha256 = "3b18635c5ccab1a3fb31fddd5ec73a5bcafd217d91b392b4bfdb152c8e60888c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/pt-PT/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/pt-PT/firefox-138.0b8.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "482fd023b60ce06b25e292c7764dd7069951dd2d88b542b80a24b1b1422a8fff";
+      sha256 = "e6c0d92e26f3c793654269f0ac041492f1a61efade8c21a8f1f5d9f5c7a462f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/rm/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/rm/firefox-138.0b8.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "2cb8a7ad00eab956ecbb001019877476d7aca116e79a0e43b05365ecba41dafb";
+      sha256 = "896fa4341255ad6edd05747b1d9b7862746649f5a17d1771e52e4d3ecfcb0f8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ro/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ro/firefox-138.0b8.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "6db1a0fbb04082c803858ce2cd222ea49965bdc81d35f1ab77bccd69aaffb9cc";
+      sha256 = "1453aa68ab6f1473ea6f2bd74b3d1bbf7867a3f874f5ac4a006f711c7f2606e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ru/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ru/firefox-138.0b8.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "7bdb6d708b8f3515549c4047c56e61cd0ed58b784b5ccef7c32ec1e204d46f97";
+      sha256 = "f66e1fe7ad4be8c611a4086e2c274315761040f8a703501b88569dfc4a47cd35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sat/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sat/firefox-138.0b8.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "1ce9947cdbd094a5e1efe8e6fdda5d4685a9457e222569151a3423661b264dc9";
+      sha256 = "9348c28b1407b57a2498eeaa8928e9b2df482414a4ce842e0fd5d32a15ef960b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sc/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sc/firefox-138.0b8.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "6988b13049e6c34ee09868c2b004e7559c39e7931ec246a50643a051c8ec4083";
+      sha256 = "5f1e203b0bc54bef4d26b799c9f0b36135a10e52a11432442a993c422009777d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sco/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sco/firefox-138.0b8.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "f61ee2344d1dc96a6b8fa13b3676376d3f43b9c1fd65dec344ff3781e448f1a4";
+      sha256 = "9d5aa39bea903a6c64798b57208a37a429a48188fc90f85e07d439a8b4d4c982";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/si/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/si/firefox-138.0b8.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "8a418e6fecb901bf0fe27ff3717159ae0e9300ed27ee2dfc83ccb54ed9c94980";
+      sha256 = "c976b9445a68b630c6b8092c3f9cf1809759d3541d9db3edd791a2c8a2c58431";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sk/firefox-138.0b8.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "5c1fc8793fde16c8bab897210a620b401d2fe2f416c766dad5617bfdc166c097";
+      sha256 = "528cfc6405d82e49ce1d3f50b982778e0666e6f2a6db2581cb85d0c32fcfb958";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/skr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/skr/firefox-138.0b8.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "789acdd8375d1f96a6ea86d0866dc164640d80400bd7d27320b103b7e3f7a210";
+      sha256 = "5888fba7e084bd38d72fb4d3b9ec8515c78f60a07e7297a02c86611f9d854645";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sl/firefox-138.0b8.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "2429564d5158a8ca350b64041a25d8678a51b4a7947cdefb5f1a006df3a2b1cd";
+      sha256 = "05713c10164b52bd8d8e0713fba0c983b3b1eb8c7aa36192e967b808ca99f3ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/son/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/son/firefox-138.0b8.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "b54c750963d11100b56055bf3be5b4397a80c3b487189cc7ba30fdfcbec4af0b";
+      sha256 = "0ba74b43e2a4c41730fba7ee8b67c3b545fc580d3f891d5498c2d2ee5d2305a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sq/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sq/firefox-138.0b8.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "aa829b9d1490c97656b785e17e6a612114fc3e5f850808f277176eda12a547fb";
+      sha256 = "d14cba8c3d12875ae5899e48a94eeaf2405f1877df587508b59bf3268fa92b0e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sr/firefox-138.0b8.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "5217c2f43e2cd8a363660ccd992705d96b9f2b7ecb7c5d3d400f70d385d85567";
+      sha256 = "7990c1a1fdd683dc42746eb062fb8c7dae0f1de5d15a6d78c1d798eb1be71f89";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sv-SE/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/sv-SE/firefox-138.0b8.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "74b995cd3793292f1cc2f8e30ee72f059aef55295fc5811e12baa6714ebb8e95";
+      sha256 = "132a876e9bb9acd950646bd8b39a098f46c5c6ebafd07cb86da8b85407758d29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/szl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/szl/firefox-138.0b8.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "86acd2e307a17b0668e756ef12515ab4d37b3ae4fa9c308d15a58e236ed1597b";
+      sha256 = "fbf778fe846332616090640a2545ffbc4c536e7769137758d22b0aa33e3534d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ta/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ta/firefox-138.0b8.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "1b1dddbd4dfa2ba4e43b0d97357876925e3a3b4fc103890c36692e4c669551f1";
+      sha256 = "49ed6296edbce85d364427a730bfb74e536dbbc92b1887a6d23878d1dffb4d65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/te/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/te/firefox-138.0b8.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "9ff90bbf310a961b3ee5ce81d87815af20a97d317835ae685b02bd11d76e4430";
+      sha256 = "df9eabaec213bdb9df7c3fb487048f5d0e03ef9e1b36edd5a508c3699409a33f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/tg/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/tg/firefox-138.0b8.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "6f5ad0a96358acbdab8eb6499adbbddfefb19da4d4add4cfdeb374eaf7b474f7";
+      sha256 = "976fb89f5111994de51ffc51d6a18e5c96aea5bc6a80c57690fb843a453eca18";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/th/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/th/firefox-138.0b8.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "29264ff4976979c5e89ed20ee4d1bf3d1f4fc174e86f1d4713fa470cc5d57e90";
+      sha256 = "509845c33718e4d66c50507a919a7eeffa65aa62795edc37bf03374056025cec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/tl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/tl/firefox-138.0b8.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "5a9edf38ba5b382c63d42c58a578af4b89840ab2996119c8cee7842a230e7161";
+      sha256 = "ce97e79ee1f295bfb92a26126efa3366681655806014e38b0218621745159dfc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/tr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/tr/firefox-138.0b8.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "b1592111fc5767078edaabf192e8fa46508479d070714181be7469284df881ed";
+      sha256 = "4d044aebd3893b607626ffb53b57ff962b3bc12770f5be7da42f12f5c03eebb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/trs/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/trs/firefox-138.0b8.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "2f535a90613b2243300da5bc35185c793796eb3d5eabbe565818c25ecc910d2f";
+      sha256 = "f7c6cdb6b7d29a66b9f5477bd8ad6e2f90d2c9c51c0ba454305fc47bdd0222fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/uk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/uk/firefox-138.0b8.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "6362f8c826d78cc5954816e5bafe40f87b168a61430330e5669163e415c63840";
+      sha256 = "544abc2450e681b0ca8ec833a13bd02ddf94bb8dab370126b190eb3d46b35548";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ur/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/ur/firefox-138.0b8.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "b267f2749c8f8395b11ad589ed0605a0c5afd1277286006bbafcf9c34b9e2b7f";
+      sha256 = "0dd23e0b02a3d25131ccada64e1ca735ec97702b8c5bd8904f04cfd93701004b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/uz/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/uz/firefox-138.0b8.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "14c173874b105b357e2c2db597da5b39974c733df54f8d3be07b341179ce8eee";
+      sha256 = "44f51fe9a06fef663ae75d5e045ad7ffabd0b111ec3a312b1d427c272719ade4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/vi/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/vi/firefox-138.0b8.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ca75da7252cf7b070515cb45474df7c2acf247731757163362ebf90bfc2432f1";
+      sha256 = "0e1514cd3dceffc592703a44afcc456d0ebb01528c3215ede19c97c86cf50937";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/xh/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/xh/firefox-138.0b8.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "dde72415aa29498cf08a7015b1e9122239705978da0028587ecfc9a125488366";
+      sha256 = "b4ac60687f69fc7d697bf6cbd3d34cf17c0135aef0044148da9bc930926a4d21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/zh-CN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/zh-CN/firefox-138.0b8.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "7eaa490631845abe7e20c88f4238de0dfa278ad7d36523898f57d469e2b8da88";
+      sha256 = "feca67d43e8cac981830b46c826c7739ed79051c51008622d5900b8184e64486";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/zh-TW/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-i686/zh-TW/firefox-138.0b8.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "22667488a77ccf885072a125735c103e7a00473d9bdad07b1cb5d318c3a94f89";
+      sha256 = "787b75e92cd96ae3808ad38dcd7300360d017ac234f3fb3fff7f11874ae3f7d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ach/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ach/firefox-138.0b8.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "ce548a0c42c7e1975e5379b7bc7134832757409ce03710ee8a22a6df2d38673e";
+      sha256 = "4dba4de14bf320c5e71a133b183b60b7d04d83a76d86cf77ac507c45bea9fb8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/af/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/af/firefox-138.0b8.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "06da5be60293d3badf10a6b5742bc3cad97023b4a306a0594810f83589268e24";
+      sha256 = "f429dd76944239dfe5d55242e1a194aad714ec352e8b0f2b10bf5dfc322c92d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/an/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/an/firefox-138.0b8.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "c7804abcbc07eb52164ceb2f1db308b12a9df64507e93b29e4786d86ec63c78e";
+      sha256 = "6a74e60087a3c6d75d805c320c6b2920ed14a5d0354b3e6cd7573fe2954cbdab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ar/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ar/firefox-138.0b8.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "0167980e4292272f83029af4cdb1da224b796e3063be21b24483723318541e3e";
+      sha256 = "59cf79704987223a349c033c00f323b4f85897f3879fac905c8b217e9f41ebdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ast/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ast/firefox-138.0b8.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "0f101d8d68702cfb4ce78633b23839b77947193a45b8519367eea3a6b5f4a62c";
+      sha256 = "e172f60107ffb37fa364f2401a63818216083e907b25dd4b8142248b999b6589";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/az/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/az/firefox-138.0b8.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "f3e4494e319e051584754307168b0e6b425d7089f645634d3fc09ae5284155b0";
+      sha256 = "70c01c89cbeab938b3d09fbd609d20393853e7b7cf9370f7d8111567477dde57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/be/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/be/firefox-138.0b8.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "130aae11edb98a9e33b081f8441015cc63279c346db8d958c643e9f3bd871271";
+      sha256 = "a1b5371d5c0f533fffe78b193e38945bc1ecefc13e6d41dc75ea6fe7a0012b8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/bg/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/bg/firefox-138.0b8.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "85f71b158f1bc589a78a9d3f4abbcaedd55a1ff4718efde4565a5d749faac35e";
+      sha256 = "f546a566fc02cd611b54da162e01eca1591c05950faa283619ff462f311e46c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/bn/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/bn/firefox-138.0b8.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "0e0d0ed99d2dc1333010b37ab71f74d9b8f5c909c7dfe9836a4c7944165993af";
+      sha256 = "83493f8396f07c94297e4d3f140b64286d5dc0aa9fabebf011640f7a31a5174e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/br/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/br/firefox-138.0b8.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "d1e4a8f7cd8fff5fc85759a87794adae6c316df07008f8aa3fa2987598cc2730";
+      sha256 = "e8f9348a03dbbb95dc54669295263412c6770ba8092668776205325c4d66c498";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/bs/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/bs/firefox-138.0b8.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "8a169af638602d6da03194a40a3ab96c251b3216ba365858e3f2d71a595a1a54";
+      sha256 = "1e8f291cc4869139abf7fe4cc0aa34bde2cd6ddd65b1de88122c190eb1fd9f41";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ca-valencia/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ca-valencia/firefox-138.0b8.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "6f29784363b9291b19f92972a48e0de87b679b0f9e0942d92b5ebee675846885";
+      sha256 = "d70218ffd6bb42aead9e52656bec4f78ff5d71e43a6a4ad74f5687e171af530c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ca/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ca/firefox-138.0b8.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "7b0d0657930eac7e2fe75e91ed4ca0eba4dde283a5aa8ee17287c779b12eb347";
+      sha256 = "92549a05b092a511ee061144204195f44a12db4e69a91962a678dd98b456e59a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/cak/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/cak/firefox-138.0b8.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "008110582b519f4b753f2f3fcb7af37fa30225c89687233ebe132b581393231b";
+      sha256 = "2b45886b54ef0e35605d76871c93df2773077bd63a19edb940fcf46e7769cdfb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/cs/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/cs/firefox-138.0b8.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "19ea0006094e57d9ff62a93d46708ccd78cc7ebdd9208fdebcce4ecd27ba471c";
+      sha256 = "13bc0c007f6cb8fdc1dd2110dcf4a688315bd72e3b5abafad0cc1143695459c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/cy/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/cy/firefox-138.0b8.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "3f5ec52e6d4fae2b875324320d07160d493eec5172c5ba0b2b8451d761a58aac";
+      sha256 = "c3a60745e0a01dcc024fb5f1a669b2ca64a44f0d3ccfd2ba55a8c54656115417";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/da/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/da/firefox-138.0b8.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "1d1d769ce702a698a6d95e5847ed05b3e299e3e4258edc6344d87990279f62c7";
+      sha256 = "455d9e99a3c6b40b1b043b9cfbcbbb1a1c591ea48f5d516255241eb393e2b574";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/de/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/de/firefox-138.0b8.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "fc629f70100300da9d040bbe4da67cfa1a734240457245546ba7f50647c66a16";
+      sha256 = "7955b14e88187ba18ca1cc548406932639d8aef074c2b95016d92d4f1d16b695";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/dsb/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/dsb/firefox-138.0b8.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "80299a2420fed5bf4bbf4fb8a32f6ac8e4bb0d73c2f78d59f770af02695d6fcf";
+      sha256 = "45ff9f1fd0ca8a5a2292dcde5e3a13e9aa0021f97cf9321f281003a3ed360fbe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/el/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/el/firefox-138.0b8.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "cbdbac410aa4734ce40e6afc65001bfdf8662ff923ae31e7b634cdf97875d859";
+      sha256 = "8c72c30ceb3a44b79b3a7c48234744c47cd726592131c71b8abc27b1c769254d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/en-CA/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/en-CA/firefox-138.0b8.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "a071d131cadfda0a918a0287f1ae7ae3c670fbf54a02679bda7737b420fadc10";
+      sha256 = "3c030eeb676ec244a66bc049abc2f7c41c4b9af648a8bea243682fdb4af400aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/en-GB/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/en-GB/firefox-138.0b8.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "28ecc1608fc7b832c1a0a1f72092bdc09fb2e09c6edabe3d55c14dc456662b75";
+      sha256 = "2e729717b9cc8029784cd2e00767552ee68b08796c20a4ccf0197076b7e2c281";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/en-US/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/en-US/firefox-138.0b8.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "4c028acfa9d519f795fe4033a9fe52ce1a2288be33e9d854cf256c4660c7946f";
+      sha256 = "c9246a995979a13b142deddff467e899954c327ec8a945cc0b22a7e20663c001";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/eo/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/eo/firefox-138.0b8.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "73ef5438bffdbe75076d6830f0521f4cfba73eaf4eb7d8a0a92a5a9c532953e8";
+      sha256 = "6faf6b3db45088f3c7c826a6a0c866c5b16fa5a7ecd6080ab448eefe056a67f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/es-AR/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/es-AR/firefox-138.0b8.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "a2ea925be3b5331a320787a2d01cb5371794131c96c20592b04f324c5d66c8b7";
+      sha256 = "d354bd8afe79bc10eee44e71ca1f0d71a0295e393fab7dfc80b58d82fe8dc0e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/es-CL/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/es-CL/firefox-138.0b8.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "ec472157a4b483f5bcd72a9819ec9f8755e8d14b2f697719e43f95eca19af71d";
+      sha256 = "36a553b846c8e2fd5880574a88a0113132634e0e049de5c712d20e6897c1c176";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/es-ES/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/es-ES/firefox-138.0b8.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "1f0fe1aa55012dee2c482309cec2dd894a3f7221e3013ec56c67ea2266b5fd2f";
+      sha256 = "3a09f6aab43b37c65585c4352e8df347d0505c84bf8d7a5c510b0e540873c23d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/es-MX/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/es-MX/firefox-138.0b8.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "24ae6e6dcbd7f5e48547aca74bcd7b46993a23c9672ae7d32f28489367dd13e5";
+      sha256 = "218d3547916fb90d9fbf3f43eb2e17473807429bd7f82cd98469f3f49c33b119";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/et/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/et/firefox-138.0b8.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "93700b3435fd867e257c831654eedc35700e175e6b4e766d853fd8b51becda75";
+      sha256 = "6522bf6eab8e7dc2856ed36f5e8a34a5a2c7938e35df288261d9bb21fb08188e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/eu/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/eu/firefox-138.0b8.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "637a0e3bd45a6e4d73d5394f7f6be9b3b6dfb14e797c8f019ee640d1fe1ea3a1";
+      sha256 = "8030d323e062a1173eda9e9ca2d29ed7a77155f202eb990b71aae790bb62fabc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fa/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fa/firefox-138.0b8.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "5be4866571ec92021bf0cd764dd4d2112bf0cfff650e69da6cd2cdc1f6b9f9d4";
+      sha256 = "7ef0bb05281b92a6b74e856fda0941c3390e5dccc3cf9a5a2d927a640ef9d1cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ff/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ff/firefox-138.0b8.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "439df3eb29b13d443466cd585f6c3bb0014391462003860486959233d228a246";
+      sha256 = "002f289c4ca6b7ff049e9e527a914d8725015f5072fafff463f9b573097a5008";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fi/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fi/firefox-138.0b8.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "c58331db4fe82801630365d5621e1ad8f82a3552a2763c68a965b0ce83180947";
+      sha256 = "96c014b4d4c3de54d2f78b9d74d1ff138410261cd09600e0fce4892c415f8de7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fr/firefox-138.0b8.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "dff4cbf811f7fcaad0259f1b0c297085fcd521f1c76efae62152470966eacf83";
+      sha256 = "e0e597b512754cc7426a75655d4fda26eed5c219afd195bf50f81849f07a3ce6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fur/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fur/firefox-138.0b8.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "3c356377b02f6f790a84dbbfa8b55d37c84dccc6296f6f8e25f089608fdca44d";
+      sha256 = "ec7bd02d2f83959143ac47889a7bef5bcfd7082b7858c276aea7513f9503d32e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fy-NL/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/fy-NL/firefox-138.0b8.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "6421023ee22edcf15f1dcdf6e747edf14852f6dcb30d9750b330fb23d43c213c";
+      sha256 = "9c0315fb65755fd68e646a3735ba7e7ace5a43b8664c3cb0131a35300e7672fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ga-IE/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ga-IE/firefox-138.0b8.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "aa506c7b34eaa2195a2653b18bc931772ccea48c30cdb7a99d9d9edee872918c";
+      sha256 = "484828425dad1a8ee77b35ec531a2144df77b5bcb0f9620aad11a994409d41c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/gd/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/gd/firefox-138.0b8.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "0d6421613741d48342ed67ae9a29c09a4836d38afbef33158cf579469e7cbb8c";
+      sha256 = "b831c4d80580ba2aecf7e724816ea26075c952c7de28c8cb78496d75af533cdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/gl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/gl/firefox-138.0b8.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "f94460f9d1a26d424659363bf7da21b7c12a7e8daa648321ccaf5e812a35d01d";
+      sha256 = "cbdd00d04fb1a9728123becc83f0279a96bfe283a27dc044898dc87a7ccb5440";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/gn/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/gn/firefox-138.0b8.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "93eddd6cd208ca63193dec9b51544c210949278495a90c043f3ff4d9cca8acc3";
+      sha256 = "389dcb60e0e20e2ea19b751cf9cba2160175e7c297b838ccb3a11e0bc78d259a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/gu-IN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/gu-IN/firefox-138.0b8.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "5034e3be1d6d382bae34b6d64f2fdadfe92885d4d78db3f8b56ee262e5d6211d";
+      sha256 = "de31fafb532f86565ec03c939250fc32537f672ed09cb3eea21272fae962eefc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/he/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/he/firefox-138.0b8.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "e80722332526c57f312309aab776b9decf362adcbcb421444559c704a7eae879";
+      sha256 = "cce0cc8fa93f6318688ef2a664159199e4c6e1a2d3aa984ec46bfbc2536fc0ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hi-IN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hi-IN/firefox-138.0b8.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "7782ba6f9d86029b0ec370e95ccd2e7818a0de2b00a01fdc11fc3c8f337d1cc7";
+      sha256 = "3dc345ff030c1ba64e95f06b6ba3e6c9a2aa175ad7464fb7bcea28d4225f175a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hr/firefox-138.0b8.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "62f77d473c2aa0f246d256f23a4885efae9582a8fd1b5ed5160f0c085eae0c97";
+      sha256 = "bed89b538d187722de5e18a3d6e2aef568c3a5bf1be7c2f9b418c263dac0f11d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hsb/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hsb/firefox-138.0b8.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "8cb41909dd42842b5a0415cfb304e2a2b34e8be60db35e7bf9fec93f8b796a44";
+      sha256 = "143ca5f040c5274775b40c3a7f6a9756ab04160423eaf7338f75b0f03629dadf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hu/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hu/firefox-138.0b8.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "23a5cce6bf6860851978cfd199e6a843b4ce8c6b810636d7044a58d03d8ae0d2";
+      sha256 = "aa979034b6fdd14f3e948eddc0f4bca691a213279f4351dadefef6d2e7bcf7b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hy-AM/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/hy-AM/firefox-138.0b8.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "671ed7bc013c4be4507fafea2d7bb11105e760a9d0bf262b1fca943cbfc2c31c";
+      sha256 = "6345b24a6ee4d5a63340c7673dac3afc729ce001e37e9019d6ca74e8606bf298";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ia/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ia/firefox-138.0b8.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "0c126080ba8c9e1721b98ac8df93a5f3a0d019724cd85c33e3905a42042c5648";
+      sha256 = "d9875bf61c807750f626237c55dbb6b9c0544fda8ad4d6f60e0c8b98293bca1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/id/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/id/firefox-138.0b8.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "854f96bc809b0687c65d27b6f9241f0f8f628ef436097c7aba587e5fe6441d5e";
+      sha256 = "b8fbad9f4bd52096ebcef09da94271a2b22914b034b0aa3dde30763061003f2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/is/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/is/firefox-138.0b8.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "089f36c0ae651bbe196078e2d98593c4c612c2b81336f6018ebe54b201cb70b7";
+      sha256 = "5905f09f368c0b8165eecd8fd896c082d4b6ad7a288e2de96223b00fae4f380a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/it/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/it/firefox-138.0b8.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "42f78e343de68b8bc33419a8fe983a2a31d83ebebc2447ddf9db02743b4103ee";
+      sha256 = "4d0051391fc367fa2f9de69ad761fa8832aa5b4aedaf4dbbc09b4668cb7c6ee7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ja/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ja/firefox-138.0b8.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "2d2c097f0ff0f15d864ec09e7ec74de30935973283ae2decc2929051fd6b4489";
+      sha256 = "c56d46da0be7190bc1112420080a1ab34e161576b53165cc189e03d2c5174e63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ka/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ka/firefox-138.0b8.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "6e0b139ad102bfd028dbd752a5488c53e2176d0b5aa59715dfd813bde861a8f3";
+      sha256 = "83149973b83d8405d1cfd3d02ee382ec79e606bf852398abf0960d7f13b100a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/kab/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/kab/firefox-138.0b8.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "31a497c03ab41039abc657e7b24b980219e25590958d0219f418a6c8a267b0b7";
+      sha256 = "4086a97e0341648b4784b8e3cec4029f4fed00ebaab536b655230123349ec24d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/kk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/kk/firefox-138.0b8.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "b8b85696af18ea3a53b8b0bb454b96713d194bbb555c081689ab3e2080c5e47f";
+      sha256 = "9232a3cb15b541e6b0375f1eb2ec7ad60c32e4a6aff255d373e3895ecfa01ed0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/km/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/km/firefox-138.0b8.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "ba9b7db2c6263a2ee3456366d145aa835b20e42828c9665359cbda626608d6d6";
+      sha256 = "777e0d9beab3480e0556a10caca424cdc8d51a2e19751e8bbcd47ba536a4a0a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/kn/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/kn/firefox-138.0b8.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "d65d064f102a20f596ca72a87c365d12a446a50e0b5c7bcf90c98d927812335c";
+      sha256 = "c15468a0a703020e1fc518b0752fdc522e047b7138b485a8b72133e4622a7d12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ko/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ko/firefox-138.0b8.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "0150bdbf754a3a5055a6684bfd370982aa80866cc5ef3673acbcacc49004c1ca";
+      sha256 = "1c49f3125f5b71e5ba2b7e5bb4331f4f1d561b0a12d8a21488bfe9a6c11d0f72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/lij/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/lij/firefox-138.0b8.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "7574d4aa6421d61bd76c83ee337a08733531b6e3ed291bf73718562fbea7f913";
+      sha256 = "919caa0bd18b0d7baaa393c0682aa250d980a045dcf4303df5d4076cd212ff07";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/lt/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/lt/firefox-138.0b8.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "259d5841f39910ecbbbcae05647e9b9e45525949e40f56d451677877998bbcdd";
+      sha256 = "7cca85b0f5cb687c4a58cb3ed8440850cad102ce8b9410978f51e42e3f3ce732";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/lv/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/lv/firefox-138.0b8.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "7af8df80da1118c9da7611bab1889fa17f25b7a05d5cc65aa1fb676551c56fe6";
+      sha256 = "3404a967cee8b521da2aa2e44de6e1fff492266f11d4e16b6130889530c4bae6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/mk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/mk/firefox-138.0b8.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "7fb1dc800a568d59100cdbde3f387279b6d81d19945318d56832776219314f4e";
+      sha256 = "3764c46ad2eaeeb18692cb23399ccb958fc855a1776096252e1362c8d6b7746d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/mr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/mr/firefox-138.0b8.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "078935be95f22dc8b15cb9e25ada5d96f31d3776333c46c5ce736267169efa04";
+      sha256 = "b953a8be0c927e09e8a32b607a2e405be0d343e2856f31d4727edd3cc21c72f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ms/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ms/firefox-138.0b8.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "3628c6d7f073b1e7dcd224e708da5c14485066e7ba0503ba546cdcb447a5ea98";
+      sha256 = "2c2654b5b7288f1b03c340a58b6cff5bb2fd28188e3a60dc36732ffc9a5d3548";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/my/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/my/firefox-138.0b8.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "3cf629fa5e4a98377c039d35a150cb66daa9ff556b3a3a8eb6975eb1a73259a7";
+      sha256 = "93a8cea90b538beff516fe946a9b6bf96fc1e8edbcf30c90bf3b311bb662340a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/nb-NO/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/nb-NO/firefox-138.0b8.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "8f2af84577fc72b2b25d2ccbcb9bb3b6a7369385253b9f54428b17667e5570da";
+      sha256 = "da4e75f2f00f535908141a3ae633f4391f6d181a7b8072cd3ff1ee36a0783a68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ne-NP/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ne-NP/firefox-138.0b8.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "684bff075da0925c758b9030a4926adf821da91d800f5d7b084becd800275bf1";
+      sha256 = "c1b57522b6628e23d74d889958fe43ed88e236d612fcd2d1b124307f9ce2a1d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/nl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/nl/firefox-138.0b8.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "9f0489801ca3b4c5e819f440d25e4eed4ea94c650d87d45ec0070954b6d60dfc";
+      sha256 = "f08d7801a35502d87ba79536d0852046db3ad086559c0f355633b24e915bc18a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/nn-NO/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/nn-NO/firefox-138.0b8.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "3d969df152796d67dc4128f8b5d4caffc27cc163d8a922643d39263228fb8201";
+      sha256 = "3caf0db9687ae89a5a4e226eefd9739179a7889ec81c2ca26186f2eedba8bcdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/oc/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/oc/firefox-138.0b8.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "4170cacefa6b4d6d7569d3fa6133b488a75b53cefc3229b87a556a5da2e11734";
+      sha256 = "46799eb3d065f4a16100afaab696827b156474d9d83b4e95ef0678c7981f52e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/pa-IN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/pa-IN/firefox-138.0b8.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "3e0987701d64d0c6054171b3587d8bc0e1ccbbd4ca2f7907c62a4146428509fa";
+      sha256 = "889931181631832037cbcbbb2c883a22a154ee4161309d9bb3f87721eb97e191";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/pl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/pl/firefox-138.0b8.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "e3dd25e8120bfd69aab6a3b67f05aa24453edba986f85393d5e6c6e281bb8819";
+      sha256 = "9ee7fa9407d5ba68483f1383e453cfaa6598e26b8e8800d9fd5b1246579d8e13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/pt-BR/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/pt-BR/firefox-138.0b8.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "560ef4c0776897f5ccec34b3d8b481bfe6f6d5096cd4d3d984a444c417688e7f";
+      sha256 = "26948401239bed611427dd907bf8c16ec8aa7fabe901817eca4b404a56dc0a13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/pt-PT/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/pt-PT/firefox-138.0b8.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "3dfc196e3079bdaac5377e467fdbf195bd93e045553990c3cdc0631feb1c8bfe";
+      sha256 = "9b61c3bc750c01a97e063533bc383cbc37b8a756685fa51fbdf0d37aca0c4a3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/rm/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/rm/firefox-138.0b8.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "a4d89476a65d7be5502aac1d85a50110198b23362de3df69d34c66bbe8c51d52";
+      sha256 = "1090ee036cf5ccc6e54c8d027c3dfc4b48d0b551b5d1e5445af9df8df3773b6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ro/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ro/firefox-138.0b8.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "1723c06b5ad3fa1fe06b6b3d7a2ff18a4a94cec217fc46501e571b69ed4bace3";
+      sha256 = "4c5ec76aa87d68d23136f8b6493cf49de7e1f4626ef6591bf7f56ba2a05e9848";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ru/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ru/firefox-138.0b8.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "dcc26bb5ad02edf2e3afa0c73b5381be48dcbdc12ffc24d9f6df6d2afb639df8";
+      sha256 = "0d689b56d5ac9feab771f71af7b5fdac84c493fa53d6df84107a97982b4816b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sat/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sat/firefox-138.0b8.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "fd686c94a6a9506bbfa6e7a362c39728ecacb59e762467725d78af5dd16a6d03";
+      sha256 = "9f7b24a649199891e9df80f418a7ac446dfa5c788654e865f5a345495912787b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sc/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sc/firefox-138.0b8.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "488066e0a984fa21637b0aab44c7e78481625acf309da28919a4dd1042ab193d";
+      sha256 = "c6ad52380b870f26799bb06b98864aab86f25b33c41666c5f2d759d51eba6ef1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sco/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sco/firefox-138.0b8.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "541a7eef9f6b9cad7498f2166e0b9a99e5eda68956649825fafb8283dd78762f";
+      sha256 = "2936d6257caa14ac7143fb2e2b94a461bb843503580906f8135210cbca57dfbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/si/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/si/firefox-138.0b8.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "7fbdcaf6588d7aecae6339e85dc50e6884c88462df6dd5789fd36bcb91f264bc";
+      sha256 = "81822c077d0970599d5eb3e5c189c8d9c2c8f7e6c81e21d2150a3448450a9859";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sk/firefox-138.0b8.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "8a322025bb0f6b59a1afda171463e200a1021666c9c5a8a013c538d2d8e253bf";
+      sha256 = "0c6478b5031dcd15a2e33a5c90be75f284eb5f6e6986681d5d47f2a6c0c77331";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/skr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/skr/firefox-138.0b8.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "1d2d7aba9d3e02d36d578e67a71ada78f85ae10d1b76107b33eb58906c48687c";
+      sha256 = "6215e72dd7d3632b7fbc6931a9a0419063ba1530ab0ab1d75b86da3a7f84af97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sl/firefox-138.0b8.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "a18a3a73b20bed6a85af824851e27e64ff437eb4fb30b0c2232827f2ea3f5b7d";
+      sha256 = "a516ff966fccccd21a7372bd657dde36140197ca2ac0f9fc2ff5a138abd74189";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/son/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/son/firefox-138.0b8.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "ce5092715fb13917401b79edc9b6cecfb08b07daf4400d70f7918bf0b5c3b614";
+      sha256 = "fbec94c4d3d4418c06d8d6efe93d42afdbc9b7de0c2cd438db14b32e65243618";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sq/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sq/firefox-138.0b8.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "24d2717b7a4c35a4722723c198223829b08490e24c463cd0dc373beec76116f9";
+      sha256 = "cdc237a4a886e5b529b8f71d23e29d8a275bd2c804e2299db2d2a5da75a34a7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sr/firefox-138.0b8.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "c482b732493da48cb9547e1c8a3159f417560d5c9ea7e1353b70d5534deff6df";
+      sha256 = "d69d4bd632eb6fc9b116449c4da3324bede43e403184b45aca638a1d1df4bafa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sv-SE/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/sv-SE/firefox-138.0b8.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "02e92e4f7a6cae0b8e7d7af5ddc822740aa11c38f395e164ef1278441f947eee";
+      sha256 = "3c113a2404605870064f1f8b792025fc23a84dac4414c422a264a316ba88af63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/szl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/szl/firefox-138.0b8.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "22f68b8e3d2cfef8f8bbc0b62b4f35b2bf731d4ab783597f71453e7b998a1fa0";
+      sha256 = "d035ef26694caac8f64cd71c2633e3309d5d8d9ad1a88884edaf9b79dfacbf6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ta/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ta/firefox-138.0b8.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "523c17cc6a6fa98fabcda73f9849ed96aac853af1a22180af19eeaf788810ba4";
+      sha256 = "5c9d1e685c27dbec4beed6c134f925c18ecfc55e1f338eaf0961f45a8aaca82a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/te/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/te/firefox-138.0b8.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "80a19adfdf06cbee81fcb7a4d8118a1f7c8928f972ce9aa98e7854b12b2d8728";
+      sha256 = "766c287ab620c1656c6a9f9f015d164b0d3d5a9aae15e528c0441a890cd4a661";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/tg/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/tg/firefox-138.0b8.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "3e2a18dfefd0f14bf92983d195e36d689ade2c5f4e1ab0379a9ebf1d0c526cc8";
+      sha256 = "50ef2e5781a433b7805c977889a34a202f3a17d1bd931a923b76c9f9bfef5d05";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/th/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/th/firefox-138.0b8.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "5e301b1865ecd3b08d8862c55b14b6e65af20bb1587214f82dd27f466ae7202c";
+      sha256 = "a26724d9359df4ebca36a0b7ac7e48dfc882e53e0624b939302a899511371061";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/tl/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/tl/firefox-138.0b8.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "1c05bb2c82fb0e1795d5c9af307c66ea3d8942e922feacf322829c6ccba630a7";
+      sha256 = "cec6563c1836c69ef503f2307cf8a2671db43fea2968eb80fbe63141c6d0c48a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/tr/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/tr/firefox-138.0b8.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "4ee13bfa40a70177d87a5a071c984bcccf004a9496013fa7fdbfa9da5ec6b3b9";
+      sha256 = "3ade583446f7858772af48080fcadad55254d97851389e3fff02dffcd74e988c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/trs/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/trs/firefox-138.0b8.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "cca347c702ee2cd6c4e11352b1eea381faa41bd692a9aeda8fbb87d5c570d3c4";
+      sha256 = "853baacdb7ea6470764de05f64fffe6eaef7563c25b4ece73fba1e1cd52eaa59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/uk/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/uk/firefox-138.0b8.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "54246050515f6891d54cdee6f5705b255c9bb73e60de6097d3c96092facd5865";
+      sha256 = "b083cae062edc44eead68adb030b5c885fd004b4c9aab63d451151c8f0a95ea7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ur/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/ur/firefox-138.0b8.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "f06793e672b05ae4b66a0bf2be25faad0ca1ed9bb8e8f654b1e6c07fd4a47c23";
+      sha256 = "7fcd0c36294c345eaa39b889364f919fcb35a07749009548cfb041ec6d0faf50";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/uz/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/uz/firefox-138.0b8.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "0c166ef499c1cc6472f041e02583be6e24dbd81ce18bc30b76766bce419f54ac";
+      sha256 = "8cdca4b49f7b61e6dce0303af91ab171ba19bc68ef26c31709cb549faf802ed0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/vi/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/vi/firefox-138.0b8.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "3f685557dc53df3df6fdce6d0c20b1cd23de9c80a5d3b78ae0a1c3c3c72d9b61";
+      sha256 = "f333e144c031925e1fb2016a9c1bac1bfca794feb8f68d32798b95c7470bbf22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/xh/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/xh/firefox-138.0b8.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "70fef2d3a7992942f12c086959162070d3687390c701910cd6cba83e6610c349";
+      sha256 = "3d04450587c1a914c9494d48f8330b131346675a5050304b59e4639a0d7d5699";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/zh-CN/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/zh-CN/firefox-138.0b8.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "18f6d9ddde4256839fe9fca9d07754b16dc98075844e502a8068a0fa814b59b3";
+      sha256 = "61ac04cad80424a04cffe63009d1f491fe83bf9aaa37fd9f53b32b6bf44045f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/zh-TW/firefox-137.0b10.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b8/linux-aarch64/zh-TW/firefox-138.0b8.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "99dc1b10d0de3ac04d2547de7e92f5db72cfd429692212325842ed5349815a17";
+      sha256 = "c887b4b68d10263a65423ccf7f7367733d9d19cc4de9ff52c6b2402ca2fc3ba5";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "137.0b6";
+  version = "137.0b10";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ach/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ach/firefox-137.0b10.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "0b80c80a818cd4dc4cf56799958b4f5b4a02566c6e83f4ea862d239e6eb33f6d";
+      sha256 = "d0f0da12027c6e9b798fc8420785809ed5f7208984e585d791846d32ffd1c085";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/af/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/af/firefox-137.0b10.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "6e62dccefe51d37ac2336619f2ba81b852799a73976d199fac1ee58d41e10c9b";
+      sha256 = "6e4620ecb89169e9b1e60dd23969c7649d62d4cac614e7c6a83308402cb67f7a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/an/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/an/firefox-137.0b10.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "7ad81d1fce3837e62b3bc968dee4a57fbba9d796baa9b951befa44a225906380";
+      sha256 = "fe2d385e510ee289d174c00349a6429b0b985fd0fabec111a50a58c59471b769";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ar/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ar/firefox-137.0b10.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "d4b5f0f6b4f0f826a084a836d72eaef9a343595578811951f24bdc959d4314c1";
+      sha256 = "f87eb7054f34a2c09409c68bfc27f69dda1d6ae01c16347edf3f44e86c9d9862";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ast/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ast/firefox-137.0b10.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "b2e66235dd0e14478d1522880db50aa4389e87cf3297895b16c6e69d44b85a5b";
+      sha256 = "356e3dab406a768b54ec641bfc32b30c503b9608e4b446218243cadc61863b3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/az/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/az/firefox-137.0b10.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "0dad65fd8d87b183014773e6c367a80f4b93ec77fc0d7048a8fd5eb905dbbe03";
+      sha256 = "fdf66de1bb5799d725377e9a2039deee49867f5d799a878db75812fe72c5cbe6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/be/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/be/firefox-137.0b10.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "eb9282214192160731f57dd7fb0f9c84f299f2619f78aee5ba5407238f16ff71";
+      sha256 = "4570956b5a82505ee705c4ee0615c98755a2e7e827e741a633387a452ff723f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/bg/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/bg/firefox-137.0b10.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "353b3e519874731b8a301869c85f3fd07625e6a855dcee79bce73c5f3b1eb040";
+      sha256 = "14e37e5a57af4ea698fb554e410c366821af7c26e007123fb66373e63641135f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/bn/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/bn/firefox-137.0b10.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "d40435bc69ff5c7a7c256fecf5c13c16a26ee270f71f6442dee8c04d4a18faaf";
+      sha256 = "63b78127c286e955a9221a38390c31d9413f92c5c4894952282359cddc91c438";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/br/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/br/firefox-137.0b10.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "6e0118d18761bb3134b5101fe0d315a8f103aa57afb0a2841961083fbf336f1d";
+      sha256 = "2e63841530a8c265e81a1e34e43f279c34f4f13928a5592931172956db7ba6f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/bs/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/bs/firefox-137.0b10.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "11e65fd236579470c27085aa7d45cdea13ca5f787aaf5335dd11ffb35799203f";
+      sha256 = "40c0bd4064c84d0197f2dfee5c77a4a5a0f6bd0eb5505c325091b23ee282174a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ca-valencia/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ca-valencia/firefox-137.0b10.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "6e47f53ca23b6a5df4d0c7ef640a4d1fe7b9d51de9cc631a727caf12ff4cc6ed";
+      sha256 = "beba161453814dc95f53074b19218abecfda9bf2d1b4571e8cd1af4376be9b9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ca/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ca/firefox-137.0b10.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "d501c2a261f66b3c68e75f8d0c1b936442574ecc0c85c9288c59bc84d1113536";
+      sha256 = "148cfe273854edd64a0841f5a4eed8c08c4e06abaf0198d0617c1b840743fd1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/cak/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/cak/firefox-137.0b10.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "98b3556316794d80e28bd2ea024f70f1875fdcf78f8ac987de3c85ce515df958";
+      sha256 = "a3250d57ab8d434a71fa48054870df3934dede3ca87ab6227654daa2c478febb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/cs/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/cs/firefox-137.0b10.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "0bc66f4eafe7e8026e3399c0510e42b63a16a8040f55fd8e0175c10e65f4f6c0";
+      sha256 = "a72f95cf2dd349a01769ba8b1f7c73c6553e9de9d406470e40563d302cb2f38e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/cy/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/cy/firefox-137.0b10.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "1c746a2f8ba686ce8bf81604665f3e9f5487733eea2eaa52bc3c47d8b8a0ec6d";
+      sha256 = "a7fc2e0893d921ce6c6bb5d9fb47183b8ea14772cb31b9333bffd48ca7a79eb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/da/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/da/firefox-137.0b10.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "3f1471af4e4845bb69d7b3142d1b7ec8f6eef052fc4afd48e51bf56230165126";
+      sha256 = "18cf5d0c1da42d49ce885e993a64b1fa39fb124f76627b3d389093efff9e429d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/de/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/de/firefox-137.0b10.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "2304f0ad0db35c44b701e1ae3b627518c72c0ceeaed568b72af92a24672804e2";
+      sha256 = "78ce80c62a025c6850bb362e026406043a246d99b33096e5449f67f09c19ed60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/dsb/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/dsb/firefox-137.0b10.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "d16b2c2c10f5593e6bb5ecb01569fc507302d46ef93f1d3adb45cf6301afcee1";
+      sha256 = "b2a0c9b51715afae4e5f6014561abaf1022c9e5e1911e9e147760458542be365";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/el/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/el/firefox-137.0b10.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "4ee7d647b45a4b37a07940cfbc3109b870055efcffed8ead274a5a76d7f0a439";
+      sha256 = "9bf8a3fa1d05c46c377d7fecb9d1ae4857fa5ab19160f81c0921f5d3721d3baf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/en-CA/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/en-CA/firefox-137.0b10.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "57c14b12cc96bb659f39e2d9f2137fb2637a999322cd2ae3315405e61f37345f";
+      sha256 = "7c74368a8aeeac88ad4587428d6dd86de51fa1c4ecab76953e41aad9bb0ccabb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/en-GB/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/en-GB/firefox-137.0b10.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "311667d8945b9feb6bdc87a94c3d7f7f653beb441d535fe77052f46949efb451";
+      sha256 = "6b8f0732d30af5eda5fed8eda112d08fc5500a1c3e02117a22db967546107036";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/en-US/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/en-US/firefox-137.0b10.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "c8348f336162709f8918178a3e11d2e70f91fbc82a8fb8839d45ffdee1c57367";
+      sha256 = "319af71913886726333110cc2f365b39cdaa120d90938869985f8967e8f4f4af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/eo/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/eo/firefox-137.0b10.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "3cae953cbe742d51bc1fd6ed242daca04563f0312cc9af006ed1fb98ee89fe66";
+      sha256 = "fcb0face5526bba1bad5fdf6fc7eba2bb96b7f5ab64df78674ed4c081c8f94a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/es-AR/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/es-AR/firefox-137.0b10.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "1d1a8fc941dbd6fc6495ea755d2ff6c496f10800ac9073ae7634c3f6cf972836";
+      sha256 = "90b7fdcc676399b320e9a068d34e00959042286e3ebb40b709c9cde9b8dfbc72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/es-CL/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/es-CL/firefox-137.0b10.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "748a34ba3cf19e0607ae84418dbed55c50cead4a5ebec541b0a2317a0b76f4b0";
+      sha256 = "eb43c4d52d87873fc58a26d935ef95d9915cb8c14851fc2ea62b5110a2ae5819";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/es-ES/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/es-ES/firefox-137.0b10.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "d4e588fa667e44d564f94ba23aed80290020eafef0fdda24b72e26e4d8c9f4ba";
+      sha256 = "1daa83de45da55f9f2ca238ed3f0a1ec23df7ec74105ecfdddc4cfabc12980e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/es-MX/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/es-MX/firefox-137.0b10.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "3c1124766a235ef50e4a0080ca6eb733e3932fb27c99d7430c4051335a9c52fe";
+      sha256 = "83ab68086711114b20f9849efaebd081e19e4e7c33a5dd73d1502cd1228b20f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/et/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/et/firefox-137.0b10.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "9eb18f967cf58f480809c7fe9ceaff94779779d4bd68eb2cd4457aa66dd701f8";
+      sha256 = "ec34b966424b586f5e384c81d10aab9b29fd684f3560ca449abdc3254add8cc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/eu/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/eu/firefox-137.0b10.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "a89194f29aabaa372b69fff8a390d552e24d621e7e70cfd81f330316fe1e3bb5";
+      sha256 = "70e64c904b0a65ac0be8ae2bac04ed1af85c4fb1169a0898941e1b956713329d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fa/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fa/firefox-137.0b10.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "988914882c269ba580c7cb5e62cea26200fba3ad8c955fae8553798019c10559";
+      sha256 = "8750c4aff9537b89e76938817dd4f98b3b31c21634f954752b0bf49724672454";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ff/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ff/firefox-137.0b10.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "d2171c0da4ad69e55c685bd246857d1999e425b2c6291990c16681f8b3ff67d2";
+      sha256 = "ef428591168086a6b6d2344394aa5fcd4551b119a85f7258d1f35bb8f28232ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fi/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fi/firefox-137.0b10.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "b3b7fd3d6df9c7c092d4425e3bf1a2fb763bdb155daddf8e79b044fda90e59e4";
+      sha256 = "fc43b3cb736b040790e92b2b4e23bc59360a58d533b167118590cbe102db521a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fr/firefox-137.0b10.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "87e5ae716fe0acb5e838625002731ad4afe733adb1106769dffb4c7f4e6346eb";
+      sha256 = "2361aa0991e71f2242e1d6fce3c97beee9dac61d0c02b0f9265cc9da199d502a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fur/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fur/firefox-137.0b10.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "00cfa45f88b920bf7c9f09e26bdef07f4cd566395e3d0e808ea439843f6872aa";
+      sha256 = "f32bd5c0c3ae17cd7893139ec20c608ba0e058744e155284a9dc6baf433b3604";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fy-NL/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/fy-NL/firefox-137.0b10.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "59d6ad377e1aa703b157a1ab458079c2b391eb21753eb4ff0a37dcf6a8fc8e82";
+      sha256 = "bf3354e2e772e827df7bd344bd7e56f958b04cab43f03de229eb724700102870";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ga-IE/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ga-IE/firefox-137.0b10.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "f4e8fa0cee317eae523456e10f3c1fcde96565286e670e3c3b7fb5a1ef411f78";
+      sha256 = "468751b8fad4eac1b1ac308319912672f8f9fbf4571f8134e734b0d09303b640";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/gd/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/gd/firefox-137.0b10.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "012b9d1cd27474388b4af06d71a5cea24dd51289cc3009fb63f881b23a3f8f46";
+      sha256 = "ce7e20daa5f1f5b6818f55569a1f68fd5582e971b0e88b2b6bb929838dde7eef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/gl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/gl/firefox-137.0b10.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "475309bd0bbf79fb6e5426f55c1b1d9032fda561778d6f6d9ac694c7994b9d98";
+      sha256 = "a472ef1726220f89dca3507e22b8c779f49944c38eae90ee67996b4647956403";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/gn/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/gn/firefox-137.0b10.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "a417875e781c7eaef98b925a568b049833a655d30f716e59b3518cfc57631636";
+      sha256 = "ad10b1dae8bf121e9a29a5aa52bd2f1dc59b5ec7519e119bccc7f8fe21065568";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/gu-IN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/gu-IN/firefox-137.0b10.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "2b371d44db67288a6bc2172536e870037586081d1da684cfdf0adb826a24992e";
+      sha256 = "f18813f2ca4e9febeaeb26eb87705f8d7c3ba0092e07035dc381e72a31537c5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/he/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/he/firefox-137.0b10.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "bd2fcd000d5041c368c6b82119efda9581fd8cd465bfeffa619f26a561b2198a";
+      sha256 = "85ae9fec9c97e72bf164b7c0d39b7d6c56243e720e500ced87aae51a92fbbb8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hi-IN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hi-IN/firefox-137.0b10.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "582df60dec748a41e718cb713b9343c3f7baf11a9ccb6149732bcbc12abc2eec";
+      sha256 = "370a23bc3d57b2c2af5835bac73cbc3ddfae78bd63b1a3e2a4e68267a3853c50";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hr/firefox-137.0b10.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "da416b662e6f115dc485cd8a1b0cde61b64b8178d34259aa2b0e59391a6bc85c";
+      sha256 = "9fc278c697d363b8210b828bcd7688babbdfacc250c15c69c5101dcee9219434";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hsb/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hsb/firefox-137.0b10.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "738adb663b48a6b6eea84b4c5de7b93f0e3827a034b72c5cbe60498250b02129";
+      sha256 = "5094b85a8c87181a9aaa18ccfdf2410a910a3b01912c3f29b5735cac009ed475";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hu/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hu/firefox-137.0b10.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "7ba4cde737e6888e0dafe4e7bf4ebe3fe87b671a94c867438aa393b451e06401";
+      sha256 = "ca43990b646a281aa3a081f2a0ad29084fa8063d060eb3205c759bce64c65cfd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hy-AM/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/hy-AM/firefox-137.0b10.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "6ba63d597c609a98ac4681ebc8353fb88ae54cf6eb1f86bfbb63221aa894631b";
+      sha256 = "443e28421a588229742e0c0cb354e2dc4a4d4a6a34b02849137902c34d4aa7ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ia/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ia/firefox-137.0b10.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "180c3ad4f1fb0e6e896179376ccfaa8fbf923a1faf3eef22de691f8ed8939153";
+      sha256 = "909554909e4ca042879e46421abbe22c7a1a697bad5b7429c73f24fa83d55352";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/id/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/id/firefox-137.0b10.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "149f7f42b2b2c5e89767e0b0b5181e0f3e3c8c5260ba157d7355207a4bdd2770";
+      sha256 = "68252135e463181f7769cba5529dcdbddd42f694a3bcb4f77d8813cd54a4cda9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/is/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/is/firefox-137.0b10.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "8ba099b4dbfafbfa5354d3d040052b6ed6b066dcfd9be95e6f0014e1b5f8c9b7";
+      sha256 = "531ccc2cfcc1d405064b6dfd793443be992f3b1d12635da826805cef2627bd15";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/it/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/it/firefox-137.0b10.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "5eb1889fcb3854249e43ead247cbf4663f673598abfbdac02cbb8e51c99ac4d7";
+      sha256 = "7e43713ef319fb08680fc1ccda216be9d6c0c2fb413630574d321cb28c3d4a3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ja/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ja/firefox-137.0b10.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "ad79250210cf55b7ed3e5cb20951b39505e88bc482f87eecf3bb6c7c5ef6fba2";
+      sha256 = "07b7a5613e9a36ed773aa400de1fac7b44e180d89b85de9c56583a7a7f3bba28";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ka/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ka/firefox-137.0b10.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "3aa35c3eb5f043bf8a0090b43cb98716332a8fb45a23045b80858f27ebfdb02e";
+      sha256 = "0f6e5f1c126816863c34654e2226a672be34dd31cd0c8567435d7c3d7563a56e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/kab/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/kab/firefox-137.0b10.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "f3d2a9b41713003abbaa032de1f27cfc1fd39aac6ae5be2ac2cecccc4ebc539a";
+      sha256 = "5dd613b222a00d6bc4294e4ac190adcbd8d1af7ea20092716d26ad0002a24673";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/kk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/kk/firefox-137.0b10.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "ca759840ef91948bc3b94f600aeb6be3118dc7191412a4fb53a7cb56f3cdc1a5";
+      sha256 = "3e94f8b72384e119500a6ddc1d750bc28507bee04bc1604de9a5618b274d3552";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/km/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/km/firefox-137.0b10.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "de257f76e50ba543cc5d2a81f9a0c9acd6b96ef8cf8325e69cdb224282f049a5";
+      sha256 = "3639933713c2291c5771fd21068a4d2fa0770fd6c7764f3e11e58c11c16ccc8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/kn/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/kn/firefox-137.0b10.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "93baafbc1ff2e8de79bf3c8c28c2cc0dd070527e4dc83f334888d2de3f035a93";
+      sha256 = "9260368ea1474d6611c9f5dbdeb9a7b398a1d465b8a42aed90989b929fb879ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ko/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ko/firefox-137.0b10.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "490086600b6637c03121737230a7a3c6ac2a3eb34c49acaa38a251e6cc346631";
+      sha256 = "abafa1b3f6de01f1a05af169c6c6b599cef374f9827aa73fbb0ee0bed2f8bd7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/lij/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/lij/firefox-137.0b10.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "426164abb9a150c9ffde322661c88fb8ecd793ba5e1f1c9a19842c716fa19de2";
+      sha256 = "98a004987887a49fe244bf3ebb1b6bce5ed97d45a093e81126eb9ed66279f411";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/lt/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/lt/firefox-137.0b10.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "f34c258b3d2008dd5e8c305d87bb29012ba5606dcf79e26dc2c8f69b7c919dac";
+      sha256 = "201855ba80fe1c88eed7eb43ac46ccc29d8db82a563381f9743c1ea798d044b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/lv/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/lv/firefox-137.0b10.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "05273dad9f1db107409844c96218ade8c392c0a06c439874fc9bfc0ee918e095";
+      sha256 = "a36ce7dfa47918d5b963fcaf1d5e9b44aa75c4fc86e46467c64f030d84ef72e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/mk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/mk/firefox-137.0b10.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "7978da086cbe6c5539cc177044b5672b812461a121938800bf5920d693d31511";
+      sha256 = "ba434cb6eb5e9c64eab8fc19ed6b63b37babee8a545823b703cd750a6d24ee75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/mr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/mr/firefox-137.0b10.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "2c5d7211c89555d5e8195228e63a3f3a56a4c50d658c1e55291fe046581c95b8";
+      sha256 = "576e06215f4c8522924e48f7fdb7078d79cc2cb1b71e8d7bb015c760faf024c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ms/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ms/firefox-137.0b10.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "bf556c09f99e6591cc13aa09ab4bf8529d0757baecc644c91f626497cc0c3202";
+      sha256 = "3e3e54688b7e8a9b464d9c23e7925b47a6b6f171f816f805bb520e05e3e2f79f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/my/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/my/firefox-137.0b10.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "305d2b27afff848e38491482e0f56cf3df41bbc349df658d7721f2ce436d6df3";
+      sha256 = "79138b0eaa972d1c7df403028f53c4b4d6d222f11cf5ecf9468565f1518c6390";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/nb-NO/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/nb-NO/firefox-137.0b10.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "7504b0c1406a0b672688864f57cc836d38b0f5e62a0f69bc9eeb2c2dc75625d7";
+      sha256 = "d33ca66814433c8971b6d37d2812ef3a0e9e9b569afd94031f98762d9f98086e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ne-NP/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ne-NP/firefox-137.0b10.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "3d4843b55d065248dbbe32a3afb39eb351768ba0e4f625aee8eec173c77ffb01";
+      sha256 = "f6aac9719ec68474b4abb58b9aacdb6122007c95df5b421752e38f124e41f1ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/nl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/nl/firefox-137.0b10.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "39412eac8a159dbf7cc98c8ae355c054de99cfa1e09c734ceab0f0564313b4d9";
+      sha256 = "5b8d31d21d06cc4b19ff9bb05d07d53d180820dd1cd86a95ee5c1e7403a1981a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/nn-NO/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/nn-NO/firefox-137.0b10.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "f58dc123f451a2b053787427132ce232100e405594dac81f2a4093f57ac83eab";
+      sha256 = "757cef127d50b804479e136ebc58ea5c000254a32f2c09f92f2d43e4a47bd999";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/oc/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/oc/firefox-137.0b10.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "3ed1789a845188c59188adf1a9b4875a795cde17e99b93716a2e18a0cd225c3d";
+      sha256 = "965405d799f1440ac0a33bb12efcf0b9511dd80849b7ca0f2cc89ad0c77e932f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/pa-IN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/pa-IN/firefox-137.0b10.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "8d3b5778593797c4c13c7ea64170b32b6c8f5b834eea9a2be576abb332478a94";
+      sha256 = "9aeafc8fae330a3e09ceaaf122dfee8f581f054e5c0e91e10bc308b435a3ada8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/pl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/pl/firefox-137.0b10.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "84a1a0b1ab876b6359478082ad6c2ee76627512e889a20f71547f5b05fe78315";
+      sha256 = "5dc8d09f27776f0f96c0302a81fc2027843a915fee40b09855d80f2692a108f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/pt-BR/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/pt-BR/firefox-137.0b10.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "a91172c138e59b49657177a4890cd71f83e35a71ebac5fa362f2b181ad262760";
+      sha256 = "fd95ca5be74c5ee2a9ee117e6f08def52b9003d80ca552b5535a6f3272f8a51b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/pt-PT/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/pt-PT/firefox-137.0b10.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "e08fcf6c96af66b034ffa3cad3478eea49c2d6595fed4160b92bad72a864289f";
+      sha256 = "1892b62ab2721d8716220c5e88af9c90fec5beb420374c3e603707ff44bc47d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/rm/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/rm/firefox-137.0b10.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "f0e9b9777c245b3044f1920aa7a8adde9346a030121949667108c0c4753bf1ad";
+      sha256 = "51d581629f587de3a2055d8c6799359ecfb7fe5fd13c11b77935f8041c2a295e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ro/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ro/firefox-137.0b10.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "b5fa465caf7dfad7e5e7536b0ac47f243f51cfa46530e1f5b080a9a5102fb4bc";
+      sha256 = "ea978843d609281f73d545e85bd0ba9c57adc91e4645b1f0e8b022dd92f9998b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ru/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ru/firefox-137.0b10.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "0241d5e6464e6501efe5d4d4c3ade2fb715fd033ae6dade5462ff47e165ae75f";
+      sha256 = "e4ab2d28171a701d63d62cd65d0cad78ff4506b7a497485b06f808037ca7ea21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sat/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sat/firefox-137.0b10.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "973c654f973d89a132d4ebd35b066e007b823b9fff29f2db826e59755a4f5c93";
+      sha256 = "b160fab29f0fdde16c5ebf99769a7dc4bf00c4ac09f3f7d726a47cd9d69cc936";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sc/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sc/firefox-137.0b10.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "3253e304d29eec457fe09a5994a51770b63edb5481ea2a44b2fe101812a8e7db";
+      sha256 = "d8213839c9e3b35db2f743d4a2789ee1ec91759f344879bccc9187c4a5acef5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sco/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sco/firefox-137.0b10.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "42e92e83f10cc8d07f932e1a6829670e093bf8d5e47025ae10f8454eea321bca";
+      sha256 = "3916653026146b6f13a98bd3559dfdf38ea2645f93b24b85cc663dee67f1c0d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/si/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/si/firefox-137.0b10.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "01569e399f1f250820a90d663260bf213f29653137d4c4ed704cc419e295a238";
+      sha256 = "d1fc184b57cf24b6041731d5f9ab2fa73ae0549a27cb695d8558491e44901210";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sk/firefox-137.0b10.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "b725685e7321d39a9bace1501330ab09fa46ec102ff7d8732a19ede241864aae";
+      sha256 = "243da2b019aca664e445a6cf486ee78a399b89da1ca1e67d560c82a9e2e1c13d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/skr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/skr/firefox-137.0b10.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "c5e67f9422140c47eeefb04afc65fc469ba870718834e9846d4bbcf1e2a68d56";
+      sha256 = "2156ab1d3c5185511c909f8072152649583a45c3f6e43b08ba91b7402b41d1a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sl/firefox-137.0b10.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "381854e32e48d02816e96bcd33adcddce35a06fc37e7b5f42962c016b2bd49e8";
+      sha256 = "6f5a698c5498603250e91c877c4e1bf021ead850ffb25d707a9fdef45f4bf560";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/son/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/son/firefox-137.0b10.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "493eb0202e4b14d2e999b7efbcfb5dbfda03bb9247d4e4bd137f4b7955b3f422";
+      sha256 = "ba839673b1adb6630233c1daf1ddcc3e905528f60076ceb390b9bf977b86c6da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sq/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sq/firefox-137.0b10.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a20351d47efd5b92178cc98313f4a3d12192e6c47c99469074330dc5f4c0470d";
+      sha256 = "36f06ea635d64e5fc0497e020def2304651a6fd385fe67844d2878c94ffca122";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sr/firefox-137.0b10.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "90e18b8410492c0b18dd69f85c3a15ae36c040bd4c888ec94f204d0d6d35a3f5";
+      sha256 = "9bb4a103678e526e0797ce4ce6c68e27637917436c431e33f48a06b4a7d5b73a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sv-SE/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/sv-SE/firefox-137.0b10.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "69c726b06c7808c5a9e3c342a41a8c026e99ec2309b4622d99486620d8872865";
+      sha256 = "99b873da9b8bf0a729f3eadee176b3bf5ebbc095ca59f119b8f7775cc96434f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/szl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/szl/firefox-137.0b10.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "d98d62d1b4b1662e8db3bd482d5ae4d8045c7948aa6a049f5b952d6ff7992e8c";
+      sha256 = "b1eb754a9421ef53d1873480938e0d26c9bc4431bc24f21f020e1d0a6ba5038b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ta/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ta/firefox-137.0b10.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "46245bbf0af4a1567bb786a3f46eab4be0908fa762aef765386330120ee84ad3";
+      sha256 = "df7acdf49fb510f12fce7ec99f00119a29e0254dd270ae1c1b52da899d7e23b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/te/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/te/firefox-137.0b10.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "aa457c8b036219386d345bf525093d51d273a342d6b72c888451d3649023be78";
+      sha256 = "4d9309859577e18c3b707283ab68112fec2ab61e66ae57ec68dd389be6235519";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/tg/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/tg/firefox-137.0b10.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "9fddb5a7bd2cd5e8ae76e7a4897f68e4bfe8f2ce6db8ac56447052042e26f919";
+      sha256 = "36044388faa92f1d2d06c18aa0fd32cd5311d8a11f5bb0f16cddda5128b0888a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/th/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/th/firefox-137.0b10.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "5c55a15960c105c273dbfbc42215e4b637b6459e832a715da3ebf3e5f76b4d2f";
+      sha256 = "1818a5657f524194b08644ff1fa2444a4d18e224774ce1a0a4d84e2dda8cfa8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/tl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/tl/firefox-137.0b10.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "73eed2fb989d1ef89c95b224c09bf83d8f8eee4ef7fd2c10e400c5f23377ccfa";
+      sha256 = "7f821360c515bb180d5f4de778bc76e96fc32b1ddf3dd7533f79c39c866d6e61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/tr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/tr/firefox-137.0b10.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "01d20355af783120a9bc331461fd849922f3c133abec7c7b0ac839b4f1a8f321";
+      sha256 = "788fad9f6ff62df7257095d0ff7f0026e651f5cfa03ca3d72976978be686465f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/trs/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/trs/firefox-137.0b10.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "265af379c901c206b8c684fd06c2e930e04c327f68b91a0264b67c7474b774ea";
+      sha256 = "51e5ffbaf0c77708323fad6c82658ebe84f16eb26401b8b252538f49841e2503";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/uk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/uk/firefox-137.0b10.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "c95a8adedbb458bda8c7c339ae022c9882262624e6c155b41eaf877a6d944d1d";
+      sha256 = "b3ea841a43f4d226580dfc9613a457fa7c945b2a638e58906ecfe5da8661f042";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ur/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/ur/firefox-137.0b10.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "1a4b943ff82063b382a1ac41206a265f8d8c3de9718a62c5b24b1ee8e9f3af69";
+      sha256 = "ee2303f9d69089f292bdc28ac67adaad40a27654e21854c93c6e493f157ea210";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/uz/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/uz/firefox-137.0b10.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "0a7e71be584c57901839d83281f2b762191b6c8d5ec003512e74190c7dbc9050";
+      sha256 = "2a2b1bddb030346c7b229153784cfc64d0b9619002cba1ad13d5530cbaecf8c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/vi/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/vi/firefox-137.0b10.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "93f588aa0c67a4637627888700358c13efab557e99fa8e579e09df3149278cb4";
+      sha256 = "fb0a54a9c393d1e62ffed1e7864444274ae9e22a3f2f027b225f3f4cdc9952e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/xh/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/xh/firefox-137.0b10.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "e469deab3c5e4f0c52aa517d1dcd24e83e2e41cd962c4c7aeed286d31615bac7";
+      sha256 = "74298cd379e0d2bfcd9cd3beeb10c1bad040cba292a09669db0861b88f3f1ef2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/zh-CN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/zh-CN/firefox-137.0b10.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "3ff075fbf2c0190d3fec17f0e0102cca2cdd17c323351fe8849799b8df52fb26";
+      sha256 = "adb07f9499ab8e1b09a6e546653192dc86b7af3878d8f6c9e1a4b94a72c891bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/zh-TW/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-x86_64/zh-TW/firefox-137.0b10.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "c4eaba808adc254c0599102d9d208afbb65265e711e897d218e2eda2061587a2";
+      sha256 = "81274c3d1fe8d0cd833821947225637b544cd64973b4456088f18b6d1dfb7cfa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ach/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ach/firefox-137.0b10.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "d03e7309d5b0a76ea4eca3d611c47eefa32770ec74a746e793026ee484ebf31d";
+      sha256 = "9df21b1ff9945ff4a8b8152e4bf4a3519e98174a29c2af5ce23e8f67b3abb7bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/af/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/af/firefox-137.0b10.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "d14fb406fe7ddcafdab89025fca3c2532a405a98f31ee74442de0c1afc929ee0";
+      sha256 = "01ba75d77f73b589e44e8bf5367700d6241d32e0ed562da4489af9f8e1ee2a65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/an/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/an/firefox-137.0b10.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "f236bef110eb14cfefd2aff7cf4f10c7b140820ec0acc72be08b40300f8fb1ee";
+      sha256 = "f75442c5fad7155bf3e339b612a1b3b024d0ceaf1f7c81e9217998a055a85bc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ar/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ar/firefox-137.0b10.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "3dc1b22bd9ec0fe7173b6d6f113044037601f330555b758fbcc03dd7d14afe1c";
+      sha256 = "aa4a2889b3baa03ceaa18cd53f3601540abe2261277d0650489bc6ac3ab5a060";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ast/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ast/firefox-137.0b10.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "c83732c33730e864889a85a93f8b47b9feaf10f8d57ccd851a8152d482371a93";
+      sha256 = "56c39b1c083063f74819655ff1929e1e3c9c2dc4bb9a1bed43859f2780ef0d72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/az/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/az/firefox-137.0b10.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "9ad1c8ebe7afe33d4ae13c1860a06fac69740f63a5c39d5c70308a6b3427091e";
+      sha256 = "877596d4171746dd7cdffe3c073c4634b610c396d99cbe5aaee6794a923bf96e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/be/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/be/firefox-137.0b10.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "92a158caaa68d68b07865ef41fb41a1a021e2c0be80a8cf55c0945b5cb7ca8b1";
+      sha256 = "66b4cb0e25fb263614775548c85479fe17d1b98b875d320cf366e8854921b2ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/bg/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/bg/firefox-137.0b10.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "6ea76637b48f4b5eb8717e340fbd6e7c60ed4b99e16bf7fd18434d120470d68b";
+      sha256 = "0a885b0ebef3041360694ab89737dcc9c98b9d749888db1d778a88bb671b587b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/bn/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/bn/firefox-137.0b10.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "40be1d0d73349b05e71113c0c493d31a521361855d65181aa27c401f8aeb7281";
+      sha256 = "af0559b15d9ff6125207d39c4e4c7be1d9127eec85c4844b2ebba56d3b9580bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/br/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/br/firefox-137.0b10.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "98165ef5fdadde38ffa0d1473c24678a3026fd46213c124781f4a66de4a200ea";
+      sha256 = "fd8ed6377e263f69b258a994c0b6a3c58da9664031be265a0eceb48a1afb73d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/bs/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/bs/firefox-137.0b10.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "a4da6bd3ff5e0284f6bbcc4da861966d67b2589b7c0541fa546a6ab1f00f57ac";
+      sha256 = "02ee80372fd1b2994e6b8fca3ad7749f14270bd19f30e0130b1c0bf72a90cb0f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ca-valencia/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ca-valencia/firefox-137.0b10.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "b304bea17cae883d6a31d5132bbbf4a49bf063e5dad3996391451fd18634230e";
+      sha256 = "4e0882dc24784f0fa990d9eca6fa7e41497de82bba12b0685c412b25e6c6563a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ca/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ca/firefox-137.0b10.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "e65a97916486f3c9ee979204d43898cc8f53279249f0554fbb8e2e631661dacb";
+      sha256 = "d36a4d9fe0a8a45d75228b10133427a8e7de10470764624849b0c753e4baa48c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/cak/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/cak/firefox-137.0b10.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "a8b33c39ef32b5745cc916e9629478f795d2e8fa43e83723f556feb46fc93452";
+      sha256 = "c0e952accd97cf53d0ac8dcc309fe3645d265c681e20fcf7ddb18d8b0bf29e56";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/cs/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/cs/firefox-137.0b10.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "74b4d7f0e21ad7277750a98adf46b4de53a431e986c220a5e458815c4e63f1ed";
+      sha256 = "1fa69b2eb220a6abe2e014357160817f805b223ede4cebc69a786a6c253c3354";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/cy/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/cy/firefox-137.0b10.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "a2fa47c796497a70accf316ad21edfdfe43fe6d404aa7b02ad2409c9907505b2";
+      sha256 = "6f3d484a3a1e883e0866e5847a94c107a355c6f38350413f9c8e054c82987418";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/da/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/da/firefox-137.0b10.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "0883128230e2026fe4c74105b97ca5847e4e9ee359e14511408dc03f5831ade7";
+      sha256 = "3618ba5f56c810e1a087ffc9cba9f39a9e9682a530b9f65420441c86d6d5fda3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/de/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/de/firefox-137.0b10.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "c3d43af424b1bc0710327d44b2c31fd2758c17e559167a0793a27464f193a2d5";
+      sha256 = "7929672a9f2631c78a0a1309a7d8c06ae2e0cd16a4133d64a998a57bdd2402f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/dsb/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/dsb/firefox-137.0b10.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "dc8e35d7fc97a5102705be59c7d66b0c9a13cf37676a0f0f7ed22eca37022dcb";
+      sha256 = "c3bab0d523d7657c6be39a21d048a83d070cd4c5ae33d01e5f0cca8733a6c30b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/el/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/el/firefox-137.0b10.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "20ceab4a4893a9dd77cf497580f6500975cd36f216fdb9de7b7d268322e08091";
+      sha256 = "5433ff937adae7f0c6559c37d6934114b170f71e84c3c2c2e9a3338370139fe5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/en-CA/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/en-CA/firefox-137.0b10.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "46c7dd3825d6f43a90737ee4698e511884a1e13ec5bb5e7f93fb894d9534b100";
+      sha256 = "c45ad41936fc1e9bfa9d59cf737d0e029e08328ac026673b27daf90a0fc8a39a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/en-GB/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/en-GB/firefox-137.0b10.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "502b1341e773559348c236f3226530639e9620d1a8f8e6dca4eeba3ebdbe0c09";
+      sha256 = "52ea4415837b9c3791d04a5563b9acc7caa6012a295c6880f461303abb65a542";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/en-US/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/en-US/firefox-137.0b10.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "f0d37a3e04b8567347b8a639cbcf6e0715cec5322d0578e05d19019b6a7225fa";
+      sha256 = "e428129f2d3cf9cbbf2701317fd222b2ee8c94b76aaf6a54f3a86de540aa3af2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/eo/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/eo/firefox-137.0b10.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "34fde3bd7aaba9f1267cc3b2a3ce7a6ebece30388219c88accebdd8514d6da32";
+      sha256 = "bc2dee43a7f7d4ccb04dcc233ff1359eb3f45dc272d01e92039fb3bcd0534fc2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/es-AR/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/es-AR/firefox-137.0b10.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "98a0221b47c5a1b4258d2c2b76425408686f77330aef118ec993264f5ecd347d";
+      sha256 = "99c747b138a8481829711c63afe7f5e5eb1b45442203c4eff8e09afb2673d00e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/es-CL/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/es-CL/firefox-137.0b10.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "1d8c545b2a354892eedf606382da8247db6c49069eaa487ee5178a380ecd0279";
+      sha256 = "eb81bd1bad7debf0a332afbed4eecfdd5765fca6fa05ed9e75ab8c8dd05b5de7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/es-ES/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/es-ES/firefox-137.0b10.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "c706b43e229502e8e68db43d4af6338127ec30756fd7413949901fd5b96519f8";
+      sha256 = "446d7d956bb878a28869a57256d2a08c090c6893276f4ea09cf2116515aaeb48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/es-MX/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/es-MX/firefox-137.0b10.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "a94f85c876cccb371e2afbb0020374fac493148e34b0b4fb8df4532b4f0ff969";
+      sha256 = "e2f4db1178e11a43e1d62f21eed61c5e25d4bd75edf91f63401ba384d29080f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/et/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/et/firefox-137.0b10.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "4c66f70827f4d392e4c9b793f965f6c6befaffc2cb6371febe4bfc97fac9fc68";
+      sha256 = "3d47570c5de25da080f2e9e7ca20641d06878b421147f4ccdbadeccde9bff61e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/eu/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/eu/firefox-137.0b10.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "c83fb9e24db2f847de51cdfa2f54de5d9e52aeb49188cd4371765b561afd1ad6";
+      sha256 = "f8631ded866eaea8ef7812ecba52958242c95b8e39e69d892f38f1c1a0ea03db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fa/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fa/firefox-137.0b10.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "22bbab8db2fcadb02c0c12b55b6353b2c920ea6ef7a50a0ad01f6a2bc96f734e";
+      sha256 = "d55346559f9cc01070bae44b1f53513f2897cbb3deef0fd5a51d692fbda6b4be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ff/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ff/firefox-137.0b10.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "5ffe25658066071c30373d91c137363513cd28c4c62deaf9abeeb7c8a71e8632";
+      sha256 = "05588e3f4b121ff1f042abe8ed9c0a011f0db6cd035d049b9c765ecf107b5bcd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fi/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fi/firefox-137.0b10.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "ef93fe928e038117a3e9236982625bc96111bd9fcb62e8b28a14279678a2c847";
+      sha256 = "3cdb70af6f7720e263c4eb9353ea1dffdbe881203227666a589e215318698e1f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fr/firefox-137.0b10.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "16beea2fe2164468d5acb351e380687f68295ec85cff046185e8f88ac1dea55f";
+      sha256 = "4c92f507c46acc5bb90849bcedf0a763068fce151cfe3e7b3c886e1a2de45c03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fur/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fur/firefox-137.0b10.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "7418fa563071416570c0be896f828754c5cd2fdec81f9638a7ca3958952bd475";
+      sha256 = "9acba01f31b0f61cecfd99432f2e7b9fe7bdce0a8a3b2a1bb3416b5b1b7b81f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fy-NL/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/fy-NL/firefox-137.0b10.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "2d6c7ab2e14db9bf0216c7a1a7d5d54d7ab35ccf535d62048696a3422e5ebdc5";
+      sha256 = "3a3955cc52c5f6b9c14b82cc18ac3668cf5c6afa01c27a037fcad4db82275cb8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ga-IE/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ga-IE/firefox-137.0b10.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "d62fb8e24c907ca3a277a0bfe4c77d62fa4a9d65942f8e0525413214a5b68621";
+      sha256 = "375281860f95bd4c80d9668c1e277540cb7f81d0ebe01fbfc5b207760d706c20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/gd/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/gd/firefox-137.0b10.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "a625e15f38dd6e19cf0b0fa8a071c5a3df48f0e1a3e93b0c7bbec3a1cc99685b";
+      sha256 = "e07c785c5c9873062d9b761c212dac14bdfe88737a8df93a3fe928190b6c28d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/gl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/gl/firefox-137.0b10.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "92519c403e3d45bb364b3f6ba7ed7dc9b93fd30eb2927503559697e6180e20da";
+      sha256 = "ced8304e694cb5a33c1fc4004debddb6a5ab001717e0fa7e70d0635680c1df12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/gn/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/gn/firefox-137.0b10.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "edd2f596c0b1ccf292b1fd757bfc49420250b350422e90ec7dd01511957adc5c";
+      sha256 = "cfa35eb30a9d4dd075dba1dc83dc1941689c40988839e761919b417b9b1e4555";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/gu-IN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/gu-IN/firefox-137.0b10.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "f58bd1fe99fc87b441a1f4df48862238fa5780b747b56a93cd8ef579c419b587";
+      sha256 = "f5efc09dc204f7872f6cda19db0f66733dc536b823f6bbb223beafb5900005d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/he/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/he/firefox-137.0b10.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "4aa99da36cf17c7627bdcd5643344cabbe1cc1c1683146558a7c4646a25eff50";
+      sha256 = "b4bf8b6bb71f713850da46ca1df1f4aaf7278174c48cbc4f4ebaeca65d9863c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hi-IN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hi-IN/firefox-137.0b10.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "b2ac807aaa4ee696a60b6f117dd165bf0a0b633f895247bb916b810103d5a739";
+      sha256 = "0f1c4f1f75517c393198cfb944ace2159e3d3f12fb9170eb532ef5edbe241d95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hr/firefox-137.0b10.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "123139a7923d0e2658745af0c6c09dff99fbd3b8973df9f41420359e43d433d9";
+      sha256 = "4bfbe567206a9c37dcd1dfedd430c6c5cbee015ae11723f654108b1ad1dd07e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hsb/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hsb/firefox-137.0b10.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6cd9c025146a3fc488828cfaa21e25544896c2332b3e8377da9816ac5bc5847a";
+      sha256 = "92cf0ae541ccc4b7609dd70bfbb37f7dc066a926e8c9f14e94d85dd2b2847638";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hu/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hu/firefox-137.0b10.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "e49de3e5576d292e86ffa3f6c274a8c05b9ac98349af5365915c90b15e8a7ab4";
+      sha256 = "05bae7f6e502256d1b7a9da81a207bdf01d529a6bd2ca85fa557062452aee498";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hy-AM/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/hy-AM/firefox-137.0b10.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "d5e268a2ecc211d9cfb0cd2967161a0a32ea8f446f9954595cacfd11ac609446";
+      sha256 = "4fbe110d0c790e317c3d052b46550ea1cfbf3d04e836cbd48b6b43c11bdd2ec2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ia/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ia/firefox-137.0b10.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "f3737f3d033af8cc9c652f83a6fb66b937a359d70e2c6dc8fcf371d600ef1e60";
+      sha256 = "dcfe829ba81b743e6835b2b8712650f45a9e6ef51e1b5b89fbcc6a8458a6d775";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/id/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/id/firefox-137.0b10.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "f0dfb488663461e358e41cec1ea3143dc5fb138bc9e16d8047020b6db12f4fc3";
+      sha256 = "d434c3c92da14dd3a75f61e1793f0e81cbaf4271bdb0a2a31db5aa2aadcecdcb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/is/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/is/firefox-137.0b10.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "13a0d185875c8f0d505eea74efacbe983c900418eb93a8d75a8812e47afdc590";
+      sha256 = "f08a607f20e20f41d0644a80e0e916a37085d37627dd0e04828a4fd22988e8e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/it/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/it/firefox-137.0b10.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "17b86c7b8185b3cc21b8e5ba89b3fa69fdb8cf37f4d1570420ec17e073b82644";
+      sha256 = "65d258db99319900e8ffb23614d70f3f54423399cd822682359bf0f3c7e5abe2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ja/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ja/firefox-137.0b10.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "c972bf498175957eca1946cd067aab8b1bdabda537a8ddc3f893d43333257c21";
+      sha256 = "4ad16c31e3be0c8e9e449c93fc201f2fc093abababdfab2d863115881533d2bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ka/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ka/firefox-137.0b10.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "1cab84871422929443ac0648daedf192f7fffa5d7af6d5d5ba28cd4b8e897c5e";
+      sha256 = "2361559e34ddd3bdb002f898bb3b5923c4958114992fa6334b057f22f33a5b5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/kab/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/kab/firefox-137.0b10.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "5ac1b192085e268dcffae59a8d167fada0ceb646c306a01e059e221d714ea03d";
+      sha256 = "aafcd78122be357a6fa4c7fbe027f45fed98f0bf3d4eacf06fa8aa24d593c2dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/kk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/kk/firefox-137.0b10.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "0aecf096a377bbec87f1ca2014f8927e22b639b9ee897404fe9590c54f64c1ab";
+      sha256 = "e44b1992c70e356c0c5118f2eb31f63ddd98c98ebbd8c5c872118584eb71c400";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/km/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/km/firefox-137.0b10.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "14416925f65a1d74e54f549a939eb2cb43dfe06b16a064d1c16d9daca8b7dec7";
+      sha256 = "0905dc9e42430fb8299ce8a0eae722b5ec7d24b8db5260612c082415f0979f14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/kn/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/kn/firefox-137.0b10.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "a59704c5f438943cf4df6bbdc31e4dc51c33fed7fd4de8d67f2e476b93f71a93";
+      sha256 = "a592fff8c6a6076bc6e4e3631f923c3ac04af775142546e42d580ae5fdc9cead";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ko/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ko/firefox-137.0b10.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "67c7e34ab93913b346ecfcc5d4e92c402b9d5adc10a852b9c9533367d6c7c5b5";
+      sha256 = "bb7bc9712d8f672f30dfafbff4901ebd2c23c68b66bb3800b5a5a9d145ff9202";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/lij/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/lij/firefox-137.0b10.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "72d62d5a7419ddd55f3c976b55e38a886801892ffc517fdc9364a2743c7845bc";
+      sha256 = "505d9ec5d3c110593da450ac6b8ae57740f2474fb92e26bfd7e372d168997973";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/lt/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/lt/firefox-137.0b10.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a2903a7cb440c05da05fec006357861b3c9d0f2e40c7f451fa3692d6a644d241";
+      sha256 = "eca8790d0866a8d694f74db9ceb7f2f913cf1a6ecadd3df77eed217de686b8fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/lv/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/lv/firefox-137.0b10.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "a333ec2272c597f5f0cdf80c9a43c049b66d2ae100da1e955684a4ad3e725861";
+      sha256 = "4d81e0900bb7d552a61ccfcab80c68495bbf883047f8d0e928f6ff2c582ad360";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/mk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/mk/firefox-137.0b10.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "98d968e5b6bec5d83572a73f779714f59667fb7836a9df73b44ff70c86abd5c0";
+      sha256 = "851b8db8097c0f872208ba92ac628b66ab85572f16412351b36faef18f733037";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/mr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/mr/firefox-137.0b10.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "13b6efac223335475e6d490a5a0ce6647ae906095f72302f1e6c1c04cde512f4";
+      sha256 = "8fdb01d7a9299d4f46b8d4fc2622eea7d343fffb8d02139b696a5125a0f525d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ms/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ms/firefox-137.0b10.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "ef300793e78bc39bc6b5c3290ca74b78dc90ec660d5d0985ad24103a0935e212";
+      sha256 = "eb9104fea4231c5096c23b4769ceee5cbfda2d06c43e6248476e5559f415c019";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/my/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/my/firefox-137.0b10.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "4c31243cbc1f21ce63ad13f3b8bc9f33fd9542c7ae3c01c912f9eb2995aa6798";
+      sha256 = "0363c1bba70dd20e047784ee7aee50b97512fa01a498de8611fdcbc424b489ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/nb-NO/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/nb-NO/firefox-137.0b10.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "cc92b5f978387bb56ee5991133dd8b6975542d689978b0839954c352113c53a6";
+      sha256 = "1d7421306ccfb6afb43649895bc71eccb9a2ae8da95c941ed5a0538add4c08b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ne-NP/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ne-NP/firefox-137.0b10.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "36ab3b215f96199a21a088d3f1a265d85859062b4973e09a61a023ba4c0884ee";
+      sha256 = "a3005348908f842726eebebfd8ed21763cb893e5416021e963b80733df1c2ad1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/nl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/nl/firefox-137.0b10.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "102ae382c7659e3fe76f14c96e594afccf7f9f66757081e1b85b527a05473e98";
+      sha256 = "8a1b2dc5c61ac95e38de823186e886531482ba75e837e9df6c8bb0b0c3ccf208";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/nn-NO/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/nn-NO/firefox-137.0b10.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "2ffdbf947a40d73f7a92ae6c3af4e090867d459cfaacc8188401fbfdb12ec6a7";
+      sha256 = "351341647bde6c40e0ba8112e98ca80be4f7af8b74da08892f82b43284a4c9e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/oc/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/oc/firefox-137.0b10.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "f576151607b97a556a1fddedbd45471737db14fd0ef0a942b53066a7fbedf77c";
+      sha256 = "d8fb3dd34388204543e4e4bb8aed424df10b77e2cd2b51f7549f091d3c7ec6c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/pa-IN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/pa-IN/firefox-137.0b10.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "0ec692dce9dda078c3da9a16ad8566bec25331b4e915b01a9f6bc854ab0b287e";
+      sha256 = "839dea66654c3efba3d733bbfba365214189eeb4a61dbbf020daa115eaa7a304";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/pl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/pl/firefox-137.0b10.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "14bfc83727d87372c041dbb27a1348070d7fcbe2c831ce6b9a09f9d723fd75c6";
+      sha256 = "20edbddca204268e30efeb2ee20995cbba5f26fdd706ab260ab4e7ae2f1b9ef5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/pt-BR/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/pt-BR/firefox-137.0b10.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "64acb0d2e6b5b159928f34e0a4f6ac1b956cc86b357770e884743f8e9840f55d";
+      sha256 = "4cf9ab194610b2405e34de6e456993b70fe31f9b04962a9a344250ecf16500aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/pt-PT/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/pt-PT/firefox-137.0b10.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "a56b34cbd55aa0797966384b9f51ca555b8e8e635c95092532376552de45ab32";
+      sha256 = "482fd023b60ce06b25e292c7764dd7069951dd2d88b542b80a24b1b1422a8fff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/rm/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/rm/firefox-137.0b10.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "49d35b339cf569469ae31e8d1d36fa1c8bfe09602ab5804c69a2adcd3253ec8b";
+      sha256 = "2cb8a7ad00eab956ecbb001019877476d7aca116e79a0e43b05365ecba41dafb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ro/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ro/firefox-137.0b10.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "f09695b14bdd1c1d22107b62f19e54157ea0aea926747d69a12a04608be7d398";
+      sha256 = "6db1a0fbb04082c803858ce2cd222ea49965bdc81d35f1ab77bccd69aaffb9cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ru/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ru/firefox-137.0b10.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "fbaf8118e83e8ea3b5dd278c379e826bb62f7ef4af532b8a818d240804943905";
+      sha256 = "7bdb6d708b8f3515549c4047c56e61cd0ed58b784b5ccef7c32ec1e204d46f97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sat/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sat/firefox-137.0b10.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "761589e7654a10c993a9895d924ce1b04c75fc3e1f3b100f4c4a52e9db4d86f3";
+      sha256 = "1ce9947cdbd094a5e1efe8e6fdda5d4685a9457e222569151a3423661b264dc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sc/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sc/firefox-137.0b10.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "196b1473965d09b2709c871633ed677679cf7f86cb26e0d985560901cb8e14a1";
+      sha256 = "6988b13049e6c34ee09868c2b004e7559c39e7931ec246a50643a051c8ec4083";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sco/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sco/firefox-137.0b10.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "7cb1df14621d63f266b59ee4691fe196ac7fb2874a068857a94427a2ac056bf9";
+      sha256 = "f61ee2344d1dc96a6b8fa13b3676376d3f43b9c1fd65dec344ff3781e448f1a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/si/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/si/firefox-137.0b10.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "35ce1453224519ec876f798a81b3a50799e8bb80e97ce57ff22ed23e38a43c8d";
+      sha256 = "8a418e6fecb901bf0fe27ff3717159ae0e9300ed27ee2dfc83ccb54ed9c94980";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sk/firefox-137.0b10.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "25c824c3d3156ee2799269566fb913e7cb13141fa89e2f6e8b5ddbff5f73eb04";
+      sha256 = "5c1fc8793fde16c8bab897210a620b401d2fe2f416c766dad5617bfdc166c097";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/skr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/skr/firefox-137.0b10.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "d0d7b6bdb1343d9ca6d3cbc6547f64925fe226047d17a7b99c1f941579c7530e";
+      sha256 = "789acdd8375d1f96a6ea86d0866dc164640d80400bd7d27320b103b7e3f7a210";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sl/firefox-137.0b10.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "2f143eb911848607c45dca7ca43deaa0afb843dd46191dd59adc6647d02b4db5";
+      sha256 = "2429564d5158a8ca350b64041a25d8678a51b4a7947cdefb5f1a006df3a2b1cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/son/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/son/firefox-137.0b10.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "e624c8fd518b244ab5a397394aebb988c9745e27f28ae7ce090e9f260e3887af";
+      sha256 = "b54c750963d11100b56055bf3be5b4397a80c3b487189cc7ba30fdfcbec4af0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sq/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sq/firefox-137.0b10.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "1f0b86ad3e99e0c6258568cc5cdb5d19c89303de7f71ece1646776d585b177cf";
+      sha256 = "aa829b9d1490c97656b785e17e6a612114fc3e5f850808f277176eda12a547fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sr/firefox-137.0b10.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "daa08744f672e8f76f2d8288fa11a1c1534d1ba8afa9e1bb3ff6ad59cdea5000";
+      sha256 = "5217c2f43e2cd8a363660ccd992705d96b9f2b7ecb7c5d3d400f70d385d85567";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sv-SE/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/sv-SE/firefox-137.0b10.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "25939b5a902e76216c71d60a64c956d97aaae4dd1b9ad73b39a3105b37e8507b";
+      sha256 = "74b995cd3793292f1cc2f8e30ee72f059aef55295fc5811e12baa6714ebb8e95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/szl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/szl/firefox-137.0b10.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "408300599eba0410714c629d8f742753a8b5f3e74cb2ea45cce991e12892a5e7";
+      sha256 = "86acd2e307a17b0668e756ef12515ab4d37b3ae4fa9c308d15a58e236ed1597b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ta/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ta/firefox-137.0b10.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "92ec5418a12a287b17c8ba7980d42cb014df9643cd6cf091f9b36961745e9a23";
+      sha256 = "1b1dddbd4dfa2ba4e43b0d97357876925e3a3b4fc103890c36692e4c669551f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/te/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/te/firefox-137.0b10.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "6274a51a39c587207e66d419d84ae681a5ae14754b0c58957ebe55ae360a9e79";
+      sha256 = "9ff90bbf310a961b3ee5ce81d87815af20a97d317835ae685b02bd11d76e4430";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/tg/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/tg/firefox-137.0b10.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "b5a2f0a11c6f4e0ee04590fd188cdd3a79b0f134327b74c0809bc6278bcb068f";
+      sha256 = "6f5ad0a96358acbdab8eb6499adbbddfefb19da4d4add4cfdeb374eaf7b474f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/th/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/th/firefox-137.0b10.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "2a9d6a54126b2c1e1c9e0c3067b90e64cce6dc1ce0c0fe2cf6d8cd4e1feebc9c";
+      sha256 = "29264ff4976979c5e89ed20ee4d1bf3d1f4fc174e86f1d4713fa470cc5d57e90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/tl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/tl/firefox-137.0b10.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "79c12559f5a040b3b5eac95c4374df8e0cc63b5e260d9c21f67015a82b4ae267";
+      sha256 = "5a9edf38ba5b382c63d42c58a578af4b89840ab2996119c8cee7842a230e7161";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/tr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/tr/firefox-137.0b10.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "786f216d432f5269fe6b301a8c611e3adf3730da31a85ba6110efaa248fa457e";
+      sha256 = "b1592111fc5767078edaabf192e8fa46508479d070714181be7469284df881ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/trs/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/trs/firefox-137.0b10.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "54d4f6ca92f63811429693c0023fbf2da6ba4bd81cf9259f9e5822199f6cb68e";
+      sha256 = "2f535a90613b2243300da5bc35185c793796eb3d5eabbe565818c25ecc910d2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/uk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/uk/firefox-137.0b10.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "c4f37a57224a749144d8c9cedee08ce3b4eb991f74f8ee8b87cf0050509f4921";
+      sha256 = "6362f8c826d78cc5954816e5bafe40f87b168a61430330e5669163e415c63840";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ur/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/ur/firefox-137.0b10.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "852d9c8df2a4742e31c5601ae02af9ebdb08fc18d56afbed52aa91a8ee7cd4d9";
+      sha256 = "b267f2749c8f8395b11ad589ed0605a0c5afd1277286006bbafcf9c34b9e2b7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/uz/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/uz/firefox-137.0b10.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "c66102f77f39c086831e310b066396b10c25282716fe86a422fa844604664b6f";
+      sha256 = "14c173874b105b357e2c2db597da5b39974c733df54f8d3be07b341179ce8eee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/vi/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/vi/firefox-137.0b10.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "6aca98758d35b92318259ef31e5b59dd5ed46fffe39fab8c3f13e8b02769fe29";
+      sha256 = "ca75da7252cf7b070515cb45474df7c2acf247731757163362ebf90bfc2432f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/xh/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/xh/firefox-137.0b10.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "3eaf8882b2688ab24ece805abdf16f3645077fe4267178079a410f3ebd69025e";
+      sha256 = "dde72415aa29498cf08a7015b1e9122239705978da0028587ecfc9a125488366";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/zh-CN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/zh-CN/firefox-137.0b10.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "b2fe0334c1e73516d7eccf3948d5c72dcc6dc4b68b45786e0540c39a9085a075";
+      sha256 = "7eaa490631845abe7e20c88f4238de0dfa278ad7d36523898f57d469e2b8da88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/zh-TW/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-i686/zh-TW/firefox-137.0b10.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "223f37741b6a971c1c91f4543fa511fbbec7d9d4d24d0125566250779b0ff5b0";
+      sha256 = "22667488a77ccf885072a125735c103e7a00473d9bdad07b1cb5d318c3a94f89";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ach/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ach/firefox-137.0b10.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "88276f7fc7b993e218e46652eeea7f448d122fa2a5e526fc1bbbff00af0651bd";
+      sha256 = "ce548a0c42c7e1975e5379b7bc7134832757409ce03710ee8a22a6df2d38673e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/af/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/af/firefox-137.0b10.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "cf1c88dc60a68ea685efbe27d6ad227206ab9089801bffc9411104ab44a7c0bb";
+      sha256 = "06da5be60293d3badf10a6b5742bc3cad97023b4a306a0594810f83589268e24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/an/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/an/firefox-137.0b10.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "8cee5d5d1ba3974484659faed676072b3d369374e4a0096fb5116b740ed4f844";
+      sha256 = "c7804abcbc07eb52164ceb2f1db308b12a9df64507e93b29e4786d86ec63c78e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ar/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ar/firefox-137.0b10.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "d34b21e81cfdc6bfac6ec63c97e74dddf1e8fc12aaefcf3a65ed1227e162c1a7";
+      sha256 = "0167980e4292272f83029af4cdb1da224b796e3063be21b24483723318541e3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ast/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ast/firefox-137.0b10.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "dfed822f4edbefff874bf0f7b09d91339ff1426fd5a6edecc1dc5ef2ae1ce9c7";
+      sha256 = "0f101d8d68702cfb4ce78633b23839b77947193a45b8519367eea3a6b5f4a62c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/az/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/az/firefox-137.0b10.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "2dd784a9fd9c4a42f6e97136ecfa901c1522bf3b56421a1d3e1eda0a6704e2dd";
+      sha256 = "f3e4494e319e051584754307168b0e6b425d7089f645634d3fc09ae5284155b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/be/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/be/firefox-137.0b10.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "4f94367ac48005eaded1579d8732788d2a74fbe40c91dc417d247dae0a6ca310";
+      sha256 = "130aae11edb98a9e33b081f8441015cc63279c346db8d958c643e9f3bd871271";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/bg/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/bg/firefox-137.0b10.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "f3d806c7a702a104661d66927f701b2c8e47319953c6fe6aaff566c691608f9e";
+      sha256 = "85f71b158f1bc589a78a9d3f4abbcaedd55a1ff4718efde4565a5d749faac35e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/bn/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/bn/firefox-137.0b10.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "c1901da130b64e8aa4e4d338a297d2ab5d73bbeb9fd29c1a4a8f13dcbd6be89a";
+      sha256 = "0e0d0ed99d2dc1333010b37ab71f74d9b8f5c909c7dfe9836a4c7944165993af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/br/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/br/firefox-137.0b10.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "0c6f21f36903d9ead0d44f8cb8c5e24e0d2005858f7c07b1b929b55749d68c3d";
+      sha256 = "d1e4a8f7cd8fff5fc85759a87794adae6c316df07008f8aa3fa2987598cc2730";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/bs/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/bs/firefox-137.0b10.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "b726a83d7b278b9f7e563731aaee91fd529d7dc5b01162c6982377c7716b8d88";
+      sha256 = "8a169af638602d6da03194a40a3ab96c251b3216ba365858e3f2d71a595a1a54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ca-valencia/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ca-valencia/firefox-137.0b10.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "e7ddd628916329e953635d232750874fe5c0774c86d3272caa0589232c0dc936";
+      sha256 = "6f29784363b9291b19f92972a48e0de87b679b0f9e0942d92b5ebee675846885";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ca/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ca/firefox-137.0b10.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "6706611a2b06a5bc01da3dcec4f3a10b32d8c2c698dd091739baca8396c77e01";
+      sha256 = "7b0d0657930eac7e2fe75e91ed4ca0eba4dde283a5aa8ee17287c779b12eb347";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/cak/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/cak/firefox-137.0b10.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "3efa06c560076610e6c67b7caf08291816ded60cf9db54cb9d6611a4ad685fd2";
+      sha256 = "008110582b519f4b753f2f3fcb7af37fa30225c89687233ebe132b581393231b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/cs/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/cs/firefox-137.0b10.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "292e2dfb57d2b0b97306aa40fac7a691da929d6d49728b80d8626c922308ef58";
+      sha256 = "19ea0006094e57d9ff62a93d46708ccd78cc7ebdd9208fdebcce4ecd27ba471c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/cy/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/cy/firefox-137.0b10.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "a320262afde097a7de59c7b4bb5b972bb90625c36e2d64bf99f73ad80745242d";
+      sha256 = "3f5ec52e6d4fae2b875324320d07160d493eec5172c5ba0b2b8451d761a58aac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/da/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/da/firefox-137.0b10.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "5ad5ea11ea0e6dc8397d0c18d0a8c66b4f733bcf68e7d66dc8d3de114fc509de";
+      sha256 = "1d1d769ce702a698a6d95e5847ed05b3e299e3e4258edc6344d87990279f62c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/de/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/de/firefox-137.0b10.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "e0e685eb7a6680da2797f3a9d6aba30871e4732d817447a9c8f06ad7b6968802";
+      sha256 = "fc629f70100300da9d040bbe4da67cfa1a734240457245546ba7f50647c66a16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/dsb/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/dsb/firefox-137.0b10.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "75bcd2e8f5418fe7d2f9259737c096a9e0b6630b5e4190546dd3594a4688bc98";
+      sha256 = "80299a2420fed5bf4bbf4fb8a32f6ac8e4bb0d73c2f78d59f770af02695d6fcf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/el/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/el/firefox-137.0b10.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "c4a8426568ed77022fb0103106c3de250bb9ad317a7a351fe028338e3da300b5";
+      sha256 = "cbdbac410aa4734ce40e6afc65001bfdf8662ff923ae31e7b634cdf97875d859";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/en-CA/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/en-CA/firefox-137.0b10.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "c8e4d62aa66275aab4c84bcaa15566498861f8f6193e269f73876d25cbdab4cf";
+      sha256 = "a071d131cadfda0a918a0287f1ae7ae3c670fbf54a02679bda7737b420fadc10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/en-GB/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/en-GB/firefox-137.0b10.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "8210e1dd0e2136b662755a3a2233484cd5e901a2154173bd3137ea5246e23b35";
+      sha256 = "28ecc1608fc7b832c1a0a1f72092bdc09fb2e09c6edabe3d55c14dc456662b75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/en-US/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/en-US/firefox-137.0b10.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "65863ad2d2985ad5feac9d4369ca6ef2a3f0e18759458e0d09b3db9813600ac1";
+      sha256 = "4c028acfa9d519f795fe4033a9fe52ce1a2288be33e9d854cf256c4660c7946f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/eo/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/eo/firefox-137.0b10.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "e500cf2d000cc29242afe07364a37153266de67a54bea2f1ba15704064fe4875";
+      sha256 = "73ef5438bffdbe75076d6830f0521f4cfba73eaf4eb7d8a0a92a5a9c532953e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/es-AR/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/es-AR/firefox-137.0b10.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "ad4fe5cb9a3904f57b98fda2267617a4df3a10b655728847df694402c19b7f49";
+      sha256 = "a2ea925be3b5331a320787a2d01cb5371794131c96c20592b04f324c5d66c8b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/es-CL/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/es-CL/firefox-137.0b10.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "6841d7eac2f3a0dcef725b6b190ed56d4e4f96ecd01e165b25fc7d7841a52fb5";
+      sha256 = "ec472157a4b483f5bcd72a9819ec9f8755e8d14b2f697719e43f95eca19af71d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/es-ES/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/es-ES/firefox-137.0b10.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "3a3ccf0031fa858361fdd816d6c650c4200998d4d4efb4ca6aa7ddb9a258a758";
+      sha256 = "1f0fe1aa55012dee2c482309cec2dd894a3f7221e3013ec56c67ea2266b5fd2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/es-MX/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/es-MX/firefox-137.0b10.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "85b48fdea7b79e39caf3a658d168db9f224157d0748710d8237ca245bc429bda";
+      sha256 = "24ae6e6dcbd7f5e48547aca74bcd7b46993a23c9672ae7d32f28489367dd13e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/et/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/et/firefox-137.0b10.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "35d2ae93d99e5e523a013a5acf6b504a9a9f27b8c3a67a778a85648b014bbedd";
+      sha256 = "93700b3435fd867e257c831654eedc35700e175e6b4e766d853fd8b51becda75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/eu/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/eu/firefox-137.0b10.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "7ce5cffe0a4b5d9fa260306c8b982526d9a7e355d5c74c840df18e864580853b";
+      sha256 = "637a0e3bd45a6e4d73d5394f7f6be9b3b6dfb14e797c8f019ee640d1fe1ea3a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fa/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fa/firefox-137.0b10.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "d9c5b02b4052ffa11071c1570e2bd45520c6de9c9f8bf7db762e53b7e15a114e";
+      sha256 = "5be4866571ec92021bf0cd764dd4d2112bf0cfff650e69da6cd2cdc1f6b9f9d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ff/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ff/firefox-137.0b10.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "480d5b05324cec89397a5b1f3afa8ac671e5c1a120ac99fa9be6a2a3c509c2ef";
+      sha256 = "439df3eb29b13d443466cd585f6c3bb0014391462003860486959233d228a246";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fi/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fi/firefox-137.0b10.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "148b12a936bfc269b6758682dd50b724d11321e0e2ea9802e95877547435be46";
+      sha256 = "c58331db4fe82801630365d5621e1ad8f82a3552a2763c68a965b0ce83180947";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fr/firefox-137.0b10.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "2cc711790474500a05c40745816142c6a38f24428a8522de4d4cdfee8368e63b";
+      sha256 = "dff4cbf811f7fcaad0259f1b0c297085fcd521f1c76efae62152470966eacf83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fur/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fur/firefox-137.0b10.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "13d5432755e7c87beb0378fe49a6b0b76e0c57486ce5e30032481bb165cb06eb";
+      sha256 = "3c356377b02f6f790a84dbbfa8b55d37c84dccc6296f6f8e25f089608fdca44d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fy-NL/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/fy-NL/firefox-137.0b10.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "c2fb6627ec55fc19bcd94bbe7a9eec311120eeca5640f26ac37de15a434a22b2";
+      sha256 = "6421023ee22edcf15f1dcdf6e747edf14852f6dcb30d9750b330fb23d43c213c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ga-IE/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ga-IE/firefox-137.0b10.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "a6dd5a234238b7333ec40058899647ed05db7e9b88059fcc8c34948ec6e56341";
+      sha256 = "aa506c7b34eaa2195a2653b18bc931772ccea48c30cdb7a99d9d9edee872918c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/gd/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/gd/firefox-137.0b10.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "d66efe3233a308514a2d06785210652b18ff0231345100f3d63617d805d87150";
+      sha256 = "0d6421613741d48342ed67ae9a29c09a4836d38afbef33158cf579469e7cbb8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/gl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/gl/firefox-137.0b10.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "e5a273dfc33a50ec815c1696f06f5f5dba2846283492bf2a7d5dc5b5d257df83";
+      sha256 = "f94460f9d1a26d424659363bf7da21b7c12a7e8daa648321ccaf5e812a35d01d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/gn/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/gn/firefox-137.0b10.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "b263e288b2a0c4e4e8117c6f862060a0853491ae52cdf24a9cbc918acd7e115d";
+      sha256 = "93eddd6cd208ca63193dec9b51544c210949278495a90c043f3ff4d9cca8acc3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/gu-IN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/gu-IN/firefox-137.0b10.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "faaa6e3494aa27b5d8edb68ff6db350f6effdeb874f7193ea6660e13a661b464";
+      sha256 = "5034e3be1d6d382bae34b6d64f2fdadfe92885d4d78db3f8b56ee262e5d6211d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/he/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/he/firefox-137.0b10.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "b0d2d40cb1fb87016e965ccebf74d8bd28a7484bed15badf362abc35e74bd29d";
+      sha256 = "e80722332526c57f312309aab776b9decf362adcbcb421444559c704a7eae879";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hi-IN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hi-IN/firefox-137.0b10.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "e9e032aa853cf7eabfc01a02a9002b012d3b89b006fac7b14fcfb33c87268bb7";
+      sha256 = "7782ba6f9d86029b0ec370e95ccd2e7818a0de2b00a01fdc11fc3c8f337d1cc7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hr/firefox-137.0b10.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "5ec922b1f96d2b18726b27bf770dc4e79ae69977b1c70297a17a5f33eacd0a91";
+      sha256 = "62f77d473c2aa0f246d256f23a4885efae9582a8fd1b5ed5160f0c085eae0c97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hsb/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hsb/firefox-137.0b10.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "eaf630700961dead46f97b63fb29ecb824785ff14221fc35fcdd21ca9be5c0a4";
+      sha256 = "8cb41909dd42842b5a0415cfb304e2a2b34e8be60db35e7bf9fec93f8b796a44";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hu/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hu/firefox-137.0b10.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "2f461c65cf7fdb0f16ed61fcbf8a739f216449808369966e11d07ccc89faaea0";
+      sha256 = "23a5cce6bf6860851978cfd199e6a843b4ce8c6b810636d7044a58d03d8ae0d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hy-AM/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/hy-AM/firefox-137.0b10.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "e76fcd5e60aab8ac13af8eb4db3a288ca6a3b3eb4795ee959f26decc5e01a6a4";
+      sha256 = "671ed7bc013c4be4507fafea2d7bb11105e760a9d0bf262b1fca943cbfc2c31c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ia/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ia/firefox-137.0b10.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "bebf863d0ac19dd7c954250b0a38c4c0e8d4253535fa063e7329ffc5228189d3";
+      sha256 = "0c126080ba8c9e1721b98ac8df93a5f3a0d019724cd85c33e3905a42042c5648";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/id/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/id/firefox-137.0b10.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "d42a5c6cfa01eada1b0eab034fe2b8ba39e5b33eb8919ab07d728e9f8fee36dd";
+      sha256 = "854f96bc809b0687c65d27b6f9241f0f8f628ef436097c7aba587e5fe6441d5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/is/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/is/firefox-137.0b10.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "9c9f167540484028a72ee6f4e30ed4cc688b9920ba4aa11bd53e6fd4f1fb11e5";
+      sha256 = "089f36c0ae651bbe196078e2d98593c4c612c2b81336f6018ebe54b201cb70b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/it/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/it/firefox-137.0b10.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "a46d0371e76022ad25fd3aa1d7bf58c765753bd6324a4e437f81cdf4eba41a01";
+      sha256 = "42f78e343de68b8bc33419a8fe983a2a31d83ebebc2447ddf9db02743b4103ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ja/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ja/firefox-137.0b10.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "bc55070a9fcae8e5584608622e3cd322e6f4df1d2e493b74bc2c59d53c49746d";
+      sha256 = "2d2c097f0ff0f15d864ec09e7ec74de30935973283ae2decc2929051fd6b4489";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ka/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ka/firefox-137.0b10.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "5fd662a2e76b4d143250e05c39e67b5ac692d59d48cfe00ac5021e8c19dd0cdc";
+      sha256 = "6e0b139ad102bfd028dbd752a5488c53e2176d0b5aa59715dfd813bde861a8f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/kab/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/kab/firefox-137.0b10.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "c0abc375c9baf681a9e692ee315d7a80321e1e5d9f4af289a9f9e35bae6dcf1d";
+      sha256 = "31a497c03ab41039abc657e7b24b980219e25590958d0219f418a6c8a267b0b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/kk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/kk/firefox-137.0b10.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "8bbe5c14183c2a00ae14e58f72572ec28ec1e699660774834d5b45d09fcf86bb";
+      sha256 = "b8b85696af18ea3a53b8b0bb454b96713d194bbb555c081689ab3e2080c5e47f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/km/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/km/firefox-137.0b10.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "5304f667494f0be0a7df6c78417d0563232951f439b7a99d1f90627605dfe8ee";
+      sha256 = "ba9b7db2c6263a2ee3456366d145aa835b20e42828c9665359cbda626608d6d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/kn/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/kn/firefox-137.0b10.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "5b213b7d990675528e56b9f1fafde38194a8abac8c5469639fc13f03f27d47f2";
+      sha256 = "d65d064f102a20f596ca72a87c365d12a446a50e0b5c7bcf90c98d927812335c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ko/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ko/firefox-137.0b10.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "288276e234fa2b7a0baa95eca519925fc9723b7e552f1b98df35c56272ecdfd4";
+      sha256 = "0150bdbf754a3a5055a6684bfd370982aa80866cc5ef3673acbcacc49004c1ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/lij/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/lij/firefox-137.0b10.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "664f8b30b18bd1e5ce4a319d345c1137fb9ff26ae8d674037a8f576557de2319";
+      sha256 = "7574d4aa6421d61bd76c83ee337a08733531b6e3ed291bf73718562fbea7f913";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/lt/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/lt/firefox-137.0b10.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "08f89f4b28b591c97ef70a8f6ad109a35218a6cf500c8b98af3664d510081b07";
+      sha256 = "259d5841f39910ecbbbcae05647e9b9e45525949e40f56d451677877998bbcdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/lv/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/lv/firefox-137.0b10.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "e51057306c5fbc07697f4b220ba0fc07eef3e8b008edf0124f52993e75eaa927";
+      sha256 = "7af8df80da1118c9da7611bab1889fa17f25b7a05d5cc65aa1fb676551c56fe6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/mk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/mk/firefox-137.0b10.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "66d0996a97c03ce1a038435fd34dab21e57a48470c7fd52d87ff68640759b866";
+      sha256 = "7fb1dc800a568d59100cdbde3f387279b6d81d19945318d56832776219314f4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/mr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/mr/firefox-137.0b10.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "c80765066a0e6028581f125e99bbb9fbe02d651e72b5ec3a7f872b6b776d9de5";
+      sha256 = "078935be95f22dc8b15cb9e25ada5d96f31d3776333c46c5ce736267169efa04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ms/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ms/firefox-137.0b10.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "895a05f22dbeda2d15a29a4b1304c3a60578672cfe6891f7dba3587eac6dd2ee";
+      sha256 = "3628c6d7f073b1e7dcd224e708da5c14485066e7ba0503ba546cdcb447a5ea98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/my/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/my/firefox-137.0b10.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "79fb7d0607143bc410aee13f3af19c560b45562d08271f3868ca6f6774b159c5";
+      sha256 = "3cf629fa5e4a98377c039d35a150cb66daa9ff556b3a3a8eb6975eb1a73259a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/nb-NO/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/nb-NO/firefox-137.0b10.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "e1c5d43c16fca703cd633c0629ffc7d5449e0b9156bb2f862d342202e666fc32";
+      sha256 = "8f2af84577fc72b2b25d2ccbcb9bb3b6a7369385253b9f54428b17667e5570da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ne-NP/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ne-NP/firefox-137.0b10.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "1c6dc22dc5159f714ef087d8e7e57588c7b4b4fb963a0f09588734a07a17b197";
+      sha256 = "684bff075da0925c758b9030a4926adf821da91d800f5d7b084becd800275bf1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/nl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/nl/firefox-137.0b10.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "c1fd85979f4c5c0ae7839940dba435ace305064a8ad5d704ba8cc36bf9f3caf5";
+      sha256 = "9f0489801ca3b4c5e819f440d25e4eed4ea94c650d87d45ec0070954b6d60dfc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/nn-NO/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/nn-NO/firefox-137.0b10.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "952333ace80370bf7e5bc9399d8063941c0b459b04dfba2d805c5710486cf8e0";
+      sha256 = "3d969df152796d67dc4128f8b5d4caffc27cc163d8a922643d39263228fb8201";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/oc/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/oc/firefox-137.0b10.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "8e84077e1bbd228761c9876c027212c63fc7b45e6096984d0f70f8f68c3d611f";
+      sha256 = "4170cacefa6b4d6d7569d3fa6133b488a75b53cefc3229b87a556a5da2e11734";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/pa-IN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/pa-IN/firefox-137.0b10.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "840c2cef56e55b9783a9f9fd700c830e4839b0e5c27533bbd74b0fdca26cccff";
+      sha256 = "3e0987701d64d0c6054171b3587d8bc0e1ccbbd4ca2f7907c62a4146428509fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/pl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/pl/firefox-137.0b10.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "ba7766fc90c1b7073c69e96939cfdb93a4275fd8bdf530072b5e13ad68004fef";
+      sha256 = "e3dd25e8120bfd69aab6a3b67f05aa24453edba986f85393d5e6c6e281bb8819";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/pt-BR/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/pt-BR/firefox-137.0b10.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "c157cf1b467f9d9da093eadcea7ba088d51730af0ab1d2a73d9b0134eda62377";
+      sha256 = "560ef4c0776897f5ccec34b3d8b481bfe6f6d5096cd4d3d984a444c417688e7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/pt-PT/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/pt-PT/firefox-137.0b10.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "12e249226eac5a7c28944fafc8cef2c9380823630b373fb5595ebada0a2c515f";
+      sha256 = "3dfc196e3079bdaac5377e467fdbf195bd93e045553990c3cdc0631feb1c8bfe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/rm/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/rm/firefox-137.0b10.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "722e41d4a9b1fa518460fd62e5398ee0cc7dea1a9c72b87166a36686a74d5ecc";
+      sha256 = "a4d89476a65d7be5502aac1d85a50110198b23362de3df69d34c66bbe8c51d52";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ro/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ro/firefox-137.0b10.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "d5f7c246005dee529593bd528acd2f0189955937ee49260695145c7ad7a48b3d";
+      sha256 = "1723c06b5ad3fa1fe06b6b3d7a2ff18a4a94cec217fc46501e571b69ed4bace3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ru/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ru/firefox-137.0b10.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "f06c0cd02fef6a3328f85643ba7a26bfbe20d5399568c514012ce7d58fc37809";
+      sha256 = "dcc26bb5ad02edf2e3afa0c73b5381be48dcbdc12ffc24d9f6df6d2afb639df8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sat/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sat/firefox-137.0b10.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "9e5fdcb827a592014db96c608e8552beb92e1546cddf024393f482139dcc7083";
+      sha256 = "fd686c94a6a9506bbfa6e7a362c39728ecacb59e762467725d78af5dd16a6d03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sc/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sc/firefox-137.0b10.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "d932bf94b8606d3a6b53adbd9daf590e48c4228e48bea17db8f9d76fa90e9951";
+      sha256 = "488066e0a984fa21637b0aab44c7e78481625acf309da28919a4dd1042ab193d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sco/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sco/firefox-137.0b10.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "5b59636a3da7e8f9e4d0931abb85f2872d99dd2d9c0c30c328e9c36a38eca279";
+      sha256 = "541a7eef9f6b9cad7498f2166e0b9a99e5eda68956649825fafb8283dd78762f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/si/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/si/firefox-137.0b10.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "5476f94cc2c43bfa771dc0d6acfeb5a3a82ab00ead49d6548af3b32c65b2f016";
+      sha256 = "7fbdcaf6588d7aecae6339e85dc50e6884c88462df6dd5789fd36bcb91f264bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sk/firefox-137.0b10.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "684e44c82b2bf8ed5cb754c75c646a8d71ed83e9026bde16379e7f0912d20d26";
+      sha256 = "8a322025bb0f6b59a1afda171463e200a1021666c9c5a8a013c538d2d8e253bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/skr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/skr/firefox-137.0b10.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "68cd2650699bbf2b60138167fa64b6825e52d1c3a4412eea604e023396a2ece6";
+      sha256 = "1d2d7aba9d3e02d36d578e67a71ada78f85ae10d1b76107b33eb58906c48687c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sl/firefox-137.0b10.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "4789f621a6a67f23adf0a90bb76458d345503ed3aeb977f6efa253b6ae214134";
+      sha256 = "a18a3a73b20bed6a85af824851e27e64ff437eb4fb30b0c2232827f2ea3f5b7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/son/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/son/firefox-137.0b10.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "f089d74a5fd936b3192aa5a9f676382ddac67f7a01057cd0c65733314231f4db";
+      sha256 = "ce5092715fb13917401b79edc9b6cecfb08b07daf4400d70f7918bf0b5c3b614";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sq/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sq/firefox-137.0b10.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "b4dbc9ed0057d448a0110743fcf090155dfde45fbe5cfb38cd56face7a11bf83";
+      sha256 = "24d2717b7a4c35a4722723c198223829b08490e24c463cd0dc373beec76116f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sr/firefox-137.0b10.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "f93e228112588c8346763eb5563ac24a456a3c79a310dc802532fcd89ec01eb2";
+      sha256 = "c482b732493da48cb9547e1c8a3159f417560d5c9ea7e1353b70d5534deff6df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sv-SE/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/sv-SE/firefox-137.0b10.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "bd71f056fba247199cd76e2659ad9fa9076923a0175456794213377d5fa04bcf";
+      sha256 = "02e92e4f7a6cae0b8e7d7af5ddc822740aa11c38f395e164ef1278441f947eee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/szl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/szl/firefox-137.0b10.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "a786e69fd7adc57b5bc0efc1cb398d3a6eb89e664aac82a6dce6499d28ab9ceb";
+      sha256 = "22f68b8e3d2cfef8f8bbc0b62b4f35b2bf731d4ab783597f71453e7b998a1fa0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ta/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ta/firefox-137.0b10.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "56eef689bf9b139b691da398e1a503c87685c68e5595efd21d9cd86a0ecafa30";
+      sha256 = "523c17cc6a6fa98fabcda73f9849ed96aac853af1a22180af19eeaf788810ba4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/te/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/te/firefox-137.0b10.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "d060a14e823995c101bfb555e68e0737d676b2ab84704e96d50b0805bf0be1e0";
+      sha256 = "80a19adfdf06cbee81fcb7a4d8118a1f7c8928f972ce9aa98e7854b12b2d8728";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/tg/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/tg/firefox-137.0b10.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "4de24a4309761005e0d2198020931c21bf4866804970b6bc369e6a5fc526b04b";
+      sha256 = "3e2a18dfefd0f14bf92983d195e36d689ade2c5f4e1ab0379a9ebf1d0c526cc8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/th/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/th/firefox-137.0b10.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "e9e5435b3236be0a81dfe7e35ba71a13d5a488391fb12dbb67bfc3885ba3224e";
+      sha256 = "5e301b1865ecd3b08d8862c55b14b6e65af20bb1587214f82dd27f466ae7202c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/tl/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/tl/firefox-137.0b10.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "e93844a494492a2694a11842f1d02102d0a3fcdabbf8bd5194ab631177916296";
+      sha256 = "1c05bb2c82fb0e1795d5c9af307c66ea3d8942e922feacf322829c6ccba630a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/tr/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/tr/firefox-137.0b10.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "295bec800c0e51d6cfa0252aa89f4fe38a2ba5df9b6315ecd6bfac3648a6fc90";
+      sha256 = "4ee13bfa40a70177d87a5a071c984bcccf004a9496013fa7fdbfa9da5ec6b3b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/trs/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/trs/firefox-137.0b10.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "279f7ed6f1cbab99448a48d5e0dcba35e0665a3ebd056f43c28777713247e41d";
+      sha256 = "cca347c702ee2cd6c4e11352b1eea381faa41bd692a9aeda8fbb87d5c570d3c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/uk/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/uk/firefox-137.0b10.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "97a5fe066b4c115501364746ff4bb539f007468ed5707aa493092f7b5f5aca09";
+      sha256 = "54246050515f6891d54cdee6f5705b255c9bb73e60de6097d3c96092facd5865";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ur/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/ur/firefox-137.0b10.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "02ae00193a2640238cd6e17063810cb610e8b92e133b042bbf698c37601f212d";
+      sha256 = "f06793e672b05ae4b66a0bf2be25faad0ca1ed9bb8e8f654b1e6c07fd4a47c23";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/uz/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/uz/firefox-137.0b10.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "b49ec7a8c9f9714b7e2b8c00b488d7591a710f5da0bcf4d9d1f990353edcb0b5";
+      sha256 = "0c166ef499c1cc6472f041e02583be6e24dbd81ce18bc30b76766bce419f54ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/vi/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/vi/firefox-137.0b10.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "3cecefc2fdcdc9b873fb9624e13907b3cea0332a2568b8777d9762866be68d3e";
+      sha256 = "3f685557dc53df3df6fdce6d0c20b1cd23de9c80a5d3b78ae0a1c3c3c72d9b61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/xh/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/xh/firefox-137.0b10.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "3663a0e91f9d25c44637f0a9e88da826450712d433ee45a67e490b2ae3124b41";
+      sha256 = "70fef2d3a7992942f12c086959162070d3687390c701910cd6cba83e6610c349";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/zh-CN/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/zh-CN/firefox-137.0b10.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "191545f20c8af7638001fd1250ec79c907f208a3ca475f6355f7077b2d89ec4c";
+      sha256 = "18f6d9ddde4256839fe9fca9d07754b16dc98075844e502a8068a0fa814b59b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/zh-TW/firefox-137.0b6.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b10/linux-aarch64/zh-TW/firefox-137.0b10.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "8f2ae93b934c275e2a2aa223b2639e9ac5ed961deb0721cc07fd09242421d8b5";
+      sha256 = "99dc1b10d0de3ac04d2547de7e92f5db72cfd429692212325842ed5349815a17";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "137.0b1";
+  version = "137.0b6";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ach/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ach/firefox-137.0b6.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "15eb3a9e5427e7a01dcf7c6ca7fc9682857210b3ba65dba2ab8f5117fc03f97a";
+      sha256 = "0b80c80a818cd4dc4cf56799958b4f5b4a02566c6e83f4ea862d239e6eb33f6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/af/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/af/firefox-137.0b6.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "57f7295b2d21a9e3611063c7bbfae764e28cfe2464c6873f6cbd2a465f584c11";
+      sha256 = "6e62dccefe51d37ac2336619f2ba81b852799a73976d199fac1ee58d41e10c9b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/an/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/an/firefox-137.0b6.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "30e1394053210a1b8c14daab3708d056544446e4d1e0ad0295046723ba58eb27";
+      sha256 = "7ad81d1fce3837e62b3bc968dee4a57fbba9d796baa9b951befa44a225906380";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ar/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ar/firefox-137.0b6.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "79d3a745afe866699934dbccd680eb4426bf33e8a3a45287d87883f9bff7a533";
+      sha256 = "d4b5f0f6b4f0f826a084a836d72eaef9a343595578811951f24bdc959d4314c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ast/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ast/firefox-137.0b6.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "1e83cf15ccd8492e613948fa9dd6a5153c8410a4fef29eed1fa445e16f331c3c";
+      sha256 = "b2e66235dd0e14478d1522880db50aa4389e87cf3297895b16c6e69d44b85a5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/az/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/az/firefox-137.0b6.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "0fa88880e0e61fd8dc97a6275ebba0372bca115a06a606ab335edf716cf2ab47";
+      sha256 = "0dad65fd8d87b183014773e6c367a80f4b93ec77fc0d7048a8fd5eb905dbbe03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/be/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/be/firefox-137.0b6.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "d885f3db818d295892b3f43cad81bc76927f384bc0594f3e4b186a02b68bf70b";
+      sha256 = "eb9282214192160731f57dd7fb0f9c84f299f2619f78aee5ba5407238f16ff71";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/bg/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/bg/firefox-137.0b6.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "cfc75eb239379b0e49322323fb9143d3d2f36a9dfb313510ef934d1765666b05";
+      sha256 = "353b3e519874731b8a301869c85f3fd07625e6a855dcee79bce73c5f3b1eb040";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/bn/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/bn/firefox-137.0b6.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "b1249e5b309efb3236c3dc47b94d3827864a1290ccffb48d6e373cf3c35ac98a";
+      sha256 = "d40435bc69ff5c7a7c256fecf5c13c16a26ee270f71f6442dee8c04d4a18faaf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/br/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/br/firefox-137.0b6.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "96bab4d56064a847ae00896423dedf004adb3ed90f536bc48c4c185db4ad13ef";
+      sha256 = "6e0118d18761bb3134b5101fe0d315a8f103aa57afb0a2841961083fbf336f1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/bs/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/bs/firefox-137.0b6.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "30d0a9f479867b017e9b39fcb1ba7db9ba76c94e7670df4547b27040385a9f1c";
+      sha256 = "11e65fd236579470c27085aa7d45cdea13ca5f787aaf5335dd11ffb35799203f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ca-valencia/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ca-valencia/firefox-137.0b6.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "29d357c4f0e74c3bc934681d20d0569fee7c5ab1e562606c1ee26636e72063da";
+      sha256 = "6e47f53ca23b6a5df4d0c7ef640a4d1fe7b9d51de9cc631a727caf12ff4cc6ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ca/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ca/firefox-137.0b6.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "a515c3614fa162a1fd93e57f99fc593d5039cae0b4e2473b3d3bb7fcc8ba08b3";
+      sha256 = "d501c2a261f66b3c68e75f8d0c1b936442574ecc0c85c9288c59bc84d1113536";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/cak/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/cak/firefox-137.0b6.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "f395c6afbb7f46c5c4113a52844c844621f5993dffac3bef6a16c047ec09dd53";
+      sha256 = "98b3556316794d80e28bd2ea024f70f1875fdcf78f8ac987de3c85ce515df958";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/cs/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/cs/firefox-137.0b6.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "901f1ec8881043460b00ee3ad1428bf44dc652b6d11d938c4c6388a1c1868de5";
+      sha256 = "0bc66f4eafe7e8026e3399c0510e42b63a16a8040f55fd8e0175c10e65f4f6c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/cy/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/cy/firefox-137.0b6.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "dead0a61068a94f6c33fd6467431c99f0ab4ac9b533f3891b2121c08d2b4c2b2";
+      sha256 = "1c746a2f8ba686ce8bf81604665f3e9f5487733eea2eaa52bc3c47d8b8a0ec6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/da/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/da/firefox-137.0b6.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "df921e6f3296c463fb7ec234806fedc19a512ee488b426bd2609a0aba61de2a6";
+      sha256 = "3f1471af4e4845bb69d7b3142d1b7ec8f6eef052fc4afd48e51bf56230165126";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/de/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/de/firefox-137.0b6.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "88965ad56dbd0f3a11c5f44998af5d34fbef310ba1689418daa91ea92cfa2531";
+      sha256 = "2304f0ad0db35c44b701e1ae3b627518c72c0ceeaed568b72af92a24672804e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/dsb/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/dsb/firefox-137.0b6.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "4e96b01cbcb937c3a21b99a5d4c38673e97d59b9e3406eabaa3c072f5172a58a";
+      sha256 = "d16b2c2c10f5593e6bb5ecb01569fc507302d46ef93f1d3adb45cf6301afcee1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/el/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/el/firefox-137.0b6.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "fd17882f4a666908b8ca5b479b1b2bf0d2bc8f82501ed7e29e716626579dcb05";
+      sha256 = "4ee7d647b45a4b37a07940cfbc3109b870055efcffed8ead274a5a76d7f0a439";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/en-CA/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/en-CA/firefox-137.0b6.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "55bb6feb436f2e966e7a6419a2e4ab0f4cd9cd2be658f662bea4f891436f32dd";
+      sha256 = "57c14b12cc96bb659f39e2d9f2137fb2637a999322cd2ae3315405e61f37345f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/en-GB/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/en-GB/firefox-137.0b6.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "c10894410b1e20ff5aaaaa2672a5f26f116c69d6c8cdd76f452612c975859e73";
+      sha256 = "311667d8945b9feb6bdc87a94c3d7f7f653beb441d535fe77052f46949efb451";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/en-US/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/en-US/firefox-137.0b6.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "98848e14e857a3562c4a2cf6fbbf7966e4f256cf6e127df0b367ac23c6638676";
+      sha256 = "c8348f336162709f8918178a3e11d2e70f91fbc82a8fb8839d45ffdee1c57367";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/eo/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/eo/firefox-137.0b6.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "12a181b73f3f30be0b10e0d0d9f1a21d92c16f58015f99168c3a5e48e7e85a5a";
+      sha256 = "3cae953cbe742d51bc1fd6ed242daca04563f0312cc9af006ed1fb98ee89fe66";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/es-AR/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/es-AR/firefox-137.0b6.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "fde5833336af5aab5082c11a68c2e2f8cd6e03427143a6671bb0d0732032797e";
+      sha256 = "1d1a8fc941dbd6fc6495ea755d2ff6c496f10800ac9073ae7634c3f6cf972836";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/es-CL/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/es-CL/firefox-137.0b6.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "3c7bb6ebd93ed72256a9c3e8b88549e741e235ebe904cac6698a3f15e2023809";
+      sha256 = "748a34ba3cf19e0607ae84418dbed55c50cead4a5ebec541b0a2317a0b76f4b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/es-ES/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/es-ES/firefox-137.0b6.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "40dba18f7fedb27531c4ccb7f1a02b6f3b2c47b34d7b6ce8dbe17d84abb1e104";
+      sha256 = "d4e588fa667e44d564f94ba23aed80290020eafef0fdda24b72e26e4d8c9f4ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/es-MX/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/es-MX/firefox-137.0b6.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "c827bfface05ded129792b7bff758983e512f0edef3b326c13481f0c0f08b13e";
+      sha256 = "3c1124766a235ef50e4a0080ca6eb733e3932fb27c99d7430c4051335a9c52fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/et/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/et/firefox-137.0b6.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "ba80040b10375ab05cadb187b7ece99e5f8fe30b68f3f0a61a1e81a1386d535b";
+      sha256 = "9eb18f967cf58f480809c7fe9ceaff94779779d4bd68eb2cd4457aa66dd701f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/eu/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/eu/firefox-137.0b6.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "cad992660bf8c7688f2b9443d5a4ec3fc0c3935526a757f77d154b589bd78d54";
+      sha256 = "a89194f29aabaa372b69fff8a390d552e24d621e7e70cfd81f330316fe1e3bb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/fa/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fa/firefox-137.0b6.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "a58dab5a2766867e4b76842e3dab534ed2f5d45092babea8310a50e3847b3502";
+      sha256 = "988914882c269ba580c7cb5e62cea26200fba3ad8c955fae8553798019c10559";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ff/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ff/firefox-137.0b6.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "132be780651f20ceb53076fe9623c9bed504970835a8506c0583600884886423";
+      sha256 = "d2171c0da4ad69e55c685bd246857d1999e425b2c6291990c16681f8b3ff67d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/fi/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fi/firefox-137.0b6.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "865c78a59c3849cfe4a30f696a67ab12ee90fa50eb8f4cc98c374109b99d7c77";
+      sha256 = "b3b7fd3d6df9c7c092d4425e3bf1a2fb763bdb155daddf8e79b044fda90e59e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/fr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fr/firefox-137.0b6.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "03c8ca615112cddc2ee68153c17b02ef5bf3d6a7624b0465a6ba0db1cb68df74";
+      sha256 = "87e5ae716fe0acb5e838625002731ad4afe733adb1106769dffb4c7f4e6346eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/fur/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fur/firefox-137.0b6.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "bc87fb42eb62cfbf6541740ead13cbd145632209e559ffc5a2fccb96b51a9f45";
+      sha256 = "00cfa45f88b920bf7c9f09e26bdef07f4cd566395e3d0e808ea439843f6872aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/fy-NL/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/fy-NL/firefox-137.0b6.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "f4fa55ff98f4981c16e2730658ce76132a4522d860b539fbf0c129b4e3d902f0";
+      sha256 = "59d6ad377e1aa703b157a1ab458079c2b391eb21753eb4ff0a37dcf6a8fc8e82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ga-IE/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ga-IE/firefox-137.0b6.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "3f41bee92a40f061118bb363c2ce9cd063e3565a3ebafed9dd26982e96364a02";
+      sha256 = "f4e8fa0cee317eae523456e10f3c1fcde96565286e670e3c3b7fb5a1ef411f78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/gd/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/gd/firefox-137.0b6.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "36a99d7e805d94fa273cb9bac1039acd6053627612d4314beaf792907d472d23";
+      sha256 = "012b9d1cd27474388b4af06d71a5cea24dd51289cc3009fb63f881b23a3f8f46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/gl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/gl/firefox-137.0b6.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "274539a12e92ae7501af337d10a432d2bec8f7e346ecb8dd5c620b6b9a7d4e85";
+      sha256 = "475309bd0bbf79fb6e5426f55c1b1d9032fda561778d6f6d9ac694c7994b9d98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/gn/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/gn/firefox-137.0b6.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "c5bc63a6d658f0595e45d141e9112bff6a63650925166a530a79955e3224013a";
+      sha256 = "a417875e781c7eaef98b925a568b049833a655d30f716e59b3518cfc57631636";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/gu-IN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/gu-IN/firefox-137.0b6.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "0ff95a96a2e445f13ac77cb18be57279376e2a84ab8572eb62fdf5803d27496b";
+      sha256 = "2b371d44db67288a6bc2172536e870037586081d1da684cfdf0adb826a24992e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/he/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/he/firefox-137.0b6.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "e118ff649a9e9ad6ce8ea1059fb12811b50982265148935b4ca77d941c21d354";
+      sha256 = "bd2fcd000d5041c368c6b82119efda9581fd8cd465bfeffa619f26a561b2198a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/hi-IN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hi-IN/firefox-137.0b6.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "393aacddfab4980ec5781cc0fa88064c35da15ab423177a1097a2cbf08be7951";
+      sha256 = "582df60dec748a41e718cb713b9343c3f7baf11a9ccb6149732bcbc12abc2eec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/hr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hr/firefox-137.0b6.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "01a002027563b05759d356995d62c0528f235a9e1768c16c5d26dd25d2511475";
+      sha256 = "da416b662e6f115dc485cd8a1b0cde61b64b8178d34259aa2b0e59391a6bc85c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/hsb/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hsb/firefox-137.0b6.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "cbd744d550793fbe950d4556e554896a8b92b8829f59e445cdb07cf1ba2b6d37";
+      sha256 = "738adb663b48a6b6eea84b4c5de7b93f0e3827a034b72c5cbe60498250b02129";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/hu/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hu/firefox-137.0b6.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "c1cdd13ba5786e2312654f8e0a00d14e3ed3d86793ecfdefb35135d62c6f2a3f";
+      sha256 = "7ba4cde737e6888e0dafe4e7bf4ebe3fe87b671a94c867438aa393b451e06401";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/hy-AM/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/hy-AM/firefox-137.0b6.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "d337ffd98b7dd8ff468dd62d2a14501b41aa4927cf92afe471099c04fe30dbd7";
+      sha256 = "6ba63d597c609a98ac4681ebc8353fb88ae54cf6eb1f86bfbb63221aa894631b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ia/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ia/firefox-137.0b6.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "c014fcee2a85128b78b836c284ad66b6f5d5fd9afa6907636571a873273280aa";
+      sha256 = "180c3ad4f1fb0e6e896179376ccfaa8fbf923a1faf3eef22de691f8ed8939153";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/id/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/id/firefox-137.0b6.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "4613adc376b557059eea6b5bc5b2b094bc30119ec14e546cf135b87d2aa462fd";
+      sha256 = "149f7f42b2b2c5e89767e0b0b5181e0f3e3c8c5260ba157d7355207a4bdd2770";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/is/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/is/firefox-137.0b6.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "c4c916a83e22ed6c10f7f7c54ba069ead025982e47bc72eb71eaa4dbb8175447";
+      sha256 = "8ba099b4dbfafbfa5354d3d040052b6ed6b066dcfd9be95e6f0014e1b5f8c9b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/it/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/it/firefox-137.0b6.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "482b13010f997bd8d71cca5cf6d9f7c40b84a19aa71d2d69d2db51195fe845bf";
+      sha256 = "5eb1889fcb3854249e43ead247cbf4663f673598abfbdac02cbb8e51c99ac4d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ja/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ja/firefox-137.0b6.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "1a497b3a141d03539303808546a1ff748234f46d970e208d9a688be0b9c1b1a6";
+      sha256 = "ad79250210cf55b7ed3e5cb20951b39505e88bc482f87eecf3bb6c7c5ef6fba2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ka/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ka/firefox-137.0b6.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "caad072838f39dd71c3fdcb8d3661da6891589ab2b5b491e0ac8ad811c6306cf";
+      sha256 = "3aa35c3eb5f043bf8a0090b43cb98716332a8fb45a23045b80858f27ebfdb02e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/kab/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/kab/firefox-137.0b6.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "31f816bfd1356442953e7311f61f5d534c81364a62cf64f4c8627545d521479d";
+      sha256 = "f3d2a9b41713003abbaa032de1f27cfc1fd39aac6ae5be2ac2cecccc4ebc539a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/kk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/kk/firefox-137.0b6.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "e5d19011ee12896310598773828c185a4bd6e554f322ad6cdbc3a4df9ce1db5f";
+      sha256 = "ca759840ef91948bc3b94f600aeb6be3118dc7191412a4fb53a7cb56f3cdc1a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/km/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/km/firefox-137.0b6.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "1f6a51629899c0f6c95334eef59d2afd3e969f1627fee39de7b29635e899737b";
+      sha256 = "de257f76e50ba543cc5d2a81f9a0c9acd6b96ef8cf8325e69cdb224282f049a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/kn/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/kn/firefox-137.0b6.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "f22497a643ddaa8b52f3027f66812c90e22897e342f36f9bfb974c03a10914a0";
+      sha256 = "93baafbc1ff2e8de79bf3c8c28c2cc0dd070527e4dc83f334888d2de3f035a93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ko/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ko/firefox-137.0b6.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "a2bc80a7569ee832673a067cc79caaf53c20bb7599cb4729af0fff6ce137b468";
+      sha256 = "490086600b6637c03121737230a7a3c6ac2a3eb34c49acaa38a251e6cc346631";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/lij/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/lij/firefox-137.0b6.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "d3b97e0b87f099be4f7df36d1e16de7fb4078642f6814ee4f8d236b856b5fab1";
+      sha256 = "426164abb9a150c9ffde322661c88fb8ecd793ba5e1f1c9a19842c716fa19de2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/lt/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/lt/firefox-137.0b6.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "107e52ffd96720eb14172115a4371d067fa34f2bddca004faf7201c5cf0b7d34";
+      sha256 = "f34c258b3d2008dd5e8c305d87bb29012ba5606dcf79e26dc2c8f69b7c919dac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/lv/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/lv/firefox-137.0b6.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "9122fcbaf1048fd2d16f6b8bf4d6e870b5b7cef80c0819947041027027979930";
+      sha256 = "05273dad9f1db107409844c96218ade8c392c0a06c439874fc9bfc0ee918e095";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/mk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/mk/firefox-137.0b6.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "20d3ffcc65800fd6d8b78921fbf1ec5460b111c377b18a0e6df46a9aa6fc1432";
+      sha256 = "7978da086cbe6c5539cc177044b5672b812461a121938800bf5920d693d31511";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/mr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/mr/firefox-137.0b6.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "0585fab5e93f0ee5654e14ab8c2f9a05fa7c6b59e9ae6323c740060bcf113c2d";
+      sha256 = "2c5d7211c89555d5e8195228e63a3f3a56a4c50d658c1e55291fe046581c95b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ms/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ms/firefox-137.0b6.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "630c9043eb2f5957d4e58f88ef9d5b0c062852087c340ae3eb7a335245883a98";
+      sha256 = "bf556c09f99e6591cc13aa09ab4bf8529d0757baecc644c91f626497cc0c3202";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/my/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/my/firefox-137.0b6.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "7a69165e9960db1dccd98773094ad6e9b225d5f8c5d27a10d4e4aa37b3708a70";
+      sha256 = "305d2b27afff848e38491482e0f56cf3df41bbc349df658d7721f2ce436d6df3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/nb-NO/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/nb-NO/firefox-137.0b6.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "4df52b31e4b719b54c67586ae933f703704295e9701cfcaf086502769e127a85";
+      sha256 = "7504b0c1406a0b672688864f57cc836d38b0f5e62a0f69bc9eeb2c2dc75625d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ne-NP/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ne-NP/firefox-137.0b6.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "b70783398059e74ae1e008b990d56bb0109131c8c9c17a26ae9768db073d4883";
+      sha256 = "3d4843b55d065248dbbe32a3afb39eb351768ba0e4f625aee8eec173c77ffb01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/nl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/nl/firefox-137.0b6.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "241af72a03a7f11c94b1c6f487418b6f164b6ed5e78b203478971ec3d1a97654";
+      sha256 = "39412eac8a159dbf7cc98c8ae355c054de99cfa1e09c734ceab0f0564313b4d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/nn-NO/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/nn-NO/firefox-137.0b6.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "61eb4cfa474f7a237f2736253b57c69464230afd5277c2bde379306d161a6b86";
+      sha256 = "f58dc123f451a2b053787427132ce232100e405594dac81f2a4093f57ac83eab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/oc/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/oc/firefox-137.0b6.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "5e07bbea75d881d356c038fbbf36759533a48880d02335b6b99cfc850e88687f";
+      sha256 = "3ed1789a845188c59188adf1a9b4875a795cde17e99b93716a2e18a0cd225c3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/pa-IN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/pa-IN/firefox-137.0b6.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "ba2247cd6193e471a956e5e2487b17fadbd41bad7a1386d494d44040190bed69";
+      sha256 = "8d3b5778593797c4c13c7ea64170b32b6c8f5b834eea9a2be576abb332478a94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/pl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/pl/firefox-137.0b6.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "9a8822b626a2033baecee378d474a34fe1f9cd86efbb9e2077b6731f47f566dc";
+      sha256 = "84a1a0b1ab876b6359478082ad6c2ee76627512e889a20f71547f5b05fe78315";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/pt-BR/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/pt-BR/firefox-137.0b6.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "067468fc1e8ee08d965a45287faad114533120840d5cb31885f6c5ebf1ed2ffc";
+      sha256 = "a91172c138e59b49657177a4890cd71f83e35a71ebac5fa362f2b181ad262760";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/pt-PT/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/pt-PT/firefox-137.0b6.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "9655b486902360b0a947d75421a3ef187d2549003ebf3bb5fef0f94913bec176";
+      sha256 = "e08fcf6c96af66b034ffa3cad3478eea49c2d6595fed4160b92bad72a864289f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/rm/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/rm/firefox-137.0b6.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "75571ac3b7fcc69ce2a07f6eda8157a844af099ee40f1be6d5b64cbd0517fe42";
+      sha256 = "f0e9b9777c245b3044f1920aa7a8adde9346a030121949667108c0c4753bf1ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ro/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ro/firefox-137.0b6.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "15bf5ada247764b379826166a35f655d6b080a5a4fcca7d1621ddaa962fa97ef";
+      sha256 = "b5fa465caf7dfad7e5e7536b0ac47f243f51cfa46530e1f5b080a9a5102fb4bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ru/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ru/firefox-137.0b6.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "824ca3c5ec780c512f34a012b99f6bea8bde2b6688e0da48a15d10f35e4d7c86";
+      sha256 = "0241d5e6464e6501efe5d4d4c3ade2fb715fd033ae6dade5462ff47e165ae75f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/sat/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sat/firefox-137.0b6.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "c414d322e6b33525e06f07287f5c66ab857378a123a811320d2971799d38ce75";
+      sha256 = "973c654f973d89a132d4ebd35b066e007b823b9fff29f2db826e59755a4f5c93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/sc/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sc/firefox-137.0b6.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "99d7365d03839b4bc27d15a36fb81b628a7bcf3b301816e4aa6e39dcb6b74f92";
+      sha256 = "3253e304d29eec457fe09a5994a51770b63edb5481ea2a44b2fe101812a8e7db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/sco/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sco/firefox-137.0b6.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "077a57638c814e7a6ddcda71295f178dcdf8f01b817cf5e71971c5a8ff7bdadc";
+      sha256 = "42e92e83f10cc8d07f932e1a6829670e093bf8d5e47025ae10f8454eea321bca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/si/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/si/firefox-137.0b6.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "e8ae450dd478cafd55fd57a6c28a62e7a676787849d7d4aa201e68d1e083b77c";
+      sha256 = "01569e399f1f250820a90d663260bf213f29653137d4c4ed704cc419e295a238";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/sk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sk/firefox-137.0b6.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "631d9625444b998b01fedb7049e00d3e0b6b719962d590c161481e7fc2ca29d0";
+      sha256 = "b725685e7321d39a9bace1501330ab09fa46ec102ff7d8732a19ede241864aae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/skr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/skr/firefox-137.0b6.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "6b29f142505038fdb6f6ebb19f2ae582bacb7c70e5ecc0ef81ff9376f3936421";
+      sha256 = "c5e67f9422140c47eeefb04afc65fc469ba870718834e9846d4bbcf1e2a68d56";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/sl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sl/firefox-137.0b6.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "68e71de6b144c38123c372b1e045060bfbd6c8823a2474f9ae8e86e98dfcbe61";
+      sha256 = "381854e32e48d02816e96bcd33adcddce35a06fc37e7b5f42962c016b2bd49e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/son/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/son/firefox-137.0b6.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "f11bfd676ae2cb09de0fdb9757138de2dfc5e75687845885ff8012cc50be58bb";
+      sha256 = "493eb0202e4b14d2e999b7efbcfb5dbfda03bb9247d4e4bd137f4b7955b3f422";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/sq/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sq/firefox-137.0b6.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "e2cc9f71a661ed115f18bbeea9e16eaf40b9ecac00241a5bd80bf705905f9ddb";
+      sha256 = "a20351d47efd5b92178cc98313f4a3d12192e6c47c99469074330dc5f4c0470d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/sr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sr/firefox-137.0b6.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "562cf610b05c1af7651463f074518c3e7fa2e0c63eea7088c902f22662d5c083";
+      sha256 = "90e18b8410492c0b18dd69f85c3a15ae36c040bd4c888ec94f204d0d6d35a3f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/sv-SE/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/sv-SE/firefox-137.0b6.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "4f39f7482a1bdec474c00c48fe670481fbcc40a9e5f577b66c14af9a69765779";
+      sha256 = "69c726b06c7808c5a9e3c342a41a8c026e99ec2309b4622d99486620d8872865";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/szl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/szl/firefox-137.0b6.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "553c88e0c708a25181b936f9021f1705a451b8a4531c1c046fed2c6278f59cea";
+      sha256 = "d98d62d1b4b1662e8db3bd482d5ae4d8045c7948aa6a049f5b952d6ff7992e8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ta/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ta/firefox-137.0b6.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "da589dfdddc0be0d794d4118a628059f5774e7a98d65b23c92df0fb341883cc9";
+      sha256 = "46245bbf0af4a1567bb786a3f46eab4be0908fa762aef765386330120ee84ad3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/te/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/te/firefox-137.0b6.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "5c2c8dbf244499c406e381bdf4052492352b21acba834e3d6ea16eb5b998184d";
+      sha256 = "aa457c8b036219386d345bf525093d51d273a342d6b72c888451d3649023be78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/tg/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/tg/firefox-137.0b6.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "dc8f8f42f162e777db3fcc0f03dfd6b0a98e6c81a4a32939526a0fdbf30a1664";
+      sha256 = "9fddb5a7bd2cd5e8ae76e7a4897f68e4bfe8f2ce6db8ac56447052042e26f919";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/th/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/th/firefox-137.0b6.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "5af6516d035c9ff66ba59b4e60f7f85855c6d792ccb845e3cb10c8ff4493bbb4";
+      sha256 = "5c55a15960c105c273dbfbc42215e4b637b6459e832a715da3ebf3e5f76b4d2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/tl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/tl/firefox-137.0b6.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "80dd41fc72eb322b74293638042a506f6f0a7779e9a5d3f248801e2b302b15ec";
+      sha256 = "73eed2fb989d1ef89c95b224c09bf83d8f8eee4ef7fd2c10e400c5f23377ccfa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/tr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/tr/firefox-137.0b6.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "74658c163d01a4b41a9f26d51c1ae1069d498d86378c84757eb065de9ca05066";
+      sha256 = "01d20355af783120a9bc331461fd849922f3c133abec7c7b0ac839b4f1a8f321";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/trs/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/trs/firefox-137.0b6.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "4e6d4c098f3e96bb9d836cee388925f4bb5d91c709b88cae5b738947afb33cd1";
+      sha256 = "265af379c901c206b8c684fd06c2e930e04c327f68b91a0264b67c7474b774ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/uk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/uk/firefox-137.0b6.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "f612c84447a79712b3a48a8bf021123874c8bd0817f9d46bd8dac24e8d8e1e3d";
+      sha256 = "c95a8adedbb458bda8c7c339ae022c9882262624e6c155b41eaf877a6d944d1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/ur/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/ur/firefox-137.0b6.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "eb81674488e54d6c97e9f7ce3adc6bd01fc38827593df8bbf53717586f764b2d";
+      sha256 = "1a4b943ff82063b382a1ac41206a265f8d8c3de9718a62c5b24b1ee8e9f3af69";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/uz/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/uz/firefox-137.0b6.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "eb37b3714fcc32bc46f44a7820e1ecdf71dbdd334ddc46b6f4b5e47aab3469ad";
+      sha256 = "0a7e71be584c57901839d83281f2b762191b6c8d5ec003512e74190c7dbc9050";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/vi/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/vi/firefox-137.0b6.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "b62d604b8b7c17e299950a94fe76e24781fd9078b90423fe718273f6c642bd2d";
+      sha256 = "93f588aa0c67a4637627888700358c13efab557e99fa8e579e09df3149278cb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/xh/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/xh/firefox-137.0b6.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "c854c3b069cb7c55433e03ea4289ae1331361b27ced42deb33c135e579fe5154";
+      sha256 = "e469deab3c5e4f0c52aa517d1dcd24e83e2e41cd962c4c7aeed286d31615bac7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/zh-CN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/zh-CN/firefox-137.0b6.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "c17d3c9287a389c8594ea8095b1d2617067f6f498386fc2623024f818a68fa6d";
+      sha256 = "3ff075fbf2c0190d3fec17f0e0102cca2cdd17c323351fe8849799b8df52fb26";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-x86_64/zh-TW/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-x86_64/zh-TW/firefox-137.0b6.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "196e2ecf076eeddfa5627a5ef2842e1c772456f3a865ca087d74f5a2a434fbd1";
+      sha256 = "c4eaba808adc254c0599102d9d208afbb65265e711e897d218e2eda2061587a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ach/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ach/firefox-137.0b6.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "6ea6d61d944f34101567a4f36e222531ece97ea2d7edf0829404b0a7af815e56";
+      sha256 = "d03e7309d5b0a76ea4eca3d611c47eefa32770ec74a746e793026ee484ebf31d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/af/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/af/firefox-137.0b6.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "9b9cf137fd1bf85d97e62a1594e8f2ad5b28d45ec1c4aca8f0b2908565611f46";
+      sha256 = "d14fb406fe7ddcafdab89025fca3c2532a405a98f31ee74442de0c1afc929ee0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/an/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/an/firefox-137.0b6.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "d0fcb62450af761ac38b23ed4ef1fe919147d3d34362a10386541a725f02836f";
+      sha256 = "f236bef110eb14cfefd2aff7cf4f10c7b140820ec0acc72be08b40300f8fb1ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ar/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ar/firefox-137.0b6.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "974a008a44401190e551a9b3df202c72094f2d778543da6ace0f9323c2f97355";
+      sha256 = "3dc1b22bd9ec0fe7173b6d6f113044037601f330555b758fbcc03dd7d14afe1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ast/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ast/firefox-137.0b6.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "7d585533a8fcca6ff6f280aa5a014f896f96fa3b9dd60526cd2f2120915e377a";
+      sha256 = "c83732c33730e864889a85a93f8b47b9feaf10f8d57ccd851a8152d482371a93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/az/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/az/firefox-137.0b6.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "03a32c65cc62c0e77e8e85f0aa85c04ebdd6d9975e7fd78b7b76e4b78125aa54";
+      sha256 = "9ad1c8ebe7afe33d4ae13c1860a06fac69740f63a5c39d5c70308a6b3427091e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/be/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/be/firefox-137.0b6.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "279492c755333cc6008eb360472512251609d27b31114a916e9fb586fc48368d";
+      sha256 = "92a158caaa68d68b07865ef41fb41a1a021e2c0be80a8cf55c0945b5cb7ca8b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/bg/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/bg/firefox-137.0b6.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "22c05aa1f6e8df46ea5fb84faa51f35f3e76a148331f81bcea6915f76d3a176b";
+      sha256 = "6ea76637b48f4b5eb8717e340fbd6e7c60ed4b99e16bf7fd18434d120470d68b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/bn/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/bn/firefox-137.0b6.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "080accecf5fe24f82fffd6f8f0c0db508f665fb12a2a9b986c6e8bd8b6df8a51";
+      sha256 = "40be1d0d73349b05e71113c0c493d31a521361855d65181aa27c401f8aeb7281";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/br/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/br/firefox-137.0b6.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "c25ae6ef6a5a3381bf84e2c802c9b9b1ba9124f7880692fd787c0ee97b34162d";
+      sha256 = "98165ef5fdadde38ffa0d1473c24678a3026fd46213c124781f4a66de4a200ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/bs/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/bs/firefox-137.0b6.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "ac1310e111497ed8413d3eada2954d76a7daa6b897c8a5587de50e412f933fe2";
+      sha256 = "a4da6bd3ff5e0284f6bbcc4da861966d67b2589b7c0541fa546a6ab1f00f57ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ca-valencia/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ca-valencia/firefox-137.0b6.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "274d55aba18d963ae4e672e06613ccb580ad234f86a53acca8218f2b80003fcf";
+      sha256 = "b304bea17cae883d6a31d5132bbbf4a49bf063e5dad3996391451fd18634230e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ca/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ca/firefox-137.0b6.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "9466bf871b3cf5e326a9f248d21199074dcdcb3acf2536b60e45f63d6929f5d9";
+      sha256 = "e65a97916486f3c9ee979204d43898cc8f53279249f0554fbb8e2e631661dacb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/cak/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/cak/firefox-137.0b6.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "3fa213135fdcbcf7b4586ebd03db949aebe2587ada2f0fff3681e76990114274";
+      sha256 = "a8b33c39ef32b5745cc916e9629478f795d2e8fa43e83723f556feb46fc93452";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/cs/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/cs/firefox-137.0b6.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "3eea6fde949969eda9c8cbb7e814a125df7731658e84b5b8f6f606787d68373a";
+      sha256 = "74b4d7f0e21ad7277750a98adf46b4de53a431e986c220a5e458815c4e63f1ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/cy/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/cy/firefox-137.0b6.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "2db944436339b86e3861cd273faca2351a79325f97221ad7838fb6fb9ae06f82";
+      sha256 = "a2fa47c796497a70accf316ad21edfdfe43fe6d404aa7b02ad2409c9907505b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/da/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/da/firefox-137.0b6.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "2fe9e224fa4208632c2b5dbe04a860b8e3705dbd8f645f80e77878c0ab87d9b0";
+      sha256 = "0883128230e2026fe4c74105b97ca5847e4e9ee359e14511408dc03f5831ade7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/de/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/de/firefox-137.0b6.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "6ee0770d7dcd2f8bae68b86afd383cf3d71e9ac32245c47cf8c9f71e998ef2d3";
+      sha256 = "c3d43af424b1bc0710327d44b2c31fd2758c17e559167a0793a27464f193a2d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/dsb/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/dsb/firefox-137.0b6.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "29ab93c8223257492cfc8097697b6b4c689a145bf66aa638d20c92caa2584b51";
+      sha256 = "dc8e35d7fc97a5102705be59c7d66b0c9a13cf37676a0f0f7ed22eca37022dcb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/el/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/el/firefox-137.0b6.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "117083f76a21af63a54e3bc4434c9ce65bf043b7750dbc9473036785b6756711";
+      sha256 = "20ceab4a4893a9dd77cf497580f6500975cd36f216fdb9de7b7d268322e08091";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/en-CA/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/en-CA/firefox-137.0b6.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "887f964a606ed1f81c7fd4ebea32e27a2fd3d9fec62d94d40b82f2fe00c56391";
+      sha256 = "46c7dd3825d6f43a90737ee4698e511884a1e13ec5bb5e7f93fb894d9534b100";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/en-GB/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/en-GB/firefox-137.0b6.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "43b7073a76778fd7579b7d83f46f864abe126f71433a960eb147aab12a8c62fd";
+      sha256 = "502b1341e773559348c236f3226530639e9620d1a8f8e6dca4eeba3ebdbe0c09";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/en-US/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/en-US/firefox-137.0b6.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "70c88d28313d2288f8fd412f66dfe45a084f862e4c3824aaee52e3d9796bd1e9";
+      sha256 = "f0d37a3e04b8567347b8a639cbcf6e0715cec5322d0578e05d19019b6a7225fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/eo/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/eo/firefox-137.0b6.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "d7862eb2b6ffa5db9be33293e80f77dd3cb1371b2466fc26dcba973a824e62ab";
+      sha256 = "34fde3bd7aaba9f1267cc3b2a3ce7a6ebece30388219c88accebdd8514d6da32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/es-AR/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/es-AR/firefox-137.0b6.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "f58bde1a30d7cfd32c42796aac80515acd1d2e83a6e88241c05d135453065f57";
+      sha256 = "98a0221b47c5a1b4258d2c2b76425408686f77330aef118ec993264f5ecd347d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/es-CL/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/es-CL/firefox-137.0b6.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "96b20d1397cdae547e3d4a77481894fec6c3c6eedf8164395f03a4c841cc6740";
+      sha256 = "1d8c545b2a354892eedf606382da8247db6c49069eaa487ee5178a380ecd0279";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/es-ES/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/es-ES/firefox-137.0b6.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "ee293c222e942ee7912d38439dc3c3b1bf53bf65822b19fb5f51fd438995cc18";
+      sha256 = "c706b43e229502e8e68db43d4af6338127ec30756fd7413949901fd5b96519f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/es-MX/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/es-MX/firefox-137.0b6.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "bcd686f6940d4ba929725d789266f2f918e40e8b40463057d15e717bbff557d2";
+      sha256 = "a94f85c876cccb371e2afbb0020374fac493148e34b0b4fb8df4532b4f0ff969";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/et/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/et/firefox-137.0b6.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "83523fdd4766d31d88f91e97863ba51197003a97b6d3875148c86232219cb3f5";
+      sha256 = "4c66f70827f4d392e4c9b793f965f6c6befaffc2cb6371febe4bfc97fac9fc68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/eu/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/eu/firefox-137.0b6.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "9486f70b321152bd8c7ff628502a1cd103ab010505c64fabc84f91ddfaf7216c";
+      sha256 = "c83fb9e24db2f847de51cdfa2f54de5d9e52aeb49188cd4371765b561afd1ad6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/fa/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fa/firefox-137.0b6.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "72fb7ec209787355d84d245cf4ae917650539deb2f9998b5359889ce4a4fee6f";
+      sha256 = "22bbab8db2fcadb02c0c12b55b6353b2c920ea6ef7a50a0ad01f6a2bc96f734e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ff/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ff/firefox-137.0b6.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "54fde8f7884307ec9f763ed0e64cdac67690621e738ee471c2f73d69379f5adf";
+      sha256 = "5ffe25658066071c30373d91c137363513cd28c4c62deaf9abeeb7c8a71e8632";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/fi/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fi/firefox-137.0b6.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "64baf75c9f320469264ed90800f32e1b45703ef4634cfc0e1f0a8fbdc80b418e";
+      sha256 = "ef93fe928e038117a3e9236982625bc96111bd9fcb62e8b28a14279678a2c847";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/fr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fr/firefox-137.0b6.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "994d546aefe04a0489ad0a49119ec73a56edb86303765083345d890f9f4e4848";
+      sha256 = "16beea2fe2164468d5acb351e380687f68295ec85cff046185e8f88ac1dea55f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/fur/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fur/firefox-137.0b6.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "45079e88883f85446e27f1f72dbf116ca452acc9283747580d9f93bf9eed22b5";
+      sha256 = "7418fa563071416570c0be896f828754c5cd2fdec81f9638a7ca3958952bd475";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/fy-NL/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/fy-NL/firefox-137.0b6.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "d4816c57074ad2fe161999ecb239fba23712c92fb897c0f66eca3d77be9db284";
+      sha256 = "2d6c7ab2e14db9bf0216c7a1a7d5d54d7ab35ccf535d62048696a3422e5ebdc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ga-IE/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ga-IE/firefox-137.0b6.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "81359050f4790cc1d481b2ab406e299f6707eca681b5592e58d564b4ed29031f";
+      sha256 = "d62fb8e24c907ca3a277a0bfe4c77d62fa4a9d65942f8e0525413214a5b68621";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/gd/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/gd/firefox-137.0b6.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "daff4c17390b0ca75f83d4ecf8efcf97ebe9fda71cd23d9194402e99b5186bc5";
+      sha256 = "a625e15f38dd6e19cf0b0fa8a071c5a3df48f0e1a3e93b0c7bbec3a1cc99685b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/gl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/gl/firefox-137.0b6.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "ba1df017c60c8bb34b6c0bc282c85f367bf6eea5c3b6e258fd5f68221871c7f2";
+      sha256 = "92519c403e3d45bb364b3f6ba7ed7dc9b93fd30eb2927503559697e6180e20da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/gn/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/gn/firefox-137.0b6.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "73973ee2e69de9a745ddc24029ced63f484abdf2e650b2b880b56f79c43cabf3";
+      sha256 = "edd2f596c0b1ccf292b1fd757bfc49420250b350422e90ec7dd01511957adc5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/gu-IN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/gu-IN/firefox-137.0b6.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "74c0f86183542ded2f4d7de6c0cf981b398cd5887d7c203cfda9d782e90081bf";
+      sha256 = "f58bd1fe99fc87b441a1f4df48862238fa5780b747b56a93cd8ef579c419b587";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/he/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/he/firefox-137.0b6.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d42e84dd9b6cd3090baf903a287d5c5f96fb2ebbb968351c8c3f7bd582c89651";
+      sha256 = "4aa99da36cf17c7627bdcd5643344cabbe1cc1c1683146558a7c4646a25eff50";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/hi-IN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hi-IN/firefox-137.0b6.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "e67b57b4e5b18e719fd365309e522ede96376af1f330dc4e87508d5cbb032096";
+      sha256 = "b2ac807aaa4ee696a60b6f117dd165bf0a0b633f895247bb916b810103d5a739";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/hr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hr/firefox-137.0b6.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "f0161cfe8e9bd6b0ed8a8b2fef68bcc6f4bbb352f21380cf6b6319327d1f8dc1";
+      sha256 = "123139a7923d0e2658745af0c6c09dff99fbd3b8973df9f41420359e43d433d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/hsb/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hsb/firefox-137.0b6.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "8abb9c9641e3dd73ba99ee75cccae7bfeea0c3ae16a087dc9904eff7da0f3d50";
+      sha256 = "6cd9c025146a3fc488828cfaa21e25544896c2332b3e8377da9816ac5bc5847a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/hu/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hu/firefox-137.0b6.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "a165da8bd0de1a4a28b31ce3cb69584e65daf1e7b2040ddbfab979599df08b49";
+      sha256 = "e49de3e5576d292e86ffa3f6c274a8c05b9ac98349af5365915c90b15e8a7ab4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/hy-AM/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/hy-AM/firefox-137.0b6.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "b8c245f544cc5c1303c2981705d1e2efc7d2bf9f34e7f30bec0c91b2c250883c";
+      sha256 = "d5e268a2ecc211d9cfb0cd2967161a0a32ea8f446f9954595cacfd11ac609446";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ia/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ia/firefox-137.0b6.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "76df96121b3951b9dfb7b1de58a11983e9795a18517db1216e47a23c0e4092d5";
+      sha256 = "f3737f3d033af8cc9c652f83a6fb66b937a359d70e2c6dc8fcf371d600ef1e60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/id/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/id/firefox-137.0b6.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "52536682539bd1e9e9f92ee2fcdc410314c3e415e320123060672564316f1e76";
+      sha256 = "f0dfb488663461e358e41cec1ea3143dc5fb138bc9e16d8047020b6db12f4fc3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/is/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/is/firefox-137.0b6.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "4b0ad542ee7ac11bc46dad663675d27b7ef7625fdf998deee2cd24f6ef12e380";
+      sha256 = "13a0d185875c8f0d505eea74efacbe983c900418eb93a8d75a8812e47afdc590";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/it/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/it/firefox-137.0b6.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "4b0a0a93de707ec9d5eb4bd625f8057cdbb5fce35dc10fcf07145632029b4e5f";
+      sha256 = "17b86c7b8185b3cc21b8e5ba89b3fa69fdb8cf37f4d1570420ec17e073b82644";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ja/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ja/firefox-137.0b6.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "9e2b155d17830ba2647ec35751868fc62c6e6e1e896b847d50ccbab68b951e19";
+      sha256 = "c972bf498175957eca1946cd067aab8b1bdabda537a8ddc3f893d43333257c21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ka/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ka/firefox-137.0b6.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "0370c48ce4cefc6f0e1c9f6d2775004bc2248facce0b4058fd8b67c541a593a6";
+      sha256 = "1cab84871422929443ac0648daedf192f7fffa5d7af6d5d5ba28cd4b8e897c5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/kab/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/kab/firefox-137.0b6.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "760a92430a5cad6346ec31d4cb92ab578c40a3a867420ff95d92547070e87197";
+      sha256 = "5ac1b192085e268dcffae59a8d167fada0ceb646c306a01e059e221d714ea03d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/kk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/kk/firefox-137.0b6.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "717812f07adfa305c7cc0013e6ecfcc8a8e8064bae3fcd8e4770a71d8ad6ce80";
+      sha256 = "0aecf096a377bbec87f1ca2014f8927e22b639b9ee897404fe9590c54f64c1ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/km/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/km/firefox-137.0b6.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "b89c46cdb02302872da568d5a884f2d442aab328ea8da7c39ee4d3c3d7827aa9";
+      sha256 = "14416925f65a1d74e54f549a939eb2cb43dfe06b16a064d1c16d9daca8b7dec7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/kn/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/kn/firefox-137.0b6.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "764a8b4923b930db4b64d58bfa4f3bcf0756970a256b114119c82282db59dda4";
+      sha256 = "a59704c5f438943cf4df6bbdc31e4dc51c33fed7fd4de8d67f2e476b93f71a93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ko/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ko/firefox-137.0b6.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "924ecb565bcdab36d6b98c7571dc3aae6c5f210a9b5195295abcb0e81ddf4069";
+      sha256 = "67c7e34ab93913b346ecfcc5d4e92c402b9d5adc10a852b9c9533367d6c7c5b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/lij/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/lij/firefox-137.0b6.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "fb4ffe459991913891d192bf6455b67f6af876819dec2a05ab8f44f3a47a019f";
+      sha256 = "72d62d5a7419ddd55f3c976b55e38a886801892ffc517fdc9364a2743c7845bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/lt/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/lt/firefox-137.0b6.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "422a7d53cb88917b219d1903d7bf3444ace336ae84ae37c587b06f502d6e42e8";
+      sha256 = "a2903a7cb440c05da05fec006357861b3c9d0f2e40c7f451fa3692d6a644d241";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/lv/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/lv/firefox-137.0b6.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "1dca2607fac854c761fd1db22e9d09557b274aa05f28159d4dcf9c1d4f2c6574";
+      sha256 = "a333ec2272c597f5f0cdf80c9a43c049b66d2ae100da1e955684a4ad3e725861";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/mk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/mk/firefox-137.0b6.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "bca576f04077f3a0eba0dcf8930ec9fc92236f51d31de198b8fc056b1382bd0d";
+      sha256 = "98d968e5b6bec5d83572a73f779714f59667fb7836a9df73b44ff70c86abd5c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/mr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/mr/firefox-137.0b6.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "0a450f9e4e3a6567c07d95c41c1ff6c68362712cbe1ec4295aa0109a723224eb";
+      sha256 = "13b6efac223335475e6d490a5a0ce6647ae906095f72302f1e6c1c04cde512f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ms/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ms/firefox-137.0b6.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "27f3d7c829db621d64f1c231590fdc05cc1dfa5c65c4636943762065c79773e5";
+      sha256 = "ef300793e78bc39bc6b5c3290ca74b78dc90ec660d5d0985ad24103a0935e212";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/my/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/my/firefox-137.0b6.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "e64f43dffa0233cc86ca7e3555505695a47b0a3261868c7f551da277a8cd7159";
+      sha256 = "4c31243cbc1f21ce63ad13f3b8bc9f33fd9542c7ae3c01c912f9eb2995aa6798";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/nb-NO/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/nb-NO/firefox-137.0b6.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "00b7f2bcc82c67bf4f5e19aae56a725d07ef1f3ababd4848b2a51cb2dbceb4df";
+      sha256 = "cc92b5f978387bb56ee5991133dd8b6975542d689978b0839954c352113c53a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ne-NP/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ne-NP/firefox-137.0b6.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "2c659192c486e51a3cb14867475dae72ecabc809bc47f7a5d32945510b423cd9";
+      sha256 = "36ab3b215f96199a21a088d3f1a265d85859062b4973e09a61a023ba4c0884ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/nl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/nl/firefox-137.0b6.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "031dc81dd60b70ba8af66774ed3264cfdcd38e71df7bc1c9b92f74f3ac730cb0";
+      sha256 = "102ae382c7659e3fe76f14c96e594afccf7f9f66757081e1b85b527a05473e98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/nn-NO/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/nn-NO/firefox-137.0b6.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "a21053c65a2e9bd3c5309f5fccbc2a317af61c70c40271b13246dbf9021d330b";
+      sha256 = "2ffdbf947a40d73f7a92ae6c3af4e090867d459cfaacc8188401fbfdb12ec6a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/oc/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/oc/firefox-137.0b6.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "b7b98f1d4d6b0eeefa05e89a5db35db86236140d3e150ddddf9e302b78bea10e";
+      sha256 = "f576151607b97a556a1fddedbd45471737db14fd0ef0a942b53066a7fbedf77c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/pa-IN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/pa-IN/firefox-137.0b6.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "e0f9f1475989277e8dae5097636b1ab1bd9f6731393384960ad283741b8a1522";
+      sha256 = "0ec692dce9dda078c3da9a16ad8566bec25331b4e915b01a9f6bc854ab0b287e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/pl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/pl/firefox-137.0b6.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "19b9dbdbc9a160b67a4ad59f680cb9565078c0e21fdc29e7c36a0fb1c4d6de1d";
+      sha256 = "14bfc83727d87372c041dbb27a1348070d7fcbe2c831ce6b9a09f9d723fd75c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/pt-BR/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/pt-BR/firefox-137.0b6.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "a384a85138cb3e6cb4c5fad22fc27846dfee66cb567afae7341062c9652b0316";
+      sha256 = "64acb0d2e6b5b159928f34e0a4f6ac1b956cc86b357770e884743f8e9840f55d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/pt-PT/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/pt-PT/firefox-137.0b6.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "a3fa4afc69faee12eb2332148c0082787d6acf8bfc4dea0fedd04a0d511df43f";
+      sha256 = "a56b34cbd55aa0797966384b9f51ca555b8e8e635c95092532376552de45ab32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/rm/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/rm/firefox-137.0b6.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "1f6f6aba18d25a2797d7e822c9a6526f18508c5e333e7f988c501abff5fb60bf";
+      sha256 = "49d35b339cf569469ae31e8d1d36fa1c8bfe09602ab5804c69a2adcd3253ec8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ro/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ro/firefox-137.0b6.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "5b3bc7f406dc3882f20a2e0b4d319b8b902d67d248af70b74d1884f8788f5659";
+      sha256 = "f09695b14bdd1c1d22107b62f19e54157ea0aea926747d69a12a04608be7d398";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ru/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ru/firefox-137.0b6.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "7686d94cda049f018b2c3f53c29e4b9f73ba22c7ca0e0eb72151299434096646";
+      sha256 = "fbaf8118e83e8ea3b5dd278c379e826bb62f7ef4af532b8a818d240804943905";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/sat/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sat/firefox-137.0b6.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "ab8298ea88b708e3b37669c9f1aecbc2c27160ae1dddf19ae903952de9af7cb0";
+      sha256 = "761589e7654a10c993a9895d924ce1b04c75fc3e1f3b100f4c4a52e9db4d86f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/sc/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sc/firefox-137.0b6.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "5b8bee75d83f912f9424acde7a215cff9ba3cbeb92bd5e860d74fa5e0cc4a33f";
+      sha256 = "196b1473965d09b2709c871633ed677679cf7f86cb26e0d985560901cb8e14a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/sco/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sco/firefox-137.0b6.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "e81e9610074659707e477d30601ae8697ed8eb9d8cb4f6d2c93b66ed884549bd";
+      sha256 = "7cb1df14621d63f266b59ee4691fe196ac7fb2874a068857a94427a2ac056bf9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/si/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/si/firefox-137.0b6.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "07f124af3b880b2a1beab96f63c89d94a368be2897bf03ad80f581d394bd3e2b";
+      sha256 = "35ce1453224519ec876f798a81b3a50799e8bb80e97ce57ff22ed23e38a43c8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/sk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sk/firefox-137.0b6.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "fa69520a3e6686a13def4112e2bfcaf3de765c29ae6531100445939527bd3cf0";
+      sha256 = "25c824c3d3156ee2799269566fb913e7cb13141fa89e2f6e8b5ddbff5f73eb04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/skr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/skr/firefox-137.0b6.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "49ca8092cd32d6c737509eb80e4677253e4b0ba8b3238f5885bdd8f9e29b1729";
+      sha256 = "d0d7b6bdb1343d9ca6d3cbc6547f64925fe226047d17a7b99c1f941579c7530e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/sl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sl/firefox-137.0b6.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "0ee47c33fa181339af9a65e896e168a6a52b3c29faa8bb5a80eaa6038eeb2fcd";
+      sha256 = "2f143eb911848607c45dca7ca43deaa0afb843dd46191dd59adc6647d02b4db5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/son/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/son/firefox-137.0b6.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "e9c632bad051a222cca9e3a1c5f4bbb0bc309b4521adb50f7e5268812090eb96";
+      sha256 = "e624c8fd518b244ab5a397394aebb988c9745e27f28ae7ce090e9f260e3887af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/sq/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sq/firefox-137.0b6.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "7982006ec61a1bd8b3ee4982a068834a043b1af44ee2dc65a7514bf409c0e933";
+      sha256 = "1f0b86ad3e99e0c6258568cc5cdb5d19c89303de7f71ece1646776d585b177cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/sr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sr/firefox-137.0b6.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "9f45fd999412d579e6465fafa86338edd77f215cd8c9592b9023fc1bc7311d75";
+      sha256 = "daa08744f672e8f76f2d8288fa11a1c1534d1ba8afa9e1bb3ff6ad59cdea5000";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/sv-SE/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/sv-SE/firefox-137.0b6.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "31138565fe6c45fb7d80e8607c5717df219e76a24481d55cf659801cd021f786";
+      sha256 = "25939b5a902e76216c71d60a64c956d97aaae4dd1b9ad73b39a3105b37e8507b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/szl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/szl/firefox-137.0b6.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "b49511ea1604b2906e5aaf41df8ecf10b83df37788cd4503cbbdee42c9a0f2d2";
+      sha256 = "408300599eba0410714c629d8f742753a8b5f3e74cb2ea45cce991e12892a5e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ta/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ta/firefox-137.0b6.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "28442b2791aac8403eaa67007020161a3086128e58f9cc5f84c0222676ac5a7c";
+      sha256 = "92ec5418a12a287b17c8ba7980d42cb014df9643cd6cf091f9b36961745e9a23";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/te/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/te/firefox-137.0b6.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "83a0898c8c5349df3e6da6eecaa14a6914ac3ca4f2414792862f4e77beeeb527";
+      sha256 = "6274a51a39c587207e66d419d84ae681a5ae14754b0c58957ebe55ae360a9e79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/tg/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/tg/firefox-137.0b6.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "6a464038f91023cf10c8698d1305621dd736a0dba5b38f059a7595b11365f7c1";
+      sha256 = "b5a2f0a11c6f4e0ee04590fd188cdd3a79b0f134327b74c0809bc6278bcb068f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/th/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/th/firefox-137.0b6.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "b53210ca41a53aa70a5980fbb11e5a9ea4186af676b31bb33e6344f8739b59af";
+      sha256 = "2a9d6a54126b2c1e1c9e0c3067b90e64cce6dc1ce0c0fe2cf6d8cd4e1feebc9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/tl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/tl/firefox-137.0b6.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "5be463ab29c279a74d381fe8eb6b78fab3c6de2655975d9eee6a29997eda457e";
+      sha256 = "79c12559f5a040b3b5eac95c4374df8e0cc63b5e260d9c21f67015a82b4ae267";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/tr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/tr/firefox-137.0b6.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "3d59d9b32855d185a1b9eca9e0a61cb3249a1aaa257fd759adc2167e451f76fa";
+      sha256 = "786f216d432f5269fe6b301a8c611e3adf3730da31a85ba6110efaa248fa457e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/trs/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/trs/firefox-137.0b6.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "6381d1ab93491311cc2f4fa4e80720e48d1254c0faded31c41eea5dd5d2170a3";
+      sha256 = "54d4f6ca92f63811429693c0023fbf2da6ba4bd81cf9259f9e5822199f6cb68e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/uk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/uk/firefox-137.0b6.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "569504754ace617f52b8b2a179d6bcfbd7b769178e6cc3d7c4edd8d330a3610c";
+      sha256 = "c4f37a57224a749144d8c9cedee08ce3b4eb991f74f8ee8b87cf0050509f4921";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/ur/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/ur/firefox-137.0b6.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "a97015c0586f3bb02d92c1bfc680439356890668aeeb67a8680c1eaba78fb0fc";
+      sha256 = "852d9c8df2a4742e31c5601ae02af9ebdb08fc18d56afbed52aa91a8ee7cd4d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/uz/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/uz/firefox-137.0b6.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "9311577d8bea89f299ebaff21c87d63771648b3342e75c3d85ac253281f50b88";
+      sha256 = "c66102f77f39c086831e310b066396b10c25282716fe86a422fa844604664b6f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/vi/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/vi/firefox-137.0b6.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "eb1a9c828e4a24191a4e76bd9fc11dbecdcc5958c370d731ebfcaa1f07e9590c";
+      sha256 = "6aca98758d35b92318259ef31e5b59dd5ed46fffe39fab8c3f13e8b02769fe29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/xh/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/xh/firefox-137.0b6.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "26b711d9daa30a0baaa5ac6c6a7df4a36012db83e236b1f17c926de139d9dc9f";
+      sha256 = "3eaf8882b2688ab24ece805abdf16f3645077fe4267178079a410f3ebd69025e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/zh-CN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/zh-CN/firefox-137.0b6.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "7d9c22fea836e2453b4df6a1e46355e955c11cc92cc48ae63f420ddca816050d";
+      sha256 = "b2fe0334c1e73516d7eccf3948d5c72dcc6dc4b68b45786e0540c39a9085a075";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-i686/zh-TW/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-i686/zh-TW/firefox-137.0b6.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0d0487b1d96a4753ec5848f062d0e06cf6e88fbedfd9b7b1229f645d64d82901";
+      sha256 = "223f37741b6a971c1c91f4543fa511fbbec7d9d4d24d0125566250779b0ff5b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ach/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ach/firefox-137.0b6.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "cf9e4153341af78f451650c4266951e8f801fb4a689225399b55e9b590dcf06c";
+      sha256 = "88276f7fc7b993e218e46652eeea7f448d122fa2a5e526fc1bbbff00af0651bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/af/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/af/firefox-137.0b6.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "95cdd9da90d428d0f921785b6546d4b13225dab33aee928d57a120bd27e98052";
+      sha256 = "cf1c88dc60a68ea685efbe27d6ad227206ab9089801bffc9411104ab44a7c0bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/an/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/an/firefox-137.0b6.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "9580705c8f66ff7d8fb56b4635aede8da56b45b971905ad2f0cc2e372d89b55b";
+      sha256 = "8cee5d5d1ba3974484659faed676072b3d369374e4a0096fb5116b740ed4f844";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ar/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ar/firefox-137.0b6.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "56fc796f08540924df2b7a6e63030eac465714585cadc267c5329db3d019397e";
+      sha256 = "d34b21e81cfdc6bfac6ec63c97e74dddf1e8fc12aaefcf3a65ed1227e162c1a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ast/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ast/firefox-137.0b6.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "f5d5664b4f1955ad8e8b69e31ee800665cccff90221440db2970e0ce45b91adc";
+      sha256 = "dfed822f4edbefff874bf0f7b09d91339ff1426fd5a6edecc1dc5ef2ae1ce9c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/az/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/az/firefox-137.0b6.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "3d40fecf0ff40d886af08cbe8842246e077f4efb094a70d3973f6ce22cb37008";
+      sha256 = "2dd784a9fd9c4a42f6e97136ecfa901c1522bf3b56421a1d3e1eda0a6704e2dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/be/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/be/firefox-137.0b6.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "4cf68e5b26574a1e9e5df7f145632aed14367b9fe8c3c1aafe8cf87f795b20e1";
+      sha256 = "4f94367ac48005eaded1579d8732788d2a74fbe40c91dc417d247dae0a6ca310";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/bg/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/bg/firefox-137.0b6.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "5c92745b72505598245747efc8cb822dee515758f2e45322a2ad02bf2e63d3a4";
+      sha256 = "f3d806c7a702a104661d66927f701b2c8e47319953c6fe6aaff566c691608f9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/bn/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/bn/firefox-137.0b6.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "f61587ca7f9385ff839ed52fe39f16cb76b90451c93ec8422c02602e845a169d";
+      sha256 = "c1901da130b64e8aa4e4d338a297d2ab5d73bbeb9fd29c1a4a8f13dcbd6be89a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/br/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/br/firefox-137.0b6.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "32cfb2792d2e299a6264f429444c4224e59f57927848ffde5b665eaf417f41a6";
+      sha256 = "0c6f21f36903d9ead0d44f8cb8c5e24e0d2005858f7c07b1b929b55749d68c3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/bs/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/bs/firefox-137.0b6.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "878dd5c4a9c7e1d96661b5b2441942c4a396492159336b28d9b5186b11397946";
+      sha256 = "b726a83d7b278b9f7e563731aaee91fd529d7dc5b01162c6982377c7716b8d88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ca-valencia/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ca-valencia/firefox-137.0b6.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "6effc0810c07b02a01292a07510106f2cad326272aa28a6e2942157475e777d7";
+      sha256 = "e7ddd628916329e953635d232750874fe5c0774c86d3272caa0589232c0dc936";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ca/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ca/firefox-137.0b6.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "059319e4201cc7e2111ee39f6494e46fd353c64a7b7e9ae1640f403d6dce44e2";
+      sha256 = "6706611a2b06a5bc01da3dcec4f3a10b32d8c2c698dd091739baca8396c77e01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/cak/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/cak/firefox-137.0b6.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "cd84785c845a52b964b827170061bf70bcee5be7e78a3e2217010525826feb8c";
+      sha256 = "3efa06c560076610e6c67b7caf08291816ded60cf9db54cb9d6611a4ad685fd2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/cs/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/cs/firefox-137.0b6.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "25dc1d8559ed2c650d626e7d1a8a3978e7ef10e07cf798fdad3b84513e1b7d94";
+      sha256 = "292e2dfb57d2b0b97306aa40fac7a691da929d6d49728b80d8626c922308ef58";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/cy/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/cy/firefox-137.0b6.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "585e5ea677ba95c93abfec36024c34345f401ad1d6475548a20ceb3e3ccae427";
+      sha256 = "a320262afde097a7de59c7b4bb5b972bb90625c36e2d64bf99f73ad80745242d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/da/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/da/firefox-137.0b6.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "4ff046d1201c16914ed7de0e4a0bd76871d037a8e41985e4c6a1c6988ce55651";
+      sha256 = "5ad5ea11ea0e6dc8397d0c18d0a8c66b4f733bcf68e7d66dc8d3de114fc509de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/de/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/de/firefox-137.0b6.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "207c7eccfc95e3a3aacf36687258f254e48f3f6a0bcf2cd7f58a63c8e4cf56f5";
+      sha256 = "e0e685eb7a6680da2797f3a9d6aba30871e4732d817447a9c8f06ad7b6968802";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/dsb/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/dsb/firefox-137.0b6.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "0ccfe20debc9af0897eb5184885f2558145f9cbd157ef9683eb08bc8806124ce";
+      sha256 = "75bcd2e8f5418fe7d2f9259737c096a9e0b6630b5e4190546dd3594a4688bc98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/el/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/el/firefox-137.0b6.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "9178ef2a0e4a8d035d6fbdd25bea8401656fb1e7ce2fc1a2cbe726f5f020b1fe";
+      sha256 = "c4a8426568ed77022fb0103106c3de250bb9ad317a7a351fe028338e3da300b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/en-CA/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/en-CA/firefox-137.0b6.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "b2436c691e1cfd1428c38fbbbb031cab1983b02435f431fc84b9c629b1e0ad8e";
+      sha256 = "c8e4d62aa66275aab4c84bcaa15566498861f8f6193e269f73876d25cbdab4cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/en-GB/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/en-GB/firefox-137.0b6.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "a5e8e32c86dcc4557b028687276db96f5baff2e7f9ce3f95fa2a9f6939fc4913";
+      sha256 = "8210e1dd0e2136b662755a3a2233484cd5e901a2154173bd3137ea5246e23b35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/en-US/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/en-US/firefox-137.0b6.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "b3db52f3bbad3bf539d894d84d22ff847fa7c0054d6156589ee8289d1bbdc696";
+      sha256 = "65863ad2d2985ad5feac9d4369ca6ef2a3f0e18759458e0d09b3db9813600ac1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/eo/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/eo/firefox-137.0b6.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "b5ec04168f4b56a695570cc727c51f06680e65521a14df39457c9ea410f8b48c";
+      sha256 = "e500cf2d000cc29242afe07364a37153266de67a54bea2f1ba15704064fe4875";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/es-AR/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/es-AR/firefox-137.0b6.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "34ff7c2248ae1fcc82761f75221c684978f33c486f4777959221d7ab777bd320";
+      sha256 = "ad4fe5cb9a3904f57b98fda2267617a4df3a10b655728847df694402c19b7f49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/es-CL/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/es-CL/firefox-137.0b6.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "29a7026693992b17613e13dd2d5964d2508b97b308ec9aaa15e46e3282d8af79";
+      sha256 = "6841d7eac2f3a0dcef725b6b190ed56d4e4f96ecd01e165b25fc7d7841a52fb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/es-ES/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/es-ES/firefox-137.0b6.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "3ba34b190339128ddecbb38528009e38f3bef66f83af0fda91f8b80b3918b4d5";
+      sha256 = "3a3ccf0031fa858361fdd816d6c650c4200998d4d4efb4ca6aa7ddb9a258a758";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/es-MX/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/es-MX/firefox-137.0b6.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "2c413a9646225490d33120bbeece3dab3f633f5eced3718520126ca644818e61";
+      sha256 = "85b48fdea7b79e39caf3a658d168db9f224157d0748710d8237ca245bc429bda";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/et/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/et/firefox-137.0b6.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "1a0eabd76f34192ec5c2c63c9f7ed5c9aae0abb75140c16eb1a7dcf22900d0f2";
+      sha256 = "35d2ae93d99e5e523a013a5acf6b504a9a9f27b8c3a67a778a85648b014bbedd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/eu/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/eu/firefox-137.0b6.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "0e0c45cd3411f697e73d727fc5ab63e497cbb4ecb907c9a453b21dd52061394c";
+      sha256 = "7ce5cffe0a4b5d9fa260306c8b982526d9a7e355d5c74c840df18e864580853b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/fa/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fa/firefox-137.0b6.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "51aeb82959f79f52f2f5fdd7e8720672e3eeaf44c6071e5fa2f3748672d51f78";
+      sha256 = "d9c5b02b4052ffa11071c1570e2bd45520c6de9c9f8bf7db762e53b7e15a114e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ff/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ff/firefox-137.0b6.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "1ff502ab25380ce8d8ca0214762ccf01318cf177a427687c5a7e1562dc82f880";
+      sha256 = "480d5b05324cec89397a5b1f3afa8ac671e5c1a120ac99fa9be6a2a3c509c2ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/fi/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fi/firefox-137.0b6.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "f0162c64e57b26f88402d3c1a023be28a197efbf88702d25a9237db57f687108";
+      sha256 = "148b12a936bfc269b6758682dd50b724d11321e0e2ea9802e95877547435be46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/fr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fr/firefox-137.0b6.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "2d11836e65d3ab1e0220a0e4b899800e3e9372a8c93c24723498386ea3de01a1";
+      sha256 = "2cc711790474500a05c40745816142c6a38f24428a8522de4d4cdfee8368e63b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/fur/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fur/firefox-137.0b6.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "8e711a87aa7bb437ea6a9f58b840a37795697e694bd7c36303d5a3df5de0e61c";
+      sha256 = "13d5432755e7c87beb0378fe49a6b0b76e0c57486ce5e30032481bb165cb06eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/fy-NL/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/fy-NL/firefox-137.0b6.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "5892c1b7d9fb60ffb7979121a334885794345c8b2a9947779b46ce2174afa7ea";
+      sha256 = "c2fb6627ec55fc19bcd94bbe7a9eec311120eeca5640f26ac37de15a434a22b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ga-IE/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ga-IE/firefox-137.0b6.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "96832c008b85d337d50bb66678f30a2c8add04ddffd7a8411f998bdd2dbc7e9f";
+      sha256 = "a6dd5a234238b7333ec40058899647ed05db7e9b88059fcc8c34948ec6e56341";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/gd/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/gd/firefox-137.0b6.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "18e540604701a9657708ba75e33b91494522288cdd85f6940766df05abe2abed";
+      sha256 = "d66efe3233a308514a2d06785210652b18ff0231345100f3d63617d805d87150";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/gl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/gl/firefox-137.0b6.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "6ab4eb285bcb879db3f2073295d8603e81f938603936c0bfc17eeb861da6f1ba";
+      sha256 = "e5a273dfc33a50ec815c1696f06f5f5dba2846283492bf2a7d5dc5b5d257df83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/gn/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/gn/firefox-137.0b6.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "e5a9728a9d60a8ad75264ddffee679d8491257c2e370091239ba6b713939d05a";
+      sha256 = "b263e288b2a0c4e4e8117c6f862060a0853491ae52cdf24a9cbc918acd7e115d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/gu-IN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/gu-IN/firefox-137.0b6.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "9e46615bf3683957953b0c5d22a34e87613b8225af5d927a9cfbfc0b8ea6271a";
+      sha256 = "faaa6e3494aa27b5d8edb68ff6db350f6effdeb874f7193ea6660e13a661b464";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/he/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/he/firefox-137.0b6.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "319de6b307948ea54475a55506fee687f1c84dd3be2b06c1638fc57488b0adfd";
+      sha256 = "b0d2d40cb1fb87016e965ccebf74d8bd28a7484bed15badf362abc35e74bd29d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/hi-IN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hi-IN/firefox-137.0b6.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "7dce9e07faeecafbde7cc1b99e027a3e2121e350084e6de6411516eaac0fd8d2";
+      sha256 = "e9e032aa853cf7eabfc01a02a9002b012d3b89b006fac7b14fcfb33c87268bb7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/hr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hr/firefox-137.0b6.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "5b038c6fa3b133ce01fab9a60a25c464a4de1cf1f3b1606152122f11624298a0";
+      sha256 = "5ec922b1f96d2b18726b27bf770dc4e79ae69977b1c70297a17a5f33eacd0a91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/hsb/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hsb/firefox-137.0b6.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "a7237bd9584d785e1a0a6395b598097e7ee855e5179ea1bd4e7499ce5fca6d94";
+      sha256 = "eaf630700961dead46f97b63fb29ecb824785ff14221fc35fcdd21ca9be5c0a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/hu/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hu/firefox-137.0b6.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "1810246f8d47f79da287b6ad496259f255471cdae35a7c4bdb35db231a9b2ed6";
+      sha256 = "2f461c65cf7fdb0f16ed61fcbf8a739f216449808369966e11d07ccc89faaea0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/hy-AM/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/hy-AM/firefox-137.0b6.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "1f521d72731031bac9e5ffd600373dbb8eab927eb1825be2c6e2d5ae761ec9e8";
+      sha256 = "e76fcd5e60aab8ac13af8eb4db3a288ca6a3b3eb4795ee959f26decc5e01a6a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ia/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ia/firefox-137.0b6.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "ba00b2c069ec716773f78f0d397274631f9a02de0e0914a3257e2a19325469f3";
+      sha256 = "bebf863d0ac19dd7c954250b0a38c4c0e8d4253535fa063e7329ffc5228189d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/id/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/id/firefox-137.0b6.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "c6defb85dd15ff4036361baf7612b7904e8545a661a7e61ae00aea9545a67f2b";
+      sha256 = "d42a5c6cfa01eada1b0eab034fe2b8ba39e5b33eb8919ab07d728e9f8fee36dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/is/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/is/firefox-137.0b6.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "1ed29ca8820548ee97cfee241e666e6e6b8d2ab9611639ee24882917ca0aad25";
+      sha256 = "9c9f167540484028a72ee6f4e30ed4cc688b9920ba4aa11bd53e6fd4f1fb11e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/it/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/it/firefox-137.0b6.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "e0a3bf323dae9d2e81a99651fd7c4289468de69744cd37bf1e13992c9a1e8c15";
+      sha256 = "a46d0371e76022ad25fd3aa1d7bf58c765753bd6324a4e437f81cdf4eba41a01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ja/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ja/firefox-137.0b6.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "903f535bd9d8333ce735063b9079d0e7c787076a8c9821c5f232fad0d561c527";
+      sha256 = "bc55070a9fcae8e5584608622e3cd322e6f4df1d2e493b74bc2c59d53c49746d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ka/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ka/firefox-137.0b6.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "2a395f1ef5210fd004bdeebf1784a89d360942f27e65a8c6a79abfac87493b25";
+      sha256 = "5fd662a2e76b4d143250e05c39e67b5ac692d59d48cfe00ac5021e8c19dd0cdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/kab/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/kab/firefox-137.0b6.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "37d5a028c5ba6e95659fc516e8ee3498277a791e1612dfe529308293246a798f";
+      sha256 = "c0abc375c9baf681a9e692ee315d7a80321e1e5d9f4af289a9f9e35bae6dcf1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/kk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/kk/firefox-137.0b6.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "b9e10e5b98931c7ed7665bc763f13a1f19511734103be631caea655b7f4fb9b2";
+      sha256 = "8bbe5c14183c2a00ae14e58f72572ec28ec1e699660774834d5b45d09fcf86bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/km/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/km/firefox-137.0b6.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "258b525aa195c2159eff0a68a690ac5371ffff7d9d246fa34414f5294e01a585";
+      sha256 = "5304f667494f0be0a7df6c78417d0563232951f439b7a99d1f90627605dfe8ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/kn/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/kn/firefox-137.0b6.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "ca2ffe96bcc19015ace7d36b0792dad61c9131731138f853a560836608248dda";
+      sha256 = "5b213b7d990675528e56b9f1fafde38194a8abac8c5469639fc13f03f27d47f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ko/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ko/firefox-137.0b6.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "d9bd90804420fb027468e640f50676a81569cf288a00d1ce4c51c4e6fde924e2";
+      sha256 = "288276e234fa2b7a0baa95eca519925fc9723b7e552f1b98df35c56272ecdfd4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/lij/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/lij/firefox-137.0b6.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "12d0bde634b6f80560c3245e16ba7d15b2b71196c2bd2fa0270085f2af84865e";
+      sha256 = "664f8b30b18bd1e5ce4a319d345c1137fb9ff26ae8d674037a8f576557de2319";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/lt/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/lt/firefox-137.0b6.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "7e51e903243ada645b5a4d88bcaf16795e36ba67687b9bc94e41a3ae6c5ab6c0";
+      sha256 = "08f89f4b28b591c97ef70a8f6ad109a35218a6cf500c8b98af3664d510081b07";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/lv/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/lv/firefox-137.0b6.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "b22a8f808acc1b3376a8cb058846dd7e0fe2a2dffcd505bb011551da4b1177b0";
+      sha256 = "e51057306c5fbc07697f4b220ba0fc07eef3e8b008edf0124f52993e75eaa927";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/mk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/mk/firefox-137.0b6.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "b575aff9376a487080b0d435127e301ebe69c30f037eb5632eb482c7d5444d7c";
+      sha256 = "66d0996a97c03ce1a038435fd34dab21e57a48470c7fd52d87ff68640759b866";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/mr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/mr/firefox-137.0b6.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "2d5a1c879b40881f9764bdfed536f0a2ab60411ce94b2f7038babd12601643e5";
+      sha256 = "c80765066a0e6028581f125e99bbb9fbe02d651e72b5ec3a7f872b6b776d9de5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ms/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ms/firefox-137.0b6.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "54f5813c8887623b965342491c16671ee0b43f608f67f0c2cd4174e2fe855b67";
+      sha256 = "895a05f22dbeda2d15a29a4b1304c3a60578672cfe6891f7dba3587eac6dd2ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/my/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/my/firefox-137.0b6.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "e73c0631f905d0668cdfd1aba898ca817e96fc02361827a93da3fffb5f1d08ad";
+      sha256 = "79fb7d0607143bc410aee13f3af19c560b45562d08271f3868ca6f6774b159c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/nb-NO/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/nb-NO/firefox-137.0b6.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "dce5870345c09641b437a0ba35e25a86e792e2d6b80674970772f4cf65e0bd7a";
+      sha256 = "e1c5d43c16fca703cd633c0629ffc7d5449e0b9156bb2f862d342202e666fc32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ne-NP/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ne-NP/firefox-137.0b6.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "296d44839cd73515cf0c79d8e5212356305f6dfb1f567637d55cb9b2cb7d30df";
+      sha256 = "1c6dc22dc5159f714ef087d8e7e57588c7b4b4fb963a0f09588734a07a17b197";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/nl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/nl/firefox-137.0b6.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "cfea681c1da364dbff2fa8f1727ed6704017baffe280fd83b0bbdf6836e28c4d";
+      sha256 = "c1fd85979f4c5c0ae7839940dba435ace305064a8ad5d704ba8cc36bf9f3caf5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/nn-NO/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/nn-NO/firefox-137.0b6.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "576abe3e2fb9ba2f97ee9d4e0fdbc60bcf6744487c010feca2f191e611ee98a9";
+      sha256 = "952333ace80370bf7e5bc9399d8063941c0b459b04dfba2d805c5710486cf8e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/oc/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/oc/firefox-137.0b6.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "e45a8bbea979e66da941de6289a04f9e42991d7327923e5e132beb72baddd89f";
+      sha256 = "8e84077e1bbd228761c9876c027212c63fc7b45e6096984d0f70f8f68c3d611f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/pa-IN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/pa-IN/firefox-137.0b6.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "1c6a898734ced45c5630f2ff33da28bae3b8bfbfbf9e9837d066c17f335ef15f";
+      sha256 = "840c2cef56e55b9783a9f9fd700c830e4839b0e5c27533bbd74b0fdca26cccff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/pl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/pl/firefox-137.0b6.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "0cf41964905e84195bdb04936038aa2df0e5d647eb1b401d7a5eeedb6de6f165";
+      sha256 = "ba7766fc90c1b7073c69e96939cfdb93a4275fd8bdf530072b5e13ad68004fef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/pt-BR/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/pt-BR/firefox-137.0b6.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "fb47747dc3bc311fa448382446d7b3fb14b8a8c7d3bbfe428755a42fbd7b9794";
+      sha256 = "c157cf1b467f9d9da093eadcea7ba088d51730af0ab1d2a73d9b0134eda62377";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/pt-PT/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/pt-PT/firefox-137.0b6.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "5bc9efa26e63d4b368919624ed01434be4196d945069186241bfe9b43b0d7080";
+      sha256 = "12e249226eac5a7c28944fafc8cef2c9380823630b373fb5595ebada0a2c515f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/rm/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/rm/firefox-137.0b6.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "005fc72e89bd385a27c3b446025b36a5274b5e326fd7307f0f4089ea9cbc9298";
+      sha256 = "722e41d4a9b1fa518460fd62e5398ee0cc7dea1a9c72b87166a36686a74d5ecc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ro/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ro/firefox-137.0b6.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "f4920edf149ba3d0b5c6c485197ce7fcf60cd4b0ef330de547a031c5e2b6f198";
+      sha256 = "d5f7c246005dee529593bd528acd2f0189955937ee49260695145c7ad7a48b3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ru/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ru/firefox-137.0b6.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "4a338b6892b588ce1d5cccd3dcf32ba227673c6c50f877de3aef2ea21716216a";
+      sha256 = "f06c0cd02fef6a3328f85643ba7a26bfbe20d5399568c514012ce7d58fc37809";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/sat/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sat/firefox-137.0b6.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "984f7b981f81e4fb16dfeb6ec5d572a41c1c4c850ed6d024accf5770df8c89a5";
+      sha256 = "9e5fdcb827a592014db96c608e8552beb92e1546cddf024393f482139dcc7083";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/sc/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sc/firefox-137.0b6.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "477cd97ef6ba163795d707c100b06d61b4e2d6dd5ee1ef7b4fa4a7f4748ff2ea";
+      sha256 = "d932bf94b8606d3a6b53adbd9daf590e48c4228e48bea17db8f9d76fa90e9951";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/sco/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sco/firefox-137.0b6.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "b6a1729b27f3c2763ffc3286b731f08ec90b1dcf71c3f681e950a76e34af2c8d";
+      sha256 = "5b59636a3da7e8f9e4d0931abb85f2872d99dd2d9c0c30c328e9c36a38eca279";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/si/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/si/firefox-137.0b6.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "6ffada82dc5ff50d1f2dee9d2f55e3c3246b147c38510324d2d5b4eacea517c7";
+      sha256 = "5476f94cc2c43bfa771dc0d6acfeb5a3a82ab00ead49d6548af3b32c65b2f016";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/sk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sk/firefox-137.0b6.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "47c3434b630e1fb53d9513169964e0cdfb51fe03f433f2c5b6e2f18b9524cb96";
+      sha256 = "684e44c82b2bf8ed5cb754c75c646a8d71ed83e9026bde16379e7f0912d20d26";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/skr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/skr/firefox-137.0b6.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "d652ba1825c5d29c18d3a2dd9177957b8a1d3781f97f51b254c827f1e3b16d58";
+      sha256 = "68cd2650699bbf2b60138167fa64b6825e52d1c3a4412eea604e023396a2ece6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/sl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sl/firefox-137.0b6.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "a0f7c89815b1936fed19de232459cad795d8fe6893387c88ba532c62db0da5c7";
+      sha256 = "4789f621a6a67f23adf0a90bb76458d345503ed3aeb977f6efa253b6ae214134";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/son/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/son/firefox-137.0b6.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "33ba7bcb2a2949df9c1dc7b51fe2c0d8b672c1a99702234df37f36cc2e4bbc02";
+      sha256 = "f089d74a5fd936b3192aa5a9f676382ddac67f7a01057cd0c65733314231f4db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/sq/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sq/firefox-137.0b6.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "d56926ab996ec03e98a29041a409e66bdae1bd4508cc5d1f678b1743171307de";
+      sha256 = "b4dbc9ed0057d448a0110743fcf090155dfde45fbe5cfb38cd56face7a11bf83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/sr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sr/firefox-137.0b6.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "b37c4034de8f247a2971a1d8fe5d6ad83968e54e5620e498a6ab0ac87acfec04";
+      sha256 = "f93e228112588c8346763eb5563ac24a456a3c79a310dc802532fcd89ec01eb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/sv-SE/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/sv-SE/firefox-137.0b6.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "4eab7047e7763a2eadf04b790f07605ec97ca63649c93f5e1ac367eb85b0fa7e";
+      sha256 = "bd71f056fba247199cd76e2659ad9fa9076923a0175456794213377d5fa04bcf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/szl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/szl/firefox-137.0b6.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "d282eb2ce46b348088f32608887714707665afc13624e4d099c648658eb05a92";
+      sha256 = "a786e69fd7adc57b5bc0efc1cb398d3a6eb89e664aac82a6dce6499d28ab9ceb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ta/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ta/firefox-137.0b6.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "5695f2c7160e33aa45ab09f5730526219e11b50db4e351f29c2c98c5755ad7ea";
+      sha256 = "56eef689bf9b139b691da398e1a503c87685c68e5595efd21d9cd86a0ecafa30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/te/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/te/firefox-137.0b6.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "790beb4fae374c5d5b776ec3e3128d3cd19941c59812bf1e5c4e7d1b38f22627";
+      sha256 = "d060a14e823995c101bfb555e68e0737d676b2ab84704e96d50b0805bf0be1e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/tg/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/tg/firefox-137.0b6.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "e79a1fbfe315699ffe9167ff9613649d307a14c7f50ee81fbd95af306eea6b3d";
+      sha256 = "4de24a4309761005e0d2198020931c21bf4866804970b6bc369e6a5fc526b04b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/th/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/th/firefox-137.0b6.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "efdc38851f67a4018c25416adaca475fc710f12513ce0b14752b2f8be67d85dd";
+      sha256 = "e9e5435b3236be0a81dfe7e35ba71a13d5a488391fb12dbb67bfc3885ba3224e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/tl/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/tl/firefox-137.0b6.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "204e30a985d411472355e05efc5855963c66e28803cd1f502c55c9965c7becdd";
+      sha256 = "e93844a494492a2694a11842f1d02102d0a3fcdabbf8bd5194ab631177916296";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/tr/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/tr/firefox-137.0b6.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "4f7c3ebf5079e03dd9a2a5ceb2222d07cd28157e0322230edc3bfd05b81211bb";
+      sha256 = "295bec800c0e51d6cfa0252aa89f4fe38a2ba5df9b6315ecd6bfac3648a6fc90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/trs/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/trs/firefox-137.0b6.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "fdbdb93f471396dedec5197a74cb17926b5e3244bd5502ba307317249abece23";
+      sha256 = "279f7ed6f1cbab99448a48d5e0dcba35e0665a3ebd056f43c28777713247e41d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/uk/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/uk/firefox-137.0b6.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "a6a8da6a216a261d5c5d259ba8cfc13c12d3ab30e2296ee345c5ef341bf98db3";
+      sha256 = "97a5fe066b4c115501364746ff4bb539f007468ed5707aa493092f7b5f5aca09";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/ur/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/ur/firefox-137.0b6.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "6a945ac569c578182a304ab5a0c63d1efa996ae300d952dfe93da5a63c62ee8f";
+      sha256 = "02ae00193a2640238cd6e17063810cb610e8b92e133b042bbf698c37601f212d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/uz/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/uz/firefox-137.0b6.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "a094ad78a6dc4ae8dd1ff1f799412da17a4848551a8ffd128a4b3acf05987334";
+      sha256 = "b49ec7a8c9f9714b7e2b8c00b488d7591a710f5da0bcf4d9d1f990353edcb0b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/vi/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/vi/firefox-137.0b6.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "332b434b8e479ae40da747dcdf2db81f0eb4034573ab3b665215ded3f3131d20";
+      sha256 = "3cecefc2fdcdc9b873fb9624e13907b3cea0332a2568b8777d9762866be68d3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/xh/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/xh/firefox-137.0b6.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "7e1be50884018fb2107c9bb672bb8e29ededc186c36c713e6ba3e9bb81b95365";
+      sha256 = "3663a0e91f9d25c44637f0a9e88da826450712d433ee45a67e490b2ae3124b41";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/zh-CN/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/zh-CN/firefox-137.0b6.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "cf6b4d544004b7bfd9de42b25b8c6b89b4008ced46b29ec883cfb1d08573201d";
+      sha256 = "191545f20c8af7638001fd1250ec79c907f208a3ca475f6355f7077b2d89ec4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b1/linux-aarch64/zh-TW/firefox-137.0b1.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/137.0b6/linux-aarch64/zh-TW/firefox-137.0b6.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "aa3b36e12a81f701224ff9e25ffcaa3905822f56a92b3c5d4fac7952f8da4447";
+      sha256 = "8f2ae93b934c275e2a2aa223b2639e9ac5ed961deb0721cc07fd09242421d8b5";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "139.0b4";
+  version = "140.0b2";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ach/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "709fe8a024c4531f515eb01a6b267a56029a03166ac5d6de413019fe0a8ba45e";
+      sha256 = "9772122fe9b864f2247c7fdb6e5d11813b25af4e86120959581ef8d1e4d43522";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/af/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "a62c1d62f6e2dfce5225df31b215f1227c7eabb220dc12043c8a5ad4c8f417f5";
+      sha256 = "dd758bbab164e46f9484b1a271b94d95dff15788998e137ba4ea6a4adc325625";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/an/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "63cc13f04ea6f0c77a6855cfad11f4f6f35bdaa3d5fc06edcf030a8ffcad7a6e";
+      sha256 = "e10bf7cb75a4b9c395aa2c0adf1f5406daaab1ed2148a6c8cad034376e79380c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ar/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "0298c9c247c673847b8154d19b35b7379345409dfb9a5d80f2a6239e972e7cdc";
+      sha256 = "09d6db922f63c3a0b9fa080050820f9a83c517c6faa0848bd104a669336789b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ast/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "f48ab573fdad0eeb69b4c70a99e8cf7af87783f6698c591d01739ed3ea870723";
+      sha256 = "5e2bed35394f61519b2cc67e341e14002e692edbf7c52b5a5aca329403ff36ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/az/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "add78dfa402bf925f4834c4e0b698b5dbe01d99e1838de9c03272f819404b8d8";
+      sha256 = "7f56c3afe0cb2a899411496e5f989b44834bafb0febda20bed7495ec5dfcd8d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/be/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "0500f7ce071b2867a712f32a830ae65a98cfd7b4beb28ea9623361affca11e62";
+      sha256 = "202cde7a9402777c80ce654b264007d13baf7e573ecb6ada8ac21a58ff80c6c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a32e773d73f2a10cf17292c65f21e0e3fc1516dd4093111ddbe54d4fd553a26b";
+      sha256 = "58d17e006afc3a024d843ad196b09a5ed19b29ab40318be8d0682b4a21e73117";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "dc1386c1677b429980463325db93c9a96c1a4178bd2604adf3e943ae6a5890a1";
+      sha256 = "8f21073aaa86facd7e5828857f3581e67949be14a359c1a99967e02ebc888a03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/br/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "26ec0871ac96b3ce28d7953d4ead1df0d2826b5c2650fe1db2af238753edfc9c";
+      sha256 = "ee8f892efd0dd4a9bb2d45609f54c7ca06e1e803c7a1abbed7bc3a80ac03cd3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "6a2ab79e63632932b673e7d22a98767b7e923094ead8ecd48511444b46be6dcc";
+      sha256 = "11308e30b1a7bb4c26779048b5cf6c36ed6f1092c6aebb19c5413379b000c245";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ca-valencia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "fb19289c0f3d03d5f66467ad740d753f43e6fc2601f87d130209ec0c836fe718";
+      sha256 = "e99bb572c923e86dab8ca768dd7016553a166bff9479ed568e0c0cf823058b8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ca/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "6380ca078dfec8f821f537a685b2b5f7b4ff9e328ef0a5acbf6257069c0b27e5";
+      sha256 = "b0cce2c03c5a3b5741cfa158f8cf294c51b881ba101695e00c91b1bd14f897e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cak/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "4947e4d6c8433efa7379115eb0523f75ec3c00bcdfa8179f97ae97ef662bd8a4";
+      sha256 = "bc26e0bd9336906decce9e79bc4501335d1144bfe4acad0e34d604982a99e799";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "49b157447c444099afa5177aa7179d98f71171fee8a89f0ce14c65fd9af58214";
+      sha256 = "d94e4fdd4aa4c2cc57c8dd5cc3f28c9287d916ac98d803048f9c254b7036b32c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cy/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "f440960100c6685444e6507a4e0f072871b410784967e2f00c04ef9427609a78";
+      sha256 = "f6e8adfabb271dc3275af1c0123a050a9acea8cb20d69da53c06b1f8b93abcb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/da/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "ea2cefb990e4bd8f283c45a14bbf7a5ca420b69542692d2bb86093c885a1f627";
+      sha256 = "a0c7e0fd4daa6f83ea721bddcb67b0dcaebfa971964d5eb8b30421c6ccf9afb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/de/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "5bacffc6c87f049f865c2a6ad00e5d26a4b4ba879092902165db0a345daaf77e";
+      sha256 = "a41061a13e540377854c68bac1e0ead0e43fb6eb398cedd1c7d072fbd1aa7d2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/dsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "f93de9c31f9d63d41fbe7635103500a81144888518bc8c2f698e39d4b0357028";
+      sha256 = "a4ee38be8dc35f327c7e10178f5d589234ece7fa82799748e51c10b9b2a03e57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/el/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "201f51c2f4f30618d8e9f614cf27b3e07e899f852504becdf46f6a15220309c7";
+      sha256 = "76c892f181579b8d86468789df62e2f61b87be550235884419966dcdf5f159b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-CA/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ef5403be996abf97e9c58c5ebcd0c74fe9a14122119c33266e30428a60c4c944";
+      sha256 = "57cf1cb329540eb612f2b2392ade585b4505a89ad32dc4bbc6adb199ec179b31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-GB/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "64b2ce817ac1cfb314a9f22456716f9e1e5d7893bf46fd6b55d203c718df6c9a";
+      sha256 = "62b77a005adc751657d1c40c8f744c7d1c0ab341a6bd3ee0e7864f69ed2759f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-US/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "21bfb99fe445e64ad8fb86822fd6d77c9c0d387530b787f3c3fc99b97723d664";
+      sha256 = "828cac8a8d7e83fd82c13c979fce4a77262be2d8bf6639612664ca1f10c96ec1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/eo/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "531b94cf1b0a20de877bbe1cc9e3ab3ae9b7dd8729586a70a43f04576909c99e";
+      sha256 = "91f3b063d16c364419ec2ccdd152c05b19a0bb38eededdd2461d79952a760753";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-AR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "f80d18dca3009011d97bb89726d9b09c548e239383412615c4a341537e157165";
+      sha256 = "b2edc4c81a5910901a6e2e9b90b2fc3c625f67e74f746cbc3ca4a32dc9115611";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-CL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f2144b0b492eff30dbd95ab92ef9523d3d7d48dbad2efc52e8401a4e4f85d561";
+      sha256 = "f35abf87c2ac7afe6f75861bf99595a06f7216de0003f91cde3c719f3a2b0124";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-ES/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "895b92176b7dc1a492574bb625e6264548377adabd1655c6ba07eb24a786c1a6";
+      sha256 = "575e9368ff7bbac6c168441d1095472bd29eeaf8dbb271bf7c1ef14d0e0c69ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-MX/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "b770be36d7b93925baf0c85fcccecb73f1c1b8845615e7631f3d83e8fafe10ce";
+      sha256 = "5ce0c62e79621a15c533768282344b523b96c478d463de58754e3808bccf4d0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/et/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e88a52d747dc3d6c5a449c5449fb2b412441f41da64c496da22f5880ba5c4752";
+      sha256 = "b8493cd786ec0beb918cd7bbe5009d039ec6e5b8fa2f8cdd80309a3325947015";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/eu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "4d7d7fe2f695c79418a746c875cfd9357cb290ad8b6d253774a3ab92fe235210";
+      sha256 = "5573776ed1d9b4dda2d0bd566b2b4c8a83906193005f2db7f953d1eb57079335";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fa/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8cb53568f15e61491f0b3c03a1e71599cac3ce278f145f638830b9d22b789ff4";
+      sha256 = "59a775986c659bf12ef00f2f13de480b69279d1881358827244eae0ba6631976";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ff/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "2f229d6811bbc2bde175dc9b6fea0b1fdf4221f9f8042cf50d67513074a45a5e";
+      sha256 = "2e5bec3ebf2b31d9a3eac67f03f9fadf249956df08529fccfb1fe6d305c99e31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "316ac34c897feb1b98f677436d4dbac7b4a5c5fc29cf07bb55341736b156ae0a";
+      sha256 = "f31288ef2e48ac0cb3fdff3395346927fd866878d22bcc9be6a70fb1c86cb441";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2b1e4ab91f25e9b95fb894231709d086d9645eb76a64e0db194dd386e8f362ac";
+      sha256 = "4d011e05781ad8cf93d704e7455e28a0325c07d0b3bd12ade2f315b918e9fe65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "1a2c3b4e20c5cbbd6531c53516bcd97478cd86f6bc8b2761fd7074cc9e0429d0";
+      sha256 = "042c4f0d7fa4a638db9dec99fd30d7af490fd11097b4adfa9f7d474bccabb4a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fy-NL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "ca55a18278f39416d4982834357d8ee4e9dbb47e129feb3d45b4912f411dcfc6";
+      sha256 = "7c44584b9bc19d943191385cc8c56420f77fba6e4f9712a229797b3cf6588639";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ga-IE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "34594aded12da96b71053623e9bdc09367d8d28281f6ea31be81dc1eab4d76f1";
+      sha256 = "33ee655e264ed6b96a3aa75e7f1d7cd6c188fa55eb6c07c633cd7a388d04ce03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gd/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "a6dffbb23c3b61f25a913933d700ace50954ae6e879a9d7d4b73c1a864954523";
+      sha256 = "24a8becd37c3836af08e14e010914563ab4a205380b8a7ebeb856afe552f6c17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "a629a7d61624ade963df689fbee4add6f3eca0f603bd8fcc75563480642e7e97";
+      sha256 = "a0be7754c2e9b50429b62decb89123da0818530ffdecfae333b2c94342d23975";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "fb827103cafe3179b1b17f8fdc21e2008a5ff24f4502b923c7426ae91fc26c91";
+      sha256 = "ad5844d9720a0847aa8ccd06fe2fb948cbebc2b1adfe0fc871d18b0461ad4591";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gu-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "e9f4437d6f8959aa9270e6cc8eb7070165a8418f4ed28c2a31e1b955948c7837";
+      sha256 = "7a32e73b96af77fbcb4a14fb6098d270a73484054ea9d8a47319247f2ba2db0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/he/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "5eedd55e647c494461a013912eaac5b1d40b20acef64a0810e74fdd72083e5df";
+      sha256 = "50a1e0ea0c17140525584a1cbb7de67801af5be12765d4d610cd70dea4ad1bfc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hi-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "3a1e543d88f0103776397decc1ae9fa2b5a96b68fddadea56c60e1d76b1120d5";
+      sha256 = "9871be936ad26228905a9bbabc94f8b027b066af8b4a27c0895fbb927dfea723";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "4dbfbb04729a97c82b4eb123d1a6623867b6ece4f26777ed12c81a9bc5f4b88e";
+      sha256 = "f950a486143e3658168f7caed53f546679d5af41994398ccd3578222c4f6c513";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "1cca8fe6f46c797b8e03923d9b4a317cab0e011c34a44feabcaea6767a4054b8";
+      sha256 = "1885e8881aa7bc06a993fd350c0368f85101d007583eb3b9145e9fc777ba2012";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "ddbb8a9b6fd89f496c47398f09cb2a56ecf51299138cdf1dff659d027f1f8055";
+      sha256 = "3efa843d3a3c1b8ca7454959ea2838ff436cb5820725b98599a99f57db4f21fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hy-AM/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "e819ccd80cfe1446cd60398e788931d12060766fbd23539932efc6e16a0a59a0";
+      sha256 = "4566fba506a4ee45d1152a5ebb716ec264e1cccfa84b011cb6bbccc1d58e5ffc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "bb5dc9c1a4cb919a2f6207fe171fe0e2c9345d038cf7a7d969fc72f6c0d9aa94";
+      sha256 = "e599c11c636a7912a5d64df4c4f642c6b23b8ac8917602319c7d1aadf2c6e15a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/id/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "04f8e8f738dad42e6c0daca2ada66ea01f7d994c2ef4f2ec329070f740a2bd0d";
+      sha256 = "788e2874ea4d845a742eb4f5ef9e02c79ad3ce156a09e1b7db19e83ed661b650";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/is/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "140e3f7a50a57f415913465372b3c0cb026f648d587eab2e2406361430c1d81e";
+      sha256 = "280b95ffa32b43aa893b0df87fdda0adb14826b8a2b195c8a8a6f21174894412";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/it/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "81eaf1ea39d5792ce31388a3936cc9597f7873eddbb6ab34ed78acf688598272";
+      sha256 = "5bf7718acb53c53244cb9979ed72c132b14b66b53caf51d554b01e601dfc116d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ja/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "5eb2dad48c1fdd9b869c89009f83433c7c43ecfbb85c6489a46bde89e935b534";
+      sha256 = "67cffcb3c101d24c384056b9ed5285f78a5a00421753524a8a4936d2ac3727c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ka/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "16cd1d3352195a758bb256d9f201d50934c016f772c4ae01133f7ff25f86f2fd";
+      sha256 = "e868d7da325cb38a4a6360aaeec5d34d2e7aa545da2682226b319b4f3aca2d53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kab/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "e9390977f31c11d995d3748329da38c45300aa43ac5639c11cc90db9cd5b8d4f";
+      sha256 = "0de027c78af9346e30d4d64595ea81d5c522bb3a44e33e380b45e0d9fcfd0f28";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "7d13ee5bf4718468f8ea20a5fc6aceff58ac0be84fa7659932e85dbbaeed867d";
+      sha256 = "411e311bac40c12392aca73a5a4315fc015ba413526d20a19c620f74a66a8200";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/km/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "999eff92897c3cb7597abef1e2c86eb962204dfa4ebd0d86842b3f2cbc7fe957";
+      sha256 = "6575b0b44caa29ba2d2ce4f69ccd0ac09c2d89b86eb9a541632a0e155e8108f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "a2d45d1ffe1a46c8178f460ac30c394a7f4177ecc8cdb4c130bf3e5c49bc2ad7";
+      sha256 = "a1757ad5a847e430271d2cc99a3ef45ea409d0f8df52d8df38012e618ddb90fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ko/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "f847db77a08952229d6ef998c7157f0c75850f06cc96953ad66fd3a024ad1713";
+      sha256 = "6aa52561db8818725fe013bc7940b81c07e38c2678ef427675d0fc58c6741da6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lij/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "5e82c700fc49d454496199107a8fcb752847cd46981754a8413af64777ba9d5f";
+      sha256 = "c07084a6bc9324dd71dc442fe24934bf29873b6e7e5158ae68eb4323507a5b0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lt/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "5d60fd80069d73d12e285b65da1e3af0eca6824c27cb80e946c856f5c3028879";
+      sha256 = "5b088e25ded761cd501be0f5617349a2126c9eec6839e3ec6bcdc0b19ec9db02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lv/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "28e9eba64a0662004171f87e2ccf23308d259bc78b2184ffdfec398ef08f89f6";
+      sha256 = "2bfe6a0bb5522305f577608ca6759013be5a947fd3e5e253191dc25376d2ab12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/mk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "83df7f0457e3ecc36c1a6376ec595f3df04543ba36d80d896cd7d68fdf6d9de5";
+      sha256 = "441e386a2c4c0f3602907f48438b390a19e1f6a00831f8160b3212724d7da07d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/mr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "879ae358c38367b634154936a9e8d093813ac8e410f8f533f7c32227845d3bb4";
+      sha256 = "c9f51bf2d9ebf2e76c80d2911f15f1ebb0272011c39059ea9a4e1c1bf83bf190";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ms/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "ec20aeaf31cd2f4b16b94ab16c62a0ebde70b738b86c739dd4deca7b50feb95b";
+      sha256 = "261acca048d14496d15c2ebd56fa069346b194c652f0f6f2cd9afbe8ffad02f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/my/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "90468dd5c6db813612f69f2b646be26db909dcaa92e66b3c3250823baea81de6";
+      sha256 = "58ba0821d03e4f362bc506b420427c02ca69ae43eb5bf241caa481ee791f1c13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nb-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "904f3f3760506b6feb246397caab176e6dd884e982dcb07274605bc067113d95";
+      sha256 = "5792c3f26540c20ba966fe7d587a1874452eb4346d72c24ede6a8bdaeaf704cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ne-NP/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "0181214f14fd5e88381952ad07df7a37efa293e8fbe903db0029e773ff1e50f9";
+      sha256 = "2f0656c6a7ae21a07a506b4293afcd85f6d3376961a71d5b45af698d67496d17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "cd1f662dcc64190d00c84b0c02d67558626246470c5cdac78fdee1408ec88cac";
+      sha256 = "e135d0459ba83b78cbd606e2fb033f8fc945ff628959103ef65747123bee7cae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nn-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "c20d2ea023e5eb1a60863cadd085db28f616dfa79c79652dc1f38c2efd2e4f49";
+      sha256 = "24ae203327f886d34d71d1820292fea86cbd39bb68400a317e1185c291739eb8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/oc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "6f387a7892a61b623ec1696adec24f5836dce98a4157c59cc47a987f11e8dfec";
+      sha256 = "fe061945a5fab1a73a03f424e02db5e90f490b3dbab11af978bf2bca27abd44c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pa-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "1973852bbe05fc0207834a6271858a8b6585254635854cc2302b45d0a10f8b07";
+      sha256 = "16e22303ce33d37a5462fe1f9cc09959a7f8efe77133d3d87b6a6b3d5fedf0d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "9919cc6421b35798c2df90729d2d25e200e24d1450003ce30794124fb88ac21d";
+      sha256 = "9e1d841a5e5457f62f20cee241e538b1336edffe42a893fcbcf616a5989044e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pt-BR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "0ca06936133a86645d2975acb69fd01d3b80fdfcbc1ab003561ecd9fc85d4467";
+      sha256 = "e7da00d2172e5ce485957061bf3b8869f7437de3e3324dc9251f095e48ae26cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pt-PT/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "48dfb1081c2bee39a5bb2729d4aa83860d29435c818bef4b80c53e02efafb807";
+      sha256 = "b44a97bb059b2c4d11fd4786be517b22db28eb61bec88dab6335fdc5820cfbfc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/rm/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "4cb0f6115a83a9e30d5800f2d7c4709431c3617fba9fa43073bfd169c7a61266";
+      sha256 = "eecf8793a52e4f64391b3f424530b2ba9fe3474ad24ef16e3388272bb0cd1839";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ro/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "cf18a73a2170ab3fc5934adab6ef6142779f8f3c1fd949b1a1051bf2ea9795b8";
+      sha256 = "b1d69873414e221ffbe2b5c7175487c5dcd97ae2b7da17011d14f0e6e1342e1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ru/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "85ea9ba70d407d009aced7ab3d1b8552b0cf1a44cb0df5d3cae35bbefec3bc8a";
+      sha256 = "823e6ec4c9a1326cc08ef9afaa50f33e892517fb94b8cf135c5df2ad0b39af49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sat/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "693a3a17e376381dba4439a35eb8b7cf03ea59dbd6c8030b4da15466475f23b1";
+      sha256 = "2c24a66abdbe63b8537c1d1eb457e1078f4768fa4e1c628ec91c801fa4e29863";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "0d031bb02cef10ec8ee44376f384df868c20a6ae96138011adcfe577a132d788";
+      sha256 = "3f49ee23328467021066957d5c46150a2b2ed2216774d4593a2bedc8c3a116f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sco/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "e38e1b62fdbf65b5893c448a8df763da3e04436ad75db1531023a800bb2fd186";
+      sha256 = "1d1ec36ea66705cd0b0d986d7f7ceca5a0b56dd98fd51cc640b3aba03454ab72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/si/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "efaac36b3c3a6da5958563d682936413851f76134eff15652cab0260038affca";
+      sha256 = "1d2609c2d3b7ef1badb501a65644d3dcd0e376a9a95fccbc751c9420aa9144ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "e60387517f08d43b27179b08a0f9f8280d9e5e1d72ebd200f1794d37ecbb7b42";
+      sha256 = "adf327cae6a85ef120eb027a8e5477654db02f829bf673db4bdcc8c05dee86d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/skr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "834d207793100f06741459b12203ebf73750abeaffb43524564562bbb7160779";
+      sha256 = "70f8da6b2e7ef52d707a80011ae8998342fa64def483ba4717f6c7e0ea1b7ac2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "9f0f2d2d7b22a2c2eb7ba28974d41d6db63fea0e66491753eea7e009ee7dd23f";
+      sha256 = "bdd9383a3d0f8f736371956852a51583e68c0227612610b3831c6601b4cbd319";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/son/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "bb57306e0b721a99b3d916ead2ca6c813315d010f51076dd6d415d53dc1e1847";
+      sha256 = "24d2724df88cedccbceeebd89e5c8087e54049bf11f291a707adacb16f4fefff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sq/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "64e95983086221f6f01d19fe37282ebce21f93516a43905dc29d3006d59b7847";
+      sha256 = "7211cb03bc81a7eb781fd4d35c6826c70df13a29fdb4486d423c718047a76859";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "456423a6a6c0c49b643d25bb3d32866c177a7856110c3cc94494f44296a836b2";
+      sha256 = "177e7e9786e45883f84939ce5eff32dfccdc08adc5c034e22437203637a9d89e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sv-SE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "960c1aade2e27b872e648f61944ea5421cfe4f7f09205dac2693cf5d6f3840af";
+      sha256 = "700f554cdf816dc5aa91b6cfbaf8bf204264538ea9b9ae3d6ef10d256450a29c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/szl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "2966c66c503b0fbdd8cf0fb141549cac9a8f34af9eb107b65aa7ed9409a629e5";
+      sha256 = "48db54afbcc1e6840e52b0a023dd6ee1956a44ee6a96930b52d10e1640155eed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ta/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "afa115d8acfa334d69f8baf6159ffbb02165dcde6593b0b9132086bebd274714";
+      sha256 = "17074b69f77f2db0bd507e334d7b74cf290854d9fe696763223487c130629ca9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/te/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "215cf233c79f4d33e0de76e4dd11f270a908b8f1fa55c6744200e86b6c862f9c";
+      sha256 = "85f1f5bb9ab7517b0ab0700bbb94048776454cec7677216005989c0c4eec6047";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "e88ab65a2a477f5ad36ec77e334c2bbe9fc39e60fdd44b5ac705ff60f01dd8b9";
+      sha256 = "417933976c3a4b3d9e001adb8817b97830c22d2500d2bd20fb3d260d4efb58f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/th/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "ba4f17f2fc2d86486dda6acaea1acfabcf4157f23c2aa39a858c35c78be3b20b";
+      sha256 = "3ebb8a62335d1ff46df072f88244c94e7af3476efc892f2116526829f854d0e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "e123514d141c959e8f29b2dfc1c8152cb9c978267aca5cfa647ca79fcfd67563";
+      sha256 = "9751edb8943cf113a14be6bf5e1f9b06368d8ad316ab3e58b0924a62fea31749";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "73988d7cc818bfbed084a626727d1bbbbb378daf849fbaa8b23f3f5a76315f63";
+      sha256 = "428675ed3f2bb5691329628bca3a1684c4154faffaf0a99d8ac7bea1e5af2f4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/trs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "2b9022ed251f2e72bc0a7f7c319e7169eaddeec9cba230ceb9789ccd6c2a4c20";
+      sha256 = "5d41e893d50d9e39325ce571341594f247b429c7316415c7df1be2d7e67524c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/uk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "f721779da0e1c681ae7ef66e789a81a3655ed7be116357c518d4eb0401937fe1";
+      sha256 = "38e28de077f6c2e70ffd42cb08d9ebdbb33873f42ec28e3f1380675818b232c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "080b7d053124ec03e821b5db14544de1a76e0b8d1aad4cbf6a5bfe7a721debba";
+      sha256 = "1f4be2e844e19a070bd976411abf5b84b8e71b68b098ef6724c0115e3347a4e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/uz/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "7fb7b3fd94aabaa611c53c6d8b75e0908c5bb93b0bdaa73a3e6e030a204d0bbc";
+      sha256 = "3b14162e19e28f35bc616fae251180a7fdf1698a7a9ebd0f43e04215fdb6dd54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/vi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "27d15b1434b9aae896a3915eb647c1078a1663b1dfd6ce4c05d8e77bc21232f5";
+      sha256 = "34aaece124bf3a1af61dd0f6a0b7a7b924f332b04a2cb86c2e9375bb40e6e32b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/xh/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "642d2ce475f6b2662ae13a54775fb4e5a01a1d25a5cec6e95bc341e8505c4856";
+      sha256 = "1055d5e93a507660405c64d8a122617467d26894b7786e998a0226442bf2e106";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/zh-CN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "1c07356d7c142aed0c17df737aa7b3e0ad38d9d4897d7df7bfd0a79a367d8ca1";
+      sha256 = "3725c141425b3977fd3120f3a6eacfbd5e2fb413a3723834e30ac3a41e5c124c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/zh-TW/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "d20921bd3d75051a61de3890349bf65280a539824403074f51d14332cb33b3df";
+      sha256 = "7ff7baece1723aa893bed76b18117ea1ec633371018443553b7eb1af90617859";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ach/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "87a70f57297d5b0c01492da28bc80d74f290682f37b19a43fc6126efd85c6079";
+      sha256 = "b884ba50b81fe756b20f463131757dd701480fcd16133185a4fc983ca17d7c6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/af/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "c14ea82b75e114e01bad4b6e0b405c9611330105659b88bf8455857e181b4913";
+      sha256 = "60654b1bfb5c2922bb55ec75cc4c5c286e415741c0fb9b648bd53b3b2abb93d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/an/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "233822a13e7ddc7eb437a6fa48b95f57c4c1d7da7a6ca54e84015b6d6cc16f8f";
+      sha256 = "ef3be35e1124bedb22f1ec478e7f55e0436c416e5a049a7ec3d97be2b87012ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ar/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "c0cd5c0d31333a5a6ba6af3de586df838adbf7da09b2d85f8310757b3c9c8253";
+      sha256 = "67f4cda86a7e272fb194b6daaee4abe1040540014a02db93fa98e01f86748b4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ast/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "e38ac58bff96c8396df39b1fe090abd67bdf9b3e410f504f25e0d24482a2d1ed";
+      sha256 = "052afbe7da0e5f8772097e25db3019a4bf8092c3369f8617052e876b162e7d4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/az/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "2c7a74321548b4d3c3c07e2c0f1127c4f54c55d1af0dabfc6704fa7eaa02b102";
+      sha256 = "394b4a7cb760e060b75031ecaa462dbb72622565583eb0ad7d3228fa1ab8b522";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/be/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "624589d8c29240678a85b5b0978b4de1c43ea7850960bab85f7c7f7a172cb4f4";
+      sha256 = "c353fdd48caf79fa4ad02148bf80d480d7ecac400368d6e865be11f479ef794a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "84b144c5d7ae2cbc95dbb4fa262b6e0653000c645c9a604022aca70ead9282d8";
+      sha256 = "12e6f03a85147c992445ad753af7ba04c265570c103a489bca7fd9e724fc9f22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "b7273dc41403f54eff659a67c8a4b70f2a4df61f62a1dd4c562b0bc75c08f909";
+      sha256 = "fe2c94b27a658388764fe5147ff989d2915f013c3efe26a60210022ab749e877";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/br/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "0815292d40fb6ebe791d7de8d699ccc0d5096c0999fd498fe30ceb55aeb7292d";
+      sha256 = "aad228d7e751e6829e9fc48a4de4c71bfd1dbbe6cf698f0c51065baab521991e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "24de75d8e893acefc305717a2f8ba2decdb722e2505385d6cddb04ad43d7fe5b";
+      sha256 = "8931cc82c8f5a22053fe21dbb2947d5b1478348f8dd7e9ee4f727771166006af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ca-valencia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "2ba91787e8af61cb24de5c122a5ff57c6081e9680f7594d02e2b363f28e16a4b";
+      sha256 = "04a5f2a9344e369adfc40c57b719446da83ab80eea582efae5dc56ff0abb50de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ca/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "da9e7f0f9a0730b2a9c4bc467da5f5c2349f98e22f683db02b5651df4a202251";
+      sha256 = "36e14338dc3686949fc391946599b523b83c8bc9638c42ee7fa424ea4f0731f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cak/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "8e77e88d9fc94f819d450ca6c7a78c618d881a97aabae5b997f7a6d69290e29f";
+      sha256 = "511fe4e4dbb53e2df4a76aa7ce83c67405f0f177d275125570b00e909c3dd327";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "a79b45aaf0e6e8f412e21e746265c1d43e7de9046a050b670ba3667b1462c620";
+      sha256 = "56f018158aa318c1ed5d4355b7fdc2de9ab98e45a2e7a86ba330a4b7f4b5c884";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cy/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "2a436e2d6a9eba59a8bcb448cb61c5730772e204665416c4c2e04564c19ac23a";
+      sha256 = "7f4a3c45b989379066dc94eb10c609c94efb62706a0ce6238c9f652b18e11972";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/da/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "c055660cefb5fe09c71ea087de51efbd4d0b8c2a349f78f2ec5d4349116ad694";
+      sha256 = "d4cbf628409e36837cfdeb25c4815bb48d469d9c21019a87960e904ef2f2bf03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/de/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "e3d546c3a20067ea5c710e6af065bcd11e6ab49a803f730873affa229a1badc8";
+      sha256 = "3cffaf86b35b6c4fc8dafac8817c958247241e617562baab0c099159f4d8445a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/dsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "50b1be16d8856605e37078f0cb87bce59f621a76c354a8d64d2f9a68e626405a";
+      sha256 = "ae5ef7bfad006e61943aab84c6b4af62beb4e2caa2b802e5bc7cd1d8cf4ca29d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/el/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "7f85663812934905be421c0bc3bb0ebcf22c5a497db7fbcf91a21b8174bdad0b";
+      sha256 = "efdbf60eeb1f6e04aebef7ef6c35d049d4719211d90203c514984dc0f506d2c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-CA/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "e5304a3d0557d7ec259e41e989ae191c14e7aa72203eea1ea2c180ba8aec1913";
+      sha256 = "72469319463c7a378e7de8de9cd28f9a64d13ba027aea08caf6cda9db297ad9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-GB/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "393f92153a7935bc161badc7d81b23803f1d6cf9ce69651097cbc383056a30d7";
+      sha256 = "593c9812fd7296bae1388d96d8b4aaf75a2f3bfcb6c1a4cb740cb28d5e34f3d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-US/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "8d61639f9b02659fa3486e2f17af815e028e87c373a1770c69e968af3c7c0b74";
+      sha256 = "eff54312f1bfa5f4be53d200cbaea6dd85f41c5cfea83611f9a6977ecc7228f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/eo/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "dcd9df03ad825bd50f3b162ebd5bc6561d09688972d7c80af15b10d1801a3fd3";
+      sha256 = "985b855971a03440ad95a69cb0042fb103b146900a7957ac61277b46dde691e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-AR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "cbe7dff319e0cf3d67126565366bf6063536188fb5b2c830e24b2b439d5410a2";
+      sha256 = "a37df3746470d646d2c97775d1e90cec189ae3e487f508fbd84523de7f6e35b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-CL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "225c027d37ea0d6da7f9de2c784ee13db182bc76ea0398ae7dd3ec90b3146b7c";
+      sha256 = "371f39656c30e7c677bf1b57696ef135191bb1b755f152b2df77638cba27afe7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-ES/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "2b349436c1ce8d99138875f11af5d5210210eaeb39f0dbdea381dafb8c5d4404";
+      sha256 = "7446b7f231a58db5feeda635bffc148ca699a3a3e792737077c177d4b7794318";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-MX/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "016fada5c527dd9c4c95b6549e2cbb7b3616ec6256c9e30c527f995af1029ebb";
+      sha256 = "b0ffd426095764a5b67cf7757f29aca249205379d2e5505f48a442e599796436";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/et/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "57eecae03d4cb2c2e86f2909e82a8e42113f86b7f30eb8711b3a6262e1157b4e";
+      sha256 = "9d67e8f49fedffb0054f6e211f6e43eb63767a0ce9733827f5ebdbb5d501305c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/eu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "af2405d4e1db8662e7cc6f212694ab80f607c854ddc707d5322d4a0565227f04";
+      sha256 = "f7902502f184288a7a3d3c22918711e9c7b615aac7e6ee233cefd0bdfcec7cdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fa/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "1170f8ca54cc2eac1a2bdd9a63eee87b29a627d30cd2f06e91e519ac2be2b05c";
+      sha256 = "7929c783bf090082fc51cee3e45398396ade4909237e9ba951c7d07ccdaa0126";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ff/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "bdc3e84a777bba9e664f29cc3e109af18dc40253b0f9b4fba57765b604d4320f";
+      sha256 = "64260c4ba89431f4537838ac0a4ad15aca7f2e771e8f7150f42cd7790be32e39";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "db78665b7ea38f0f5f054949d3045239f6971b827e781bf740650596e7d91580";
+      sha256 = "388366eeed2c2487cbfea71ec8469c317b9b4315fe775e4aa629daf1ca6bee6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "9a41a156bf9c002d3f438c2895e3154ac483a67ebe6f80e0eee2b01b7fd7244e";
+      sha256 = "b5cd62e23ee855775e0529f849936dc0ff949605372e217b9cdb4dbcab135a3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "56220f6634ea0e7e69a29f07736120b46f2c1911e82df13a842e4101ab0e7cf0";
+      sha256 = "4fe3aee24eec68a7b88c40e23f035848030525b74cf3e17acc81bc84d5c0e086";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fy-NL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "9334756030f7495ee55780665ba0f8587331364ef4221393106194b9ab938362";
+      sha256 = "2efb11fc2c9ac5591828fa237c4f3549ac6a708cc8ddbccb5517f6408c362eb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ga-IE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "96a68363e3a6593f3657da4d5add4af443b2db60d30efdcf23485244472e59eb";
+      sha256 = "64e96b326e33d74c2fed43d45c1900d3c90593c9ef8da0ecf15c1b5a509a5f1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gd/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "2a21ee5ca1acca96a81cbd1c0f6f0ce8c3a52ed88ba787d98d6059bbc097e22f";
+      sha256 = "947d98a1333460ef5d722becc2d28599425e4f877c522f2f11bc320edebb8a77";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "bd8a9e005ba534d5ab7436f78b02cc84f380bd36a4044a797085f529b23466eb";
+      sha256 = "8f3b052afdbe5371a4d2c87100f005aa1878a06ffae8cbf75dd95cc6003a7d97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "3d6aa78558ec05bfcab9872160c7ee06eda338aacdf78974022dab4fd047adaf";
+      sha256 = "c9fff849e03704d1324680eb856d01b051e8395e7dea9ee80ceba2ecb1c2c83a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gu-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "37a683ae33978ad481ef68f40b3c83f27a85b13aa1b55b905905c2d3ed1ceafb";
+      sha256 = "d1ba1fd9a19556f8d1128d3b6025cd862210d8635f35221ae96a894414c1acbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/he/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "1916e775b875911d87365bfdbbf549ae728ab674814ac222edb955853a224273";
+      sha256 = "5624f4bc7a3b700e602af22443d40da302fcb604240258c5ff1864a32040421e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hi-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "72a3b2387777f16e2b5f8232522d4080a276bf60b853a564f5e70c37d9fd2e3b";
+      sha256 = "d67706f3213f12d475250f0c1ee4d7e618b03bba9130803bf7cea24d5d46e770";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "4186afabb2595f717bda2555348fc082ea7167e6c83f03755d925ff2c084a31d";
+      sha256 = "55b89834e35ef17fb1d619a7ac949f0e662531892ea2c0d17fa5f6131e4575d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6b12f273ce7cb98e913ebe1785e2271813c351fe85203a8e96558bee3d8b802b";
+      sha256 = "1c112a4996b5c32971ba5d784379ece5bab5f9ff10d3568884f76dc2e985e47f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "f689294ca4226c898df2ebcbfcd60c4b9fb8bf529bc51df60b36896a77b3fb95";
+      sha256 = "748830a3236b3165c25cf4ceb91e99d1c082c0df507e76e49825fa7b8437320e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hy-AM/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "c1483077c18d4527053c7d979f9d8abc10710580295056f6fc14ce0034dd0711";
+      sha256 = "f836c11a40efc7cf1aecaa7719713f282d8d983c1df5d747669fde975f9173ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "11829a72579c847b78622bedf1aa6e5af500bf2eebc04bd10cbf8c7ea7790b3f";
+      sha256 = "9b814a6c15a9418f4e412cc265798d630fa2a935fa714db4db17b2916f3dc73f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/id/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "2217188bd592ca5c4cc8e2749ea31015861287c59fc14780335e42275b559cae";
+      sha256 = "d47fa1a73c96f23fa169fb0ca4dcf977e4bfe264be21620a61e91776381d09d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/is/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1ffab05f776dc59104a34baa0164d6de764dc8882f4c7ab2748b59c492823c4d";
+      sha256 = "2c431df3eac6468a456d568e5659d422abf7b529e7405c522b63ab5151011825";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/it/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "3e9965d635107eaf2607463508d0da22906bcac4db645dd43708ad885c037ddb";
+      sha256 = "67d030c97665b64ea8ce7c61e9f2f42b1e2f917debbb072887552bd2640aa031";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ja/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "1a971c6f7e1558b6a47ca204a398c5b1b9be44700726b8daf0c0298271b5562c";
+      sha256 = "28a3bdbe49900a2b290a986800665bd610aaba582ed852c7d7c16b36efff4f90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ka/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "4b7c001d19b96b0254fc3d5760feb2f473014e5ba1602d320fe179d8c8e8e1f5";
+      sha256 = "55871733f141fce7cb20244efa9cce6811e79c45f5f77177de5e9ac48bfd2c1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kab/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "4022280fc975d0fdccfe02ec6ee4159936a9de99ca2eed8d6c496f290a5a6d0a";
+      sha256 = "859ca377458e20fab592010257ab7d10552a8bb60d93d3936519c1b6cb6a82d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "06612dc7f831654df0ca60cf3c2ab4fd1e72b4cba16ec496f02528c0fd4fbfd8";
+      sha256 = "1759ea36efa1ccdb77734b0886c00c797356435994fed5747dc644ba0a18a477";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/km/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "91ed4c4b6b6f294b8d47b013393bfa48402a63c6f4d2f986947d51729c624f12";
+      sha256 = "f0f9886f6324a6fcce0e76c48457ade4a891f3c38e1a91997b5f97c34ed66e5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "a4a2e2c5759805640ae3080c563fd0e5ca127e8b5067351928b6dfd10e45a761";
+      sha256 = "7d79b905a38e09d9551e423760ec2ca4e92fa1ef07c676da822567d9e157b400";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ko/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "2e09752b2c02315d79185c86e546f66d314a5c158720e1163132c54934c06ebe";
+      sha256 = "030fc4bde9e14dd0f67c8007827f52dac7a623112b250e39c67ec4621818f2e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lij/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ebf2dd79fc7c373feaf517f3030bddec4fb22879452cc3abd6192d5868333fc2";
+      sha256 = "2042102cf667d81d62870df30e00cfb6015c7032f6367d2eee65bbc646aaa13f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lt/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "71aa1ff3f47b4be838e06bdb791bfa70b638c09dbddae37128c90ff4b4974998";
+      sha256 = "53e504395c32ae53b926505cf3fba5f3dcbae8995eec8657be085200e79bff6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lv/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "90b01be8cb7b2ebddbb2966a45f6ca29a86feb1285db233012ef85f301ca4fed";
+      sha256 = "0924feafc5ffefa07bf2d805ebb3396b8ab565f92714ad438a2077f395dfe3b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/mk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "f6fa830344486666e46113e5515e1f24a0c32943db3c6bb7f02e5ad3db6de2d9";
+      sha256 = "44c9fff89d42c44ab2eeeed8ac54e9ece3d52ca3f3c05a7cc800f5ae458861b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/mr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "2c58107d0ab0cd7c5fa0a4030e047c892808c9d6de05123cd0337ce36e54360d";
+      sha256 = "1740dd34a0d1a0f4b529535473714b016bda43c2838879b5991e43c8ff11eef4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ms/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "8afefb023e6bd415c29f075e484bd0783f5f05f10616d4f191cff8839ce372ba";
+      sha256 = "669c371e0103d0da8df990f002e1f67632de4fe01f4c4fa18c620445176de1ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/my/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a713b3d904d5590488141f331d89560b0fe3c163287861b6c709133521aeda99";
+      sha256 = "2a312674d939b1cbffdb708a36d8159c1c7d7ae18fb839952db0a99909e11692";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nb-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "40e037728d2697304965ff04db4e8d8206335a7e52866954241766182d9f150e";
+      sha256 = "a8df416206c09635d76ef4b76f194c2044bf7527b187787e46cd445361270c87";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ne-NP/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "32e752b56699102d5d0e65a5fbb2644b7d95059f12c737944a56c9807fcb5d4b";
+      sha256 = "9551f9f3a19efd9827cf8302bdd4ccffd9c84c5bcd34a874bff741a8e2f8b312";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "086f26eb82543f2f536b3546782d9531b2367c090244bb3dd7d7b3766f5e3bdb";
+      sha256 = "9766566147c5d4b1c2150258dbbb719d1f9dd971bbb8c81c0b2a1feeeb867046";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nn-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "8f7faf5cf79fece9aa05dead8931cc51829399c1e77d865fc7a2e90586ffa68d";
+      sha256 = "413bfb495237e4f7bbcfed9a2a6511c0c9e0ddd84c08c7ebe939675039969b7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/oc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "7a6743d63d6ebd2c8019e5e4431d0251eb1764e5cb4c2bcd2da43489c304e0a0";
+      sha256 = "a51718ea3fcee92b96445f592ad90c51e011dad048c00e547566929968101f2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pa-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "25c72f3a21ca5c1e09b4d6c97fe8ccda39c107ee4ac23c447cd7097d0fdd8eef";
+      sha256 = "98bdcd33a7053afe0a770818337d7cbc358c387f263a6a587065adeab091d5ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "f1adf8d5eedd479cc763fefd80306a4f400a0b8838b356d223aab85f305c0b51";
+      sha256 = "80d06c0c7d211136e715bc0d708b261da09f17e4182d302ae2c673265251452c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pt-BR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "ca70a854d9930a008fba706f839840408dfd37b7805b1fc686786c7804906c1b";
+      sha256 = "857d512372876071be9741ab69ead9641221578e66b46c08be0bd4b9ceb67ee5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pt-PT/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b81b41f9aca42e313941fe69c2a884118144640f5faa53fb16b21e0d19ffc640";
+      sha256 = "b8b555872fcd6f6dfdaa08f084ca65fbf33d58bcd8419973f2efe25b3d03e5e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/rm/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "68b07bd5a6f6adf58851980157e1a04f6a0a069d4418fbf74108eb7101e39905";
+      sha256 = "ca253108c8246320aa47376f5e6dd0663d76c7c05fcb8d156f3d4e236b1329e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ro/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "34962c09e2f96ff552733d3e70363989122e58657d85488d215b12aba6a478de";
+      sha256 = "8006f4534e48d7dd26725dd3cd7cae56aff960181f9f7a8e63648c90c3afafac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ru/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "631f44ac7908c217df544986041576f22afa37ada0b550ceb4f143b68f6f044d";
+      sha256 = "c57b4c19aae50965bd88d0fdece6b999f02885987d2fe52ce251e2cedb175c2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sat/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "f55ed94a407e02de8f519e0db3731c778ae27f53dba62a4d27dea12ee5c69d67";
+      sha256 = "a15d19aafd33c8a95b2fd7e9f35086043e08151255b7eab880918422a2c6c727";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "ecdeba036f6d3c69377b282fc11b16137ddcc97c55d49f12a6497b3ddd857758";
+      sha256 = "9843fc42dec2c3af953736915c4ba815b170276442f679c448ce094bd844d152";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sco/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "a9c5742f64b9018906b5fabd9373e5fe8805a447a001acbc3106818f081ff09b";
+      sha256 = "b6991a246b2328c04ddd385ac16438f4e73da1ed9ad2485e3ac322b26e3c3a68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/si/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "3621682261e1243d64012ae5ef4508458ef088a20c097f22d0d3889b2c0fad00";
+      sha256 = "2f93452a96fed41bfbaf5467f33372ebb6b9f6c0ba5ba40cd1f349b8c983e71e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "15ee029ae13f93060ceb44bc032e90062fbeb4e7f1cddd4acbdd8c03187441b2";
+      sha256 = "47e6d512ce895898505b8ca6b7105ddcb6017a1f3b0878dd904244c2826140a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/skr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "c61dbb39288239c7620c87d799fd745f02f1e2e4320ce8f44f92aeff38e35204";
+      sha256 = "871e23a7c187230462ebb61550c9083b2d898c5f76160e95913a0fad8f60742e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "701b3105c92bf18dc0baa508008c6a9208ba69a67babe16f7404dc50e5b5c822";
+      sha256 = "57db29bc5fd0f98b231338bb256e07953fb54867cf483de08b7b530526f8defb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/son/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "a7b5fb0c9cf055db86b411d5b4d8fe7b154dd79da1e0d23f050bb890e111584a";
+      sha256 = "72873188351e9dd5ba46fb229eff1306713944a45dfb6c96ca24bb5ab4ad61f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sq/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e88c917629b50cc933daed3134bf61bb9a7021db66d5840c00e179afd22af58b";
+      sha256 = "5acec6030e5705819159886d9a719fefc5aafad0d69b58d3cbcdcda1311264fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "c06aa97b94fee81c474784e005ea0b87fb108dbc023697caa036e0c8b394e825";
+      sha256 = "74ac1e41660b8127c701b30e616131ba46e87b47665095c0836fb70bc9525d10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sv-SE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "972103e2717945e1c7f53e6606bbc6b8939f9030a4bcb2d4fc718e230669eaff";
+      sha256 = "62676a28d5791d0bdb0ab45996313442d9ebe8e36a401f1750e3522f2148bbb8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/szl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "04adc5b6186a5af52d0e49dfb798bfd7da80553cd284763b5affc471dd1e8328";
+      sha256 = "89c2be0bfcddaa8c44bfca3ab3c91f9c257b1ecebcbeacea203673f4a4e0edb8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ta/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "44934dc8cc75f9e0d96812ad7f60de98b1fc7f2008926afa61a3ac81d3c43977";
+      sha256 = "6df705686cc62e94fff63e1eea2c962e6ac8e45c797755809f4ef7657e97f489";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/te/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "a65484fff230858c4f0ce1c8554928e469fe06c5c0eb941217ba770a15cf3762";
+      sha256 = "011478d18c5a07bee2dc417a618be95ed94b10f9e97c315c2114405219f4f633";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "78ea45f86204077dafa932bc892159ae11bf1bf8f32a86b9bb79742944115250";
+      sha256 = "bf71f9da12c8060543ebe48ebfdcc6e2e16a8b86b930a138a7a35996d6308974";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/th/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "937d5f0858d4701a739557a54df30dc20ed3dfa0c92d9c08909b64c57ee34dc9";
+      sha256 = "f8c6c9c5a8d51df500f463cab3951addd59a11eda3bc92228d9c42a56c3883a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "977abd61324f94d41a030ed8affb6d7c99a9f44cd89df35ae5e075ff746e3b45";
+      sha256 = "45c02ae216dfbff769daf7236a31d4efd7aaca3b419ed037d3250b2a5c03658d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "a9de20042a68a2afa8726b31da47e950a5fb1578a9f1c3855fe04700dd3461a5";
+      sha256 = "ff6ab57920b494349951ba85e1e604f135a6b706a89d26a93ec5945ebba7932d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/trs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "7de7776812f6188e1b88aad5293f1472975356c989bb6dd61b53d634c1595d9e";
+      sha256 = "e3999c0c31fa0c1210cbf52ae4a936ee08d1cee6a53e9f6a2b294167317bed99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/uk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "ccc2e770e91aed87bf1690dd82e52107ef49efe2062cb08ac4a4e372b097770b";
+      sha256 = "85af79aed55ab6b5f5f700540bd0a6d382195cbf0f7749e21a9705fc9cc2fc66";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "1e61bbf085a439b6a51add991499e582a58f50453c2018d15548f0ce50f95191";
+      sha256 = "8efb1afcb3555911be2816f62db5d2d2115f416804064f4a7ea016d368605bce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/uz/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "7b4120e694d31a901d7e9224ca42034db85f27f9062463f1fbe7aa8dd7afcfd6";
+      sha256 = "bbc614544c7b2272e812ea8ebd058adef37bc905bfb989e28259c270d837eda7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/vi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "9798b0741ff2e5eb5eadf5234d54fc5c2e473ef3d093079b7b6ac23518e06404";
+      sha256 = "f6d77d1d12ebcd17795be230395f42f8499ae4fd2c954d96a2fea50102141bcd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/xh/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "17e717b6a62c34d7f0e74b9c6b4af4e04e0bb9e6e0624b5691f1762c8ac734ab";
+      sha256 = "06427fbd032094695659c8aac0b7d48b8ac49207750c72a20bd96516a086e3e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/zh-CN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "a32bd1b70bfb1c5fdcf33d0c4413fc1f3d4c7c1b355e06c1e7fa571657078682";
+      sha256 = "afb4e3d700f9c67efe6ca59e1baf98dcbe014f9abcae6aa3326a94f47540556c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/zh-TW/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0ee631ecf8b7de2ffcb9a77aba4e4dd20cb62f2a1aab53650c1c12b39c5b48a2";
+      sha256 = "1eb8189e613d855bdb4da3d929fa59ae00c87c7ce4caf26e242b77dfe4ef9e46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ach/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "d754b7c77338934ad9c988af0ca76c20b9d0eeb9f63beb9423d48902cf39579c";
+      sha256 = "7cd042bf81247ca4bf869772140a28da2cac0f38336c1b21774753ef0935c252";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/af/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "9e3893fe70cff031562b1f9b6d1a8651a591d050a02733126d00d24c8d676bf2";
+      sha256 = "0b46b672ec0ba920946e8a19b66c4c15618457fa0d70f80283e9339efe919b88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/an/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "01055cd10e6bb1e963a7b7366233faf8d2951318576a02a9f1e81aa7a1c4c50b";
+      sha256 = "cc4e3757e933755b79c35946f87b88a4dd0e9fd68ad8391e2f0a1ec758707c35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ar/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "d1cd5710aee5418d9c903f195d96f2fff01bee31875877e737399c9f4479e056";
+      sha256 = "7ca7a1330d97c5c2d242dcb9b0681768cceabbe931796d78d1db4e434c555cc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ast/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "55834b6c054928aa733035366c5b45ad19503f03730001d70a41ba6510d5bd72";
+      sha256 = "67976e71bcd80adbfd9e5910708ebba978a1ec02db046b209bee54c0e9fe4e7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/az/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "41c91dba441d06e022af5e90d2d8e77e2051e09e1cb4cec1a5fcb4bbc93dc97d";
+      sha256 = "f99cdbb0b61406a82b6d31e87a5ad60cc11b654ba20199eef7e6ff6a0211e0b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/be/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "be5610c2f38693dd6a1f8c4949bb8df06e201f4e769b986df4b3e404d9a0e494";
+      sha256 = "baa9da20ff4f0cd15f67ca190982a26ab45635a83d6fb2a60a0c537cdf3f0d9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "8bd908287a0c2871839dfc027e0e6279218addfdf0de06a62b4018097375e2cd";
+      sha256 = "493851b1cdeba502582e3f311858296883637763c6b3875c4e2c8fe1832726d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "f74f9db667a9774b4c3eae709facd5a33b432cbf18fb72365c57ce0ce9e8c1da";
+      sha256 = "7ecad658638c5b4357e06043c33ede20870f50055f3840fa76e0829341e8ed2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/br/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "a00ab0024862e999d7d739722f441b2b63368ba227346fee3e9bc80c31807771";
+      sha256 = "90cb3c30c226a64ee8e04c89ba4511741b788a08c29305e4bd37f15c568c0790";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "39b8da8c52d4fa01498d9684e0f80d2431ac029e72ca39ef431533333b4318a0";
+      sha256 = "359bce9cb8555fcfd5e3782755345c74a023fd5196629993b9c7ddb4c159d29c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ca-valencia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "de6ec7c3bfffbfb4f0783ab91c708449f0f90dc21d412220044715e56f209469";
+      sha256 = "d0c0a903e7f49cdd4e7abbc010362ef7f9f94f0ddaede5c073b7d5ed492c8b4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ca/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "43a84887bc56e8e775a1fc77238a9a5b311a3922b342c0b8937a10864a58e1df";
+      sha256 = "065d8a4d120a5f6bcdc2aaf598e96950b87439b3f091c6ab45ba42c42d9dc493";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cak/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "b781db306b99c87420a371d5504505613258001326341e12d53cad1c6d22eef9";
+      sha256 = "f1e95e51e3c73a2c28632e3f23d53d3aaf1211d9db640b8c110eaed94a97ff8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "a0e7e2d60296d59eb438d67e9e6f7e7397cec1ced5b8eda1210e244fa10a0205";
+      sha256 = "1cabba2333c315ec8a8ffa64609ffdaf3664428b6f109dfbb3f9bcefe6a08326";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cy/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "c985bf38fcb61a264e3e7cefe00ba90bdb935009546533bf018d4bd173b88c60";
+      sha256 = "aeaea449bd1427315022606358eda4907a611248ee48cf94b8936c68067f93cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/da/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "31b86f8656a3c5a92439457714d2215481e175718dad2e71a0bd12cb9d8d53ab";
+      sha256 = "baccce03f5a023e9c4db5c786416108d1e9a3b34f8e224c11b0c50089b5044b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/de/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "2931c7cdfbb9113176130df3551731c1313c06168257a1e1a393a4d8c71fc648";
+      sha256 = "cc7f6ce82a0c27854cc0b2c1aded7f589c29e73741746fa3a9dcad685ddd8b62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/dsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "e4970af22566a2c423138dfc68a7d58b58e7d3284e88f4c7f3e9d00940739cf5";
+      sha256 = "0a3aba29ef00869e8a543e5196188c42ca87331df9b283d61238ba1a8a724f3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/el/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "b12bf7bbb352c7b34d9bfb11478a0ae7717325f4807c2baef04aa4f250400a90";
+      sha256 = "d87b9a60fa65911acfe8535ccb1c8d4e6cbfad290d9979692cc7899ce0ac6b38";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-CA/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "09e94e0803a321b313a740036171cb59e049a826e737a4151713f072c797953d";
+      sha256 = "026ad7b1f2b3b746c85a31860910ae1487e0871d406b63ffbdb87e374c517bb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-GB/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "cf6922dd5832202593dab94022f82e91af46685f8c16cdf92ee6fd2665ac225c";
+      sha256 = "f26d62c55973c679153ad8b2378c00a28b068748db76c38c61c9aee03aa7bf96";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-US/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "4edba8a869dfe9c906649b5e7989748490665e99599b44c653c2fbe896f268e5";
+      sha256 = "fb8905d9af83f43bb09b453a0fbd85e23adc70eefa07efcf015395a534140450";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/eo/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "8ce7a3c2d44ec47d0c76a896005cc485a5e325f5991a50833e244cf69b8a7645";
+      sha256 = "347cbb9195e8012d39d18cfd8ada8302a5f5746674bcff21c68926d93edcbc35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-AR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "d1c49d9227b3d9e27e73f9788171c718c73829c077040520b05dc9b9a02cc839";
+      sha256 = "c3e04df1298513e487072a6bb5eda83e3921f3217408cb0f86f33c6a52bcc7e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-CL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "79c5b47dc1962faec8ef4db9860698a160b2e724145dbc3520a3b179073d2aaf";
+      sha256 = "040bc8601a976587a173a5d82b4b3ed7474dc6d274e1be504fd516eacb951174";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-ES/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "c3ea8d8ca383dc7271537b5fb888ea0c155c94b0f1a7988a69359d4930b1624c";
+      sha256 = "ed4197fe2d0279979e879eda7f51a5f3bc19b161ba0e6a031f6cea2cb22b5229";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-MX/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "fe673d9624ff97fafb5e41d4bbcb0142d24051201fcdd58ddf8863b0a169010c";
+      sha256 = "290ae698fca93612144db3d7821b38a9a7708ba1bd9aacda09f9efee8e5a2fcd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/et/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "721727d911c456833e9207f35b5fa574561789eb9d5aef2cf70c07a41996604f";
+      sha256 = "7b174a91b10efbd8d5628ea29d95a4dc7dbc986ae64dc5c7709df3f7a9aeb113";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/eu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "c1d51c11fe6eb6b74a1170e93ceb910aa01b227ff67181a436abd9a272f4006a";
+      sha256 = "36ee14d1be91e8aa663439cd08f71ec6bde8e4b13f5aaf4a17f95df4080b4e00";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fa/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "d48577e912bc8d9302164ce233c02bb0d1a802bbf6923d2f6e3e40466753e7ef";
+      sha256 = "1b538780607b5fcc3a153c4198a0ea086b245c4c6f246561179d5aec98e6032d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ff/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "6397792fe1f9b6cf9e074f6dbdc620d2bb9e5a81cd9203a6b9e19d8ebe4af951";
+      sha256 = "64362226245b8694ef956f4bd3d285c45aa5f7a31830c043fe23b96071e09280";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "8f5c2ca086de1cda97c4383b0032cbe134a4af7231def94e19abdcf794d3a858";
+      sha256 = "1f810aa9a14a0f47c48d2a485397d8164c71f9a833cea682949d582ac30c4091";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "cea552b5a870c9a0842dfc56bde4d91927fbc40cef6a1f0e36d0399b65ceac7a";
+      sha256 = "2861e18226f50259f0ec8426e419c93b268c2e9113c0cae1a3d4923dd906c139";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "baa9819189ba1ff16efeeb80052f6d0afc2306a09757630e978c4a92a74147d6";
+      sha256 = "42e8d9e6582267a374246cd83cb51a71dfb24b5c54d5b8230dcab93d47e89ecc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fy-NL/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "c1b1b141ced5a635383e2e0066f36c56b852e0e44842e86b684d6ceb8209aa4a";
+      sha256 = "5ed467f0a335d41d82007f39b078c60e244faa7f7614e3386991f7e687fc10dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ga-IE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "6a9348174c586c70f55d77ac9076c203287590eed6254b3d1eeed9cc8424b076";
+      sha256 = "edb53eec33ed84ead0b00d90930c9e0d93cf7f95835f003884190a6379d61664";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gd/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "c6f367eced3add25b7a51b8eb1d55b42d7cd5c674cc934c33fa9de86d6ef5c81";
+      sha256 = "dabd8721dbe812bfe349d89011317bffeb2eb8578dfd580e97fb962c6b234ccf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "30fcda0e983a655e8f0a87f40bf1f7e877569808b4b0e6710e58d446ec3913fe";
+      sha256 = "4c2cedbd7c26cbdc2869a5186ae3e766c27f059a5be4b745f91cb3b7d334c1de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "9c458bf9d63fec82a51b92391bc7d7b3030cce9e6228f14d5d5cde80c577349b";
+      sha256 = "557eb831214ae85f8954b609fc6c381c7334a6c8fe98c98f0b5ab5d6e3afd9d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gu-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "92e5e135ac587dd6b7bea7a4df4803eaabf509a55b98ec2a127af3293a10c048";
+      sha256 = "937e4455d075a52b5dc546840a7be025ab14266d36c287dbbfa415f9db5edb38";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/he/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "ec64a5e068e2223c95ac1c90531ef9d857fa72f03a5b4b200242029b661344e3";
+      sha256 = "2a660ac10700d2d0c8e223a7e7ccc641923e53001a9ed8f523126766919e3694";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hi-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "434c8bfea7979d256f40f3f3766c1230b8a403678893ad988b54c19188ca82be";
+      sha256 = "d2714b679ca967305693eb28655127e381ad7a4adf7e8dfc09c4ebb92385ac61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "59d09b703c2ed3dc3e289310503e505507b345b1c5b2133da6ce59df9f952b06";
+      sha256 = "8c42af036a26589817096562c089d62c035726be61137b04de137e72fbe0f784";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hsb/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "55ac7f1a2a6b00118aae7d3acab31a563cf05a23e4f35389795cdd7afd613b6c";
+      sha256 = "8233a55b9d57fa591fb5b6ced9163c9e1ad3ac0efc16106f7900e0938b9bc505";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hu/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "75265bbd21c0c783c373f2ff57dfaebedb3baa8e8f635adb764d00ae340df15b";
+      sha256 = "e36fcfe99e3885cf8eaff441d917f8b714314688484ed31bc82061eba6cb78a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hy-AM/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "825bb3ab555455af7204fc3081d4e881bfaad7272b97c7a52d574711ac6fce43";
+      sha256 = "caa0557f2ba798d0d0d0b2e1d2b084079baf1203bade06c580062983fa53fde4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ia/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "07b43f7d3dbf12f9d8a9a4b2d393b0cc9fe3ce0d333431b9d8c694abf2948607";
+      sha256 = "66c4626de30fca547e690fbae7ef8d665f138548ed29b973630c1e5fea8cba1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/id/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "bf34449bee65bd3bf8ca7568683c111e19af99323970f6070bac75ae5d8df14e";
+      sha256 = "afeb6eb9c996a7f6bfe93c2e0606f29af90b9d46d9a35633ffd6218b76dd367b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/is/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "4b825583d13bf6f4b75cba352d1bf0eba3ab97c92f62da2c16aae79174f6f185";
+      sha256 = "ddf3e0190f6ded182ed3d9cc80cb3456d2251f5a3a5af42a4eee4d6144cb04d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/it/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "2dff0bac0c85f40cb21103c48e0489573cd12a21078b8edc5af5cfd6c1c5be9f";
+      sha256 = "cd16a0d3b70e4e746f2d5a19ce448b4c8f3761e1b4879c6fb50902e5779f73b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ja/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "7012be903c3b748178a4bdd87849251f01bc341bb1d418e43c15adb8a5236697";
+      sha256 = "2761071a3916fdaf81608d12fc7356450c4abc27fe2315d7ae1768b048751a85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ka/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "bb7b562895a31c2985e5b57dcd697ea65e0627c3ca92a7a1031de12d88f2d112";
+      sha256 = "2fa470435b4e3ecd4389639b135f840f2869ba1f997e495d5b7ca3b3b472a14e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kab/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "534d152fd21b7206fa1d781167d2d39114224e694cd6e0ce0df0c51f632be8d9";
+      sha256 = "23a15e2d7667bb0cad5069a555ce7eb5ebd647d01dcd5b5008df5dd3a25c41f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "c914ef270be6d93b244e77eae73f0b8dc81ccae98d1e5648c9f36df3534b5b83";
+      sha256 = "c9ab7d7695204eab0aaf2d395484df8331dcdd5a2d3cf7bcc2ea544e5877443f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/km/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "4c4b716afcad883b4c3d4ef98f256fd3a7383c6f6f9daf004ed57dc66c9cc1d3";
+      sha256 = "6740c9921ea366cae10b37b3c5de4076f1f1710b4169030c68be12b5070c633b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kn/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "bf36d322be0eb143d16b3266f468218e4db77edf5752d92d0527737d5699bead";
+      sha256 = "938558327b5c687bdebc00007467cc911084ed13d347b3dca50bd4064a1ed0a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ko/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "d306fe18f0afb856b5eca468cadf0661a0f296900aa213693f9dfce7ce01e693";
+      sha256 = "d610e561841fa970c6be608a25f030e7bebc0812b674c65e1f32e0f3a722f494";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lij/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "4134c5b66369b7e7baaf9ed18e686aec1f6fba8dabfcea557c8801e271099604";
+      sha256 = "3f8a986918ca0504c5f7e16996d62e52a59ae812aa10b521c93f71e5495a26f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lt/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "d02e63dc5244755d70d7c6adf8809e809ad5624b5b2cf7db5d549fe873c8e030";
+      sha256 = "41c516c24cbdb6c3953cd378272039c8cbd92c4dfcd45e807224dee8ead1edad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lv/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "49906a5a4bf59e755de8002436a431adf3a26ae70865a5c14cf2b1148d67be46";
+      sha256 = "fee89b89b07fdb6de208967bdfdf0cd09ff47ef4b382b5ff6dad823e2038f3bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/mk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "d0baccadc36ae94f9038e2c22b0a90d2084c512b71471af4e8f744548c92a79d";
+      sha256 = "fc713d3a275cb918aac2960e5d02ed55c1e53a588cd1d7b3072ce4ef1d322010";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/mr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "f8015e7594ec2b02914884f5be2d50f2cf0236bbe496fec731592ac81eeeb9a9";
+      sha256 = "9770d1c413bb780ba5734397fc44a4a750759fafbf092baa2dff9b0ca03f3778";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ms/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "fd820b03aebcfda8057f630f881c49d443f14661a6bf55ddd4b9a26b4cdb9308";
+      sha256 = "c0b6fcb678b449c2a7341fee0602591178dc3f783ad914f5e2e1fde3b3889dd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/my/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "f2286cf08af4be1daf434cfe972049f40ed68b1d59a0073c0f022c9f02dee1ca";
+      sha256 = "af5a3b599a09708b6981cb3079e3b1512ab3f271c09f506c953b39936e6e0952";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nb-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "668569c1fccef37f1398b1ecd9e9974081e6c055edd0577bc464fde69e5e7ada";
+      sha256 = "0c6dd74781697f69a8cfd7b657e8971d2272f0c2c7c37efb5476a3c6d226e8d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ne-NP/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "6ce7d8b5d852ca4abd94fd8505e52a2482b5b1ba207d48fd02dce6f585ef0fd6";
+      sha256 = "22c46f8ecc726cb41d302149b6ee4816d8e5f4afc3322ce6a38621f0edfcfc55";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "b57bac3e8a06c66f93f7c98a77accfe6a21661d6bdfc148cb2d8f3ce83bdbb80";
+      sha256 = "c19785a813e1d190ff83eae04d02c6647e5423d9e3dbfa5bbdbc124aa20c0b01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nn-NO/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "01ee287813e78d073926bbeaab9cafae2a11e9239f8da1db3c45b5d6168a5f8b";
+      sha256 = "1f5e90790da565b4e661726b11fa2d07a006c25d6ba41557e20cd8fc53972e7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/oc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "7af2c95d9d6c9241fb98dc21a4c542f6e038098eca89a72aad53d03d834cf8d7";
+      sha256 = "8280752b38cf4e19ea5400ffe96c370888df59999be3ba73a6ff358df55eb973";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pa-IN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "c109cbbfc292aa3ad04656c79ee5fcd0b839032fc156499dadb60aed37d93c13";
+      sha256 = "8496cd59b2f13317622e23e3840a086f70217566bade2b749288d884f6d08326";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "ad2ee57783e372d968b9a76b4b0c5f4cf039e53f6ab8ab5169d556bc9733b04e";
+      sha256 = "466931bbf9058183abe611c927a2bf147e254c84f159a9c1c528bae40d8b62e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pt-BR/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "c4b649b39622a0cdd8afaffdf531681659ae6c092221786df71ada4f8e5dc81f";
+      sha256 = "3c9cdc685156255ad8cdc5e557a3c58de63c3d3c1293c92ea816b2abcca69863";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pt-PT/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "d84337d337c87390e8ac98f43d8b1199d3b8bf640d55ddd2eda86f3c6c2f9084";
+      sha256 = "b89c7c4d38f667b70ea74e66cb052525e692829a001b0415387f806021ceaf54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/rm/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "a8d422e2ebeb5c76a27e3df7dc8ca4052be628022d3d7df38255aae4b14089d7";
+      sha256 = "47595af5bf7ad9e8ccd76abe627037bad388bb733b625cd9200414fbe385bad1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ro/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "4b222f477c9291a0ed28dd51f57588914e26efd69c0a249cd2f4a3251ef2b3cf";
+      sha256 = "48cc3b4168318447044806f63dd4ab2d84aff91ed3315846df63ad9dfdf7e0a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ru/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "caa6d2698ce1e5508f5fad2bf90563b10a8f9961042c089f2f1a5e4d61822246";
+      sha256 = "2413517aa76e06fcfb7122c949ba8acca175201ae338b8425eb28a5ffc2ad253";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sat/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "3f17440f5a67e6ac0f7f0a67eea72a4beae7c20627ba97c786f4740563adb4ff";
+      sha256 = "802f635513658ff4c9f146b7988763bf363e9676c7c3c8edaad7d15e99baf22f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sc/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "3eb57781a60c295918d7f065edc1429bcd2685f01398c3176fbfd097bf88e059";
+      sha256 = "4b88d2609d1fd79ca3ec2c0e5f6f8313953a79ff321df92a66aadc0150001635";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sco/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "a6c32b5c1d63728429ada5211857a49c056ce93b23d428f26a8d00efbb143e91";
+      sha256 = "b89f86a38a1595d8b4052b74e1f9beb741c859f4015c7dbf9b894a08eca6fdc1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/si/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "dc50c48c50cd0fa013b0754dfcecd15015392d23e0247f33b3ad15cd7aa309a6";
+      sha256 = "cf5854ec14f712d1a12502edd0026288078d81273ee260244c8d09bc45b1f704";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "35906da5afd4bf8a52ddbd2ddeeb9ce01b40d5e93968e4e1f66541d0dcfb1b88";
+      sha256 = "54f6863f9dd7ca0b48ddd5b1b46b4b3b929fd01349bc5e2933f314388972757a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/skr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "0af03523f3a0987e32c36d182d51c318f62efba1f614d2864e571837ca8eab13";
+      sha256 = "a051e36dbcec29dde148453fd95881c7073cd8ede0ef92e3c1e2263fcb5e1c94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "d7b9c75397dddb544fc4287e43f255929f04ba3e5cbd9c8c737f1f47d4d8353f";
+      sha256 = "e18c4b176463416e35438b155748b69714a965f54e87e8cc578c483a2454d30e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/son/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "7ab390ad40c8c7db2029a5ff103e523f2dce8691926e4f3f140c911a862937c3";
+      sha256 = "46461fa15f488234915e4a6f39fc0e241c1256c6ade93d584e686552fae53d49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sq/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "3fa9746d65d15ebed2d0bef82e16c26c25fe40671ea71651c3ea55f23769a5d1";
+      sha256 = "b6bb2006bff76cd6fa875e18e0717a357ddfbd09a419126f41ac1f614bf56adc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "954194b63497a3c490f819188c7353139af87a0c6ab2a0b87ce5db1a942d8b68";
+      sha256 = "f24fb9fdd5ec517efd56a5c539916a756c6ecb1686e0ec1b1437bc30b78b9168";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sv-SE/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "ef30b8f7ba31857b871c4e41d139eee7ac6bfc759a461c0addec73b1e1559695";
+      sha256 = "5d25e7d100840d8259a7c9043e14d2e50daef0fe14ef766aec19ca6fe30e8db5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/szl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "ba038643ce7af49c6e16e6eece4a56b4bbe85a9a14639d534b9cf64884046154";
+      sha256 = "0ebdd8c0dc4f1d1f6567a9319688c7b71aff30a6999d4d57bb6ca3e50fb66031";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ta/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "b12d92276744680c57aeabdbd714bf5d3f2ea09030858d6d38d4aae80099989c";
+      sha256 = "e89ad50eb57568f223fc96751b6b426741826a41f1895fde4e0b1d3e3e48a0ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/te/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "eb5b186241b7fde86cc0f57fbe3712ef1d3831700d741c1955fd89efe84aed96";
+      sha256 = "e2e94525844616c4f9f3c51ae82a7c6b1cb4ca39272f76fc77c0c21bd1ef2278";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tg/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "b3f5feef512525cc09d11935cc1fb0b7086756158bd6cc6dffcd22cf3ec9497f";
+      sha256 = "bf8d5f5ea4c8ecc6e6764560966affcc969acacb0a6015153b2c46688b165574";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/th/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "2d187742b7e8a60f0a427b60f41f1d684d19360e562d2fc9d0f968cce4581b21";
+      sha256 = "23046863b1c3405f5ecd184a0ba82207f46c4489e1672e43110c47f5d6a522bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tl/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "44c490eccdae6a1c0fd08d7c3b589de398498f4ff705292ff6f72366f27dd768";
+      sha256 = "0955e3bbc514eccf2774d3e70ec94d890be12b50c555787937ab38b2b30e1eb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tr/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "b784b58007959048c3067a041950813ec8be9ae30a73dc24bd0b5f1b3d702460";
+      sha256 = "a99c19d94963709c38ab298199263643f9e5f55459648d4ce9a98ec46f087db9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/trs/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "611991646e94273c6b142f2af670755fe18878f2a5c61a2e9f13a0fea99ce775";
+      sha256 = "e4f033ccdf9ff353d4de0a5fd5aaf239f95c7340a90873a35ca51ad1730f6e5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/uk/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "90c25ceb18b53030e881e0f44b7d3e23c5b6c9cd380babfdcad957783d0e0c4e";
+      sha256 = "d16f97ed40b919d179a530d344a16520cf957141d3cbb68987ccffcb7a69fa62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ur/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "9be466dcebfd73ff9b5a4b0982a9421034654310ccf077fb812d652b67d6d284";
+      sha256 = "0eee3a71fdbedcdadf3ffe9025c3436a0e551e7596a0b2f386175d196d3dc73a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/uz/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "9d58ea902acb5ad35b19cd87f5423b21fb7772512156198d2fd05f84c08a778f";
+      sha256 = "b7e3707e6c76bdf87c83ca237895c651b9137b83814e8975569512c2c5c9cb10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/vi/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "2cfc4c3f5d129a3041096dde196f3e887498a886dac1ab6845fb54b7eeae16d2";
+      sha256 = "2ddbdf7c755241c1400656f65a181e6c117b08743d52127943882f3f0172c405";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/xh/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "4eab0c87e4bd3f54d1e77b83a8c82b084c23beb0d0882d542e04bb19e798c98a";
+      sha256 = "b4fadd9165a04b491c81273273e894a81667de20e06479d166cf36942edd6ccc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/zh-CN/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "e6094469887c77d367ca255d0b461d47f9a352b12602042caaf668846b5f295a";
+      sha256 = "0e6b7ff8960f0cbbc1b34a3a44bb7d8bef6a832d40f6d9bd85e8d8a54f03b9f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/zh-TW/firefox-139.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "4b5490a70185a206ad337404876cf943bd49681065d87e302a2856d2543b0329";
+      sha256 = "fbc5b78a7b6e022d8e6784c741d29d0adb6bad2afed4c5b3ff878b26f6dcdd00";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "138.0b9";
+  version = "139.0b4";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ach/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ach/firefox-139.0b4.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "b3ffb3ddcd92974bb68092b0f192e709f8c6ea4dd04a53cdd01ae3e1265e4ce1";
+      sha256 = "709fe8a024c4531f515eb01a6b267a56029a03166ac5d6de413019fe0a8ba45e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/af/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/af/firefox-139.0b4.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "873329379f2ebc5423e088baad11bc8e9e1dd9f86ad28dbaf9bff78e85a9cd9e";
+      sha256 = "a62c1d62f6e2dfce5225df31b215f1227c7eabb220dc12043c8a5ad4c8f417f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/an/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/an/firefox-139.0b4.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "6b664107a382ad84cfb4bf88f614f7a551daed5f09e52125cf4b9963288af052";
+      sha256 = "63cc13f04ea6f0c77a6855cfad11f4f6f35bdaa3d5fc06edcf030a8ffcad7a6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ar/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ar/firefox-139.0b4.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "2157430396d0e622b5bb3432b6c2da4d98355f07bcab57f768ffa4f961c7422c";
+      sha256 = "0298c9c247c673847b8154d19b35b7379345409dfb9a5d80f2a6239e972e7cdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ast/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ast/firefox-139.0b4.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "5f4041933b0788a94982d5abe82c2bd320562c42e3bf5e9ee11439ac31bd0657";
+      sha256 = "f48ab573fdad0eeb69b4c70a99e8cf7af87783f6698c591d01739ed3ea870723";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/az/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/az/firefox-139.0b4.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "b60de8fe2b27f47cec99b0fda40355b6dd0aba9f13af9b0369ea6c0149426491";
+      sha256 = "add78dfa402bf925f4834c4e0b698b5dbe01d99e1838de9c03272f819404b8d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/be/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/be/firefox-139.0b4.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "6472c3c7ea0316d54a10fc48c8648446c270c97b3605b3e84517e556a42fbafb";
+      sha256 = "0500f7ce071b2867a712f32a830ae65a98cfd7b4beb28ea9623361affca11e62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/bg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bg/firefox-139.0b4.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "a5c59d142b5d09047f1a9bca0a6f5b02d64a1a78768ad7d2845dcb52c2e108d6";
+      sha256 = "a32e773d73f2a10cf17292c65f21e0e3fc1516dd4093111ddbe54d4fd553a26b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/bn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bn/firefox-139.0b4.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "1645b8c44d52a7fe9f06de75877c845cd5e48e1cfe72323b76d9d14c274a91fb";
+      sha256 = "dc1386c1677b429980463325db93c9a96c1a4178bd2604adf3e943ae6a5890a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/br/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/br/firefox-139.0b4.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "c22c1d557970a63cbe6f215b9432755514db1d491379ba948a5f5b03c4cfcbdd";
+      sha256 = "26ec0871ac96b3ce28d7953d4ead1df0d2826b5c2650fe1db2af238753edfc9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/bs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/bs/firefox-139.0b4.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "56040544746128cbb94a5064266c366b6e15d1d4e7c4ca83e146a911cc0f4a2f";
+      sha256 = "6a2ab79e63632932b673e7d22a98767b7e923094ead8ecd48511444b46be6dcc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ca-valencia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ca-valencia/firefox-139.0b4.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "05ff5e1862b32b8cd1f298bc7cb33b10fcc23e96c9fdf9d0c6a6bbeda0555710";
+      sha256 = "fb19289c0f3d03d5f66467ad740d753f43e6fc2601f87d130209ec0c836fe718";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ca/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ca/firefox-139.0b4.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "168cd1cf9c6d44a579d0d6aac0ec94e70264346c6d0a7d1b27c794454c5917c0";
+      sha256 = "6380ca078dfec8f821f537a685b2b5f7b4ff9e328ef0a5acbf6257069c0b27e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/cak/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cak/firefox-139.0b4.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "052649cd769e1cb1c39fd9ec17d936402890af702f1e727744e16ecae0bdc1e3";
+      sha256 = "4947e4d6c8433efa7379115eb0523f75ec3c00bcdfa8179f97ae97ef662bd8a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/cs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cs/firefox-139.0b4.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "7f216ca4ce4914abd5c1bea28a9e70e73053a6ab3f4e88954f5c6f57dd13aa6e";
+      sha256 = "49b157447c444099afa5177aa7179d98f71171fee8a89f0ce14c65fd9af58214";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/cy/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/cy/firefox-139.0b4.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "7797275f345510fd867ef8f70f26df1352f2a96b8cccd0e05a8335013f81a33a";
+      sha256 = "f440960100c6685444e6507a4e0f072871b410784967e2f00c04ef9427609a78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/da/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/da/firefox-139.0b4.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "b38d4e85485e147ade0ac5b7fab531f04853923bedab7a5cb749985ac3a60ea4";
+      sha256 = "ea2cefb990e4bd8f283c45a14bbf7a5ca420b69542692d2bb86093c885a1f627";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/de/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/de/firefox-139.0b4.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "1a537b14a9182b0544d36c1bccf6b7e3036d50112f2502b36e42ea6de963e55c";
+      sha256 = "5bacffc6c87f049f865c2a6ad00e5d26a4b4ba879092902165db0a345daaf77e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/dsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/dsb/firefox-139.0b4.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "41299aef70f687ea7d6311ce2c5c00fbabac1b7b2303dab693168ec677977fdf";
+      sha256 = "f93de9c31f9d63d41fbe7635103500a81144888518bc8c2f698e39d4b0357028";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/el/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/el/firefox-139.0b4.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "5f0aad046a2b534f08eab6d15a8e8646f6ecbdb6384916feec72b23e56f17d59";
+      sha256 = "201f51c2f4f30618d8e9f614cf27b3e07e899f852504becdf46f6a15220309c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/en-CA/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-CA/firefox-139.0b4.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "02d1ea886eac8dbe58d8797c8a9be6910bc8940dbc67b4dc99077f64cff73e8f";
+      sha256 = "ef5403be996abf97e9c58c5ebcd0c74fe9a14122119c33266e30428a60c4c944";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/en-GB/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-GB/firefox-139.0b4.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "d0e216f4e50b266e407bfdd7017711459cf5c50507a1750f9fc3d366dbd0ef0b";
+      sha256 = "64b2ce817ac1cfb314a9f22456716f9e1e5d7893bf46fd6b55d203c718df6c9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/en-US/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/en-US/firefox-139.0b4.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "ca4f673d6abd3b2b4adc971097057664ad1a097ffd67b99257e08ea50ad5fed5";
+      sha256 = "21bfb99fe445e64ad8fb86822fd6d77c9c0d387530b787f3c3fc99b97723d664";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/eo/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/eo/firefox-139.0b4.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "3403de04ae3603a88748a290b50dbae659e03dbeaf2b5d53dea22b6192c2b141";
+      sha256 = "531b94cf1b0a20de877bbe1cc9e3ab3ae9b7dd8729586a70a43f04576909c99e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/es-AR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-AR/firefox-139.0b4.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "2d7908dc8106b20c98edd6853acee8c9227a0c4c9cf7dae885f7c3ecb8f84f8e";
+      sha256 = "f80d18dca3009011d97bb89726d9b09c548e239383412615c4a341537e157165";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/es-CL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-CL/firefox-139.0b4.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "90b98d20b4b59ce0b5267ef629fa902ffb80d3f7f0d16497a4c669cd2504b7fa";
+      sha256 = "f2144b0b492eff30dbd95ab92ef9523d3d7d48dbad2efc52e8401a4e4f85d561";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/es-ES/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-ES/firefox-139.0b4.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "26bcf7dac7ddb3d91a657414c6773eca8a4f7188dd2a53a55b01bec1922e3356";
+      sha256 = "895b92176b7dc1a492574bb625e6264548377adabd1655c6ba07eb24a786c1a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/es-MX/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/es-MX/firefox-139.0b4.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "a2c1b2dfa990ac22dca8d2e84a44edd1d7f5c7364a5c923cbfcf71f60020ca67";
+      sha256 = "b770be36d7b93925baf0c85fcccecb73f1c1b8845615e7631f3d83e8fafe10ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/et/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/et/firefox-139.0b4.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "d5fe2ce37d7d372f9509607016ef06c941dc5a090b260b1745975af377bcbe56";
+      sha256 = "e88a52d747dc3d6c5a449c5449fb2b412441f41da64c496da22f5880ba5c4752";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/eu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/eu/firefox-139.0b4.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "b081e24e03eccb7e0c6ce5fd9b692902dee0939d18673378323230680662bbdc";
+      sha256 = "4d7d7fe2f695c79418a746c875cfd9357cb290ad8b6d253774a3ab92fe235210";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fa/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fa/firefox-139.0b4.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "0bb48d3c9d84e5f894bd741d507b4a854b9ad20c3152bfca41e1c4178d6f558d";
+      sha256 = "8cb53568f15e61491f0b3c03a1e71599cac3ce278f145f638830b9d22b789ff4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ff/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ff/firefox-139.0b4.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "bb17a6d3cfccd4cf08ee169f0b5395c21fd5195f76b4814011743319403392da";
+      sha256 = "2f229d6811bbc2bde175dc9b6fea0b1fdf4221f9f8042cf50d67513074a45a5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fi/firefox-139.0b4.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "070758f58f545ad51645f50bff333b3ccbf5743a41ce32da3758b1bd0ade188b";
+      sha256 = "316ac34c897feb1b98f677436d4dbac7b4a5c5fc29cf07bb55341736b156ae0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fr/firefox-139.0b4.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "586d5cd79456e96e9303d3fa3061cd53e7400138a36e44dbb1ec36f7af1e727d";
+      sha256 = "2b1e4ab91f25e9b95fb894231709d086d9645eb76a64e0db194dd386e8f362ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fur/firefox-139.0b4.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "835e029784412037746780450e6cf4b359c55a8424a5449f0df3c40eba480b47";
+      sha256 = "1a2c3b4e20c5cbbd6531c53516bcd97478cd86f6bc8b2761fd7074cc9e0429d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/fy-NL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/fy-NL/firefox-139.0b4.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "1e5990cfbbfed896480276c49220a5a01c079fcd67b93a622a6176bd85d2f657";
+      sha256 = "ca55a18278f39416d4982834357d8ee4e9dbb47e129feb3d45b4912f411dcfc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ga-IE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ga-IE/firefox-139.0b4.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "88d99fbd512d6069f233c54fe8979c14de8e4f80df75b6a3ed25c9ae7bf82eb9";
+      sha256 = "34594aded12da96b71053623e9bdc09367d8d28281f6ea31be81dc1eab4d76f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/gd/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gd/firefox-139.0b4.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "e709f3a79328849e8eed16c763a99e75ea98301262b7b7e2696d364e9bd09f22";
+      sha256 = "a6dffbb23c3b61f25a913933d700ace50954ae6e879a9d7d4b73c1a864954523";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/gl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gl/firefox-139.0b4.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "4bb992cc7899db5f287fb308e5cf46e6a0de88ba3f309dfaa7572849bffe3631";
+      sha256 = "a629a7d61624ade963df689fbee4add6f3eca0f603bd8fcc75563480642e7e97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/gn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gn/firefox-139.0b4.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "394dfc68789fb34a9660cded12d0c068b6bbabf32752df26c5d0ce17054ac15f";
+      sha256 = "fb827103cafe3179b1b17f8fdc21e2008a5ff24f4502b923c7426ae91fc26c91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/gu-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/gu-IN/firefox-139.0b4.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "3bd178b93097d42a1e1889370f9ebb2e694b838126bae3d3499a1cfd74f76bc4";
+      sha256 = "e9f4437d6f8959aa9270e6cc8eb7070165a8418f4ed28c2a31e1b955948c7837";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/he/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/he/firefox-139.0b4.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "55eabfc77a302c7c3c563aaaf9e6166dc8ca69bf8ba6cc7d6f4436dbb3bbc618";
+      sha256 = "5eedd55e647c494461a013912eaac5b1d40b20acef64a0810e74fdd72083e5df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hi-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hi-IN/firefox-139.0b4.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "1ce9e995742d6adb6354983e4dfa59a5ae137dd44a0fd4f7d109e1535cf5e16a";
+      sha256 = "3a1e543d88f0103776397decc1ae9fa2b5a96b68fddadea56c60e1d76b1120d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hr/firefox-139.0b4.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "b443f56294322beeeaa49b1d56b55d583071cebca3f1ebbcad935dade5863dd3";
+      sha256 = "4dbfbb04729a97c82b4eb123d1a6623867b6ece4f26777ed12c81a9bc5f4b88e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hsb/firefox-139.0b4.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "4feac595468c1b186b83acaf4caa350e07467adea1a5072559427cd2a26bc1bc";
+      sha256 = "1cca8fe6f46c797b8e03923d9b4a317cab0e011c34a44feabcaea6767a4054b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hu/firefox-139.0b4.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "2ba338240f527f390e0a2b1b4cb87a3c2d2a6c2f3074f202c26d893f06b84227";
+      sha256 = "ddbb8a9b6fd89f496c47398f09cb2a56ecf51299138cdf1dff659d027f1f8055";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/hy-AM/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/hy-AM/firefox-139.0b4.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "340f077ec7ec896d012497227261427a083313ab968a1ddb7ed946e86f1efec8";
+      sha256 = "e819ccd80cfe1446cd60398e788931d12060766fbd23539932efc6e16a0a59a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ia/firefox-139.0b4.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "4799ba81ad1e9dced07bd4455b74614513b9dc0e35278cf5e3314519375abece";
+      sha256 = "bb5dc9c1a4cb919a2f6207fe171fe0e2c9345d038cf7a7d969fc72f6c0d9aa94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/id/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/id/firefox-139.0b4.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "1a0b703975abbefaf41b0aa680f7363961f00cbfd976ee0dfc61d859abe2c6a3";
+      sha256 = "04f8e8f738dad42e6c0daca2ada66ea01f7d994c2ef4f2ec329070f740a2bd0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/is/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/is/firefox-139.0b4.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "f773b68f7d330150cae95fee13e04bd6ed64acaf492a1765f8e2bcf38e2088a5";
+      sha256 = "140e3f7a50a57f415913465372b3c0cb026f648d587eab2e2406361430c1d81e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/it/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/it/firefox-139.0b4.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "9d5bd4ed52733d584ae38dfd1ab740524bca0288779936b0e14828fa3010cb97";
+      sha256 = "81eaf1ea39d5792ce31388a3936cc9597f7873eddbb6ab34ed78acf688598272";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ja/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ja/firefox-139.0b4.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "833364c8524891fefee36123c27beef3117e28e807cda7392f8aba58e817a5c0";
+      sha256 = "5eb2dad48c1fdd9b869c89009f83433c7c43ecfbb85c6489a46bde89e935b534";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ka/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ka/firefox-139.0b4.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "90056e9ec3bd80f1c54c640360334b25a333de3a81622a5acaded9dd09a8f244";
+      sha256 = "16cd1d3352195a758bb256d9f201d50934c016f772c4ae01133f7ff25f86f2fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/kab/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kab/firefox-139.0b4.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "1ff4af65294c6bb720b0d37ca78ce28dec5cf8391fc73e9854ee595f9a214807";
+      sha256 = "e9390977f31c11d995d3748329da38c45300aa43ac5639c11cc90db9cd5b8d4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/kk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kk/firefox-139.0b4.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "add96c9ee56fa8c01ab79dfb28bea67ffe4aae659b766802d164d47c821567e7";
+      sha256 = "7d13ee5bf4718468f8ea20a5fc6aceff58ac0be84fa7659932e85dbbaeed867d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/km/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/km/firefox-139.0b4.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "a7c05b16e60e878af35441d7fa76bf0f1c3230a12f870ba68926d6366b5c29ec";
+      sha256 = "999eff92897c3cb7597abef1e2c86eb962204dfa4ebd0d86842b3f2cbc7fe957";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/kn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/kn/firefox-139.0b4.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "bb3378b00e4587b338edd0a757c6c2b33400ab60cb187ea08d154b78bec8166d";
+      sha256 = "a2d45d1ffe1a46c8178f460ac30c394a7f4177ecc8cdb4c130bf3e5c49bc2ad7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ko/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ko/firefox-139.0b4.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "07156a96ff4de2c7caa722acc9054545d7e754ca66071749fc82e5b40b08b753";
+      sha256 = "f847db77a08952229d6ef998c7157f0c75850f06cc96953ad66fd3a024ad1713";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/lij/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lij/firefox-139.0b4.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "8d42b8110e3d405aeb59662c2893c9683757913787d813e67f7095ed98c41404";
+      sha256 = "5e82c700fc49d454496199107a8fcb752847cd46981754a8413af64777ba9d5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/lt/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lt/firefox-139.0b4.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "9b0f537416a21ba0924ec129cb674f972957800c00ce4da928bdf69b6f54f02a";
+      sha256 = "5d60fd80069d73d12e285b65da1e3af0eca6824c27cb80e946c856f5c3028879";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/lv/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/lv/firefox-139.0b4.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "f52a391a83ef35e9cdb9477a1fd79f02e3bc57efb3c96dce4dd6500588b64b2c";
+      sha256 = "28e9eba64a0662004171f87e2ccf23308d259bc78b2184ffdfec398ef08f89f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/mk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/mk/firefox-139.0b4.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "f795a11e9f59b57c94f2ae68c30de75bce11ae615871c829b4a1b335cc7cfc4d";
+      sha256 = "83df7f0457e3ecc36c1a6376ec595f3df04543ba36d80d896cd7d68fdf6d9de5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/mr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/mr/firefox-139.0b4.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "03a7b2e164c6a6f7d261671382f267667864e67f5f138468a636bc2424f1ab51";
+      sha256 = "879ae358c38367b634154936a9e8d093813ac8e410f8f533f7c32227845d3bb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ms/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ms/firefox-139.0b4.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "b58d49b20d7d180b6544f8e0e247e4e03c2dcf116ac7ecfc39bc4bded19df6a9";
+      sha256 = "ec20aeaf31cd2f4b16b94ab16c62a0ebde70b738b86c739dd4deca7b50feb95b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/my/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/my/firefox-139.0b4.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "5bff0e7a50047b9adad4ca7bea17367143e8d77c1f837e992bf9a4c886e1e370";
+      sha256 = "90468dd5c6db813612f69f2b646be26db909dcaa92e66b3c3250823baea81de6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/nb-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nb-NO/firefox-139.0b4.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "55f8264e3a2fc66d27a9244b4d44f005df38a6df07ef887a496faf9a403bd5dd";
+      sha256 = "904f3f3760506b6feb246397caab176e6dd884e982dcb07274605bc067113d95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ne-NP/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ne-NP/firefox-139.0b4.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "22f21bdcbdc27e2bc030f04e3af51236a1115d90b9c60f0dbef1c55842dfded6";
+      sha256 = "0181214f14fd5e88381952ad07df7a37efa293e8fbe903db0029e773ff1e50f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/nl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nl/firefox-139.0b4.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "473638a89dd5d60dc516064739d7a1267b3c3c1f0d16ab1a685361eb27c11cbd";
+      sha256 = "cd1f662dcc64190d00c84b0c02d67558626246470c5cdac78fdee1408ec88cac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/nn-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/nn-NO/firefox-139.0b4.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "3bdb958681516c6bbb38bae154527fac7daf5516ba4141085fa7aa7746ef2d27";
+      sha256 = "c20d2ea023e5eb1a60863cadd085db28f616dfa79c79652dc1f38c2efd2e4f49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/oc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/oc/firefox-139.0b4.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "a5fb11472289e634e367b9cf2eeefa642b7acc56836db219a8d8d7e74bcc78a2";
+      sha256 = "6f387a7892a61b623ec1696adec24f5836dce98a4157c59cc47a987f11e8dfec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/pa-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pa-IN/firefox-139.0b4.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "4fb2ed5330fa4fe6cbd63eafc2f4509c4e9e8874a547798ad67ff45c85aa4f72";
+      sha256 = "1973852bbe05fc0207834a6271858a8b6585254635854cc2302b45d0a10f8b07";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/pl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pl/firefox-139.0b4.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "99d726eca2197ed9403487f92da9551d2f43ebff80782f6a176556f72d2a3af7";
+      sha256 = "9919cc6421b35798c2df90729d2d25e200e24d1450003ce30794124fb88ac21d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/pt-BR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pt-BR/firefox-139.0b4.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "3d87b053809abc2cc7e4bb89d449952f4d6ddd08335bc9a7336b4fb97783149e";
+      sha256 = "0ca06936133a86645d2975acb69fd01d3b80fdfcbc1ab003561ecd9fc85d4467";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/pt-PT/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/pt-PT/firefox-139.0b4.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "595b743edb3704645c6ff28ffe3a0a657d8ee8150e2c8c2f0cf9b8498049a1d3";
+      sha256 = "48dfb1081c2bee39a5bb2729d4aa83860d29435c818bef4b80c53e02efafb807";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/rm/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/rm/firefox-139.0b4.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "f61220acc62f3d02113f8f05cb480340aa0e409ed15a9cc132f527ead602d748";
+      sha256 = "4cb0f6115a83a9e30d5800f2d7c4709431c3617fba9fa43073bfd169c7a61266";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ro/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ro/firefox-139.0b4.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "b9f36eebe2b1ef701234191aac9af5a9a1095e51efcd6657e39385e9310820bc";
+      sha256 = "cf18a73a2170ab3fc5934adab6ef6142779f8f3c1fd949b1a1051bf2ea9795b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ru/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ru/firefox-139.0b4.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "4d16a70498e872c802fa8a131a4efde2fde2a6517a2fcebaddc9fe9b155f86e1";
+      sha256 = "85ea9ba70d407d009aced7ab3d1b8552b0cf1a44cb0df5d3cae35bbefec3bc8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sat/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sat/firefox-139.0b4.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "3bbc7f387ab8433be069dac9ef7f54ac04a29953291e554c77c3f0df8f701285";
+      sha256 = "693a3a17e376381dba4439a35eb8b7cf03ea59dbd6c8030b4da15466475f23b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sc/firefox-139.0b4.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "7d91a6dbd6532344b9283a77443ec67613f56d1dc0655b923a2f416d9ef3d861";
+      sha256 = "0d031bb02cef10ec8ee44376f384df868c20a6ae96138011adcfe577a132d788";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sco/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sco/firefox-139.0b4.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "5ded3b7312c290de1688443e29a215ab88c5b2df07afda9009aeb525b05d3e9d";
+      sha256 = "e38e1b62fdbf65b5893c448a8df763da3e04436ad75db1531023a800bb2fd186";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/si/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/si/firefox-139.0b4.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "4bb65aced228724c99efdf333e7187e135c363de2724911a51483ae16af1d211";
+      sha256 = "efaac36b3c3a6da5958563d682936413851f76134eff15652cab0260038affca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sk/firefox-139.0b4.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "6fe12385a2ccbbaccc0f3cd7af00b214a7cc62358979d8a323b341bba0c0fe9d";
+      sha256 = "e60387517f08d43b27179b08a0f9f8280d9e5e1d72ebd200f1794d37ecbb7b42";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/skr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/skr/firefox-139.0b4.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "d6281da91df61ad271b3728fa537853afb23ac1d5b9c5f197daee9d0f69ddb83";
+      sha256 = "834d207793100f06741459b12203ebf73750abeaffb43524564562bbb7160779";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sl/firefox-139.0b4.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "1fd528f21c3428a8354e0441968002845a3191741aa4d273863345316a0edf58";
+      sha256 = "9f0f2d2d7b22a2c2eb7ba28974d41d6db63fea0e66491753eea7e009ee7dd23f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/son/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/son/firefox-139.0b4.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "c09191f749e15748de1d64c5258271bef58922fd52ad73e6a2958f4af22840c4";
+      sha256 = "bb57306e0b721a99b3d916ead2ca6c813315d010f51076dd6d415d53dc1e1847";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sq/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sq/firefox-139.0b4.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "cbb55d0e073e06531aaad1ae2237e18c8e7e89e2f564f4405e64b6bbe5001c87";
+      sha256 = "64e95983086221f6f01d19fe37282ebce21f93516a43905dc29d3006d59b7847";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sr/firefox-139.0b4.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "7a4ea65224574e81385b60f5eb960d3c9252427d7602727483441204e96c4f8d";
+      sha256 = "456423a6a6c0c49b643d25bb3d32866c177a7856110c3cc94494f44296a836b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/sv-SE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/sv-SE/firefox-139.0b4.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e014bb87ed0bd09f514a2d89a58ab3d0e3c94c10a86a0c6cf391732e186fe39f";
+      sha256 = "960c1aade2e27b872e648f61944ea5421cfe4f7f09205dac2693cf5d6f3840af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/szl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/szl/firefox-139.0b4.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "0097c9696d4c7cac646360afe6c0620e4378fecec285f8e8514ecd1391393076";
+      sha256 = "2966c66c503b0fbdd8cf0fb141549cac9a8f34af9eb107b65aa7ed9409a629e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ta/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ta/firefox-139.0b4.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "1072f19ee7f6c0b0a9ce927907f891bc0a4aaa61e8d72f355ba455a6c81ac12b";
+      sha256 = "afa115d8acfa334d69f8baf6159ffbb02165dcde6593b0b9132086bebd274714";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/te/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/te/firefox-139.0b4.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "c49a4e9ca7a52a524cd5a6e8e90124e964cae0529f9a08a449349939cd4d3a94";
+      sha256 = "215cf233c79f4d33e0de76e4dd11f270a908b8f1fa55c6744200e86b6c862f9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/tg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tg/firefox-139.0b4.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "07b0eac74d886c8e9b4f3d40bd9013895dd968e8e0dbf84062137427e5f4041a";
+      sha256 = "e88ab65a2a477f5ad36ec77e334c2bbe9fc39e60fdd44b5ac705ff60f01dd8b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/th/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/th/firefox-139.0b4.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "c372a1bbb565c0f7f1b47506d72cb549bdfc74f6fc8a38227255b08dc6bce84f";
+      sha256 = "ba4f17f2fc2d86486dda6acaea1acfabcf4157f23c2aa39a858c35c78be3b20b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/tl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tl/firefox-139.0b4.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "0dcba23318509f033f5d080108f26fb546674e1f672cc4c6f60bdb7ebb3bcc22";
+      sha256 = "e123514d141c959e8f29b2dfc1c8152cb9c978267aca5cfa647ca79fcfd67563";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/tr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/tr/firefox-139.0b4.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "ebf9f41cc25946c0eb12dbb1238d7740a8ddf76159f8df6167415a9afc2032dc";
+      sha256 = "73988d7cc818bfbed084a626727d1bbbbb378daf849fbaa8b23f3f5a76315f63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/trs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/trs/firefox-139.0b4.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "64d9d779bd9eac33d0fd8945598a4a2168440dcc4396316fe7a3b16fed9e7ff2";
+      sha256 = "2b9022ed251f2e72bc0a7f7c319e7169eaddeec9cba230ceb9789ccd6c2a4c20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/uk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/uk/firefox-139.0b4.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "fe8999f25346cb39bf18e13cc13fdbe2e0add0b70dd6a62f633623e7fc108f65";
+      sha256 = "f721779da0e1c681ae7ef66e789a81a3655ed7be116357c518d4eb0401937fe1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/ur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/ur/firefox-139.0b4.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "62e031e5ba00b90cdde5d8c5c6a232e2f02799dab6a645b2836b5d497fb4e138";
+      sha256 = "080b7d053124ec03e821b5db14544de1a76e0b8d1aad4cbf6a5bfe7a721debba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/uz/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/uz/firefox-139.0b4.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "22a7748c964ec5bec57caa2312fcef75538fab00fdb3880355d7abe967f7aed4";
+      sha256 = "7fb7b3fd94aabaa611c53c6d8b75e0908c5bb93b0bdaa73a3e6e030a204d0bbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/vi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/vi/firefox-139.0b4.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "3a4cd26ace63c2e9b9a2267a3f799d34d3cb4bff301413b5a30fb38cf84f7f22";
+      sha256 = "27d15b1434b9aae896a3915eb647c1078a1663b1dfd6ce4c05d8e77bc21232f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/xh/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/xh/firefox-139.0b4.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "2088e63127590fef556dbfd0b8f2badceb82565a67758f32a3f9a4b5be1f9ef4";
+      sha256 = "642d2ce475f6b2662ae13a54775fb4e5a01a1d25a5cec6e95bc341e8505c4856";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/zh-CN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/zh-CN/firefox-139.0b4.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "d5999efb8f70e8170117292aabc9fedf0ff69b0ecae6833352c636f3e2d743be";
+      sha256 = "1c07356d7c142aed0c17df737aa7b3e0ad38d9d4897d7df7bfd0a79a367d8ca1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-x86_64/zh-TW/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-x86_64/zh-TW/firefox-139.0b4.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "fc9c4fc99157dfc6885202296e7bfbfd8d7757c135f3863179db219849a208cd";
+      sha256 = "d20921bd3d75051a61de3890349bf65280a539824403074f51d14332cb33b3df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ach/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ach/firefox-139.0b4.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "7ce28f002755dcbfb1fe21a415c0852a1fbcb20e4667d7c8e9561f1bacd8ae5d";
+      sha256 = "87a70f57297d5b0c01492da28bc80d74f290682f37b19a43fc6126efd85c6079";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/af/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/af/firefox-139.0b4.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "2e6c6e55d30ab8376e0abe0e347bc8f54e668066af222658e24750fcd54b96d2";
+      sha256 = "c14ea82b75e114e01bad4b6e0b405c9611330105659b88bf8455857e181b4913";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/an/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/an/firefox-139.0b4.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "5768efea60392994777b11e8fae1081522343b15e9943ce26a1feba0a01e471e";
+      sha256 = "233822a13e7ddc7eb437a6fa48b95f57c4c1d7da7a6ca54e84015b6d6cc16f8f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ar/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ar/firefox-139.0b4.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "14bc94bcdc76cc220064deb656b2b38f891048366d2f801f822757b6ee326217";
+      sha256 = "c0cd5c0d31333a5a6ba6af3de586df838adbf7da09b2d85f8310757b3c9c8253";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ast/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ast/firefox-139.0b4.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "af00bb8c1b4ae9522dd3f08f83f4d98f69537dbe016e5f70882176354beb67e8";
+      sha256 = "e38ac58bff96c8396df39b1fe090abd67bdf9b3e410f504f25e0d24482a2d1ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/az/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/az/firefox-139.0b4.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "b4b44fdd925df1316a086757f207b569345c6121a29a24703a5260e3226d7c60";
+      sha256 = "2c7a74321548b4d3c3c07e2c0f1127c4f54c55d1af0dabfc6704fa7eaa02b102";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/be/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/be/firefox-139.0b4.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "9c81aac5cc32a640f83cc550444654e70a96cb170079ceeacdacb63ba47e6909";
+      sha256 = "624589d8c29240678a85b5b0978b4de1c43ea7850960bab85f7c7f7a172cb4f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/bg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bg/firefox-139.0b4.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "d479c27b0d8ede199fced85de653eb655470290fe34b7fa9835c3a849195a8f4";
+      sha256 = "84b144c5d7ae2cbc95dbb4fa262b6e0653000c645c9a604022aca70ead9282d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/bn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bn/firefox-139.0b4.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "6ccebe56abc1d453eb87d28b3bf9956fe2c0339bb1f3da50b9b22d42b147ec97";
+      sha256 = "b7273dc41403f54eff659a67c8a4b70f2a4df61f62a1dd4c562b0bc75c08f909";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/br/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/br/firefox-139.0b4.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "af48d70e9dda8ba429a0e9e56c55ca296f4fd8cbd11954fa90bd43335301ab94";
+      sha256 = "0815292d40fb6ebe791d7de8d699ccc0d5096c0999fd498fe30ceb55aeb7292d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/bs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/bs/firefox-139.0b4.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "bcb9bb9c923e6d7911e9c4a6498f473227608eb5d52aec3bc0bac029a847cecc";
+      sha256 = "24de75d8e893acefc305717a2f8ba2decdb722e2505385d6cddb04ad43d7fe5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ca-valencia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ca-valencia/firefox-139.0b4.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "5f17bb1126de1442bc2c47c494b3e7bd23018c3cf813d4f69a0858454c244322";
+      sha256 = "2ba91787e8af61cb24de5c122a5ff57c6081e9680f7594d02e2b363f28e16a4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ca/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ca/firefox-139.0b4.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "2ed1124e2518525121b44ec3a7ce536559d5b48826e1a5bed3f2ac4080aec48e";
+      sha256 = "da9e7f0f9a0730b2a9c4bc467da5f5c2349f98e22f683db02b5651df4a202251";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/cak/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cak/firefox-139.0b4.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "d4da5d3d237ea1125d579ef37154b3812c0dc3bbf0eebaff44c2f8b962542ef9";
+      sha256 = "8e77e88d9fc94f819d450ca6c7a78c618d881a97aabae5b997f7a6d69290e29f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/cs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cs/firefox-139.0b4.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "0c26a5b6424a8e75105afb35357348e61609bfea05e8e5edabc2cb3dfe0d28fa";
+      sha256 = "a79b45aaf0e6e8f412e21e746265c1d43e7de9046a050b670ba3667b1462c620";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/cy/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/cy/firefox-139.0b4.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "1016ca93fec5c4a62665d9d5db84d374ca589611963744e7e1ece7188fd8cf62";
+      sha256 = "2a436e2d6a9eba59a8bcb448cb61c5730772e204665416c4c2e04564c19ac23a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/da/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/da/firefox-139.0b4.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "7b73f8a206a2f1a2c78600cdda2add1d06a052230cb0404b6c1376e3fef1715a";
+      sha256 = "c055660cefb5fe09c71ea087de51efbd4d0b8c2a349f78f2ec5d4349116ad694";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/de/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/de/firefox-139.0b4.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "6e43a1c86555426646fecbbbae6b06e471766818f88ed62fbbeec82047247ac2";
+      sha256 = "e3d546c3a20067ea5c710e6af065bcd11e6ab49a803f730873affa229a1badc8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/dsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/dsb/firefox-139.0b4.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "6e61c2cfad4397d9203ea0ecca7f77520ebe8281218d3ab543080b11de5bfac4";
+      sha256 = "50b1be16d8856605e37078f0cb87bce59f621a76c354a8d64d2f9a68e626405a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/el/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/el/firefox-139.0b4.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "9eb70baf74e6211020905a81d8bb85606448e16b1fe5542dca2b9e153b1ed9a8";
+      sha256 = "7f85663812934905be421c0bc3bb0ebcf22c5a497db7fbcf91a21b8174bdad0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/en-CA/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-CA/firefox-139.0b4.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "74280be6ef4d49607bcea1fa913543e96408895aad19a4e214c85d35f857e1aa";
+      sha256 = "e5304a3d0557d7ec259e41e989ae191c14e7aa72203eea1ea2c180ba8aec1913";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/en-GB/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-GB/firefox-139.0b4.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "02c2fe632d98fe4d8505ef53de2cb2e6e6da6090326ca230d12fc042ab229c18";
+      sha256 = "393f92153a7935bc161badc7d81b23803f1d6cf9ce69651097cbc383056a30d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/en-US/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/en-US/firefox-139.0b4.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "0a549086503c09cca2c9d7f89e586c5d110b341a500610c3f4a2d3e9ed25a409";
+      sha256 = "8d61639f9b02659fa3486e2f17af815e028e87c373a1770c69e968af3c7c0b74";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/eo/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/eo/firefox-139.0b4.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "f93d71d5e38e301e5f7232734aa54639ca4dba844a4a056c593f79bb517529c2";
+      sha256 = "dcd9df03ad825bd50f3b162ebd5bc6561d09688972d7c80af15b10d1801a3fd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/es-AR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-AR/firefox-139.0b4.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "beb858411f25c11cbeae0de8603820b723313ff1c50d62545f844037030aaecc";
+      sha256 = "cbe7dff319e0cf3d67126565366bf6063536188fb5b2c830e24b2b439d5410a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/es-CL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-CL/firefox-139.0b4.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "dcc809b75597e3ee0c9d320fe895169fd55b02fd0b5083ac974ba23251499f06";
+      sha256 = "225c027d37ea0d6da7f9de2c784ee13db182bc76ea0398ae7dd3ec90b3146b7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/es-ES/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-ES/firefox-139.0b4.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "67c62f317a1e6b8d8e054fb41feb2891886f2a2322da6eba6caf2449c3b5f122";
+      sha256 = "2b349436c1ce8d99138875f11af5d5210210eaeb39f0dbdea381dafb8c5d4404";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/es-MX/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/es-MX/firefox-139.0b4.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "e82a9713de44ab3a65b5d6a2479e302b755882b0f1a9e7bda8a729d0f9f5800a";
+      sha256 = "016fada5c527dd9c4c95b6549e2cbb7b3616ec6256c9e30c527f995af1029ebb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/et/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/et/firefox-139.0b4.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "cf9c51d12336f421de096354de51964d1f1c167a71e1ddf42b942365f36bcff3";
+      sha256 = "57eecae03d4cb2c2e86f2909e82a8e42113f86b7f30eb8711b3a6262e1157b4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/eu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/eu/firefox-139.0b4.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "19db396937697d20534d4b277e305a88fa58aefd53622b30f62dca15d2248315";
+      sha256 = "af2405d4e1db8662e7cc6f212694ab80f607c854ddc707d5322d4a0565227f04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fa/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fa/firefox-139.0b4.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "88644cade82ed0e852bee544b031bc7eb9c9d3cf5e81d70d620c7e24525e0dee";
+      sha256 = "1170f8ca54cc2eac1a2bdd9a63eee87b29a627d30cd2f06e91e519ac2be2b05c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ff/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ff/firefox-139.0b4.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "1f89e5c3bdc3612c9dcc7e50246acf7afb46451c09f2411d788b8c85a7e7c3ad";
+      sha256 = "bdc3e84a777bba9e664f29cc3e109af18dc40253b0f9b4fba57765b604d4320f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fi/firefox-139.0b4.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "32fc8b17a67d35332ef39e575d35384dc152f999cf985ae787b88b8ee70da1b5";
+      sha256 = "db78665b7ea38f0f5f054949d3045239f6971b827e781bf740650596e7d91580";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fr/firefox-139.0b4.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "c8a27b7c343e542712281c20c77403e982ddbf2ae5c1bde8cc0a1ca4feb6494b";
+      sha256 = "9a41a156bf9c002d3f438c2895e3154ac483a67ebe6f80e0eee2b01b7fd7244e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fur/firefox-139.0b4.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "c21eb646929dcda7e4c5b079159ab60636d3f4cf5b4e1ebf1c169df1ed6a2692";
+      sha256 = "56220f6634ea0e7e69a29f07736120b46f2c1911e82df13a842e4101ab0e7cf0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/fy-NL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/fy-NL/firefox-139.0b4.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "ee6f585f8e1bab66422c43a214de40b4c964102f6f8443312511134300f7718d";
+      sha256 = "9334756030f7495ee55780665ba0f8587331364ef4221393106194b9ab938362";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ga-IE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ga-IE/firefox-139.0b4.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "fd8c8f859675ff8a23c3923f88fe96e67cf6fca84011de64ace8febf1dc1974f";
+      sha256 = "96a68363e3a6593f3657da4d5add4af443b2db60d30efdcf23485244472e59eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/gd/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gd/firefox-139.0b4.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "f3c69b4ef87dabd047b51780f8dbbbd3bb5102138ba67b5792418923faaee3a1";
+      sha256 = "2a21ee5ca1acca96a81cbd1c0f6f0ce8c3a52ed88ba787d98d6059bbc097e22f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/gl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gl/firefox-139.0b4.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "f8412a360248f60eedaf98b5bb973c17f0f586f02a700d58fb15de0a8dc30751";
+      sha256 = "bd8a9e005ba534d5ab7436f78b02cc84f380bd36a4044a797085f529b23466eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/gn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gn/firefox-139.0b4.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "475058f84ce6c87022d24782476ab300776e99f2c941e0a2c37c43ce4b16743c";
+      sha256 = "3d6aa78558ec05bfcab9872160c7ee06eda338aacdf78974022dab4fd047adaf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/gu-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/gu-IN/firefox-139.0b4.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "326b7c5a12ecdef9879b09af9dee007be2c8d962173cc03d28dc06e904d9259b";
+      sha256 = "37a683ae33978ad481ef68f40b3c83f27a85b13aa1b55b905905c2d3ed1ceafb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/he/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/he/firefox-139.0b4.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "67a0961a17ab0ed020d6f0599e27bb76f205cd6b6f601c7dcb41c8241da529a4";
+      sha256 = "1916e775b875911d87365bfdbbf549ae728ab674814ac222edb955853a224273";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hi-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hi-IN/firefox-139.0b4.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "8c62141bab666ea189ec431bbe1246bb31df639fcbd19e1841441da8addae021";
+      sha256 = "72a3b2387777f16e2b5f8232522d4080a276bf60b853a564f5e70c37d9fd2e3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hr/firefox-139.0b4.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "63cd4ad08842e62b8df6dda22183e30f93fd2528e5b4013cf83eeb92e50d256e";
+      sha256 = "4186afabb2595f717bda2555348fc082ea7167e6c83f03755d925ff2c084a31d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hsb/firefox-139.0b4.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "889f9366ff2251e4228be3165171b582ce5c29d7ce3587ca3ffef0d35a4070ca";
+      sha256 = "6b12f273ce7cb98e913ebe1785e2271813c351fe85203a8e96558bee3d8b802b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hu/firefox-139.0b4.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "552b9c7e629dd2dc51f5aa3bc554ce575da71e07a8038fc6bb52d7fc375d8698";
+      sha256 = "f689294ca4226c898df2ebcbfcd60c4b9fb8bf529bc51df60b36896a77b3fb95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/hy-AM/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/hy-AM/firefox-139.0b4.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "15f0aa48bacc5faa3e70d5aa1273f9f366440bc7e59827a1a77a2954eda3062e";
+      sha256 = "c1483077c18d4527053c7d979f9d8abc10710580295056f6fc14ce0034dd0711";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ia/firefox-139.0b4.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "3d0649f01e2c0ecfd22a593aadec114b6d1d005157dfea0e1f8ec0dc2c2b5503";
+      sha256 = "11829a72579c847b78622bedf1aa6e5af500bf2eebc04bd10cbf8c7ea7790b3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/id/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/id/firefox-139.0b4.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "a80ef0db6a0723a41a270f83e39fef4bc18103a66ead7dff209d800e2e785189";
+      sha256 = "2217188bd592ca5c4cc8e2749ea31015861287c59fc14780335e42275b559cae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/is/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/is/firefox-139.0b4.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "38e9415aee3673604144fca76825352e6f2cfc87aa3b43ca9a2f56af22542dab";
+      sha256 = "1ffab05f776dc59104a34baa0164d6de764dc8882f4c7ab2748b59c492823c4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/it/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/it/firefox-139.0b4.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "eb75d8b9ae3afc769cb65f512f0cd0c4809ae089c39f073d61095969bea9297f";
+      sha256 = "3e9965d635107eaf2607463508d0da22906bcac4db645dd43708ad885c037ddb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ja/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ja/firefox-139.0b4.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "3015c6d1fa6680403314f0c793f4cd702dc3d591234d5a948457aa10b8541810";
+      sha256 = "1a971c6f7e1558b6a47ca204a398c5b1b9be44700726b8daf0c0298271b5562c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ka/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ka/firefox-139.0b4.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "513d1d6d81ef85f93516ca07e22c667f56d8c74c5b7dd97085eae9c3201e0227";
+      sha256 = "4b7c001d19b96b0254fc3d5760feb2f473014e5ba1602d320fe179d8c8e8e1f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/kab/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kab/firefox-139.0b4.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "77cc93beefce3542b29c9ee6cc9268f74b805a06b2a11f25ec6e0e3248d1ed48";
+      sha256 = "4022280fc975d0fdccfe02ec6ee4159936a9de99ca2eed8d6c496f290a5a6d0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/kk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kk/firefox-139.0b4.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "839056e0bf61a4f639b4e790bbc66314aef173cbf7b09e5f80a20c78099fc0db";
+      sha256 = "06612dc7f831654df0ca60cf3c2ab4fd1e72b4cba16ec496f02528c0fd4fbfd8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/km/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/km/firefox-139.0b4.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "743ac6c946cc7d9a52e1c97fc5c0dbe26412fbe302247d55113815ecfa9f9c2d";
+      sha256 = "91ed4c4b6b6f294b8d47b013393bfa48402a63c6f4d2f986947d51729c624f12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/kn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/kn/firefox-139.0b4.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "d4a2a27c7b4707218b72e7ea65c22ea68d9aaf53e3af8b7e1479f053373481fa";
+      sha256 = "a4a2e2c5759805640ae3080c563fd0e5ca127e8b5067351928b6dfd10e45a761";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ko/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ko/firefox-139.0b4.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "c57ea249d8470d9fd59aacf877574ed7710e8b4b67937bc991ba214269dbd11e";
+      sha256 = "2e09752b2c02315d79185c86e546f66d314a5c158720e1163132c54934c06ebe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/lij/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lij/firefox-139.0b4.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "f79206346a6eee3c582bee7dcdb1442e230f0dba4ffa4af221199108cc31fb9d";
+      sha256 = "ebf2dd79fc7c373feaf517f3030bddec4fb22879452cc3abd6192d5868333fc2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/lt/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lt/firefox-139.0b4.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "72cbbb299ae282f20eac44f00c42e41a8ec59bb02b35135cabb3689820b1d2b3";
+      sha256 = "71aa1ff3f47b4be838e06bdb791bfa70b638c09dbddae37128c90ff4b4974998";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/lv/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/lv/firefox-139.0b4.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "26da34db3ed639b3ec7931d78ad5bc541b056a3fe0c08e6c9612e30a10c8f878";
+      sha256 = "90b01be8cb7b2ebddbb2966a45f6ca29a86feb1285db233012ef85f301ca4fed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/mk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/mk/firefox-139.0b4.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "1d49cd2a297bd97f1c4fb2852064959b70ce2a22fbdf9aadb9b0f8a702aa236c";
+      sha256 = "f6fa830344486666e46113e5515e1f24a0c32943db3c6bb7f02e5ad3db6de2d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/mr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/mr/firefox-139.0b4.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "d0c0f33616bc6cec80af9480d9498ac5b1908938c6adf099e542e4e890c6d3d8";
+      sha256 = "2c58107d0ab0cd7c5fa0a4030e047c892808c9d6de05123cd0337ce36e54360d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ms/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ms/firefox-139.0b4.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "5fe8361933deebfed59b871af864da3402954179c7185d153d513718059e0c48";
+      sha256 = "8afefb023e6bd415c29f075e484bd0783f5f05f10616d4f191cff8839ce372ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/my/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/my/firefox-139.0b4.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "bf4c16418ff1c09f0f32cd75701734a89323bd4b58f45d29b54d85e3ca46502d";
+      sha256 = "a713b3d904d5590488141f331d89560b0fe3c163287861b6c709133521aeda99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/nb-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nb-NO/firefox-139.0b4.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "f6cd1229d9909ab4082dbb27305ea4c4568b910d19a3bb71bcede6ca62c61d47";
+      sha256 = "40e037728d2697304965ff04db4e8d8206335a7e52866954241766182d9f150e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ne-NP/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ne-NP/firefox-139.0b4.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "373e6dfbdd023eafb0604346bbc29f70f9be5bc354cc861244c68040557cf0e1";
+      sha256 = "32e752b56699102d5d0e65a5fbb2644b7d95059f12c737944a56c9807fcb5d4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/nl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nl/firefox-139.0b4.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "0a93d10dd9800759ced99444ec5628f48914f8c10f900bed3fb72dbd2e45a69a";
+      sha256 = "086f26eb82543f2f536b3546782d9531b2367c090244bb3dd7d7b3766f5e3bdb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/nn-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/nn-NO/firefox-139.0b4.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "4525142f8879b8b4dbac13af7eeaf7c6551aaeaa4c8c1d9f0868cc0d5822ca8f";
+      sha256 = "8f7faf5cf79fece9aa05dead8931cc51829399c1e77d865fc7a2e90586ffa68d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/oc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/oc/firefox-139.0b4.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "f65837831aa178b4c11b7dfb6300539238bc86c201ba01507594118119888810";
+      sha256 = "7a6743d63d6ebd2c8019e5e4431d0251eb1764e5cb4c2bcd2da43489c304e0a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/pa-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pa-IN/firefox-139.0b4.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "bb3cb018cfb3a3ce9f2da7d84abc547124f88940e03d15ba13cbdb4c41c996c0";
+      sha256 = "25c72f3a21ca5c1e09b4d6c97fe8ccda39c107ee4ac23c447cd7097d0fdd8eef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/pl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pl/firefox-139.0b4.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "dd99387cb9df41d09939532c3e44b5718eb927a8062816ea38ef9340e5268bfc";
+      sha256 = "f1adf8d5eedd479cc763fefd80306a4f400a0b8838b356d223aab85f305c0b51";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/pt-BR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pt-BR/firefox-139.0b4.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "9b8d90f71be0959bcc5a0f55d5df3b34054426e2c7ee39443cdf531bd24c3290";
+      sha256 = "ca70a854d9930a008fba706f839840408dfd37b7805b1fc686786c7804906c1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/pt-PT/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/pt-PT/firefox-139.0b4.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "7fcb4b787f79200699315a2991acfedf0fcff022dd1816953d5b441717cfa27e";
+      sha256 = "b81b41f9aca42e313941fe69c2a884118144640f5faa53fb16b21e0d19ffc640";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/rm/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/rm/firefox-139.0b4.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "0d5fe4fd2b1d8fa8fc828cae26410e5dc306528fd26cb1b2f0e9407e684a067a";
+      sha256 = "68b07bd5a6f6adf58851980157e1a04f6a0a069d4418fbf74108eb7101e39905";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ro/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ro/firefox-139.0b4.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "80639cd1d6d35da3ffdf9879857841cd1f5e457248c3d74827b0185c80ef78dc";
+      sha256 = "34962c09e2f96ff552733d3e70363989122e58657d85488d215b12aba6a478de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ru/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ru/firefox-139.0b4.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "20de91eb62d677a3b38e9af038f73c83ff29703d82bdbfcda4d0bde5d289f604";
+      sha256 = "631f44ac7908c217df544986041576f22afa37ada0b550ceb4f143b68f6f044d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sat/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sat/firefox-139.0b4.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "14f1492ba249fedf9b3d64192a3ffe033c053ad412efdecc9a9c5e6fb188b148";
+      sha256 = "f55ed94a407e02de8f519e0db3731c778ae27f53dba62a4d27dea12ee5c69d67";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sc/firefox-139.0b4.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "149ae0e4e41f7e3d45b80e905b1ed21b4559af34d4082f6a37dd0cc29acb1aad";
+      sha256 = "ecdeba036f6d3c69377b282fc11b16137ddcc97c55d49f12a6497b3ddd857758";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sco/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sco/firefox-139.0b4.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "5dcb0ed695c0a0c5b8ed0702e035881c1ae0d2339fd8efdf667c7e0e153f09c0";
+      sha256 = "a9c5742f64b9018906b5fabd9373e5fe8805a447a001acbc3106818f081ff09b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/si/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/si/firefox-139.0b4.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "4550b500d57c250eb81842562643f9f590102fcda1ff22f9495fde5b0f710fea";
+      sha256 = "3621682261e1243d64012ae5ef4508458ef088a20c097f22d0d3889b2c0fad00";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sk/firefox-139.0b4.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "2805569e2503c28584871f16e5793d5ae21d0e886a2fc06a71fb5b2e445b025f";
+      sha256 = "15ee029ae13f93060ceb44bc032e90062fbeb4e7f1cddd4acbdd8c03187441b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/skr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/skr/firefox-139.0b4.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "67c457cfb2d5259859380312876f446b67b12f1f90c10d2af5265dc7f268ef1e";
+      sha256 = "c61dbb39288239c7620c87d799fd745f02f1e2e4320ce8f44f92aeff38e35204";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sl/firefox-139.0b4.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "d727b93beb813e17596dad9255b8268a036ae206047119125caca31011f91079";
+      sha256 = "701b3105c92bf18dc0baa508008c6a9208ba69a67babe16f7404dc50e5b5c822";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/son/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/son/firefox-139.0b4.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "2316c93c31ca52db0683decc256116a1c1195013f92a98b554fce2e5fcef22a1";
+      sha256 = "a7b5fb0c9cf055db86b411d5b4d8fe7b154dd79da1e0d23f050bb890e111584a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sq/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sq/firefox-139.0b4.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "14eb34f915c76c6d156739581f4a0dd5c184c6b3a5dea1e5609febd288d6ff9d";
+      sha256 = "e88c917629b50cc933daed3134bf61bb9a7021db66d5840c00e179afd22af58b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sr/firefox-139.0b4.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "b1ee34d1db9d61695a01e2bca1d020064a927a97cbe731bcc61413549221f7dd";
+      sha256 = "c06aa97b94fee81c474784e005ea0b87fb108dbc023697caa036e0c8b394e825";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/sv-SE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/sv-SE/firefox-139.0b4.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "da1d0e004484fef9637b42971ab8863d3fa9e27d8d079aa75609a46c745eb94b";
+      sha256 = "972103e2717945e1c7f53e6606bbc6b8939f9030a4bcb2d4fc718e230669eaff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/szl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/szl/firefox-139.0b4.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "1a9cc76e14217ac4b41e78b0838763c6bee4117994cf79bdd23bedd28f557efe";
+      sha256 = "04adc5b6186a5af52d0e49dfb798bfd7da80553cd284763b5affc471dd1e8328";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ta/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ta/firefox-139.0b4.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "1d307fc31ccb8567d6a118835f9233bd3880403275b466f2c7289ebba4c667d4";
+      sha256 = "44934dc8cc75f9e0d96812ad7f60de98b1fc7f2008926afa61a3ac81d3c43977";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/te/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/te/firefox-139.0b4.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "15aa89919b9d96d1a338122cdc1cc29a83643b63d5a761b7e8a819c33be009f5";
+      sha256 = "a65484fff230858c4f0ce1c8554928e469fe06c5c0eb941217ba770a15cf3762";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/tg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tg/firefox-139.0b4.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "82c69afd7dd65e3efc9ed8df2f269e9ea0b9a26ca8c03a215ecefe971925bee2";
+      sha256 = "78ea45f86204077dafa932bc892159ae11bf1bf8f32a86b9bb79742944115250";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/th/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/th/firefox-139.0b4.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "aee29d229015401c5f5e619df494ab687997c77c7f177e52e8c027b1240e5b5a";
+      sha256 = "937d5f0858d4701a739557a54df30dc20ed3dfa0c92d9c08909b64c57ee34dc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/tl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tl/firefox-139.0b4.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "d8de7515395316fa30d58d0b0dc3b684e9f5d2e3aa46a65142ff82731c0eb488";
+      sha256 = "977abd61324f94d41a030ed8affb6d7c99a9f44cd89df35ae5e075ff746e3b45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/tr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/tr/firefox-139.0b4.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "dedf256fef420ea2d8e5231ad02c681064cf00bb978d97bf07c4a5624ddc883d";
+      sha256 = "a9de20042a68a2afa8726b31da47e950a5fb1578a9f1c3855fe04700dd3461a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/trs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/trs/firefox-139.0b4.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "547dfa2d5e3b6bc3cfa536b2e29a925be1b8001ef23db9f91681bf946ea72cd0";
+      sha256 = "7de7776812f6188e1b88aad5293f1472975356c989bb6dd61b53d634c1595d9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/uk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/uk/firefox-139.0b4.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "536e095a95c64dff9ed40f60748af048b935d0bf2cf7b94def0e6b5bd9567a3c";
+      sha256 = "ccc2e770e91aed87bf1690dd82e52107ef49efe2062cb08ac4a4e372b097770b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/ur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/ur/firefox-139.0b4.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "2a4feeef97879302c6a64dc60f8a81f200eba292b23292cec5cfeddb5d0481d1";
+      sha256 = "1e61bbf085a439b6a51add991499e582a58f50453c2018d15548f0ce50f95191";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/uz/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/uz/firefox-139.0b4.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "38ec2a3424b6c2a587c720c5d4a73bcc0fc54459e1e36e7bc8ae7f97256253a4";
+      sha256 = "7b4120e694d31a901d7e9224ca42034db85f27f9062463f1fbe7aa8dd7afcfd6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/vi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/vi/firefox-139.0b4.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "8f66051904bd6675a8e6eb0a08747f076509d1e0fce8b77fabe43b2b9d15c034";
+      sha256 = "9798b0741ff2e5eb5eadf5234d54fc5c2e473ef3d093079b7b6ac23518e06404";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/xh/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/xh/firefox-139.0b4.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "f113652ecf2ea05717079c75c86a56edadb04660c5de4bbd1bec42dff9f302b4";
+      sha256 = "17e717b6a62c34d7f0e74b9c6b4af4e04e0bb9e6e0624b5691f1762c8ac734ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/zh-CN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/zh-CN/firefox-139.0b4.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "2cf9172ff5665370b5bf1dc96b482cbe1fd61dbcac2b28cc8c07c7a9d3d88707";
+      sha256 = "a32bd1b70bfb1c5fdcf33d0c4413fc1f3d4c7c1b355e06c1e7fa571657078682";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-i686/zh-TW/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-i686/zh-TW/firefox-139.0b4.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "09da69ee59a9c8c9896d64c83e45e9bec02510cfbc899bab7743573459e4eb22";
+      sha256 = "0ee631ecf8b7de2ffcb9a77aba4e4dd20cb62f2a1aab53650c1c12b39c5b48a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ach/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ach/firefox-139.0b4.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "5e3a47e49853d2f50247538cadfb55d0b9090657ad529fea54718d06267a806d";
+      sha256 = "d754b7c77338934ad9c988af0ca76c20b9d0eeb9f63beb9423d48902cf39579c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/af/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/af/firefox-139.0b4.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "81116a42585f5055e59380b553a824a5cafa9db59c55368368f7cff925b5cfa9";
+      sha256 = "9e3893fe70cff031562b1f9b6d1a8651a591d050a02733126d00d24c8d676bf2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/an/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/an/firefox-139.0b4.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "e03b451a6c36d82e693b0e7e91d16df8c3ec44a3df6575a9e43ae85642aa21a2";
+      sha256 = "01055cd10e6bb1e963a7b7366233faf8d2951318576a02a9f1e81aa7a1c4c50b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ar/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ar/firefox-139.0b4.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "d0fec6cda884d47ef9cb7d59b4601e2804a6fab505b1a4105d35ca6f3c7511a4";
+      sha256 = "d1cd5710aee5418d9c903f195d96f2fff01bee31875877e737399c9f4479e056";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ast/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ast/firefox-139.0b4.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "858524559c1d4c8dfc08e78da932c46dbef4eacb3d3a14c8504f116c9345a80e";
+      sha256 = "55834b6c054928aa733035366c5b45ad19503f03730001d70a41ba6510d5bd72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/az/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/az/firefox-139.0b4.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "5f52c31274a50c978f29614d33e41fd2bb75b4753b0f5a7f1ba99ef12296594c";
+      sha256 = "41c91dba441d06e022af5e90d2d8e77e2051e09e1cb4cec1a5fcb4bbc93dc97d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/be/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/be/firefox-139.0b4.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "cb7d7f7af9949e2fab6ec9ea506167b32deeaf623a597a480f832118b90e1d20";
+      sha256 = "be5610c2f38693dd6a1f8c4949bb8df06e201f4e769b986df4b3e404d9a0e494";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/bg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bg/firefox-139.0b4.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "9e6eab8a7d726360a7111e0a33d7d293d782eb0708de5325696f6324942d6a91";
+      sha256 = "8bd908287a0c2871839dfc027e0e6279218addfdf0de06a62b4018097375e2cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/bn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bn/firefox-139.0b4.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "c9c9c27437e507d65956ffa1e6f7d72cd518a80e8246ac3468305b83f9e14fd3";
+      sha256 = "f74f9db667a9774b4c3eae709facd5a33b432cbf18fb72365c57ce0ce9e8c1da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/br/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/br/firefox-139.0b4.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "88328aeef69c610e176cf13f0505a498da6ece55acc7918bf93385775d103333";
+      sha256 = "a00ab0024862e999d7d739722f441b2b63368ba227346fee3e9bc80c31807771";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/bs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/bs/firefox-139.0b4.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "e0ed2d31920ddeaaa253efc5ce6a88b0d410c393e43a528304928db60bc571bf";
+      sha256 = "39b8da8c52d4fa01498d9684e0f80d2431ac029e72ca39ef431533333b4318a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ca-valencia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ca-valencia/firefox-139.0b4.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "e19a51c97579ee162255869d4dae6c5be99955a1f0aa3af39d42ecadfc4c949b";
+      sha256 = "de6ec7c3bfffbfb4f0783ab91c708449f0f90dc21d412220044715e56f209469";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ca/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ca/firefox-139.0b4.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "bfb1a6818fe98a2f514d1c7a6bd2c4421158443b7e7845c866dcb005db1b7d41";
+      sha256 = "43a84887bc56e8e775a1fc77238a9a5b311a3922b342c0b8937a10864a58e1df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/cak/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cak/firefox-139.0b4.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "1177513167534f2893b8d5e40da2d9240c8171514b3206fcd21ff480a610fad2";
+      sha256 = "b781db306b99c87420a371d5504505613258001326341e12d53cad1c6d22eef9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/cs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cs/firefox-139.0b4.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "0227f210716065e251e3c3b69feea728d689cbfa6cea637e114c675fee3510be";
+      sha256 = "a0e7e2d60296d59eb438d67e9e6f7e7397cec1ced5b8eda1210e244fa10a0205";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/cy/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/cy/firefox-139.0b4.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "bead0d7876df8c62cf66c9f1b497547b7374affb325a7c3817df69554a3a7690";
+      sha256 = "c985bf38fcb61a264e3e7cefe00ba90bdb935009546533bf018d4bd173b88c60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/da/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/da/firefox-139.0b4.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "c6e30d23b71facbbebf2123603d5043af13bf77428c24bf4e82f8998dccaa8a1";
+      sha256 = "31b86f8656a3c5a92439457714d2215481e175718dad2e71a0bd12cb9d8d53ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/de/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/de/firefox-139.0b4.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "0b44715056d449255557bd1d79b6b342ebf87f218a5764010f27b0acc80a7919";
+      sha256 = "2931c7cdfbb9113176130df3551731c1313c06168257a1e1a393a4d8c71fc648";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/dsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/dsb/firefox-139.0b4.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "9b3ce960970fea55ebc905af93e86cf08130249cb761ed7845d4b9d949e22db5";
+      sha256 = "e4970af22566a2c423138dfc68a7d58b58e7d3284e88f4c7f3e9d00940739cf5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/el/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/el/firefox-139.0b4.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "83b8fa1155fbb5a4fe47713dd954d05d365faf1e94f76b6bf69f258ac0cda546";
+      sha256 = "b12bf7bbb352c7b34d9bfb11478a0ae7717325f4807c2baef04aa4f250400a90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/en-CA/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-CA/firefox-139.0b4.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "8b1faddb955b3f6f66816ccaed1224d0ecc2d558c34e9fa9a2ae11ec1337757f";
+      sha256 = "09e94e0803a321b313a740036171cb59e049a826e737a4151713f072c797953d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/en-GB/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-GB/firefox-139.0b4.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "d309c99711904629a5f2f28256f39489966bcabc13c93b477b9129a73de90822";
+      sha256 = "cf6922dd5832202593dab94022f82e91af46685f8c16cdf92ee6fd2665ac225c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/en-US/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/en-US/firefox-139.0b4.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "e30ba28b3d4cd0122edac0185c9948af1bf46d99dceafbd7549bc560e6fca824";
+      sha256 = "4edba8a869dfe9c906649b5e7989748490665e99599b44c653c2fbe896f268e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/eo/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/eo/firefox-139.0b4.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "8b62f77cd305122bdc8434128bda39ed5a5b719d09e5019697a47ed7c3cf06b1";
+      sha256 = "8ce7a3c2d44ec47d0c76a896005cc485a5e325f5991a50833e244cf69b8a7645";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/es-AR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-AR/firefox-139.0b4.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "a2fd10d9ae8854581939f1fc1b17de5d3849b49e35073e2b8e51fda98ae435e4";
+      sha256 = "d1c49d9227b3d9e27e73f9788171c718c73829c077040520b05dc9b9a02cc839";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/es-CL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-CL/firefox-139.0b4.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "e22a22a4c12f1fd3127898848b11183a0e3256700e747aabc0bbba03f8b7e3a9";
+      sha256 = "79c5b47dc1962faec8ef4db9860698a160b2e724145dbc3520a3b179073d2aaf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/es-ES/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-ES/firefox-139.0b4.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "3daff8ee93b00a5f45908f4271fdfb32d4f46ffb7c3309a283ab9c1668985ff2";
+      sha256 = "c3ea8d8ca383dc7271537b5fb888ea0c155c94b0f1a7988a69359d4930b1624c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/es-MX/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/es-MX/firefox-139.0b4.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "0b93af4b976bfb4381422b26c20f82cdbd751ea1027a34e53e385dc27bd9730c";
+      sha256 = "fe673d9624ff97fafb5e41d4bbcb0142d24051201fcdd58ddf8863b0a169010c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/et/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/et/firefox-139.0b4.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "f944396258f6d7b15241cb54a8e299eea0116c314093fb66ad35be36c2273059";
+      sha256 = "721727d911c456833e9207f35b5fa574561789eb9d5aef2cf70c07a41996604f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/eu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/eu/firefox-139.0b4.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "0cf77645cea356217270228d70458f450075260b90e00287d5613a3ef0dade24";
+      sha256 = "c1d51c11fe6eb6b74a1170e93ceb910aa01b227ff67181a436abd9a272f4006a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fa/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fa/firefox-139.0b4.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "b2898e4c79921744d7536c2ea49669158044b25aa4d52c812d15d2428e24f3b2";
+      sha256 = "d48577e912bc8d9302164ce233c02bb0d1a802bbf6923d2f6e3e40466753e7ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ff/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ff/firefox-139.0b4.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "e208fd92fee2998746840149ba8db5f57be571dc77681bce374d3092510eefaa";
+      sha256 = "6397792fe1f9b6cf9e074f6dbdc620d2bb9e5a81cd9203a6b9e19d8ebe4af951";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fi/firefox-139.0b4.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "74be727c6a4c6e7f0900d00d0fefab5dc47bf3b1fec9c755c7a4cd01ac059340";
+      sha256 = "8f5c2ca086de1cda97c4383b0032cbe134a4af7231def94e19abdcf794d3a858";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fr/firefox-139.0b4.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "b272e4764673d06d9aff452bfb008e121a161c14d1f181a078b480f530e0a5d2";
+      sha256 = "cea552b5a870c9a0842dfc56bde4d91927fbc40cef6a1f0e36d0399b65ceac7a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fur/firefox-139.0b4.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "d465858108df841e2f2f6f58a89f9312390044132ddbb20aea32dac1c1d4e618";
+      sha256 = "baa9819189ba1ff16efeeb80052f6d0afc2306a09757630e978c4a92a74147d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/fy-NL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/fy-NL/firefox-139.0b4.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "498808abd06f0d076d0753a0bb4489634b3d462982a4549fe3af4471c6b49db5";
+      sha256 = "c1b1b141ced5a635383e2e0066f36c56b852e0e44842e86b684d6ceb8209aa4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ga-IE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ga-IE/firefox-139.0b4.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "cfa34d2677bc39e3122c5598dae7fd203f5e9b1d25807dd4ba9de0f669e7f3e8";
+      sha256 = "6a9348174c586c70f55d77ac9076c203287590eed6254b3d1eeed9cc8424b076";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/gd/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gd/firefox-139.0b4.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "17721331129c81f92eb62391dbf304518defe8b44caa45336dfcaff68e19843b";
+      sha256 = "c6f367eced3add25b7a51b8eb1d55b42d7cd5c674cc934c33fa9de86d6ef5c81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/gl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gl/firefox-139.0b4.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "1c42e35bd71b2757c5dab64f76112f7364e5a3c20a64127279943435f452f663";
+      sha256 = "30fcda0e983a655e8f0a87f40bf1f7e877569808b4b0e6710e58d446ec3913fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/gn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gn/firefox-139.0b4.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "2d867826ff6a89331107921d095b8f1b4fce4bd42e84be759822a625c99362a0";
+      sha256 = "9c458bf9d63fec82a51b92391bc7d7b3030cce9e6228f14d5d5cde80c577349b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/gu-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/gu-IN/firefox-139.0b4.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "84e2b7d754a5ac24a9abf31fb1686200d15a95c72b19f758df314f55a129cdc7";
+      sha256 = "92e5e135ac587dd6b7bea7a4df4803eaabf509a55b98ec2a127af3293a10c048";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/he/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/he/firefox-139.0b4.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "5bb6ec9c4223a87615290a35a5cdaddc5ff0800d85a807ab3daef0f3dd4665e2";
+      sha256 = "ec64a5e068e2223c95ac1c90531ef9d857fa72f03a5b4b200242029b661344e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hi-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hi-IN/firefox-139.0b4.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "4aa787d3a09962e752c6e727ca07b3221a35954f49644407ab0aac22b920a339";
+      sha256 = "434c8bfea7979d256f40f3f3766c1230b8a403678893ad988b54c19188ca82be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hr/firefox-139.0b4.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "41c46b1269ef9ca0972dea37a17701a428bd0c7ce64f19c94d838cadefc2a231";
+      sha256 = "59d09b703c2ed3dc3e289310503e505507b345b1c5b2133da6ce59df9f952b06";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hsb/firefox-139.0b4.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "f359c2f20e3ee863a617419c6020818395c136a4b10991c930adbbc41087fa9f";
+      sha256 = "55ac7f1a2a6b00118aae7d3acab31a563cf05a23e4f35389795cdd7afd613b6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hu/firefox-139.0b4.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "8b5ac5424dc438b4e10673a3f6019d85134b0045259c1407355c2df1768e5643";
+      sha256 = "75265bbd21c0c783c373f2ff57dfaebedb3baa8e8f635adb764d00ae340df15b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/hy-AM/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/hy-AM/firefox-139.0b4.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "718c98bcdbb5aaffb0dd1647a632159554cbf215d4a33824212f578d1b2837d6";
+      sha256 = "825bb3ab555455af7204fc3081d4e881bfaad7272b97c7a52d574711ac6fce43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ia/firefox-139.0b4.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "cb77e02f475bac87767a91fc6448070aea9e13ea36513a510c36ceb64910d895";
+      sha256 = "07b43f7d3dbf12f9d8a9a4b2d393b0cc9fe3ce0d333431b9d8c694abf2948607";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/id/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/id/firefox-139.0b4.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "9f3be1d02453213115639060ac02cc5d154aeb30eafffee5a258cee6c41a1187";
+      sha256 = "bf34449bee65bd3bf8ca7568683c111e19af99323970f6070bac75ae5d8df14e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/is/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/is/firefox-139.0b4.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "c360c3a27aa8b174e38d05c9a4dd40a72d3b9968b3efb705fba97433aaeaa66c";
+      sha256 = "4b825583d13bf6f4b75cba352d1bf0eba3ab97c92f62da2c16aae79174f6f185";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/it/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/it/firefox-139.0b4.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "fbbe8510405a558eb15d1ec6e99f7e307743220f2a5886c85fc6600e36048cc0";
+      sha256 = "2dff0bac0c85f40cb21103c48e0489573cd12a21078b8edc5af5cfd6c1c5be9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ja/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ja/firefox-139.0b4.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "8d16338d16eaae1a065afe8d34477eeb3a246679cc8f65e79725450735d40d0c";
+      sha256 = "7012be903c3b748178a4bdd87849251f01bc341bb1d418e43c15adb8a5236697";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ka/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ka/firefox-139.0b4.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "fc08a082a89d3edca2bcf61f295fd624cd86e93cb9a1615638c8212f526a4b4a";
+      sha256 = "bb7b562895a31c2985e5b57dcd697ea65e0627c3ca92a7a1031de12d88f2d112";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/kab/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kab/firefox-139.0b4.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "4bea9b3c151c7521b0bef38a21bfe7685e4a24c29c645765f42604cbb55ba854";
+      sha256 = "534d152fd21b7206fa1d781167d2d39114224e694cd6e0ce0df0c51f632be8d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/kk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kk/firefox-139.0b4.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "b54663b35c23513ffd45bdce3e0baff2d0f4539ecedea99d3a2ec31ee0d954b1";
+      sha256 = "c914ef270be6d93b244e77eae73f0b8dc81ccae98d1e5648c9f36df3534b5b83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/km/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/km/firefox-139.0b4.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "240df5bc306c8eb09fbc707592f92e3a8a50026491b01120aeceea835204d007";
+      sha256 = "4c4b716afcad883b4c3d4ef98f256fd3a7383c6f6f9daf004ed57dc66c9cc1d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/kn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/kn/firefox-139.0b4.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "2eb01ed15c38fbf823310f0500046fec193ffce8e260674e48e9940545362fb6";
+      sha256 = "bf36d322be0eb143d16b3266f468218e4db77edf5752d92d0527737d5699bead";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ko/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ko/firefox-139.0b4.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "3443871e1e0b6f332379cbfd4bc9b4ba4902973644c091d91304cb9197519ce8";
+      sha256 = "d306fe18f0afb856b5eca468cadf0661a0f296900aa213693f9dfce7ce01e693";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/lij/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lij/firefox-139.0b4.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "24be60be0493df639d1fdcec1067c331dace4067d9caf6fddd8833c706edb937";
+      sha256 = "4134c5b66369b7e7baaf9ed18e686aec1f6fba8dabfcea557c8801e271099604";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/lt/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lt/firefox-139.0b4.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "1c4db0a32b53ebfa0868d743dd61b6578655db2559902b834a6e3c878e546831";
+      sha256 = "d02e63dc5244755d70d7c6adf8809e809ad5624b5b2cf7db5d549fe873c8e030";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/lv/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/lv/firefox-139.0b4.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "6902fe65dfa7d5ff8761835b4ae5c3a545b5fda885ef59c69bfcc102f8caeeb0";
+      sha256 = "49906a5a4bf59e755de8002436a431adf3a26ae70865a5c14cf2b1148d67be46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/mk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/mk/firefox-139.0b4.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "7e6c17647447da936ba569bf2e1773b3b56de0f2703f47104b53d4e69e78dafd";
+      sha256 = "d0baccadc36ae94f9038e2c22b0a90d2084c512b71471af4e8f744548c92a79d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/mr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/mr/firefox-139.0b4.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "4e0aca0d5e4d994ea9c1b223afc6a5c5b31b48c130c57be8db5d28a4886a6260";
+      sha256 = "f8015e7594ec2b02914884f5be2d50f2cf0236bbe496fec731592ac81eeeb9a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ms/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ms/firefox-139.0b4.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "8cee31a6791556810ac791ebcef8ac5d30fc1cb72678cb2935e0555f62651ad4";
+      sha256 = "fd820b03aebcfda8057f630f881c49d443f14661a6bf55ddd4b9a26b4cdb9308";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/my/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/my/firefox-139.0b4.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "c8a7d8b72da9930d9e8a013c01e028ead5c5525cc46c5043180fbbc924ce38ac";
+      sha256 = "f2286cf08af4be1daf434cfe972049f40ed68b1d59a0073c0f022c9f02dee1ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/nb-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nb-NO/firefox-139.0b4.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "7e53fb62a519456519531e4e279bdd004a626b4de690e9524eb2bcba16457224";
+      sha256 = "668569c1fccef37f1398b1ecd9e9974081e6c055edd0577bc464fde69e5e7ada";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ne-NP/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ne-NP/firefox-139.0b4.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "e503ff023e51e5c772bb4460b74534be7539083803491eb6901559c41fa93d25";
+      sha256 = "6ce7d8b5d852ca4abd94fd8505e52a2482b5b1ba207d48fd02dce6f585ef0fd6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/nl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nl/firefox-139.0b4.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "a6f442c5cbeada795d317e3245e1c28d865b302a1b01e484009cb34130067576";
+      sha256 = "b57bac3e8a06c66f93f7c98a77accfe6a21661d6bdfc148cb2d8f3ce83bdbb80";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/nn-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/nn-NO/firefox-139.0b4.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "24bb3d9bba4549696ae339edefaa3d3f231ca1cc5672d2d52909c1cd09f8439d";
+      sha256 = "01ee287813e78d073926bbeaab9cafae2a11e9239f8da1db3c45b5d6168a5f8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/oc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/oc/firefox-139.0b4.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "502ec34f615bee8b3bdfa9cb95960f9518e3ec90d4db802bd9b68f1a9efe1a60";
+      sha256 = "7af2c95d9d6c9241fb98dc21a4c542f6e038098eca89a72aad53d03d834cf8d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/pa-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pa-IN/firefox-139.0b4.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "2ffcf30b6ba7373b232bbf82f6bf33704a85bb0be7f498f42d505c47bc6dd620";
+      sha256 = "c109cbbfc292aa3ad04656c79ee5fcd0b839032fc156499dadb60aed37d93c13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/pl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pl/firefox-139.0b4.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "51d5b980a1b086f8a4ab728a357ca705c8b4fd495c77ad233f08ef7b84c7ae73";
+      sha256 = "ad2ee57783e372d968b9a76b4b0c5f4cf039e53f6ab8ab5169d556bc9733b04e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/pt-BR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pt-BR/firefox-139.0b4.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "77bca34213ea30dce4f105f0322832ced7ca2f52d4d6fa07345069a8af6be4fe";
+      sha256 = "c4b649b39622a0cdd8afaffdf531681659ae6c092221786df71ada4f8e5dc81f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/pt-PT/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/pt-PT/firefox-139.0b4.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "8e6ce8af8690284c764bcfa6588ca52997c2e6e31dadec887a063b3652a2e45a";
+      sha256 = "d84337d337c87390e8ac98f43d8b1199d3b8bf640d55ddd2eda86f3c6c2f9084";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/rm/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/rm/firefox-139.0b4.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "7e69cb160def7fa4dc050cbd442635b94f2700c93aaf35cef02b0bc81834f07d";
+      sha256 = "a8d422e2ebeb5c76a27e3df7dc8ca4052be628022d3d7df38255aae4b14089d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ro/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ro/firefox-139.0b4.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "af8a4e1bbd653f5e81e0e2b53e7ead8397327cb0aa6bc12dd57de051b22ac6ad";
+      sha256 = "4b222f477c9291a0ed28dd51f57588914e26efd69c0a249cd2f4a3251ef2b3cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ru/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ru/firefox-139.0b4.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "1b4f515de80b1ed1783644d22b61cc9f9e120831b55e354d67a95d47cb8915de";
+      sha256 = "caa6d2698ce1e5508f5fad2bf90563b10a8f9961042c089f2f1a5e4d61822246";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sat/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sat/firefox-139.0b4.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "f95bef736c704afcef3c1a04cfaa85f06d5b44d7e7cc9dc16a7e953281efad08";
+      sha256 = "3f17440f5a67e6ac0f7f0a67eea72a4beae7c20627ba97c786f4740563adb4ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sc/firefox-139.0b4.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "8a376905176ea8e58b761cba3fd844c3995db46e1784215e197944babe498dbe";
+      sha256 = "3eb57781a60c295918d7f065edc1429bcd2685f01398c3176fbfd097bf88e059";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sco/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sco/firefox-139.0b4.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "ecadf0d2b59f3c3ca78cda22a305cfc29943690769303e4402457002f1ad5668";
+      sha256 = "a6c32b5c1d63728429ada5211857a49c056ce93b23d428f26a8d00efbb143e91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/si/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/si/firefox-139.0b4.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "ef2f594a5582765bd6f32c1089182a3e5c6bdd5f42d68e6984501190a9f524cd";
+      sha256 = "dc50c48c50cd0fa013b0754dfcecd15015392d23e0247f33b3ad15cd7aa309a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sk/firefox-139.0b4.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "b4b6faecd8bb2c21fef94b2ac1dd2cd05031f04ce07bba5b0e69fabb68a2f9bf";
+      sha256 = "35906da5afd4bf8a52ddbd2ddeeb9ce01b40d5e93968e4e1f66541d0dcfb1b88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/skr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/skr/firefox-139.0b4.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "0c2d8fd72ca6c597092ff5e24be16a17a3a4600428b2acc8ed98ea3a0c6732a8";
+      sha256 = "0af03523f3a0987e32c36d182d51c318f62efba1f614d2864e571837ca8eab13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sl/firefox-139.0b4.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "7edce37cad96c5c5555f63d804ec2fb61dea416e231a8d39725e835dda35133a";
+      sha256 = "d7b9c75397dddb544fc4287e43f255929f04ba3e5cbd9c8c737f1f47d4d8353f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/son/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/son/firefox-139.0b4.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "c11063194e36ee19681d777aa415565dca2ee736648c34cf37cb30b52f2ba700";
+      sha256 = "7ab390ad40c8c7db2029a5ff103e523f2dce8691926e4f3f140c911a862937c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sq/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sq/firefox-139.0b4.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "4f4c1bddcad1e0483da836f75aa93f2bc8282ee0d9861e9c1bf27df60793c4f1";
+      sha256 = "3fa9746d65d15ebed2d0bef82e16c26c25fe40671ea71651c3ea55f23769a5d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sr/firefox-139.0b4.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "a0faf86b492539e7def08c4b90ecb279e3b006e14a043dc48534746206d7e555";
+      sha256 = "954194b63497a3c490f819188c7353139af87a0c6ab2a0b87ce5db1a942d8b68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/sv-SE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/sv-SE/firefox-139.0b4.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "63f3cd89b64671e31bf1cbff9112d80b95199e12e6df9e516069c1d86d5a34c3";
+      sha256 = "ef30b8f7ba31857b871c4e41d139eee7ac6bfc759a461c0addec73b1e1559695";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/szl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/szl/firefox-139.0b4.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "1ad7b45cbe71bf50ae0837993a359ca81a4841e59d6b537a72475c28df79612c";
+      sha256 = "ba038643ce7af49c6e16e6eece4a56b4bbe85a9a14639d534b9cf64884046154";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ta/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ta/firefox-139.0b4.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "b75104161d68cbb513aa6c1f0bf5215997de73345b9ca7c7899061bef2cd5d78";
+      sha256 = "b12d92276744680c57aeabdbd714bf5d3f2ea09030858d6d38d4aae80099989c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/te/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/te/firefox-139.0b4.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "a6836538ff1c2a98ee049af9ed6bb6bb5d50d7a852c7d5566a7334f7ed7c3ca2";
+      sha256 = "eb5b186241b7fde86cc0f57fbe3712ef1d3831700d741c1955fd89efe84aed96";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/tg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tg/firefox-139.0b4.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "9f731f33297fa4061047b7c40d331eeacd5debc8162140de8736ed50676ef563";
+      sha256 = "b3f5feef512525cc09d11935cc1fb0b7086756158bd6cc6dffcd22cf3ec9497f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/th/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/th/firefox-139.0b4.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "0143fd3b0899b6e93188290c486cceb96066627c1c39a1aa446d4fe1bba17bb9";
+      sha256 = "2d187742b7e8a60f0a427b60f41f1d684d19360e562d2fc9d0f968cce4581b21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/tl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tl/firefox-139.0b4.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "c8411db1ee1aa0180fd354f4571d299edb962e3b8ef60951f9fc08c886b11fea";
+      sha256 = "44c490eccdae6a1c0fd08d7c3b589de398498f4ff705292ff6f72366f27dd768";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/tr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/tr/firefox-139.0b4.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "448201c4e9f0d6952d838de9ff6bcfe69a4769c2714228949d0148f56d9330a3";
+      sha256 = "b784b58007959048c3067a041950813ec8be9ae30a73dc24bd0b5f1b3d702460";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/trs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/trs/firefox-139.0b4.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "f725dee6d30b294e83f75942834f51705bf34b67c77cf4ffeaf196dda137b75d";
+      sha256 = "611991646e94273c6b142f2af670755fe18878f2a5c61a2e9f13a0fea99ce775";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/uk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/uk/firefox-139.0b4.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "6953218f8567be687af1d53a50ca9f725248877ef662b4e0ef008063c763e8d7";
+      sha256 = "90c25ceb18b53030e881e0f44b7d3e23c5b6c9cd380babfdcad957783d0e0c4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/ur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/ur/firefox-139.0b4.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "aeefe7e4096ac1af3f7ec767606306ffc73d1040d09f43f54f201b451a23b401";
+      sha256 = "9be466dcebfd73ff9b5a4b0982a9421034654310ccf077fb812d652b67d6d284";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/uz/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/uz/firefox-139.0b4.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "f4589f2e3a49c207b90875dbd01d358d519bd2f5105f6d6045a1364d89a44d65";
+      sha256 = "9d58ea902acb5ad35b19cd87f5423b21fb7772512156198d2fd05f84c08a778f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/vi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/vi/firefox-139.0b4.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "5d768acd15e31d66445a7548324e4d782ccf88922a5bfa56c0a4d3caf75a0db7";
+      sha256 = "2cfc4c3f5d129a3041096dde196f3e887498a886dac1ab6845fb54b7eeae16d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/xh/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/xh/firefox-139.0b4.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "798a0636308acde4888372e94d6e3f993fbe906c089613e96b4e626273783f87";
+      sha256 = "4eab0c87e4bd3f54d1e77b83a8c82b084c23beb0d0882d542e04bb19e798c98a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/zh-CN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/zh-CN/firefox-139.0b4.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "8fa3a3be5c1db35edea30715d7d2bfa0a6435d88b4e17d400a57be323df77d62";
+      sha256 = "e6094469887c77d367ca255d0b461d47f9a352b12602042caaf668846b5f295a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/138.0b9/linux-aarch64/zh-TW/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/139.0b4/linux-aarch64/zh-TW/firefox-139.0b4.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "8bca45e1549d5dedb8e3ff67a6df7b3f212e82de1f6e21dbe1bb3cc355db03b4";
+      sha256 = "4b5490a70185a206ad337404876cf943bd49681065d87e302a2856d2543b0329";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "138.0b9";
+  version = "139.0b3";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ach/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ach/firefox-139.0b3.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "fac3e45580dda38a3dc66a2a7676d01d1108de924d55197199a56367558c7ffc";
+      sha256 = "fd57bc7e6844cedf2c85e685246c42d929d3156a77e1d0ded40b8bca1099d5a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/af/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/af/firefox-139.0b3.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "ccf8e5ccf092102b0e8f3c948e51372103801784c3ec1fd5436a70409e5f2030";
+      sha256 = "5fdb91b4dee48d1ca0a4191b6d4be2ea44bc2b1513efa50434b763f1fcd9d69e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/an/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/an/firefox-139.0b3.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "d578ed10644fc11855c24f978489935b6b33ee6ac79766d33468921fdbcb042d";
+      sha256 = "ddb7dea1828c4906c5a6126f1d325d4eafade0a247d0f22fcc9c4e212bb79010";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ar/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ar/firefox-139.0b3.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "618c70e0754444d6b7eec2ecd3a18bcf197246331938a77b2286c1565bef6880";
+      sha256 = "cf581f622fb37c71e2886fd122bdc826600ab04cb8a2a5725905d29ea087157a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ast/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ast/firefox-139.0b3.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "3d7edf7c2071964b06daa31f238d041f91e3018faa9ddefb2a3225d5e1c77321";
+      sha256 = "436e4ab12e59de6b5cb5cba78d3e68db43e0408460ba46b25b81e03effd71eb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/az/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/az/firefox-139.0b3.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "5f7b178ad698e76a4ed22acdd0db16838149bde97d7c4b21d0321c5493d5739b";
+      sha256 = "1d62aa36c32b2dc2f4af25ba12679436bcf79e50c2b73db1624e4fd7bf46933b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/be/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/be/firefox-139.0b3.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "e582ca01ee37c17c02e370a8fac3b55d581b968208b3bcbeaaada42c912aadb2";
+      sha256 = "f054bea6716d06ef8aecbbf147d3c81cb61f514e82ad57f515204aa176abc33d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/bg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bg/firefox-139.0b3.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "d2f149d28656df733ccebc6db3363ef3a82f33d36dc6b05c1244ff532e179ab7";
+      sha256 = "ffb4c108609792de752947becc51c2e2975e90ea0fe46d44601c186f804eab49";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/bn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bn/firefox-139.0b3.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "abe3f081f61b49b44f65cf83534e39e9c58bfea366fab944ab8011e79806cea3";
+      sha256 = "877a26a16590cde1bcd678b0d419bec76f09cf4be230d0fc93fddf751c08b13e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/br/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/br/firefox-139.0b3.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "90161de073a2e82e6fff864c54bea3f20341482409c5caa818e581fb8d75ab45";
+      sha256 = "55bd564631ecc2614080ce653ad5312ec5d7de98df948b1bbe8dd9e613cc77a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/bs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bs/firefox-139.0b3.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "47a09824419075a2e8c49e2101b106d4845d5d21720f8f03a2d62ccdc16fa5d4";
+      sha256 = "f33fbced526a89acab9fc34a860e4811cb83842a583f6d7871d11152ff1fee4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ca-valencia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ca-valencia/firefox-139.0b3.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "a501ae1bb0c16f424ce8b2fb32630e22ffcdf5119f604748c577a14e70425b66";
+      sha256 = "d9c250c770914d018f596cb15ff87c0d009ef0121a040f09c1c2e8c95e415570";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ca/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ca/firefox-139.0b3.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "76369f8acfd8ea3f0c233b416513c4bcbefb7dbbabdf1561bc33587535b61206";
+      sha256 = "1a675352282c3fb2966287a0e763defc6f259ea396ee17c9ba4d71e79ce263ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/cak/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cak/firefox-139.0b3.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "8d7e3a3b6e946dd51bdef1e8b026be61506a80298e5055532d56d514429d2de3";
+      sha256 = "3a672f2a6b1132d0cc37c9fac289c7029588d585e887a05943e01d2df0059562";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/cs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cs/firefox-139.0b3.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "a2c0dac2d345b7fbb055c65ad78a357abec5a3268deb83ae641547dab2b6b202";
+      sha256 = "f83bde54b11b0cb95c49a953d74f5d9dba8351e775ddb53238debeee26ab558b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/cy/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cy/firefox-139.0b3.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "eecf598f5e8f8f35a7651e9529f250caa18555e13407a4cf7593d7fdb3aeb071";
+      sha256 = "6876cb45e012664a3ddeeb8d833a28d97af191b3653a850393ba24c850c1c327";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/da/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/da/firefox-139.0b3.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "eff5993b3a3b0ece22d329789c9b6407949ce5b55f0d19aad8241d41efb30205";
+      sha256 = "438f790a0a0c8648c9d265a4e3d487d87ffd6b41beb91bddc8b60e538e2a7d40";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/de/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/de/firefox-139.0b3.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "a1a13e306d24dac00e554d41b1c7ec531eded5776ea3e59b206dadfb06a5e8a0";
+      sha256 = "70d4882852da68a7e431de93377cb7b7a1f68b906c2b3332f6b65ec705f5256b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/dsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/dsb/firefox-139.0b3.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "30884b572ff03760da2c24be3c2411e9e02419c304bb3f416117888eebd9a6ee";
+      sha256 = "7e845675e5a334b6080505f62790e6dda22aca0f07af1e1599faa9b2478ac3f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/el/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/el/firefox-139.0b3.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "a4aea75a8bab414d2459826896d8f3e127421793b12ab1561532490bc8903b7e";
+      sha256 = "07675440e77b87a0b64a83b28e59be294fc559f7fe4d5d6506cd34fe4dfa69f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/en-CA/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-CA/firefox-139.0b3.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "f55cac940705067f1db247a7ff8cbe2dc1ea94d2d871715e2c6637b8b107e47d";
+      sha256 = "988e4e463a5e3684df5633e11e5e37dace06626bb20e04b1b69e9ef089d962cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/en-GB/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-GB/firefox-139.0b3.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "355ae21779afa49529d4326aa90a34f769a173d05f37867bad22f35ca2246e4d";
+      sha256 = "b1c268a2c350a065e37cf259c81b6e535c0597c15e046fbac6dbcc064625bcdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/en-US/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-US/firefox-139.0b3.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "9e46180848c5325eb89ed8abfcbdbd3b9f456505d974a94db5251aa16b42d1b4";
+      sha256 = "7a5f6f3816f25442272606ed5e45a9db22c507f0ceaec5858e55d02e4dc10d54";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/eo/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/eo/firefox-139.0b3.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "ef8d7e854713c7290216eed11a0c955b84b1d420ffae158213b969982c4e9a43";
+      sha256 = "b36ab4a47cb20b07b1c1ac77c3cd24fb850feb40261d398bc0b1f16d7e1f0e1f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/es-AR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-AR/firefox-139.0b3.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "ca5f6fdbc881484d81d8d8c51b6287efbd094d99f9e855a15971be6c5892e570";
+      sha256 = "cd03f278e58beb350683174d9614b78e41f2f0ec1552d50882dc1c405bc37ee6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/es-CL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-CL/firefox-139.0b3.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "4094838744161c74dd52d9d162eaa1141cbe1c6c1fa8d758de10d9e9494ab226";
+      sha256 = "1ff43a0e99f0f540944209470ae660756cd41a1b9e5fa267a78cdfa1b6ddb287";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/es-ES/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-ES/firefox-139.0b3.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "7b592155ce80524c9c70ba1ffe7ac828f2120947d1299f852e584f5e3c129355";
+      sha256 = "9a8abef988292db0d3e2b7d728770d6e8b397f90493acba75b2910ff348114dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/es-MX/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-MX/firefox-139.0b3.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "9b43a551c24950bb913470851306b4a639b9e0dd03c795bc9a9757e3514fe9da";
+      sha256 = "f76653c3b4a3d7244eef6adb61ea79903f42133deb4ec5c93715cbe06dbaa1e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/et/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/et/firefox-139.0b3.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "0c8f1f7999bedb0079d60161c980aa815d3e35476b20150aef8aa61e77c4819b";
+      sha256 = "3f725c9a2c84f3eb329d321ddd4b3a3ea6a21cf64fb3f18dd0fb681af378b007";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/eu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/eu/firefox-139.0b3.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "008aabc5712b6d6f5fe891327c8581c46267f9c001fb805417b8a98c6452ec73";
+      sha256 = "bec67bfbfae8f1a0969c1bd083d200db25e9d7efadea0192955e2ca5be3a506d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/fa/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fa/firefox-139.0b3.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "6510fbb67a2660f8c77aec275cc2c0a5084a5348f310caa4d9da692f80fea7f1";
+      sha256 = "c37543777fc3c90368768c730398c1782400f94e05b26601cb6068f0b947284f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ff/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ff/firefox-139.0b3.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "272562480de6352c02e55405339685b95b9a22344e2fc303edea0e5bbb4aca8c";
+      sha256 = "cd4af2a894a4a6f523aced106bad12f91ec41ae9409d0a5b32a1ee99f09c184a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/fi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fi/firefox-139.0b3.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "b5da682b425762a87f0bb444e0d44144cd2ef0acf640030e20ee9a35b2bf08aa";
+      sha256 = "7e9e1692e2d870375e17d8f91be4808118409088160bc61df8d2ea99fc4879b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/fr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fr/firefox-139.0b3.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2eda0823bc291693442b10585825975ed31c91f5586f9dd000bf9dad557688cd";
+      sha256 = "2d1eb3ef8903cf00994a8b0b249cc806f0085b8ac4de11da66cc0611ec9ca62c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/fur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fur/firefox-139.0b3.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "e5463ef4123e78a059d44296ff735a0644157264476851829467a2d7605eff3c";
+      sha256 = "1b6a9f6592e3b2d35553c39b8bd59a1d0e7975c16d6e742fb748fc5071e61c8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/fy-NL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fy-NL/firefox-139.0b3.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "438dafcdaed91b4f2f919fd7f07659cd803148f7d1b8a4e40241dd9434a4e1f1";
+      sha256 = "9bea116bfd10e2687fd903fa533642f9380901196a4068a8d19d05176aa9b8df";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ga-IE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ga-IE/firefox-139.0b3.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "c2d1f2276f1190d9870c52ea65bf3271c61e83b5b42092207cc807d4a92e4569";
+      sha256 = "fcc39ffaccfddff75c5b9dff184a7f67df03c24598910dd4d89380e29fc9fbdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/gd/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gd/firefox-139.0b3.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "c84325d4f12d485d16b2258dce59bc9999f8bc61cd0471eea396175ca8f51516";
+      sha256 = "3bfc75d90fd3c4cc7a271350e7b4474ac5dab71f742aee22bd994c775906fab9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/gl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gl/firefox-139.0b3.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "d84e04bf50646dbd48c41a6cfa7bfa4c18388bfe6c526cc3ec97867fdc06cdce";
+      sha256 = "9a1008adc5c74857777bf8379bfcfd5592c987c36b9495534ae6c5cbd1be740d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/gn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gn/firefox-139.0b3.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "0cf550c094fcee7c4dddf72a255ddd3de897e3d50abed9ae5de8e99deaa7728c";
+      sha256 = "46aa366e2df1df9365ff81214b637ab563689d53714f78c4950bca7e78334678";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/gu-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gu-IN/firefox-139.0b3.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "f4ed2271454fd1f97e677d9e927921661b88056465b859be8775df9da17918f8";
+      sha256 = "c6a34a993efa290921958cc79bf4a59a9fe66548a7684710a8eaf07f1e62d9ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/he/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/he/firefox-139.0b3.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "16b0996fd62d9d06047fd4136b7de73959047d19d653d358909a64f0777d3d54";
+      sha256 = "86462bfc1e78034b69e106d1c3a728ccdd1f18ded37563fd9d7ee37d2b98fedb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/hi-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hi-IN/firefox-139.0b3.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "a5d9e4132c1ef8398083fb0d05f146b3e40dcc4a4188d99999193319a3b6c529";
+      sha256 = "36235be9dc59e2c093a43ad0d7ec6ae8341f8afa9fc939c6d29590acbd384e72";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/hr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hr/firefox-139.0b3.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "e3f7b4e448c6cc2af483c4a21f7ace2091163d4620691b7f1ee8f40dc079e76d";
+      sha256 = "20eafa0b16a86da30b39dcda17e232d69b0df3e02f1301d7c52e192768ed52f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/hsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hsb/firefox-139.0b3.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "1f56c9c98120587c6b798154a2c86928c72f70114ec99826a67c735482981630";
+      sha256 = "e99331dc0ecd3f9be2dfa63dfabb71c2b3d8d84b62fbdbe67faaa6e106cfe2b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/hu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hu/firefox-139.0b3.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "05767b1295a83e4a3d176799da30980f06e06a9d7076895d57d6af01fc42eebc";
+      sha256 = "1d14b5d69e230ef6ec21f2376b07230b64981e66f79c968c47ff109b34fe421a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/hy-AM/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hy-AM/firefox-139.0b3.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "f1cc29065cac79af1a37f23c43ab21aba4b46421b48fc73c33e0512a453829eb";
+      sha256 = "cf226323063c8d2786031a888b9001b18f282708e858247f9180a1bea3451282";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ia/firefox-139.0b3.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "07c6d4b5aae436063c302449bf1f46256913af0ce3292ae9011af21e3466c7a2";
+      sha256 = "b4d61eab8372f1cc20f28c1a3e8c1f72b21d584c0dd45266a715ac116e4e0c04";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/id/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/id/firefox-139.0b3.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "e6fb154b7416661d4f10da95440bef64d59542b8bf15169b7c0bc1b04617cf6d";
+      sha256 = "7086deb11a567fb9e15a2b301fe4234aff8ba5125cd6a9371700f10e6e89a06f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/is/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/is/firefox-139.0b3.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "a44dadf3dca261ddb53f28d201363f5f8617be6bd4fa86f1101ffd0df05ce228";
+      sha256 = "f37387831ad3722a61a9bdf082e15cdcbdf6f9757be183bf2f4ff44b7e44d1e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/it/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/it/firefox-139.0b3.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "74842c5d3754162465ccf49dbc3ce7393fd3d55cedac86e00cc2504a0e725028";
+      sha256 = "9957340442c44bbc4ce06897545bb977a290263377ee3eae5b64616e561b1a21";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ja/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ja/firefox-139.0b3.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "5f18fbbe6b87776a7605d531bdeb2c170b500634bae8d887675409d7303bb856";
+      sha256 = "8eebb7e6d6351a8269b83fd8095b86bf8b2f4177565cd2fdd323717cef6971ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ka/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ka/firefox-139.0b3.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "6d6e229b209575fece7c5397fe4d32921301468bb96836a2be25251708d2437a";
+      sha256 = "fafdbba964ad85b38565589118323d1551ac5021e041a00e29b8a629229e2085";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/kab/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kab/firefox-139.0b3.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "cf47e8c71ceb87f68a8780e16feed71e2e23bfca5e1e5bc7ee4469a25f52c9bb";
+      sha256 = "ef2f0225bab971c7b6b6237cf2795e9281730b459812209f2d11656ad39e698d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/kk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kk/firefox-139.0b3.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "57860d964a8d7a40b5b541d98d6ae22ef1f29bb6aba736f7e7dabfde10f6171d";
+      sha256 = "cdfebcd9afe5c55c6ff84543580e08108f3e362751f09b99cb703c20dc1de3fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/km/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/km/firefox-139.0b3.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "c2f8a0fdbefc7a07fc27375a1cb5a117122193d3af2622356d450e366fa76e21";
+      sha256 = "ea997189f11e283f1d37e7e8a148f45ae0f7557fefc23501d2cf534a4f4d423f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/kn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kn/firefox-139.0b3.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "448f47e9ec0c0385abbf82edf342c393d682ad1589439ef3c789b401d32c6181";
+      sha256 = "005b89059b12d1369c338f9206e899c76c0d5a97ad94f28564778fc092694814";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ko/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ko/firefox-139.0b3.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "7f2389efad36243928ed469e7d92cafc658747b3ee5b9afb7b2dfbef9103d9d6";
+      sha256 = "56282aec275e94b3a556e3a9b95e107e68cf366f6d2a9dc8ce7fbcea9bc23ddd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/lij/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lij/firefox-139.0b3.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "385ddef8582f0cea7fa5064bfb0800ac18c668f2031959917c91c581187c3adb";
+      sha256 = "8ff69cc72d47d3e212280b8ae004abbb9a34b6e052cfb81f6fed4b1c0d85f8cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/lt/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lt/firefox-139.0b3.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "0a3872c32a391c5590996360a8e27febf0d0d67f9b326950c661b77a57e0dedb";
+      sha256 = "353a5ff5baa875628c32f6a0b7cbe5234209616684641032493394c986811cdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/lv/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lv/firefox-139.0b3.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "564268bebf76c199e999504fb1dc50611264c6048108629f460d3731a9de8eaf";
+      sha256 = "7eb1a0e3e0441da2df5082693588135b8e7069a29c82c1331d3defdf3e68b837";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/mk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/mk/firefox-139.0b3.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "fba1e3e6b1ca45d52c28065f937de750dc6ffb86fd6482ea3a795d699537fbe6";
+      sha256 = "d7df7d215f440025117d472c7962f10b3db26536d424b633860bd0a2b8634e13";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/mr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/mr/firefox-139.0b3.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "f1783b6ebfff648efc8df599a1371493a18739c1256e4461241c086a38106e3c";
+      sha256 = "9d6b1174365423cac77f4066e174ac0e24808cb8147cb0fc4a04f526883f3038";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ms/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ms/firefox-139.0b3.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "65317e650639b4becf2a3faebd8391f0571a1caf482e096ef5ce7db4343089e8";
+      sha256 = "1e3eb5e62665157538768e85c30728e1b0916e9637a4d7d5f3fb390c9bba31c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/my/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/my/firefox-139.0b3.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "7d55d83d055b9ca35a7b20e32a1c68e2b86e17f7fd26615298c8b97872654261";
+      sha256 = "76fed1cabb2e1ec137e939d6b0318c32e23e5fa9d5602c08f6a9e56f0a469734";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/nb-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nb-NO/firefox-139.0b3.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "dc80b779c4b3bd18ec56a2add03aefceac05d403b10dc014a8c541864a449ff7";
+      sha256 = "afb07ebb11a8e3247b8689a7809bb33a83cbe88ded223e5967d4251541f3d55b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ne-NP/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ne-NP/firefox-139.0b3.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "2ff85a09b59cc7325f445b2f0abf0f9e786524d34c9de5bac895977926dbba4e";
+      sha256 = "a877b86d57e978bb020d9a4447a96ae85f0d8c9bad117373f81561e8379ac051";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/nl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nl/firefox-139.0b3.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "8b46a4fd2f14ff32a9590e6a8a799f1f0f91f8867bd27178a0f72b08e022e417";
+      sha256 = "5aead7a62bbfa6f765be274d64d6d8a6402b2dd6ee68a571600e64433a871854";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/nn-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nn-NO/firefox-139.0b3.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "ee59ab82add8c564d15eb54f183e94c4d53cc293541d85a99ce487605b746718";
+      sha256 = "d35f50beb12afd6427c615f4faba025e2679289b7eed8772b9c2521c0f096130";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/oc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/oc/firefox-139.0b3.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "4c2ffb26b88227f3bed20b4bbca3f70a88b54dd01c72b980ac2760f9e500a40a";
+      sha256 = "a309df62f5d50210dab2d410ddf72cf8ce83124e49250d010a3098d45a519403";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/pa-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pa-IN/firefox-139.0b3.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "8b2c5d33193d0e6fabe775c4f36a74db8620ce6162f8d6b2415e2f9dffa03c8d";
+      sha256 = "76fa9af171ca8ef48f2d40dd357dff2f4f434ec5972934d8d5660b975d9ff14e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/pl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pl/firefox-139.0b3.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "27e6d0deb8bb6a0fab1ef365dded0560dd45eb1da380d56e477ca86ee1731c20";
+      sha256 = "441c0d7aa570ab16c13da29e1eef27bd58277b0546481dd455af687eed1c3546";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/pt-BR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pt-BR/firefox-139.0b3.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "85c77c2a27b55135dc69ab3b9b96e2e177600ee95b27230af5ddfc9265daa039";
+      sha256 = "401cbd05af87d88f8351a6780a200f32d3e5521ddf8dea09f4caceb565eff554";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/pt-PT/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pt-PT/firefox-139.0b3.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "83efbd2d771a51214ed189c20e5a0c9fd88bd5de8d437dea5e22d4a2119ef8ab";
+      sha256 = "1a64160ff804281709b279c0671be0a378020c3e9cbbafc21c537212af67566d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/rm/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/rm/firefox-139.0b3.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "de71bcda7f802216262c210babb3192b63f94c7938d21af645c97249b1f868ec";
+      sha256 = "d05161f9d5a54db76b46be34c13bd628645f57175e237d691b4607f8bb1ad13c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ro/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ro/firefox-139.0b3.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "68c95805748130967096fd268dd12d197fbe1b272e1fe85909098df96a0246ff";
+      sha256 = "01813e83959f3c51d841d5d5a134b903fdd6908c77f932219f7f2976be33d151";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ru/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ru/firefox-139.0b3.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "da6b03ae99992d4235529a3cc042c0eb049b9a1e49b3db10aa049a2c7c7f8807";
+      sha256 = "60562e6b5bad99bd61b31790993b1af13d66b71888b75680ea2ff2a0a429a682";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/sat/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sat/firefox-139.0b3.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "9214a0b9e499e1b75bc78925cd7097b0f9e1a441dc0ee461e59d895b0f766767";
+      sha256 = "363eedd05b26529651905995a75d4fa7cc4a4cb0eabd71223011df8819b2c9e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/sc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sc/firefox-139.0b3.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "e93fbd4c7e2b472928ad2397bb2a6454c0dd8604988497475007df8336186420";
+      sha256 = "d4893587265913d0cdab363809038afd61a0c96f8add8605f8f709d7cf6df1c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/sco/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sco/firefox-139.0b3.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "357e87c474e1dd7f726fea603a017ad6f30f89b918c8c0100c793e0935bc2f60";
+      sha256 = "9c56abbb7208a26d8fbf1ebd3dccf42f23da60c73df628eaa44b9293e128f5d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/si/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/si/firefox-139.0b3.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "584a1aefc82ecbfe1ed5bea7ea6c7b2eb302f2a7b500b380693b5f15d340e505";
+      sha256 = "f9d59c8e43c249293c844c8e46fe001aaea050fc32a9e06dac0544319b248872";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/sk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sk/firefox-139.0b3.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "9b285d5a1626e06f40fceb89aed727d54eb5306e25d0d83144dad2a5e7bc8d5e";
+      sha256 = "d7e396c453b86e7181a0af09f5a608b7b3120d0b2df93fbce472c4935ee1cb25";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/skr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/skr/firefox-139.0b3.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "7c9aa64cd038e56ab0a8722b7c47303fcee660f403d2b721ca04c95ec02a7519";
+      sha256 = "4b120fda51484bcc9e7251ffa267a42dea1328148476252dff33c22aa10da3c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/sl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sl/firefox-139.0b3.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "efa15ab67af92fa3f22bb20c93b114b8ad377e1ec836987b66b5ada8a6d9b064";
+      sha256 = "c145d10b2a5ed42b1e0ec7aac49caf51468f200f361b0d3b576430f14825e0ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/son/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/son/firefox-139.0b3.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "8dc8a1b716cd83e50071650dff2feb3b11969681586757d03158c4ed4fbcbc25";
+      sha256 = "bb0a17d3089ea0fd8809fffc43258b2ea2d98e8a3ce96385ea80fd859f82ba2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/sq/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sq/firefox-139.0b3.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "24ecb794824095370137a16b9580381d378d8463eb4d1ad38e46c3c4acbd47a7";
+      sha256 = "a013d51f7dfd0ac9da4cb6159034027ef7bc3360de3421211f5ff453912d9065";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/sr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sr/firefox-139.0b3.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "3f202e21e3a2e21da1359fe5a2690b6dd8d036187a01bfa1f49f74dd36a19ae0";
+      sha256 = "5388d19db672524f2a4d5975070a4e5fe09d9bddba8b9a3a54c2cb3052b3c28f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/sv-SE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sv-SE/firefox-139.0b3.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "2d78cddb8a9c44b35b3de171b894edd03ec964aefcbec0b1a2d2df9f0f778299";
+      sha256 = "49600c47143f89d34657577d1175db5c415d4a4a6766e1c410db58337371004b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/szl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/szl/firefox-139.0b3.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "2ba55f08d9580790fa1169f69ed7a06557448d68e2157d1804290299e2d7f10a";
+      sha256 = "25a6cce7c972c74bb8f8f881200417765ae7deab09405a947a4010002cb5fa82";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ta/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ta/firefox-139.0b3.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "c63e9aa68f7aa9552a6b698509fba6a9f6355b43b248c41579f41ace02c19bbf";
+      sha256 = "ca4eb3d2ffcbfdf0e70a42bc358854b99fb9d8b297959530b25db69fff8da6b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/te/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/te/firefox-139.0b3.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "5c2c225476b8e0cda930aa37ff5b05a297fb3d2c24b0212181f7637a1795d105";
+      sha256 = "a642f8335f263b9fc58ec32128ac3467c1dd2879ab72b90e74411afa723685eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/tg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tg/firefox-139.0b3.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "f2abf27d7dd96e277e765c4b9b4cd7f0e2c9478b9ef4c31dfd66df4d0ccbe543";
+      sha256 = "08636c243613e677caf9726e73e640165f90d0fb3b7f5d7a85535a9d20af06e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/th/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/th/firefox-139.0b3.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "99f9cc264e86314bb4d569ba8bcd4c0fddf7338e701dad77048d80ce2e686d35";
+      sha256 = "4586b68f7a73cbaa86eab8a2a67b904a3300ae485b85ff878f442e58f2c25a86";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/tl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tl/firefox-139.0b3.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "c378d139dba47534502d8f512b114ace44325e1021b4fc0d290a18a48655ec9f";
+      sha256 = "29d943a1e465b089e4b4216bff1343a3b267bc2d0e6757429dfdefe1123c87be";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/tr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tr/firefox-139.0b3.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "bd897d907b02775004c7c3d863cce2e792bef36ea4635016d3ceb46754f9cb7c";
+      sha256 = "c0ebd1339d95eff201d85bf549f38ca93907021853a2841dbb48bb7587f84890";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/trs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/trs/firefox-139.0b3.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "96420af7e0420daf942359df461f101a6ffe5a4b32a859db85e3a2a5740d3fe7";
+      sha256 = "fbdd2bf864b5d2cbb0b633b733c70c71457c04cb405b0aa14c4dc83a5380f4e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/uk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/uk/firefox-139.0b3.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "8730ebbe06debaf3207d9a531b8bd84dbf14379f06a1b9a14434f001c9c74c76";
+      sha256 = "9f2af01f2187bc3dece162cd493ffa46bbb7b4af25aed176f81bc1bf99ab8f3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/ur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ur/firefox-139.0b3.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "9a6c3c65fc5fa82ee89b6ca2b796d16bd227ca77df387262840a4b3775dc002b";
+      sha256 = "4d3e57b37ea0d9f498701e768e6a1d3ebed495c83715df9b0623845b9ebf4464";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/uz/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/uz/firefox-139.0b3.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "4900d8eba1e173c69d579958745eb135aadcf197911f863461944d55bbbb372a";
+      sha256 = "c9419b604b2a6e91cdf9f3c7fcc1a7213eeba095a7ca4950138d4757326a5337";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/vi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/vi/firefox-139.0b3.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "5ef94b23f1bc198a4fe5a089ec9d27c5410b1f446e666aa50f674888d36ce403";
+      sha256 = "436b6789d5c91955affae937528b38532c09b96f80cca4ff893b593c10720138";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/xh/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/xh/firefox-139.0b3.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "aa75ae373bf281cf70c1effd147f51c005feb8c3cd34a151ad34a7b7b3894e8c";
+      sha256 = "ad35a67010effc02db685ab1b05a534e8454a3d7d8d9eac2abb20ea3494440bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/zh-CN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/zh-CN/firefox-139.0b3.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "c678705fc9d4f23b91663843500752628c30bc77c4b003ccf8b1a9d92afbeb54";
+      sha256 = "25efcfc912e9e20d7479ec869afb471d4a4be279500e06f2609bfb5df9d65e21";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-x86_64/zh-TW/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/zh-TW/firefox-139.0b3.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "4736c0abd7376347f4a2aefb7560c32cf7c43e47e5180199e67c66efe0779981";
+      sha256 = "a694e1461292c471cbf263f1fca962b27e5bc1dcc655cd9c0f22b6ec868b0196";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ach/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ach/firefox-139.0b3.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "89894fad304ca482951db3b4f1a699e11ae60e5814c1c39778a8e39993d54e5f";
+      sha256 = "8acea013f0230e45e5dfe7cb2d1495fc31fe8f62e3f0c71021faaeed56f88d90";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/af/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/af/firefox-139.0b3.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "fd40aedcb8533e86110e8aa1b14ae204a04a7174b71f4df266ed9e0c8126b96e";
+      sha256 = "e9cd59e8ecb6f05aa3f71fbdc898e38f5fe16e7366283a899dc918639bbfabe2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/an/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/an/firefox-139.0b3.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "846242a63ef55a8051450f3965e6f42279bec51068cd7ab4819f65df1da10f4a";
+      sha256 = "06f077e94b604c14d4b23b5c7ca90988a91fd77b4923762880a8ecf6d0d96549";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ar/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ar/firefox-139.0b3.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "962896ad8b97af44377e28abb76c5ae1d344219dbee62339419ed76f2e1e175a";
+      sha256 = "d766a8ce6766609052f059d44b324cf67e872eea704095190a00099b472d1312";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ast/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ast/firefox-139.0b3.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "3b741a6f64c0abebc4ce10c4806b2ea4535959faff56853db9f68adcafc2c576";
+      sha256 = "2b4f5ea265d192b4ff27e24ccc60a1b2e70b5e19f5957ab482c6b0d36a4182eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/az/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/az/firefox-139.0b3.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "0091669358d879e7d4e2317af1ec8ba23408b13e157475a5d787b51ac04e5d6b";
+      sha256 = "1659ad578e6b9768e3a2bd2dd2ccffcf1b8d8060c08bb2dd9f45a5a8b35ce6fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/be/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/be/firefox-139.0b3.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "3dd146471721b8eec89360ba25b2a61a6727c521a164593d1323ccd021fb13d2";
+      sha256 = "7959c9e95a1858961a2322ea9ff572c53d08c5f1e855d5115cf68343f1dfce63";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/bg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bg/firefox-139.0b3.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "226d8eced2f6615208a856bdb212289f232775456f70dbc9de5ccb869c50d029";
+      sha256 = "74d7142554e8621b5662d322c5d1eb63a6bb4422365d037212813fc2b1ca17c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/bn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bn/firefox-139.0b3.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "d43481217bd985bf3590c1796d7d3da6dc6c7448e8787adebddcc6bda5d5b439";
+      sha256 = "5d40f8cdadf7510337271c98350a14b002462dbb58fd89c7f5a5e898d4d96522";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/br/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/br/firefox-139.0b3.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "3386e6ed67c7b72521d0f6d5dbc70619b3736a493080e897ce557932d24973c5";
+      sha256 = "98606dd41a554c6642b07c7012c8fc0e831cae305c77b17018abd7cf1f835126";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/bs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bs/firefox-139.0b3.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "893d73b210f91839d30b8c06ab3b2af20ebd42f998020bb4fb3194cdc1805bb9";
+      sha256 = "319901c06f9ae63714f5e50def341f7af82446d657a4792f6aa0dacefa6c5aa5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ca-valencia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ca-valencia/firefox-139.0b3.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "df345e3dbda2e45e5c620535f24f3ad6df0adcda47dfdfb0d062ce76e35f6a60";
+      sha256 = "bdbee33f7f53270a075e45854b42f5879eb081875310285ad4b99dfc2494c766";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ca/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ca/firefox-139.0b3.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "399bfcfcbefbbc14b7076c1b75d15a44c61e455c1bef06b54f8faa8231141e8b";
+      sha256 = "9b8af77f7db2bd74065f7b56823ea68db58822db1d55e1a9c98d4654d5178e42";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/cak/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cak/firefox-139.0b3.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "8b2fc08debe84c88f76b39b5449041a3fb82ab9cb24c4c14b316ee688b9c12df";
+      sha256 = "649a2617e215d8f3610de863ddfc29dc0c2b27fb7d642c1e0c9f2c6aa365ecbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/cs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cs/firefox-139.0b3.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "82bea1608c3f788499b07a23e64d784b1c2d53f4e6a023b3e5307da81c789bb3";
+      sha256 = "8e8c2e892caa8bc5db5804f42332ad57d1264eda034feb467d6d75827c3a7cd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/cy/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cy/firefox-139.0b3.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "d54240c2df1d0ff774ee77a73429732f2d2be0c00a80f4ea9e3b4cb90852350e";
+      sha256 = "394bb39242b8631d46d42586611e91b54028fea43d78248af3bb446e6c6834e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/da/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/da/firefox-139.0b3.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "19181e61774ef4310906fc09ff1d0396a5908becdf6b9e36b91d54d57722876d";
+      sha256 = "b42f902cab834a1a177afec0812b118280f3733adba9433d31098df63d184d83";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/de/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/de/firefox-139.0b3.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "c705f6ef08281205d5698e1a60304e324012afc8858774b1d926dc6e1cd56c24";
+      sha256 = "420f1853b37b823edbccdb02e19669d5caca76b2ba3f607a81d11b5654f04c1e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/dsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/dsb/firefox-139.0b3.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "ff55e26a952fb6537a72368189b7be8950aad58b1829f0534f1ed8ce7e57d46c";
+      sha256 = "5987303e490b524c31619d18cdbcedff7f24d70a1652bb9bba15120d34befed6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/el/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/el/firefox-139.0b3.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "ade704a5da98041eb2a525fa9e8b0a8c651e064ef226968b2eadcf48e908be86";
+      sha256 = "4001d4bce1fff3dba641b7c38c2b26338e40ba28ddad8554c4f7dbbebf1536d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/en-CA/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-CA/firefox-139.0b3.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "09e33d7f3e3197d9e96ccae77f0db355647b5c5cdc4ab36d44b603394b86fd3c";
+      sha256 = "35707a5d0e7df572c341da8d4ccb76f560267feeb8df785eec304e6c920da3f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/en-GB/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-GB/firefox-139.0b3.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "6971f080ea3b6978ad3db66f32baf9cfce0026f74a13fae21aee89687f9c7d06";
+      sha256 = "02b5a1f051e02b949e7c8df2d4196e6e45cc02a0ae0178f8500c99b67737042d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/en-US/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-US/firefox-139.0b3.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "26c5b243b0f0c3f75d8f8c364481b70a6789e5f77fbab69201f79ab916b6462d";
+      sha256 = "ddf19c5fd706f7d20060d009e26e5f98d15707d7ce1130a3e5209a80237c4d45";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/eo/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/eo/firefox-139.0b3.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "a1b958fd56a86d1ab6f64c568ecfb51169e7d859995cd803999127ec4776934c";
+      sha256 = "75a9e8c3f3f1a11b22be4501fcc6743f6d7233591df6f1f3eee8243fea27e6a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/es-AR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-AR/firefox-139.0b3.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "c9bfc6821b53a9f6e200d042d4d9aa331662dab4daa1700a32eb03b2ce2118f6";
+      sha256 = "5a66e9d13ae53b0e163630f1b9a20c4b68f4e7cdbf88c2d2ca702fcf9846d064";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/es-CL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-CL/firefox-139.0b3.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "d4dca0bb8c7624da40b642923fd14d122b50e06cbde078ba53a93be77e7d6d7f";
+      sha256 = "79dd1dcc771346f0aadab81fdfcbc6fe1d532001ae17793447b423b1a85a4aae";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/es-ES/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-ES/firefox-139.0b3.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "83e21b44b770d6c0fd9e07dc50b39e4c8d836d57e2ec8bc3d1f373b0e93c7b97";
+      sha256 = "90054b5ee7292a1df8f0e7688b35fedcb19f2a8945f0bfb440c44913bd123c4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/es-MX/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-MX/firefox-139.0b3.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "6df7ba5c45cfe788f0bf8cf9e9b6fcdb7f23ea5b8504d66cfde7bddafc1e4ddd";
+      sha256 = "f18593686f6a02b0bfb66b364b93fbf1f868365eb96e8152ce1500d6c739b457";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/et/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/et/firefox-139.0b3.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "958b84623adb5e7c7ed9e298da6bff103e4322710fdd5bb782c484922985ba31";
+      sha256 = "b6f65d28916d962223af04027a1b5550ef7e6326924f83115a7b86791220bf2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/eu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/eu/firefox-139.0b3.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "457e57f9a55684671748240a72edd9c6134324fa1c75204dd2d9612a30e6f325";
+      sha256 = "410f33a12c705d8ff753b4cbb11942df9aaca3777774e7cb2db5277b7791de1f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/fa/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fa/firefox-139.0b3.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "d774345364c67bb61b7e76efd9503eec409f75cc92f3c84180f7b8b045775927";
+      sha256 = "67728e0982b672da05cf00b46a12e18539a0ce2c3cfbc3f91e0c5b62b6d01408";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ff/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ff/firefox-139.0b3.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "d02b6f69339cbe6dc1d334d48e85d4419c38d71b401a3205eae8fde17ee2a61f";
+      sha256 = "ea729dd3c19b979d00c25b6dfdd2f2d633055a9ca389ad5cde5b5154886d25d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/fi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fi/firefox-139.0b3.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "2e50df0c5dadc298a8f721d60ab948ffa083a3c12834e207977d9cf3a64efe06";
+      sha256 = "40b78a9e4cea933865f06a41c8a32d276a59bae2488601afa6d6e936669eef4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/fr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fr/firefox-139.0b3.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "9615920c2688134eac09812d6c0f02022c2da06e77b83e03ad82ae9af187c40e";
+      sha256 = "5828e6b8ebc7b7508f363f9309554b544205479c22b9632e230340774c46e442";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/fur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fur/firefox-139.0b3.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "89d360207bd2fb523bc2ad743930524e406f15978b787cf679e05e2babe2dfff";
+      sha256 = "bae0801fdbab156db54f0562f246a59eb5f8c24c79ba17fe2b6c98fc9ed91c58";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/fy-NL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fy-NL/firefox-139.0b3.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "7944a1abe59442b2a6e06ccc027adc18acd8dcc0535fd896dffb21ef4539c038";
+      sha256 = "0e21ed14bcfc78650f62cffa63d1d9f1a8f21b64b0d258b0e15e346b6f497f93";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ga-IE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ga-IE/firefox-139.0b3.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "2490bfcb417c036236f39ce5ae87d5fc9ecb5dbf664cfc7b166d7da5776112f4";
+      sha256 = "a873d3ce455f8f8c82901d9e2b6795e59515263380443801b2e0c9fd050f03b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/gd/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gd/firefox-139.0b3.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "e6db2fbf9a1fd51dfd089347b2a69d1cb67c9b79e93508da9f2f209b27c7c478";
+      sha256 = "13d114359f5c30759febb7bfffe79286f3261477a160a35faa3d5d2e1e236271";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/gl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gl/firefox-139.0b3.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "9d7f9108689a1c4124ac5cea775350cd5ee22d1e8c1ee0bde75f7cfa95409746";
+      sha256 = "57c6b29e1b05a4e75224085c7a8f13a3948930e92204f882092cc71efc7d4071";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/gn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gn/firefox-139.0b3.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "04cbb945ab2f01a16864b7072efce947c165f3338b9eed1ad4a67a1e051a6cdd";
+      sha256 = "6a197a8c1b138f1eb95f85770e4734fcb400679fe18c0241352dc9d0d025dc5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/gu-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gu-IN/firefox-139.0b3.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "35737e02983683729f962558c5850ddf7261a95fe99f21358d2d89a0bd25f44f";
+      sha256 = "53bb01d3b87a5a463b993e69ea9472b9b7dce818ffd41a3efc74b0def2880c10";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/he/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/he/firefox-139.0b3.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "a8dd0648697d3a3fce9208efd4419dc10ebece434af32921b93373b6edfec703";
+      sha256 = "d2f51a83e9f625df054c75b6212c95a2ee98a6ac6912fb37f6dcce151f0d8cc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/hi-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hi-IN/firefox-139.0b3.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "9663460904cceeec00fc23c0ac6584da8597f0d110b1f81d0fb86e4e8883917b";
+      sha256 = "72b1cb85cf3c3774befbafbec03aa95084356b955b6c86acdc2d12fad9a05d57";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/hr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hr/firefox-139.0b3.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "b87651ad298fc9f7f7a9f361591529643a1f84edd08c8c43c7ae2a65bc550431";
+      sha256 = "9d0b4cfa3f23f962e2784f9a17e8998d2a6ee1a3e54740317473e32c790fb1b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/hsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hsb/firefox-139.0b3.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "a0ef948a3da1330f075f05b7156bcb76f77f32f0ec63d7a76479f8d8c393132a";
+      sha256 = "6ad41bdaeaa4bba9360ea98787f0c84760f849570452425508f3dbb0472e7349";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/hu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hu/firefox-139.0b3.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "4509e62b0d60cd1243821939bef6b3939eee045dac4518368a60b72f6f7f8ef2";
+      sha256 = "583782cc9ee0da5f8ff488643ea6a1573979653130bb6120affc1a7ba57d10c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/hy-AM/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hy-AM/firefox-139.0b3.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "4f3950d83a428b9acbad9634ccff5a5e3ac376e360af2f76dbace858443ea9c0";
+      sha256 = "bab8bcfd4374d076023b6e1fccf797fb3d83f26d0fa8df75a0d3c5f69879c5c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ia/firefox-139.0b3.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "f0060c657b60a0b14e38f48ddd531256912c375a0213ee9db411fb023d8d782c";
+      sha256 = "2bd01c27ac6e282be53d72b7993fe9b35847ef5639104924a5d45fc20a42e56e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/id/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/id/firefox-139.0b3.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "4e1ffc82b1ebbdb66ad723ff262b948d18e2030dfc63fd3b7e04281876f43664";
+      sha256 = "d110ba5a2d529cc020a476fcaa8781c35f1071224b33814983b83722fcad0078";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/is/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/is/firefox-139.0b3.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "6fb23628a67f65721205a93b216325f2eca2ccd79e33eaa51c69325ec3e9a082";
+      sha256 = "1bb68a757bb2c9ec9c87522d91733fe55cf5aab0ccfec58cbee67c3a3764df85";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/it/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/it/firefox-139.0b3.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "8ffa77b4d9d84dd7a574ca012e3ee6a1340b8431a8b17219b3da48235fcf39c0";
+      sha256 = "6eeaaa32990d457aaaf37804f54e39fee7fbcf90e024797461c76b7b1522bb84";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ja/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ja/firefox-139.0b3.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "0c08d895915ab5720ce864a8e8ce27b07d95bfcc350723e6d323d3237fbe313c";
+      sha256 = "ad3d2dc245f06c540b7705e4c43b18477f3ef2b6cb21046f2c6aea5ec3343744";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ka/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ka/firefox-139.0b3.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "d5b0abecc7811727a93c85535a4140e0a68bd800a7987d89a4992b94caeab132";
+      sha256 = "5d1c0a0642967fcd4646e2a615c5033634913b4e55b53669de1a27f6de18d39d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/kab/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kab/firefox-139.0b3.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "73c48e63038e2422d9912bc6af71bd7793a0a9eef96344f35a7141101e23b561";
+      sha256 = "fb3636bc0836dc5754a86f40274e3cabb1d32ea1e493cb84bdd0f61b1ce526ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/kk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kk/firefox-139.0b3.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "2dbafca0507719032236be0d1cf0f8cd3e2f54e5e81d46f58847625ee60eea2b";
+      sha256 = "ff7faeccbc3977063bc69628c64320e0113a6cf0cf487fc0b6253debd7c1da04";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/km/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/km/firefox-139.0b3.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "0d4acba5c88bc61e6d55d8c178e33036072302cb87e85db6fd23e0085816a1d8";
+      sha256 = "fad1f93e314bde16894eb472b2cc2ea41b5227f4d916d15c536b3892fead5587";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/kn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kn/firefox-139.0b3.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "2a9315a50c7ac26b0185139cb677e7c032b32c717292e6c522f8db35548fcc55";
+      sha256 = "32891d6d78f97ce1eb3f72751252e8ac15474a67ff3b69e0fe78f21efbe50aea";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ko/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ko/firefox-139.0b3.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "7d7e8d7d211f3e9f3dbed52da10135f7fed7fa8b45a6b42b2a887f6bcbc06b72";
+      sha256 = "f4f7315ddffe3bd50d927cb29e6a29887f31601c6c062dd349e26920fa1faaa2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/lij/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lij/firefox-139.0b3.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "8867659c881c8d92ca5e6e799c9cea94948046738efe702e519e583abdaf936d";
+      sha256 = "ffd066b6b01c2180e8d85ac3c91521b3c2d0a349184bd6c3a5daa220dde51942";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/lt/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lt/firefox-139.0b3.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "2ad32eedaa77fcd4666b0f1196c061d761c9775e6f03a925ce1d7c6fc7f0f7a1";
+      sha256 = "6d14d17de1c256b6c2f44dc032a09b99244cf9dc81619c18cb750f9900857f94";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/lv/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lv/firefox-139.0b3.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "5d886b62bc55e6ecdbd3f0f08a75716e43073c9167600a25fdba212b52628155";
+      sha256 = "d9f0720f4d1b663406b14db66f739ff1d0e2dc5e849f88640d0899c3de528f4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/mk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/mk/firefox-139.0b3.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "8d7ce8f4d7e4e0f79239eae01b0f93de7277c14ee57f6818900f1d74fbbe913d";
+      sha256 = "e770c64d793af8d63bb33434f427ecc9cdffb49345ef966ee7b27232214a11ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/mr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/mr/firefox-139.0b3.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "849214cefd34b75b15de9cb5926c29b961c8b4881a01871c53d8b885c9ab02f0";
+      sha256 = "bf0a4fb9bec478a1fa1d48be903509b5f23c45dfa7754afb78aca3962e7fd21e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ms/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ms/firefox-139.0b3.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "a24f9d600b3ce0a8561aa99cf5fffe90f00c28bb54c9dacd472ca08f1df0eb48";
+      sha256 = "8d09acce703795b35bc04887cb26e4020af5c397fa396c2f2806548b5980b6da";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/my/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/my/firefox-139.0b3.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "ab5754a38510b66cb23f2dc24676b8d4c39b34bb7f1806547aa55c72397d4d65";
+      sha256 = "f0b894a6462f5a80c23cf83a1a011c491a0fcbf61fc04c2b0aad6a0ecf9b6a42";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/nb-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nb-NO/firefox-139.0b3.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "dde5193f0ca8a933216627d92dbaa9e19bd4f7bf6f3511a58d1ac81dc8ef9556";
+      sha256 = "2af8e1f308a6010c3b8523c1e9d12d0e1b5b9724ad1f444394ca58433a2298c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ne-NP/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ne-NP/firefox-139.0b3.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "c02e890883d586b575224a915a9a5bf16eeb6da1d84ac92d8650c2a8a10ccb81";
+      sha256 = "004f3b52f367a1bbd35aa06d7040035bfaf5da5524370810c789746ed78af888";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/nl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nl/firefox-139.0b3.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "1a96b2068406b8c155d73d408294f025f161342065d2c5359e36acb0cb685e71";
+      sha256 = "eef545c2a3937500dd825e5e0ba94735246bb2e8750a3b3c2266026f5b1859b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/nn-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nn-NO/firefox-139.0b3.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "df309c090da0637354b80ef39c4e83482e107dd2c9d6c271e02bc46b9b5b0463";
+      sha256 = "794b917cedc6dc92964665da249dd018ddf288f837ab2968794b63c2360a8cce";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/oc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/oc/firefox-139.0b3.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "c5512c9718b52c21581035327f7ea8df840785e54d9dba9d6208c993d442fb6a";
+      sha256 = "3b83f2fbbf74b91e44a7f0043940d242b1b736d75394caecbb9401e328e23da6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/pa-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pa-IN/firefox-139.0b3.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "d02302098b4308df71c625c0939e590748dcd53012a6d3d6ac98a3e0dcc2639d";
+      sha256 = "72e016689aa5823d0c1023afa000780e6e60bcf752eaa7f1fd68da107f22f6e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/pl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pl/firefox-139.0b3.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "72d357e0a5acafc716146a38397bcbf8acdf556495a03da1a112de27f263392f";
+      sha256 = "263dbd2d79cbc7a2c0a0b21a3fbff69fa22383f39d7824ffdc31194f03a69327";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/pt-BR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pt-BR/firefox-139.0b3.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "5b65b370ba52bb1dcc70a4b325836d5872681a3ea187b3cd94cac752af7645fe";
+      sha256 = "2c9b08173760317cebebe8ab746b8a024db38bc7a7aaf4e9de034bfb50abe5be";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/pt-PT/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pt-PT/firefox-139.0b3.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "bb45fc8efa8ec0783d8c028ec363682697d326bb59de986541c9690e6a748d05";
+      sha256 = "df8fdc9ca8a2a16decff55ac6b64775ae2dc7c64d6dbdd8fc15df014a8f8a656";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/rm/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/rm/firefox-139.0b3.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "d9261888fdef4083a4b8e65cdced18e036e1f453322b20b9c095a15f44cf55c8";
+      sha256 = "2b6f3c308e293955fd8243fa724dc969d054b7c0d086bc1a243e2c19bef27bed";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ro/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ro/firefox-139.0b3.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "cef2a3081b5f057b864095c74c74b02ddbc8715861a00c73ec268f6c62e7636a";
+      sha256 = "81d6fb48b838aeb5e9fbbfaffac8936f376289b162958169a50e8a48bdb4bdbe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ru/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ru/firefox-139.0b3.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "618449ccfda5ca281799e6a53887e5ab82b0c6582f2f8bb89d756bd5d90e6bb6";
+      sha256 = "6fbcd6ea92f5e2c81c926dd407ff2523e551f388b56154a3324c1f04f66c80b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/sat/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sat/firefox-139.0b3.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "d1df51654703a7aee9009f0fe19646158a5b8b40f4469a68297161835e473af9";
+      sha256 = "77b8647e8702ec7dd982ec622151de4eac6e1873fd632c57bc174d4ebcadb675";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/sc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sc/firefox-139.0b3.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "498f18bdf582d6cd9c8508dfca07e8c9b429cd2c7c3533a5088431ab45e9ff91";
+      sha256 = "cb23ce760425c17792dfb75fe52d39f4fd377b640f69ba8bb575df6fba3f80d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/sco/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sco/firefox-139.0b3.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "92178b44127b1b3b17a66b3b7ceb8fed1e62d2b47863e82f9236984ff9b0e5f3";
+      sha256 = "f1f71c42b2626d0dcfc3552a1224db422328f4f312512b3fce292b69b24b7560";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/si/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/si/firefox-139.0b3.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "df40ad66bfcb8d668c0884e98904a3cc795c082a7eb9323215689b0c096b32b4";
+      sha256 = "7600e8c27c2e795f7cc4481badc279b461901aa516bbb0728128874791d6639b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/sk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sk/firefox-139.0b3.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "432aac4bbaa20a8cdb94978dcade325895b2ad902e5cdaf576c3081237458fd9";
+      sha256 = "45d7b3b578ead0d40175954f9e65e124853e295a0c528dd6abde891622534e3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/skr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/skr/firefox-139.0b3.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "f0f1b1d95efbefe60565c4417f92d2516ce4e8db33ccb3c9c311ad254ab412e1";
+      sha256 = "187fbb481c64cc981b20de374913b9d17c3b117a80ab1feec58c18c965ef3e4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/sl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sl/firefox-139.0b3.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "b25855ab43daa7c65edba0e078b85fbe7312de07289c4e05b1b5d5ab3c5ccd10";
+      sha256 = "17b5faa5a116cc9ab8fa1a322bf6555450f4bcee1a2abf09709645b17bd46ecc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/son/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/son/firefox-139.0b3.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "79591504796de1b699a8febe19f038fee6e21c53ced325671b524924d60e1fcd";
+      sha256 = "4639c5d5d267896d07214291c468546ff26478c26c435ee4d10cb2e9dc307e65";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/sq/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sq/firefox-139.0b3.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "4aa03570a5770691d44c1b516b07a4fbee49e8b6c7c49b714d5c506ec8f0cca7";
+      sha256 = "a0aa72766d7cee37f9d9a4c3a28ae8b954a2d28810bf553cbf442b30edd623d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/sr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sr/firefox-139.0b3.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "6bf3b13861ab008fbd2848638ca8e31f4908b62653750311bd5d04b943df9a60";
+      sha256 = "607d5e9a73671eb99735e619a2ee701f31ed6dc55ba016a237618de6fe159933";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/sv-SE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sv-SE/firefox-139.0b3.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "a5147c697309b8382b3b455f88fac597edb69e9b86bf50fbe82941a643e63077";
+      sha256 = "dada2e913de21d7ecf323d302fe2b9263ef6820450622b3b06e73963a6d48f9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/szl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/szl/firefox-139.0b3.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "3eecde28f0d74b81c89784a8382b8585bc71b2e3f668753b0ffb800829794c9d";
+      sha256 = "12526451c0f4c8a8446b0638be2e3c24a52cbd8277928a45e9dafb2c65eb2d03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ta/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ta/firefox-139.0b3.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "81a448c362b79e99ab5c81992f1c0a898bc568dadccbd8ecb001507d177eeb39";
+      sha256 = "d3153deeb5951fc6dbff2fac07a51e587d98559042cf1cfea70a55c4c8ad25c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/te/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/te/firefox-139.0b3.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "68549f4aa2148b1a0fbccca32dc9ece402940eed6a739017bbe21f6085607e75";
+      sha256 = "21377ea235bb38c01aa1a21516722e2a91ce679ef7d1b32487c8813f1cdd2aea";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/tg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tg/firefox-139.0b3.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "deab8219a6f0e6fd29366337286a9efd5169f81aa67da43de0dc455ecac94fdb";
+      sha256 = "a428becb1a20753379791ae6538b0b1bf0ebad0d55f98d7d8c19af0a7294f7e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/th/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/th/firefox-139.0b3.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "b17593081414d93c346a20455e0fae8c01c3fc1d76ccd604ac64498ac98d3208";
+      sha256 = "28a30d8cda25aa1e63fbbcd1bbcdda5a3ae990e1d973f10d4744499a27f13ef8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/tl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tl/firefox-139.0b3.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "1a5880027e379bfcf6c111b5a71cad5c930e2aac3921d6fb61c11173fdefbdaa";
+      sha256 = "80bd0de1021edfe3178abc43017669dbcfe1885c66b71729372bcdb27d381ab5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/tr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tr/firefox-139.0b3.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "f009df9f1135d25a99892918ef5a2aa012673cf2934bd81319a98e76aeeda218";
+      sha256 = "f9bc32e243c091be454fc5b4356b986cbbd87bb76135e7cb9f9dd44115af2f5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/trs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/trs/firefox-139.0b3.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "bda503e515b051257f797daf5677c4063aac06a29b86b1f8e86f91b1e5dc04df";
+      sha256 = "fc7e927f0ed152dea1940b6965c79c3f2a21d22c117d52d9f32568d5f80bd48f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/uk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/uk/firefox-139.0b3.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "64fcdbb6dfa902c320f5df52c5e9380c5d092bab18f874cdfd0d953eca7f1021";
+      sha256 = "f529c85cd2f12c7b2fb66b1f79268af7ba889c8a6c4cc1accc5b19b74f77301f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/ur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ur/firefox-139.0b3.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "b16eaa083626d390e733298fd17c824967ba71594b61fcfe3fb06fb4b7b20b8b";
+      sha256 = "e677de49b31054981a22dfa36d9b29339cdc2dc230077b48a381edefa1a17271";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/uz/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/uz/firefox-139.0b3.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "fde686b53a4bbb25bc5cb524f259fc57317550197160dc4d05c2158503c68f63";
+      sha256 = "46d1fa8b789e3c4adb313883a438a8dc051b67b3f005541a31967921b4cf280f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/vi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/vi/firefox-139.0b3.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "862e225b537c9942f8066c375f6a266bd10cf30f7995042360025c546ec3ac14";
+      sha256 = "65e242430ce65fa104fbb0bdaff6cc53a5c0dc60b2094362f2dcebc9aecabb3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/xh/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/xh/firefox-139.0b3.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "6314a7c898a8a371284f85c75948b1fa17bd71f36a38285810f247ecbd5e835b";
+      sha256 = "979438f443e8c0ab980af19e9bead77f3039c955c46a2c450db7265bbcf6259e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/zh-CN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/zh-CN/firefox-139.0b3.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "5fcac58db3829a7ab281fb76aa4aae0467ed593d1bee530b42cd2a72e4d305dc";
+      sha256 = "c79ad34593f9ef472d0231fe57082a1d4ec62bb4c7cc870c4e510cee5ba3ff44";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-i686/zh-TW/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/zh-TW/firefox-139.0b3.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "08f41e28c063e2f470138c0be4a9ebee5dcdb57611ebd9a9fc5f923c28410ef9";
+      sha256 = "0e169aa02e3102b396e0d721b15138fe39277e4d84935fe6c8931ef69117b4fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ach/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ach/firefox-139.0b3.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "b3a5dcdf90048cc49bbe57cfd68e4f210bb30518088e48e480a58902e8563091";
+      sha256 = "bd3e5c69934115d423aa111c257520f9cc5219a29588843ee1c5b61b1a3e3da5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/af/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/af/firefox-139.0b3.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "61616db98577db4d813f3b2712fa1774d5da4dc7255965fcee5a680c264f6f40";
+      sha256 = "f3b63934c1632d71f49d9a401dc8bf6073936dcd656fb0462a3d34e352075352";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/an/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/an/firefox-139.0b3.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "3dfc27a2d687c00b48828c9af94b1a97dbeb9d7efd65092794719dea0361c149";
+      sha256 = "313da7d73bf645cea5125e3909c310f3aa81b1713297fb7b66493b79f16d34cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ar/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ar/firefox-139.0b3.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "014a805ce15b122479c219c07c8dc1d7f0aaab69ee79bd7e3f32066dba41f591";
+      sha256 = "9bd0294aec83fb9bdb4164eb8eeeeda22fc3b2d26e8cb8b1a5e036251be3bcdd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ast/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ast/firefox-139.0b3.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "d4e0ddc34e456c1efefd2ede0a73f6b72f4ce2a71b52cf270deef8b947afb153";
+      sha256 = "2a3229c50482cd3b86ba9892985680b6cffe4259503d3efcee1ecd6fad4a6005";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/az/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/az/firefox-139.0b3.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "cc96766d10bebe896deadbb7734ce79f43b1d1f5cc031eddcc65b70f1f0bf1b1";
+      sha256 = "b64a348dab5618276f0102c23d7e74b4e1bc2af38b36e678b3db53fac08e3125";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/be/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/be/firefox-139.0b3.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "aa78deee5a644cc709c0793d7864fe613a8a811a4095978fd700ea83cff53926";
+      sha256 = "6e19e16df133ea7b7b796a92c470ddec4ad9db281361210dc249851dd9c05e3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/bg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bg/firefox-139.0b3.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "a3fac26ec3379387260297a207a3698c74704cb296d2ba52c17ce712dfd6b0a8";
+      sha256 = "c691fcf4ff5aa896b51e12c01b5faddf1ab8d3e990fcb5a37c89450511647335";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/bn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bn/firefox-139.0b3.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "bb51c9c58df3fcc342117dcfa52efbe78f5e42e9f4eff42dc30b095563ecc165";
+      sha256 = "b88a34520fbc6cfa328e879478857b10a738dd5ed6c99d6db16d380e1b80b71a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/br/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/br/firefox-139.0b3.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "a609173876f5ee8aabd2788cfa97a9f10c746c0cb4da45a47c996e85a5e95837";
+      sha256 = "d2a051c03154c151367d01d887dd22d9c029c948c7ff406e5ba975a981e3270d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/bs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bs/firefox-139.0b3.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "d4760426b56355bf41a2576938ce69529f7dc3ece3bcb240b3895a747ad7a5e5";
+      sha256 = "b7ba2f914aacea218596d2118c001961c1151b9df842b5afb498d7729f4c7efc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ca-valencia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ca-valencia/firefox-139.0b3.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "431e4ad0950c85baf95a50fa23e545c57ac8ac85f2d429bda9fd7d1fbcb0a350";
+      sha256 = "3d9cb24a0d049de007c4125efa869119aef50263f70bad64fb8ce328cce6abb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ca/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ca/firefox-139.0b3.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "7a45db02f918b511399e2ee8c39a6e35be202308c1131e8532330d02843c3789";
+      sha256 = "40288f778e9706bb3c2bccd641b7f79a9b96f5129bfb282a88fe891f95d20e9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/cak/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cak/firefox-139.0b3.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "58291146a026b5687e2fb8470ebd6973d1de4f65a8a9bfddf03a0477a192d98c";
+      sha256 = "79a734a1a83b350d123b7c76dd991e9139d14c84b795486587bac3e001e43fdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/cs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cs/firefox-139.0b3.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "ae76e0fbd3eb5fc9ef01898e29da8e8583095257fa10453eefafb84e624389c9";
+      sha256 = "3fbf932baa5ecb2c4ba06c6f8f29251d8c33c173df96ceef38250decdef6d73a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/cy/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cy/firefox-139.0b3.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "26733d6bc8d8a67f2dbacdea565045f619ecfe2a53bcef17836b1fa5132b3486";
+      sha256 = "4bf4c523a593907dba5ef4ed211d721ce89ca13af52852b61a8a812f7da6473f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/da/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/da/firefox-139.0b3.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "5fba08c281f591ae5361df0ea1fc5415071228a4d4fe5bd59fdfce2f2ac4af48";
+      sha256 = "f459937cbe98b49931130dc0ff35741600d919afc84226a0907f6b373496090d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/de/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/de/firefox-139.0b3.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "9f61e04068005e94a75b412bd5e7f2b098825a8f0b1db65dc3bfe833ba82d042";
+      sha256 = "c1cbb2e1a978612c0fa60ba060fcd00f45ab0610a49f42f3ea59a0032c1fdc5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/dsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/dsb/firefox-139.0b3.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "8e6508d47efa031e918cce5bc12fff6533dc7bd14652079a9f6e5fb8c31277a1";
+      sha256 = "94288aba032c65e197001b10641ae42ea05a9a6c87f8ca6d98b48f5924ccb314";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/el/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/el/firefox-139.0b3.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "6f55e7c404a7b717e8b08026cdf9008e965e0f7c126506dc5d9f3634b9d4ec0b";
+      sha256 = "143f849d261a87f066952914b466e6737a337cbd412117add91e7731b088c89e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/en-CA/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-CA/firefox-139.0b3.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "8e9e4f753958ab818c0da70c63083fd48a9b9eb3c223749f033b68e4a6591720";
+      sha256 = "a08ab6a5968ebf60d9c4c082475e1c7cfd840d90e8dc1265d999eab45d0bb26f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/en-GB/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-GB/firefox-139.0b3.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "5f0c8566c3bf8a77286066ec9f8c2d5dcbc96a70f7e20c475481ce35f4912445";
+      sha256 = "a14d387031ea588bddc104982f11480983a45f2d4e08c814ae91a6f9e8bdc4be";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/en-US/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-US/firefox-139.0b3.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "bd505a4382ac7712d3c3ca078d3a61b0f23aa6ac8524f3c1492f160760f90522";
+      sha256 = "a8b95ece65cf5ebc5d5ae2144943c66135a2a32d64d7ca1c2424a621b8ffc152";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/eo/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/eo/firefox-139.0b3.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "5603cad76d242acae6fd09b215959733edeb82f3b6dd7584e0c4f8b7a963fc0a";
+      sha256 = "0bf932cdb5b2b672bad8875e4bd59da43fda2fc8293b14f5b6fa5cf58c11dee1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/es-AR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-AR/firefox-139.0b3.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "aa55cf4b5c45be8ce73a198dbe95f549940d2e46481c4db12fe12250f56f643f";
+      sha256 = "991cd0e2894a4293fe8d8bb78dadc51b7c0527a1d64b1bbad6328e553b65ec7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/es-CL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-CL/firefox-139.0b3.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "34f0b4ce329cb4baeaba6ae6de573083bd7e6f0968a94f4c8f9e01098c19971c";
+      sha256 = "15f27bd91d2d9f1833a3dff0ebf957bff6ab740bd5de214482e348240968259c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/es-ES/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-ES/firefox-139.0b3.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "1cd37693cdefec97b03f2819188674bc78726d3816a70e0cd516a239d788b12e";
+      sha256 = "0abd7d09a96262f226564b01633ddf9912ab190e448b57422c965d7ab544bdaa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/es-MX/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-MX/firefox-139.0b3.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "29aa931f1de67ac4b4629efacd5b87d407ffd32dd178c6742381c70b92dd78e1";
+      sha256 = "651f09eb5e0818805219e57f9e9567fde5ea538e62b0970270547349cdd6bf09";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/et/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/et/firefox-139.0b3.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "14bc35cbb1361fd4c94796b44f6bb7a49023a7f3b402f9bcf056c96828fa5e6e";
+      sha256 = "3f970da97eba78efcb840aaa9e7812fc07340ead7b8939648fb8839c743298cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/eu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/eu/firefox-139.0b3.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "8bb160e6b106bc8cd73c2e5effbadf06098635f26f8a61360a6791697c173829";
+      sha256 = "eb5464b8618eeda6aa507d09e403528ac991f883e4ea6070c01ecf7ccb34a2f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/fa/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fa/firefox-139.0b3.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "84af9ca5b7f6d1b0bc04c53b97aebff06d9abe5a97763fd44fe9312535f68d7c";
+      sha256 = "6f78eb8b602d2b349d564d08e1797f7dd381a818b4f5fc4916e5e2d80a6890d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ff/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ff/firefox-139.0b3.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "122fb1ea611489489315197ac978d9c5611df18963258c904ca314399c65494b";
+      sha256 = "dd74dfd1b55dc2005764ee2237f4bd0cd841a90dcca88f97f4d7ea1cda57be28";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/fi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fi/firefox-139.0b3.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "376bdc8270248da5c87013cd77d9745ddf78072955be2d124de1726d9bf84a16";
+      sha256 = "108304dedc88ed30195dc443a62df7f1d579a8540fef911e7ebecc544aeebd2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/fr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fr/firefox-139.0b3.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "e29430e6192fbfd9a7b21fda2e7ea97fbc3c22c0ef73ae88852a4f8cbe0a2c35";
+      sha256 = "c02dfe50d5b405f8fb90868ad317f1020c85d6bd15c6167d4bb8af152af29f29";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/fur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fur/firefox-139.0b3.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "2379c204e2880d13b1469232599620895e81f014a8cd8b9ca76af48fbb0b36cf";
+      sha256 = "c110494b901de0d5cf4623bab3fb7aa523c2c8afe14ce1339207a07715c24e0c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/fy-NL/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fy-NL/firefox-139.0b3.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "2675eee6a02884e89d89dd6f1b890965bbf4b1c9cb6133ffb1859f58a5370aee";
+      sha256 = "09fefbf594c1c840dc18611d303c8aeae70eb7126e17b5d0e41e96868601acbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ga-IE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ga-IE/firefox-139.0b3.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "9e3c2e165a0781ccb07d3df328f825167da645779e666ea00e74af478fa13ce3";
+      sha256 = "51e4f9ad18f29f46875ce2e146a4300afb0f3b860f0bc9bbab2cd6be9c20a564";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/gd/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gd/firefox-139.0b3.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "52ed80ce3510e6d64599e23234a0e0bcb223406a65b7ddc35d4afc903b1e1d6b";
+      sha256 = "cab4cdd9d7b1af933f53863be982d427f59435522f24bdef27a302b9221dac7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/gl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gl/firefox-139.0b3.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "e48b93aceb646321799b04ee43fbde6cc863ad99c63f6d6c12f79378672df3dd";
+      sha256 = "48b3771b813b62c8ade64e55ca5ea2e39671f2556e6057c49374b089adfbd2c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/gn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gn/firefox-139.0b3.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "d377e6f7b97fea0bc0ce80cc2cf7fcf60e4ac3e5601599b471a017bd2e59d525";
+      sha256 = "63e40c6ee16180e62fa6ef06f0bf1bf04fc9b368940013f2442e034229bbe586";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/gu-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gu-IN/firefox-139.0b3.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "9240c39ae1ed22715a9eb4179191ff8415a499e70dfe167fb599f425467b1ab3";
+      sha256 = "3c3c3847fc36800336e000c7a5ca479edf4832f80b44ca7b4f79151a67119a16";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/he/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/he/firefox-139.0b3.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "5c867a8a82947d7489e7c57206f49f73476a29c0a519b127584f33a26acb2c8a";
+      sha256 = "b77b031493a228f911f29ad93d55d9895005c31ba90a99a5b1b4e2d7d7034cbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/hi-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hi-IN/firefox-139.0b3.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "f49675fe5e4c934485a47deba2646232b7f110a0264b3d072d2ac327293e1e77";
+      sha256 = "a0ada0fe2c28f6e0bf6abdfcdf60ceb5cdab896ff1c86a58d33c9bfb4faedeec";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/hr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hr/firefox-139.0b3.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "c9bbaa0acfa79eb9be658b49e8af0e2abd3a7a8840dacd78281fd38ba187925c";
+      sha256 = "56fdf616a68d2701b4c505da83e70c14a6c08541ec826c7a187c23a30323c8a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/hsb/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hsb/firefox-139.0b3.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "02ec3ab3f1ef13d7320143dfeb10c653566c057dc4bc4c18bcd0dd4c89988d40";
+      sha256 = "dc133236dcd7500e46b2bb806212a41b11e906cf66a744dad2ab6aef663ab482";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/hu/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hu/firefox-139.0b3.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "963b2a9338dd1d07d9be66ca581eed34448ef67769ea01db327ca38d05ecade6";
+      sha256 = "d2c85ea926529b2caea6f3d5a07a954eac9fcb1feb1cd1780a7115fb38f7d03b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/hy-AM/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hy-AM/firefox-139.0b3.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "1795ba98bb256743d6cfef5129f702b50408ea9364046e01bd51c906b0bbfad9";
+      sha256 = "b7e324693725687422ec9ffad3bec53e559fc755d9eb169783a0737edd9b173e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ia/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ia/firefox-139.0b3.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "46048dcc9202695c89c791690e591f9b5035487b9281dcec47e2985639d4d8de";
+      sha256 = "1016c382f3add7c82860d4a7f980770ca8d2332e182b1b14a958012378f272f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/id/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/id/firefox-139.0b3.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "9f7120fd470a5b94fe141f570ff4f330260bc3ab48065ff3537a6d5b9fc63d67";
+      sha256 = "331b1885e004f602ebc004460ad4780725dbb3829ed04714b21df919e4972661";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/is/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/is/firefox-139.0b3.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "bae7747d465a9cab6feeeb686fad9df3ae02ca3aa295959e510e6b0a8b59f97d";
+      sha256 = "4ec80ba6afb69479b2cbc942551cc129aa0d8887ee32a2803b07ae14de800744";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/it/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/it/firefox-139.0b3.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "f9119db9309e404a3bc0754529eef7622805a44b45d1bad2f6650e66cdc2dce9";
+      sha256 = "9d04dfe6d24db792b2091f6726f8ba5edf0ab2d9373f2e0957c951f1a055dce4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ja/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ja/firefox-139.0b3.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "678d1a867e95585bb80f880f8dfdc7e77559e38fa5df7a19bcc8eb06931948d2";
+      sha256 = "7d2b0709f649b8a6b2edb124a2a501f2309b2570b1807efb038c5400cb0216b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ka/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ka/firefox-139.0b3.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "045f9c26d36ed832caab5453324d7383dab8b4bf02d8d37e00aace412abbcbbd";
+      sha256 = "06eef2411c405e2a17267bddd6d958c7fb55497478b6213fe259e40fb273dcff";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/kab/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kab/firefox-139.0b3.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "be2fa3225ce3d124f92dd54d01e4e0a278eabd38d9204b650cc80393cc8ddf79";
+      sha256 = "eaafc34c8c596602091810cbc2af966e003d870c66a647c0cdd2a2a343f4a068";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/kk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kk/firefox-139.0b3.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "3327b59d11dada324c5a520be43b33308981c4f95dbc8cbe1b8482aa2d2327bb";
+      sha256 = "dfef47c7d3255b1a711b611afd9adbb53be80eebefdac763da04af2157faece1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/km/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/km/firefox-139.0b3.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "b924d50652b15b215776138ace620651589f83765b4968287b56400c0f11b638";
+      sha256 = "9074c6ee90c6582c1202582d35d81f97b43789ebc3f9019261130dabcb01fd46";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/kn/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kn/firefox-139.0b3.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "679115c2a945256af04c0eb58f43613c9a3264498b8588128575684b6756dff8";
+      sha256 = "f8badc895b36bdcb7666510faf5f775470ab90733ac31201f147f3b45dc4ad9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ko/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ko/firefox-139.0b3.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "6abcb8fecaab5e40ca52f52c7cbd83c27a7dd5b7baf7bc29c8ad5337e678b024";
+      sha256 = "9d8739e1e382c5b96240a6564219c7b0ce161524386539141f4dcc020cbb5fee";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/lij/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lij/firefox-139.0b3.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "9635e07ff9d90b64de6467171693c59e353be6ec61adf4c2f48dc2657373e285";
+      sha256 = "c36fd45434f81e1c20c8793bd52cb85637999206b06ea9b094b2d1b0442f95cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/lt/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lt/firefox-139.0b3.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "8ceb7a07a87bae1e69ed16651d1226c530ed58339b3f5c4cc9f3930b8bb35ecb";
+      sha256 = "24d94d2ef16561bb3750d607fda39f4b39060efb83fd4d435cbef7383bf8f76d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/lv/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lv/firefox-139.0b3.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "1964406e0e6651ef2fc8bbd87fcd5981c6fab2a07cdbaec02228ae69561da551";
+      sha256 = "6eb7553cd275cbf11b387088e52d9f508486d3f737b2482d1f53af1a2c1e0dbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/mk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/mk/firefox-139.0b3.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "d2a17fda49006d15fd1e0c160b0a165e3ab0b5b0707913754a699d96ae9ac6ca";
+      sha256 = "8a1b20b6be53d68dd1effedc3522fec9b2d8c64a4d8e30c7a7113bf0fdb2317c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/mr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/mr/firefox-139.0b3.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "43db65397b767b0b51e067ae721787369c25e7669169234a76ce1e9587fb7643";
+      sha256 = "4dc0347a86f3e4f784ae32e2324f3d134ce5b4fdec4eec34572f51c13763889b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ms/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ms/firefox-139.0b3.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "d93b2cdf1e7ef6e293503ca4cca93c363e07d820827fdf4f7f9296096c2bf416";
+      sha256 = "7b3fbd663639fe8575eaadf01d3a9299f0c132a4b2fbbf25ddc2d18378102cf4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/my/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/my/firefox-139.0b3.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "86a890cfc60f6688f71149136dc8e013b1aaab3aaee05ac0abcad220363a2f71";
+      sha256 = "8a039ed198a5b338fd32dd632f05c4de8a9dd61cb09247d5f37a1ffbc640e0fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/nb-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nb-NO/firefox-139.0b3.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "f02dff85efe2df1a74b6a94f9cab6652d896c0bd8502a726d4c432f2b761b39d";
+      sha256 = "70404a9fe3361dff890f344eebb61001bdcb6a3d4356cc06386783d70a163857";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ne-NP/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ne-NP/firefox-139.0b3.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "9a2479d11d4a920b20f232f01a1e4edcffbb92fd9750c3fd436f94530c8f4c00";
+      sha256 = "e148000a58bd8b834985ad9dee1eb6724ed2550fc70279ab915c06fea148afe1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/nl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nl/firefox-139.0b3.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "b5faddbb954f0de75128bf1c2c291fca9e35ff27e106960ff479f320f2397283";
+      sha256 = "b15ebbf39c475a53fc5b01d1c5c6559f74c42e35c1d7b7bbd4cda37366359fee";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/nn-NO/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nn-NO/firefox-139.0b3.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "ea432a5d3d36a5ab2fb3f873f98e72748cc1e9b67703ccb7bf4dd83b21f146eb";
+      sha256 = "90221ff410eca0d1aed97186e45106b7ab826029965e2b4fb54d93c74f743ee0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/oc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/oc/firefox-139.0b3.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "4722cd4ea6298d9eddfe51c7d4e86c5532f12926707b7437f262547becac514f";
+      sha256 = "7cbad01d0adb697bcae6c072bb69cb151e83920f39b67df2a340f7c1dc4faaf2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/pa-IN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pa-IN/firefox-139.0b3.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "f3d596b36c35fb0bead0ab8706086543115b0b982e1fe34e41f3da02d3cb8c65";
+      sha256 = "1601a8192da0564af21b4cb7e63d87b6015d5533c08e96187a0d895e32bb03fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/pl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pl/firefox-139.0b3.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "0e2f4a3da5549c45169c1bfa59c3de69ccb50b4c2423c5888596e67f2f880f95";
+      sha256 = "f62fa06e9e651e7db14cfdbd0af5acac3d6f282a2842e41bed7b6ea323342ff7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/pt-BR/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pt-BR/firefox-139.0b3.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "153b9ac626d7f6ea196f0fbbd7a75aea514eb43e367d345f40f6a59a5b2cdb88";
+      sha256 = "493c505bc795451989d58049e0a16397eb32c6d26f3ff5c285b845b35cf63a53";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/pt-PT/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pt-PT/firefox-139.0b3.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "2a14831dfe8d975e6791d9175bf138166d830943058b9dda12148b492d53b3f8";
+      sha256 = "ce1caab07d4ca3f93e5be33580e09c1109f3a19176144d7cfa06e97ab04fe7fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/rm/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/rm/firefox-139.0b3.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "2300ff2ef21cc24d54d62e73eca0e696e3cd8b638f8eed701528a332cfb1c36d";
+      sha256 = "d580649d6aa0f7fc519dbbc7c72943b36a437806020f6a56fb7659befb9dea7a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ro/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ro/firefox-139.0b3.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "ecf8c132a50f70cfa47037370e21e8d1b3ec20b26b7e83cca741acc80cde1519";
+      sha256 = "a78d357d761f72d5795608199701c429f2016ad618e2899c10d13b9f7ee8e3ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ru/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ru/firefox-139.0b3.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "96fd4dd88a55fad60031b76247a0bcb4a8ccd2321f2d77a90b79d65588a080a1";
+      sha256 = "8892c5688612eda284319c1df7c366d529be0d0c96a55d89958d7185a78ab30e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/sat/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sat/firefox-139.0b3.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "48457e19f2d041545c6bb991a6504814f84176962ec262a85834505551438c2a";
+      sha256 = "c6d9eec9c8ebe83c966c904611d6d865328b5a7f401b42b06d72dae32174fec3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/sc/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sc/firefox-139.0b3.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "59e1b805484c3db70d002b58fee09a0c5b062558c36635bc73df99c84beb3f3b";
+      sha256 = "d504d52b43598ec3fdcf02949868fa65d6e6a72f78f131c53fce804817de4ee2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/sco/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sco/firefox-139.0b3.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "0e11d0746ab91b2a49398e3ef5cae1928cd119ed9bb29862025534af6e292945";
+      sha256 = "89962ba5d9de002d3f03b4527eb9ef84235d59c19abb46165dfa9c52a085ad2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/si/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/si/firefox-139.0b3.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "7f9005fb73d6bc79a459b9296447cf51e5d7f32919377613642f0439f4469a84";
+      sha256 = "247261439dc9594b9ad95fa066431ce1629537b8cfc01df7716c491044a7c72a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/sk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sk/firefox-139.0b3.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "7f907c90e416f4538067853e3ba6877aa9e8ac6720fc4b1fc708980d8fadee1a";
+      sha256 = "29cb232a5339abc4890b306a12b0f55cd2700cfe2521fa745491903ee87a26ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/skr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/skr/firefox-139.0b3.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "a72da3fd15ed45d33a697e41a8e2469bac5cdc097b1b6003ab7b9297302c2b75";
+      sha256 = "f606442e9a6f87616a77d2fd392412a8dd61e596ddc8c067e38846331cbfca0f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/sl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sl/firefox-139.0b3.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "46173b2890ad67d51d159206b99af9df09508303b10e0e89510cc50f319d5f9d";
+      sha256 = "43cc2db32879fce3424c1a3ff2f862cca4835b0a4c5df5c3e28def64812ce73c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/son/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/son/firefox-139.0b3.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "8062d7eb1d41995eabb13df2166b91a1fb6490b1d69b349c47e5d0eeafcac3c4";
+      sha256 = "cfec396b94bcc091927c0884ccddd3969f69acba8c09467609319c54c0bef55e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/sq/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sq/firefox-139.0b3.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "635a912bb9eb191570b4fd72236555bf8e4756c4d51fc957b42746f07c418b07";
+      sha256 = "ec827f911bb4553cd7caefbdf2aa3aa6b4521059beab32b23e65e80f9858181c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/sr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sr/firefox-139.0b3.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "6bcddcd3690c970fd1d2a1681384eb6a5ccfe91db46ef14ba404ea44ecd069f3";
+      sha256 = "284b34324291ba29a1d1d7b36cff68fff0f00213a7e12fa7f48536fc5a80990a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/sv-SE/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sv-SE/firefox-139.0b3.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "33ae8f77d6c641fff24f81c6f52e1fbb002b978e9efc0c4749f3970f8d893d30";
+      sha256 = "07e48d548cfbc4c4ab3fb3b4ec630385a125d3c5cbe30526be95d0476b4d8f87";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/szl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/szl/firefox-139.0b3.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "35de5f3c2245996b9b782092a442ac8ae9d862386b51e61df5515ff1337a0805";
+      sha256 = "84cfbf70da99b4f544193d6d167a2280142f8ae37d8de1e9b4093f7ca6671fea";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ta/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ta/firefox-139.0b3.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "7b10692fb923dc7639270ce26f1821f87c068c56ae52d486ddc3620eac807a5b";
+      sha256 = "dca3f4fd1b468cae66bdb6ef3817860760a2527b94928359c302e789ca2c04c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/te/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/te/firefox-139.0b3.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "b2c3dafa4a9b2a21c77dc97569c15b0c17159dde8d534d7a0cfd981cb748e249";
+      sha256 = "bfa4f775d02a2b2cf0dfcfbf4ed3d2342f7db943256c2e73bddd7f9a8077484c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/tg/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tg/firefox-139.0b3.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "844e601560c6d8fc2a9139bb9f3000f3685a82fa51d49e56ccd743b77a8f501a";
+      sha256 = "1515a00b6d53e074bfb60b1bc7e37ac60fd977131a6ac6e772433b1daaaa4efa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/th/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/th/firefox-139.0b3.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "7de1e10d58696ec64446d44aa372dbc1cf685379e37258b951ece720b375c435";
+      sha256 = "507d9c041c8874095a52f57e5a46adf8db6d4116d5ccdca0b100d831c41c0422";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/tl/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tl/firefox-139.0b3.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "1faa389eb1eec33db30a1a2faf91adf7e21a9a625231d55b7312a3d4e5d340af";
+      sha256 = "cba3d10cee0a09ed530f6e8ec71e1da36fc29c972136bcf6beacd7ccf91bd162";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/tr/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tr/firefox-139.0b3.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "3739faaaa71f287b2b9f092dd8a0e8854a801aa457741a28c6c97cfb28f54c3e";
+      sha256 = "f5e68e280db29872b7570484dbc841756693b3d00eda2cc0840a77e5600628af";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/trs/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/trs/firefox-139.0b3.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "92b65b41479f11698e22a84d0a0a0baed2c165ff3ab554c1c22f861ba00f573a";
+      sha256 = "028e3728920e5978501773da88c2eb1d5d86927d83e5f51e910692fd4482d9f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/uk/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/uk/firefox-139.0b3.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "a3b14065f7d2edaa7231053251c3457586e1a3950332fed04ba6b0642be5b4fa";
+      sha256 = "9e63e86af01787ceec6b4776b78cd98db74230287f1c065eeda6b5e5f6133b42";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/ur/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ur/firefox-139.0b3.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "8abaedd96efcfa46166e4d6856213104be938d33bba80ba2a1f47fd8fb70d2a3";
+      sha256 = "964b123de671b9f763861d626a444c86d48516cdefe9ab71f866dc564428d119";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/uz/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/uz/firefox-139.0b3.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "445157c2c60542d012d33bf409ed8d498ae55f01a69d51437d44387defac62c1";
+      sha256 = "e603da60f6be77a60584bd361f773a5e12612e8fad84f0aecaf33756fa13d9a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/vi/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/vi/firefox-139.0b3.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "08993658fa19a360374bd5fb0fd6c2d22967a7e75d5914f1668fa6277c851b6c";
+      sha256 = "c8ce7aa8546ecaa76af778e29de3bfb12490c2e9e4f667888449939ac424f122";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/xh/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/xh/firefox-139.0b3.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "3b324f18ce85aeaba1fc11d92680e2a2ccbadd8b7149a50330a56092902f17fd";
+      sha256 = "dc9071c3a8553cee661223eadaccb949944d11f4631cef76775e6b3d93f89eaa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/zh-CN/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/zh-CN/firefox-139.0b3.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "6f4e9410c342f0fcd2dcb1823cdbda770e445e2f420ded3d4b445c6cb2f5441b";
+      sha256 = "f8561851a5acce3ba9ea763855464592777d2371d1918d70cce0a01d833ee77c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/138.0b9/linux-aarch64/zh-TW/firefox-138.0b9.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/zh-TW/firefox-139.0b3.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "cddd4934d1ecc6e20fa82ec79d7c9d7846956aacb51e5a8d8e3b4283558a1bb1";
+      sha256 = "180c46473119cdbe027f13a26a53234e63e1f2dfd291925b0af2edf68ff05650";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "139.0b3";
+  version = "140.0b2";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ach/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "fd57bc7e6844cedf2c85e685246c42d929d3156a77e1d0ded40b8bca1099d5a7";
+      sha256 = "6304038c471eb73b1c8581f0d0812ba328de0f8d7db7f2b17f587e194754d2a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/af/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "5fdb91b4dee48d1ca0a4191b6d4be2ea44bc2b1513efa50434b763f1fcd9d69e";
+      sha256 = "8cd9c38cce4f6672d7c1017e1309f65481af918314a4ceb43c6acd20ac1bba2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/an/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "ddb7dea1828c4906c5a6126f1d325d4eafade0a247d0f22fcc9c4e212bb79010";
+      sha256 = "2380b688d5f54edb3b0a5ec3fa7adc5f6f01513551a3d02bfed1a0ada05ddc05";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ar/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "cf581f622fb37c71e2886fd122bdc826600ab04cb8a2a5725905d29ea087157a";
+      sha256 = "fde74a9a25843aa6141c796958f9cef020b3265a9578aa63a268365cc1be8e69";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ast/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "436e4ab12e59de6b5cb5cba78d3e68db43e0408460ba46b25b81e03effd71eb0";
+      sha256 = "3112d67a4d293f672694661266791521d16e3cde918eedf65f3157e9a2b9f008";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/az/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "1d62aa36c32b2dc2f4af25ba12679436bcf79e50c2b73db1624e4fd7bf46933b";
+      sha256 = "1904894b09994f8f9ffccc32a295237ffb94779787ff04e2f427416d0912f319";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/be/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "f054bea6716d06ef8aecbbf147d3c81cb61f514e82ad57f515204aa176abc33d";
+      sha256 = "9393160070ed056e5d1568e90f68ebdd13323e894b79fd05afea64f207231131";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "ffb4c108609792de752947becc51c2e2975e90ea0fe46d44601c186f804eab49";
+      sha256 = "c521605cfd30f37dffb5b1063d18f40c35d843782480befa7b4e3a91c9960b80";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "877a26a16590cde1bcd678b0d419bec76f09cf4be230d0fc93fddf751c08b13e";
+      sha256 = "3d31bd1fbd7d9cac8ce4c4a9f1ed2595d17319dbe640aa8d07b96fce80abba28";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/br/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "55bd564631ecc2614080ce653ad5312ec5d7de98df948b1bbe8dd9e613cc77a5";
+      sha256 = "39c1e6cfca4001c63698e066753269d29328fd3188f9fd2ee8c89a35b72da079";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/bs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "f33fbced526a89acab9fc34a860e4811cb83842a583f6d7871d11152ff1fee4c";
+      sha256 = "406e850b89cf20211936221b208bc164a8a73b02fc5d6a9bf791cdf7a7e9c439";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ca-valencia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "d9c250c770914d018f596cb15ff87c0d009ef0121a040f09c1c2e8c95e415570";
+      sha256 = "0093fcdc460bc29b826f66da5711bba2b70fe584c41c830e2555f71f33111baf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ca/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "1a675352282c3fb2966287a0e763defc6f259ea396ee17c9ba4d71e79ce263ad";
+      sha256 = "9ed9e2eeb261926aa79faa89122887e7ad0a07b2dd764f05ef140e709a413779";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cak/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "3a672f2a6b1132d0cc37c9fac289c7029588d585e887a05943e01d2df0059562";
+      sha256 = "1b4b3619ef9114b3713a64aa5afec1f33861dc6335bcce5449b86676f4b6a0ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "f83bde54b11b0cb95c49a953d74f5d9dba8351e775ddb53238debeee26ab558b";
+      sha256 = "89ada949f223c2579be305656a3dcbdead12465bde6d6ee2a464bb3c92455e77";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/cy/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "6876cb45e012664a3ddeeb8d833a28d97af191b3653a850393ba24c850c1c327";
+      sha256 = "4c18ce881a44473dd2e4e5ad1b7732bfafbac5519d92e036ee59f61319d2de4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/da/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "438f790a0a0c8648c9d265a4e3d487d87ffd6b41beb91bddc8b60e538e2a7d40";
+      sha256 = "d00cecaa47c94d895a6b94e155e8e24fa43abdd83d9f96aacdc34a1c70b2d6eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/de/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "70d4882852da68a7e431de93377cb7b7a1f68b906c2b3332f6b65ec705f5256b";
+      sha256 = "6039041822411f42a6757c4f53f85f1036c2094b8e8a8d8ec6a26f3c1abe521e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/dsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "7e845675e5a334b6080505f62790e6dda22aca0f07af1e1599faa9b2478ac3f0";
+      sha256 = "9845539a1db4a76ce1f31047471815f2a2ca4adef51d2b56c6fe487f7b9eafb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/el/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "07675440e77b87a0b64a83b28e59be294fc559f7fe4d5d6506cd34fe4dfa69f7";
+      sha256 = "b468c6b5ca6163aeb94ec45ef16fb856cc02a75fc55d939d2aab6181a777d8f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-CA/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "988e4e463a5e3684df5633e11e5e37dace06626bb20e04b1b69e9ef089d962cc";
+      sha256 = "ebadf4008439945b4909f0b4bc68515e89837ea871fe09c76dfd78e194469797";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-GB/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "b1c268a2c350a065e37cf259c81b6e535c0597c15e046fbac6dbcc064625bcdf";
+      sha256 = "f73ac36adeae16e5b0a383dd65ccde3946072de55094b52259cf96b5ee78d732";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/en-US/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "7a5f6f3816f25442272606ed5e45a9db22c507f0ceaec5858e55d02e4dc10d54";
+      sha256 = "ab17cf4f447bc681649903aca837c950f62e7fee004eaaa9fc2c894f6d001891";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/eo/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "b36ab4a47cb20b07b1c1ac77c3cd24fb850feb40261d398bc0b1f16d7e1f0e1f";
+      sha256 = "6f61eb153692e3de7bf83da4670c44d524aee1761aec5c8e54c9fef3ac843d72";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-AR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "cd03f278e58beb350683174d9614b78e41f2f0ec1552d50882dc1c405bc37ee6";
+      sha256 = "1ad06fdea8283a58544922066eedb16801d07ad7ed72cc6fc817a33f36741e69";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-CL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "1ff43a0e99f0f540944209470ae660756cd41a1b9e5fa267a78cdfa1b6ddb287";
+      sha256 = "79963ea997d12e82e245364556fd7c4deceacdaeb1e0c7e4376c7e10df6d5eca";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-ES/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "9a8abef988292db0d3e2b7d728770d6e8b397f90493acba75b2910ff348114dc";
+      sha256 = "cc966099a59e66bfddfae99a9a5874490ed5716fd5af99b9db03e3f13125dd80";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/es-MX/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "f76653c3b4a3d7244eef6adb61ea79903f42133deb4ec5c93715cbe06dbaa1e9";
+      sha256 = "ad8b1bf472d0a377fea8e0f5b532a144b397d1447ae85c7c14f871d9029cab19";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/et/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "3f725c9a2c84f3eb329d321ddd4b3a3ea6a21cf64fb3f18dd0fb681af378b007";
+      sha256 = "296e93456cc6e9027d187ca7b59923acd330066b36829f8140ca16d4ec423d20";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/eu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "bec67bfbfae8f1a0969c1bd083d200db25e9d7efadea0192955e2ca5be3a506d";
+      sha256 = "9269d0e584c4d004d6cb2c6f3d3859329947fada0413141b77cab3e4270e594d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fa/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "c37543777fc3c90368768c730398c1782400f94e05b26601cb6068f0b947284f";
+      sha256 = "02a5f409e51ec0010f551afde246a7b405a642fbdc9c85e8e021c7bbacc298b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ff/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "cd4af2a894a4a6f523aced106bad12f91ec41ae9409d0a5b32a1ee99f09c184a";
+      sha256 = "89a1e5d4e8d81ed4c3e2b0db3cb82acfe85f00c7875a993d9ef97a895a2c1e8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "7e9e1692e2d870375e17d8f91be4808118409088160bc61df8d2ea99fc4879b6";
+      sha256 = "feb7014dad2848a0e70bf2cb6f59fd7cbe4526566e9517ca636c7f81af1fd227";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "2d1eb3ef8903cf00994a8b0b249cc806f0085b8ac4de11da66cc0611ec9ca62c";
+      sha256 = "d8c21f84f555a7ed705d7a21098151195a18a1ceeb8838a6204aa8b346e3b77e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "1b6a9f6592e3b2d35553c39b8bd59a1d0e7975c16d6e742fb748fc5071e61c8d";
+      sha256 = "df6870ff18a549566f89c864349f6e1b1be1e996af61a23f6ba8c8ebdc43ea99";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/fy-NL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "9bea116bfd10e2687fd903fa533642f9380901196a4068a8d19d05176aa9b8df";
+      sha256 = "800b0a1ca94fdb9bf745c163053816152a62bfc374682fcb46920c281de24c7b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ga-IE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "fcc39ffaccfddff75c5b9dff184a7f67df03c24598910dd4d89380e29fc9fbdd";
+      sha256 = "60d3d9b322ed276db8495119171dbc822dac0720fa67d6e0e2417d5f7d903303";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gd/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "3bfc75d90fd3c4cc7a271350e7b4474ac5dab71f742aee22bd994c775906fab9";
+      sha256 = "fdc316f98f0b7c6c58e11a85df0596763276f506b224a79c17314bbcedd76b18";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "9a1008adc5c74857777bf8379bfcfd5592c987c36b9495534ae6c5cbd1be740d";
+      sha256 = "3f541084a75bfd470f9684ff0e9c64566ae1ae70ec6cab992f641d1ea711f56f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "46aa366e2df1df9365ff81214b637ab563689d53714f78c4950bca7e78334678";
+      sha256 = "403181843d5b8b0a511fb1c8526ac04938750ea19ce5bea725c6f6e67aab4cd9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/gu-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "c6a34a993efa290921958cc79bf4a59a9fe66548a7684710a8eaf07f1e62d9ec";
+      sha256 = "a0a75e18c30ba231bbb8696d47f203f35800bfa945b010e4b67102e9ea995a57";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/he/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "86462bfc1e78034b69e106d1c3a728ccdd1f18ded37563fd9d7ee37d2b98fedb";
+      sha256 = "da0a1845ead82dbec393b3951ddfb050ea7b1eddf07d1dd52c6ea3941629373c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hi-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "36235be9dc59e2c093a43ad0d7ec6ae8341f8afa9fc939c6d29590acbd384e72";
+      sha256 = "9cfca47a6e5c5ce56679575657cc52da56a04cbdfeba9fdde7eed2f7dca21e01";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "20eafa0b16a86da30b39dcda17e232d69b0df3e02f1301d7c52e192768ed52f6";
+      sha256 = "e2412f9401f913fb3f78c68c242ed2bc7727e4798145f6d78e7ea7bb1e2330b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "e99331dc0ecd3f9be2dfa63dfabb71c2b3d8d84b62fbdbe67faaa6e106cfe2b6";
+      sha256 = "eef6641537eb1902fb5c80f85c028012151a864a011d87dfabdfff4860adcdea";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "1d14b5d69e230ef6ec21f2376b07230b64981e66f79c968c47ff109b34fe421a";
+      sha256 = "338ce874b6b6e7c18c805488eddbaae60cc0070dede2768e1fe8bd807efa858c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/hy-AM/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "cf226323063c8d2786031a888b9001b18f282708e858247f9180a1bea3451282";
+      sha256 = "fce3954dab579911bc3f3f2daa4139b6567ec48ba209119fa7a890835abb25b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "b4d61eab8372f1cc20f28c1a3e8c1f72b21d584c0dd45266a715ac116e4e0c04";
+      sha256 = "cd252dfb69f3c202f6a10a1f94a3958474b281c5648c86fe1fd7058f1cc0daf4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/id/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "7086deb11a567fb9e15a2b301fe4234aff8ba5125cd6a9371700f10e6e89a06f";
+      sha256 = "c4110ddcbb1ffe4ef89423626887c8f2f093c26e449f109eeec04e23c8f86f82";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/is/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "f37387831ad3722a61a9bdf082e15cdcbdf6f9757be183bf2f4ff44b7e44d1e2";
+      sha256 = "27093bd2b6373dc87174473b087afa19fb9073978819157adca9afac9c1b01a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/it/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "9957340442c44bbc4ce06897545bb977a290263377ee3eae5b64616e561b1a21";
+      sha256 = "d7cd7f8f77550be23ac2f834ec892711bdfd40301eb60eb8041b6373881a8063";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ja/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "8eebb7e6d6351a8269b83fd8095b86bf8b2f4177565cd2fdd323717cef6971ef";
+      sha256 = "547d409c2fae32d519b85a0ecaa4fa798035de83a99a24b8679841450816e918";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ka/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "fafdbba964ad85b38565589118323d1551ac5021e041a00e29b8a629229e2085";
+      sha256 = "7c8283de2bd1b175da442f54374737d1c483714ff5a65614393a831d87da5587";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kab/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "ef2f0225bab971c7b6b6237cf2795e9281730b459812209f2d11656ad39e698d";
+      sha256 = "f79764adead47510e6af35e084c4bc23e550a07d700e9bf315825eaab019da2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "cdfebcd9afe5c55c6ff84543580e08108f3e362751f09b99cb703c20dc1de3fe";
+      sha256 = "efafd746dbcc752c401d19475513a567cbd334f6ea3f9d64470bb5e1f67bf443";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/km/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "ea997189f11e283f1d37e7e8a148f45ae0f7557fefc23501d2cf534a4f4d423f";
+      sha256 = "5f06885bc54c63e176f521e39030a5cc6efa850a49b1329a06332881143d9d56";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/kn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "005b89059b12d1369c338f9206e899c76c0d5a97ad94f28564778fc092694814";
+      sha256 = "2af7d765a6093ad174cfb34b89782d6c0ce17555d6b12650ac9e17f4fd383d87";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ko/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "56282aec275e94b3a556e3a9b95e107e68cf366f6d2a9dc8ce7fbcea9bc23ddd";
+      sha256 = "7ebf5fda02c87f0eeae2036ba3ef26f166cddc131ee165ae4e18c50e69ed676f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lij/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "8ff69cc72d47d3e212280b8ae004abbb9a34b6e052cfb81f6fed4b1c0d85f8cd";
+      sha256 = "c864a48999305e753d72ece78900eb7a97a3dad8eedfc8a72374c58f1d5227ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lt/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "353a5ff5baa875628c32f6a0b7cbe5234209616684641032493394c986811cdc";
+      sha256 = "04d711be33f1fae9366442584a7f2bbffd74fc3b3854728db5dcce37e50f31c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/lv/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "7eb1a0e3e0441da2df5082693588135b8e7069a29c82c1331d3defdf3e68b837";
+      sha256 = "1568ed415833621077555b9c9ab1341882ec1f8f1ba17c596d51bbf40bace3bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/mk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "d7df7d215f440025117d472c7962f10b3db26536d424b633860bd0a2b8634e13";
+      sha256 = "f7fab263b90e197038ced58d845c8ff1220d4b7b10dc2afa3265ad0027856353";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/mr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "9d6b1174365423cac77f4066e174ac0e24808cb8147cb0fc4a04f526883f3038";
+      sha256 = "6e7b7b1d9977bc6d4462e08ed6e2a49ce22dcc8ae408dcc832f63d04b878e5e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ms/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "1e3eb5e62665157538768e85c30728e1b0916e9637a4d7d5f3fb390c9bba31c1";
+      sha256 = "17306a80a5bbbaa00ca9c1bb3717f25c49ed94c18c58c751c01292e8a92e8a03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/my/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "76fed1cabb2e1ec137e939d6b0318c32e23e5fa9d5602c08f6a9e56f0a469734";
+      sha256 = "eff89fa784ad8b0f039fa182ed67159aca185093402ddbf33752ef327bb4dd43";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nb-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "afb07ebb11a8e3247b8689a7809bb33a83cbe88ded223e5967d4251541f3d55b";
+      sha256 = "cddb858d97fd0206ad5b138d41d29acff16199b35cd6fcbe1c70d3ca126da3e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ne-NP/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "a877b86d57e978bb020d9a4447a96ae85f0d8c9bad117373f81561e8379ac051";
+      sha256 = "291570b761874ce5146d1282972abde6da445c7cf63be89f3d4a2abb5ae52369";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "5aead7a62bbfa6f765be274d64d6d8a6402b2dd6ee68a571600e64433a871854";
+      sha256 = "00139cb8cc6c4c5f6f478c476ffc00450d57ba239288462bd296b72aee205562";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/nn-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "d35f50beb12afd6427c615f4faba025e2679289b7eed8772b9c2521c0f096130";
+      sha256 = "1c3f80cd5e39d450564a7266a58104e117f892243a5166ba6a5c79a12371cb66";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/oc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "a309df62f5d50210dab2d410ddf72cf8ce83124e49250d010a3098d45a519403";
+      sha256 = "6fafc879c80e60d49c32b7752dce41906213132e3a19e3eaef5edeccb2d6b389";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pa-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "76fa9af171ca8ef48f2d40dd357dff2f4f434ec5972934d8d5660b975d9ff14e";
+      sha256 = "c7bf8f30d961adcd6b560d855357a0503bfb5ffa0295ced4f92f6e7b6f0c63b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "441c0d7aa570ab16c13da29e1eef27bd58277b0546481dd455af687eed1c3546";
+      sha256 = "43345fd177e16fda3bead11b3e6c094ce947b4913d401c2d849b13607d8f1474";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pt-BR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "401cbd05af87d88f8351a6780a200f32d3e5521ddf8dea09f4caceb565eff554";
+      sha256 = "8d20b449e1f5dec93f7526bddcb01682478df46b7d6b647235f94d86ff47327d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/pt-PT/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "1a64160ff804281709b279c0671be0a378020c3e9cbbafc21c537212af67566d";
+      sha256 = "0f9febcfb684ea28734508fa27dcbb89282174c8ab04fca0d99adb2596b1bb08";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/rm/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "d05161f9d5a54db76b46be34c13bd628645f57175e237d691b4607f8bb1ad13c";
+      sha256 = "505a664aa0b5eb7fb919437655f807f87224ca346bdde982eaa6bc755e14bae1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ro/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "01813e83959f3c51d841d5d5a134b903fdd6908c77f932219f7f2976be33d151";
+      sha256 = "fe1317999e0d07e634f4da7813e25d553844339ef484d055115be201d351c94d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ru/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "60562e6b5bad99bd61b31790993b1af13d66b71888b75680ea2ff2a0a429a682";
+      sha256 = "45808d9eaff267c7aa5263291352f459e30988e00a3ec867ac0e4eb9e3fa5828";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sat/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "363eedd05b26529651905995a75d4fa7cc4a4cb0eabd71223011df8819b2c9e2";
+      sha256 = "e2ddcf9086a5aab8039b2ee40264ea5349bf27f424c8cebfd8d3f8be64b4812c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "d4893587265913d0cdab363809038afd61a0c96f8add8605f8f709d7cf6df1c2";
+      sha256 = "6c10bf086c38c7f030cd1ac37ddeee3e7900262367a26d873f1130f1b1a3fa1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sco/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "9c56abbb7208a26d8fbf1ebd3dccf42f23da60c73df628eaa44b9293e128f5d7";
+      sha256 = "fc5a205155469cdd157423b526c5ddbb8ef6619518543d0a13138e4548902c98";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/si/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "f9d59c8e43c249293c844c8e46fe001aaea050fc32a9e06dac0544319b248872";
+      sha256 = "f0165747a086b031eaed9fe6d56a6a664d48cc2cc1fcb4acf4cb2980680bbb18";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "d7e396c453b86e7181a0af09f5a608b7b3120d0b2df93fbce472c4935ee1cb25";
+      sha256 = "3139af3d80de44cabe66907b1ff1a0c9abd6d4dcce7cb8f6a8a4c64cc96d0d6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/skr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "4b120fda51484bcc9e7251ffa267a42dea1328148476252dff33c22aa10da3c2";
+      sha256 = "4bfd49af3b1a4af17b4830ddad90e3d4742baf9ad3b296ad82c186e46e002c43";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "c145d10b2a5ed42b1e0ec7aac49caf51468f200f361b0d3b576430f14825e0ea";
+      sha256 = "e58e08c08ce875647350c17919a247d1d959e9aa7cf090b9e1f631e3904e1c49";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/son/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "bb0a17d3089ea0fd8809fffc43258b2ea2d98e8a3ce96385ea80fd859f82ba2e";
+      sha256 = "df8df3a9d363721f5d7284c95e690938a9669bad7d1cbc659318e71807bfef61";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sq/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a013d51f7dfd0ac9da4cb6159034027ef7bc3360de3421211f5ff453912d9065";
+      sha256 = "78c45ef74932ad3264ceffa6ca2a3d5863642b8febd784016b5dbe4ad515ce3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "5388d19db672524f2a4d5975070a4e5fe09d9bddba8b9a3a54c2cb3052b3c28f";
+      sha256 = "9a3b7e25cd80c19c9ee0ebf2b9cd7fb956969b1a699348859193bb3d138a16f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/sv-SE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "49600c47143f89d34657577d1175db5c415d4a4a6766e1c410db58337371004b";
+      sha256 = "864703a7933ca315ef1dcaf1e978b9fa61035a160cc3017bb6df53d50e42cfe9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/szl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "25a6cce7c972c74bb8f8f881200417765ae7deab09405a947a4010002cb5fa82";
+      sha256 = "e63cd0f41501fccf3d6da7779e6926971122b9a40509cb57719ca987417d6231";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ta/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "ca4eb3d2ffcbfdf0e70a42bc358854b99fb9d8b297959530b25db69fff8da6b1";
+      sha256 = "8d45af2c0e6cf88a02c25b7c5fb31dc844bb90ddc8aeec774ad8c700ec12919c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/te/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "a642f8335f263b9fc58ec32128ac3467c1dd2879ab72b90e74411afa723685eb";
+      sha256 = "0d0868ec91ad13430488eba13840a0fdb238a355a0b74ede0bd536c6cdc2d013";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "08636c243613e677caf9726e73e640165f90d0fb3b7f5d7a85535a9d20af06e2";
+      sha256 = "2112d847a6377c3f4b6fddc2064891f17348a0639a6341833cc6a8681aca2496";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/th/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "4586b68f7a73cbaa86eab8a2a67b904a3300ae485b85ff878f442e58f2c25a86";
+      sha256 = "a49f6e380f2ee83e08b9bce632ac9adc8863eff92f043886e6dff361af0d9fd6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "29d943a1e465b089e4b4216bff1343a3b267bc2d0e6757429dfdefe1123c87be";
+      sha256 = "a05dc7b3b86eb5c6c8e8bbd405c356ce6716ff7f57048c502a16dba1dc616778";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/tr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c0ebd1339d95eff201d85bf549f38ca93907021853a2841dbb48bb7587f84890";
+      sha256 = "be4ff7df882a6bbbb82426868abd07b3bc31328b72faab12c50f44910a04157b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/trs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "fbdd2bf864b5d2cbb0b633b733c70c71457c04cb405b0aa14c4dc83a5380f4e1";
+      sha256 = "b59cd940914a1dc6034648cb4d2eb98a27db282a63f549670112c005a4fc2c22";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/uk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "9f2af01f2187bc3dece162cd493ffa46bbb7b4af25aed176f81bc1bf99ab8f3e";
+      sha256 = "cd723b22c8bf8d857e68ba7b7101a42451fd4e0e9216898165194dba6f66600c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/ur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "4d3e57b37ea0d9f498701e768e6a1d3ebed495c83715df9b0623845b9ebf4464";
+      sha256 = "23307a580138e4f1e8de9de441c1dfa274b871daa68274510683ce02d1bc4554";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/uz/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "c9419b604b2a6e91cdf9f3c7fcc1a7213eeba095a7ca4950138d4757326a5337";
+      sha256 = "75554e0cb06a1244106e2cab513286d0a48c4b5c5c2645b373e20245d8163d5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/vi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "436b6789d5c91955affae937528b38532c09b96f80cca4ff893b593c10720138";
+      sha256 = "a502e8408f00db0089081072b813debb97bc5c60e31c632b460cdc3d1f9f3d71";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/xh/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "ad35a67010effc02db685ab1b05a534e8454a3d7d8d9eac2abb20ea3494440bb";
+      sha256 = "a87cb0aff09dfd91acac6931f5f8ff1bd000533448f8e79950dee7baa29f072b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/zh-CN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "25efcfc912e9e20d7479ec869afb471d4a4be279500e06f2609bfb5df9d65e21";
+      sha256 = "7616247e8ee73956d925b4a4d4b3ba1b269db286390250ff04ffd066c37e6323";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-x86_64/zh-TW/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "a694e1461292c471cbf263f1fca962b27e5bc1dcc655cd9c0f22b6ec868b0196";
+      sha256 = "1070fc52e45b0827958fc4ebe74f4fd4643738a1d20a9647b37620066cf18896";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ach/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "8acea013f0230e45e5dfe7cb2d1495fc31fe8f62e3f0c71021faaeed56f88d90";
+      sha256 = "15dd9a2a6103f8b4e11d558aa1b5def0119929f304fe330f14fec35452ba88fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/af/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "e9cd59e8ecb6f05aa3f71fbdc898e38f5fe16e7366283a899dc918639bbfabe2";
+      sha256 = "076016952832f1f9923426ccabc14fdce0016572134be4413c323f04929d2b7a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/an/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "06f077e94b604c14d4b23b5c7ca90988a91fd77b4923762880a8ecf6d0d96549";
+      sha256 = "55e43ac6458d7be27db5aeeef0a4e25732555645faba647f379140b5b18f1cca";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ar/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "d766a8ce6766609052f059d44b324cf67e872eea704095190a00099b472d1312";
+      sha256 = "1640b262104f1f637240480cb5d7727aadc003ce320f444fa7446b2345239a8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ast/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "2b4f5ea265d192b4ff27e24ccc60a1b2e70b5e19f5957ab482c6b0d36a4182eb";
+      sha256 = "726dad49420e6f8f6f48b00df01419fa1e25022e1a9034c917732f591d899ab5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/az/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "1659ad578e6b9768e3a2bd2dd2ccffcf1b8d8060c08bb2dd9f45a5a8b35ce6fc";
+      sha256 = "32f38f9452d6bfe9ed0059402286ba86b8e7d49767b84ef68a807009b3928a71";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/be/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "7959c9e95a1858961a2322ea9ff572c53d08c5f1e855d5115cf68343f1dfce63";
+      sha256 = "d205be69a64a92dd2dd4938cbe3804e41f9370bd572b0e6bde337feaacc7c80a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "74d7142554e8621b5662d322c5d1eb63a6bb4422365d037212813fc2b1ca17c4";
+      sha256 = "a6a8a3d4b40853a7bcbcae6c142896b69632720d1cd8ff0ef38944dee718110d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "5d40f8cdadf7510337271c98350a14b002462dbb58fd89c7f5a5e898d4d96522";
+      sha256 = "b1ee7cd72876760977922e48ac38cbf55f45bdd191015fd98b72b9169f88c905";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/br/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "98606dd41a554c6642b07c7012c8fc0e831cae305c77b17018abd7cf1f835126";
+      sha256 = "df82db0effa2010c5c90fb0795ba63cd8985716d68649d97e15408dc37c6c84e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/bs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "319901c06f9ae63714f5e50def341f7af82446d657a4792f6aa0dacefa6c5aa5";
+      sha256 = "87c0752bd5b5a9c2b87c6e538621c2626b4464bd585f906e305e4c5715f97c86";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ca-valencia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "bdbee33f7f53270a075e45854b42f5879eb081875310285ad4b99dfc2494c766";
+      sha256 = "632893b5ad32cc730ade803beef2b413b4df144ea80f233e2b24574092a8036c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ca/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "9b8af77f7db2bd74065f7b56823ea68db58822db1d55e1a9c98d4654d5178e42";
+      sha256 = "000cfb032ec853d10c5130b04e88da02998fd57bf70a07844390cbff55f9885f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cak/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "649a2617e215d8f3610de863ddfc29dc0c2b27fb7d642c1e0c9f2c6aa365ecbc";
+      sha256 = "009ba5baaa7d454aa9dcfde0b2b4e6940590b6fd6ad7d5a90003ebaf450a93f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "8e8c2e892caa8bc5db5804f42332ad57d1264eda034feb467d6d75827c3a7cd7";
+      sha256 = "67ebd37c779ce36133ccac10894ced3faf9d1131a6d0a71a9f35d73bf4bbae36";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/cy/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "394bb39242b8631d46d42586611e91b54028fea43d78248af3bb446e6c6834e6";
+      sha256 = "baad091e481f7e3c3e7affc3261a22a5a390e3cb739875af53b4fd09f8995ec6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/da/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "b42f902cab834a1a177afec0812b118280f3733adba9433d31098df63d184d83";
+      sha256 = "62315dee7ee9cbe3eef1b01359ccfd45ef7348d526fb6adf35077c74178dbacd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/de/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "420f1853b37b823edbccdb02e19669d5caca76b2ba3f607a81d11b5654f04c1e";
+      sha256 = "c32d7e2e8f07db2c92c876f835d506568d5aa5df587742aac5b5b38b1d741224";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/dsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "5987303e490b524c31619d18cdbcedff7f24d70a1652bb9bba15120d34befed6";
+      sha256 = "9bfbe5c14cc47de7c04d89fc8d753e8cb07e0722b01e694e40769578ab41f80c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/el/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "4001d4bce1fff3dba641b7c38c2b26338e40ba28ddad8554c4f7dbbebf1536d6";
+      sha256 = "b847df7a731151defb9a7195e52e5170f914df02f125474c44e3aa63c676c34a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-CA/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "35707a5d0e7df572c341da8d4ccb76f560267feeb8df785eec304e6c920da3f8";
+      sha256 = "7812b2ddeda5bc1ed121e8512ba2d019edf1596a0ebd5d1a8349613e1745d685";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-GB/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "02b5a1f051e02b949e7c8df2d4196e6e45cc02a0ae0178f8500c99b67737042d";
+      sha256 = "5b7e6a78a8d98b36cf640282e2aec5b34d9d54dc1c244d45e043de18be59ede4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/en-US/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "ddf19c5fd706f7d20060d009e26e5f98d15707d7ce1130a3e5209a80237c4d45";
+      sha256 = "60ca80fc4bdfbabe6810ba4ffb1b49eb02147fb05134a3c3eb19cbb2d7ef5ff3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/eo/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "75a9e8c3f3f1a11b22be4501fcc6743f6d7233591df6f1f3eee8243fea27e6a6";
+      sha256 = "61947e8887d2f0010de1b1cdd1df5ece9dcf4f9abaa17c76deb48b47a14ef79b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-AR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "5a66e9d13ae53b0e163630f1b9a20c4b68f4e7cdbf88c2d2ca702fcf9846d064";
+      sha256 = "8c0c291f1150c6cc45180dce4d94540c947791aaee2172e2f37b57b002aa1784";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-CL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "79dd1dcc771346f0aadab81fdfcbc6fe1d532001ae17793447b423b1a85a4aae";
+      sha256 = "aa1444a6092cb96637ef7dc9c44506702cb96eaf633a39302673d040f0b2a9ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-ES/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "90054b5ee7292a1df8f0e7688b35fedcb19f2a8945f0bfb440c44913bd123c4e";
+      sha256 = "0442ff731adeae06a0ea178098ef17c1d0aca3f34ab854a7807c56d2b1ace7d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/es-MX/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f18593686f6a02b0bfb66b364b93fbf1f868365eb96e8152ce1500d6c739b457";
+      sha256 = "b260521cef1779ccd7d6b1cbfe66ac2d5cd8ee72f282b6e81110ea40995e9b30";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/et/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "b6f65d28916d962223af04027a1b5550ef7e6326924f83115a7b86791220bf2c";
+      sha256 = "f7b752e18302aeab61df546a0423fbdc297d538c35b2038e6e9dd3f0432d55fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/eu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "410f33a12c705d8ff753b4cbb11942df9aaca3777774e7cb2db5277b7791de1f";
+      sha256 = "e0d403ce1c3fb69e692c0679c7ed65464bd28cdfcb107756bcf66b03bb20f15a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fa/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "67728e0982b672da05cf00b46a12e18539a0ce2c3cfbc3f91e0c5b62b6d01408";
+      sha256 = "75eefefa501b4e46f84672aacd3d8e5c96f4bbee41dd652436624de5bbd837e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ff/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "ea729dd3c19b979d00c25b6dfdd2f2d633055a9ca389ad5cde5b5154886d25d3";
+      sha256 = "197ccaeb27559a1dd913969a3a8dd011555c8125fcbb55a28caf4a6074b963b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "40b78a9e4cea933865f06a41c8a32d276a59bae2488601afa6d6e936669eef4e";
+      sha256 = "61ac2a275d6410f7eb8cc4f9bfd70e1e5e56fd63eaac9447a56f15920221be7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "5828e6b8ebc7b7508f363f9309554b544205479c22b9632e230340774c46e442";
+      sha256 = "9322f072928c09b3d45e9e683ef26480f404def390315f46eaad3aa76c5db4a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "bae0801fdbab156db54f0562f246a59eb5f8c24c79ba17fe2b6c98fc9ed91c58";
+      sha256 = "4ca712790eb5a98804b6b21e68cf1d875f9dccd5bd729a7f1231cd3d7b4c85a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/fy-NL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "0e21ed14bcfc78650f62cffa63d1d9f1a8f21b64b0d258b0e15e346b6f497f93";
+      sha256 = "3ca2c4a2ef1de935d5a3ec0f29314596ef64611fb9025efbee2e809b8bf51da2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ga-IE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "a873d3ce455f8f8c82901d9e2b6795e59515263380443801b2e0c9fd050f03b9";
+      sha256 = "2e43d6679a844f9241110f67a785525b09124f004d697b41400686851a45811a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gd/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "13d114359f5c30759febb7bfffe79286f3261477a160a35faa3d5d2e1e236271";
+      sha256 = "a51f8e4c872a39f307bbd8c71e56a3f90d84163feed7ca79067ab0f51f7eef11";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "57c6b29e1b05a4e75224085c7a8f13a3948930e92204f882092cc71efc7d4071";
+      sha256 = "24fdfac7aa372ea38d4ce642b5e30cdd49c46428e5431b004f368c40d52a450e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "6a197a8c1b138f1eb95f85770e4734fcb400679fe18c0241352dc9d0d025dc5e";
+      sha256 = "9f81e0d531c7a9826889328afcd0e8e8c29cf00b253b0b6ef420fb798ea3d2de";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/gu-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "53bb01d3b87a5a463b993e69ea9472b9b7dce818ffd41a3efc74b0def2880c10";
+      sha256 = "72ca1ecac233a4e8d51a70edc8d39d6bcbf036827e868b14c9d166c70a7140f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/he/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d2f51a83e9f625df054c75b6212c95a2ee98a6ac6912fb37f6dcce151f0d8cc5";
+      sha256 = "2cbffa2df9acd1b30b7e96b14e9dd7d9cc9658779fc24d87cf89f5a5989770df";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hi-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "72b1cb85cf3c3774befbafbec03aa95084356b955b6c86acdc2d12fad9a05d57";
+      sha256 = "301469bd1372c6153612dda25c686461d55d5140e65a8f4048d9159b7fba67d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "9d0b4cfa3f23f962e2784f9a17e8998d2a6ee1a3e54740317473e32c790fb1b4";
+      sha256 = "b00411fb0539a1de5a4d025fc938f6352cd38f2a3d586d7c5023cea8d3fc976f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6ad41bdaeaa4bba9360ea98787f0c84760f849570452425508f3dbb0472e7349";
+      sha256 = "0e9daab014b58ca0b5b065ceb8429b576765ddf692886c0b2709f9cecda54373";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "583782cc9ee0da5f8ff488643ea6a1573979653130bb6120affc1a7ba57d10c4";
+      sha256 = "d1ebe95c9ca85f7ad097a42f01728f7ca4b67e0b0325993cd7a8788bfaacf186";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/hy-AM/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "bab8bcfd4374d076023b6e1fccf797fb3d83f26d0fa8df75a0d3c5f69879c5c3";
+      sha256 = "84d00b6cf98ff0a2ffc08ead1b7dc61e74f689d69a946f2ab8c0c7ce96299f3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "2bd01c27ac6e282be53d72b7993fe9b35847ef5639104924a5d45fc20a42e56e";
+      sha256 = "54fff386745c615db563a7e1344ad4c0dfedbfe9ff1b69311fb96106130eda46";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/id/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d110ba5a2d529cc020a476fcaa8781c35f1071224b33814983b83722fcad0078";
+      sha256 = "d52a44a22505daf7236e289b1653b991d640c2b2be5a9ac4effe0a819e9ef063";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/is/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "1bb68a757bb2c9ec9c87522d91733fe55cf5aab0ccfec58cbee67c3a3764df85";
+      sha256 = "f01b7bc84a711c72491dffe4be999cff939ba3fd433572f693d9e3a0a97d2a6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/it/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "6eeaaa32990d457aaaf37804f54e39fee7fbcf90e024797461c76b7b1522bb84";
+      sha256 = "b885a44f52597ece4a719245709263626fefdc94702162523d0c6392e95a9817";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ja/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "ad3d2dc245f06c540b7705e4c43b18477f3ef2b6cb21046f2c6aea5ec3343744";
+      sha256 = "5deaef5a05465c8bfa5f10480f0c0928a498c1b5f495e198bbf5bb187c2139dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ka/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "5d1c0a0642967fcd4646e2a615c5033634913b4e55b53669de1a27f6de18d39d";
+      sha256 = "6c8ea6cab65bae0429c9f63b906e63f40233a01dffb061b0c37d60b0c966346d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kab/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "fb3636bc0836dc5754a86f40274e3cabb1d32ea1e493cb84bdd0f61b1ce526ae";
+      sha256 = "2c1b647450c0e179548aef5794a596e2053322be9c4b36da78616cad106537b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "ff7faeccbc3977063bc69628c64320e0113a6cf0cf487fc0b6253debd7c1da04";
+      sha256 = "36349bedecc9a5d3cc4eca66232925583b82a5f9b7ec2104259f7e5ab2704041";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/km/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "fad1f93e314bde16894eb472b2cc2ea41b5227f4d916d15c536b3892fead5587";
+      sha256 = "a50643354ee4c99602b2a31c6ab79a651a6a74692eee373c988c0ccba8ae9574";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/kn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "32891d6d78f97ce1eb3f72751252e8ac15474a67ff3b69e0fe78f21efbe50aea";
+      sha256 = "bf484b8f53ce0703250f4ae0adca41b327addd29319a99087a930abaf92296d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ko/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "f4f7315ddffe3bd50d927cb29e6a29887f31601c6c062dd349e26920fa1faaa2";
+      sha256 = "4297f9355f72fbbddb7a337f0de9877c88cfe6a74b98262791d4eea48a9e8b44";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lij/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ffd066b6b01c2180e8d85ac3c91521b3c2d0a349184bd6c3a5daa220dde51942";
+      sha256 = "d1128743a077f51f9dabfc3b949a64500dbe5936bd29347e0042ce118b5621f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lt/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "6d14d17de1c256b6c2f44dc032a09b99244cf9dc81619c18cb750f9900857f94";
+      sha256 = "ca2d1ae064e99bd1cc490b8d47cac1a342419ab23a3dd39919873d102d416d7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/lv/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "d9f0720f4d1b663406b14db66f739ff1d0e2dc5e849f88640d0899c3de528f4c";
+      sha256 = "cab179bfcd42b5a93311a3b0e7d298ff1130e17c5c5493b8321693b9149b5b48";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/mk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "e770c64d793af8d63bb33434f427ecc9cdffb49345ef966ee7b27232214a11ad";
+      sha256 = "ddbf2ffebf122e83bc865808782cb3d1e0700cc29467b6ad8506ee03499580bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/mr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "bf0a4fb9bec478a1fa1d48be903509b5f23c45dfa7754afb78aca3962e7fd21e";
+      sha256 = "b7635fbe1baff6f7edeb4b832aabd21d12582a7c66cd086b95b0a02aebba4f56";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ms/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "8d09acce703795b35bc04887cb26e4020af5c397fa396c2f2806548b5980b6da";
+      sha256 = "953a47f53c007d2cf02b22a787e8c476c763ebc5b15796973cc406d34301440c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/my/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "f0b894a6462f5a80c23cf83a1a011c491a0fcbf61fc04c2b0aad6a0ecf9b6a42";
+      sha256 = "a6ff85aead2ee5d55bcf055a42452d44439b9a51ae25b5336a3b22a573c0b46a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nb-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "2af8e1f308a6010c3b8523c1e9d12d0e1b5b9724ad1f444394ca58433a2298c0";
+      sha256 = "ae4dadeba15ae17d3307f09392ebb3f85f0212332f9a9a857ba5b6118452c2cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ne-NP/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "004f3b52f367a1bbd35aa06d7040035bfaf5da5524370810c789746ed78af888";
+      sha256 = "28e20f4d661bd7e95495155249faecf8fbb5e7e654298ed1fbdd62cc971476e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "eef545c2a3937500dd825e5e0ba94735246bb2e8750a3b3c2266026f5b1859b6";
+      sha256 = "dafc7696a404c8fad558b649677988c076c5eb4685fb801840710657631c5356";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/nn-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "794b917cedc6dc92964665da249dd018ddf288f837ab2968794b63c2360a8cce";
+      sha256 = "992fe42be2e1521e85b9f5baed59f0e87ed71bf62c99190801bf9c2f5f5351f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/oc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "3b83f2fbbf74b91e44a7f0043940d242b1b736d75394caecbb9401e328e23da6";
+      sha256 = "accf61fd69c7e00bdd48163403b6bbacb37202a2db113983fbaf8dc1a3598b0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pa-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "72e016689aa5823d0c1023afa000780e6e60bcf752eaa7f1fd68da107f22f6e3";
+      sha256 = "6fe0de8669c63d79837ea4dc062f4550b5ee709446c24cdb54572fa9a3916469";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "263dbd2d79cbc7a2c0a0b21a3fbff69fa22383f39d7824ffdc31194f03a69327";
+      sha256 = "71d4c24b490678d5941caa81eb9206c8aef0688eb6d134766588b2ba1a4fd808";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pt-BR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2c9b08173760317cebebe8ab746b8a024db38bc7a7aaf4e9de034bfb50abe5be";
+      sha256 = "85a69113a9348f3aea241a7de7439dea2c3ce3768ddd8d4b2a3ca5c1769059fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/pt-PT/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "df8fdc9ca8a2a16decff55ac6b64775ae2dc7c64d6dbdd8fc15df014a8f8a656";
+      sha256 = "4586e1e50cb48044075c4128ae7671d23daa9ea186c8d60272aed76ac5d3bc7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/rm/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "2b6f3c308e293955fd8243fa724dc969d054b7c0d086bc1a243e2c19bef27bed";
+      sha256 = "d06072037678bb49711952a3f5c7a082b0a39258bbbc951578110ab7f1314bf8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ro/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "81d6fb48b838aeb5e9fbbfaffac8936f376289b162958169a50e8a48bdb4bdbe";
+      sha256 = "cdc758063dc9dff54e5d4ca6809798e239c7e096ab7c21c91738c86bd50c4499";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ru/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "6fbcd6ea92f5e2c81c926dd407ff2523e551f388b56154a3324c1f04f66c80b7";
+      sha256 = "094f692ad849c608df35112dcaab251f3710145fd28a6426f578d984de4e2bef";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sat/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "77b8647e8702ec7dd982ec622151de4eac6e1873fd632c57bc174d4ebcadb675";
+      sha256 = "5922623b038eb20d5e600d1dfe48af7cadf9e731de85abb5fa12f6e11b59629b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "cb23ce760425c17792dfb75fe52d39f4fd377b640f69ba8bb575df6fba3f80d1";
+      sha256 = "922dd68c7737deab349f55f8c978a2408e6d405b5a6add9c9ec0728dac4d8e72";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sco/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "f1f71c42b2626d0dcfc3552a1224db422328f4f312512b3fce292b69b24b7560";
+      sha256 = "b5aa0dc79307853f86a37404d9bc42fbedbd94d94c5d65b2600e4505ff4a8553";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/si/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "7600e8c27c2e795f7cc4481badc279b461901aa516bbb0728128874791d6639b";
+      sha256 = "3b43ce4e8f2ff93ce083d4202269ca316c7f74407b30386b0cb8c290dc88b895";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "45d7b3b578ead0d40175954f9e65e124853e295a0c528dd6abde891622534e3e";
+      sha256 = "38d4002072a718b74a479e5c733a572565e761a68b906bd7f0e0bc6fd896366a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/skr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "187fbb481c64cc981b20de374913b9d17c3b117a80ab1feec58c18c965ef3e4b";
+      sha256 = "39bb8166cb65e836fa2d4462c8af2bda38ce896b918304a776f1d2cce1419f98";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "17b5faa5a116cc9ab8fa1a322bf6555450f4bcee1a2abf09709645b17bd46ecc";
+      sha256 = "6c72f3e2c35c677ef755e9dfa39ff8c9947a341b4b91d3a8906350fa9395030c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/son/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "4639c5d5d267896d07214291c468546ff26478c26c435ee4d10cb2e9dc307e65";
+      sha256 = "2d0711bdbfc89da98a0baa43ce8ef0027c86aa7db78b0a1bd18672b667ab0e30";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sq/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "a0aa72766d7cee37f9d9a4c3a28ae8b954a2d28810bf553cbf442b30edd623d1";
+      sha256 = "1435a9477d2040a926eae4161026f7d343c15dd154af39c785fd0c69a60ccb10";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "607d5e9a73671eb99735e619a2ee701f31ed6dc55ba016a237618de6fe159933";
+      sha256 = "ce3002b8360b73d0ad16175dc65ced8a6a5051b01947ef747bf7aa4bbd2c9ac1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/sv-SE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "dada2e913de21d7ecf323d302fe2b9263ef6820450622b3b06e73963a6d48f9a";
+      sha256 = "56dbd4190064e6f4e34d85c25771b30decdf97c7050336badb6875137780c70b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/szl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "12526451c0f4c8a8446b0638be2e3c24a52cbd8277928a45e9dafb2c65eb2d03";
+      sha256 = "a3f255842ba2050b100d26ee84a6afb31665f8dbe701db7557449b14672a3c12";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ta/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "d3153deeb5951fc6dbff2fac07a51e587d98559042cf1cfea70a55c4c8ad25c7";
+      sha256 = "73f008cf652c7a4453d710674d9d8c635e1feb3187f615a087b3ec87b4b16035";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/te/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "21377ea235bb38c01aa1a21516722e2a91ce679ef7d1b32487c8813f1cdd2aea";
+      sha256 = "4307336f634d2bd01aacaeeab52bc995cbc127bc8fd5d9503dbec7c24a4d2f0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "a428becb1a20753379791ae6538b0b1bf0ebad0d55f98d7d8c19af0a7294f7e0";
+      sha256 = "97b28078ce5f731948c1e12f0920fa4a307a03d2ed65efe12019ec29b23ab7a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/th/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "28a30d8cda25aa1e63fbbcd1bbcdda5a3ae990e1d973f10d4744499a27f13ef8";
+      sha256 = "c159df215ddea3e0372cc738d13897a89470031d4302a0d28612ace823ce1398";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "80bd0de1021edfe3178abc43017669dbcfe1885c66b71729372bcdb27d381ab5";
+      sha256 = "bd888218d668794483dc75778fbe4afd83443a655b9eaf2c9b367cf32c95d7c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/tr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "f9bc32e243c091be454fc5b4356b986cbbd87bb76135e7cb9f9dd44115af2f5d";
+      sha256 = "88b9244ee99bdd1ffd602df92cd25d02b240ff4aa3a45cd931c0bd9f5d4c9893";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/trs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "fc7e927f0ed152dea1940b6965c79c3f2a21d22c117d52d9f32568d5f80bd48f";
+      sha256 = "14278135b7debd30d31853d9189ec21f400c2d32cc8a390f1e01675f26aec36c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/uk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "f529c85cd2f12c7b2fb66b1f79268af7ba889c8a6c4cc1accc5b19b74f77301f";
+      sha256 = "93b22572fdbd3095d8e30deea395625b788fb9a778ac2229cb195ce63bfcfe46";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/ur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "e677de49b31054981a22dfa36d9b29339cdc2dc230077b48a381edefa1a17271";
+      sha256 = "f3917596f5f0ca2afd8faa99e916ee272e99bb969c0532775b4b250492e80065";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/uz/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "46d1fa8b789e3c4adb313883a438a8dc051b67b3f005541a31967921b4cf280f";
+      sha256 = "cd5eba259c10496a1febcb3e45af097fef27a1988b46d3da92f41acd2f0ae523";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/vi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "65e242430ce65fa104fbb0bdaff6cc53a5c0dc60b2094362f2dcebc9aecabb3a";
+      sha256 = "f40f814223621311d4e61330aba019463bce28b238176ee241b5182dcd23fd5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/xh/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "979438f443e8c0ab980af19e9bead77f3039c955c46a2c450db7265bbcf6259e";
+      sha256 = "194e2abca87a28bc6fac3fd8a2e81c2948d82bb02e9a21d77ebbb852d4d3323d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/zh-CN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "c79ad34593f9ef472d0231fe57082a1d4ec62bb4c7cc870c4e510cee5ba3ff44";
+      sha256 = "19d5bd43ee524ec3a7b4bf7d743c382ab21ad8738f821359fa5b076e38dc71a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-i686/zh-TW/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "0e169aa02e3102b396e0d721b15138fe39277e4d84935fe6c8931ef69117b4fe";
+      sha256 = "aae9ed93330ba2097ea3b3281ea5c91dcd21f4577acdc87b368a5b2a30f8e46c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ach/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ach/firefox-140.0b2.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "bd3e5c69934115d423aa111c257520f9cc5219a29588843ee1c5b61b1a3e3da5";
+      sha256 = "8e333cc92651318838354682396e621d91346f82515106a44645db9d58a3af4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/af/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/af/firefox-140.0b2.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "f3b63934c1632d71f49d9a401dc8bf6073936dcd656fb0462a3d34e352075352";
+      sha256 = "b73650f86928fb676d4a1b4ad13abd48a99b3a87c69099f4e67891f2f16b8916";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/an/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/an/firefox-140.0b2.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "313da7d73bf645cea5125e3909c310f3aa81b1713297fb7b66493b79f16d34cf";
+      sha256 = "0087d94bccd33bf7cd38e5272b4722fc6ce0654c86329e5fa400212ba2deae5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ar/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ar/firefox-140.0b2.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "9bd0294aec83fb9bdb4164eb8eeeeda22fc3b2d26e8cb8b1a5e036251be3bcdd";
+      sha256 = "ea37bd6670ac8c1074db798729b2b6372ddc081546f05f5ab492e45edf491280";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ast/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ast/firefox-140.0b2.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "2a3229c50482cd3b86ba9892985680b6cffe4259503d3efcee1ecd6fad4a6005";
+      sha256 = "048e5268852cbb2882daa7e768b661b0168feadd538068724b771564addafd32";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/az/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/az/firefox-140.0b2.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "b64a348dab5618276f0102c23d7e74b4e1bc2af38b36e678b3db53fac08e3125";
+      sha256 = "69be7ed2489c62f4d4aabe0b6e0e356ae0708fd963243a43843f098624883218";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/be/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/be/firefox-140.0b2.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "6e19e16df133ea7b7b796a92c470ddec4ad9db281361210dc249851dd9c05e3b";
+      sha256 = "831ac7b7469b7a94a63f8687f8c8d1a6626d0555f084602b341b7875100ec6e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/bg/firefox-140.0b2.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "c691fcf4ff5aa896b51e12c01b5faddf1ab8d3e990fcb5a37c89450511647335";
+      sha256 = "071125d022f167f209c6b5fa6099a1eb4819ac095e44e28c72835af09dfc857d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/bn/firefox-140.0b2.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "b88a34520fbc6cfa328e879478857b10a738dd5ed6c99d6db16d380e1b80b71a";
+      sha256 = "05bdb1c8f3bb8d673b2956471a60b616565d9acdc3ab673004c5fe30d4dd8b03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/br/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/br/firefox-140.0b2.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "d2a051c03154c151367d01d887dd22d9c029c948c7ff406e5ba975a981e3270d";
+      sha256 = "cce32f7d6985778559a2559f9dd2d27acee239823176676732869f99fd114ac8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/bs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/bs/firefox-140.0b2.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "b7ba2f914aacea218596d2118c001961c1151b9df842b5afb498d7729f4c7efc";
+      sha256 = "22b677d215dfc64350e9cc08cf77facdf56f2248d0be32136310014fcb8bc4c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ca-valencia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ca-valencia/firefox-140.0b2.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "3d9cb24a0d049de007c4125efa869119aef50263f70bad64fb8ce328cce6abb0";
+      sha256 = "070138cb5c1576458df1acf2d7c735aeee45fd831cf6a5c058f705a555f08074";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ca/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ca/firefox-140.0b2.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "40288f778e9706bb3c2bccd641b7f79a9b96f5129bfb282a88fe891f95d20e9d";
+      sha256 = "3397ef999dabaef0f21e9c94597e5c1da632a525aac547635fc39ecdc4f7f8de";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cak/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/cak/firefox-140.0b2.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "79a734a1a83b350d123b7c76dd991e9139d14c84b795486587bac3e001e43fdf";
+      sha256 = "f4bdcf93142b268ad5ece77deff6684197acc671c39ec3408269a5636761e9c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/cs/firefox-140.0b2.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "3fbf932baa5ecb2c4ba06c6f8f29251d8c33c173df96ceef38250decdef6d73a";
+      sha256 = "f93563b2f365be59e77b205cd582fbab900aef88aa954c1bece23a6ee8d01a2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/cy/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/cy/firefox-140.0b2.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "4bf4c523a593907dba5ef4ed211d721ce89ca13af52852b61a8a812f7da6473f";
+      sha256 = "6ffa2b32e82102eec535998ee3593f9c6bae6290546425ad3d19f6038be42d7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/da/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/da/firefox-140.0b2.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "f459937cbe98b49931130dc0ff35741600d919afc84226a0907f6b373496090d";
+      sha256 = "4cb2c407cf89df1a1add90caa9aaae5947ae389a322666ac5fc3f4534ab9f3be";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/de/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/de/firefox-140.0b2.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "c1cbb2e1a978612c0fa60ba060fcd00f45ab0610a49f42f3ea59a0032c1fdc5c";
+      sha256 = "25e3d5ff4e13d7b716d664f92bb60bedc0b695700c743cc27badba490df4cc2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/dsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/dsb/firefox-140.0b2.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "94288aba032c65e197001b10641ae42ea05a9a6c87f8ca6d98b48f5924ccb314";
+      sha256 = "a85a8c6d39afb495e1b34a896b3cc1aa930334fa8e720a06ba86620ebcb64641";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/el/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/el/firefox-140.0b2.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "143f849d261a87f066952914b466e6737a337cbd412117add91e7731b088c89e";
+      sha256 = "9a2abda0113c66b95d1bade25336432618e0123c3e344b97ed27f59a03257b13";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-CA/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/en-CA/firefox-140.0b2.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "a08ab6a5968ebf60d9c4c082475e1c7cfd840d90e8dc1265d999eab45d0bb26f";
+      sha256 = "05b6af15963426fbd845b2b43dc45499d366d476ad59cc80a1558009bd1d63a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-GB/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/en-GB/firefox-140.0b2.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "a14d387031ea588bddc104982f11480983a45f2d4e08c814ae91a6f9e8bdc4be";
+      sha256 = "b1babf23c66ddf5ac23188b272cbc61d0c9821c8d2ce4924b15d7231aaca96cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/en-US/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/en-US/firefox-140.0b2.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "a8b95ece65cf5ebc5d5ae2144943c66135a2a32d64d7ca1c2424a621b8ffc152";
+      sha256 = "b6b38968b00781bbc144065f0294947bdcd1f23bfa641f57efb6e88f5905cb40";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/eo/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/eo/firefox-140.0b2.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "0bf932cdb5b2b672bad8875e4bd59da43fda2fc8293b14f5b6fa5cf58c11dee1";
+      sha256 = "195e8ad6973822bd5f1919a82bdf2206cf9d12baa7ed38e467eb360dc5dd2c42";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-AR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-AR/firefox-140.0b2.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "991cd0e2894a4293fe8d8bb78dadc51b7c0527a1d64b1bbad6328e553b65ec7d";
+      sha256 = "b4c3d0c5fe505ac5e7c9a38584683ce3c8236ecd497f055c7ffcd7b08604fc3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-CL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-CL/firefox-140.0b2.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "15f27bd91d2d9f1833a3dff0ebf957bff6ab740bd5de214482e348240968259c";
+      sha256 = "42fdd9a3dc09de733adb19bc07eb40448390a4ae9a32039f695564915fca8537";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-ES/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-ES/firefox-140.0b2.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "0abd7d09a96262f226564b01633ddf9912ab190e448b57422c965d7ab544bdaa";
+      sha256 = "8946e80d10fbf064eb6fe4565afbf4b7c320d3e224871c33fd45a4c22c53554d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/es-MX/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-MX/firefox-140.0b2.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "651f09eb5e0818805219e57f9e9567fde5ea538e62b0970270547349cdd6bf09";
+      sha256 = "2e04c6985567aaec38c91f7d45da067153b12d6d800ff6653356af6a39bde95e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/et/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/et/firefox-140.0b2.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "3f970da97eba78efcb840aaa9e7812fc07340ead7b8939648fb8839c743298cd";
+      sha256 = "a331657da8a21a447d94ccf778b766abf845f73f2350fd75b4066a1a97cb7255";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/eu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/eu/firefox-140.0b2.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "eb5464b8618eeda6aa507d09e403528ac991f883e4ea6070c01ecf7ccb34a2f9";
+      sha256 = "1b10be47d311454b148558de6e6a98947286d66b32627fe9da586f6e764b3846";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fa/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fa/firefox-140.0b2.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "6f78eb8b602d2b349d564d08e1797f7dd381a818b4f5fc4916e5e2d80a6890d1";
+      sha256 = "61ec0edc1639d7c69f258b4860135955addb730c382cd693faccd07acc9ee59e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ff/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ff/firefox-140.0b2.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "dd74dfd1b55dc2005764ee2237f4bd0cd841a90dcca88f97f4d7ea1cda57be28";
+      sha256 = "97a5d77fd30cf21502b8b9c8005112180396f26d24dce88f6086671b3711d710";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fi/firefox-140.0b2.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "108304dedc88ed30195dc443a62df7f1d579a8540fef911e7ebecc544aeebd2c";
+      sha256 = "180a4a853a9f03cb5c4b6467b8476edeee17ea5cf324ea4415648dcf3d85b228";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fr/firefox-140.0b2.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "c02dfe50d5b405f8fb90868ad317f1020c85d6bd15c6167d4bb8af152af29f29";
+      sha256 = "6490b20b7cdb731df9d8e0df8ca46bc834b362c577c235d5397665a617b271ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fur/firefox-140.0b2.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "c110494b901de0d5cf4623bab3fb7aa523c2c8afe14ce1339207a07715c24e0c";
+      sha256 = "6d7c83bb94c905b02365b0502cb5d1ed7924eff2ffac575994598d7382aa4635";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/fy-NL/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fy-NL/firefox-140.0b2.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "09fefbf594c1c840dc18611d303c8aeae70eb7126e17b5d0e41e96868601acbb";
+      sha256 = "9b11642f4ebd8e27f12d3c244ee467a668976a17edfb12b71e94238eb2a98d6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ga-IE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ga-IE/firefox-140.0b2.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "51e4f9ad18f29f46875ce2e146a4300afb0f3b860f0bc9bbab2cd6be9c20a564";
+      sha256 = "2fea6d116c6be60aa0a0a46278fe29e29f0ea2d6b48396211d500fdfe5669d29";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gd/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gd/firefox-140.0b2.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "cab4cdd9d7b1af933f53863be982d427f59435522f24bdef27a302b9221dac7f";
+      sha256 = "22832b70b7504b7bea490b45a70ed88488951d4b9f4e50cec6869cedf5fdf916";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gl/firefox-140.0b2.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "48b3771b813b62c8ade64e55ca5ea2e39671f2556e6057c49374b089adfbd2c7";
+      sha256 = "0fefa4add517fbd4a49ef4305c0a37dab58d5cd1cc579ac9dc4db005fd434e9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gn/firefox-140.0b2.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "63e40c6ee16180e62fa6ef06f0bf1bf04fc9b368940013f2442e034229bbe586";
+      sha256 = "0dd0a13c53de0ff825cb563381ad0fd2956cc1b485f270cd9fd07fb791d7da79";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/gu-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gu-IN/firefox-140.0b2.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "3c3c3847fc36800336e000c7a5ca479edf4832f80b44ca7b4f79151a67119a16";
+      sha256 = "0afc4e0cf35f8668cd41026532b05070f5bfb116213d7f195a9e2458a2538c33";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/he/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/he/firefox-140.0b2.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "b77b031493a228f911f29ad93d55d9895005c31ba90a99a5b1b4e2d7d7034cbc";
+      sha256 = "f53438739efa25fb3bf2e76ea57105005c048ee8f87e3fdbaddb6987bd8b41f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hi-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hi-IN/firefox-140.0b2.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "a0ada0fe2c28f6e0bf6abdfcdf60ceb5cdab896ff1c86a58d33c9bfb4faedeec";
+      sha256 = "e82d7805936223b363613138e1641e7ef042ca6229896b1f261cf9db85095921";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hr/firefox-140.0b2.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "56fdf616a68d2701b4c505da83e70c14a6c08541ec826c7a187c23a30323c8a2";
+      sha256 = "5ccbd439a15849ab7cf33899e52190d7823042c05ad119e54d968284fd95cbc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hsb/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hsb/firefox-140.0b2.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "dc133236dcd7500e46b2bb806212a41b11e906cf66a744dad2ab6aef663ab482";
+      sha256 = "6671d4973471337ff156fb0aa8d8a89026ea001a82a3c39151236e450ba83d11";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hu/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hu/firefox-140.0b2.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "d2c85ea926529b2caea6f3d5a07a954eac9fcb1feb1cd1780a7115fb38f7d03b";
+      sha256 = "f2b96cd0724c64b2bb946d03fbe4f689e06aeacfe25546521a85fc823df19190";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/hy-AM/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hy-AM/firefox-140.0b2.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "b7e324693725687422ec9ffad3bec53e559fc755d9eb169783a0737edd9b173e";
+      sha256 = "9b57ab8d9dc9cf31b1e8c5983085ca6380b4edabc78c823cc5957862011c14d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ia/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ia/firefox-140.0b2.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "1016c382f3add7c82860d4a7f980770ca8d2332e182b1b14a958012378f272f0";
+      sha256 = "188793a0c4619be9fafb870583c716f2f71026505312050b38c90ba69a7ecba3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/id/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/id/firefox-140.0b2.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "331b1885e004f602ebc004460ad4780725dbb3829ed04714b21df919e4972661";
+      sha256 = "69601bbff0fe4b1719d9f76326ff363aed11404d0cc3b1babd6de85f174beae9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/is/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/is/firefox-140.0b2.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "4ec80ba6afb69479b2cbc942551cc129aa0d8887ee32a2803b07ae14de800744";
+      sha256 = "a446c41c5055ab8b81d28394aa0c3a204012a7409028a610269d6b8c31cab303";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/it/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/it/firefox-140.0b2.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "9d04dfe6d24db792b2091f6726f8ba5edf0ab2d9373f2e0957c951f1a055dce4";
+      sha256 = "68ec8352f64a031b2e12f43104822a2fbcd80b4061d8cd8ce87498112fd7e5a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ja/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ja/firefox-140.0b2.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "7d2b0709f649b8a6b2edb124a2a501f2309b2570b1807efb038c5400cb0216b2";
+      sha256 = "a21480a969ac74e85749a6e2904af86dcbee8a85b799b45e09b23c9e7553b783";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ka/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ka/firefox-140.0b2.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "06eef2411c405e2a17267bddd6d958c7fb55497478b6213fe259e40fb273dcff";
+      sha256 = "279672ac2c1b8d7f0e0d942f027a7fdfa7245c9676a406889f420e6b55131ae7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kab/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/kab/firefox-140.0b2.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "eaafc34c8c596602091810cbc2af966e003d870c66a647c0cdd2a2a343f4a068";
+      sha256 = "502c7aefb553e3dd95dd66ee5c20f3314996e0a9551c6da66b3210a2af3268b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/kk/firefox-140.0b2.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "dfef47c7d3255b1a711b611afd9adbb53be80eebefdac763da04af2157faece1";
+      sha256 = "71b29a6a4b5d8520c74b4321da341fd7d249396d898535f5ddcabdcb63c3fd05";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/km/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/km/firefox-140.0b2.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "9074c6ee90c6582c1202582d35d81f97b43789ebc3f9019261130dabcb01fd46";
+      sha256 = "dd9e94f1c57b55e16cbeaffa85ad406a9a845b7f67c2675b7f0cce97837b389c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/kn/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/kn/firefox-140.0b2.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "f8badc895b36bdcb7666510faf5f775470ab90733ac31201f147f3b45dc4ad9e";
+      sha256 = "9ef46633c7abf9862442181598534019b5da16d64cb0150bfa82a06c85a3410f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ko/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ko/firefox-140.0b2.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "9d8739e1e382c5b96240a6564219c7b0ce161524386539141f4dcc020cbb5fee";
+      sha256 = "bcfa77af5b291c24b0c60e730c39dd0217a6ff54818e2728ccbf84e04d20d2f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lij/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/lij/firefox-140.0b2.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "c36fd45434f81e1c20c8793bd52cb85637999206b06ea9b094b2d1b0442f95cb";
+      sha256 = "2ab2cd1914eb0cf2429d9f02e95f5752a5284e12f85e29c54fbfde1ba95bff55";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lt/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/lt/firefox-140.0b2.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "24d94d2ef16561bb3750d607fda39f4b39060efb83fd4d435cbef7383bf8f76d";
+      sha256 = "21854475ae62c250dd11e3265b109ccc755cfe4b7827c6911dd4246f26987318";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/lv/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/lv/firefox-140.0b2.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "6eb7553cd275cbf11b387088e52d9f508486d3f737b2482d1f53af1a2c1e0dbb";
+      sha256 = "1fb6f3e717bd7f285f1d084fea8be957eb7959c29035c4c1de3b116a21f9af67";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/mk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/mk/firefox-140.0b2.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "8a1b20b6be53d68dd1effedc3522fec9b2d8c64a4d8e30c7a7113bf0fdb2317c";
+      sha256 = "9f52a7a077d6578820ae9011936ba436eb121814aeeae80e3c5aae097fc3af28";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/mr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/mr/firefox-140.0b2.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "4dc0347a86f3e4f784ae32e2324f3d134ce5b4fdec4eec34572f51c13763889b";
+      sha256 = "3f2b240659b7354b2d3cbdd8175f33a2a5884c90133fa394cd15b4f6e86ba4a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ms/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ms/firefox-140.0b2.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "7b3fbd663639fe8575eaadf01d3a9299f0c132a4b2fbbf25ddc2d18378102cf4";
+      sha256 = "73a18b565e742dbf56c406f2f1cf729a0dd0cbbb3c8660c8c01b2081cc924fba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/my/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/my/firefox-140.0b2.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "8a039ed198a5b338fd32dd632f05c4de8a9dd61cb09247d5f37a1ffbc640e0fa";
+      sha256 = "e5e43ede829a329c553e786659e980d5e6e94f5228c42c2a44eb34b399210bb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nb-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/nb-NO/firefox-140.0b2.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "70404a9fe3361dff890f344eebb61001bdcb6a3d4356cc06386783d70a163857";
+      sha256 = "bd5feca0d1a34e6ba4cc4839ba50d89bf0beda61ba975a2ef76f1a053d725605";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ne-NP/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ne-NP/firefox-140.0b2.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "e148000a58bd8b834985ad9dee1eb6724ed2550fc70279ab915c06fea148afe1";
+      sha256 = "864e1ede94813108b75fbd870884f93f77628e6cce0449b76018b9118a2c4b0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/nl/firefox-140.0b2.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "b15ebbf39c475a53fc5b01d1c5c6559f74c42e35c1d7b7bbd4cda37366359fee";
+      sha256 = "4bba7f1feaa30adc2bfcc769469eb03361b6193260424d3af0092047c6e777a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/nn-NO/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/nn-NO/firefox-140.0b2.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "90221ff410eca0d1aed97186e45106b7ab826029965e2b4fb54d93c74f743ee0";
+      sha256 = "968d80dbeb5418f968d584ce0c51bfd322b1189c2122a1205f64c0ade22b66f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/oc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/oc/firefox-140.0b2.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "7cbad01d0adb697bcae6c072bb69cb151e83920f39b67df2a340f7c1dc4faaf2";
+      sha256 = "66f45ad09dd4a90a3b0c6d66a73b8833a1f1f62f58719a98905ae57c60805b9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pa-IN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pa-IN/firefox-140.0b2.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "1601a8192da0564af21b4cb7e63d87b6015d5533c08e96187a0d895e32bb03fd";
+      sha256 = "05f4b146691ca748e27b524c7e1889bee07290d417b8bab59c0582d48019f61e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pl/firefox-140.0b2.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "f62fa06e9e651e7db14cfdbd0af5acac3d6f282a2842e41bed7b6ea323342ff7";
+      sha256 = "da9d5833e75feba4034b9b708ff0d17dd93364f0d2f0b5bcb2fcfa5b70717fba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pt-BR/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pt-BR/firefox-140.0b2.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "493c505bc795451989d58049e0a16397eb32c6d26f3ff5c285b845b35cf63a53";
+      sha256 = "680f083f8dcae74b053214b8a20ff2e253829b3b811212356847f99a108438d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/pt-PT/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pt-PT/firefox-140.0b2.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "ce1caab07d4ca3f93e5be33580e09c1109f3a19176144d7cfa06e97ab04fe7fd";
+      sha256 = "0a5eb3f4a0c9f0c47fd157a26bc8ea6b70007f912f5e50d38d6ea1487c23f7c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/rm/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/rm/firefox-140.0b2.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "d580649d6aa0f7fc519dbbc7c72943b36a437806020f6a56fb7659befb9dea7a";
+      sha256 = "33f73c88fd97ac68c415c9bb55db59c68cc7f482d381ca1a96b235ba2854b9d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ro/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ro/firefox-140.0b2.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "a78d357d761f72d5795608199701c429f2016ad618e2899c10d13b9f7ee8e3ef";
+      sha256 = "77c641e73af901a2986661790890dbd831e586b579ae398433ce98117e310b8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ru/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ru/firefox-140.0b2.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "8892c5688612eda284319c1df7c366d529be0d0c96a55d89958d7185a78ab30e";
+      sha256 = "cc6994ffc7d98817352c390db1d06cd215acb5459121d657862c15a95f27ce4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sat/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sat/firefox-140.0b2.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "c6d9eec9c8ebe83c966c904611d6d865328b5a7f401b42b06d72dae32174fec3";
+      sha256 = "f2ca87b4c371399e211874e60e25abbcc320eae84993c066ae9c491d6eece514";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sc/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sc/firefox-140.0b2.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "d504d52b43598ec3fdcf02949868fa65d6e6a72f78f131c53fce804817de4ee2";
+      sha256 = "3703ff4a67d1c503fe90726aa63dfa4cb266350aa4c0b5f29723a57ce677fda1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sco/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sco/firefox-140.0b2.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "89962ba5d9de002d3f03b4527eb9ef84235d59c19abb46165dfa9c52a085ad2a";
+      sha256 = "963234677f4cd4c3beb7299541700f865132646b39df9e12e89d0f99d2d9e8df";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/si/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/si/firefox-140.0b2.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "247261439dc9594b9ad95fa066431ce1629537b8cfc01df7716c491044a7c72a";
+      sha256 = "3632f156201c1c86b9497e09b45707f3126cb02b0cd93a936f9fbcea47af57e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sk/firefox-140.0b2.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "29cb232a5339abc4890b306a12b0f55cd2700cfe2521fa745491903ee87a26ad";
+      sha256 = "e5b6158136204fc90b960d1650e5c7f0f8b74ecaa46529f3f48c9a9bf7a9cbe6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/skr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/skr/firefox-140.0b2.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "f606442e9a6f87616a77d2fd392412a8dd61e596ddc8c067e38846331cbfca0f";
+      sha256 = "ee71bf891c728250978a0d19290ddad63e893a68362f73e47249c8600e496c58";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sl/firefox-140.0b2.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "43cc2db32879fce3424c1a3ff2f862cca4835b0a4c5df5c3e28def64812ce73c";
+      sha256 = "1b38a650fd3e2c41e4e20e19468483b4001719741bc2de99ab555784baea34f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/son/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/son/firefox-140.0b2.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "cfec396b94bcc091927c0884ccddd3969f69acba8c09467609319c54c0bef55e";
+      sha256 = "5b0ee6db02cb38b7f340f074d4e454c29babf2bab55282aa29bc51174cebe9fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sq/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sq/firefox-140.0b2.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "ec827f911bb4553cd7caefbdf2aa3aa6b4521059beab32b23e65e80f9858181c";
+      sha256 = "14fcb51691a9a4addb2b4d01c0bfff630359c7e1c94181a1b1f41a0bc64f9a9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sr/firefox-140.0b2.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "284b34324291ba29a1d1d7b36cff68fff0f00213a7e12fa7f48536fc5a80990a";
+      sha256 = "9297b97dd92c4a9b848a0b59f6490014c323d54c63965512719cb766b5ec98b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/sv-SE/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sv-SE/firefox-140.0b2.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "07e48d548cfbc4c4ab3fb3b4ec630385a125d3c5cbe30526be95d0476b4d8f87";
+      sha256 = "36c4d22521d6515ef705d59b42cbc86ea385b6713049bac544db89cbe79929f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/szl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/szl/firefox-140.0b2.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "84cfbf70da99b4f544193d6d167a2280142f8ae37d8de1e9b4093f7ca6671fea";
+      sha256 = "47cef94cb8d05f1e67fa3c805761bc556181769778d86f91014b01e722da0a95";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ta/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ta/firefox-140.0b2.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "dca3f4fd1b468cae66bdb6ef3817860760a2527b94928359c302e789ca2c04c3";
+      sha256 = "eb1ba963923ff35be8d85e2e432db2eea1815e23245006c153616fa643a923af";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/te/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/te/firefox-140.0b2.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "bfa4f775d02a2b2cf0dfcfbf4ed3d2342f7db943256c2e73bddd7f9a8077484c";
+      sha256 = "f20e07229cd5cb062b1ce2c07bce7eace439dee11c1de11b956a2ed3dbbde26b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tg/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/tg/firefox-140.0b2.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "1515a00b6d53e074bfb60b1bc7e37ac60fd977131a6ac6e772433b1daaaa4efa";
+      sha256 = "b25eac2f5a213045980536b4d5ca04f802f083c0467c56dd02680370ea3c7329";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/th/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/th/firefox-140.0b2.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "507d9c041c8874095a52f57e5a46adf8db6d4116d5ccdca0b100d831c41c0422";
+      sha256 = "d2242d267cfa67a147becb147b6ce9540d24049d601a4f00776c0eceac02849b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tl/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/tl/firefox-140.0b2.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "cba3d10cee0a09ed530f6e8ec71e1da36fc29c972136bcf6beacd7ccf91bd162";
+      sha256 = "74891370d6b308e15b200355152ba34a31a23fcccee53ad2472a4be17a38667f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/tr/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/tr/firefox-140.0b2.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "f5e68e280db29872b7570484dbc841756693b3d00eda2cc0840a77e5600628af";
+      sha256 = "6ffa80dc70a4b37da1a0dd45ee26512b60352f5f0a7d7753ae0f786dc3ecc120";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/trs/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/trs/firefox-140.0b2.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "028e3728920e5978501773da88c2eb1d5d86927d83e5f51e910692fd4482d9f4";
+      sha256 = "c34973c0d13355f79461880372fed959c4a5872a72b22f570c8480cee4e403ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/uk/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/uk/firefox-140.0b2.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "9e63e86af01787ceec6b4776b78cd98db74230287f1c065eeda6b5e5f6133b42";
+      sha256 = "f0c0b73f4dddc526b058954b4ad3c6757388646dcad0c1fd694947f7f06bb479";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/ur/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ur/firefox-140.0b2.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "964b123de671b9f763861d626a444c86d48516cdefe9ab71f866dc564428d119";
+      sha256 = "7cfa2930a547d9b0b15e6ebc571ec8447c42b6a845fd228ccc023df7ddbce914";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/uz/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/uz/firefox-140.0b2.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "e603da60f6be77a60584bd361f773a5e12612e8fad84f0aecaf33756fa13d9a5";
+      sha256 = "1d86c24fcac2d62b946d9bc957a9dfeeebc7d519b4662f5a973beb509b946cdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/vi/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/vi/firefox-140.0b2.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "c8ce7aa8546ecaa76af778e29de3bfb12490c2e9e4f667888449939ac424f122";
+      sha256 = "126e1f815c3e57cade53f92fdb57f0f2c8f93436523f5947df4e1bc64ad32263";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/xh/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/xh/firefox-140.0b2.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "dc9071c3a8553cee661223eadaccb949944d11f4631cef76775e6b3d93f89eaa";
+      sha256 = "e3cf2284986f716bb80eac9bc258af4ad089fcb9f24e20dedbc718da3324370e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/zh-CN/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/zh-CN/firefox-140.0b2.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "f8561851a5acce3ba9ea763855464592777d2371d1918d70cce0a01d833ee77c";
+      sha256 = "4b4d6d3dbf2fff5efea5c659d5d95c45b55fbc68d0767f7cbd8c052bfdcc5a0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/139.0b3/linux-aarch64/zh-TW/firefox-139.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/zh-TW/firefox-140.0b2.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "180c46473119cdbe027f13a26a53234e63e1f2dfd291925b0af2edf68ff05650";
+      sha256 = "7725257c301afb843517120dbd5f28d2af0e394aa838d56e208680e8a51183ca";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-beta.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-beta.nix
@@ -9,11 +9,11 @@
 
 buildMozillaMach rec {
   pname = "firefox-beta";
-  version = "138.0b4";
+  version = "140.0b2";
   applicationName = "Mozilla Firefox Beta";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "a8f9e645c80d9c40b0435ee00261aa9fcac801efcfcbf42b10e6af9390290b9f643358aca6a01d9465eab3b64f46b2b71b4a3ea4c7e0a8f96bdfce15bf817f92";
+    sha512 = "c8010b6cdf90f52d5105971d726139460a0194ca7e84ed57184897f4f258957ff64117ef14a38a6dba4cab3074f3a92aee0eaf221ecf22218f6408636ab9c960";
   };
 
   meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
@@ -9,13 +9,13 @@
 
 buildMozillaMach rec {
   pname = "firefox-devedition";
-  version = "138.0b5";
+  version = "138.0b9";
   applicationName = "Mozilla Firefox Developer Edition";
   requireSigning = false;
   branding = "browser/branding/aurora";
   src = fetchurl {
     url = "mirror://mozilla/devedition/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "07da38a6aa19de812539ba9b286d5189607ef45e7d8665a0f42facdcf7b3f7854561ad3cb54dce7e049199574b7d6dff01dba03763730e49306efb82833270fb";
+    sha512 = "cf737b8c394150430cda512a84ebdf04426db0c413863eb37a327c44fc952db7de1be07956aaded3ddb769480fb307a102c1f4f7dab4ba8a38f2371fdd35a961";
   };
 
   meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
@@ -9,13 +9,13 @@
 
 buildMozillaMach rec {
   pname = "firefox-devedition";
-  version = "138.0b9";
+  version = "140.0b2";
   applicationName = "Mozilla Firefox Developer Edition";
   requireSigning = false;
   branding = "browser/branding/aurora";
   src = fetchurl {
     url = "mirror://mozilla/devedition/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "cf737b8c394150430cda512a84ebdf04426db0c413863eb37a327c44fc952db7de1be07956aaded3ddb769480fb307a102c1f4f7dab4ba8a38f2371fdd35a961";
+    sha512 = "4a369638dab1202f21f071a1eb48552888adf01e49ee4e029dfe7b42919312719004099b203a066057fd4d9ef9a684e5f95b0aa06ecf82cc88df0025f33f6368";
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
(cherry picked from commit bfe0eaf)