### PR TITLE
nvidia: PRIME offloading: Explain how to run Xorg on Intel

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -472,7 +472,7 @@ in
           #   "nvidia" driver.
           # - Add the AllowEmptyInitialConfiguration option to the Screen section for the
           #   "nvidia" driver, in order to allow the X server to start without any outputs.
-          # - Ad the `BusID`s to the configuration of the iGPU `Device` sections.
+          # - Add the `BusID`s to the configuration of the iGPU `Device` sections.
           #   Note that here we do not _add_ these `Device` sections, but make that
           #   _if_ such a `Device` section is generated on the system
           #   (based on what's in `services.xserver.videoDrivers`), then it will


### PR DESCRIPTION
Fixes accidentally running Xorg on nvidia, defeating offload mode.

Based on the findings at:
https://discourse.nixos.org/t/how-to-use-nvidia-prime-offload-to-run-the-x-server-on-the-integrated-board/9091/31

Reviewers from past nvidia-offload contributions: @eadwu @Gerg-L @SuperSandro2000 @GaetanLepage 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Docs/manual only change
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
