### PR TITLE
jq: *actually* fix CVE-2025-48060

### DIFF
--- a/pkgs/by-name/jq/jq/0001-Improve-performance-of-repeating-strings-3272.patch
+++ b/pkgs/by-name/jq/jq/0001-Improve-performance-of-repeating-strings-3272.patch
@@ -1,7 +1,7 @@
 From c15fc903e00fdd3b460e64d5a6a540f944e1eca6 Mon Sep 17 00:00:00 2001
 From: itchyny <itchyny@cybozu.co.jp>
 Date: Tue, 4 Mar 2025 22:13:55 +0900
-Subject: [PATCH 1/4] Improve performance of repeating strings (#3272)
+Subject: [PATCH 1/5] Improve performance of repeating strings (#3272)
 
 This commit improves the performance of repeating strings, by copying
 the result string instead of the string being repeated. Also it adds

--- a/pkgs/by-name/jq/jq/0002-fix-jv_number_value-should-cache-the-double-value-of.patch
+++ b/pkgs/by-name/jq/jq/0002-fix-jv_number_value-should-cache-the-double-value-of.patch
@@ -1,7 +1,7 @@
 From df0ddb83feb656230157f5bc9b7f34caef1f82be Mon Sep 17 00:00:00 2001
 From: itchyny <itchyny@cybozu.co.jp>
 Date: Sun, 16 Feb 2025 22:08:36 +0900
-Subject: [PATCH 2/4] fix: `jv_number_value` should cache the double value of
+Subject: [PATCH 2/5] fix: `jv_number_value` should cache the double value of
  literal numbers (#3245)
 
 The code of `jv_number_value` is intended to cache the double value of

--- a/pkgs/by-name/jq/jq/0003-Reject-NaN-with-payload-while-parsing-JSON.patch
+++ b/pkgs/by-name/jq/jq/0003-Reject-NaN-with-payload-while-parsing-JSON.patch
@@ -1,7 +1,7 @@
 From dfd25612454deacb6df47329787844795bf59821 Mon Sep 17 00:00:00 2001
 From: itchyny <itchyny@cybozu.co.jp>
 Date: Wed, 5 Mar 2025 07:43:54 +0900
-Subject: [PATCH 3/4] Reject NaN with payload while parsing JSON
+Subject: [PATCH 3/5] Reject NaN with payload while parsing JSON
 
 This commit drops support for parsing NaN with payload in JSON like
 `NaN123` and fixes CVE-2024-53427. Other JSON extensions like `NaN` and

--- a/pkgs/by-name/jq/jq/0004-Fix-signed-integer-overflow-in-jvp_array_write-and-j.patch
+++ b/pkgs/by-name/jq/jq/0004-Fix-signed-integer-overflow-in-jvp_array_write-and-j.patch
@@ -1,7 +1,7 @@
 From dc65d5af447f266d8a4037551e028785aab31e04 Mon Sep 17 00:00:00 2001
 From: itchyny <itchyny@cybozu.co.jp>
 Date: Wed, 21 May 2025 07:45:00 +0900
-Subject: [PATCH 4/4] Fix signed integer overflow in jvp_array_write and
+Subject: [PATCH 4/5] Fix signed integer overflow in jvp_array_write and
  jvp_object_rehash
 
 This commit fixes signed integer overflow and SEGV issues on growing

--- a/pkgs/by-name/jq/jq/0005-Fix-heap-buffer-overflow-when-formatting-an-empty-st.patch
+++ b/pkgs/by-name/jq/jq/0005-Fix-heap-buffer-overflow-when-formatting-an-empty-st.patch
@@ -1,0 +1,45 @@
+From d73a79035e1d24011a3363d52bf36b4eaea67aa6 Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Sat, 31 May 2025 11:46:40 +0900
+Subject: [PATCH 5/5] Fix heap buffer overflow when formatting an empty string
+
+The `jv_string_empty` did not properly null-terminate the string data,
+which could lead to a heap buffer overflow. The test case of
+GHSA-p7rr-28xf-3m5w (`0[""*0]`) was fixed by the commit dc849e9bb74a,
+but another case (`0[[]|implode]`) was still vulnerable. This commit
+ensures string data is properly null-terminated, and fixes CVE-2025-48060.
+---
+ src/jv.c      | 1 +
+ tests/jq.test | 4 ++++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/src/jv.c b/src/jv.c
+index 6e8cdd3..3303286 100644
+--- a/src/jv.c
++++ b/src/jv.c
+@@ -1121,6 +1121,7 @@ static jv jvp_string_empty_new(uint32_t length) {
+   jvp_string* s = jvp_string_alloc(length);
+   s->length_hashed = 0;
+   memset(s->data, 0, length);
++  s->data[length] = 0;
+   jv r = {JVP_FLAGS_STRING, 0, 0, 0, {&s->refcnt}};
+   return r;
+ }
+diff --git a/tests/jq.test b/tests/jq.test
+index 10b20e3..680706b 100644
+--- a/tests/jq.test
++++ b/tests/jq.test
+@@ -2042,6 +2042,10 @@ map(try implode catch .)
+ [123,["a"],[nan]]
+ ["implode input must be an array","string (\"a\") can't be imploded, unicode codepoint needs to be numeric","number (null) can't be imploded, unicode codepoint needs to be numeric"]
+ 
++try 0[implode] catch .
++[]
++"Cannot index number with string \"\""
++
+ # walk
+ walk(.)
+ {"x":0}
+-- 
+2.49.0
+

--- a/pkgs/by-name/jq/jq/package.nix
+++ b/pkgs/by-name/jq/jq/package.nix
@@ -44,6 +44,11 @@ stdenv.mkDerivation rec {
     # CVE-2024-23337
     # https://github.com/jqlang/jq/commit/de21386681c0df0104a99d9d09db23a9b2a78b1e
     ./0004-Fix-signed-integer-overflow-in-jvp_array_write-and-j.patch
+
+    # CVE-2025-48060, part two
+    # Improve-performance-of-repeating-strings is only a partial fix
+    # https://github.com/jqlang/jq/commit/c6e041699d8cd31b97375a2596217aff2cfca85b
+    ./0005-Fix-heap-buffer-overflow-when-formatting-an-empty-st.patch
   ];
 
   # https://github.com/jqlang/jq/issues/2871


### PR DESCRIPTION
see https://github.com/jqlang/jq/issues/3327#issuecomment-2924552289


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
