### PR TITLE
workflows: cancel running jobs on pull request updates

### DIFF
--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -10,6 +10,10 @@ on:
       - 'staging-**'
       - '!staging-next'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -6,6 +6,10 @@ on:
       - .github/workflows/check-format.yml
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -9,6 +9,10 @@ on:
       - 'shell.nix'
       - 'ci/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -29,6 +29,10 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:

--- a/.github/workflows/edited.yml
+++ b/.github/workflows/edited.yml
@@ -16,6 +16,10 @@ on:
   pull_request_target:
     types: [edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/eval-aliases.yml
+++ b/.github/workflows/eval-aliases.yml
@@ -6,6 +6,10 @@ on:
       - .github/workflows/eval-aliases.yml
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -16,6 +16,10 @@ on:
       - haskell-updates
       - python-updates
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -290,3 +294,5 @@ jobs:
     if: needs.prepare.outputs.targetSha
     uses: ./.github/workflows/reviewers.yml
     secrets: inherit
+    with:
+      caller: ${{ github.workflow }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -8,6 +8,10 @@ name: "Label PR"
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write # needed to create *new* labels

--- a/.github/workflows/lib-tests.yml
+++ b/.github/workflows/lib-tests.yml
@@ -9,6 +9,10 @@ on:
       - 'lib/**'
       - 'maintainers/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -18,6 +18,10 @@ on:
       # Since the lib functions are used to 'massage' the options before producing the manual
       - "lib/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -10,6 +10,10 @@ on:
       - 'lib/**'
       - 'pkgs/by-name/ni/nixdoc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/nix-parse-v2.yml
+++ b/.github/workflows/nix-parse-v2.yml
@@ -6,6 +6,10 @@ on:
       - .github/workflows/nix-parse-v2.yml
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -11,6 +11,10 @@ on:
       - .github/workflows/nixpkgs-vet.yml
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 # We don't use a concurrency group here, because the action is triggered quite often (due to the PR edit trigger), and contributors would get notified on any canceled run.

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -10,6 +10,15 @@ on:
   pull_request_target:
     types: [ready_for_review]
   workflow_call:
+    inputs:
+      caller:
+        description: Name of the calling workflow.
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ inputs.caller }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions: {}
 


### PR DESCRIPTION
We can avoid running old jobs to completion, when pushing changes to a pull request. This is done via concurrency groups. We set them on the workflow level, with the following keys in the group name:
- `github.workflow` to only cancel / block the same workflow.
- `github.event_name` to avoid blocking between pull_request and pull_request_target.
- `github.head_ref` which is unique for a PR, but the same when changing it. This will cause PRs to cancel in progress jobs. Unset on pushes to master & co.
- `github.run_id` as fallback for push events. In this case, the run_id is unique for every push, thus *no* cancelling happens on the dev branches.

Previously proposed in #357990.

Note, that there is one long-standing issue with cancelling running jobs: https://github.com/orgs/community/discussions/13015. This means that you will get a notification email each time a run of one of your jobs is cancelled. For a push to a PR shortly after opening it, for example, you will get a bunch of notifications. I tried a variety of things to get rid of them - no chance. But, the good thing is, that those notifications have a clear pattern which can be filtered out automatically. So I have set up a filter in my email client to delete all mails which match this pattern:
- From contains `notifications@github.com`
- Subject contains `Run cancelled:`

I can't quantify it exacty, but I'm pretty sure we will save quite a bit of resources / parallel jobs with this change, so I think this is well worth it.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
