### PR TITLE
nixos/librechat: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21717,6 +21717,12 @@
     keys = [ { fingerprint = "7DCA 5615 8AB2 621F 2F32  9FF4 1C7C E491 479F A273"; } ];
     name = "Rahul Butani";
   };
+  rrvsh = {
+    email = "rafiq@rrv.sh";
+    github = "rrvsh";
+    githubId = 20300874;
+    name = "Mohammad Rafiq";
+  };
   rseichter = {
     email = "nixos.org@seichter.de";
     github = "rseichter";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -15,6 +15,8 @@
 - [gtklock](https://github.com/jovanlanik/gtklock), a GTK-based lockscreen for Wayland. Available as [programs.gtklock](#opt-programs.gtklock.enable).
 - [Chrysalis](https://github.com/keyboardio/Chrysalis), a graphical configurator for Kaleidoscope-powered keyboards. Available as [programs.chrysalis](#opt-programs.chrysalis.enable).
 
+- [LibreChat](https://www.librechat.ai/), open-source self-hostable ChatGPT clone with Agents and RAG APIs. Available as [services.librechat](#opt-services.librechat.enable).
+
 - [Pi-hole](https://pi-hole.net/), a DNS sinkhole for advertisements based on Dnsmasq. Available as [services.pihole-ftl](#opt-services.pihole-ftl.enable), and [services.pihole-web](#opt-services.pihole-web.enable) for the web GUI and API.
 
 - [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files. Available as [services.filebrowser](#opt-services.filebrowser.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1592,6 +1592,7 @@
   ./services/web-apps/lanraragi.nix
   ./services/web-apps/lasuite-docs.nix
   ./services/web-apps/lemmy.nix
+  ./services/web-apps/librechat.nix
   ./services/web-apps/limesurvey.nix
   ./services/web-apps/mainsail.nix
   ./services/web-apps/mastodon.nix

--- a/nixos/modules/services/web-apps/librechat.nix
+++ b/nixos/modules/services/web-apps/librechat.nix
@@ -1,0 +1,188 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.librechat;
+  format = pkgs.formats.yaml { };
+  configFile = format.generate "librechat.yaml" cfg.settings;
+  exportCredentials = n: _: ''export ${n}="$(${pkgs.systemd}/bin/systemd-creds cat ${n}_FILE)"'';
+  exportAllCredentials = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList exportCredentials vars);
+  getLoadCredentialList = lib.mapAttrsToList (n: v: "${n}_FILE:${v}") cfg.credentials;
+in
+{
+  options.services.librechat = {
+    enable = lib.mkEnableOption "the LibreChat server";
+    package = lib.mkPackageOption pkgs "librechat" { };
+    openFirewall = lib.mkEnableOption null // {
+      description = "Whether to open the port in the firewall.";
+    };
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/librechat";
+      example = "/persist/librechat";
+      description = "Absolute path for where the LibreChat server will use as its data directory to store logs, user uploads, and generated images.";
+    };
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3080;
+      example = 2309;
+      description = "The value that will be passed to the PORT environment variable, telling LibreChat what to listen on.";
+    };
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "librechat";
+      example = "alice";
+      description = "The user to run the service as.";
+    };
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "librechat";
+      example = "users";
+      description = "The group to run the service as.";
+    };
+    credentials = lib.mkOption {
+      type = lib.types.attrsOf lib.types.path;
+      default = { };
+      example = {
+        CREDS_KEY = /run/secrets/creds_key;
+      };
+      description = "Environment variables which are loaded from the contents of files at a file paths, mainly used for secrets. See https://www.librechat.ai/docs/configuration/dotenv for a full list.";
+    };
+    env = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          str
+          path
+          int
+          float
+        ]);
+      example = {
+        ALLOW_REGISTRATION = "true";
+        HOST = "0.0.0.0";
+        CONSOLE_JSON_STRING_LENGTH = 255;
+      };
+      default = { };
+      description = "Environment variables that will be set for the service. See https://www.librechat.ai/docs/configuration/dotenv for a full list.";
+    };
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+      };
+      default = { };
+      example = # nix
+        ''
+          {
+            version = "1.0.8";
+            cache = true;
+            interface = {
+              privacyPolicy = {
+                externalUrl = "https://librechat.ai/privacy-policy";
+                openNewTab = true;
+              };
+            };
+            endpoints = {
+              custom = [
+                {
+                  name = "OpenRouter";
+                  # Note that the following $ should be escaped with a backslash, not '''
+                  apiKey = "''${OPENROUTER_KEY}";
+                  baseURL = "https://openrouter.ai/api/v1";
+                  models = {
+                    default = ["meta-llama/llama-3-70b-instruct"];
+                    fetch = true;
+                  };
+                  titleConvo = true;
+                  titleModule = "meta-llama/llama-3-70b-instruct";
+                  dropParams = ["stop"];
+                  modelDisplayLabel = "OpenRouter";
+                }
+              ];
+            };
+          }
+        '';
+      description = "A free-form attribute set that will be written to librechat.yaml. You can use environment variables by wrapping them in \${}. Take care to escape the \$ character.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          (cfg.env ? CREDS_KEY || cfg.credentials ? CREDS_KEY)
+          && (cfg.env ? CREDS_IV || cfg.credentials ? CREDS_IV)
+          && (cfg.env ? JWT_SECRET || cfg.credentials ? JWT_SECRET)
+          && (cfg.env ? JWT_REFRESH_SECRET || cfg.credentials ? JWT_REFRESH_SECRET)
+          && (cfg.env ? MONGO_URI || cfg.credentials ? MONGO_URI);
+        message = "CREDS_KEY, CREDS_IV, JWT_SECRET, JWT_REFRESH_SECRET, and MONGO_URI must all be set in either env or credentials.";
+      }
+    ];
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall cfg.port;
+    systemd.tmpfiles.settings."10-librechat"."${cfg.dataDir}".d = {
+      mode = "0755";
+      inherit (cfg) user group;
+    };
+    systemd.services.librechat = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "tmpfiles.target" ];
+      description = "Open-source app for all your AI conversations, fully customizable and compatible with any AI provider";
+      environment = cfg.env // {
+        CONFIG_PATH = configFile;
+        PORT = builtins.toString cfg.port;
+      };
+      script = # sh
+        ''
+          ${exportAllCredentials cfg.credentials}
+          cd ${cfg.dataDir}
+          ${lib.getExe cfg.package}
+        '';
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = builtins.baseNameOf cfg.dataDir;
+        WorkingDirectory = cfg.dataDir;
+        LoadCredential = getLoadCredentialList;
+        Restart = "on-failure";
+        RestartSec = 10;
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        PrivateUsers = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        UMask = "0077";
+      };
+    };
+    users.users.librechat = lib.mkIf (cfg.user == "librechat") {
+      name = "librechat";
+      isSystemUser = true;
+      group = "librechat";
+      description = "LibreChat server user";
+    };
+    users.groups.librechat = lib.mkIf (cfg.user == "librechat") { };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    rrvsh
+    niklaskorz
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -747,6 +747,7 @@ in
   lightdm = runTest ./lightdm.nix;
   lighttpd = runTest ./lighttpd.nix;
   livekit = runTest ./networking/livekit.nix;
