### PR TITLE
treewide: remove `with lib`  usage affecting changelog version

### DIFF
--- a/pkgs/applications/audio/librespot/default.nix
+++ b/pkgs/applications/audio/librespot/default.nix
@@ -61,12 +61,12 @@ rustPlatform.buildRustPackage rec {
       --set ALSA_PLUGIN_DIR '${alsa-plugins}/lib/alsa-lib'
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Open Source Spotify client library and playback daemon";
     mainProgram = "librespot";
     homepage = "https://github.com/librespot-org/librespot";
     changelog = "https://github.com/librespot-org/librespot/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ bennofs ];
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ bennofs ];
   };
 }

--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -142,16 +142,16 @@ stdenv.mkDerivation rec {
     cp "$rules" "$out/lib/udev/rules.d/69-mixxx-usb-uaccess.rules"
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://mixxx.org";
     description = "Digital DJ mixing software";
     mainProgram = "mixxx";
     changelog = "https://github.com/mixxxdj/mixxx/blob/${version}/CHANGELOG.md";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [
       benley
       bfortz
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/audio/mopidy/musicbox-webclient.nix
+++ b/pkgs/applications/audio/mopidy/musicbox-webclient.nix
@@ -22,11 +22,11 @@ pythonPackages.buildPythonApplication rec {
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Mopidy frontend extension and web client with additional features for Pi MusicBox";
     homepage = "https://github.com/pimusicbox/mopidy-musicbox-webclient";
     changelog = "https://github.com/pimusicbox/mopidy-musicbox-webclient/blob/v${version}/CHANGELOG.rst";
-    license = licenses.asl20;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/applications/audio/samplebrain/default.nix
+++ b/pkgs/applications/audio/samplebrain/default.nix
@@ -61,13 +61,13 @@ stdenv.mkDerivation rec {
     install -m 444 -D desktop/samplebrain.svg $out/share/icons/hicolor/scalable/apps/samplebrain.svg
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Custom sample mashing app";
     mainProgram = "samplebrain";
     homepage = "https://thentrythis.org/projects/samplebrain";
     changelog = "https://gitlab.com/then-try-this/samplebrain/-/releases/v${version}_release";
-    maintainers = with maintainers; [ mitchmindtree ];
-    license = licenses.gpl2;
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ mitchmindtree ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/audio/strawberry/default.nix
+++ b/pkgs/applications/audio/strawberry/default.nix
@@ -116,14 +116,14 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Music player and music collection organizer";
     homepage = "https://www.strawberrymusicplayer.org/";
     changelog = "https://raw.githubusercontent.com/jonaski/strawberry/${version}/Changelog";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ peterhoeg ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ peterhoeg ];
     # upstream says darwin should work but they lack maintainers as of 0.6.6
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "strawberry";
   };
 }

--- a/pkgs/applications/blockchains/bitcoin-abc/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-abc/default.nix
@@ -79,7 +79,7 @@ mkDerivation rec {
     find ./. -type f -iname "*.sh" -exec chmod +x {} \;
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Peer-to-peer electronic cash system (Cash client)";
     longDescription = ''
       Bitcoin ABC is the name of open source software which enables the use of Bitcoin.
@@ -90,10 +90,10 @@ mkDerivation rec {
     '';
     homepage = "https://bitcoinabc.org/";
     changelog = "https://www.bitcoinabc.org/doc/release-notes/release-notes-${version}.html";
-    maintainers = with maintainers; [ lassulus ];
-    license = licenses.mit;
+    maintainers = with lib.maintainers; [ lassulus ];
+    license = lib.licenses.mit;
     broken = stdenv.hostPlatform.isDarwin;
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     mainProgram = "bitcoin-cli";
   };
 }

--- a/pkgs/applications/blockchains/bitcoin-knots/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots/default.nix
@@ -89,15 +89,15 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "Derivative of Bitcoin Core with a collection of improvements";
     homepage = "https://bitcoinknots.org/";
     changelog = "https://github.com/bitcoinknots/bitcoin/blob/v${version}/doc/release-notes.md";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       prusnak
       mmahut
     ];
-    license = licenses.mit;
-    platforms = platforms.unix;
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/applications/editors/qxmledit/default.nix
+++ b/pkgs/applications/editors/qxmledit/default.nix
@@ -49,12 +49,12 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = true;
 
-  meta = with lib; {
+  meta = {
     broken = stdenv.hostPlatform.isDarwin;
     description = "Simple XML editor based on qt libraries";
     homepage = "https://sourceforge.net/projects/qxmledit";
-    license = licenses.lgpl2;
-    platforms = platforms.unix;
+    license = lib.licenses.lgpl2;
+    platforms = lib.platforms.unix;
     changelog = "https://github.com/lbellonda/qxmledit/blob/${version}/NEWS";
     mainProgram = "qxmledit";
   };

--- a/pkgs/applications/editors/your-editor/default.nix
+++ b/pkgs/applications/editors/your-editor/default.nix
@@ -22,13 +22,13 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Your-editor (yed) is a small and simple terminal editor core that is meant to be extended through a powerful plugin architecture";
     homepage = "https://your-editor.org/";
     changelog = "https://github.com/your-editor/yed/blob/${version}/CHANGELOG.md";
-    license = with licenses; [ mit ];
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ uniquepointer ];
+    license = with lib.licenses; [ mit ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ uniquepointer ];
     mainProgram = "yed";
   };
 }

--- a/pkgs/applications/gis/qmapshack/default.nix
+++ b/pkgs/applications/gis/qmapshack/default.nix
@@ -50,15 +50,15 @@ stdenv.mkDerivation rec {
     }"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Consumer grade GIS software";
     homepage = "https://github.com/Maproom/qmapshack";
     changelog = "https://github.com/Maproom/qmapshack/blob/V_${version}/changelog.txt";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
       dotlambda
       sikmir
     ];
-    platforms = with platforms; linux;
+    platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -127,7 +127,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Desktop version of draw.io for creating diagrams";
     homepage = "https://about.draw.io/";
     license = with lib.licenses; [
@@ -138,8 +138,8 @@ stdenv.mkDerivation rec {
       unfreeRedistributable
     ];
     changelog = "https://github.com/jgraph/drawio-desktop/releases/tag/v${version}";
-    maintainers = with maintainers; [ darkonion0 ];
-    platforms = platforms.darwin ++ platforms.linux;
+    maintainers = with lib.maintainers; [ darkonion0 ];
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
     mainProgram = "drawio";
   };
 }

--- a/pkgs/applications/graphics/xournalpp/default.nix
+++ b/pkgs/applications/graphics/xournalpp/default.nix
@@ -79,13 +79,13 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Xournal++ is a handwriting Notetaking software with PDF annotation support";
     homepage = "https://xournalpp.github.io/";
     changelog = "https://github.com/xournalpp/xournalpp/blob/v${version}/CHANGELOG.md";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ sikmir ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ sikmir ];
+    platforms = lib.platforms.unix;
     mainProgram = "xournalpp";
   };
 }

--- a/pkgs/applications/misc/bitwarden-menu/default.nix
+++ b/pkgs/applications/misc/bitwarden-menu/default.nix
@@ -31,12 +31,12 @@ buildPythonApplication rec {
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/firecat53/bitwarden-menu/releases/tag/v${version}";
     description = "Dmenu/Rofi frontend for managing Bitwarden vaults. Uses the Bitwarden CLI tool to interact with the Bitwarden database";
     mainProgram = "bwm";
     homepage = "https://github.com/firecat53/bitwarden-menu";
-    license = licenses.mit;
-    maintainers = with maintainers; [ aman9das ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aman9das ];
   };
 }

