### PR TITLE
llvm_{12,13,14,15}: fix build with Python 3.13

### DIFF
--- a/pkgs/development/compilers/llvm/12/llvm/no-pipes.patch
+++ b/pkgs/development/compilers/llvm/12/llvm/no-pipes.patch
@@ -1,0 +1,19 @@
+diff --git a/test/Bindings/Go/lit.local.cfg b/test/Bindings/Go/lit.local.cfg
+index 91a0ad89..4da83a1a 100644
+--- a/test/Bindings/Go/lit.local.cfg
++++ b/test/Bindings/Go/lit.local.cfg
+@@ -1,5 +1,4 @@
+ import os
+-import pipes
+ import shlex
+ import sys
+ 
+@@ -56,7 +55,7 @@ def fixup_compiler_path(compiler):
+     except (AttributeError, OSError):
+         pass
+ 
+-    return ' '.join([pipes.quote(arg) for arg in args])
++    return ' '.join([shlex.quote(arg) for arg in args])
+ 
+ config.environment['CC'] = fixup_compiler_path(config.host_cc)
+ config.environment['CXX'] = fixup_compiler_path(config.host_cxx)

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -208,16 +208,16 @@ stdenv.mkDerivation (
               stripLen = 1;
             }
           )
-      ++
-        lib.optional (lib.versionOlder release_version "16")
-          # Fix musl build.
-          (
-            fetchpatch {
-              url = "https://github.com/llvm/llvm-project/commit/5cd554303ead0f8891eee3cd6d25cb07f5a7bf67.patch";
-              relative = "llvm";
-              hash = "sha256-XPbvNJ45SzjMGlNUgt/IgEvM2dHQpDOe6woUJY+nUYA=";
-            }
-          )
+      ++ lib.optionals (lib.versionOlder release_version "16") [
+        # Fix musl build.
+        (fetchpatch {
+          url = "https://github.com/llvm/llvm-project/commit/5cd554303ead0f8891eee3cd6d25cb07f5a7bf67.patch";
+          relative = "llvm";
+          hash = "sha256-XPbvNJ45SzjMGlNUgt/IgEvM2dHQpDOe6woUJY+nUYA=";
+        })
+        # Fix for Python 3.13
+        (getVersionFile "llvm/no-pipes.patch")
+      ]
       ++ lib.optionals (lib.versionOlder release_version "14") [
         # Backport gcc-13 fixes with missing includes.
         (fetchpatch {

--- a/pkgs/development/compilers/llvm/common/patches.nix
+++ b/pkgs/development/compilers/llvm/common/patches.nix
@@ -204,6 +204,12 @@
       path = ../12;
     }
   ];
+  "llvm/no-pipes.patch" = [
+    {
+      before = "16";
+      path = ../12;
+    }
+  ];
   "openmp/fix-find-tool.patch" = [
     {
       after = "17";


### PR DESCRIPTION
Python 3.13 removed the "pipes" module, which LLVM used through v16.

So we need a patch. It's only used once though!

A similar patch was used by Arch: https://gitlab.archlinux.org/archlinux/packaging/packages/llvm15/-/blob/main/nopipes.diff?ref_type=heads


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
