### PR TITLE
flif: init at 0.4; wuimg: init at 1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14542,6 +14542,12 @@
     githubId = 4701504;
     name = "James Robinson";
   };
+  leguteape = {
+    email = "workerap@protonmail.com";
+    github = "leguteape";
+    githubId = 45424904;
+    name = "Aashish P";
+  };
   leha44581 = {
     email = "leha55481@gmail.com";
     github = "Leha44581";

--- a/pkgs/by-name/fl/flif/package.nix
+++ b/pkgs/by-name/fl/flif/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  libpng,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "flif";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "FLIF-hub";
+    repo = "FLIF";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-S2RYno5u50jCgu412yMeXxUoyQzeaCqr8U13XC43y8o=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libpng ];
+
+  # Enable lto with parallel compilation
+  env.CXXFLAGS = "-flto=auto";
+
+  postUnpack = ''
+    sourceRoot=''${sourceRoot}/src
+    echo Source root reset to ''${sourceRoot}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    make install PREFIX=$out
+    make install-dev PREFIX=$out
+
+    runHook postInstall
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
+  meta = {
+    description = "Free Lossless Image Format";
+    homepage = "https://flif.info";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ leguteape ];
+    mainProgram = "flif";
+    platforms = lib.platforms.unix;
+    longDescription = ''
+      A novel lossless image format which outperforms PNG,
+      lossless WebP, lossless BPG, lossless JPEG2000,
+      and lossless JPEG XR in terms of compression ratio.
+    '';
+  };
+})

--- a/pkgs/by-name/wu/wuimg/package.nix
+++ b/pkgs/by-name/wu/wuimg/package.nix
@@ -1,0 +1,173 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  wayland-scanner,
+  libarchive,
+  libepoxy,
+  exiv2,
+  icu,
+  lcms,
+  libuchardet,
+  wayland,
+  libGL,
+  libxkbcommon,
+  wayland-protocols,
+  libdrm,
+  libgbm,
+  glfw,
+  zlib,
+  libavif,
+  flif,
+  giflib,
+  libheif,
+  jbigkit,
+  jbig2dec,
+  libjpeg,
+  openjpeg,
+  charls,
+  libjxl,
+  lerc,
+  libpng,
+  libraw,
+  librsvg,
+  libtiff,
+  libwebp,
+  withX11 ? false,
+  exoticImageFormats ? true,
+}:
+let
+  # Use `ar` with lto support
+  ar =
+    stdenv.cc.bintools.targetPrefix
+    + (
+      if stdenv.cc.isClang then
+        "llvm-ar"
+      else if stdenv.cc.isGNU then
+        "gcc-ar"
+      else
+        "ar"
+    );
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wuimg";
+  version = "1.3";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "kaleido";
+    repo = "wuimg";
+    tag = "w${finalAttrs.version}";
+    hash = "sha256-TT3dGFKuWPyNiGxBDLoVswXcpB1vNaAMTMdMMLL1BO0=";
+  };
+
+  mesonFlags = [
+    # Enable lto
+    "-Db_lto=true"
+  ]
+  ++ lib.optionals (!withX11) [
+    # Configure X11 support
+    "-Dwindow_glfw=disabled"
+  ]
+  ++ lib.optionals (!exoticImageFormats) [
+    # Disable all external formats
+    "-Dauto_features=disabled"
+    "-Ddisable_external=true"
+    # Except jpeg, png, svg, webp
+    "-Djpeg=enabled"
+    "-Dpng=enabled"
+    "-Dsvg=enabled"
+    "-Dwebp=enabled"
+    # Also, enable wayland and drm backends
+    "-Dwindow_wayland=enabled"
+    "-Dwindow_drm=enabled"
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    # Minimum
+    libarchive
+    libepoxy
+    exiv2
+    icu
+    lcms
+    libuchardet
+
+    # Wayland
+    wayland
+    libGL
+    libxkbcommon
+    wayland-protocols
+
+    # DRM/KMS
+    libdrm
+    libgbm
+
+    # Minimal external formats
+    libjpeg
+    libpng
+    librsvg
+    libwebp
+  ]
+  ++ lib.optionals withX11 [ glfw ]
+  ++ lib.optionals exoticImageFormats [
+    # More exotic external formats
+    zlib
+    libavif
+    flif
+    giflib
+    libheif
+    jbigkit
+    jbig2dec
+    openjpeg
+    charls
+    libjxl
+    lerc
+    libraw
+    libtiff
+  ];
+
+  preConfigure = ''
+    export AR="${ar}"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    meson compile
+    meson compile wuconv
+
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    install -Dm755 src/wuconv $out/bin
+  '';
+
+  meta = {
+    description = "Minimalistic but not barebones image viewer";
+    homepage = "https://codeberg.org/kaleido/wuimg";
+    license = lib.licenses.bsd0;
+    maintainers = with lib.maintainers; [ leguteape ];
+    platforms = lib.platforms.linux;
+    mainProgram = "wu";
+    longDescription = ''
+      wu is a minimalistic but not barebones image viewer. It aims for comfort,
+      speed, accurate color rendering, and format documentation/preservation.
+      wu is meant as a terminal companion, so launching from one is recommended.
+    '';
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added a new package [`wuimg`](https://codeberg.org/kaleido/wuimg) and its dependency [`flif`](https://github.com/FLIF-hub/FLIF), which was missing from nixpkgs.

This PR solves #405934.

**From the README of `wuimg`**
`wu` is a minimalistic but not barebones image viewer. It aims for comfort,
speed, accurate color rendering, and format documentation/preservation.

`wu` is meant as a terminal companion, so launching from one is recommended.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