+  librechat = runTest ./librechat.nix;
   limesurvey = runTest ./limesurvey.nix;
   limine = import ./limine { inherit runTest; };
   listmonk = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./listmonk.nix { };

--- a/nixos/tests/librechat.nix
+++ b/nixos/tests/librechat.nix
@@ -1,0 +1,30 @@
+{
+  name = "librechat";
+
+  nodes.machine = {
+    # Run this test with NIXPKGS_ALLOW_UNFREE=1
+    services.mongodb.enable = true;
+    services.librechat = {
+      enable = true;
+      env = {
+        # The following were randomly generated with https://www.librechat.ai/toolkit/creds_generator
+        CREDS_KEY = "6d6deb03cdfb27ea454f6b9ddd42494bdce4af25d50d8aee454ddce583690cc5";
+        CREDS_IV = "7c09a571f65ac793611685cc9ab1dbe7";
+        JWT_SECRET = "29c4dc7f7de15306accf5eddb4cb8a70eb233d9fba4301f8f47f14c8c047ac81";
+        JWT_REFRESH_SECRET = "f2c1685561f2f570b3e7955df267b5c602ee099f14dc5caa0dacc320580ea180";
+        MONGO_URI = "mongodb://localhost:27017";
+      };
+    };
+  };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("librechat.service")
+    machine.wait_for_open_port(3080)
+
+    machine.succeed("curl --fail http://localhost:3080/")
+
+    machine.shutdown()
+  '';
+}

--- a/pkgs/by-name/li/librechat/package.nix
+++ b/pkgs/by-name/li/librechat/package.nix
@@ -6,6 +6,7 @@
   node-gyp,
   vips,
   nix-update-script,
+  nixosTests,
 }:
 
 buildNpmPackage rec {
@@ -60,6 +61,9 @@ buildNpmPackage rec {
         "--version-regex"
         "^v(\\d+\\.\\d+\\.\\d+)$"
       ];
+    };
+    tests = {
+      inherit (nixosTests) librechat;
     };
   };
 


### PR DESCRIPTION
This is a NixOS module for [LibreChat](https://librechat.ai), a self-hostable enhanced ChatGPT clone with agents and RAG API capability, among others.

Closes #352044.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
