### PR TITLE
arpa2-leaf: init at 0.2

### DIFF
--- a/pkgs/by-name/ar/arpa2-leaf/package.nix
+++ b/pkgs/by-name/ar/arpa2-leaf/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  arpa2cm,
+  quickder,
+  quickmem,
+  quick-sasl,
+  lillydap,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  # leaf is already used
+  pname = "arpa2-leaf";
+  version = "0.2";
+
+  src = fetchFromGitLab {
+    owner = "arpa2";
+    repo = "leaf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-s52gtxM+BmG7oVrB5F0ORjkb4F3fWONiOxIWdDn2P5k=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    arpa2cm
+    quickder
+    quickmem
+    quick-sasl
+    lillydap
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "LDAP Extended Attribute Filter";
+    homepage = "https://gitlab.com/arpa2/leaf";
+    changelog = "https://gitlab.com/arpa2/leaf/-/blob/v${finalAttrs.version}/CHANGES";
+    license = lib.licenses.bsd2;
+    teams = with lib.teams; [ ngi ];
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/li/lillydap/package.nix
+++ b/pkgs/by-name/li/lillydap/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  gperf,
+  arpa2cm,
+  quickder,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lillydap";
+  version = "1.0.1";
+
+  src = fetchFromGitLab {
+    owner = "arpa2";
+    repo = "lillydap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SQuvu1A9Iq/fKthfYyVQGWFuyHYnhIry/wvnwgdMKHY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gperf
+  ];
+
+  buildInputs = [
+    arpa2cm
+    quickder
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Little LDAP: Event-driven, lock-free kernel for dynamic data servers, clients, filters";
+    homepage = "https://gitlab.com/arpa2/lillydap";
+    changelog = "https://gitlab.com/arpa2/lillydap/-/blob/v${finalAttrs.version}/CHANGES";
+    license = lib.licenses.bsd2;
+    teams = with lib.teams; [ ngi ];
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes: https://github.com/ngi-nix/projects/issues/1886
Closes: https://github.com/ngi-nix/projects/issues/1887

Leaf is named `leaf-arpa2` because there is already a `leaf` package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