--- a/pkgs/applications/misc/heimer/default.nix
+++ b/pkgs/applications/misc/heimer/default.nix
@@ -27,13 +27,13 @@ mkDerivation rec {
     qtbase
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Simple cross-platform mind map and note-taking tool written in Qt";
     mainProgram = "heimer";
     homepage = "https://github.com/juzzlin/Heimer";
     changelog = "https://github.com/juzzlin/Heimer/blob/${version}/CHANGELOG";
-    license = licenses.gpl3Plus;
-    maintainers = [ ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/misc/klayout/default.nix
+++ b/pkgs/applications/misc/klayout/default.nix
@@ -84,13 +84,13 @@ mkDerivation rec {
   # and no format arguments [-Werror=format-security]"
   hardeningDisable = [ "format" ];
 
-  meta = with lib; {
+  meta = {
     description = "High performance layout viewer and editor with support for GDS and OASIS";
     mainProgram = "klayout";
-    license = with licenses; [ gpl2Plus ];
+    license = with lib.licenses; [ gpl2Plus ];
     homepage = "https://www.klayout.de/";
     changelog = "https://www.klayout.de/development.html#${version}";
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/applications/misc/opentrack/default.nix
+++ b/pkgs/applications/misc/opentrack/default.nix
@@ -96,12 +96,12 @@ mkDerivation {
     })
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/opentrack/opentrack";
     description = "Head tracking software for MS Windows, Linux, and Apple OSX";
     mainProgram = "opentrack";
     changelog = "https://github.com/opentrack/opentrack/releases/tag/${version}";
-    license = licenses.isc;
-    maintainers = with maintainers; [ zaninime ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ zaninime ];
   };
 }

--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -137,13 +137,13 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = lib.optional (!withGUI) true;
 
-  meta = with lib; {
+  meta = {
     description = "Share one mouse and keyboard between multiple computers";
     homepage = "https://symless.com/synergy";
     changelog = "https://github.com/symless/synergy-core/blob/${version}/ChangeLog";
     mainProgram = lib.optionalString (!withGUI) "synergyc";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ talyz ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ talyz ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/applications/misc/valentina/default.nix
+++ b/pkgs/applications/misc/valentina/default.nix
@@ -54,12 +54,12 @@ stdenv.mkDerivation rec {
     install -Dm644 dist/debian/valentina.sharedmimeinfo $out/share/mime/packages/valentina.xml
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Open source sewing pattern drafting software";
     homepage = "https://smart-pattern.com.ua/";
     changelog = "https://gitlab.com/smart-pattern/valentina/-/blob/v${version}/ChangeLog.txt";
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
-    maintainers = [ ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/applications/misc/whalebird/default.nix
+++ b/pkgs/applications/misc/whalebird/default.nix
@@ -102,13 +102,13 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Single-column Fediverse client for desktop";
     mainProgram = "whalebird";
     homepage = "https://whalebird.social";
     changelog = "https://github.com/h3poteto/whalebird-desktop/releases/tag/v${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ weathercold ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ weathercold ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/applications/networking/cluster/calico/default.nix
+++ b/pkgs/applications/networking/cluster/calico/default.nix
@@ -32,13 +32,13 @@ builtins.mapAttrs
         "-w"
       ];
 
-      meta = with lib; {
+      meta = {
         homepage = "https://projectcalico.docs.tigera.io";
         changelog = "https://github.com/projectcalico/calico/releases/tag/v${version}";
         description = "Cloud native networking and network security";
-        license = licenses.asl20;
-        maintainers = with maintainers; [ urandom ];
-        platforms = platforms.linux;
+        license = lib.licenses.asl20;
+        maintainers = with lib.maintainers; [ urandom ];
+        platforms = lib.platforms.linux;
         inherit mainProgram;
       };
     }

--- a/pkgs/applications/networking/cluster/kuma/default.nix
+++ b/pkgs/applications/networking/cluster/kuma/default.nix
@@ -63,11 +63,11 @@ buildGoModule rec {
       "-X ${prefix}.buildDate=${version}"
     ];
 
-  meta = with lib; {
+  meta = {
     description = "Service mesh controller";
     homepage = "https://kuma.io/";
     changelog = "https://github.com/kumahq/kuma/blob/${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ zbioe ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ zbioe ];
   };
 }

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -150,17 +150,17 @@ buildGoModule (finalAttrs: {
       // moduleTests;
   } // (lib.mapAttrs (_: value: fetchurl value) imagesVersions);
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/rancher/rke2";
     description = "RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution";
-    changelog = "https://github.com/rancher/rke2/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    changelog = "https://github.com/rancher/rke2/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       rorosen
       zimbatm
       zygot
     ];
     mainProgram = "rke2";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/networking/cluster/sonobuoy/default.nix
+++ b/pkgs/applications/networking/cluster/sonobuoy/default.nix
@@ -46,7 +46,7 @@ buildGoModule rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Diagnostic tool that makes it easier to understand the state of a Kubernetes cluster";
     longDescription = ''
       Sonobuoy is a diagnostic tool that makes it easier to understand the state of
@@ -56,9 +56,9 @@ buildGoModule rec {
 
     homepage = "https://sonobuoy.io";
     changelog = "https://github.com/vmware-tanzu/sonobuoy/releases/tag/v${version}";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     mainProgram = "sonobuoy";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       carlosdagos
       saschagrunert
       wilsonehusin

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -75,12 +75,12 @@ let
 
         subPackages = [ "." ];
 
-        meta = with lib; {
+        meta = {
           description = "Tool for building, changing, and versioning infrastructure";
           homepage = "https://www.terraform.io/";
           changelog = "https://github.com/hashicorp/terraform/blob/v${version}/CHANGELOG.md";
-          license = licenses.bsl11;
-          maintainers = with maintainers; [
+          license = lib.licenses.bsl11;
+          maintainers = with lib.maintainers; [
             Chili-Man
             kalbasit
             timstott

--- a/pkgs/applications/networking/compactor/default.nix
+++ b/pkgs/applications/networking/compactor/default.nix
@@ -90,12 +90,12 @@ stdenv.mkDerivation rec {
     wireshark-cli
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tools to capture DNS traffic and record it in C-DNS files";
     homepage = "https://dns-stats.org/";
     changelog = "https://github.com/dns-stats/compactor/raw/${version}/ChangeLog.txt";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [ fdns ];
-    platforms = platforms.unix;
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ fdns ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -60,18 +60,18 @@ telegram-desktop.override {
       })
     ];
 
-    meta = with lib; {
+    meta = {
       description = "Kotatogram – experimental Telegram Desktop fork";
       longDescription = ''
         Unofficial desktop client for the Telegram messenger, based on Telegram Desktop.
 
         It contains some useful (or purely cosmetic) features, but they could be unstable. A detailed list is available here: https://kotatogram.github.io/changes
       '';
-      license = licenses.gpl3Only;
-      platforms = platforms.all;
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.all;
       homepage = "https://kotatogram.github.io";
       changelog = "https://github.com/kotatogram/kotatogram-desktop/releases/tag/k${version}";
-      maintainers = with maintainers; [ ilya-fedin ];
+      maintainers = with lib.maintainers; [ ilya-fedin ];
       mainProgram = if stdenv.hostPlatform.isLinux then "kotatogram-desktop" else "Kotatogram";
     };
   };

--- a/pkgs/applications/networking/instant-messengers/twinkle/default.nix
+++ b/pkgs/applications/networking/instant-messengers/twinkle/default.nix
@@ -61,12 +61,12 @@ mkDerivation rec {
     # "-DWITH_DIAMONDCARD=On" seems ancient and broken
   ];
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/LubosD/twinkle/blob/${version}/NEWS";
     description = "SIP-based VoIP client";
     homepage = "http://twinkle.dolezel.info/";
-    license = licenses.gpl2Plus;
-    maintainers = [ maintainers.mkg20001 ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.mkg20001 ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/networking/maestral-qt/default.nix
+++ b/pkgs/applications/networking/maestral-qt/default.nix
@@ -59,16 +59,16 @@ python3.pkgs.buildPythonApplication rec {
 
   passthru.tests.maestral = nixosTests.maestral;
 
-  meta = with lib; {
+  meta = {
     description = "GUI front-end for maestral (an open-source Dropbox client) for Linux";
     homepage = "https://maestral.app";
     changelog = "https://github.com/samschott/maestral/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       peterhoeg
       sfrijters
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "maestral_qt";
   };
 }

--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -217,16 +217,16 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Mail indexer";
     homepage = "https://notmuchmail.org/";
-    changelog = "https://git.notmuchmail.org/git?p=notmuch;a=blob_plain;f=NEWS;hb=${version}";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
+    changelog = "https://git.notmuchmail.org/git?p=notmuch;a=blob_plain;f=NEWS;hb=${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
       flokli
       puckipedia
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     mainProgram = "notmuch";
   };
 })

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -128,13 +128,13 @@ stdenv.mkDerivation {
     gtk3 = gtk3;
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://www.thunderbird.net/en-US/thunderbird/${version}/releasenotes/";
     description = "Mozilla Thunderbird, a full-featured email client (binary package)";
     homepage = "http://www.mozilla.org/thunderbird/";
     mainProgram = "thunderbird";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.mpl20;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ lovesegfault ];
     platforms = builtins.attrNames mozillaPlatforms;
     hydraPlatforms = [ ];

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -60,21 +60,21 @@ let
         icu77 = icu77';
       };
 
-      meta = with lib; {
+      meta = {
         changelog = "https://www.thunderbird.net/en-US/thunderbird/${version}/releasenotes/";
         description = "Full-featured e-mail client";
         homepage = "https://thunderbird.net/";
         mainProgram = "thunderbird";
-        maintainers = with maintainers; [
+        maintainers = with lib.maintainers; [
           lovesegfault
           pierron
           vcunat
         ];
-        platforms = platforms.unix;
+        platforms = lib.platforms.unix;
         broken = stdenv.buildPlatform.is32bit;
         # since Firefox 60, build on 32-bit platforms fails with "out of memory".
         # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
-        license = licenses.mpl20;
+        license = lib.licenses.mpl20;
       };
     }).override
       {

--- a/pkgs/applications/networking/netmaker/default.nix
+++ b/pkgs/applications/networking/netmaker/default.nix
@@ -37,12 +37,12 @@ buildGoModule rec {
     xorg.libXrandr
   ];
 
-  meta = with lib; {
+  meta = {
     description = "WireGuard automation from homelab to enterprise";
     homepage = "https://netmaker.io";
     changelog = "https://github.com/gravitl/netmaker/-/releases/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       urandom
       qjoly
     ];

--- a/pkgs/applications/networking/newsreaders/quiterss/default.nix
+++ b/pkgs/applications/networking/newsreaders/quiterss/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     sqlite.dev
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Qt-based RSS/Atom news feed reader";
     longDescription = ''
       QuiteRSS is a open-source cross-platform RSS/Atom news feeds reader
@@ -42,8 +42,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://quiterss.org";
     changelog = "https://github.com/QuiteRSS/quiterss/blob/${version}/CHANGELOG";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ primeos ];
   };
 }

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -214,7 +214,7 @@ stdenv.mkDerivation rec {
     cp -r $out/lib/wireshark/extcap $out/Applications/Wireshark.app/Contents/MacOS/extcap
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Powerful network protocol analyzer";
     longDescription = ''
       Wireshark (formerly known as "Ethereal") is a powerful network
@@ -223,9 +223,9 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.wireshark.org";
     changelog = "https://www.wireshark.org/docs/relnotes/wireshark-${version}.html";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [
       bjornfor
       fpletz
     ];

--- a/pkgs/applications/networking/sync/rclone/default.nix
+++ b/pkgs/applications/networking/sync/rclone/default.nix
@@ -99,13 +99,13 @@ buildGoModule rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Command line program to sync files and directories to and from major cloud storage";
     homepage = "https://rclone.org";
     changelog = "https://github.com/rclone/rclone/blob/v${version}/docs/content/changelog.md";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "rclone";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       SuperSandro2000
     ];
   };

--- a/pkgs/applications/networking/wgnord/default.nix
+++ b/pkgs/applications/networking/wgnord/default.nix
@@ -56,13 +56,13 @@ resholve.mkDerivation rec {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "NordVPN Wireguard (NordLynx) client in POSIX shell";
     homepage = "https://github.com/phirecc/wgnord";
     changelog = "https://github.com/phirecc/wgnord/releases/tag/v${version}";
     maintainers = with lib.maintainers; [ urandom ];
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "wgnord";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/office/kbibtex/default.nix
+++ b/pkgs/applications/office/kbibtex/default.nix
@@ -79,13 +79,13 @@ mkDerivation rec {
     "${lib.makeBinPath [ bibutils ]}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Bibliography editor for KDE";
     mainProgram = "kbibtex";
     homepage = "https://userbase.kde.org/KBibTeX";
     changelog = "https://invent.kde.org/office/kbibtex/-/raw/v${version}/ChangeLog";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ dotlambda ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ dotlambda ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/science/astronomy/celestia/default.nix
+++ b/pkgs/applications/science/astronomy/celestia/default.nix
@@ -51,13 +51,13 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://celestiaproject.space/";
     description = "Real-time 3D simulation of space";
     mainProgram = "celestia";
     changelog = "https://github.com/CelestiaProject/Celestia/releases/tag/${version}";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ hjones2199 ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ hjones2199 ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/science/biology/nest/default.nix
+++ b/pkgs/applications/science/biology/nest/default.nix
@@ -78,15 +78,15 @@ stdenv.mkDerivation rec {
     command = "nest --version";
   };
 
-  meta = with lib; {
+  meta = {
     description = "NEST is a command line tool for simulating neural networks";
     homepage = "https://www.nest-simulator.org/";
     changelog = "https://github.com/nest/nest-simulator/releases/tag/v${version}";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
       jiegec
       davidcromp
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/applications/science/electronics/gerbv/default.nix
+++ b/pkgs/applications/science/electronics/gerbv/default.nix
@@ -45,13 +45,13 @@ stdenv.mkDerivation rec {
     "--disable-update-desktop-database"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Gerber (RS-274X) viewer";
     mainProgram = "gerbv";
     homepage = "https://gerbv.github.io/";
     changelog = "https://github.com/gerbv/gerbv/releases/tag/v${version}";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ mog ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ mog ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/applications/science/misc/sasview/default.nix
+++ b/pkgs/applications/science/misc/sasview/default.nix
@@ -69,11 +69,11 @@ python3.pkgs.buildPythonApplication rec {
     "test_data_reader_exception"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Fitting and data analysis for small angle scattering data";
     homepage = "https://www.sasview.org";
     changelog = "https://github.com/SasView/sasview/releases/tag/v${version}";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ rprospero ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ rprospero ];
   };
 }

--- a/pkgs/applications/version-management/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-machete/default.nix
@@ -48,12 +48,12 @@ buildPythonApplication rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/VirtusLab/git-machete";
     description = "Git repository organizer and rebase/merge workflow automation tool";
     changelog = "https://github.com/VirtusLab/git-machete/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ blitz ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ blitz ];
     mainProgram = "git-machete";
   };
 }

--- a/pkgs/applications/video/mpv/scripts/mpris.nix
+++ b/pkgs/applications/video/mpv/scripts/mpris.nix
@@ -40,12 +40,12 @@ stdenv.mkDerivation rec {
   stripDebugList = [ "share/mpv/scripts" ];
   passthru.scriptName = "mpris.so";
 
-  meta = with lib; {
+  meta = {
     description = "MPRIS plugin for mpv";
     homepage = "https://github.com/hoyon/mpv-mpris";
-    license = licenses.mit;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ ajs124 ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ajs124 ];
     changelog = "https://github.com/hoyon/mpv-mpris/releases/tag/${version}";
   };
 }

--- a/pkgs/applications/video/mpv/scripts/thumbnail.nix
+++ b/pkgs/applications/video/mpv/scripts/thumbnail.nix
@@ -26,12 +26,12 @@ buildLua rec {
   extraScripts = [ "mpv_thumbnail_script_server.lua" ];
   passthru.scriptName = "mpv_thumbnail_script_{client_osc,server}.lua";
 
-  meta = with lib; {
+  meta = {
     description = "Lua script to show preview thumbnails in mpv's OSC seekbar";
     homepage = "https://github.com/marzzzello/mpv_thumbnail_script";
     changelog = "https://github.com/marzzzello/mpv_thumbnail_script/releases/tag/${version}";
-    license = licenses.gpl3Plus;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/applications/video/obs-studio/plugins/obs-multi-rtmp/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-multi-rtmp/default.nix
@@ -50,12 +50,12 @@ stdenv.mkDerivation rec {
     rm -rf $out/dist
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/sorayuki/obs-multi-rtmp/";
     changelog = "https://github.com/sorayuki/obs-multi-rtmp/releases/tag/${version}";
     description = "Multi-site simultaneous broadcast plugin for OBS Studio";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ jk ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ jk ];
     platforms = [
       "x86_64-linux"
       "i686-linux"

--- a/pkgs/applications/video/obs-studio/plugins/obs-vaapi/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vaapi/default.nix
@@ -57,15 +57,15 @@ stdenv.mkDerivation rec {
     mv $out/lib/obs-vaapi.so $out/lib/obs-plugins/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "OBS Studio VAAPI support via GStreamer";
     homepage = "https://github.com/fzwoch/obs-vaapi";
     changelog = "https://github.com/fzwoch/obs-vaapi/releases/tag/${version}";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       ahuzik
       pedrohlc
     ];
-    license = licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
     platforms = [
       "x86_64-linux"
       "i686-linux"

--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -85,11 +85,11 @@ buildGoModule rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/lima-vm/lima";
     description = "Linux virtual machines (on macOS, in most cases)";
     changelog = "https://github.com/lima-vm/lima/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ anhduy ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ anhduy ];
   };
 }

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -73,13 +73,13 @@ stdenv.mkDerivation rec {
     updateScript = directoryListingUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Settings app for mobile specific things";
     mainProgram = "phosh-mobile-settings";
     homepage = "https://gitlab.gnome.org/World/Phosh/phosh-mobile-settings";
     changelog = "https://gitlab.gnome.org/World/Phosh/phosh-mobile-settings/-/blob/v${version}/debian/changelog";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ rvl ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ rvl ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ac/accerciser/package.nix
+++ b/pkgs/by-name/ac/accerciser/package.nix
@@ -69,13 +69,13 @@ python3.pkgs.buildPythonApplication rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.gnome.org/GNOME/accerciser";
     changelog = "https://gitlab.gnome.org/GNOME/accerciser/-/blob/${version}/NEWS?ref_type=tags";
     description = "Interactive Python accessibility explorer";
     mainProgram = "accerciser";
-    teams = [ teams.gnome ];
-    license = licenses.bsd3;
-    platforms = platforms.linux;
+    teams = [ lib.teams.gnome ];
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ac/acme-sh/package.nix
+++ b/pkgs/by-name/ac/acme-sh/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
       runHook postInstall
     '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://acme.sh/";
     changelog = "https://github.com/acmesh-official/acme.sh/releases/tag/${version}";
     description = "Pure Unix shell script implementing ACME client protocol";
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
       - IPv6 ready
       - Cron job notifications for renewal or error etc.
     '';
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
     teams = [ lib.teams.serokell ];
     inherit (coreutils.meta) platforms;
     mainProgram = "acme.sh";

--- a/pkgs/by-name/ad/adalanche/package.nix
+++ b/pkgs/by-name/ad/adalanche/package.nix
@@ -28,12 +28,12 @@ buildGoModule rec {
     "-X=github.com/lkarlslund/adalanche/modules/version.Version=${version}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Active Directory ACL Visualizer and Explorer";
     homepage = "https://github.com/lkarlslund/adalanche";
     changelog = "https://github.com/lkarlslund/Adalanche/releases/tag/v${version}";
-    license = licenses.agpl3Only;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "adalanche";
   };
 }

--- a/pkgs/by-name/ad/adbtuifm/package.nix
+++ b/pkgs/by-name/ad/adbtuifm/package.nix
@@ -13,13 +13,13 @@ buildGoModule rec {
     hash = "sha256-TK93O9XwMrsrQT3EG0969HYMtYkK0a4PzG9FSTqHxAY=";
   };
   vendorHash = "sha256-voVoowjM90OGWXF4REEevO8XEzT7azRYiDay4bnGBks=";
-  meta = with lib; {
+  meta = {
     description = "TUI-based file manager for the Android Debug Bridge";
     homepage = "https://github.com/darkhz/adbtuifm";
     changelog = "https://github.com/darkhz/adbtuifm/releases/tag/v${version}";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ daru-san ];
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ daru-san ];
     mainProgram = "adbtuifm";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ad/adreaper/package.nix
+++ b/pkgs/by-name/ad/adreaper/package.nix
@@ -22,14 +22,14 @@ buildGoModule rec {
     mv $out/bin/ADReaper $out/bin/$pname
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Enumeration tool for Windows Active Directories";
     homepage = "https://github.com/AidenPearce369/ADReaper";
     changelog = "https://github.com/AidenPearce369/ADReaper/releases/tag/ADReaperv${version}";
     # Upstream doesn't have a license yet
     # https://github.com/AidenPearce369/ADReaper/issues/2
-    license = with licenses; [ unfree ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ unfree ];
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "ADReaper";
   };
 }

--- a/pkgs/by-name/ad/adriconf/package.nix
+++ b/pkgs/by-name/ad/adriconf/package.nix
@@ -57,13 +57,13 @@ stdenv.mkDerivation rec {
       -t $out/share/icons/hicolor/256x256/apps/
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.freedesktop.org/mesa/adriconf/";
     changelog = "https://gitlab.freedesktop.org/mesa/adriconf/-/releases/v${version}";
     description = "GUI tool used to configure open source graphics drivers";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ muscaln ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ muscaln ];
+    platforms = lib.platforms.linux;
     mainProgram = "adriconf";
   };
 }

--- a/pkgs/by-name/ad/advancecomp/package.nix
+++ b/pkgs/by-name/ad/advancecomp/package.nix
@@ -27,11 +27,11 @@ stdenv.mkDerivation rec {
     echo "${version}" >.version
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Set of tools to optimize deflate-compressed files";
-    license = licenses.gpl3;
-    maintainers = [ maintainers.raskin ];
-    platforms = platforms.linux ++ platforms.darwin;
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.raskin ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     homepage = "https://github.com/amadvance/advancecomp";
     changelog = "https://github.com/amadvance/advancecomp/blob/v${version}/HISTORY";
   };

--- a/pkgs/by-name/ad/adwaita-icon-theme/package.nix
+++ b/pkgs/by-name/ad/adwaita-icon-theme/package.nix
@@ -53,11 +53,11 @@ stdenv.mkDerivation rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.gnome.org/GNOME/adwaita-icon-theme";
     changelog = "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/blob/${version}/NEWS?ref_type=tags";
-    platforms = with platforms; linux ++ darwin;
-    teams = [ teams.gnome ];
-    license = licenses.cc-by-sa-30;
+    platforms = with lib.platforms; linux ++ darwin;
+    teams = [ lib.teams.gnome ];
+    license = lib.licenses.cc-by-sa-30;
   };
 }

--- a/pkgs/by-name/ai/aide/package.nix
+++ b/pkgs/by-name/ai/aide/package.nix
@@ -44,13 +44,13 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://aide.github.io/";
     changelog = "https://github.com/aide/aide/blob/v${version}/ChangeLog";
     description = "File and directory integrity checker";
     mainProgram = "aide";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ happysalada ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ happysalada ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ai/aiodnsbrute/package.nix
+++ b/pkgs/by-name/ai/aiodnsbrute/package.nix
@@ -30,12 +30,12 @@ python3.pkgs.buildPythonApplication rec {
     "aiodnsbrute.cli"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "DNS brute force utility";
     mainProgram = "aiodnsbrute";
     homepage = "https://github.com/blark/aiodnsbrute";
     changelog = "https://github.com/blark/aiodnsbrute/releases/tag/v${version}";
-    license = with licenses; [ gpl3Only ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ gpl3Only ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/ai/airgeddon/package.nix
+++ b/pkgs/by-name/ai/airgeddon/package.nix
@@ -162,13 +162,13 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Multi-use TUI to audit wireless networks";
     mainProgram = "airgeddon";
     homepage = "https://github.com/v1s1t0r1sh3r3/airgeddon";
     changelog = "https://github.com/v1s1t0r1sh3r3/airgeddon/blob/v${version}/CHANGELOG.md";
-    license = licenses.gpl3Plus;
-    maintainers = [ ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ai/airlift/package.nix
+++ b/pkgs/by-name/ai/airlift/package.nix
@@ -47,12 +47,12 @@ python3.pkgs.buildPythonApplication rec {
   pythonImportsCheck = [
     "airlift"
   ];
-  meta = with lib; {
+  meta = {
     description = "Flexible, configuration driven CLI for Apache Airflow local development";
     homepage = "https://github.com/jl178/airlift";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     changelog = "https://github.com/jl178/airlift/releases/tag/v${version}";
-    maintainers = with maintainers; [ jl178 ];
+    maintainers = with lib.maintainers; [ jl178 ];
     mainProgram = "airlift";
   };
 }

--- a/pkgs/by-name/ai/airscan/package.nix
+++ b/pkgs/by-name/ai/airscan/package.nix
@@ -17,12 +17,12 @@ buildGoModule rec {
 
   vendorHash = "sha256-I5JRGaff6OIwx4q7BjpFwvJiQe4kw03V8+McYPcJhho=";
 
-  meta = with lib; {
+  meta = {
     description = "Package to scan paper documents using the Apple AirScan (eSCL) protocol";
     mainProgram = "airscan1";
     homepage = "https://github.com/stapelberg/airscan";
     changelog = "https://github.com/stapelberg/airscan/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ johannwagner ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ johannwagner ];
   };
 }

--- a/pkgs/by-name/al/alacritty/package.nix
+++ b/pkgs/by-name/al/alacritty/package.nix
@@ -128,16 +128,16 @@ rustPlatform.buildRustPackage rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cross-platform, GPU-accelerated terminal emulator";
     homepage = "https://github.com/alacritty/alacritty";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     mainProgram = "alacritty";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       Br1ght0ne
       rvdp
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     changelog = "https://github.com/alacritty/alacritty/blob/v${version}/CHANGELOG.md";
   };
 }

--- a/pkgs/by-name/al/alejandra/package.nix
+++ b/pkgs/by-name/al/alejandra/package.nix
@@ -24,12 +24,12 @@ rustPlatform.buildRustPackage rec {
     version = testers.testVersion { package = alejandra; };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Uncompromising Nix Code Formatter";
     homepage = "https://github.com/kamadorueda/alejandra";
     changelog = "https://github.com/kamadorueda/alejandra/blob/${version}/CHANGELOG.md";
-    license = licenses.unlicense;
-    maintainers = with maintainers; [
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [
       _0x4A6F
       kamadorueda
       sciencentistguy

--- a/pkgs/by-name/al/ali/package.nix
+++ b/pkgs/by-name/al/ali/package.nix
@@ -18,13 +18,13 @@ buildGoModule rec {
 
   vendorHash = "sha256-YWx9K04kTMaI0FXebwRQVCt0nxIwZ6xlbtI2lk3qp0M=";
 
-  meta = with lib; {
+  meta = {
     description = "Generate HTTP load and plot the results in real-time";
     homepage = "https://github.com/nakabonne/ali";
     changelog = "https://github.com/nakabonne/ali/releases/tag/v${version}";
-    license = licenses.mit;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ farcaller ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ farcaller ];
     mainProgram = "ali";
     # Broken on darwin for Go toolchain > 1.22, with error:
     # 'link: golang.org/x/net/internal/socket: invalid reference to syscall.recvmsg'

--- a/pkgs/by-name/al/alienarena/package.nix
+++ b/pkgs/by-name/al/alienarena/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       --replace libGL.so.1 ${libGL}/lib/libGL.so.1
   '';
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/alienarena/alienarena/releases/tag/${version}";
     description = "Free, stand-alone first-person shooter computer game";
     longDescription = ''
@@ -59,9 +59,9 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://alienarena.org";
     # Engine is under GPLv2, everything else is under
-    license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ astsmtl ];
-    platforms = platforms.linux;
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = with lib.maintainers; [ astsmtl ];
+    platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
   };
 }

--- a/pkgs/by-name/al/alterx/package.nix
+++ b/pkgs/by-name/al/alterx/package.nix
@@ -17,12 +17,12 @@ buildGoModule rec {
 
   vendorHash = "sha256-aTA5KGeYmJnbVRbEhT9LigQoJFLD17q9spzBV4BGhNw=";
 
-  meta = with lib; {
+  meta = {
     description = "Fast and customizable subdomain wordlist generator using DSL";
     mainProgram = "alterx";
     homepage = "https://github.com/projectdiscovery/alterx";
     changelog = "https://github.com/projectdiscovery/alterx/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/al/alvr/package.nix
+++ b/pkgs/by-name/al/alvr/package.nix
@@ -136,16 +136,16 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Stream VR games from your PC to your headset via Wi-Fi";
     homepage = "https://github.com/alvr-org/ALVR/";
     changelog = "https://github.com/alvr-org/ALVR/releases/tag/v${version}";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "alvr_dashboard";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       luNeder
       jopejoe1
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/am/amass/package.nix
+++ b/pkgs/by-name/am/amass/package.nix
@@ -31,7 +31,7 @@ buildGoModule rec {
   # https://github.com/OWASP/Amass/issues/640
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "In-Depth DNS Enumeration and Network Mapping";
     longDescription = ''
       The OWASP Amass tool suite obtains subdomain names by scraping data
@@ -46,8 +46,8 @@ buildGoModule rec {
     '';
     homepage = "https://owasp.org/www-project-amass/";
     changelog = "https://github.com/OWASP/Amass/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       kalbasit
       fab
     ];

--- a/pkgs/by-name/am/amazon-ssm-agent/package.nix
+++ b/pkgs/by-name/am/amazon-ssm-agent/package.nix
@@ -169,13 +169,13 @@ buildGoModule rec {
 
   __darwinAllowLocalNetworking = true;
 
-  meta = with lib; {
+  meta = {
     description = "Agent to enable remote management of your Amazon EC2 instance configuration";
     changelog = "https://github.com/aws/amazon-ssm-agent/releases/tag/${version}";
     homepage = "https://github.com/aws/amazon-ssm-agent";
-    license = licenses.asl20;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
       manveru
       anthonyroussel
       arianvp

--- a/pkgs/by-name/am/ameba/package.nix
+++ b/pkgs/by-name/am/ameba/package.nix
@@ -19,12 +19,12 @@ crystal.buildCrystalPackage rec {
   format = "make";
   installFlags = [ "INSTALL_BIN=${coreutils}/bin/install" ];
 
-  meta = with lib; {
+  meta = {
     description = "Static code analysis tool for Crystal";
     mainProgram = "ameba";
     homepage = "https://crystal-ameba.github.io";
     changelog = "https://github.com/crystal-ameba/ameba/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/am/amfora/package.nix
+++ b/pkgs/by-name/am/amfora/package.nix
@@ -23,12 +23,12 @@ buildGoModule rec {
     install -Dm644 amfora.desktop -t $out/share/applications
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Fancy terminal browser for the Gemini protocol";
     mainProgram = "amfora";
     homepage = "https://github.com/makeworld-the-better-one/amfora";
-    license = with licenses; [ gpl3 ];
-    maintainers = with maintainers; [ deifactor ];
+    license = with lib.licenses; [ gpl3 ];
+    maintainers = with lib.maintainers; [ deifactor ];
     changelog = "https://github.com/makeworld-the-better-one/amfora/blob/v${version}/CHANGELOG.md";
   };
 }

--- a/pkgs/by-name/ap/apachetomcatscanner/package.nix
+++ b/pkgs/by-name/ap/apachetomcatscanner/package.nix
@@ -41,12 +41,12 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "apachetomcatscanner" ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to scan for Apache Tomcat server vulnerabilities";
     homepage = "https://github.com/p0dalirius/ApacheTomcatScanner";
     changelog = "https://github.com/p0dalirius/ApacheTomcatScanner/releases/tag/${version}";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "ApacheTomcatScanner";
   };
 }

--- a/pkgs/by-name/ap/aperture/package.nix
+++ b/pkgs/by-name/ap/aperture/package.nix
@@ -19,12 +19,12 @@ buildGoModule rec {
 
   subPackages = [ "cmd/aperture" ];
 
-  meta = with lib; {
+  meta = {
     description = "L402 (Lightning HTTP 402) Reverse Proxy";
     homepage = "https://github.com/lightninglabs/aperture";
     changelog = "https://github.com/lightninglabs/aperture/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       sputn1ck
       HannahMR
     ];

--- a/pkgs/by-name/ap/apkeep/package.nix
+++ b/pkgs/by-name/ap/apkeep/package.nix
@@ -30,12 +30,12 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Command-line tool for downloading APK files from various sources";
     homepage = "https://github.com/EFForg/apkeep";
     changelog = "https://github.com/EFForg/apkeep/blob/${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "apkeep";
   };
 }

--- a/pkgs/by-name/ap/apkleaks/package.nix
+++ b/pkgs/by-name/ap/apkleaks/package.nix
@@ -30,12 +30,12 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "apkleaks" ];
 
-  meta = with lib; {
+  meta = {
     description = "Scanning APK file for URIs, endpoints and secrets";
     homepage = "https://github.com/dwisiswant0/apkleaks";
     changelog = "https://github.com/dwisiswant0/apkleaks/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "apkleaks";
   };
 }

--- a/pkgs/by-name/ap/apktool/package.nix
+++ b/pkgs/by-name/ap/apktool/package.nix
@@ -33,14 +33,14 @@ stdenv.mkDerivation rec {
         --prefix PATH : ${lib.getBin aapt}
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Tool for reverse engineering Android apk files";
     mainProgram = "apktool";
     homepage = "https://ibotpeaches.github.io/Apktool/";
     changelog = "https://github.com/iBotPeaches/Apktool/releases/tag/v${version}";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.asl20;
-    maintainers = with maintainers; [ offline ];
-    platforms = with platforms; unix;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ offline ];
+    platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/by-name/ar/arduino-ide/package.nix
+++ b/pkgs/by-name/ar/arduino-ide/package.nix
@@ -26,13 +26,13 @@ appimageTools.wrapType2 {
 
   extraPkgs = pkgs: [ pkgs.libsecret ];
 
-  meta = with lib; {
+  meta = {
     description = "Open-source electronics prototyping platform";
     homepage = "https://www.arduino.cc/en/software";
     changelog = "https://github.com/arduino/arduino-ide/releases/tag/${version}";
-    license = licenses.agpl3Only;
+    license = lib.licenses.agpl3Only;
     mainProgram = "arduino-ide";
-    maintainers = with maintainers; [ clerie ];
+    maintainers = with lib.maintainers; [ clerie ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/ar/arduino-language-server/package.nix
+++ b/pkgs/by-name/ar/arduino-language-server/package.nix
@@ -33,12 +33,12 @@ buildGoModule rec {
       "-extldflags '-static'"
     ];
 
-  meta = with lib; {
+  meta = {
     description = "Arduino Language Server based on Clangd to Arduino code autocompletion";
     mainProgram = "arduino-language-server";
     homepage = "https://github.com/arduino/arduino-language-server";
     changelog = "https://github.com/arduino/arduino-language-server/releases/tag/${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ BattleCh1cken ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ BattleCh1cken ];
   };
 }

--- a/pkgs/by-name/ar/argc/package.nix
+++ b/pkgs/by-name/ar/argc/package.nix
@@ -61,16 +61,16 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Command-line options, arguments and sub-commands parser for bash";
     mainProgram = "argc";
     homepage = "https://github.com/sigoden/argc";
     changelog = "https://github.com/sigoden/argc/releases/tag/v${version}";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit
       # or
       asl20
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/by-name/ar/argo-workflows/package.nix
+++ b/pkgs/by-name/ar/argo-workflows/package.nix
@@ -88,13 +88,13 @@ buildGoModule rec {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Container native workflow engine for Kubernetes";
     mainProgram = "argo";
     homepage = "https://github.com/argoproj/argo";
     changelog = "https://github.com/argoproj/argo-workflows/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ groodt ];
-    platforms = platforms.unix;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ groodt ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ar/argocd-vault-plugin/package.nix
+++ b/pkgs/by-name/ar/argocd-vault-plugin/package.nix
@@ -36,12 +36,12 @@ buildGoModule rec {
     version = "argocd-vault-plugin v${version} (unknown) BuildDate: 1970-01-01T00:00:00Z";
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://argocd-vault-plugin.readthedocs.io";
     changelog = "https://github.com/argoproj-labs/argocd-vault-plugin/releases/tag/v${version}";
     description = "Argo CD plugin to retrieve secrets from Secret Management tools and inject them into Kubernetes secrets";
     mainProgram = "argocd-vault-plugin";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ urandom ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ urandom ];
   };
 }

--- a/pkgs/by-name/ar/aria2/package.nix
+++ b/pkgs/by-name/ar/aria2/package.nix
@@ -69,14 +69,14 @@ stdenv.mkDerivation rec {
     aria2 = nixosTests.aria2;
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://aria2.github.io";
     changelog = "https://github.com/aria2/aria2/releases/tag/release-${version}";
     description = "Lightweight, multi-protocol, multi-source, command-line download utility";
     mainProgram = "aria2c";
-    license = licenses.gpl2Plus;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
       Br1ght0ne
       koral
       timhae

--- a/pkgs/by-name/ar/arjun/package.nix
+++ b/pkgs/by-name/ar/arjun/package.nix
@@ -33,12 +33,12 @@ python3.pkgs.buildPythonApplication rec {
     "arjun"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "HTTP parameter discovery suite";
     homepage = "https://github.com/s0md3v/Arjun";
     changelog = "https://github.com/s0md3v/Arjun/blob/${version}/CHANGELOG.md";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ octodi ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ octodi ];
     mainProgram = "arjun";
   };
 }

--- a/pkgs/by-name/ar/artem/package.nix
+++ b/pkgs/by-name/ar/artem/package.nix
@@ -38,12 +38,12 @@ rustPlatform.buildRustPackage rec {
       --zsh $releaseDir/build/artem-*/out/_artem
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Small CLI program to convert images to ASCII art";
     homepage = "https://github.com/finefindus/artem";
     changelog = "https://github.com/finefindus/artem/blob/v${version}/CHANGELOG.md";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "artem";
   };
 }

--- a/pkgs/by-name/as/askalono/package.nix
+++ b/pkgs/by-name/as/askalono/package.nix
@@ -17,12 +17,12 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-ug79p75Oa5lsd9COWO2aIx3jN7de1QZggMFiOPAN5kQ=";
 
-  meta = with lib; {
+  meta = {
     description = "Tool to detect open source licenses from texts";
     homepage = "https://github.com/jpeddicord/askalono";
     changelog = "https://github.com/jpeddicord/askalono/blob/${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "askalono";
   };
 }

--- a/pkgs/by-name/as/asn/package.nix
+++ b/pkgs/by-name/as/asn/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
       }"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "OSINT command line tool for investigating network data";
     longDescription = ''
       ASN / RPKI validity / BGP stats / IPv4v6 / Prefix / URL / ASPath / Organization /
@@ -57,8 +57,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/nitefood/asn";
     changelog = "https://github.com/nitefood/asn/releases/tag/v${version}";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ devhell ];
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ devhell ];
     mainProgram = "asn";
   };
 }

--- a/pkgs/by-name/as/asnmap/package.nix
+++ b/pkgs/by-name/as/asnmap/package.nix
@@ -25,12 +25,12 @@ buildGoModule rec {
   # Tests require network access
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Tool to gather network ranges using ASN information";
     homepage = "https://github.com/projectdiscovery/asnmap";
     changelog = "https://github.com/projectdiscovery/asnmap/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "asnmap";
   };
 }

--- a/pkgs/by-name/as/assh/package.nix
+++ b/pkgs/by-name/as/assh/package.nix
@@ -41,12 +41,12 @@ buildGoModule rec {
     $out/bin/assh --help > /dev/null
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Advanced SSH config - Regex, aliases, gateways, includes and dynamic hosts";
     homepage = "https://github.com/moul/assh";
     changelog = "https://github.com/moul/assh/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ];
-    platforms = with platforms; linux ++ darwin;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    platforms = with lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/by-name/aw/await/package.nix
+++ b/pkgs/by-name/aw/await/package.nix
@@ -42,13 +42,13 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
   versionCheckProgramArg = "--version";
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/slavaGanzin/await/releases/tag/${version}";
     description = "Small binary that runs a list of commands in parallel and awaits termination";
     homepage = "https://github.com/slavaGanzin/await";
-    license = licenses.mit;
-    maintainers = with maintainers; [ chewblacka ];
-    platforms = platforms.all;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ chewblacka ];
+    platforms = lib.platforms.all;
     mainProgram = "await";
   };
 }

--- a/pkgs/by-name/aw/aws-encryption-sdk-cli/package.nix
+++ b/pkgs/by-name/aw/aws-encryption-sdk-cli/package.nix
@@ -73,12 +73,12 @@ localPython.pkgs.buildPythonApplication rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://aws-encryption-sdk-cli.readthedocs.io/";
     changelog = "https://github.com/aws/aws-encryption-sdk-cli/blob/v${version}/CHANGELOG.rst";
     description = "CLI wrapper around aws-encryption-sdk-python";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     mainProgram = "aws-encryption-cli";
-    maintainers = with maintainers; [ anthonyroussel ];
+    maintainers = with lib.maintainers; [ anthonyroussel ];
   };
 }

--- a/pkgs/by-name/aw/aws-iam-authenticator/package.nix
+++ b/pkgs/by-name/aw/aws-iam-authenticator/package.nix
@@ -31,12 +31,12 @@ buildGoModule rec {
 
   subPackages = [ "cmd/aws-iam-authenticator" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/kubernetes-sigs/aws-iam-authenticator";
     description = "AWS IAM credentials for Kubernetes authentication";
     mainProgram = "aws-iam-authenticator";
     changelog = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ srhb ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ srhb ];
   };
 }

--- a/pkgs/by-name/aw/aws-sam-cli/package.nix
+++ b/pkgs/by-name/aw/aws-sam-cli/package.nix
@@ -151,13 +151,13 @@ python3.pkgs.buildPythonApplication rec {
 
   __darwinAllowLocalNetworking = true;
 
-  meta = with lib; {
+  meta = {
     description = "CLI tool for local development and testing of Serverless applications";
     homepage = "https://github.com/aws/aws-sam-cli";
     changelog = "https://github.com/aws/aws-sam-cli/releases/tag/v${version}";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     mainProgram = "sam";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       lo1tuma
       anthonyroussel
     ];

--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -186,12 +186,12 @@ py.pkgs.buildPythonApplication rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Unified tool to manage your AWS services";
     homepage = "https://aws.amazon.com/cli/";
     changelog = "https://github.com/aws/aws-cli/blob/${version}/CHANGELOG.rst";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       bhipple
       davegallant
       bryanasdev000

--- a/pkgs/by-name/aw/awsebcli/package.nix
+++ b/pkgs/by-name/aw/awsebcli/package.nix
@@ -93,12 +93,12 @@ python.pkgs.buildPythonApplication rec {
     "test_aws_eb_profile_environment_variable_found__profile_exists_in_credentials_file"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Command line interface for Elastic Beanstalk";
     homepage = "https://aws.amazon.com/elasticbeanstalk/";
     changelog = "https://github.com/aws/aws-elastic-beanstalk-cli/blob/${version}/CHANGES.rst";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ kirillrdy ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kirillrdy ];
     mainProgram = "eb";
   };
 }

--- a/pkgs/by-name/aw/awslimitchecker/package.nix
+++ b/pkgs/by-name/aw/awslimitchecker/package.nix
@@ -52,12 +52,12 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "awslimitchecker.checker" ];
 
-  meta = with lib; {
+  meta = {
     description = "Script and python package to check your AWS service limits and usage via boto3";
     homepage = "http://awslimitchecker.readthedocs.org";
     changelog = "https://github.com/jantman/awslimitchecker/blob/${version}/CHANGES.rst";
-    license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ zakame ];
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ zakame ];
     mainProgram = "awslimitchecker";
   };
 }

--- a/pkgs/by-name/ba/baboossh/package.nix
+++ b/pkgs/by-name/ba/baboossh/package.nix
@@ -30,12 +30,12 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "baboossh" ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to do SSH spreading";
     homepage = "https://github.com/cybiere/baboossh";
     changelog = "https://github.com/cybiere/baboossh/releases/tag/v${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "baboossh";
   };
 }

