### PR TITLE
pushlog: init at 0.3.1 (pkg+module)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22905,6 +22905,12 @@
     githubId = 56278796;
     name = "Sergio Ribera";
   };
+  serpent213 = {
+    name = "Steffen Beyer";
+    email = "steffen@beyer.io";
+    github = "serpent213";
+    githubId = 106662;
+  };
   servalcatty = {
     email = "servalcat@pm.me";
     github = "servalcatty";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -714,6 +714,7 @@
   ./services/logging/logrotate.nix
   ./services/logging/logstash.nix
   ./services/logging/promtail.nix
+  ./services/logging/pushlog.nix
   ./services/logging/rsyslogd.nix
   ./services/logging/syslog-ng.nix
   ./services/logging/syslogd.nix

--- a/nixos/modules/services/logging/pushlog.md
+++ b/nixos/modules/services/logging/pushlog.md
@@ -1,0 +1,65 @@
+# Pushlog {#module-services-pushlog}
+
+A lightweight Python daemon that filters and forwards journald log messages
+to [Pushover](https://pushover.net/).
+
+## Features
+
+- Filter messages by systemd unit name with regex patterns
+- Filter messages by priority levels
+- Include/exclude messages based on content patterns
+- Deduplication with fuzzy matching to avoid notification spam
+- Configurable notification batching with timeout window
+- Map journald priorities to Pushover priorities
+
+## Configuration
+
+```nix
+services.pushlog = {
+  enable = true;
+  # Load Pushover credentials from an environment file
+  # Contains PUSHLOG_PUSHOVER_TOKEN and PUSHLOG_PUSHOVER_USER_KEY
+  environmentFile = "/path/to/pushlog.env";
+
+  settings = {
+    # Optional Pushover title for all notifications
+    title = "System Logs";
+
+    # Optional journald to Pushover priority mapping
+    priority-map = {
+      "0" = 2;  # emerg -> emergency (2)
+      "1" = 1;  # alert -> high (1)
+      "2" = 1;  # crit -> high (1)
+    };
+
+    # Units to monitor (first match wins, exclude wins over include)
+    # Match, include and exclude are regular expressions.
+    # Priorities: emerg (0), alert (1), crit (2), err (3),
+    #             warning (4), notice (5), info (6), debug (7)
+    units = [
+      {
+        match = "node-red";
+        priorities = [ 0 1 2 3 4 5 6 ];
+        include = [];
+        exclude = [ "[{}]" ];
+      }
+      {
+        match = ".*";
+        priorities = [ 0 1 2 3 4 5 6 ];
+        include = [ "error" "warning" "critical" ];
+        exclude = [];
+      }
+    ];
+  };
+};
+```
+
+If using agenix for secrets, you can use:
+
+```nix
+services.pushlog = {
+  enable = true;
+  environmentFile = config.age.secrets."pushlog.env".path;
+  # ... rest of configuration
+};
+```

--- a/nixos/modules/services/logging/pushlog.nix
+++ b/nixos/modules/services/logging/pushlog.nix
@@ -1,0 +1,175 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optionalAttrs
+    types
+    ;
+  cfg = config.services.pushlog;
+  settingsFormat = pkgs.formats.yaml { };
+  unitType = types.submodule {
+    options = {
+      match = mkOption {
+        type = types.str;
+        default = ".*";
+        description = "Regex pattern to match against the systemd unit name";
+      };
+      priorities = mkOption {
+        type = types.listOf types.int;
+        default = lib.lists.range 0 6; # exclude debug
+        description = "List of journald priorities to include (0-7)";
+      };
+      include = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "List of regex patterns to match in message content (empty matches all)";
+      };
+      exclude = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "List of regex patterns to exclude from matches";
+      };
+    };
+  };
+in
+{
+  options.services.pushlog = {
+    enable = mkEnableOption "pushlog service to forward journald logs to Pushover";
+
+    package = mkPackageOption pkgs "pushlog" { };
+
+    environmentFile = mkOption {
+      type = with types; nullOr str;
+      description = lib.mdDoc ''
+        File containing the Pushover API credentials, in the
+        format of an EnvironmentFile as described in systemd.exec(5)
+
+        PUSHLOG_PUSHOVER_TOKEN, PUSHLOG_PUSHOVER_USER_KEY
+      '';
+      default = null;
+    };
+
+    settings = mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        options = {
+          collect-timeout = mkOption {
+            type = types.int;
+            description = "Wait n seconds before sendings logs to bundle multiple messages";
+            default = 5;
+          };
+          deduplication-window = mkOption {
+            type = types.int;
+            description = "Remember messages for n minutes and avoid sending duplicates";
+            default = 30;
+          };
+          fuzzy-threshold = mkOption {
+            type = types.int;
+            description = "Use fuzzy matching with the given threshold (similarity in percent) to detect duplicates, set to 100 to disable";
+            default = 95;
+          };
+          title = mkOption {
+            type = with types; nullOr str;
+            description = "Optional title to use for all Pushover notifications";
+            default = null;
+          };
+          priority-map = mkOption {
+            type = with types; attrsOf (ints.between (-2) 2);
+            description = "Optional mapping from journald priorities (0-7) to Pushover priorities (-2, -1, 0, 1, 2), unmapped priorities will be mapped to 0";
+            default = { };
+            example = literalExpression ''
+              {
+                "0" = 2;  # emerg -> emergency (2)
+                "1" = 1;  # alert -> high (1)
+                "2" = 1;  # crit -> high (1)
+                "3" = 0;  # err -> normal (0)
+                "4" = -1; # warning -> low (-1)
+                "5" = -2; # notice -> lowest (-2)
+                "6" = -2; # info -> lowest (-2)
+                "7" = -2; # debug -> lowest (-2)
+              }
+            '';
+          };
+          units = mkOption {
+            type = types.listOf unitType;
+            description = "List of units to care about";
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (
+    let
+      format = pkgs.formats.yaml { };
+      configFile = format.generate "pushlog.yaml" cfg.settings;
+    in
+    {
+      systemd.services.pushlog = {
+        description = "Pushlog journal forwarder";
+        requires = [
+          "network-online.target"
+          "systemd-journald.service"
+        ];
+        after = [
+          "network-online.target"
+          "systemd-journald.service"
+        ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig =
+          {
+            ExecStart = "${getExe cfg.package} --config ${configFile}";
+            Type = "simple";
+            Restart = "always";
+            RestartSec = "5s";
+
+            # Hardening
+            CapabilityBoundingSet = "";
+            DynamicUser = true;
+            Group = "systemd-journal";
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            NoNewPrivileges = true;
+            PrivateDevices = true;
+            PrivateTmp = true;
+            PrivateUsers = true;
+            ProtectControlGroups = true;
+            ProtectHome = true;
+            ProtectHostname = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectProc = "noaccess";
+            ProtectSystem = "strict";
+            RestrictAddressFamilies = [
+              "AF_INET"
+              "AF_INET6"
+            ];
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            SystemCallFilter = "~@aio @chown @clock @cpu-emulation @debug @keyring @ipc @module @mount @obsolete @raw-io @reboot @setuid @swap @privileged @resources";
+            UMask = "0077";
+          }
+          // optionalAttrs (cfg.environmentFile != null) {
+            EnvironmentFile = cfg.environmentFile;
+          };
+      };
+    }
+  );
+
+  meta = {
+    maintainers = with lib.maintainers; [ serpent213 ];
+    doc = ./pushlog.md;
+  };
+}

--- a/pkgs/by-name/pu/pushlog/package.nix
+++ b/pkgs/by-name/pu/pushlog/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "pushlog";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "serpent213";
+    repo = "pushlog";
+    tag = "v${version}";
+    sha256 = "sha256-xlzEBSV6AKj24E/RZKksBnYQtNAaHZaff9p0K6Lxvco=";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    fuzzywuzzy
+    levenshtein
+    pyyaml
+    systemd
+  ];
+
+  checkInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Lightweight Python daemon that filters and forwards systemd journal to Pushover";
+    homepage = "https://github.com/serpent213/pushlog";
+    platforms = lib.platforms.linux;
+    mainProgram = "pushlog";
+    license = lib.licenses.bsd0;
+    maintainers = with lib.maintainers; [ serpent213 ];
+  };
+}


### PR DESCRIPTION
A lightweight Python daemon that filters and forwards journald log messages to [Pushover](https://pushover.net/).

Depends on [python-systemd](https://github.com/systemd/python-systemd), so it typically will only run on Linux systems.

See https://github.com/serpent213/pushlog for more details.

This is my first contribution to nixpkgs, looking forward to reviews.

(Former PR #402143)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
