### PR TITLE
workflows/{check-shell,lib-tests}: use cachix and avoid rebuilds on maintainers-only changes

### DIFF
--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -44,5 +44,11 @@ jobs:
 
       - uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
 
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        with:
+          # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
+          name: nixpkgs-ci
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
       - name: Build shell
         run: nix-build untrusted/ci -A shell

--- a/.github/workflows/lib-tests.yml
+++ b/.github/workflows/lib-tests.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           extra_nix_config: sandbox = true
 
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        with:
+          # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
+          name: nixpkgs-ci
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
       - name: Building Nixpkgs lib-tests
         run: |
           nix-build untrusted/ci -A lib-tests

--- a/lib/tests/maintainers.nix
+++ b/lib/tests/maintainers.nix
@@ -54,7 +54,7 @@ let
 
   missingGithubIds = lib.concatLists (lib.mapAttrsToList checkMaintainer lib.maintainers);
 
-  success = pkgs.runCommand "checked-maintainers-success" { } ">$out";
+  success = pkgs.runCommand "checked-maintainers-success" { } "mkdir $out";
 
   failure =
     pkgs.runCommand "checked-maintainers-failure"

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -28,5 +28,14 @@ let
 in
 pkgsBB.symlinkJoin {
   name = "nixpkgs-lib-tests";
-  paths = map testWithNix nixVersions;
+  paths = map testWithNix nixVersions ++ [
+    (import ./maintainers.nix {
+      inherit pkgs;
+      lib = import ../.;
+    })
+    (import ./teams.nix {
+      inherit pkgs;
+      lib = import ../.;
+    })
+  ];
 }

--- a/lib/tests/test-with-nix.nix
+++ b/lib/tests/test-with-nix.nix
@@ -19,14 +19,6 @@ pkgs.runCommand "nixpkgs-lib-tests-nix-${nix.version}"
     buildInputs = [
       (import ./check-eval.nix)
       (import ./fetchers.nix)
-      (import ./maintainers.nix {
-        inherit pkgs;
-        lib = import ../.;
-      })
-      (import ./teams.nix {
-        inherit pkgs;
-        lib = import ../.;
-      })
       (import ../path/tests {
         inherit pkgs;
       })


### PR DESCRIPTION
The check-shell workflow needs to rebuild treefmt on 4 systems, whenever it runs, while the lib-tests need to rerun all their tests on every single change to the maintainers file. We can improve both of that by enabling cachix for those workflows and a little bit of restructuring for the lib-tests.

@Mic92 since the `lib/tests/test-with-nix.nix` file seems to be used by NixOS/nix, this technically decreases test coverage *slightly* for Nix: The maintainers and teams files are not build that way anymore. See commit message for details.

## Things done

I can't test the fact that cachix will avoid rebuilds, because my fork can't write to the cache - and I didn't feel like setting up another cache just for that. But that should be fine.

- [x] Tested the lib-tests changes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
