### PR TITLE
androidenv: emulator: fix non-Linux path/binary symlink

### DIFF
--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -57,7 +57,7 @@ deployAndroidPackage {
       libxshmfence
     ])
     ++ lib.optional (os == "linux" && stdenv.isx86_64) pkgsi686Linux.glibc;
-  patchInstructions = lib.optionalString (os == "linux") ''
+  patchInstructions = (lib.optionalString (os == "linux") ''
     addAutoPatchelfSearchPath $packageBaseDir/lib
     addAutoPatchelfSearchPath $packageBaseDir/lib64
     addAutoPatchelfSearchPath $packageBaseDir/lib64/qt/lib
@@ -85,7 +85,8 @@ deployAndroidPackage {
       } \
       --set QT_XKB_CONFIG_ROOT ${pkgs.xkeyboard_config}/share/X11/xkb \
       --set QTCOMPOSE ${pkgs.xorg.libX11.out}/share/X11/locale
-
+  '')
+  + ''
     mkdir -p $out/bin
     cd $out/bin
     find $out/libexec/android-sdk/emulator -type f -executable -mindepth 1 -maxdepth 1 | while read i; do

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -57,45 +57,46 @@ deployAndroidPackage {
       libxshmfence
     ])
     ++ lib.optional (os == "linux" && stdenv.isx86_64) pkgsi686Linux.glibc;
-  patchInstructions = (lib.optionalString (os == "linux") ''
-    addAutoPatchelfSearchPath $packageBaseDir/lib
-    addAutoPatchelfSearchPath $packageBaseDir/lib64
-    addAutoPatchelfSearchPath $packageBaseDir/lib64/qt/lib
-    # autoPatchelf is not detecting libuuid :(
-    addAutoPatchelfSearchPath ${pkgs.libuuid.out}/lib
+  patchInstructions =
+    (lib.optionalString (os == "linux") ''
+      addAutoPatchelfSearchPath $packageBaseDir/lib
+      addAutoPatchelfSearchPath $packageBaseDir/lib64
+      addAutoPatchelfSearchPath $packageBaseDir/lib64/qt/lib
+      # autoPatchelf is not detecting libuuid :(
+      addAutoPatchelfSearchPath ${pkgs.libuuid.out}/lib
 
-    # This library is linked against a version of libtiff that nixpkgs doesn't have
-    for file in $out/libexec/android-sdk/emulator/*/qt/plugins/imageformats/libqtiffAndroidEmu.so; do
-      patchelf --replace-needed libtiff.so.5 libtiff.so "$file" || true
-    done
+      # This library is linked against a version of libtiff that nixpkgs doesn't have
+      for file in $out/libexec/android-sdk/emulator/*/qt/plugins/imageformats/libqtiffAndroidEmu.so; do
+        patchelf --replace-needed libtiff.so.5 libtiff.so "$file" || true
+      done
 
-    for file in $out/libexec/android-sdk/emulator/lib64/vulkan/libvulkan_lvp.so; do
-      patchelf --replace-needed libLLVM-15.so.1 libLLVM-15.so "$file" || true
-    done
+      for file in $out/libexec/android-sdk/emulator/lib64/vulkan/libvulkan_lvp.so; do
+        patchelf --replace-needed libLLVM-15.so.1 libLLVM-15.so "$file" || true
+      done
 
-    autoPatchelf $out
+      autoPatchelf $out
 
-    # Wrap emulator so that it can load required libraries at runtime
-    wrapProgram $out/libexec/android-sdk/emulator/emulator \
-      --prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath [
-          pkgs.dbus
-          pkgs.systemd
-        ]
-      } \
-      --set QT_XKB_CONFIG_ROOT ${pkgs.xkeyboard_config}/share/X11/xkb \
-      --set QTCOMPOSE ${pkgs.xorg.libX11.out}/share/X11/locale
-  '')
-  + ''
-    mkdir -p $out/bin
-    cd $out/bin
-    find $out/libexec/android-sdk/emulator -type f -executable -mindepth 1 -maxdepth 1 | while read i; do
-      ln -s $i
-    done
+      # Wrap emulator so that it can load required libraries at runtime
+      wrapProgram $out/libexec/android-sdk/emulator/emulator \
+        --prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath [
+            pkgs.dbus
+            pkgs.systemd
+          ]
+        } \
+        --set QT_XKB_CONFIG_ROOT ${pkgs.xkeyboard_config}/share/X11/xkb \
+        --set QTCOMPOSE ${pkgs.xorg.libX11.out}/share/X11/locale
+    '')
+    + ''
+      mkdir -p $out/bin
+      cd $out/bin
+      find $out/libexec/android-sdk/emulator -type f -executable -mindepth 1 -maxdepth 1 | while read i; do
+        ln -s $i
+      done
 
-    cd $out/libexec/android-sdk
-    ${postInstall}
-  '';
+      cd $out/libexec/android-sdk
+      ${postInstall}
+    '';
   dontMoveLib64 = true;
 
   inherit meta;


### PR DESCRIPTION
Symlinking to `bin/` should be done for *all* OSs, not be limited to Linux.

With this patch the proper (non-legacy) `emulator` binary becomes available on Darwin in $PATH.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
