### PR TITLE
corrscope: 0.10.1 -> 0.11.0, migrate to Qt6

### DIFF
--- a/pkgs/by-name/co/corrscope/package.nix
+++ b/pkgs/by-name/co/corrscope/package.nix
@@ -1,45 +1,40 @@
 {
   stdenv,
   lib,
-  python3Packages,
   fetchFromGitHub,
   ffmpeg,
-  libsForQt5,
+  python3Packages,
+  qt6Packages,
   testers,
   corrscope,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "corrscope";
-  version = "0.10.1";
+  version = "0.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "corrscope";
     repo = "corrscope";
     tag = version;
-    hash = "sha256-WSv65jEu/w6iNrL/f5PN147FBjmR0j30H1D39dd+KN8=";
+    hash = "sha256-76qa4jOSncK1eDly/uXJzpWWdsEz7Hg3DyFb7rmrQBc=";
   };
 
-  pythonRelaxDeps = [
-    "attrs"
-    "ruamel.yaml"
+  nativeBuildInputs = with qt6Packages; [
+    wrapQtAppsHook
   ];
 
-  nativeBuildInputs =
-    (with libsForQt5; [
-      wrapQtAppsHook
-    ])
-    ++ (with python3Packages; [
-      poetry-core
-    ]);
+  build-system = with python3Packages; [
+    hatchling
+  ];
 
   buildInputs =
     [
       ffmpeg
     ]
     ++ (
-      with libsForQt5;
+      with qt6Packages;
       [
         qtbase
       ]
@@ -48,20 +43,24 @@ python3Packages.buildPythonApplication rec {
       ]
     );
 
-  propagatedBuildInputs = with python3Packages; [
-    appdirs
-    appnope
-    atomicwrites
-    attrs
-    click
-    matplotlib
-    numpy
-    packaging
-    qtpy
-    pyqt5
-    ruamel-yaml
-    colorspacious
-  ];
+  dependencies = (
+    with python3Packages;
+    [
+      appdirs
+      atomicwrites
+      attrs
+      click
+      colorspacious
+      matplotlib
+      numpy
+      qtpy
+      pyqt6
+      ruamel-yaml
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      appnope
+    ]
+  );
 
   dontWrapQtApps = true;
 
@@ -80,7 +79,7 @@ python3Packages.buildPythonApplication rec {
     command = "env HOME=$TMPDIR ${lib.getExe corrscope} --version";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Render wave files into oscilloscope views, featuring advanced correlation-based triggering algorithm";
     longDescription = ''
       Corrscope renders oscilloscope views of WAV files recorded from chiptune (game music from
@@ -90,9 +89,10 @@ python3Packages.buildPythonApplication rec {
       Genesis/FM synthesis) which jump around on other oscilloscope programs.
     '';
     homepage = "https://github.com/corrscope/corrscope";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.all;
+    changelog = "https://github.com/corrscope/corrscope/releases/tag/${version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    platforms = lib.platforms.all;
     mainProgram = "corr";
   };
 }


### PR DESCRIPTION
https://github.com/corrscope/corrscope/releases/tag/0.11.0

![Bildschirmfoto_2025-05-31_14-33-01](https://github.com/user-attachments/assets/1c0d1d99-9857-4e3d-96c3-81e161566bfa)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