--- a/pkgs/by-name/ba/badrobot/package.nix
+++ b/pkgs/by-name/ba/badrobot/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
       --zsh <($out/bin/badrobot completion zsh)
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/controlplaneio/badrobot";
     changelog = "https://github.com/controlplaneio/badrobot/blob/v${version}/CHANGELOG.md";
     description = "Operator Security Audit Tool";
@@ -45,7 +45,7 @@ buildGoModule rec {
       likelihood that a compromised Operator would be able to obtain full
       cluster permissions.
     '';
-    license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ jk ];
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ jk ];
   };
 }

--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -189,16 +189,16 @@ stdenv.mkDerivation rec {
     mv $out/README.md $out/share/BambuStudio/README.md
   '';
 
-  meta = with lib; {
+  meta = {
     description = "PC Software for BambuLab's 3D printers";
     homepage = "https://github.com/bambulab/BambuStudio";
     changelog = "https://github.com/bambulab/BambuStudio/releases/tag/v${version}";
-    license = licenses.agpl3Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [
       zhaofengli
       dsluijk
     ];
     mainProgram = "bambu-studio";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ba/bat/package.nix
+++ b/pkgs/by-name/ba/bat/package.nix
@@ -76,16 +76,16 @@ rustPlatform.buildRustPackage rec {
     runHook postInstallCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Cat(1) clone with syntax highlighting and Git integration";
     homepage = "https://github.com/sharkdp/bat";
     changelog = "https://github.com/sharkdp/bat/raw/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
     mainProgram = "bat";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       dywedir
       zowoq
       SuperSandro2000

--- a/pkgs/by-name/ba/batmon/package.nix
+++ b/pkgs/by-name/ba/batmon/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-0SXb8jBAYKnNFguamSMosPE6gH9aUzydF16w3SLhOU4=";
 
-  meta = with lib; {
+  meta = {
     description = "Interactive batteries viewer";
     longDescription = ''
       An interactive viewer, similar to top, htop and other *top utilities,
@@ -26,10 +26,10 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://github.com/6543/batmon/";
     changelog = "https://github.com/6543/batmon/releases/tag/v${version}";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     mainProgram = "batmon";
-    platforms = with platforms; unix ++ windows;
+    platforms = with lib.platforms; unix ++ windows;
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
-    maintainers = with maintainers; [ _6543 ];
+    maintainers = with lib.maintainers; [ _6543 ];
   };
 }

--- a/pkgs/by-name/ba/bazel-buildtools/package.nix
+++ b/pkgs/by-name/ba/bazel-buildtools/package.nix
@@ -34,15 +34,15 @@ buildGoModule rec {
     "-X main.buildScmRevision=${src.rev}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tools for working with Google's bazel buildtool. Includes buildifier, buildozer, and unused_deps";
     homepage = "https://github.com/bazelbuild/buildtools";
     changelog = "https://github.com/bazelbuild/buildtools/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       elasticdog
       uri-canva
     ];
-    teams = [ teams.bazel ];
+    teams = [ lib.teams.bazel ];
   };
 }

--- a/pkgs/by-name/ba/bazel-remote/package.nix
+++ b/pkgs/by-name/ba/bazel-remote/package.nix
@@ -27,13 +27,13 @@ buildGoModule rec {
     "-X main.gitCommit=${version}"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/buchgr/bazel-remote";
     description = "Remote HTTP/1.1 cache for Bazel";
     mainProgram = "bazel-remote";
     changelog = "https://github.com/buchgr/bazel-remote/releases/tag/v${version}";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     teams = [ lib.teams.bazel ];
-    platforms = platforms.darwin ++ platforms.linux;
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ba/bazelisk/package.nix
+++ b/pkgs/by-name/ba/bazelisk/package.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
     "-X main.BazeliskVersion=${version}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "User-friendly launcher for Bazel";
     mainProgram = "bazelisk";
     longDescription = ''
@@ -31,7 +31,7 @@ buildGoModule rec {
     '';
     homepage = "https://github.com/bazelbuild/bazelisk";
     changelog = "https://github.com/bazelbuild/bazelisk/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ elasticdog ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ elasticdog ];
   };
 }

--- a/pkgs/by-name/be/bearer/package.nix
+++ b/pkgs/by-name/be/bearer/package.nix
@@ -34,11 +34,11 @@ buildGoModule rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Code security scanning tool (SAST) to discover, filter and prioritize security and privacy risks";
     homepage = "https://github.com/bearer/bearer";
     changelog = "https://github.com/Bearer/bearer/releases/tag/v${version}";
-    license = with licenses; [ elastic20 ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ elastic20 ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/be/beatprints/package.nix
+++ b/pkgs/by-name/be/beatprints/package.nix
@@ -36,7 +36,7 @@ python3Packages.buildPythonApplication rec {
     spotipy
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Create eye-catching, Pinterest-style music posters effortlessly";
     longDescription = ''
       Create eye-catching, Pinterest-style music posters effortlessly. BeatPrints integrates with Spotify and LRClib API to help you design custom posters for your favorite tracks or albums. 🍀
@@ -44,8 +44,8 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://beatprints.readthedocs.io";
     changelog = "https://github.com/TrueMyst/BeatPrints/releases/tag/v${version}";
     mainProgram = "beatprints";
-    license = licenses.cc-by-nc-sa-40;
-    maintainers = with maintainers; [ DataHearth ];
-    platforms = platforms.all;
+    license = lib.licenses.cc-by-nc-sa-40;
+    maintainers = with lib.maintainers; [ DataHearth ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/be/beluga/package.nix
+++ b/pkgs/by-name/be/beluga/package.nix
@@ -36,12 +36,12 @@ ocamlPackages.buildDunePackage rec {
     cp -r tools/beluga-mode.el $out/share/emacs/site-lisp/beluga
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Functional language for reasoning about formal systems";
     homepage = "https://complogic.cs.mcgill.ca/beluga";
     changelog = "https://github.com/Beluga-lang/Beluga/releases/tag/v${version}";
-    license = licenses.gpl3Plus;
-    maintainers = [ maintainers.bcdarwin ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.bcdarwin ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/bi/bigquery-emulator/package.nix
+++ b/pkgs/by-name/bi/bigquery-emulator/package.nix
@@ -33,12 +33,12 @@ buildGoModule.override
 
     doCheck = false;
 
-    meta = with lib; {
+    meta = {
       description = "BigQuery emulator server implemented in Go.";
       homepage = "https://github.com/goccy/bigquery-emulator";
       changelog = "https://github.com/goccy/pname/releases/tag/v${version}";
-      license = licenses.mit;
-      maintainers = with maintainers; [ tarantoj ];
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ tarantoj ];
       mainProgram = "bigquery-emulator";
     };
   }

--- a/pkgs/by-name/bi/biodiff/package.nix
+++ b/pkgs/by-name/bi/biodiff/package.nix
@@ -26,11 +26,11 @@ rustPlatform.buildRustPackage rec {
   buildNoDefaultFeatures = true;
   buildFeatures = [ "wfa2" ];
 
-  meta = with lib; {
+  meta = {
     description = "Hex diff viewer using alignment algorithms from biology";
     homepage = "https://github.com/8051Enthusiast/biodiff";
     changelog = "https://github.com/8051Enthusiast/biodiff/blob/v${version}/CHANGELOG";
-    license = licenses.mit;
-    maintainers = with maintainers; [ newam ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ newam ];
   };
 }

--- a/pkgs/by-name/bi/bird-lg/package.nix
+++ b/pkgs/by-name/bi/bird-lg/package.nix
@@ -27,12 +27,12 @@ let
 
       inherit modRoot vendorHash;
 
-      meta = with lib; {
+      meta = {
         description = "Bird Looking Glass";
         homepage = "https://github.com/xddxdd/bird-lg-go";
         changelog = "https://github.com/xddxdd/bird-lg-go/releases/tag/v${version}";
-        license = licenses.gpl3Plus;
-        maintainers = with maintainers; [
+        license = lib.licenses.gpl3Plus;
+        maintainers = with lib.maintainers; [
           tchekda
           e1mo
         ];

--- a/pkgs/by-name/bi/bird2/package.nix
+++ b/pkgs/by-name/bi/bird2/package.nix
@@ -46,12 +46,12 @@ stdenv.mkDerivation rec {
 
   passthru.tests = nixosTests.bird;
 
-  meta = with lib; {
+  meta = {
     changelog = "https://gitlab.nic.cz/labs/bird/-/blob/v${version}/NEWS";
     description = "BIRD Internet Routing Daemon";
     homepage = "https://bird.network.cz";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ herbetom ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ herbetom ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/bi/bird3/package.nix
+++ b/pkgs/by-name/bi/bird3/package.nix
@@ -45,12 +45,12 @@ stdenv.mkDerivation rec {
 
   passthru.tests = nixosTests.bird;
 
-  meta = with lib; {
+  meta = {
     changelog = "https://gitlab.nic.cz/labs/bird/-/blob/v${version}/NEWS";
     description = "BIRD Internet Routing Daemon";
     homepage = "https://bird.nic.cz/";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ herbetom ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ herbetom ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/bl/blackbox-terminal/package.nix
+++ b/pkgs/by-name/bl/blackbox-terminal/package.nix
@@ -106,16 +106,16 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [ "-Dblackbox_is_flatpak=false" ];
 
-  meta = with lib; {
+  meta = {
     description = "Beautiful GTK 4 terminal";
     mainProgram = "blackbox";
     homepage = "https://gitlab.gnome.org/raggesilver/blackbox";
     changelog = "https://gitlab.gnome.org/raggesilver/blackbox/-/raw/v${version}/CHANGELOG.md";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
       chuangzhu
       linsui
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/bl/blueman/package.nix
+++ b/pkgs/by-name/bl/blueman/package.nix
@@ -94,12 +94,12 @@ stdenv.mkDerivation rec {
     wrapPythonProgramsIn "$out/libexec" "$out $pythonPath"
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/blueman-project/blueman";
     description = "GTK-based Bluetooth Manager";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
     changelog = "https://github.com/blueman-project/blueman/releases/tag/${version}";
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with lib.maintainers; [ abbradar ];
   };
 }

--- a/pkgs/by-name/bl/bluetuith/package.nix
+++ b/pkgs/by-name/bl/bluetuith/package.nix
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "TUI-based bluetooth connection manager";
     longDescription = ''
       Bluetuith can transfer files via OBEX, perform authenticated pairing,
@@ -38,11 +38,11 @@ buildGoModule (finalAttrs: {
       devices. The TUI has mouse support.
     '';
     homepage = "https://github.com/darkhz/bluetuith";
-    changelog = "https://github.com/darkhz/bluetuith/releases/tag/v${version}";
-    license = licenses.mit;
-    platforms = platforms.linux;
+    changelog = "https://github.com/darkhz/bluetuith/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
     mainProgram = "bluetuith";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       pyrox0
       katexochen
     ];

--- a/pkgs/by-name/bl/bluewalker/package.nix
+++ b/pkgs/by-name/bl/bluewalker/package.nix
@@ -22,12 +22,12 @@ buildGoModule rec {
     "-s"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Simple command line Bluetooth LE scanner";
     homepage = "https://gitlab.com/jtaimisto/bluewalker";
     changelog = "https://gitlab.com/jtaimisto/bluewalker/-/tags/v${version}";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ cimm ];
-    platforms = platforms.linux;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ cimm ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/bo/bom/package.nix
+++ b/pkgs/by-name/bo/bom/package.nix
@@ -60,12 +60,12 @@ buildGoModule rec {
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/kubernetes-sigs/bom";
     changelog = "https://github.com/kubernetes-sigs/bom/releases/tag/v${version}";
     description = "Utility to generate SPDX-compliant Bill of Materials manifests";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ developer-guy ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ developer-guy ];
     mainProgram = "bom";
   };
 }

--- a/pkgs/by-name/bo/bomber-go/package.nix
+++ b/pkgs/by-name/bo/bomber-go/package.nix
@@ -26,12 +26,12 @@ buildGoModule rec {
     "-skip=TestEnrich" # Requires network access
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to scans Software Bill of Materials (SBOMs) for vulnerabilities";
     homepage = "https://github.com/devops-kung-fu/bomber";
     changelog = "https://github.com/devops-kung-fu/bomber/releases/tag/v${version}";
-    license = licenses.mpl20;
+    license = lib.licenses.mpl20;
     mainProgram = "bomber";
-    maintainers = with maintainers; [ fab ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/bo/boofuzz/package.nix
+++ b/pkgs/by-name/bo/boofuzz/package.nix
@@ -57,12 +57,12 @@ python3.pkgs.buildPythonApplication rec {
     "boofuzz"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Network protocol fuzzing tool";
     mainProgram = "boo";
     homepage = "https://github.com/jtpereyda/boofuzz";
     changelog = "https://github.com/jtpereyda/boofuzz/blob/v${version}/CHANGELOG.rst";
-    license = with licenses; [ gpl2Plus ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ gpl2Plus ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/bo/bosh-cli/package.nix
+++ b/pkgs/by-name/bo/bosh-cli/package.nix
@@ -34,12 +34,12 @@ buildGoModule rec {
     wrapProgram $out/bin/bosh --prefix PATH : '${lib.makeBinPath [ openssh ]}'
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Command line interface to CloudFoundry BOSH";
     homepage = "https://bosh.io";
     changelog = "https://github.com/cloudfoundry/bosh-cli/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ ris ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ris ];
     mainProgram = "bosh";
   };
 }

--- a/pkgs/by-name/bo/boundary/package.nix
+++ b/pkgs/by-name/bo/boundary/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = ./update.sh;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://boundaryproject.io/";
     changelog = "https://github.com/hashicorp/boundary/blob/v${version}/CHANGELOG.md";
     description = "Enables identity-based access management for dynamic infrastructure";
@@ -67,13 +67,13 @@ stdenv.mkDerivation rec {
       and resilient. It can run in clouds, on-prem, secure enclaves and more,
       and does not require an agent to be installed on every end host.
     '';
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.bsl11;
-    maintainers = with maintainers; [
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.bsl11;
+    maintainers = with lib.maintainers; [
       jk
       techknowlogick
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     mainProgram = "boundary";
   };
 }

--- a/pkgs/by-name/br/breads-ad/package.nix
+++ b/pkgs/by-name/br/breads-ad/package.nix
@@ -29,12 +29,12 @@ python3.pkgs.buildPythonApplication rec {
   # Project has no tests
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Tool to evaluate Active Directory Security";
     homepage = "https://github.com/oppsec/breads";
     changelog = "https://github.com/oppsec/breads/blob/${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "breads-ad";
   };
 }

--- a/pkgs/by-name/br/brev-cli/package.nix
+++ b/pkgs/by-name/br/brev-cli/package.nix
@@ -30,12 +30,12 @@ buildGoModule rec {
     mv $out/bin/brev-cli $out/bin/brev
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Connect your laptop to cloud computers";
     mainProgram = "brev";
     homepage = "https://github.com/brevdev/brev-cli";
     changelog = "https://github.com/brevdev/brev-cli/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ dit7ya ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dit7ya ];
   };
 }

--- a/pkgs/by-name/br/browsr/package.nix
+++ b/pkgs/by-name/br/browsr/package.nix
@@ -85,12 +85,12 @@ python3.pkgs.buildPythonApplication rec {
     "test_textual_app_context_path"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "File explorer in your terminal";
     mainProgram = "browsr";
     homepage = "https://juftin.com/browsr";
     changelog = "https://github.com/juftin/browsr/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/by-name/ca/cadaver/package.nix
+++ b/pkgs/by-name/ca/cadaver/package.nix
@@ -31,13 +31,13 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Command-line WebDAV client";
     homepage = "https://notroj.github.io/cadaver/";
     changelog = "https://github.com/notroj/cadaver/blob/${version}/NEWS";
-    maintainers = with maintainers; [ ianwookim ];
-    license = licenses.gpl2Plus;
-    platforms = with platforms; linux ++ freebsd ++ openbsd;
+    maintainers = with lib.maintainers; [ ianwookim ];
+    license = lib.licenses.gpl2Plus;
+    platforms = with lib.platforms; linux ++ freebsd ++ openbsd;
     mainProgram = "cadaver";
   };
 }

--- a/pkgs/by-name/ca/caerbannog/package.nix
+++ b/pkgs/by-name/ca/caerbannog/package.nix
@@ -51,12 +51,12 @@ python3.pkgs.buildPythonApplication rec {
     pygobject3
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Mobile-friendly Gtk frontend for password-store";
     mainProgram = "caerbannog";
     homepage = "https://sr.ht/~craftyguy/caerbannog/";
     changelog = "https://git.sr.ht/~craftyguy/caerbannog/refs/${version}";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ dotlambda ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ dotlambda ];
   };
 }

--- a/pkgs/by-name/ca/caf/package.nix
+++ b/pkgs/by-name/ca/caf/package.nix
@@ -28,13 +28,13 @@ stdenv.mkDerivation rec {
   doCheck = !stdenv.hostPlatform.isDarwin;
   checkTarget = "test";
 
-  meta = with lib; {
+  meta = {
     description = "Open source implementation of the actor model in C++";
     homepage = "http://actor-framework.org/";
-    license = licenses.bsd3;
-    platforms = platforms.unix;
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
     changelog = "https://github.com/actor-framework/actor-framework/raw/${version}/CHANGELOG.md";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       bobakker
       tobim
     ];

--- a/pkgs/by-name/ca/caffeine-ng/package.nix
+++ b/pkgs/by-name/ca/caffeine-ng/package.nix
@@ -82,13 +82,13 @@ python3Packages.buildPythonApplication rec {
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
-  meta = with lib; {
+  meta = {
     mainProgram = "caffeine";
-    maintainers = with maintainers; [ marzipankaiser ];
+    maintainers = with lib.maintainers; [ marzipankaiser ];
     description = "Status bar application to temporarily inhibit screensaver and sleep mode";
     homepage = "https://codeberg.org/WhyNotHugo/caffeine-ng";
     changelog = "https://codeberg.org/WhyNotHugo/caffeine-ng/src/tag/v${version}/CHANGELOG.rst";
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ca/calcurse/package.nix
+++ b/pkgs/by-name/ca/calcurse/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     patchPythonScript $out/bin/calcurse-caldav
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Calendar and scheduling application for the command line";
     longDescription = ''
       calcurse is a calendar and scheduling application for the command line. It helps
@@ -43,8 +43,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://calcurse.org/";
     changelog = "https://git.calcurse.org/calcurse.git/plain/CHANGES.md?h=v${version}";
-    license = licenses.bsd2;
-    platforms = platforms.unix;
-    maintainers = [ maintainers.matthiasbeyer ];
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.matthiasbeyer ];
   };
 }

--- a/pkgs/by-name/ca/cameradar/package.nix
+++ b/pkgs/by-name/ca/cameradar/package.nix
@@ -33,12 +33,12 @@ buildGoModule rec {
   # At least one test is outdated
   #doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "RTSP stream access tool";
     homepage = "https://github.com/Ullaakut/cameradar";
     changelog = "https://github.com/Ullaakut/cameradar/releases/tag/v${version}";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ fab ];
     # Upstream issue, doesn't build with latest curl, see
     # https://github.com/Ullaakut/cameradar/issues/320
     # https://github.com/andelf/go-curl/issues/84

--- a/pkgs/by-name/ca/cansina/package.nix
+++ b/pkgs/by-name/ca/cansina/package.nix
@@ -29,12 +29,12 @@ python3.pkgs.buildPythonApplication rec {
     "cansina"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Web Content Discovery Tool";
     homepage = "https://github.com/deibit/cansina";
     changelog = "https://github.com/deibit/cansina/blob/${version}/CHANGELOG.md";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cansina";
   };
 }

--- a/pkgs/by-name/ca/cargo-about/package.nix
+++ b/pkgs/by-name/ca/cargo-about/package.nix
@@ -28,15 +28,15 @@ rustPlatform.buildRustPackage rec {
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cargo plugin to generate list of all licenses for a crate";
     homepage = "https://github.com/EmbarkStudios/cargo-about";
     changelog = "https://github.com/EmbarkStudios/cargo-about/blob/${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       evanjs
       figsoda
       matthiasbeyer

--- a/pkgs/by-name/ca/cargo-audit/package.nix
+++ b/pkgs/by-name/ca/cargo-audit/package.nix
@@ -33,16 +33,16 @@ rustPlatform.buildRustPackage rec {
   # The tests require network access which is not available in sandboxed Nix builds.
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Audit Cargo.lock files for crates with security vulnerabilities";
     mainProgram = "cargo-audit";
     homepage = "https://rustsec.org";
     changelog = "https://github.com/rustsec/rustsec/blob/cargo-audit/v${version}/cargo-audit/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       basvandijk
       figsoda
       jk

--- a/pkgs/by-name/ca/cargo-binstall/package.nix
+++ b/pkgs/by-name/ca/cargo-binstall/package.nix
@@ -58,12 +58,12 @@ rustPlatform.buildRustPackage rec {
     "--skip=gh_api_client::test::test_gh_api_client_cargo_binstall_v0_20_1"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool for installing rust binaries as an alternative to building from source";
     mainProgram = "cargo-binstall";
     homepage = "https://github.com/cargo-bins/cargo-binstall";
     changelog = "https://github.com/cargo-bins/cargo-binstall/releases/tag/v${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/by-name/ca/cargo-binutils/package.nix
+++ b/pkgs/by-name/ca/cargo-binutils/package.nix
@@ -16,18 +16,18 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-QdW0HiVhKFuXj7hWZw1lkrFmvVIqbeMKRF2qnBX9wRI=";
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommands to invoke the LLVM tools shipped with the Rust toolchain";
     longDescription = ''
       In order for this to work, you either need to run `rustup component add llvm-tools-preview` or install the `llvm-tools-preview` component using your Nix library (e.g. fenix or rust-overlay)
     '';
     homepage = "https://github.com/rust-embedded/cargo-binutils";
     changelog = "https://github.com/rust-embedded/cargo-binutils/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       stupremee
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-c/package.nix
+++ b/pkgs/by-name/ca/cargo-c/package.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
     inherit rav1e;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand to build and install C-ABI compatible dynamic and static libraries";
     longDescription = ''
       Cargo C-ABI helpers. A cargo applet that produces and installs a correct
@@ -60,8 +60,8 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://github.com/lu-zero/cargo-c";
     changelog = "https://github.com/lu-zero/cargo-c/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       cpu
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-clone/package.nix
+++ b/pkgs/by-name/ca/cargo-clone/package.nix
@@ -31,16 +31,16 @@ rustPlatform.buildRustPackage rec {
   # requires internet access
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand to fetch the source code of a Rust crate";
     mainProgram = "cargo-clone";
     homepage = "https://github.com/janlikar/cargo-clone";
     changelog = "https://github.com/janlikar/cargo-clone/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       matthiasbeyer
       janlikar

--- a/pkgs/by-name/ca/cargo-cross/package.nix
+++ b/pkgs/by-name/ca/cargo-cross/package.nix
@@ -32,15 +32,15 @@ rustPlatform.buildRustPackage rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Zero setup cross compilation and cross testing";
     homepage = "https://github.com/cross-rs/cross";
     changelog = "https://github.com/cross-rs/cross/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ otavio ];
+    maintainers = with lib.maintainers; [ otavio ];
     mainProgram = "cross";
   };
 }

--- a/pkgs/by-name/ca/cargo-deadlinks/package.nix
+++ b/pkgs/by-name/ca/cargo-deadlinks/package.nix
@@ -31,15 +31,15 @@ rustPlatform.buildRustPackage rec {
       # assumes the target is x86_64-unknown-linux-gnu
       "--skip simple_project::it_checks_okay_project_correctly";
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand to check rust documentation for broken links";
     homepage = "https://github.com/deadlinks/cargo-deadlinks";
     changelog = "https://github.com/deadlinks/cargo-deadlinks/blob/${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       newam
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-deny/package.nix
+++ b/pkgs/by-name/ca/cargo-deny/package.nix
@@ -35,16 +35,16 @@ rustPlatform.buildRustPackage rec {
   # tests require internet access
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Cargo plugin for linting your dependencies";
     mainProgram = "cargo-deny";
     homepage = "https://github.com/EmbarkStudios/cargo-deny";
     changelog = "https://github.com/EmbarkStudios/cargo-deny/blob/${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       matthiasbeyer
       jk

--- a/pkgs/by-name/ca/cargo-diet/package.nix
+++ b/pkgs/by-name/ca/cargo-diet/package.nix
@@ -18,13 +18,13 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-crdRRlRi3H8j/ojGH+oqmaeSS8ee8dUALorZPWE/j1Y=";
 
-  meta = with lib; {
+  meta = {
     description = "Help computing optimal include directives for your Cargo.toml manifest";
     mainProgram = "cargo-diet";
     homepage = "https://github.com/the-lean-crate/cargo-diet";
     changelog = "https://github.com/the-lean-crate/cargo-diet/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       figsoda
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-docset/package.nix
+++ b/pkgs/by-name/ca/cargo-docset/package.nix
@@ -26,13 +26,13 @@ rustPlatform.buildRustPackage rec {
     rev-prefix = "v";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand to generate a Dash/Zeal docset for your Rust packages";
     mainProgram = "cargo-docset";
     homepage = "https://github.com/Robzz/cargo-docset";
     changelog = "https://github.com/Robzz/cargo-docset/blob/${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       colinsane
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-edit/package.nix
+++ b/pkgs/by-name/ca/cargo-edit/package.nix
@@ -30,15 +30,15 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = false; # integration tests depend on changing cargo config
 
-  meta = with lib; {
+  meta = {
     description = "Utility for managing cargo dependencies from the command line";
     homepage = "https://github.com/killercup/cargo-edit";
     changelog = "https://github.com/killercup/cargo-edit/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       Br1ght0ne
       figsoda
       gerschtli

--- a/pkgs/by-name/ca/cargo-expand/package.nix
+++ b/pkgs/by-name/ca/cargo-expand/package.nix
@@ -18,15 +18,15 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-4HH25MEj3iCrm9iCW8vWVMDou/F3YidRIWDH0m5FTaY=";
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand to show result of macro expansion";
     homepage = "https://github.com/dtolnay/cargo-expand";
     changelog = "https://github.com/dtolnay/cargo-expand/releases/tag/${version}";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit
       asl20
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       xrelkd
     ];

--- a/pkgs/by-name/ca/cargo-generate/package.nix
+++ b/pkgs/by-name/ca/cargo-generate/package.nix
@@ -71,16 +71,16 @@ rustPlatform.buildRustPackage rec {
     LIBGIT2_NO_VENDOR = 1;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Tool to generate a new Rust project by leveraging a pre-existing git repository as a template";
     mainProgram = "cargo-generate";
     homepage = "https://github.com/cargo-generate/cargo-generate";
     changelog = "https://github.com/cargo-generate/cargo-generate/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       turbomack
       matthiasbeyer

--- a/pkgs/by-name/ca/cargo-hack/package.nix
+++ b/pkgs/by-name/ca/cargo-hack/package.nix
@@ -19,15 +19,15 @@ rustPlatform.buildRustPackage rec {
   # some necessary files are absent in the crate version
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand to provide various options useful for testing and continuous integration";
     mainProgram = "cargo-hack";
     homepage = "https://github.com/taiki-e/cargo-hack";
     changelog = "https://github.com/taiki-e/cargo-hack/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/by-name/ca/cargo-insta/package.nix
+++ b/pkgs/by-name/ca/cargo-insta/package.nix
@@ -29,13 +29,13 @@ rustPlatform.buildRustPackage rec {
     "--skip=env::test_get_cargo_workspace_manifest_dir"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand for snapshot testing";
     mainProgram = "cargo-insta";
     homepage = "https://github.com/mitsuhiko/insta";
     changelog = "https://github.com/mitsuhiko/insta/blob/${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       figsoda
       oxalica
       matthiasbeyer

--- a/pkgs/by-name/ca/cargo-leptos/package.nix
+++ b/pkgs/by-name/ca/cargo-leptos/package.nix
@@ -21,12 +21,12 @@ rustPlatform.buildRustPackage rec {
   buildFeatures = [ "no_downloads" ]; # cargo-leptos will try to install missing dependencies on its own otherwise
   doCheck = false; # Check phase tries to query crates.io
 
-  meta = with lib; {
+  meta = {
     description = "Build tool for the Leptos web framework";
     mainProgram = "cargo-leptos";
     homepage = "https://github.com/leptos-rs/cargo-leptos";
     changelog = "https://github.com/leptos-rs/cargo-leptos/releases/tag/v${version}";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ benwis ];
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ benwis ];
   };
 }

--- a/pkgs/by-name/ca/cargo-lock/package.nix
+++ b/pkgs/by-name/ca/cargo-lock/package.nix
@@ -18,16 +18,16 @@ rustPlatform.buildRustPackage rec {
 
   buildFeatures = [ "cli" ];
 
-  meta = with lib; {
+  meta = {
     description = "Self-contained Cargo.lock parser with graph analysis";
     mainProgram = "cargo-lock";
     homepage = "https://github.com/rustsec/rustsec/tree/main/cargo-lock";
     changelog = "https://github.com/rustsec/rustsec/blob/cargo-lock/v${version}/cargo-lock/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-make/package.nix
+++ b/pkgs/by-name/ca/cargo-make/package.nix
@@ -42,12 +42,12 @@ rustPlatform.buildRustPackage rec {
   #   https://travis-ci.org/sagiegurari/cargo-make
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Rust task runner and build tool";
     homepage = "https://github.com/sagiegurari/cargo-make";
     changelog = "https://github.com/sagiegurari/cargo-make/blob/${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       figsoda
       xrelkd
     ];

--- a/pkgs/by-name/ca/cargo-outdated/package.nix
+++ b/pkgs/by-name/ca/cargo-outdated/package.nix
@@ -23,16 +23,16 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ openssl ];
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand for displaying when Rust dependencies are out of date";
     mainProgram = "cargo-outdated";
     homepage = "https://github.com/kbknapp/cargo-outdated";
     changelog = "https://github.com/kbknapp/cargo-outdated/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       ivan
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-public-api/package.nix
+++ b/pkgs/by-name/ca/cargo-public-api/package.nix
@@ -29,12 +29,12 @@ rustPlatform.buildRustPackage rec {
   # Tests fail
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations";
     mainProgram = "cargo-public-api";
     homepage = "https://github.com/Enselic/cargo-public-api";
     changelog = "https://github.com/Enselic/cargo-public-api/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
   };
 }

--- a/pkgs/by-name/ca/cargo-rdme/package.nix
+++ b/pkgs/by-name/ca/cargo-rdme/package.nix
@@ -16,12 +16,12 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-W800jepxDv6OjbcxRKphAnDU2OuBGGGSLELe8gAfTr8=";
 
-  meta = with lib; {
+  meta = {
     description = "Cargo command to create the README.md from your crate's documentation";
     mainProgram = "cargo-rdme";
     homepage = "https://github.com/orium/cargo-rdme";
     changelog = "https://github.com/orium/cargo-rdme/blob/v${version}/release-notes.md";
-    license = with licenses; [ mpl20 ];
-    maintainers = with maintainers; [ GoldsteinE ];
+    license = with lib.licenses; [ mpl20 ];
+    maintainers = with lib.maintainers; [ GoldsteinE ];
   };
 }

--- a/pkgs/by-name/ca/cargo-release/package.nix
+++ b/pkgs/by-name/ca/cargo-release/package.nix
@@ -44,16 +44,16 @@ rustPlatform.buildRustPackage rec {
   # disable vendored-libgit2 and vendored-openssl
   buildNoDefaultFeatures = true;
 
-  meta = with lib; {
+  meta = {
     description = ''Cargo subcommand "release": everything about releasing a rust crate'';
     mainProgram = "cargo-release";
     homepage = "https://github.com/crate-ci/cargo-release";
     changelog = "https://github.com/crate-ci/cargo-release/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       gerschtli
     ];

--- a/pkgs/by-name/ca/cargo-run-bin/package.nix
+++ b/pkgs/by-name/ca/cargo-run-bin/package.nix
@@ -19,13 +19,13 @@ rustPlatform.buildRustPackage rec {
   # multiple impurities in tests
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Build, cache, and run binaries scoped in Cargo.toml rather than installing globally. This acts similarly to npm run and gomodrun, and allows your teams to always be running the same tooling versions";
     mainProgram = "cargo-bin";
     homepage = "https://github.com/dustinblackman/cargo-run-bin";
     changelog = "https://github.com/dustinblackman/cargo-run-bin/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       mightyiam
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-show-asm/package.nix
+++ b/pkgs/by-name/ca/cargo-show-asm/package.nix
@@ -38,15 +38,15 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand showing the assembly, LLVM-IR and MIR generated for Rust code";
     homepage = "https://github.com/pacak/cargo-show-asm";
     changelog = "https://github.com/pacak/cargo-show-asm/blob/${version}/Changelog.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       oxalica
       matthiasbeyer

--- a/pkgs/by-name/ca/cargo-sort/package.nix
+++ b/pkgs/by-name/ca/cargo-sort/package.nix
@@ -18,16 +18,16 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-nQ1g0rBWx7yHQO9U/J0/XI76quEAvpCyhZDcTJKYYXo=";
 
-  meta = with lib; {
+  meta = {
     description = "Tool to check that your Cargo.toml dependencies are sorted alphabetically";
     mainProgram = "cargo-sort";
     homepage = "https://github.com/devinr528/cargo-sort";
     changelog = "https://github.com/devinr528/cargo-sort/blob/v${version}/changelog.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-spellcheck/package.nix
+++ b/pkgs/by-name/ca/cargo-spellcheck/package.nix
@@ -28,16 +28,16 @@ rustPlatform.buildRustPackage rec {
     "--skip=tests::e2e::issue_226"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Checks rust documentation for spelling and grammar mistakes";
     mainProgram = "cargo-spellcheck";
     homepage = "https://github.com/drahnr/cargo-spellcheck";
     changelog = "https://github.com/drahnr/cargo-spellcheck/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       newam
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-sync-readme/package.nix
+++ b/pkgs/by-name/ca/cargo-sync-readme/package.nix
@@ -18,13 +18,13 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-A1LZKENNOcgUz6eacUo9WCKIZWA7dJa0zuZrgzRr/Js=";
 
-  meta = with lib; {
+  meta = {
     description = "Cargo plugin that generates a Markdown section in your README based on your Rust documentation";
     mainProgram = "cargo-sync-readme";
     homepage = "https://github.com/phaazon/cargo-sync-readme";
     changelog = "https://github.com/phaazon/cargo-sync-readme/blob/${version}/CHANGELOG.md";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
       b4dm4n
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-tally/package.nix
+++ b/pkgs/by-name/ca/cargo-tally/package.nix
@@ -16,16 +16,16 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-9p5IfGfOWyDanaUt1h6bnq4mDxp+VdU4scNdWGRiWYE=";
 
-  meta = with lib; {
+  meta = {
     description = "Graph the number of crates that depend on your crate over time";
     mainProgram = "cargo-tally";
     homepage = "https://github.com/dtolnay/cargo-tally";
     changelog = "https://github.com/dtolnay/cargo-tally/releases/tag/${version}";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-toml-lint/package.nix
+++ b/pkgs/by-name/ca/cargo-toml-lint/package.nix
@@ -16,16 +16,16 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-ymf91oCLOY5vo1pncCT83j3k8wyLEwAl3/8lnAyPdzI=";
 
-  meta = with lib; {
+  meta = {
     description = "Simple linter for Cargo.toml manifests";
     mainProgram = "cargo-toml-lint";
     homepage = "https://github.com/fuellabs/cargo-toml-lint";
     changelog = "https://github.com/fuellabs/cargo-toml-lint/releases/tag/v${version}";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       mitchmindtree
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-ui/package.nix
+++ b/pkgs/by-name/ca/cargo-ui/package.nix
@@ -58,17 +58,17 @@ rustPlatform.buildRustPackage rec {
     LIBGIT2_NO_VENDOR = 1;
   };
 
-  meta = with lib; {
+  meta = {
     description = "GUI for Cargo";
     mainProgram = "cargo-ui";
     homepage = "https://github.com/slint-ui/cargo-ui";
     changelog = "https://github.com/slint-ui/cargo-ui/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit
       asl20
       gpl3Only
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-update/package.nix
+++ b/pkgs/by-name/ca/cargo-update/package.nix
@@ -63,12 +63,12 @@ rustPlatform.buildRustPackage rec {
     LIBGIT2_NO_VENDOR = 1;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cargo subcommand for checking and applying updates to installed executables";
     homepage = "https://github.com/nabijaczleweli/cargo-update";
     changelog = "https://github.com/nabijaczleweli/cargo-update/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       gerschtli
       Br1ght0ne
       johntitor

--- a/pkgs/by-name/ca/cargo-workspaces/package.nix
+++ b/pkgs/by-name/ca/cargo-workspaces/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     LIBSSH2_SYS_USE_PKG_CONFIG = true;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Tool for managing cargo workspaces and their crates, inspired by lerna";
     longDescription = ''
       A tool that optimizes the workflow around cargo workspaces with
@@ -43,8 +43,8 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://github.com/pksunkara/cargo-workspaces";
     changelog = "https://github.com/pksunkara/cargo-workspaces/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       figsoda
       macalinao
       matthiasbeyer

--- a/pkgs/by-name/ca/cargo-zigbuild/package.nix
+++ b/pkgs/by-name/ca/cargo-zigbuild/package.nix
@@ -27,12 +27,12 @@ rustPlatform.buildRustPackage rec {
       --prefix PATH : ${zig}/bin
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Tool to compile Cargo projects with zig as the linker";
     mainProgram = "cargo-zigbuild";
     homepage = "https://github.com/messense/cargo-zigbuild";
     changelog = "https://github.com/messense/cargo-zigbuild/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/by-name/ca/cariddi/package.nix
+++ b/pkgs/by-name/ca/cariddi/package.nix
@@ -22,12 +22,12 @@ buildGoModule rec {
     "-s"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Crawler for URLs and endpoints";
     homepage = "https://github.com/edoardottt/cariddi";
     changelog = "https://github.com/edoardottt/cariddi/releases/tag/v${version}";
-    license = with licenses; [ gpl3Plus ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cariddi";
   };
 }

--- a/pkgs/by-name/ca/cascadia-code/package.nix
+++ b/pkgs/by-name/ca/cascadia-code/package.nix
@@ -33,12 +33,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Monospaced font that includes programming ligatures and is designed to enhance the modern look and feel of the Windows Terminal";
     homepage = "https://github.com/microsoft/cascadia-code";
-    changelog = "https://github.com/microsoft/cascadia-code/raw/v${version}/FONTLOG.txt";
-    license = licenses.ofl;
-    maintainers = with maintainers; [ ryanccn ];
-    platforms = platforms.all;
+    changelog = "https://github.com/microsoft/cascadia-code/raw/v${finalAttrs.version}/FONTLOG.txt";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ ryanccn ];
+    platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/cd/cdecrypt/package.nix
+++ b/pkgs/by-name/cd/cdecrypt/package.nix
@@ -19,13 +19,13 @@ stdenv.mkDerivation rec {
     install -Dm755 cdecrypt $out/bin/cdecrypt
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Utility that decrypts Wii U NUS content files";
     mainProgram = "cdecrypt";
     homepage = "https://github.com/VitaSmith/cdecrypt";
     changelog = "https://github.com/VitaSmith/cdecrypt/releases/tag/v${version}";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ hughobrien ];
-    platforms = platforms.linux ++ platforms.darwin;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ hughobrien ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/pkgs/by-name/cd/cdk-go/package.nix
+++ b/pkgs/by-name/cd/cdk-go/package.nix
@@ -21,12 +21,12 @@ buildGoModule rec {
   # At least one test is outdated
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Container penetration toolkit";
     homepage = "https://github.com/cdk-team/CDK";
     changelog = "https://github.com/cdk-team/CDK/releases/tag/v${version}";
-    license = with licenses; [ gpl2Only ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ gpl2Only ];
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cdk";
     broken = stdenv.hostPlatform.isDarwin; # needs to update gopsutil to at least v3.21.3 to include https://github.com/shirou/gopsutil/pull/1042
   };

--- a/pkgs/by-name/cd/cdncheck/package.nix
+++ b/pkgs/by-name/cd/cdncheck/package.nix
@@ -31,12 +31,12 @@ buildGoModule rec {
       --replace-fail "TestCheckDNSResponse" "SkipTestCheckDNSResponse"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Tool to detect various technology for a given IP address";
     homepage = "https://github.com/projectdiscovery/cdncheck";
     changelog = "https://github.com/projectdiscovery/cdncheck/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cdncheck";
   };
 }

--- a/pkgs/by-name/ce/cent/package.nix
+++ b/pkgs/by-name/ce/cent/package.nix
@@ -22,12 +22,12 @@ buildGoModule rec {
     "-w"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to handle Nuclei community templates";
     homepage = "https://github.com/xm1k3/cent";
     changelog = "https://github.com/xm1k3/cent/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "cent";
   };
 }

--- a/pkgs/by-name/ce/cero/package.nix
+++ b/pkgs/by-name/ce/cero/package.nix
@@ -25,12 +25,12 @@ buildGoModule rec {
   # Tests are comparing output
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Scrape domain names from SSL certificates of arbitrary hosts";
     homepage = "https://github.com/glebarez/cero";
     changelog = "https://github.com/glebarez/cero/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cero";
   };
 }

--- a/pkgs/by-name/ch/chain-bench/package.nix
+++ b/pkgs/by-name/ch/chain-bench/package.nix
@@ -40,7 +40,7 @@ buildGoModule rec {
     runHook postInstallCheck
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/aquasecurity/chain-bench";
     changelog = "https://github.com/aquasecurity/chain-bench/releases/tag/v${version}";
     description = "Open-source tool for auditing your software supply chain stack for security compliance based on a new CIS Software Supply Chain benchmark";
@@ -53,7 +53,7 @@ buildGoModule rec {
       hackers and protect your sensitive data and customer trust, you need to
       ensure your code is compliant with your organization's policies.
     '';
-    license = licenses.asl20;
-    maintainers = with maintainers; [ jk ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jk ];
   };
 }

--- a/pkgs/by-name/ch/changelogger/package.nix
+++ b/pkgs/by-name/ch/changelogger/package.nix
@@ -34,12 +34,12 @@ buildGoModule rec {
       --zsh <($out/bin/changelogger completion zsh)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Tool to manage your changelog file in Markdown";
     homepage = "https://github.com/MarkusFreitag/changelogger";
     changelog = "https://github.com/MarkusFreitag/changelogger/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ tomsiewert ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tomsiewert ];
     mainProgram = "changelogger";
   };
 }

--- a/pkgs/by-name/ch/changie/package.nix
+++ b/pkgs/by-name/ch/changie/package.nix
@@ -35,13 +35,13 @@ buildGoModule rec {
       --zsh <($out/bin/changie completion zsh)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Automated changelog tool for preparing releases with lots of customization options";
     mainProgram = "changie";
     homepage = "https://changie.dev";
     changelog = "https://github.com/miniscruff/changie/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       figsoda
       matthiasbeyer
     ];

--- a/pkgs/by-name/ch/chaos/package.nix
+++ b/pkgs/by-name/ch/chaos/package.nix
@@ -31,12 +31,12 @@ buildGoModule rec {
 
   versionCheckProgramArg = "--version";
 
-  meta = with lib; {
+  meta = {
     description = "Tool to communicate with Chaos DNS API";
     homepage = "https://github.com/projectdiscovery/chaos-client";
     changelog = "https://github.com/projectdiscovery/chaos-client/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "chaos";
   };
 }

--- a/pkgs/by-name/ch/charm-freeze/package.nix
+++ b/pkgs/by-name/ch/charm-freeze/package.nix
@@ -23,13 +23,13 @@ buildGoModule rec {
     "-X=main.Version=${version}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to generate images of code and terminal output";
     mainProgram = "freeze";
     homepage = "https://github.com/charmbracelet/freeze";
     changelog = "https://github.com/charmbracelet/freeze/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       caarlos0
       maaslalani
     ];

--- a/pkgs/by-name/ch/charm/package.nix
+++ b/pkgs/by-name/ch/charm/package.nix
@@ -23,12 +23,12 @@ buildGoModule rec {
     "-X=main.Version=${version}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Manage your charm account on the CLI";
     homepage = "https://github.com/charmbracelet/charm";
     changelog = "https://github.com/charmbracelet/charm/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ penguwin ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ penguwin ];
     mainProgram = "charm";
   };
 }

--- a/pkgs/by-name/ch/checkip/package.nix
+++ b/pkgs/by-name/ch/checkip/package.nix
@@ -25,12 +25,12 @@ buildGoModule rec {
   # Requires network
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "CLI tool that checks an IP address using various public services";
     homepage = "https://github.com/jreisinger/checkip";
     changelog = "https://github.com/jreisinger/checkip/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "checkip";
   };
 }

--- a/pkgs/by-name/ch/checkmate/package.nix
+++ b/pkgs/by-name/ch/checkmate/package.nix
@@ -19,12 +19,12 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  meta = with lib; {
+  meta = {
     description = "Pluggable code security analysis tool";
     mainProgram = "checkmate";
     homepage = "https://github.com/adedayo/checkmate";
     changelog = "https://github.com/adedayo/checkmate/releases/tag/v${version}";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/ch/checkov/package.nix
+++ b/pkgs/by-name/ch/checkov/package.nix
@@ -179,7 +179,7 @@ python3.pkgs.buildPythonApplication rec {
     chmod +x $out/bin/checkov
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Static code analysis tool for infrastructure-as-code";
     homepage = "https://github.com/bridgecrewio/checkov";
     changelog = "https://github.com/bridgecrewio/checkov/releases/tag/${version}";
@@ -187,8 +187,8 @@ python3.pkgs.buildPythonApplication rec {
       Prevent cloud misconfigurations during build-time for Terraform, Cloudformation,
       Kubernetes, Serverless framework and other infrastructure-as-code-languages.
     '';
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       anhdle14
       fab
     ];

--- a/pkgs/by-name/ch/checkpwn/package.nix
+++ b/pkgs/by-name/ch/checkpwn/package.nix
@@ -21,12 +21,12 @@ rustPlatform.buildRustPackage rec {
     "--skip=test_cli_"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Check Have I Been Pwned and see if it's time for you to change passwords";
     homepage = "https://github.com/brycx/checkpwn";
     changelog = "https://github.com/brycx/checkpwn/releases/tag/${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "checkpwn";
   };
 }

--- a/pkgs/by-name/ch/checkstyle/package.nix
+++ b/pkgs/by-name/ch/checkstyle/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Checks Java source against a coding standard";
     mainProgram = "checkstyle";
     longDescription = ''
@@ -38,9 +38,9 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "https://checkstyle.org/";
     changelog = "https://checkstyle.org/releasenotes.html#Release_${version}";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.lgpl21;
-    maintainers = with maintainers; [ pSub ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ pSub ];
     platforms = jre.meta.platforms;
   };
 }

--- a/pkgs/by-name/ch/cheese/package.nix
+++ b/pkgs/by-name/ch/cheese/package.nix
@@ -109,13 +109,13 @@ stdenv.mkDerivation rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.gnome.org/GNOME/cheese";
     changelog = "https://gitlab.gnome.org/GNOME/cheese/-/blob/${version}/NEWS?ref_type=tags";
     description = "Take photos and videos with your webcam, with fun graphical effects";
     mainProgram = "cheese";
-    maintainers = with maintainers; [ aleksana ];
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ aleksana ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/ch/cherrybomb/package.nix
+++ b/pkgs/by-name/ch/cherrybomb/package.nix
@@ -16,12 +16,12 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-j9CT2HHFY4ANWKvx8t/jgCc3aOiSEJlq8CHstjSc+O4=";
 
-  meta = with lib; {
+  meta = {
     description = "CLI tool that helps you avoid undefined user behavior by validating your API specifications";
     mainProgram = "cherrybomb";
     homepage = "https://github.com/blst-security/cherrybomb";
     changelog = "https://github.com/blst-security/cherrybomb/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/by-name/ch/chisel/package.nix
+++ b/pkgs/by-name/ch/chisel/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
   # Tests require access to the network
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "TCP/UDP tunnel over HTTP";
     longDescription = ''
       Chisel is a fast TCP/UDP tunnel, transported over HTTP, secured via
@@ -36,7 +36,7 @@ buildGoModule rec {
     '';
     homepage = "https://github.com/jpillora/chisel";
     changelog = "https://github.com/jpillora/chisel/releases/tag/v${version}";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/cl/clair/package.nix
+++ b/pkgs/by-name/cl/clair/package.nix
@@ -45,11 +45,11 @@ buildGoModule rec {
       }"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Vulnerability Static Analysis for Containers";
     homepage = "https://github.com/quay/clair";
     changelog = "https://github.com/quay/clair/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/cl/clairvoyance/package.nix
+++ b/pkgs/by-name/cl/clairvoyance/package.nix
@@ -46,12 +46,12 @@ python3.pkgs.buildPythonApplication rec {
     "test_probe_typename"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to obtain GraphQL API schemas";
     mainProgram = "clairvoyance";
     homepage = "https://github.com/nikitastupin/clairvoyance";
     changelog = "https://github.com/nikitastupin/clairvoyance/releases/tag/v${version}";
-    license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/cl/clever-tools/package.nix
+++ b/pkgs/by-name/cl/clever-tools/package.nix
@@ -46,12 +46,12 @@ buildNpmPackage rec {
       --zsh <($out/bin/clever --zsh-autocomplete-script $out/bin/clever)
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/CleverCloud/clever-tools";
     changelog = "https://github.com/CleverCloud/clever-tools/blob/${version}/CHANGELOG.md";
     description = "Deploy on Clever Cloud and control your applications, add-ons, services from command line";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     mainProgram = "clever";
-    teams = [ teams.clevercloud ];
+    teams = [ lib.teams.clevercloud ];
   };
 }

--- a/pkgs/by-name/cl/clj-kondo/package.nix
+++ b/pkgs/by-name/cl/clj-kondo/package.nix
@@ -21,13 +21,13 @@ buildGraalvmNativeImage rec {
     "--no-fallback"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Linter for Clojure code that sparks joy";
     homepage = "https://github.com/clj-kondo/clj-kondo";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.epl10;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.epl10;
     changelog = "https://github.com/clj-kondo/clj-kondo/blob/v${version}/CHANGELOG.md";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       jlesquembre
       bandresen
     ];

--- a/pkgs/by-name/cl/cljfmt/package.nix
+++ b/pkgs/by-name/cl/cljfmt/package.nix
@@ -33,13 +33,13 @@ buildGraalvmNativeImage rec {
     command = "cljfmt --version";
   };
 
-  meta = with lib; {
+  meta = {
     mainProgram = "cljfmt";
     description = "Tool for formatting Clojure code";
     homepage = "https://github.com/weavejester/cljfmt";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.epl10;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.epl10;
     changelog = "https://github.com/weavejester/cljfmt/blob/${version}/CHANGELOG.md";
-    maintainers = with maintainers; [ sg-qwt ];
+    maintainers = with lib.maintainers; [ sg-qwt ];
   };
 }

--- a/pkgs/by-name/cl/cloud-custodian/package.nix
+++ b/pkgs/by-name/cl/cloud-custodian/package.nix
@@ -45,12 +45,12 @@ python3.pkgs.buildPythonApplication rec {
     $out/bin/custodian --help
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Rules engine for cloud security, cost optimization, and governance";
     homepage = "https://cloudcustodian.io";
     changelog = "https://github.com/cloud-custodian/cloud-custodian/releases/tag/${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ bhipple ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bhipple ];
     mainProgram = "custodian";
   };
 }

--- a/pkgs/by-name/cl/cloud-hypervisor/package.nix
+++ b/pkgs/by-name/cl/cloud-hypervisor/package.nix
@@ -42,16 +42,16 @@ rustPlatform.buildRustPackage rec {
     "vmm" # /dev/kvm
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor";
     description = "Open source Virtual Machine Monitor (VMM) that runs on top of KVM";
     changelog = "https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v${version}";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20
       bsd3
     ];
     mainProgram = "cloud-hypervisor";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       offline
       qyliss
     ];

--- a/pkgs/by-name/cl/cloud-nuke/package.nix
+++ b/pkgs/by-name/cl/cloud-nuke/package.nix
@@ -34,12 +34,12 @@ buildGoModule rec {
     wrapProgram $out/bin/cloud-nuke --set-default DISABLE_TELEMETRY true
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/gruntwork-io/cloud-nuke";
     description = "Tool for cleaning up your cloud accounts by nuking (deleting) all resources within it";
     mainProgram = "cloud-nuke";
     changelog = "https://github.com/gruntwork-io/cloud-nuke/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/cl/cloudflare-dynamic-dns/package.nix
+++ b/pkgs/by-name/cl/cloudflare-dynamic-dns/package.nix
@@ -32,12 +32,12 @@ buildGoModule rec {
 
   passthru.tests.version = testers.testVersion { package = cloudflare-dynamic-dns; };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/Zebradil/cloudflare-dynamic-dns/blob/${version}/CHANGELOG.md";
     description = "Dynamic DNS client for Cloudflare";
     homepage = "https://github.com/Zebradil/cloudflare-dynamic-dns";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "cloudflare-dynamic-dns";
-    maintainers = [ maintainers.zebradil ];
+    maintainers = [ lib.maintainers.zebradil ];
   };
 }

--- a/pkgs/by-name/cl/cloudflared/package.nix
+++ b/pkgs/by-name/cl/cloudflared/package.nix
@@ -77,13 +77,13 @@ buildGoModule rec {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cloudflare Tunnel daemon, Cloudflare Access toolkit, and DNS-over-HTTPS client";
     homepage = "https://www.cloudflare.com/products/tunnel";
     changelog = "https://github.com/cloudflare/cloudflared/releases/tag/${version}";
-    license = licenses.asl20;
-    platforms = platforms.unix ++ platforms.windows;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+    maintainers = with lib.maintainers; [
       bbigras
       enorris
       thoughtpolice

--- a/pkgs/by-name/cl/cloudfox/package.nix
+++ b/pkgs/by-name/cl/cloudfox/package.nix
@@ -25,12 +25,12 @@ buildGoModule rec {
   # Some tests are failing because of wrong filename/path
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Tool for situational awareness of cloud penetration tests";
     homepage = "https://github.com/BishopFox/cloudfox";
     changelog = "https://github.com/BishopFox/cloudfox/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cloudfox";
   };
 }

--- a/pkgs/by-name/cl/cloudhunter/package.nix
+++ b/pkgs/by-name/cl/cloudhunter/package.nix
@@ -42,12 +42,12 @@ python3.pkgs.buildPythonApplication rec {
   # Project has no tests
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Cloud bucket scanner";
     mainProgram = "cloudhunter";
     homepage = "https://github.com/belane/CloudHunter";
     changelog = "https://github.com/belane/CloudHunter/releases/tag/v${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/cl/cloudlist/package.nix
+++ b/pkgs/by-name/cl/cloudlist/package.nix
@@ -31,12 +31,12 @@ buildGoModule rec {
 
   versionCheckProgramArg = "--version";
 
-  meta = with lib; {
+  meta = {
     description = "Tool for listing assets from multiple cloud providers";
     homepage = "https://github.com/projectdiscovery/cloudlist";
     changelog = "https://github.com/projectdiscovery/cloudlist/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cloudlist";
   };
 }

--- a/pkgs/by-name/cl/cloudrecon/package.nix
+++ b/pkgs/by-name/cl/cloudrecon/package.nix
@@ -22,12 +22,12 @@ buildGoModule rec {
     "-w"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to find assets from certificates";
     homepage = "https://github.com/g0ldencybersec/CloudRecon";
     changelog = "https://github.com/g0ldencybersec/CloudRecon/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cloudrecon";
   };
 }

--- a/pkgs/by-name/cl/cloudsmith-cli/package.nix
+++ b/pkgs/by-name/cl/cloudsmith-cli/package.nix
@@ -81,13 +81,13 @@ python3.pkgs.buildPythonApplication rec {
     cd "$out"
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://help.cloudsmith.io/docs/cli/";
     description = "Cloudsmith Command Line Interface";
     mainProgram = "cloudsmith";
     changelog = "https://github.com/cloudsmith-io/cloudsmith-cli/blob/v${version}/CHANGELOG.md";
-    maintainers = [ ];
-    license = licenses.asl20;
-    platforms = with platforms; unix;
+    maintainers = with lib.maintainers; [ ];
+    license = lib.licenses.asl20;
+    platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/by-name/cm/cmark-gfm/package.nix
+++ b/pkgs/by-name/cm/cmark-gfm/package.nix
@@ -19,13 +19,13 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "GitHub's fork of cmark, a CommonMark parsing and rendering library and program in C";
     mainProgram = "cmark-gfm";
     homepage = "https://github.com/github/cmark-gfm";
     changelog = "https://github.com/github/cmark-gfm/raw/${version}/changelog.txt";
-    maintainers = with maintainers; [ cyplo ];
-    platforms = platforms.unix;
-    license = licenses.bsd2;
+    maintainers = with lib.maintainers; [ cyplo ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/by-name/cm/cmark/package.nix
+++ b/pkgs/by-name/cm/cmark/package.nix
@@ -34,13 +34,13 @@ stdenv.mkDerivation rec {
       export ${lib_path}=$(readlink -f ./src)
     '';
 
-  meta = with lib; {
+  meta = {
     description = "CommonMark parsing and rendering library and program in C";
     mainProgram = "cmark";
     homepage = "https://github.com/commonmark/cmark";
     changelog = "https://github.com/commonmark/cmark/raw/${version}/changelog.txt";
-    maintainers = [ maintainers.michelk ];
-    platforms = platforms.all;
-    license = licenses.bsd2;
+    maintainers = [ lib.maintainers.michelk ];
+    platforms = lib.platforms.all;
+    license = lib.licenses.bsd2;
   };
 }

--- a/pkgs/by-name/cn/cnquery/package.nix
+++ b/pkgs/by-name/cn/cnquery/package.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
     "-s"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Cloud-native, graph-based asset inventory";
     longDescription = ''
       cnquery is a cloud-native tool for querying your entire fleet. It answers thousands of
@@ -33,7 +33,7 @@ buildGoModule rec {
     '';
     homepage = "https://mondoo.com/cnquery";
     changelog = "https://github.com/mondoohq/cnquery/releases/tag/v${version}";
-    license = licenses.bsl11;
-    maintainers = with maintainers; [ mariuskimmina ];
+    license = lib.licenses.bsl11;
+    maintainers = with lib.maintainers; [ mariuskimmina ];
   };
 }

--- a/pkgs/by-name/co/cobra-cli/package.nix
+++ b/pkgs/by-name/co/cobra-cli/package.nix
@@ -35,12 +35,12 @@ buildGoModule rec {
       --prefix PATH : ${go}/bin
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Cobra CLI tool to generate applications and commands";
     mainProgram = "cobra-cli";
     homepage = "https://github.com/spf13/cobra-cli/";
     changelog = "https://github.com/spf13/cobra-cli/releases/tag/${version}";
-    license = licenses.afl20;
-    maintainers = [ maintainers.ivankovnatsky ];
+    license = lib.licenses.afl20;
+    maintainers = [ lib.maintainers.ivankovnatsky ];
   };
 }

--- a/pkgs/by-name/co/codeberg-pages/package.nix
+++ b/pkgs/by-name/co/codeberg-pages/package.nix
@@ -39,13 +39,13 @@ buildGoModule rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     mainProgram = "pages";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       laurent-f1z1
       christoph-heiss
     ];
-    license = licenses.eupl12;
+    license = lib.licenses.eupl12;
     homepage = "https://codeberg.org/Codeberg/pages-server";
     description = "Static websites hosting from Gitea repositories";
     changelog = "https://codeberg.org/Codeberg/pages-server/releases/tag/v${version}";

--- a/pkgs/by-name/co/codechecker/package.nix
+++ b/pkgs/by-name/co/codechecker/package.nix
@@ -110,19 +110,19 @@ python3Packages.buildPythonApplication rec {
     }
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/Ericsson/codechecker";
     changelog = "https://github.com/Ericsson/codechecker/releases/tag/v${version}";
     description = "Analyzer tooling, defect database and viewer extension for the Clang Static Analyzer and Clang Tidy";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20
       llvm-exception
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       zebreus
       felixsinger
     ];
     mainProgram = "CodeChecker";
-    platforms = platforms.darwin ++ platforms.linux;
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/co/coercer/package.nix
+++ b/pkgs/by-name/co/coercer/package.nix
@@ -33,12 +33,12 @@ python3.pkgs.buildPythonApplication rec {
     rm Coercer.py
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Tool to automatically coerce a Windows server";
     homepage = "https://github.com/p0dalirius/Coercer";
     changelog = "https://github.com/p0dalirius/Coercer/releases/tag/${version}";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "coercer";
   };
 }

--- a/pkgs/by-name/co/coinlive/package.nix
+++ b/pkgs/by-name/co/coinlive/package.nix
@@ -36,12 +36,12 @@ rustPlatform.buildRustPackage rec {
 
   doInstallCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Live cryptocurrency prices CLI";
     homepage = "https://github.com/mayeranalytics/coinlive";
     changelog = "https://github.com/mayeranalytics/coinlive/releases/tag/v${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "coinlive";
   };
 }

--- a/pkgs/by-name/co/commitmsgfmt/package.nix
+++ b/pkgs/by-name/co/commitmsgfmt/package.nix
@@ -23,12 +23,12 @@ rustPlatform.buildRustPackage rec {
     command = "commitmsgfmt -V";
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://gitlab.com/mkjeldsen/commitmsgfmt";
     changelog = "https://gitlab.com/mkjeldsen/commitmsgfmt/-/raw/v${version}/CHANGELOG.md";
     description = "Formats commit messages better than fmt(1) and Vim";
     mainProgram = "commitmsgfmt";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ mmlb ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mmlb ];
   };
 }

--- a/pkgs/by-name/co/commix/package.nix
+++ b/pkgs/by-name/co/commix/package.nix
@@ -34,12 +34,12 @@ python3.pkgs.buildPythonApplication rec {
   # Project has no tests
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Automated Command Injection Exploitation Tool";
     mainProgram = "commix";
     homepage = "https://github.com/commixproject/commix";
     changelog = "https://github.com/commixproject/commix/releases/tag/v${version}";
-    license = with licenses; [ gpl3Plus ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/co/comodoro/package.nix
+++ b/pkgs/by-name/co/comodoro/package.nix
@@ -41,12 +41,12 @@ rustPlatform.buildRustPackage rec {
         --zsh <($out/bin/comodoro completion zsh)
     '';
 
-  meta = with lib; {
+  meta = {
     description = "CLI to manage your time";
     homepage = "https://github.com/pimalaya/comodoro";
     changelog = "https://github.com/soywod/comodoro/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ soywod ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ soywod ];
     mainProgram = "comodoro";
   };
 }

--- a/pkgs/by-name/co/comrak/package.nix
+++ b/pkgs/by-name/co/comrak/package.nix
@@ -18,13 +18,13 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-MFSyxoNzPzIP2Yi3lCyEcsAx4DvNmk2Jr75oD/tX9iE=";
 
-  meta = with lib; {
+  meta = {
     description = "CommonMark-compatible GitHub Flavored Markdown parser and formatter";
     mainProgram = "comrak";
     homepage = "https://github.com/kivikakk/comrak";
     changelog = "https://github.com/kivikakk/comrak/blob/v${version}/changelog.txt";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
       figsoda
       kivikakk
     ];

--- a/pkgs/by-name/co/conkeyscan/package.nix
+++ b/pkgs/by-name/co/conkeyscan/package.nix
@@ -57,12 +57,12 @@ python.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "conkeyscan" ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to scan Confluence for keywords";
     homepage = "https://github.com/CompassSecurity/conkeyscan";
     changelog = "https://github.com/CompassSecurity/conkeyscan/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "conkeyscan";
   };
 }

--- a/pkgs/by-name/co/conpass/package.nix
+++ b/pkgs/by-name/co/conpass/package.nix
@@ -31,12 +31,12 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "conpass" ];
 
-  meta = with lib; {
+  meta = {
     description = "Continuous password spraying tool";
     homepage = "https://github.com/login-securite/conpass";
     changelog = "https://github.com/login-securite/conpass/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "conpass";
   };
 }

--- a/pkgs/by-name/co/consul/package.nix
+++ b/pkgs/by-name/co/consul/package.nix
@@ -50,13 +50,13 @@ buildGoModule rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Tool for service discovery, monitoring and configuration";
     changelog = "https://github.com/hashicorp/consul/releases/tag/v${version}";
     homepage = "https://www.consul.io/";
-    platforms = platforms.linux ++ platforms.darwin;
-    license = licenses.bsl11;
-    maintainers = with maintainers; [
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    license = lib.licenses.bsl11;
+    maintainers = with lib.maintainers; [
       adamcstephens
       pradeepchhetri
       vdemeester

--- a/pkgs/by-name/co/container2wasm/package.nix
+++ b/pkgs/by-name/co/container2wasm/package.nix
@@ -27,12 +27,12 @@ buildGoModule rec {
     "cmd/c2w"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Container to WASM converter";
     homepage = "https://github.com/ktock/container2wasm";
     changelog = "https://github.com/ktock/container2wasm/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ dit7ya ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dit7ya ];
     mainProgram = "c2w";
   };
 }

--- a/pkgs/by-name/co/copilot-cli/package.nix
+++ b/pkgs/by-name/co/copilot-cli/package.nix
@@ -45,12 +45,12 @@ buildGoModule rec {
     version = "v${version}";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Build, Release and Operate Containerized Applications on AWS";
     homepage = "https://github.com/aws/copilot-cli";
     changelog = "https://github.com/aws/copilot-cli/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ jiegec ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jiegec ];
     mainProgram = "copilot";
   };
 }

--- a/pkgs/by-name/co/coreth/package.nix
+++ b/pkgs/by-name/co/coreth/package.nix
@@ -35,11 +35,11 @@ buildGoModule rec {
 
   postInstall = "mv $out/bin/{plugin,evm}";
 
-  meta = with lib; {
+  meta = {
     description = "Code and wrapper to extract Ethereum blockchain functionalities without network/consensus, for building custom blockchain services";
     homepage = "https://github.com/ava-labs/coreth";
     changelog = "https://github.com/ava-labs/coreth/releases/tag/v${version}";
-    license = licenses.lgpl3Only;
-    maintainers = with maintainers; [ urandom ];
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ urandom ];
   };
 }

--- a/pkgs/by-name/co/coturn/package.nix
+++ b/pkgs/by-name/co/coturn/package.nix
@@ -61,13 +61,13 @@ stdenv.mkDerivation rec {
 
   passthru.tests.coturn = nixosTests.coturn;
 
-  meta = with lib; {
+  meta = {
     description = "TURN server";
     homepage = "https://coturn.net/";
     changelog = "https://github.com/coturn/coturn/blob/${version}/ChangeLog";
-    license = with licenses; [ bsd3 ];
-    platforms = platforms.all;
-    maintainers = with maintainers; [ _0x4A6F ];
+    license = with lib.licenses; [ bsd3 ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ _0x4A6F ];
     broken = stdenv.hostPlatform.isDarwin; # 2018-10-21
   };
 }

--- a/pkgs/by-name/co/cozette/package.nix
+++ b/pkgs/by-name/co/cozette/package.nix
@@ -28,12 +28,12 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Bitmap programming font optimized for coziness";
     homepage = "https://github.com/slavfox/cozette";
     changelog = "https://github.com/slavfox/Cozette/blob/v.${version}/CHANGELOG.md";
-    license = licenses.mit;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ brettlyons ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ brettlyons ];
   };
 }

--- a/pkgs/by-name/cp/cpufetch/package.nix
+++ b/pkgs/by-name/cp/cpufetch/package.nix
@@ -31,12 +31,12 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Simplistic yet fancy CPU architecture fetching tool";
-    license = licenses.gpl2Only;
+    license = lib.licenses.gpl2Only;
     homepage = "https://github.com/Dr-Noob/cpufetch";
     changelog = "https://github.com/Dr-Noob/cpufetch/releases/tag/v${version}";
-    maintainers = with maintainers; [ devhell ];
+    maintainers = with lib.maintainers; [ devhell ];
     mainProgram = "cpufetch";
   };
 }

--- a/pkgs/by-name/cr/crabz/package.nix
+++ b/pkgs/by-name/cr/crabz/package.nix
@@ -21,15 +21,15 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ cmake ];
 
-  meta = with lib; {
+  meta = {
     description = "Cross platform, fast, compression and decompression tool";
     homepage = "https://github.com/sstadick/crabz";
     changelog = "https://github.com/sstadick/crabz/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       unlicense # or
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "crabz";
   };
 }

--- a/pkgs/by-name/cr/crcpp/package.nix
+++ b/pkgs/by-name/cr/crcpp/package.nix
@@ -20,12 +20,12 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/d-bahr/CRCpp";
     changelog = "https://github.com/d-bahr/CRCpp/releases/tag/release-${version}";
     description = "Easy to use and fast C++ CRC library";
-    platforms = platforms.all;
-    maintainers = [ ];
-    license = licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ];
+    license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/by-name/cr/crossplane-cli/package.nix
+++ b/pkgs/by-name/cr/crossplane-cli/package.nix
@@ -40,12 +40,12 @@ buildGoModule rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.crossplane.io/";
     changelog = "https://github.com/crossplane/crossplane/releases/tag/v${version}";
     description = "Utility to make using Crossplane easier";
     mainProgram = "crossplane";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ selfuryon ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ selfuryon ];
   };
 }

--- a/pkgs/by-name/cr/crosswords/package.nix
+++ b/pkgs/by-name/cr/crosswords/package.nix
@@ -40,13 +40,13 @@ stdenv.mkDerivation rec {
     libipuz
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Crossword player and editor for GNOME";
     homepage = "https://gitlab.gnome.org/jrb/crosswords";
     changelog = "https://gitlab.gnome.org/jrb/crosswords/-/blob/${version}/NEWS.md?ref_type=tags";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
     mainProgram = "crosswords";
-    maintainers = with maintainers; [ aleksana ];
-    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ aleksana ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/cr/crowdsec/package.nix
+++ b/pkgs/by-name/cr/crowdsec/package.nix
@@ -62,7 +62,7 @@ buildGoModule rec {
     fi
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://crowdsec.net/";
     changelog = "https://github.com/crowdsecurity/crowdsec/releases/tag/v${version}";
     description = "CrowdSec is a free, open-source and collaborative IPS";
@@ -77,8 +77,8 @@ buildGoModule rec {
       etc.) while the aggressive IP can be sent to CrowdSec for curation before
       being shared among all users to further improve everyone's security.
     '';
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       jk
       urandom
     ];

--- a/pkgs/by-name/cr/crun/package.nix
+++ b/pkgs/by-name/cr/crun/package.nix
@@ -85,13 +85,13 @@ stdenv.mkDerivation rec {
 
   passthru.tests = { inherit (nixosTests) podman; };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/containers/crun/releases/tag/${version}";
     description = "Fast and lightweight fully featured OCI runtime and C library for running containers";
     homepage = "https://github.com/containers/crun";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-    teams = [ teams.podman ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.podman ];
     mainProgram = "crun";
   };
 }

--- a/pkgs/by-name/cr/cryfs/package.nix
+++ b/pkgs/by-name/cr/cryfs/package.nix
@@ -90,16 +90,16 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Cryptographic filesystem for the cloud";
     homepage = "https://www.cryfs.org/";
     changelog = "https://github.com/cryfs/cryfs/raw/${version}/ChangeLog.txt";
-    license = licenses.lgpl3Only;
-    maintainers = with maintainers; [
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [
       peterhoeg
       c0bw3b
       sigmasquadron
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/cy/cyberchef/package.nix
+++ b/pkgs/by-name/cy/cyberchef/package.nix
@@ -20,12 +20,12 @@ stdenv.mkDerivation rec {
     mv * "$out/share/cyberchef"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Cyber Swiss Army Knife for encryption, encoding, compression and data analysis";
     homepage = "https://gchq.github.io/CyberChef";
     changelog = "https://github.com/gchq/CyberChef/blob/v${version}/CHANGELOG.md";
-    maintainers = with maintainers; [ sebastianblunt ];
-    license = licenses.asl20;
-    platforms = platforms.all;
+    maintainers = with lib.maintainers; [ sebastianblunt ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/cy/cyclonedx-cli/package.nix
+++ b/pkgs/by-name/cy/cyclonedx-cli/package.nix
@@ -29,14 +29,14 @@ buildDotnetModule rec {
       --replace-fail 'net6.0' 'net8.0'
   '';
 
-  meta = with lib; {
+  meta = {
     description = "CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions";
     homepage = "https://github.com/CycloneDX/cyclonedx-cli";
     changelog = "https://github.com/CycloneDX/cyclonedx-cli/releases/tag/v${version}";
-    maintainers = with maintainers; [ thillux ];
-    teams = [ teams.cyberus ];
-    license = licenses.asl20;
-    platforms = with platforms; (linux ++ darwin);
+    maintainers = with lib.maintainers; [ thillux ];
+    teams = [ lib.teams.cyberus ];
+    license = lib.licenses.asl20;
+    platforms = with lib.platforms; (linux ++ darwin);
     mainProgram = "cyclonedx";
   };
 }

--- a/pkgs/by-name/da/dalfox/package.nix
+++ b/pkgs/by-name/da/dalfox/package.nix
@@ -25,12 +25,12 @@ buildGoModule rec {
   # Tests require network access
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Tool for analysing parameter and XSS scanning";
     homepage = "https://github.com/hahwul/dalfox";
     changelog = "https://github.com/hahwul/dalfox/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "dalfox";
   };
 }

--- a/pkgs/by-name/da/darkstat/package.nix
+++ b/pkgs/by-name/da/darkstat/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "Network statistics web interface";
     longDescription = ''
       Captures network traffic, calculates statistics about usage, and serves
@@ -52,8 +52,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://unix4lyfe.org/darkstat";
     changelog = "https://github.com/emikulic/darkstat/releases/tag/${version}";
-    license = licenses.gpl2Only;
-    platforms = with platforms; unix;
+    license = lib.licenses.gpl2Only;
+    platforms = with lib.platforms; unix;
     mainProgram = "darkstat";
   };
 }

--- a/pkgs/by-name/da/darktile/package.nix
+++ b/pkgs/by-name/da/darktile/package.nix
@@ -42,15 +42,15 @@ buildGoModule rec {
 
   passthru.tests.test = nixosTests.terminal-emulators.darktile;
 
-  meta = with lib; {
+  meta = {
     description = "GPU rendered terminal emulator designed for tiling window managers";
     homepage = "https://github.com/liamg/darktile";
     downloadPage = "https://github.com/liamg/darktile/releases";
     changelog = "https://github.com/liamg/darktile/releases/tag/v${version}";
-    license = licenses.mit;
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
     badPlatforms = [ "aarch64-linux" ];
-    maintainers = with maintainers; [ mikaelfangel ];
+    maintainers = with lib.maintainers; [ mikaelfangel ];
     mainProgram = "darktile";
   };
 }

--- a/pkgs/by-name/da/das/package.nix
+++ b/pkgs/by-name/da/das/package.nix
@@ -40,12 +40,12 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "das" ];
 
-  meta = with lib; {
+  meta = {
     description = "Divide full port scan results and use it for targeted Nmap runs";
     homepage = "https://github.com/snovvcrash/DivideAndScan";
     changelog = "https://github.com/snovvcrash/DivideAndScan/releases/tag/v${version}";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "das";
   };
 }

--- a/pkgs/by-name/da/dasel/package.nix
+++ b/pkgs/by-name/da/dasel/package.nix
@@ -47,7 +47,7 @@ buildGoModule rec {
     runHook postInstallCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Query and update data structures from the command line";
     longDescription = ''
       Dasel (short for data-selector) allows you to query and modify data structures using selector strings.
@@ -55,8 +55,8 @@ buildGoModule rec {
     '';
     homepage = "https://github.com/TomWright/dasel";
     changelog = "https://github.com/TomWright/dasel/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "dasel";
-    maintainers = with maintainers; [ _0x4A6F ];
+    maintainers = with lib.maintainers; [ _0x4A6F ];
   };
 }

--- a/pkgs/by-name/da/databricks-sql-cli/package.nix
+++ b/pkgs/by-name/da/databricks-sql-cli/package.nix
@@ -42,12 +42,12 @@ python3.pkgs.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  meta = with lib; {
+  meta = {
     description = "CLI for querying Databricks SQL";
     mainProgram = "dbsqlcli";
     homepage = "https://github.com/databricks/databricks-sql-cli";
     changelog = "https://github.com/databricks/databricks-sql-cli/releases/tag/v${version}";
-    license = licenses.databricks;
-    maintainers = with maintainers; [ kfollesdal ];
+    license = lib.licenses.databricks;
+    maintainers = with lib.maintainers; [ kfollesdal ];
   };
 }

--- a/pkgs/by-name/da/datree/package.nix
+++ b/pkgs/by-name/da/datree/package.nix
@@ -43,7 +43,7 @@ buildGoModule rec {
     command = "datree version";
   };
 
-  meta = with lib; {
+  meta = {
     description = "CLI tool to ensure K8s manifests and Helm charts follow best practices";
     mainProgram = "datree";
     longDescription = ''
@@ -54,8 +54,8 @@ buildGoModule rec {
     '';
     homepage = "https://datree.io/";
     changelog = "https://github.com/datreeio/datree/releases/tag/${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       azahi
       jceb
     ];

--- a/pkgs/by-name/da/dav1d/package.nix
+++ b/pkgs/by-name/da/dav1d/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
       ;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cross-platform AV1 decoder focused on speed and correctness";
     longDescription = ''
       The goal of this project is to provide a decoder for most platforms, and
@@ -85,8 +85,8 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     changelog = "https://code.videolan.org/videolan/dav1d/-/tags/${version}";
     # More technical: https://code.videolan.org/videolan/dav1d/blob/${version}/NEWS
-    license = licenses.bsd2;
-    platforms = platforms.unix ++ platforms.windows;
-    maintainers = with maintainers; [ primeos ];
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+    maintainers = with lib.maintainers; [ primeos ];
   };
 }

--- a/pkgs/by-name/db/dbmate/package.nix
+++ b/pkgs/by-name/db/dbmate/package.nix
@@ -19,12 +19,12 @@ buildGoModule rec {
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Database migration tool";
     mainProgram = "dbmate";
     homepage = "https://github.com/amacneil/dbmate";
     changelog = "https://github.com/amacneil/dbmate/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ manveru ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ manveru ];
   };
 }

--- a/pkgs/by-name/de/debootstrap/package.nix
+++ b/pkgs/by-name/de/debootstrap/package.nix
@@ -96,13 +96,13 @@ stdenv.mkDerivation rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://salsa.debian.org/installer-team/debootstrap/-/blob/${version}/debian/changelog";
     description = "Tool to create a Debian system in a chroot";
     homepage = "https://wiki.debian.org/Debootstrap";
-    license = licenses.mit;
-    maintainers = with maintainers; [ marcweber ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marcweber ];
+    platforms = lib.platforms.linux;
     mainProgram = "debootstrap";
   };
 }

--- a/pkgs/by-name/de/deckmaster/package.nix
+++ b/pkgs/by-name/de/deckmaster/package.nix
@@ -36,13 +36,13 @@ buildGoModule rec {
       --prefix XDG_DATA_DIRS : "${roboto.out}/share/" \
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Application to control your Elgato Stream Deck on Linux";
     mainProgram = "deckmaster";
     homepage = "https://github.com/muesli/deckmaster";
     changelog = "https://github.com/muesli/deckmaster/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/de/delta/package.nix
+++ b/pkgs/by-name/de/delta/package.nix
@@ -59,12 +59,12 @@ rustPlatform.buildRustPackage rec {
     "--skip=test_diff_real_files"
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/dandavison/delta";
     description = "Syntax-highlighting pager for git";
     changelog = "https://github.com/dandavison/delta/releases/tag/${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       zowoq
       SuperSandro2000
       figsoda

--- a/pkgs/by-name/de/denaro/package.nix
+++ b/pkgs/by-name/de/denaro/package.nix
@@ -63,16 +63,16 @@ buildDotnetModule rec {
 
   passthru.updateScript = ./update.sh;
 
-  meta = with lib; {
+  meta = {
     description = "Personal finance manager for GNOME";
     homepage = "https://github.com/nlogozzo/NickvisionMoney";
     mainProgram = "NickvisionMoney.GNOME";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     changelog = "https://github.com/nlogozzo/NickvisionMoney/releases/tag/${version}";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       chuangzhu
       kashw2
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/de/dendrite/package.nix
+++ b/pkgs/by-name/de/dendrite/package.nix
@@ -65,12 +65,12 @@ buildGoModule rec {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://element-hq.github.io/dendrite";
     description = "Second-generation Matrix homeserver written in Go";
     changelog = "https://github.com/element-hq/dendrite/releases/tag/v${version}";
-    license = licenses.agpl3Plus;
-    teams = [ teams.matrix ];
-    platforms = platforms.unix;
+    license = lib.licenses.agpl3Plus;
+    teams = [ lib.teams.matrix ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/de/dep-scan/package.nix
+++ b/pkgs/by-name/de/dep-scan/package.nix
@@ -64,12 +64,12 @@ python3.pkgs.buildPythonApplication rec {
     "test_query_metadata2"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Security and risk audit tool based on known vulnerabilities, advisories, and license limitations for project dependencies";
     homepage = "https://github.com/owasp-dep-scan/dep-scan";
     changelog = "https://github.com/owasp-dep-scan/dep-scan/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "dep-scan";
   };
 }

--- a/pkgs/by-name/de/dependency-track-exporter/package.nix
+++ b/pkgs/by-name/de/dependency-track-exporter/package.nix
@@ -24,12 +24,12 @@ buildGoModule rec {
     "-X=github.com/prometheus/common/version.BuildDate=1970-01-01T00:00:00Z"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Helper to export Prometheus metrics for Dependency-Track";
     homepage = "https://github.com/jetstack/dependency-track-exporter";
     changelog = "https://github.com/jetstack/dependency-track-exporter/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "dependency-track-exporter";
   };
 }

--- a/pkgs/by-name/de/depotdownloader/package.nix
+++ b/pkgs/by-name/de/depotdownloader/package.nix
@@ -23,11 +23,11 @@ buildDotnetModule rec {
 
   passthru.updateScript = ./update.sh;
 
-  meta = with lib; {
+  meta = {
     description = "Steam depot downloader utilizing the SteamKit2 library";
     changelog = "https://github.com/SteamRE/DepotDownloader/releases/tag/DepotDownloader_${version}";
-    license = licenses.gpl2Only;
-    maintainers = [ maintainers.babbaj ];
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.babbaj ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/by-name/de/desync/package.nix
+++ b/pkgs/by-name/de/desync/package.nix
@@ -20,13 +20,13 @@ buildGoModule rec {
   # nix builder doesn't have access to test data; tests fail for reasons unrelated to binary being bad.
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Content-addressed binary distribution system";
     mainProgram = "desync";
     longDescription = "An alternate implementation of the casync protocol and storage mechanism with a focus on production-readiness";
     homepage = "https://github.com/folbricht/desync";
     changelog = "https://github.com/folbricht/desync/releases/tag/v${version}";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ chaduffy ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ chaduffy ];
   };
 }

--- a/pkgs/by-name/de/devhelp/package.nix
+++ b/pkgs/by-name/de/devhelp/package.nix
@@ -80,13 +80,13 @@ stdenv.mkDerivation rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "API documentation browser for GNOME";
     mainProgram = "devhelp";
     homepage = "https://apps.gnome.org/Devhelp/";
     changelog = "https://gitlab.gnome.org/GNOME/devhelp/-/blob/${version}/NEWS?ref_type=tags";
-    license = licenses.gpl3Plus;
-    teams = [ teams.gnome ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    teams = [ lib.teams.gnome ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/de/devpi-client/package.nix
+++ b/pkgs/by-name/de/devpi-client/package.nix
@@ -69,12 +69,12 @@ python3.pkgs.buildPythonApplication rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Client for devpi, a pypi index server and packaging meta tool";
     homepage = "http://doc.devpi.net";
     changelog = "https://github.com/devpi/devpi/blob/client-${version}/client/CHANGELOG";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       lewo
       makefu
     ];

--- a/pkgs/by-name/de/devspace/package.nix
+++ b/pkgs/by-name/de/devspace/package.nix
@@ -33,11 +33,11 @@ buildGoModule rec {
     package = devspace;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Open-source developer tool for Kubernetes that lets you develop and deploy cloud-native software faster";
     homepage = "https://devspace.sh/";
     changelog = "https://github.com/devspace-sh/devspace/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ darkonion0 ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ darkonion0 ];
   };
 }

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -315,7 +315,7 @@ python.pkgs.buildPythonApplication rec {
     '';
   };
 
-  meta = with lib; {
+  meta = {
     description = "Perform in-depth comparison of files, archives, and directories";
     longDescription = ''
       diffoscope will try to get to the bottom of what makes files or directories
@@ -329,13 +329,13 @@ python.pkgs.buildPythonApplication rec {
     '';
     homepage = "https://diffoscope.org/";
     changelog = "https://diffoscope.org/news/diffoscope-${version}-released/";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
       dezgeg
       danielfullmer
       raitobezarius
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     mainProgram = "diffoscope";
   };
 }

--- a/pkgs/by-name/di/dinish/package.nix
+++ b/pkgs/by-name/di/dinish/package.nix
@@ -25,13 +25,13 @@ stdenvNoCC.mkDerivation rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/playbeing/dinish";
     changelog = "https://github.com/playbeing/dinish/blob/v${version}/FONTLOG.txt";
     description = "Modern computer font inspired by DIN 1451";
     longDescription = "DINish is one of many modern computer fonts that were inspired by the lettering of the German Autobahn road signs. It is professionally designed, and usable for body text and captions, even spreadsheets. Its unadorned style is easy to read, and although it is close to a century old maintains a fresh look.";
-    license = licenses.ofl;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ vji ];
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ vji ];
   };
 }

--- a/pkgs/by-name/di/discocss/package.nix
+++ b/pkgs/by-name/di/discocss/package.nix
@@ -34,13 +34,13 @@ stdenvNoCC.mkDerivation rec {
       ln -s ${discord}/share/* $out/share
     '';
 
-  meta = with lib; {
+  meta = {
     description = "Tiny Discord css-injector";
     changelog = "https://github.com/mlvzk/discocss/releases/tag/v${version}";
     homepage = "https://github.com/mlvzk/discocss";
-    license = licenses.mpl20;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ mlvzk ];
+    license = lib.licenses.mpl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ mlvzk ];
     mainProgram = "discocss";
   };
 }

--- a/pkgs/by-name/di/discordchatexporter-cli/package.nix
+++ b/pkgs/by-name/di/discordchatexporter-cli/package.nix
@@ -35,13 +35,13 @@ buildDotnetModule rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Tool to export Discord chat logs to a file";
     homepage = "https://github.com/Tyrrrz/DiscordChatExporter";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
     changelog = "https://github.com/Tyrrrz/DiscordChatExporter/blob/${version}/Changelog.md";
-    maintainers = with maintainers; [ ];
-    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.unix;
     mainProgram = "discordchatexporter-cli";
   };
 }

--- a/pkgs/by-name/di/discordchatexporter-desktop/package.nix
+++ b/pkgs/by-name/di/discordchatexporter-desktop/package.nix
@@ -35,12 +35,12 @@ buildDotnetModule rec {
     updateScript = ./updater.sh;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Tool to export Discord chat logs to a file (GUI version)";
     homepage = "https://github.com/Tyrrrz/DiscordChatExporter";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
     changelog = "https://github.com/Tyrrrz/DiscordChatExporter/blob/${version}/Changelog.md";
-    maintainers = with maintainers; [ willow ];
+    maintainers = with lib.maintainers; [ willow ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "discordchatexporter";
   };

--- a/pkgs/by-name/di/distribution/package.nix
+++ b/pkgs/by-name/di/distribution/package.nix
@@ -35,7 +35,7 @@ buildGoModule (finalAttrs: {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Toolkit to pack, ship, store, and deliver container content";
     longDescription = ''
       Distribution is a Open Source Registry implementation for storing and distributing container
@@ -44,10 +44,10 @@ buildGoModule (finalAttrs: {
       or running a simple private registry.
     '';
     homepage = "https://distribution.github.io/distribution/";
-    changelog = "https://github.com/distribution/distribution/releases/tag/v${version}";
-    license = licenses.asl20;
+    changelog = "https://github.com/distribution/distribution/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ katexochen ];
     mainProgram = "registry";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/di/dive/package.nix
+++ b/pkgs/by-name/di/dive/package.nix
@@ -35,12 +35,12 @@ buildGoModule rec {
     "-X main.version=${version}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool for exploring each layer in a docker image";
     mainProgram = "dive";
     homepage = "https://github.com/wagoodman/dive";
     changelog = "https://github.com/wagoodman/dive/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/by-name/do/docker-compose-language-service/package.nix
+++ b/pkgs/by-name/do/docker-compose-language-service/package.nix
@@ -17,12 +17,12 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-G1X9WrnwN6wM9S76PsGrPTmmiMBUKu4T2Al3HH3Wo+w=";
 
-  meta = with lib; {
+  meta = {
     description = "Language service for Docker Compose documents";
     homepage = "https://github.com/microsoft/compose-language-service";
     changelog = "https://github.com/microsoft/compose-language-service/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ natsukium ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
     mainProgram = "docker-compose-langserver";
   };
 }

--- a/pkgs/by-name/do/docker-credential-gcr/package.nix
+++ b/pkgs/by-name/do/docker-credential-gcr/package.nix
@@ -42,7 +42,7 @@ buildGoModule rec {
 
   __darwinAllowLocalNetworking = true;
 
-  meta = with lib; {
+  meta = {
     description = "Docker credential helper for GCR (https://gcr.io) users";
     longDescription = ''
       docker-credential-gcr is Google Container Registry's Docker credential
@@ -51,8 +51,8 @@ buildGoModule rec {
     '';
     homepage = "https://github.com/GoogleCloudPlatform/docker-credential-gcr";
     changelog = "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       suvash
       anthonyroussel
     ];

--- a/pkgs/by-name/do/docker-slim/package.nix
+++ b/pkgs/by-name/do/docker-slim/package.nix
@@ -44,12 +44,12 @@ buildGoModule rec {
     wrapProgram "$out/bin/slim" --add-flags '--state-path "$(pwd)"'
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Minify and secure Docker containers";
     homepage = "https://slimtoolkit.org/";
     changelog = "https://github.com/slimtoolkit/slim/raw/${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       Br1ght0ne
       mbrgm
     ];

--- a/pkgs/by-name/do/dockle/package.nix
+++ b/pkgs/by-name/do/dockle/package.nix
@@ -45,7 +45,7 @@ buildGoModule rec {
     runHook postInstallCheck
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://containers.goodwith.tech";
     changelog = "https://github.com/goodwithtech/dockle/releases/tag/v${version}";
     description = "Container Image Linter for Security";
@@ -55,7 +55,7 @@ buildGoModule rec {
       Helping build the Best-Practice Docker Image.
       Easy to start.
     '';
-    license = licenses.asl20;
-    maintainers = with maintainers; [ jk ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jk ];
   };
 }

--- a/pkgs/by-name/do/dontgo403/package.nix
+++ b/pkgs/by-name/do/dontgo403/package.nix
@@ -22,12 +22,12 @@ buildGoModule rec {
     "-s"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to bypass 40X response codes";
     mainProgram = "nomore403";
     homepage = "https://github.com/devploit/dontgo403";
     changelog = "https://github.com/devploit/dontgo403/releases/tag/${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/do/dooit/package.nix
+++ b/pkgs/by-name/do/dooit/package.nix
@@ -63,12 +63,12 @@ python3.pkgs.buildPythonApplication rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "TUI todo manager";
     homepage = "https://github.com/dooit-org/dooit";
     changelog = "https://github.com/dooit-org/dooit/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       khaneliman
       wesleyjrz
       kraanzu

--- a/pkgs/by-name/do/doq/package.nix
+++ b/pkgs/by-name/do/doq/package.nix
@@ -34,12 +34,12 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "doq" ];
 
-  meta = with lib; {
+  meta = {
     description = "Docstring generator for Python";
     homepage = "https://github.com/heavenshell/py-doq";
     changelog = "https://github.com/heavenshell/py-doq/releases/tag/${version}";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ natsukium ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ natsukium ];
     mainProgram = "doq";
   };
 }

--- a/pkgs/by-name/do/dos2unix/package.nix
+++ b/pkgs/by-name/do/dos2unix/package.nix
@@ -21,12 +21,12 @@ stdenv.mkDerivation rec {
   ];
   makeFlags = [ "prefix=${placeholder "out"}" ];
 
-  meta = with lib; {
+  meta = {
     description = "Convert text files with DOS or Mac line breaks to Unix line breaks and vice versa";
     homepage = "https://waterlan.home.xs4all.nl/dos2unix.html";
     changelog = "https://sourceforge.net/p/dos2unix/dos2unix/ci/dos2unix-${version}/tree/dos2unix/NEWS.txt?format=raw";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ c0bw3b ];
-    platforms = platforms.all;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ c0bw3b ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/do/dotool/package.nix
+++ b/pkgs/by-name/do/dotool/package.nix
@@ -49,11 +49,11 @@ buildGoModule rec {
     installManPage doc/dotool.1
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Command to simulate input anywhere";
     homepage = "https://git.sr.ht/~geb/dotool";
     changelog = "https://git.sr.ht/~geb/dotool/tree/${version}/item/CHANGELOG.md";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ dit7ya ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dit7ya ];
   };
 }

--- a/pkgs/by-name/dy/dynamips/package.nix
+++ b/pkgs/by-name/dy/dynamips/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Cisco router emulator";
     longDescription = ''
       Dynamips is an emulator computer program that was written to emulate Cisco
@@ -42,12 +42,12 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/GNS3/dynamips";
     changelog = "https://github.com/GNS3/dynamips/releases/tag/v${version}";
-    license = licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
     mainProgram = "dynamips";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       primeos
       anthonyroussel
     ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/pkgs/by-name/dy/dyndnsc/package.nix
+++ b/pkgs/by-name/dy/dyndnsc/package.nix
@@ -48,7 +48,7 @@ python3Packages.buildPythonApplication rec {
   # Allow tests that bind or connect to localhost on macOS.
   __darwinAllowLocalNetworking = true;
 
-  meta = with lib; {
+  meta = {
     description = "Dynamic DNS update client with support for multiple protocols";
     longDescription = ''
       Dyndnsc is a command line client for sending updates to Dynamic
@@ -62,9 +62,9 @@ python3Packages.buildPythonApplication rec {
     '';
     homepage = "https://github.com/infothrill/python-dyndnsc";
     changelog = "https://github.com/infothrill/python-dyndnsc/releases/tag/${version}";
-    license = licenses.mit;
-    maintainers = [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "dyndnsc";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ec/ec2stepshell/package.nix
+++ b/pkgs/by-name/ec/ec2stepshell/package.nix
@@ -37,12 +37,12 @@ python3.pkgs.buildPythonApplication rec {
     "ec2stepshell"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "AWS post-exploitation tool";
     mainProgram = "ec2stepshell";
     homepage = "https://github.com/saw-your-packet/EC2StepShell";
     changelog = "https://github.com/saw-your-packet/EC2StepShell/blob/${version}/CHANGELOG.txt";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/ec/ecs-agent/package.nix
+++ b/pkgs/by-name/ec/ecs-agent/package.nix
@@ -26,13 +26,13 @@ buildGoModule rec {
     "-w"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Agent that runs on AWS EC2 container instances and starts containers on behalf of Amazon ECS";
     homepage = "https://github.com/aws/amazon-ecs-agent";
     changelog = "https://github.com/aws/amazon-ecs-agent/raw/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    platforms = platforms.linux;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "agent";
   };
 }

--- a/pkgs/by-name/ek/eksctl/package.nix
+++ b/pkgs/by-name/ek/eksctl/package.nix
@@ -43,12 +43,12 @@ buildGoModule rec {
       --zsh  <($out/bin/eksctl completion zsh)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "CLI for Amazon EKS";
     homepage = "https://github.com/weaveworks/eksctl";
     changelog = "https://github.com/eksctl-io/eksctl/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       xrelkd
       Chili-Man
     ];

--- a/pkgs/by-name/el/elan/package.nix
+++ b/pkgs/by-name/el/elan/package.nix
@@ -81,15 +81,15 @@ rustPlatform.buildRustPackage rec {
     $out/bin/elan completions zsh >  "$out/share/zsh/site-functions/_elan"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Small tool to manage your installations of the Lean theorem prover";
     homepage = "https://github.com/leanprover/elan";
     changelog = "https://github.com/leanprover/elan/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "elan";
   };
 }

--- a/pkgs/by-name/el/elasticsearch-curator/package.nix
+++ b/pkgs/by-name/el/elasticsearch-curator/package.nix
@@ -78,11 +78,11 @@ python3.pkgs.buildPythonApplication rec {
     updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Curate, or manage, your Elasticsearch indices and snapshots";
     homepage = "https://github.com/elastic/curator";
     changelog = "https://github.com/elastic/curator/releases/tag/v${version}";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     longDescription = ''
       Elasticsearch Curator helps you curate, or manage, your Elasticsearch
       indices and snapshots by:
@@ -96,6 +96,6 @@ python3.pkgs.buildPythonApplication rec {
       * Perform various actions on the items which remain in the actionable list.
     '';
     mainProgram = "curator";
-    maintainers = with maintainers; [ basvandijk ];
+    maintainers = with lib.maintainers; [ basvandijk ];
   };
 }

--- a/pkgs/by-name/el/elfinfo/package.nix
+++ b/pkgs/by-name/el/elfinfo/package.nix
@@ -17,12 +17,12 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  meta = with lib; {
+  meta = {
     description = "Small utility for showing information about ELF files";
     mainProgram = "elfinfo";
     homepage = "https://elfinfo.roboticoverlords.org/";
     changelog = "https://github.com/xyproto/elfinfo/releases/tag/${version}";
-    license = licenses.bsd3;
-    maintainers = [ ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/el/ell/package.nix
+++ b/pkgs/by-name/el/ell/package.nix
@@ -55,16 +55,16 @@ stdenv.mkDerivation rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://git.kernel.org/pub/scm/libs/ell/ell.git";
     description = "Embedded Linux Library";
     longDescription = ''
       The Embedded Linux* Library (ELL) provides core, low-level functionality for system daemons. It typically has no dependencies other than the Linux kernel, C standard library, and libdl (for dynamic linking). While ELL is designed to be efficient and compact enough for use on embedded Linux platforms, it is not limited to resource-constrained systems.
     '';
     changelog = "https://git.kernel.org/pub/scm/libs/ell/ell.git/tree/ChangeLog?h=${version}";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
       mic92
       dtzWill
     ];

--- a/pkgs/by-name/en/enc/package.nix
+++ b/pkgs/by-name/en/enc/package.nix
@@ -38,7 +38,7 @@ buildGoModule rec {
       --zsh <($out/bin/enc completion zsh)
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/life4/enc";
     changelog = "https://github.com/life4/enc/releases/tag/v${version}";
     description = "Modern and friendly alternative to GnuPG";
@@ -50,7 +50,7 @@ buildGoModule rec {
       Our goal was to make encryption available to all engineers without the need to learn a lot of new words, concepts,
       and commands. It is the most beginner-friendly CLI tool for encryption, and keeping it that way is our top priority.
     '';
-    license = licenses.mit;
-    maintainers = with maintainers; [ rvnstn ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rvnstn ];
   };
 }

--- a/pkgs/by-name/en/endlessh-go/package.nix
+++ b/pkgs/by-name/en/endlessh-go/package.nix
@@ -29,12 +29,12 @@ buildGoModule rec {
     inherit (nixosTests) endlessh-go;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Implementation of endlessh exporting Prometheus metrics";
     homepage = "https://github.com/shizunge/endlessh-go";
     changelog = "https://github.com/shizunge/endlessh-go/releases/tag/${version}";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ azahi ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ azahi ];
     mainProgram = "endlessh-go";
   };
 }

--- a/pkgs/by-name/en/endlessh/package.nix
+++ b/pkgs/by-name/en/endlessh/package.nix
@@ -28,13 +28,13 @@ stdenv.mkDerivation rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "SSH tarpit that slowly sends an endless banner";
     homepage = "https://github.com/skeeto/endlessh";
     changelog = "https://github.com/skeeto/endlessh/releases/tag/${version}";
-    license = licenses.unlicense;
-    maintainers = with maintainers; [ azahi ];
-    platforms = platforms.unix;
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ azahi ];
+    platforms = lib.platforms.unix;
     mainProgram = "endlessh";
   };
 }

--- a/pkgs/by-name/en/engelsystem/package.nix
+++ b/pkgs/by-name/en/engelsystem/package.nix
@@ -41,13 +41,13 @@ stdenv.mkDerivation rec {
 
   passthru.tests = nixosTests.engelsystem;
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/engelsystem/engelsystem/releases/tag/v${version}";
     description = "Coordinate your volunteers in teams, assign them to work shifts or let them decide for themselves when and where they want to help with what";
     homepage = "https://engelsystem.de";
-    license = licenses.gpl2Only;
+    license = lib.licenses.gpl2Only;
     mainProgram = "migrate";
-    maintainers = [ ];
-    platforms = platforms.all;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/en/entr/package.nix
+++ b/pkgs/by-name/en/entr/package.nix
@@ -25,13 +25,13 @@ stdenv.mkDerivation rec {
 
   TARGET_OS = stdenv.hostPlatform.uname.system;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://eradman.com/entrproject/";
     description = "Run arbitrary commands when files change";
     changelog = "https://github.com/eradman/entr/raw/${version}/NEWS";
-    license = licenses.isc;
-    platforms = platforms.all;
-    maintainers = with maintainers; [
+    license = lib.licenses.isc;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
       pSub
       synthetica
     ];

--- a/pkgs/by-name/en/enum4linux-ng/package.nix
+++ b/pkgs/by-name/en/enum4linux-ng/package.nix
@@ -30,7 +30,7 @@ python3.pkgs.buildPythonApplication rec {
   # It's only a script and not a Python module. Project has no tests
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Windows/Samba enumeration tool";
     longDescription = ''
       enum4linux-ng.py is a rewrite of Mark Lowe's enum4linux.pl, a tool for
@@ -38,8 +38,8 @@ python3.pkgs.buildPythonApplication rec {
     '';
     homepage = "https://github.com/cddmp/enum4linux-ng";
     changelog = "https://github.com/cddmp/enum4linux-ng/releases/tag/v${version}";
-    license = with licenses; [ gpl3Plus ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "enum4linux-ng";
   };
 }

--- a/pkgs/by-name/en/enumerepo/package.nix
+++ b/pkgs/by-name/en/enumerepo/package.nix
@@ -22,12 +22,12 @@ buildGoModule rec {
     "-w"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to list all public repositories for (valid) GitHub usernames";
     mainProgram = "enumerepo";
     homepage = "https://github.com/trickest/enumerepo";
     changelog = "https://github.com/trickest/enumerepo/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/by-name/en/envio/package.nix
+++ b/pkgs/by-name/en/envio/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     installManPage man/*.1
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://envio-cli.github.io/home";
     changelog = "https://github.com/envio-cli/envio/blob/${version}/CHANGELOG.md";
     description = "Modern and secure CLI tool for managing environment variables";
@@ -47,11 +47,11 @@ rustPlatform.buildRustPackage rec {
       switch between different configurations and apply them to their current
       environment.
     '';
-    license = with licenses; [
+    license = with lib.licenses; [
       mit
       asl20
     ];
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ afh ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ afh ];
   };
 }

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -297,13 +297,13 @@ buildBazelPackage rec {
         '';
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://envoyproxy.io";
     changelog = "https://github.com/envoyproxy/envoy/releases/tag/v${version}";
     description = "Cloud-native edge and service proxy";
     mainProgram = "envoy";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ lukegb ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lukegb ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/by-name/es/espflash/package.nix
+++ b/pkgs/by-name/es/espflash/package.nix
@@ -50,15 +50,15 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Serial flasher utility for Espressif SoCs and modules based on esptool.py";
     homepage = "https://github.com/esp-rs/espflash";
     changelog = "https://github.com/esp-rs/espflash/blob/v${version}/CHANGELOG.md";
     mainProgram = "espflash";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
   };
 }

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -159,15 +159,15 @@ python.pkgs.buildPythonApplication rec {
     tests = { inherit (nixosTests) esphome; };
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/esphome/esphome/releases/tag/${version}";
     description = "Make creating custom firmwares for ESP32/ESP8266 super easy";
     homepage = "https://esphome.io/";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit # The C++/runtime codebase of the ESPHome project (file extensions .c, .cpp, .h, .hpp, .tcc, .ino)
       gpl3Only # The python codebase and all other parts of this codebase
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       hexa
     ];
     mainProgram = "esphome";

--- a/pkgs/by-name/eu/eureka-ideas/package.nix
+++ b/pkgs/by-name/eu/eureka-ideas/package.nix
@@ -30,12 +30,12 @@ rustPlatform.buildRustPackage rec {
 
   useNextest = true;
 
-  meta = with lib; {
+  meta = {
     description = "CLI tool to input and store your ideas without leaving the terminal";
     homepage = "https://github.com/simeg/eureka";
     changelog = "https://github.com/simeg/eureka/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "eureka";
   };
 }

--- a/pkgs/by-name/fa/fable/package.nix
+++ b/pkgs/by-name/fa/fable/package.nix
@@ -17,14 +17,14 @@ buildDotnetGlobalTool (finalAttrs: {
     version = "[37m${finalAttrs.version}";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Fable is an F# to JavaScript compiler";
     mainProgram = "fable";
     homepage = "https://github.com/fable-compiler/fable";
-    changelog = "https://github.com/fable-compiler/fable/releases/tag/v${version}";
-    license = licenses.mit;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [
+    changelog = "https://github.com/fable-compiler/fable/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
       anpin
       mdarocha
     ];

--- a/pkgs/by-name/fa/faketty/package.nix
+++ b/pkgs/by-name/fa/faketty/package.nix
@@ -20,15 +20,15 @@ rustPlatform.buildRustPackage rec {
     patchShebangs tests/test.sh
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Wrapper to execute a command in a pty, even if redirecting the output";
     homepage = "https://github.com/dtolnay/faketty";
     changelog = "https://github.com/dtolnay/faketty/releases/tag/${version}";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20 # or
       mit
     ];
-    maintainers = with maintainers; [ figsoda ];
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "faketty";
   };
 }

--- a/pkgs/by-name/fa/fangfrisch/package.nix
+++ b/pkgs/by-name/fa/fangfrisch/package.nix
@@ -39,12 +39,12 @@ python3.pkgs.buildPythonApplication {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Update and verify unofficial Clam Anti-Virus signatures";
     homepage = "https://github.com/rseichter/fangfrisch";
     changelog = "https://github.com/rseichter/fangfrisch/blob/${version}/CHANGELOG.rst";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ happysalada ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ happysalada ];
     mainProgram = "fangfrisch";
   };
 }

--- a/pkgs/by-name/fa/faraday-agent-dispatcher/package.nix
+++ b/pkgs/by-name/fa/faraday-agent-dispatcher/package.nix
@@ -70,12 +70,12 @@ python3.pkgs.buildPythonApplication rec {
     "faraday_agent_dispatcher"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to send result from tools to the Faraday Platform";
     homepage = "https://github.com/infobyte/faraday_agent_dispatcher";
     changelog = "https://github.com/infobyte/faraday_agent_dispatcher/releases/tag/${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "faraday-dispatcher";
   };
 }

--- a/pkgs/by-name/fa/faraday-cli/package.nix
+++ b/pkgs/by-name/fa/faraday-cli/package.nix
@@ -42,12 +42,12 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "faraday_cli" ];
 
-  meta = with lib; {
+  meta = {
     description = "Command Line Interface for Faraday";
     homepage = "https://github.com/infobyte/faraday-cli";
     changelog = "https://github.com/infobyte/faraday-cli/releases/tag/${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "faraday-cli";
   };
 }

--- a/pkgs/by-name/fa/fastjet-contrib/package.nix
+++ b/pkgs/by-name/fa/fastjet-contrib/package.nix
@@ -48,12 +48,12 @@ stdenv.mkDerivation rec {
     make fragile-shared-install
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Third party extensions for FastJet";
     homepage = "http://fastjet.fr/";
     changelog = "https://phab.hepforge.org/source/fastjetsvn/browse/contrib/tags/${version}/NEWS?as=source&blame=off";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ veprbl ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ veprbl ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/fa/fastnetmon-advanced/package.nix
+++ b/pkgs/by-name/fa/fastnetmon-advanced/package.nix
@@ -57,13 +57,13 @@ stdenv.mkDerivation rec {
 
   passthru.tests = { inherit (nixosTests) fastnetmon-advanced; };
 
-  meta = with lib; {
+  meta = {
     description = "High performance DDoS detector / sensor - commercial edition";
     homepage = "https://fastnetmon.com";
     changelog = "https://github.com/FastNetMon/fastnetmon-advanced-releases/releases/tag/v${version}";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    teams = [ teams.wdz ];
-    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    teams = [ lib.teams.wdz ];
+    license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/fc/fcft/package.nix
+++ b/pkgs/by-name/fc/fcft/package.nix
@@ -84,18 +84,18 @@ stdenv.mkDerivation rec {
     onlyGraphemeShaping = fcft.override { withShapingTypes = [ "grapheme" ]; };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://codeberg.org/dnkl/fcft";
     changelog = "https://codeberg.org/dnkl/fcft/releases/tag/${version}";
     description = "Simple library for font loading and glyph rasterization";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       fionera
       sternenseemann
     ];
-    license = with licenses; [
+    license = with lib.licenses; [
       mit
       zlib
     ];
-    platforms = with platforms; linux;
+    platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/by-name/fe/fead/package.nix
+++ b/pkgs/by-name/fe/fead/package.nix
@@ -31,12 +31,12 @@ stdenv.mkDerivation rec {
   # The package has no tests.
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Advert generator from web feeds";
     homepage = "https://trong.loang.net/~cnx/fead";
-    license = licenses.agpl3Plus;
+    license = lib.licenses.agpl3Plus;
     changelog = "https://trong.loang.net/~cnx/fead/tag?h=${version}";
-    maintainers = with maintainers; [ McSinyx ];
+    maintainers = with lib.maintainers; [ McSinyx ];
     mainProgram = "fead";
   };
 }

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -145,15 +145,15 @@ buildNpmPackage {
     })
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Full-featured Subsonic/Jellyfin compatible desktop music player";
     homepage = "https://github.com/jeffvli/feishin";
     changelog = "https://github.com/jeffvli/feishin/releases/tag/v${version}";
-    sourceProvenance = with sourceTypes; [ fromSource ];
-    license = licenses.gpl3Plus;
-    platforms = platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
     mainProgram = "feishin";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       onny
       jlbribeiro
     ];

--- a/pkgs/by-name/fe/felix-fm/package.nix
+++ b/pkgs/by-name/fe/felix-fm/package.nix
@@ -50,12 +50,12 @@ rustPlatform.buildRustPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Tui file manager with vim-like key mapping";
     homepage = "https://github.com/kyoheiu/felix";
     changelog = "https://github.com/kyoheiu/felix/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "fx";
   };
 }

--- a/pkgs/by-name/fe/fend/package.nix
+++ b/pkgs/by-name/fe/fend/package.nix
@@ -93,12 +93,12 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Arbitrary-precision unit-aware calculator";
     homepage = "https://github.com/printfn/fend";
     changelog = "https://github.com/printfn/fend/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       djanatyn
       liff
     ];

--- a/pkgs/by-name/fe/fernglas/package.nix
+++ b/pkgs/by-name/fe/fernglas/package.nix
@@ -72,13 +72,13 @@ rustPlatform.buildRustPackage rec {
     popd
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Looking glass for your network using BGP and BMP as data source";
     homepage = "https://wobcom.github.io/fernglas/";
     changelog = "https://github.com/wobcom/fernglas/releases/tag/fernglas-${version}";
-    license = licenses.eupl12;
-    platforms = platforms.linux;
-    teams = [ teams.wdz ];
+    license = lib.licenses.eupl12;
+    platforms = lib.platforms.linux;
+    teams = [ lib.teams.wdz ];
     mainProgram = "fernglas";
   };
 }


### PR DESCRIPTION
This PR removes `meta = with lib` pattern when `version` is used within `changelog`. It was inspired from this discussion about maintenance pitfalls of `meta = with lib;`: https://github.com/NixOS/nixpkgs/issues/292468#issuecomment-2016454242

- Remove `with lib` only from meta (#208242)
- Fix `finalAttrs` when is missing

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
