### PR TITLE
OWNERS: simplify workflow/ci owners

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -15,12 +15,9 @@
 
 # CI
 /.github/*_TEMPLATE*                    @SigmaSquadron
-/.github/actions                        @NixOS/Security @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther
-/.github/workflows                      @NixOS/Security @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther
-/.github/workflows/check-format.yml     @infinisil @wolfgangwalther
-/.github/workflows/codeowners-v2.yml    @infinisil @wolfgangwalther
-/.github/workflows/nixpkgs-vet.yml      @infinisil @philiptaron @wolfgangwalther
-/ci                                     @infinisil @philiptaron @NixOS/Security @wolfgangwalther
+/.github/actions                        @NixOS/Security @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
+/.github/workflows                      @NixOS/Security @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
+/ci                                     @NixOS/Security @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
 /ci/OWNERS                              @infinisil @philiptaron
 
 # Development support


### PR DESCRIPTION
The current setup causes the Security team and the other owners of .github/workflows to **not** be pinged for the
check-format/codeowners-v2/nixpkgs-vet workflows. This was highly likely unintended when adding those additional rules, so removing them.

Also, we have some owners looking after `workflows/`, but not `ci/` - and some the other way around. This doesn't make much sense to me, since both parts depend on each other very much. But, I might be missing something, so maybe some of that was on purpose.

There are changes for:
- @Mic92, @zowoq and @azuwis, who were not owning `ci/` before.
- @philiptaron, who was not owing `workflows/` before.

Please speak up if you're not OK with these changes. Of course, you are also free to comment if you're good with them ;)

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
