### PR TITLE
workflows/manual-nixos: run on stable branches

### DIFF
--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -7,6 +7,7 @@ on:
   pull_request_target:
     branches:
       - master
+      - release-*
     paths:
       - "nixos/**"
       # Also build when the nixpkgs doc changed, since we take things like
@@ -52,7 +53,7 @@ jobs:
 
       - name: Build NixOS manual
         id: build-manual
-        run: NIX_PATH=nixpkgs=$(pwd)/untrusted nix-build --option restrict-eval true untrusted/ci -A manual-nixos --argstr system ${{ matrix.system }}
+        run: nix-build untrusted/ci -A manual-nixos --argstr system ${{ matrix.system }}
 
       - name: Upload NixOS manual
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
There is no reason not to build the NixOS manual on stable branches as well.

Also removing the restricted-eval, because it turned out not to be necessary for the nixpkgs-manual either.

Addresses https://github.com/NixOS/nixpkgs/pull/412102#issuecomment-2924574738.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
