### PR TITLE
vivaldi: re-init at 7.4.3684.43

### DIFF
--- a/pkgs/by-name/vi/vivaldi/package.nix
+++ b/pkgs/by-name/vi/vivaldi/package.nix
@@ -1,0 +1,251 @@
+{
+  lib,
+  stdenv,
+  coreutils,
+  fetchurl,
+  zlib,
+  libX11,
+  libXext,
+  libSM,
+  libICE,
+  libxkbcommon,
+  libxshmfence,
+  libXfixes,
+  libXt,
+  libXi,
+  libXcursor,
+  libXScrnSaver,
+  libXcomposite,
+  libXdamage,
+  libXtst,
+  libXrandr,
+  alsa-lib,
+  dbus,
+  cups,
+  libexif,
+  ffmpeg,
+  systemd,
+  libva,
+  libGL,
+  freetype,
+  fontconfig,
+  libXft,
+  libXrender,
+  libxcb,
+  expat,
+  libuuid,
+  libxml2,
+  glib,
+  gtk3,
+  pango,
+  gdk-pixbuf,
+  cairo,
+  atk,
+  at-spi2-atk,
+  at-spi2-core,
+  qt5,
+  libdrm,
+  libgbm,
+  vulkan-loader,
+  nss,
+  nspr,
+  patchelf,
+  makeWrapper,
+  wayland,
+  pipewire,
+  isSnapshot ? false,
+  proprietaryCodecs ? false,
+  vivaldi-ffmpeg-codecs ? null,
+  enableWidevine ? false,
+  widevine-cdm ? null,
+  commandLineArgs ? "",
+  pulseSupport ? stdenv.hostPlatform.isLinux,
+  libpulseaudio,
+  kerberosSupport ? true,
+  libkrb5,
+}:
+
+let
+  branch = if isSnapshot then "snapshot" else "stable";
+  vivaldiName = if isSnapshot then "vivaldi-snapshot" else "vivaldi";
+in
+stdenv.mkDerivation rec {
+  pname = "vivaldi";
+  version = "7.4.3684.43";
+
+  suffix =
+    {
+      aarch64-linux = "arm64";
+      x86_64-linux = "amd64";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://downloads.vivaldi.com/${branch}/vivaldi-${branch}_${version}-1_${suffix}.deb";
+    hash =
+      {
+        aarch64-linux = "sha256-/Zmxwm65HjIL/JdWJtvcgxk4Bj4VcTXr/px6eCJHy0I=";
+        x86_64-linux = "sha256-tDGoew5jEOqoHIHSvoOsBcuEzq817YT0pFSO3Li48OU=";
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  unpackPhase = ''
+    ar vx $src
+    tar -xvf data.tar.xz
+  '';
+
+  nativeBuildInputs = [
+    patchelf
+    makeWrapper
+    qt5.wrapQtAppsHook
+  ];
+
+  dontWrapQtApps = true;
+
+  buildInputs =
+    [
+      stdenv.cc.cc
+      stdenv.cc.libc
+      zlib
+      libX11
+      libXt
+      libXext
+      libSM
+      libICE
+      libxcb
+      libxkbcommon
+      libxshmfence
+      libXi
+      libXft
+      libXcursor
+      libXfixes
+      libXScrnSaver
+      libXcomposite
+      libXdamage
+      libXtst
+      libXrandr
+      atk
+      at-spi2-atk
+      at-spi2-core
+      alsa-lib
+      dbus
+      cups
+      gtk3
+      gdk-pixbuf
+      libexif
+      ffmpeg
+      systemd
+      libva
+      qt5.qtbase
+      qt5.qtwayland
+      freetype
+      fontconfig
+      libXrender
+      libuuid
+      expat
+      glib
+      nss
+      nspr
+      libGL
+      libxml2
+      pango
+      cairo
+      libdrm
+      libgbm
+      vulkan-loader
+      wayland
+      pipewire
+    ]
+    ++ lib.optional proprietaryCodecs vivaldi-ffmpeg-codecs
+    ++ lib.optional pulseSupport libpulseaudio
+    ++ lib.optional kerberosSupport libkrb5;
+
+  libPath =
+    lib.makeLibraryPath buildInputs
+    + lib.optionalString (stdenv.hostPlatform.is64bit) (
+      ":" + lib.makeSearchPathOutput "lib" "lib64" buildInputs
+    )
+    + ":$out/opt/${vivaldiName}/lib";
+
+  buildPhase =
+    ''
+      runHook preBuild
+      echo "Patching Vivaldi binaries"
+      for f in chrome_crashpad_handler vivaldi-bin vivaldi-sandbox ; do
+        patchelf \
+          --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          --set-rpath "${libPath}" \
+          opt/${vivaldiName}/$f
+      done
+
+      for f in libGLESv2.so libqt5_shim.so ; do
+        patchelf --set-rpath "${libPath}" opt/${vivaldiName}/$f
+      done
+    ''
+    + lib.optionalString proprietaryCodecs ''
+      ln -s ${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so opt/${vivaldiName}/libffmpeg.so.''${version%\.*\.*}
+    ''
+    + ''
+      echo "Finished patching Vivaldi binaries"
+      runHook postBuild
+    '';
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase =
+    ''
+      runHook preInstall
+      mkdir -p "$out"
+      cp -r opt "$out"
+      mkdir "$out/bin"
+      ln -s "$out/opt/${vivaldiName}/${vivaldiName}" "$out/bin/vivaldi"
+      mkdir -p "$out/share"
+      cp -r usr/share/{applications,xfce4} "$out"/share
+      substituteInPlace "$out"/share/applications/*.desktop \
+        --replace /usr/bin/${vivaldiName} "$out"/bin/vivaldi
+      substituteInPlace "$out"/share/applications/*.desktop \
+        --replace vivaldi-stable vivaldi
+      local d
+      for d in 16 22 24 32 48 64 128 256; do
+        mkdir -p "$out"/share/icons/hicolor/''${d}x''${d}/apps
+        ln -s \
+          "$out"/opt/${vivaldiName}/product_logo_''${d}.png \
+          "$out"/share/icons/hicolor/''${d}x''${d}/apps/vivaldi.png
+      done
+      wrapProgram "$out/bin/vivaldi" \
+        --add-flags ${lib.escapeShellArg commandLineArgs} \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+        --set-default FONTCONFIG_FILE "${fontconfig.out}/etc/fonts/fonts.conf" \
+        --set-default FONTCONFIG_PATH "${fontconfig.out}/etc/fonts" \
+        --suffix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}/ \
+        --prefix PATH : ${coreutils}/bin \
+        ''${qtWrapperArgs[@]} \
+        ${lib.optionalString enableWidevine "--suffix LD_LIBRARY_PATH : ${libPath}"}
+    ''
+    + lib.optionalString enableWidevine ''
+      ln -sf ${widevine-cdm}/share/google/chrome/WidevineCdm $out/opt/${vivaldiName}/WidevineCdm
+    ''
+    + ''
+      runHook postInstall
+    '';
+
+  passthru.updateScript = ./update-vivaldi.sh;
+
+  meta = with lib; {
+    description = "Browser for our Friends, powerful and personal";
+    homepage = "https://vivaldi.com";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = "vivaldi";
+    maintainers = with maintainers; [
+      otwieracz
+      badmutex
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/pkgs/by-name/vi/vivaldi/update-vivaldi.sh
+++ b/pkgs/by-name/vi/vivaldi/update-vivaldi.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+
+set -eu -o pipefail
+
+version=$(curl -sS https://vivaldi.com/download/ | sed -rne 's/.*vivaldi-stable_([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)-1_amd64\.deb.*/\1/p')
+
+update_hash() {
+    url="https://downloads.vivaldi.com/stable/vivaldi-stable_$version-1_$2.deb"
+    hash=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "$url"))
+    update-source-version vivaldi "$version" "$hash" --system=$1 --ignore-same-version
+}
+
+update_hash aarch64-linux arm64
+update_hash x86_64-linux amd64

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2005,7 +2005,6 @@ mapAliases {
   vistafonts = vista-fonts; # Added 2025-02-03
   vistafonts-chs = vista-fonts-chs; # Added 2025-02-03
   vistafonts-cht = vista-fonts-cht; # Added 2025-02-03
-  vivaldi = throw "'vivaldi' has been removed due to lack of maintenance in nixpkgs"; # Added 2025-05-29
   vkBasalt = vkbasalt; # Added 2022-11-22
   vkdt-wayland = vkdt; # Added 2024-04-19
   vocal = throw "'vocal' has been archived upstream. Consider using 'gnome-podcasts' or 'kasts' instead."; # Added 2025-04-12


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



## Things done

1.  Replaced qt5 with qt6 as dependency
2.  Removed isSnapshot option, only stable branch is built
3.  Updated build inputs and patching for qt6
4.  Adjusted wrapper setup and environment variables
5.  Updated maintainer in meta



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
