### PR TITLE
kaldi: treefmt

### DIFF
--- a/pkgs/by-name/ka/kaldi/package.nix
+++ b/pkgs/by-name/ka/kaldi/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r ../egs $out/share/kaldi
   '';
 
-  dontCheckForBrokenSymlinks = true;  #TODO: investigate
+  dontCheckForBrokenSymlinks = true; # TODO: investigate
 
   passthru = {
     sources = {


### PR DESCRIPTION
Introduced in #412663.

## Things done

- [x] Ran treefmt locally
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
