### PR TITLE
firefox-{devedition,beta}{,-bin}-unwrapped: 140.0b2 -> 140.0b3

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,2477 +1,2477 @@
 {
-  version = "140.0b2";
+  version = "140.0b3";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ach/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ach/firefox-140.0b3.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "9772122fe9b864f2247c7fdb6e5d11813b25af4e86120959581ef8d1e4d43522";
+      sha256 = "87c1f8aa057b132bdf97b81aa911cde1b76df420f4319052dac1fb36f73aeaa7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/af/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/af/firefox-140.0b3.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "dd758bbab164e46f9484b1a271b94d95dff15788998e137ba4ea6a4adc325625";
+      sha256 = "995fb3776e849a87271df8f7967fff46febbb57ac4e513e520fe2790947e8e04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/an/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/an/firefox-140.0b3.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "e10bf7cb75a4b9c395aa2c0adf1f5406daaab1ed2148a6c8cad034376e79380c";
+      sha256 = "a3daa36f2d0477ff3bf8af4df84b1bbd6d001093b1b7453489486efabfc1c0c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ar/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ar/firefox-140.0b3.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "09d6db922f63c3a0b9fa080050820f9a83c517c6faa0848bd104a669336789b1";
+      sha256 = "36bb911e75abad10dd74d9d1aa541ee8b34f7918f5867acbfeb2682386d1b875";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ast/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ast/firefox-140.0b3.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "5e2bed35394f61519b2cc67e341e14002e692edbf7c52b5a5aca329403ff36ec";
+      sha256 = "3df5f717c4ba64c88fcf873e01a667dc72ec006be98e4ccdf776381fb5c2999f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/az/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/az/firefox-140.0b3.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "7f56c3afe0cb2a899411496e5f989b44834bafb0febda20bed7495ec5dfcd8d7";
+      sha256 = "0fbc914fed6b0344f6701dda29c92a613650987a9c5c3b6cc6f5f99f1d77df47";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/be/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/be/firefox-140.0b3.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "202cde7a9402777c80ce654b264007d13baf7e573ecb6ada8ac21a58ff80c6c0";
+      sha256 = "0e07670b6e2f0912d3c7c599b7db147212b0cad36737681d8012f2dca7d8c22e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/bg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/bg/firefox-140.0b3.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "58d17e006afc3a024d843ad196b09a5ed19b29ab40318be8d0682b4a21e73117";
+      sha256 = "7d96d3e05a94d268accf129fe008688fe492472ae1edbb8eb50fc29f7c899be9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/bn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/bn/firefox-140.0b3.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "8f21073aaa86facd7e5828857f3581e67949be14a359c1a99967e02ebc888a03";
+      sha256 = "0788fda0e35abb70344cc4030bb54af725ec4dc3725f8ebc12df70ceeb860fdb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/br/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/br/firefox-140.0b3.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "ee8f892efd0dd4a9bb2d45609f54c7ca06e1e803c7a1abbed7bc3a80ac03cd3e";
+      sha256 = "5a45b3c49e0ccd7314881494d825badb16372fda7bb94fd704b8eb49fe9492c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/bs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/bs/firefox-140.0b3.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "11308e30b1a7bb4c26779048b5cf6c36ed6f1092c6aebb19c5413379b000c245";
+      sha256 = "e4dd687373bf633cfde18764d9b424ac245349925a7fdb5a45fd1698b8ed1164";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ca-valencia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ca-valencia/firefox-140.0b3.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "e99bb572c923e86dab8ca768dd7016553a166bff9479ed568e0c0cf823058b8e";
+      sha256 = "f4dd916b333e0abc0551d7651156e94cdf31049d7fe7e51b2f46f877066fc144";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ca/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ca/firefox-140.0b3.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "b0cce2c03c5a3b5741cfa158f8cf294c51b881ba101695e00c91b1bd14f897e6";
+      sha256 = "020a985e9841238d683fa817e26f1791ea60946701c91e8eab3def9c2db23278";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/cak/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/cak/firefox-140.0b3.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "bc26e0bd9336906decce9e79bc4501335d1144bfe4acad0e34d604982a99e799";
+      sha256 = "542b5987fb29f278c2d1c0451053a37874f8a9ee1c80a3e2d818821b740a465c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/cs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/cs/firefox-140.0b3.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "d94e4fdd4aa4c2cc57c8dd5cc3f28c9287d916ac98d803048f9c254b7036b32c";
+      sha256 = "390df2e96d9b0f2c6a5c5ef01b9f4790e0d65a5bd559bcd7b5645e632fe05b6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/cy/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/cy/firefox-140.0b3.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "f6e8adfabb271dc3275af1c0123a050a9acea8cb20d69da53c06b1f8b93abcb5";
+      sha256 = "a0cd0379ffe29c33eb1f34dce54f56e9c6801cf25378633e4c3cf9a0badfae22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/da/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/da/firefox-140.0b3.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "a0c7e0fd4daa6f83ea721bddcb67b0dcaebfa971964d5eb8b30421c6ccf9afb2";
+      sha256 = "582033616abeaa16914802635720708294de44afb42c118098b5d30a3df96968";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/de/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/de/firefox-140.0b3.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "a41061a13e540377854c68bac1e0ead0e43fb6eb398cedd1c7d072fbd1aa7d2c";
+      sha256 = "e05ae143147e96e5b5c686813f8284640b193b12fa1ecc878a033d7a6b62572a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/dsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/dsb/firefox-140.0b3.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "a4ee38be8dc35f327c7e10178f5d589234ece7fa82799748e51c10b9b2a03e57";
+      sha256 = "bf11f20d86bd8c8fec4a4d9fa14adfba00e9bce9b40f9a899a0fe8cafdfaa89e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/el/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/el/firefox-140.0b3.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "76c892f181579b8d86468789df62e2f61b87be550235884419966dcdf5f159b0";
+      sha256 = "f4758465dedcc1a1abbef1dfbfa1c1a0e630714eddfa98038826033f7baaddca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/en-CA/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/en-CA/firefox-140.0b3.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "57cf1cb329540eb612f2b2392ade585b4505a89ad32dc4bbc6adb199ec179b31";
+      sha256 = "75949735b5d56b36a143410517d109d55139bd670d505d0b467288094ccd34bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/en-GB/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/en-GB/firefox-140.0b3.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "62b77a005adc751657d1c40c8f744c7d1c0ab341a6bd3ee0e7864f69ed2759f4";
+      sha256 = "e81b992506abce52d839623334376229a35659699c8770516b3c7e34d810ead7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/en-US/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/en-US/firefox-140.0b3.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "828cac8a8d7e83fd82c13c979fce4a77262be2d8bf6639612664ca1f10c96ec1";
+      sha256 = "c1428da2dfc7a16deb7b9570fcccba94c13158373a359804233a4b5f330746a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/eo/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/eo/firefox-140.0b3.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "91f3b063d16c364419ec2ccdd152c05b19a0bb38eededdd2461d79952a760753";
+      sha256 = "54790c6e1050b34d380e6daf96f387379aa825249af5889c71752eb728ecb10d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-AR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/es-AR/firefox-140.0b3.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "b2edc4c81a5910901a6e2e9b90b2fc3c625f67e74f746cbc3ca4a32dc9115611";
+      sha256 = "d4dc96fba97c8f0c96ec5d596aaf6e30fe5f467399b59307ba1e91b5471979d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-CL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/es-CL/firefox-140.0b3.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f35abf87c2ac7afe6f75861bf99595a06f7216de0003f91cde3c719f3a2b0124";
+      sha256 = "c9888370387548a0c7b26facd131e8effc9b43bf27d4d2ad31cec12c3e39eecd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-ES/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/es-ES/firefox-140.0b3.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "575e9368ff7bbac6c168441d1095472bd29eeaf8dbb271bf7c1ef14d0e0c69ed";
+      sha256 = "6fd830a501cebe0dd6a005cc00eb326cc82c30f38836da4ba46a79be13401377";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/es-MX/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/es-MX/firefox-140.0b3.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "5ce0c62e79621a15c533768282344b523b96c478d463de58754e3808bccf4d0b";
+      sha256 = "0f65338c18d4cd2bc4fc5b4eecaf62d759e532059588a920ce19de13d941ec7a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/et/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/et/firefox-140.0b3.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "b8493cd786ec0beb918cd7bbe5009d039ec6e5b8fa2f8cdd80309a3325947015";
+      sha256 = "904917e0115be1015954139ddf50395ec69e297082bd37f14a280415471116cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/eu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/eu/firefox-140.0b3.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "5573776ed1d9b4dda2d0bd566b2b4c8a83906193005f2db7f953d1eb57079335";
+      sha256 = "9e03aeda162aa17a17eb3336e430dffbc415685cd211aadfc43a5f616c8e8758";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fa/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fa/firefox-140.0b3.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "59a775986c659bf12ef00f2f13de480b69279d1881358827244eae0ba6631976";
+      sha256 = "6054bf75fad6b65c29b2f7c4e223df75f02b5ccabceb86b9c5e5e42b741f7bfd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ff/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ff/firefox-140.0b3.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "2e5bec3ebf2b31d9a3eac67f03f9fadf249956df08529fccfb1fe6d305c99e31";
+      sha256 = "ebea919c503fc4523e1c594216ce8079316c9d377ba9bae6a6729ee3182c9df3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fi/firefox-140.0b3.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "f31288ef2e48ac0cb3fdff3395346927fd866878d22bcc9be6a70fb1c86cb441";
+      sha256 = "3126d98ccd0c5f16b77a71ad4c11423482cd5c7d8f7d10f7828e9e6d11e0f461";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fr/firefox-140.0b3.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "4d011e05781ad8cf93d704e7455e28a0325c07d0b3bd12ade2f315b918e9fe65";
+      sha256 = "9ddfee47dd74850d20f7aa87cbf92b46ff237d0a934d871025b92a364b2cb4c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fur/firefox-140.0b3.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "042c4f0d7fa4a638db9dec99fd30d7af490fd11097b4adfa9f7d474bccabb4a1";
+      sha256 = "05025972440fdc4087266a88d02e6968b52a43ff6d77f0190a659eac6ae816c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/fy-NL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fy-NL/firefox-140.0b3.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "7c44584b9bc19d943191385cc8c56420f77fba6e4f9712a229797b3cf6588639";
+      sha256 = "4243921762a60f5ce51e7737b6d3fe9bcc4dfea67c9198a1b917290efba9d0f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ga-IE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ga-IE/firefox-140.0b3.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "33ee655e264ed6b96a3aa75e7f1d7cd6c188fa55eb6c07c633cd7a388d04ce03";
+      sha256 = "71a26a2fbaaf721ea307a8c3a8b083ef70077765f3a7278d25385b531ac315dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gd/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/gd/firefox-140.0b3.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "24a8becd37c3836af08e14e010914563ab4a205380b8a7ebeb856afe552f6c17";
+      sha256 = "c44b110b0fc96d3826103b0799bbd3df88cee0c8972f7e60f556590e053d9636";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/gl/firefox-140.0b3.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "a0be7754c2e9b50429b62decb89123da0818530ffdecfae333b2c94342d23975";
+      sha256 = "a6707479746e71d8c3d5af40500433c2290fce9d2ff98bd3ecd89bdbb9cd182c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/gn/firefox-140.0b3.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "ad5844d9720a0847aa8ccd06fe2fb948cbebc2b1adfe0fc871d18b0461ad4591";
+      sha256 = "d2dcd4701b0563af8825c3eb3aa22ffd2702d9a8458cd0ed4896a9bf57c0d291";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/gu-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/gu-IN/firefox-140.0b3.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "7a32e73b96af77fbcb4a14fb6098d270a73484054ea9d8a47319247f2ba2db0d";
+      sha256 = "eec813b14a376b6f0e7c251ada0e972fbaae06db077e1e5ad63f5a069c81ad97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/he/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/he/firefox-140.0b3.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "50a1e0ea0c17140525584a1cbb7de67801af5be12765d4d610cd70dea4ad1bfc";
+      sha256 = "e3952c61718e26ea8f9aeb73a3b8146bd0163aa87388db2f518e997aed1163a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hi-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hi-IN/firefox-140.0b3.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "9871be936ad26228905a9bbabc94f8b027b066af8b4a27c0895fbb927dfea723";
+      sha256 = "b00059920c29e3e11dbb2fe3051acee804dda39838706a65c3716bdccabf7e9b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hr/firefox-140.0b3.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "f950a486143e3658168f7caed53f546679d5af41994398ccd3578222c4f6c513";
+      sha256 = "d77d3d50678d17098e9996edb0642bd8e6a1ccb983ea68e376d59e2ae0529779";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hsb/firefox-140.0b3.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "1885e8881aa7bc06a993fd350c0368f85101d007583eb3b9145e9fc777ba2012";
+      sha256 = "45e839005799d5bdbcbed3869680da6ca0ad42c3f9932b61e0f8e3fbc0316fee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hu/firefox-140.0b3.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "3efa843d3a3c1b8ca7454959ea2838ff436cb5820725b98599a99f57db4f21fe";
+      sha256 = "2c655b6b1e91265befe5f7c1745a9ea8f4a97f6995ed2f4c4b3eede9fd07c8a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/hy-AM/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hy-AM/firefox-140.0b3.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "4566fba506a4ee45d1152a5ebb716ec264e1cccfa84b011cb6bbccc1d58e5ffc";
+      sha256 = "bcc23fec185ab50660111850185ad9caeafabc056a77e6b8d99e12962da030ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ia/firefox-140.0b3.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "e599c11c636a7912a5d64df4c4f642c6b23b8ac8917602319c7d1aadf2c6e15a";
+      sha256 = "c70ac08f5d1ac3c2175b5c1f0fed88564a8fc921771e0cb6082bfe9502f08407";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/id/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/id/firefox-140.0b3.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "788e2874ea4d845a742eb4f5ef9e02c79ad3ce156a09e1b7db19e83ed661b650";
+      sha256 = "b77533733de76fde27cdcb220f2f4c985784aeeb65456a8aa4f22689d1a78633";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/is/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/is/firefox-140.0b3.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "280b95ffa32b43aa893b0df87fdda0adb14826b8a2b195c8a8a6f21174894412";
+      sha256 = "e8d28dfed20bc64fdb431c6149c8f46a1601dcdb7c198e6aaac3bc26849ed564";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/it/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/it/firefox-140.0b3.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "5bf7718acb53c53244cb9979ed72c132b14b66b53caf51d554b01e601dfc116d";
+      sha256 = "aa7017e3cc75ee281523f109c5a804a2686cb2d120af07f639cbe6e0b529f95b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ja/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ja/firefox-140.0b3.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "67cffcb3c101d24c384056b9ed5285f78a5a00421753524a8a4936d2ac3727c9";
+      sha256 = "aac539dc6adaed5e46f5dc180e6d5df7e58e7d06c9b3eb8840f67bb3005a3d1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ka/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ka/firefox-140.0b3.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "e868d7da325cb38a4a6360aaeec5d34d2e7aa545da2682226b319b4f3aca2d53";
+      sha256 = "dca7592228e259a535805f0b40473448dbf5406f8bec1a313ae39621ba3a22e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/kab/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/kab/firefox-140.0b3.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "0de027c78af9346e30d4d64595ea81d5c522bb3a44e33e380b45e0d9fcfd0f28";
+      sha256 = "02cea8e48adce2143ffa78f564da31a26355572df7bf1a379e743a7ec4949a90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/kk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/kk/firefox-140.0b3.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "411e311bac40c12392aca73a5a4315fc015ba413526d20a19c620f74a66a8200";
+      sha256 = "12e9811a0fb02ff7c52790d2fdfd116e2232fc6788cfd84e9d52009ab480d846";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/km/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/km/firefox-140.0b3.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "6575b0b44caa29ba2d2ce4f69ccd0ac09c2d89b86eb9a541632a0e155e8108f2";
+      sha256 = "fbde93d1aad4c0cd059b14ae9ae0bd1ccf95374009aaafe68e830007b4cf496a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/kn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/kn/firefox-140.0b3.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "a1757ad5a847e430271d2cc99a3ef45ea409d0f8df52d8df38012e618ddb90fe";
+      sha256 = "975aaf5d7a139ea4ecb3d92b2cff56373a63069e7735478eafa596e1dca2a7d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ko/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ko/firefox-140.0b3.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "6aa52561db8818725fe013bc7940b81c07e38c2678ef427675d0fc58c6741da6";
+      sha256 = "6c43fd5ae7e8d8af3e87940dfb49a6183c540fc18e98fcfe00ffce137b5682af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/lij/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/lij/firefox-140.0b3.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "c07084a6bc9324dd71dc442fe24934bf29873b6e7e5158ae68eb4323507a5b0a";
+      sha256 = "da9bf66ee9231718bcbcbf16662b631984b75bb73bef82e58d1442560a2c0232";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/lt/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/lt/firefox-140.0b3.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "5b088e25ded761cd501be0f5617349a2126c9eec6839e3ec6bcdc0b19ec9db02";
+      sha256 = "c8f018f9494291e01e4dedd3dc0e496c1c4fc4d346896f5225972d182f231c57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/lv/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/lv/firefox-140.0b3.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "2bfe6a0bb5522305f577608ca6759013be5a947fd3e5e253191dc25376d2ab12";
+      sha256 = "6a46324a4abedeea12aaeeb6f88af8b0277af5863a4977f06c33a0df7d3a9f3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/mk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/mk/firefox-140.0b3.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "441e386a2c4c0f3602907f48438b390a19e1f6a00831f8160b3212724d7da07d";
+      sha256 = "b1f2fc79baff629f24d0ae75fb8b29559a607b8b1434d745e8b9b5ab0c40ef14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/mr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/mr/firefox-140.0b3.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "c9f51bf2d9ebf2e76c80d2911f15f1ebb0272011c39059ea9a4e1c1bf83bf190";
+      sha256 = "04eceab79c3d3156fb27968108abbe0d7b0f01608f788eed474512bb82412fd8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ms/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ms/firefox-140.0b3.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "261acca048d14496d15c2ebd56fa069346b194c652f0f6f2cd9afbe8ffad02f0";
+      sha256 = "17e8527080d60c18a363ced9e36548ed5bf575e8ad62bf5c397cf26fe06cb078";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/my/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/my/firefox-140.0b3.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "58ba0821d03e4f362bc506b420427c02ca69ae43eb5bf241caa481ee791f1c13";
+      sha256 = "19e137672d04c8eefff895b9c434a5b940c881aca4669b5f31947081c202c476";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/nb-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/nb-NO/firefox-140.0b3.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "5792c3f26540c20ba966fe7d587a1874452eb4346d72c24ede6a8bdaeaf704cb";
+      sha256 = "97deb521ad609263c0dbe13458c4500021422a4f3bc84bbdd2a1aa290d288abf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ne-NP/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ne-NP/firefox-140.0b3.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "2f0656c6a7ae21a07a506b4293afcd85f6d3376961a71d5b45af698d67496d17";
+      sha256 = "717d6e19cd002fc19208cf2506f2d4508561316f759154ff212928a20a44a195";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/nl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/nl/firefox-140.0b3.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "e135d0459ba83b78cbd606e2fb033f8fc945ff628959103ef65747123bee7cae";
+      sha256 = "765d8adf054295479e63d40fead98656d3d672bb7f4a42a8dc9c0cd5e8c29815";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/nn-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/nn-NO/firefox-140.0b3.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "24ae203327f886d34d71d1820292fea86cbd39bb68400a317e1185c291739eb8";
+      sha256 = "74d183d64ed423bc1dea8972a4f32378aded5c733b6f58a1e6d178f49024f7c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/oc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/oc/firefox-140.0b3.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "fe061945a5fab1a73a03f424e02db5e90f490b3dbab11af978bf2bca27abd44c";
+      sha256 = "883fe66e83b2af674d9596a52910f28703548bd7c0615e15587a980a93d38c16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pa-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/pa-IN/firefox-140.0b3.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "16e22303ce33d37a5462fe1f9cc09959a7f8efe77133d3d87b6a6b3d5fedf0d6";
+      sha256 = "ee586be768d0035a681acf83b5c68cc1c5cab04054afe8deb141a4c9f21d2890";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/pl/firefox-140.0b3.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "9e1d841a5e5457f62f20cee241e538b1336edffe42a893fcbcf616a5989044e0";
+      sha256 = "c65c7e68fb0ccf5b01bf17aee844c4e4ecf5192a630a2b4e2bb30de5752a9f9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pt-BR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/pt-BR/firefox-140.0b3.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "e7da00d2172e5ce485957061bf3b8869f7437de3e3324dc9251f095e48ae26cf";
+      sha256 = "a097d98e98410dff2c051bd1d9a2667d54da22df0a1578c0d558e028835dd372";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/pt-PT/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/pt-PT/firefox-140.0b3.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "b44a97bb059b2c4d11fd4786be517b22db28eb61bec88dab6335fdc5820cfbfc";
+      sha256 = "788048f852dd4f215dcca69d6e658e75bf52fa9a2bdc7118b27d47025343d55a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/rm/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/rm/firefox-140.0b3.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "eecf8793a52e4f64391b3f424530b2ba9fe3474ad24ef16e3388272bb0cd1839";
+      sha256 = "b691ae86cfc7a1d4d22a25c04d84e89e3b616970012559bc182225539af0a92b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ro/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ro/firefox-140.0b3.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "b1d69873414e221ffbe2b5c7175487c5dcd97ae2b7da17011d14f0e6e1342e1c";
+      sha256 = "b9f502952d67e13bec4a5d4c7a780ed5f06c628463cb6c4a3c5b70febb2724f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ru/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ru/firefox-140.0b3.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "823e6ec4c9a1326cc08ef9afaa50f33e892517fb94b8cf135c5df2ad0b39af49";
+      sha256 = "daa5e9adffeff031b2bd764802482730cb37335a6a4b5ba011e708ebe39f771c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sat/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sat/firefox-140.0b3.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "2c24a66abdbe63b8537c1d1eb457e1078f4768fa4e1c628ec91c801fa4e29863";
+      sha256 = "3a2ebe89dc72f8b6988fb6742340623423df9d166030ed691c884d013de0fa83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sc/firefox-140.0b3.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "3f49ee23328467021066957d5c46150a2b2ed2216774d4593a2bedc8c3a116f6";
+      sha256 = "db27ece945871d6f988ae710daf52874e4d6cbe03eb950c4a4faeff6d67bd9b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sco/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sco/firefox-140.0b3.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "1d1ec36ea66705cd0b0d986d7f7ceca5a0b56dd98fd51cc640b3aba03454ab72";
+      sha256 = "976b40edd9700fbc012b55584824c77b4839be8cc2269dc8a178c6b2b3e57041";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/si/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/si/firefox-140.0b3.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "1d2609c2d3b7ef1badb501a65644d3dcd0e376a9a95fccbc751c9420aa9144ec";
+      sha256 = "e7d94105a1bbfbb30d220e7b10b6c59118a7556541bb2a25ba4aa3b454827841";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sk/firefox-140.0b3.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "adf327cae6a85ef120eb027a8e5477654db02f829bf673db4bdcc8c05dee86d6";
+      sha256 = "cc38654e9236e9dfc8b58e3795c9d347447f3832c8d5b6d50afbfc1298c1c996";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/skr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/skr/firefox-140.0b3.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "70f8da6b2e7ef52d707a80011ae8998342fa64def483ba4717f6c7e0ea1b7ac2";
+      sha256 = "12e95e82e29358039287da28a81a7f90d9d6dc7262f0f2aa541253856931eab6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sl/firefox-140.0b3.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "bdd9383a3d0f8f736371956852a51583e68c0227612610b3831c6601b4cbd319";
+      sha256 = "bc6c1f3f4a8540baaa764aa34d571bb5743e2364cebd49d3326ddb01ba6b20cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/son/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/son/firefox-140.0b3.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "24d2724df88cedccbceeebd89e5c8087e54049bf11f291a707adacb16f4fefff";
+      sha256 = "d949c0da8ab52490c03fb8577dcd10a96cdf68378b4a70d5fd9ac28f6cb660e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sq/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sq/firefox-140.0b3.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "7211cb03bc81a7eb781fd4d35c6826c70df13a29fdb4486d423c718047a76859";
+      sha256 = "fb531412139967abb42c99a5a68fad323892b6101953e8e6207d45b9f62a6f94";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sr/firefox-140.0b3.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "177e7e9786e45883f84939ce5eff32dfccdc08adc5c034e22437203637a9d89e";
+      sha256 = "a04d2d0347fb2761ad58b85304e0f8f9ffd343366608fd17cf687c2d53e61009";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/sv-SE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sv-SE/firefox-140.0b3.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "700f554cdf816dc5aa91b6cfbaf8bf204264538ea9b9ae3d6ef10d256450a29c";
+      sha256 = "ae8abbd42e9dd09213511f359d0a069e8f58b8fb8b1139600fe678cc437e7fa1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/szl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/szl/firefox-140.0b3.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "48db54afbcc1e6840e52b0a023dd6ee1956a44ee6a96930b52d10e1640155eed";
+      sha256 = "9939bccff2b5b00e0da9764d0d859eb17dc68477553c61c3bf8a3dd632779638";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ta/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ta/firefox-140.0b3.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "17074b69f77f2db0bd507e334d7b74cf290854d9fe696763223487c130629ca9";
+      sha256 = "844ea991305f8b946b0c5ac059788ed661abb033016e8c2e096d872784ecf20e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/te/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/te/firefox-140.0b3.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "85f1f5bb9ab7517b0ab0700bbb94048776454cec7677216005989c0c4eec6047";
+      sha256 = "bb21e776ffa953c82444f34ae9f81d06fa8d725c5a86e5b85b25d4171ce6079f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/tg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/tg/firefox-140.0b3.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "417933976c3a4b3d9e001adb8817b97830c22d2500d2bd20fb3d260d4efb58f2";
+      sha256 = "2f3d94b992a2a89169cb3628eb807967c0f4b02fb25c14ee7f9ea925c4d78e85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/th/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/th/firefox-140.0b3.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "3ebb8a62335d1ff46df072f88244c94e7af3476efc892f2116526829f854d0e7";
+      sha256 = "cf58b75d8a9f1a4b8dd702a5dc4f3b8fb676e0f1c0d8949b445cef0aede13586";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/tl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/tl/firefox-140.0b3.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "9751edb8943cf113a14be6bf5e1f9b06368d8ad316ab3e58b0924a62fea31749";
+      sha256 = "8cb619b4d8caa1a6e492b8b2815b4c41a25fe3b6f53852d99ca55da56fab8815";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/tr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/tr/firefox-140.0b3.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "428675ed3f2bb5691329628bca3a1684c4154faffaf0a99d8ac7bea1e5af2f4f";
+      sha256 = "e5b39883c5e0a906873f4af0e8d6a630337d05467759741276077b70deeaa23a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/trs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/trs/firefox-140.0b3.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "5d41e893d50d9e39325ce571341594f247b429c7316415c7df1be2d7e67524c2";
+      sha256 = "a19d8f0262019768cbc61edbe3ce7b5eb69571b5ca1c5cc9736025f10e6250ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/uk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/uk/firefox-140.0b3.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "38e28de077f6c2e70ffd42cb08d9ebdbb33873f42ec28e3f1380675818b232c6";
+      sha256 = "4525800927692a4230034a5ac44351b87857e5292e5bec60aa478d52f55c0606";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/ur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ur/firefox-140.0b3.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "1f4be2e844e19a070bd976411abf5b84b8e71b68b098ef6724c0115e3347a4e2";
+      sha256 = "fad4ca04ddb978bfb405ef496cecfc54e0f59ad5cfe0adefe9f79bd55da6dc9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/uz/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/uz/firefox-140.0b3.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "3b14162e19e28f35bc616fae251180a7fdf1698a7a9ebd0f43e04215fdb6dd54";
+      sha256 = "9098b78744b8b8af558fd4edbab5be3a573048405b05376d0a08a9d2282784c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/vi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/vi/firefox-140.0b3.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "34aaece124bf3a1af61dd0f6a0b7a7b924f332b04a2cb86c2e9375bb40e6e32b";
+      sha256 = "cc10fc7919e04a0401f910ed84092e8eeb8f926c2410c4ab2a9feb34b0a1fd80";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/xh/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/xh/firefox-140.0b3.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "1055d5e93a507660405c64d8a122617467d26894b7786e998a0226442bf2e106";
+      sha256 = "a9c75ada1290493a0f1265d47ed584dd5fe4c6ff3d763baee03d5c6741775394";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/zh-CN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/zh-CN/firefox-140.0b3.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "3725c141425b3977fd3120f3a6eacfbd5e2fb413a3723834e30ac3a41e5c124c";
+      sha256 = "0423bc10bc9f1affe9c4a54387c9c06d003fa5d600c42e351cccd1b94c096a13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-x86_64/zh-TW/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/zh-TW/firefox-140.0b3.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "7ff7baece1723aa893bed76b18117ea1ec633371018443553b7eb1af90617859";
+      sha256 = "e07202200f0f41d691d8d4a4225b332b51fd00c14af0e5c2c61c1317938a69bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ach/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ach/firefox-140.0b3.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "b884ba50b81fe756b20f463131757dd701480fcd16133185a4fc983ca17d7c6d";
+      sha256 = "3c3f09f172315420d76a89352cf556095d3120cc8fce3384b825680978682886";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/af/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/af/firefox-140.0b3.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "60654b1bfb5c2922bb55ec75cc4c5c286e415741c0fb9b648bd53b3b2abb93d1";
+      sha256 = "eaedf8f14d1a89141cfdd02d1331982d57c283810229f1bc4a2add6acf47a7dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/an/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/an/firefox-140.0b3.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "ef3be35e1124bedb22f1ec478e7f55e0436c416e5a049a7ec3d97be2b87012ab";
+      sha256 = "52d635cf3d2cb3fe60f2f5a120714c011b6c5ddf46715450102d457fc9962318";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ar/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ar/firefox-140.0b3.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "67f4cda86a7e272fb194b6daaee4abe1040540014a02db93fa98e01f86748b4a";
+      sha256 = "893cad4f3e9ff8f6eb46861c17873d29ce07cecab1a52c666f3af91ac94b0f4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ast/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ast/firefox-140.0b3.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "052afbe7da0e5f8772097e25db3019a4bf8092c3369f8617052e876b162e7d4f";
+      sha256 = "c7981fccfb22d3afb4e36e34ca11629bbb064b2256d297e0717dd7a7c76ef502";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/az/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/az/firefox-140.0b3.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "394b4a7cb760e060b75031ecaa462dbb72622565583eb0ad7d3228fa1ab8b522";
+      sha256 = "a1192052f0a9dfc637fe6dfea16b4bcc4a1e7a6881d025efcbe65f4dd4a49027";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/be/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/be/firefox-140.0b3.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "c353fdd48caf79fa4ad02148bf80d480d7ecac400368d6e865be11f479ef794a";
+      sha256 = "575d234e0d09dc61dd7eb2574b0db946b866472e31f45e80c6af90c99dd83cf6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/bg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/bg/firefox-140.0b3.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "12e6f03a85147c992445ad753af7ba04c265570c103a489bca7fd9e724fc9f22";
+      sha256 = "39c2fc75618ea33423a5ae0c606d416484c0c6bceb82f6ca79e12e26efb23220";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/bn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/bn/firefox-140.0b3.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "fe2c94b27a658388764fe5147ff989d2915f013c3efe26a60210022ab749e877";
+      sha256 = "c92ac4831df0e4e4f8af68ddcb82d3bae98505845f04bfd39bb3e573639d648d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/br/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/br/firefox-140.0b3.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "aad228d7e751e6829e9fc48a4de4c71bfd1dbbe6cf698f0c51065baab521991e";
+      sha256 = "39c3b934fe6bb0eb593d52fc17983994a680261e74f5764c9cf2dd5e0ecc0527";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/bs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/bs/firefox-140.0b3.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "8931cc82c8f5a22053fe21dbb2947d5b1478348f8dd7e9ee4f727771166006af";
+      sha256 = "dd4b8a6c02cbe11536ef7de6d1ea64bb17eb16806aa6dcf838847f7b2649ba22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ca-valencia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ca-valencia/firefox-140.0b3.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "04a5f2a9344e369adfc40c57b719446da83ab80eea582efae5dc56ff0abb50de";
+      sha256 = "3a43a9986e3bafbcb8c59904f8de749cd9a8e11a5a6424780c1db1f75e57a152";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ca/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ca/firefox-140.0b3.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "36e14338dc3686949fc391946599b523b83c8bc9638c42ee7fa424ea4f0731f1";
+      sha256 = "0e11daa82aa4663c1d07f96fa68cdd7e06d404ac372887e510173db91456203b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/cak/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/cak/firefox-140.0b3.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "511fe4e4dbb53e2df4a76aa7ce83c67405f0f177d275125570b00e909c3dd327";
+      sha256 = "d3558555d2e55d4089a224c6f49cc9d4ae60cc5b55b95ea29b131f53e9516693";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/cs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/cs/firefox-140.0b3.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "56f018158aa318c1ed5d4355b7fdc2de9ab98e45a2e7a86ba330a4b7f4b5c884";
+      sha256 = "a6c2c7db6633d6fe5fd24ee17efb6cff59e00959fa0226234bc90805247fe0bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/cy/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/cy/firefox-140.0b3.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "7f4a3c45b989379066dc94eb10c609c94efb62706a0ce6238c9f652b18e11972";
+      sha256 = "59c697c88dcf4658cd4ea85d5c110239b786df15d84e21006c3ae9254d932122";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/da/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/da/firefox-140.0b3.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "d4cbf628409e36837cfdeb25c4815bb48d469d9c21019a87960e904ef2f2bf03";
+      sha256 = "42c2bd817b7f337146f52c00b3671ddbc48f4a1b39bbece4e9fbcd3a97545e33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/de/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/de/firefox-140.0b3.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "3cffaf86b35b6c4fc8dafac8817c958247241e617562baab0c099159f4d8445a";
+      sha256 = "c8a4c21ce54d08d9539d2dedbc14a108842c401354e59b2a2e3f79f0322305e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/dsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/dsb/firefox-140.0b3.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "ae5ef7bfad006e61943aab84c6b4af62beb4e2caa2b802e5bc7cd1d8cf4ca29d";
+      sha256 = "7eab0cdf71a1571227b505450ed7af7d5605c306116a1fdb92697e2a5653afa7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/el/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/el/firefox-140.0b3.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "efdbf60eeb1f6e04aebef7ef6c35d049d4719211d90203c514984dc0f506d2c2";
+      sha256 = "f903fe1eb373a4ef6160aa6137f7081f52c2134301b807417c4a9fbd66cc3ad2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/en-CA/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/en-CA/firefox-140.0b3.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "72469319463c7a378e7de8de9cd28f9a64d13ba027aea08caf6cda9db297ad9c";
+      sha256 = "b9718d0a1333f27862797531fc96a410d28f483537f9eb23d8c42ce5abe755b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/en-GB/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/en-GB/firefox-140.0b3.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "593c9812fd7296bae1388d96d8b4aaf75a2f3bfcb6c1a4cb740cb28d5e34f3d4";
+      sha256 = "cf2534426f9b5fce7e8aa5fc301c3e59b4e1718fb87a9b2737f9d04de1011a8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/en-US/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/en-US/firefox-140.0b3.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "eff54312f1bfa5f4be53d200cbaea6dd85f41c5cfea83611f9a6977ecc7228f7";
+      sha256 = "71ae3e6d03e16c80d8f7f41e79954a4dfb9aaac6df0bc04264672cf4027b0488";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/eo/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/eo/firefox-140.0b3.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "985b855971a03440ad95a69cb0042fb103b146900a7957ac61277b46dde691e4";
+      sha256 = "651ea1186149d9cd455c0b9dbc7c2c7dc70a46963d5690a576acc59cba6e56c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-AR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/es-AR/firefox-140.0b3.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "a37df3746470d646d2c97775d1e90cec189ae3e487f508fbd84523de7f6e35b3";
+      sha256 = "d11382ca1dc4b707c5330b06cc9e951bdcaeea3846516195f52027e2c557bbbd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-CL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/es-CL/firefox-140.0b3.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "371f39656c30e7c677bf1b57696ef135191bb1b755f152b2df77638cba27afe7";
+      sha256 = "9e26cf06cc5e01059711dd2d79dc25cf8635b28d17eba1f0d08c25eb61305a01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-ES/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/es-ES/firefox-140.0b3.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "7446b7f231a58db5feeda635bffc148ca699a3a3e792737077c177d4b7794318";
+      sha256 = "164c2f0347d9244651104c835d75d9f4093218a0f67ea7709cb1f4162ee294d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/es-MX/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/es-MX/firefox-140.0b3.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "b0ffd426095764a5b67cf7757f29aca249205379d2e5505f48a442e599796436";
+      sha256 = "bd092ea5d5dd484a092605d72fce5358e86537e89a9a7a8974dd6576b02c8bf4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/et/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/et/firefox-140.0b3.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "9d67e8f49fedffb0054f6e211f6e43eb63767a0ce9733827f5ebdbb5d501305c";
+      sha256 = "3d19ddfefeabd49b3703fcfb0708bb6a46b19ad8bda204f91d4901e059b4d5ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/eu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/eu/firefox-140.0b3.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "f7902502f184288a7a3d3c22918711e9c7b615aac7e6ee233cefd0bdfcec7cdd";
+      sha256 = "b02d55efc88c1b8348dd719a599b568363db17923d5fcfb26952d551940557a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fa/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fa/firefox-140.0b3.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "7929c783bf090082fc51cee3e45398396ade4909237e9ba951c7d07ccdaa0126";
+      sha256 = "043510f251a179077cb270d628d9cca62785f746668c5bf8291ad8907b624b2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ff/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ff/firefox-140.0b3.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "64260c4ba89431f4537838ac0a4ad15aca7f2e771e8f7150f42cd7790be32e39";
+      sha256 = "8f52a213ab4f324f5fd94ba105c2c1e9970d69af93b2f9b30311a8bd7da615d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fi/firefox-140.0b3.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "388366eeed2c2487cbfea71ec8469c317b9b4315fe775e4aa629daf1ca6bee6a";
+      sha256 = "efae201318b19f549e69cb5aa4f59dc1bc87d682b40362203e25a5c1371b6d2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fr/firefox-140.0b3.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "b5cd62e23ee855775e0529f849936dc0ff949605372e217b9cdb4dbcab135a3d";
+      sha256 = "e43116b71ad9f1b9158187c3a4299c36e5719da985d00be7a871bdeada36b192";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fur/firefox-140.0b3.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "4fe3aee24eec68a7b88c40e23f035848030525b74cf3e17acc81bc84d5c0e086";
+      sha256 = "23740807dd3b010a48486200bfa8ed888beb9b4e0aafa83b241409954f93365f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/fy-NL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fy-NL/firefox-140.0b3.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "2efb11fc2c9ac5591828fa237c4f3549ac6a708cc8ddbccb5517f6408c362eb1";
+      sha256 = "49063a53eb3ad9f9c62c859211bd19a9ac55f2b60a277e27bc1d82297e919f19";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ga-IE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ga-IE/firefox-140.0b3.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "64e96b326e33d74c2fed43d45c1900d3c90593c9ef8da0ecf15c1b5a509a5f1a";
+      sha256 = "0deb27c1880f256fef7916633f78423128b1a8ff76a977bfcc265dfa77173a0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gd/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/gd/firefox-140.0b3.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "947d98a1333460ef5d722becc2d28599425e4f877c522f2f11bc320edebb8a77";
+      sha256 = "c3ce807880680a92dfef22fdb9cb8e638dc686a59049c6cf01efab4ac3732ce2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/gl/firefox-140.0b3.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "8f3b052afdbe5371a4d2c87100f005aa1878a06ffae8cbf75dd95cc6003a7d97";
+      sha256 = "a978a9abb6a675968285efaa76ed1ea89e8741c071ff976ded923e83e242f75d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/gn/firefox-140.0b3.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "c9fff849e03704d1324680eb856d01b051e8395e7dea9ee80ceba2ecb1c2c83a";
+      sha256 = "40d423c64850455905b955f9c84c0aceff20e79a469a654bb04722d1bf04c928";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/gu-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/gu-IN/firefox-140.0b3.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "d1ba1fd9a19556f8d1128d3b6025cd862210d8635f35221ae96a894414c1acbb";
+      sha256 = "bf94bab9f91d5ea82131e43ed3d432b0261e3b2090c2d2db95fb035e4e961346";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/he/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/he/firefox-140.0b3.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "5624f4bc7a3b700e602af22443d40da302fcb604240258c5ff1864a32040421e";
+      sha256 = "db191d3e2a3fff647a1bf9a955075919de5cb5a376a4a1474a8adac44c3df841";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hi-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hi-IN/firefox-140.0b3.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "d67706f3213f12d475250f0c1ee4d7e618b03bba9130803bf7cea24d5d46e770";
+      sha256 = "c6a51b472c569cda3b50d7dc9e9d0a36cf820a8a788a8b5b4cdb582f175e7ce5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hr/firefox-140.0b3.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "55b89834e35ef17fb1d619a7ac949f0e662531892ea2c0d17fa5f6131e4575d1";
+      sha256 = "54aca88fb64a6b5141746ad4da23b081a482d94e04a7517b9c731340fa5440df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hsb/firefox-140.0b3.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "1c112a4996b5c32971ba5d784379ece5bab5f9ff10d3568884f76dc2e985e47f";
+      sha256 = "6c586090e9fe87bc44892ac85637ad540ab5d5e158c17c5f14c68f9f63ee3a74";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hu/firefox-140.0b3.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "748830a3236b3165c25cf4ceb91e99d1c082c0df507e76e49825fa7b8437320e";
+      sha256 = "dea07e07f30d00b08c14b7dbabf5a38cd7911923808cf9224293d32921c2a65a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/hy-AM/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hy-AM/firefox-140.0b3.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "f836c11a40efc7cf1aecaa7719713f282d8d983c1df5d747669fde975f9173ea";
+      sha256 = "5d5fe665856bd0790e63edd43651ff9754608ef8fbaab38a8cae31a1252d1751";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ia/firefox-140.0b3.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "9b814a6c15a9418f4e412cc265798d630fa2a935fa714db4db17b2916f3dc73f";
+      sha256 = "e90c989cc7c7b8eada6272566265c263eebba4cbab6e258e0d5a2d431b1dd7da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/id/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/id/firefox-140.0b3.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d47fa1a73c96f23fa169fb0ca4dcf977e4bfe264be21620a61e91776381d09d8";
+      sha256 = "5482412883d928072d3a0e334213199e947cc03fd3db6fc598f7a915976dbbf6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/is/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/is/firefox-140.0b3.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "2c431df3eac6468a456d568e5659d422abf7b529e7405c522b63ab5151011825";
+      sha256 = "5684323f967b0edcb1de2199f1ac3d15730bf87b19a0091776b5dabae99c3c1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/it/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/it/firefox-140.0b3.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "67d030c97665b64ea8ce7c61e9f2f42b1e2f917debbb072887552bd2640aa031";
+      sha256 = "12df3e97e46b5b6291f6317c827381635cc1916c042aa18a3da928646c3298b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ja/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ja/firefox-140.0b3.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "28a3bdbe49900a2b290a986800665bd610aaba582ed852c7d7c16b36efff4f90";
+      sha256 = "208ab74c7967a65a4b73edf57d9d8189341007554e6aa75906df6255505b984f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ka/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ka/firefox-140.0b3.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "55871733f141fce7cb20244efa9cce6811e79c45f5f77177de5e9ac48bfd2c1b";
+      sha256 = "5f193f7cb6008dfa55e7f2fcfa914c13d44a5d27dd18c291932d913a049d3c54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/kab/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/kab/firefox-140.0b3.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "859ca377458e20fab592010257ab7d10552a8bb60d93d3936519c1b6cb6a82d6";
+      sha256 = "616a5fae71e292e4cfadf83c670879a5436337d859bcdb693498f2318a33e9e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/kk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/kk/firefox-140.0b3.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "1759ea36efa1ccdb77734b0886c00c797356435994fed5747dc644ba0a18a477";
+      sha256 = "7e90e3cf6ef7db5c534474a4b7eb458582c914814f5ab3e9faede1aeaedf288f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/km/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/km/firefox-140.0b3.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "f0f9886f6324a6fcce0e76c48457ade4a891f3c38e1a91997b5f97c34ed66e5d";
+      sha256 = "638c185fe326bdbc6e122fa900ed54600abede47bbc702b4c2aeace7fe81ea59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/kn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/kn/firefox-140.0b3.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "7d79b905a38e09d9551e423760ec2ca4e92fa1ef07c676da822567d9e157b400";
+      sha256 = "4f1bce2457170735ca89a1fdd49355b3ce66862eb25c4650018f29786a3e628c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ko/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ko/firefox-140.0b3.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "030fc4bde9e14dd0f67c8007827f52dac7a623112b250e39c67ec4621818f2e5";
+      sha256 = "912d16eb2952971879b9a4a12d5bc0596bd26a3a446a0836d644d95322c0d88f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/lij/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/lij/firefox-140.0b3.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "2042102cf667d81d62870df30e00cfb6015c7032f6367d2eee65bbc646aaa13f";
+      sha256 = "c9d88715308eb1dc9a7408e70d791619b96bfeb513a497264bbe4b35a2a6c21a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/lt/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/lt/firefox-140.0b3.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "53e504395c32ae53b926505cf3fba5f3dcbae8995eec8657be085200e79bff6c";
+      sha256 = "2a04604e7455fe01534470c36a35fdec6b833c6fbf37a415ad65a2a33ac685eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/lv/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/lv/firefox-140.0b3.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "0924feafc5ffefa07bf2d805ebb3396b8ab565f92714ad438a2077f395dfe3b9";
+      sha256 = "a820fa038bd93794e06cf1e42a69759bbf6cde44196d1103fe7f877602510f8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/mk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/mk/firefox-140.0b3.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "44c9fff89d42c44ab2eeeed8ac54e9ece3d52ca3f3c05a7cc800f5ae458861b2";
+      sha256 = "b6417ebc9f7f9f811346bcd013c65ae873bd3b2671d6a0c25f02c9d1fdf15f8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/mr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/mr/firefox-140.0b3.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "1740dd34a0d1a0f4b529535473714b016bda43c2838879b5991e43c8ff11eef4";
+      sha256 = "d9600fee7682011fa3eae2b090b50d67bab743c0393c5deff03c5667fa11f78f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ms/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ms/firefox-140.0b3.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "669c371e0103d0da8df990f002e1f67632de4fe01f4c4fa18c620445176de1ae";
+      sha256 = "faffaf6851c21ebd1181c93772f912709bf81ab59b795cf4eb7201a162aedda4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/my/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/my/firefox-140.0b3.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "2a312674d939b1cbffdb708a36d8159c1c7d7ae18fb839952db0a99909e11692";
+      sha256 = "97f5cea2c18b3e07388496fc45126dca7bf58a837eccb14385b2b29701d11108";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/nb-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/nb-NO/firefox-140.0b3.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "a8df416206c09635d76ef4b76f194c2044bf7527b187787e46cd445361270c87";
+      sha256 = "9205b0871af11b98e802ca77f3c8504894cac12cbf1cbfa502767eb975eec6c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ne-NP/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ne-NP/firefox-140.0b3.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "9551f9f3a19efd9827cf8302bdd4ccffd9c84c5bcd34a874bff741a8e2f8b312";
+      sha256 = "449ad603575859ce4627e743d808e5ffbfd2d595c1d492fa764a8cf059816b7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/nl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/nl/firefox-140.0b3.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "9766566147c5d4b1c2150258dbbb719d1f9dd971bbb8c81c0b2a1feeeb867046";
+      sha256 = "ad5fa26a8566c22f9efd33ca0268736d4a38ffa3309fdf21f98c0a29f60462ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/nn-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/nn-NO/firefox-140.0b3.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "413bfb495237e4f7bbcfed9a2a6511c0c9e0ddd84c08c7ebe939675039969b7c";
+      sha256 = "1bd652bbb01825a9ad3efc7991fe315dff9fdc3596d197c413658c055f97efbf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/oc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/oc/firefox-140.0b3.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "a51718ea3fcee92b96445f592ad90c51e011dad048c00e547566929968101f2f";
+      sha256 = "79732be6d97e6f7fb812da0a718998bde7808f571d5a57fd8042d5b33584b79b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pa-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/pa-IN/firefox-140.0b3.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "98bdcd33a7053afe0a770818337d7cbc358c387f263a6a587065adeab091d5ca";
+      sha256 = "85076e967a48f3ba02fd785adbba0af0f6525c133efbda4a3884b5110c4d2a7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/pl/firefox-140.0b3.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "80d06c0c7d211136e715bc0d708b261da09f17e4182d302ae2c673265251452c";
+      sha256 = "eef5081b1c72402758b244d7bfe7d1aeec301ccb2b3f1436fe8fac2ed5c8fa22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pt-BR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/pt-BR/firefox-140.0b3.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "857d512372876071be9741ab69ead9641221578e66b46c08be0bd4b9ceb67ee5";
+      sha256 = "eaf150b7ea5496a4cd7648da0ecf507091ba7b4412a037db6ea48dc5614fd6f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/pt-PT/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/pt-PT/firefox-140.0b3.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b8b555872fcd6f6dfdaa08f084ca65fbf33d58bcd8419973f2efe25b3d03e5e4";
+      sha256 = "81f6ab621772995f3bb3492695e32eaac1d667142e7bd4f6de0bb8825ed5b48c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/rm/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/rm/firefox-140.0b3.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "ca253108c8246320aa47376f5e6dd0663d76c7c05fcb8d156f3d4e236b1329e9";
+      sha256 = "f26cd0a09eecdafbac993a9e305f3ec9969906cd06fdff5f5101dce71b7b48f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ro/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ro/firefox-140.0b3.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "8006f4534e48d7dd26725dd3cd7cae56aff960181f9f7a8e63648c90c3afafac";
+      sha256 = "6513741a8ac710a7016a33b3e3c00969954db50e3c2ddfa4a2debb5992e4c8ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ru/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ru/firefox-140.0b3.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "c57b4c19aae50965bd88d0fdece6b999f02885987d2fe52ce251e2cedb175c2e";
+      sha256 = "325d70559d8be33846c519a9aeda98d2a42651daaf9c12602d1d29059029a6b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sat/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sat/firefox-140.0b3.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "a15d19aafd33c8a95b2fd7e9f35086043e08151255b7eab880918422a2c6c727";
+      sha256 = "6ab0592eb32fdd72b6e5ac121199d2c7c46320b2e3215fa043112c8c60b72396";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sc/firefox-140.0b3.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "9843fc42dec2c3af953736915c4ba815b170276442f679c448ce094bd844d152";
+      sha256 = "7202e3e121225c034724e67f2bd1d0f5dc1359c5c316e76fb45e1522d975a2e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sco/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sco/firefox-140.0b3.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "b6991a246b2328c04ddd385ac16438f4e73da1ed9ad2485e3ac322b26e3c3a68";
+      sha256 = "a3cfd6eabb41224e3a7ff23b19c2bfe3bee8b662c259eac3ff504d9dd371e4d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/si/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/si/firefox-140.0b3.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "2f93452a96fed41bfbaf5467f33372ebb6b9f6c0ba5ba40cd1f349b8c983e71e";
+      sha256 = "10b49deeca01bf571c8de9a49f18f51bd761d1eef4a00b15eb8740c734a69962";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sk/firefox-140.0b3.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "47e6d512ce895898505b8ca6b7105ddcb6017a1f3b0878dd904244c2826140a7";
+      sha256 = "ea6a2c21f49066ff5bd7e45d7e5cbb6fa1eb737ed111e2fadc325da659cb3e50";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/skr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/skr/firefox-140.0b3.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "871e23a7c187230462ebb61550c9083b2d898c5f76160e95913a0fad8f60742e";
+      sha256 = "0f2421d1617932b5a17c158ca04b01e820c2adb6c7eda9d6f54e7b22e99ded02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sl/firefox-140.0b3.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "57db29bc5fd0f98b231338bb256e07953fb54867cf483de08b7b530526f8defb";
+      sha256 = "654864b81f5abf3518f67787d5d9e404e3d5462953916649f3ada78f5ec8e3ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/son/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/son/firefox-140.0b3.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "72873188351e9dd5ba46fb229eff1306713944a45dfb6c96ca24bb5ab4ad61f2";
+      sha256 = "e7b42884848ddf9b32783020eb41c6e616c46a7b4b46bd1e2d32c99c78842bac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sq/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sq/firefox-140.0b3.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "5acec6030e5705819159886d9a719fefc5aafad0d69b58d3cbcdcda1311264fa";
+      sha256 = "d82fb6ce158e37cbd74971d6a9cfe6c57004614c3f406f817f342c1f523b6c2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sr/firefox-140.0b3.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "74ac1e41660b8127c701b30e616131ba46e87b47665095c0836fb70bc9525d10";
+      sha256 = "028c133c6823549f499b1a079d07052c50f890c5f431412e856e6e9b52fa6797";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/sv-SE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sv-SE/firefox-140.0b3.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "62676a28d5791d0bdb0ab45996313442d9ebe8e36a401f1750e3522f2148bbb8";
+      sha256 = "8e7eea05f48a536dab3b6924dada5d4f0fa11ccf6a691d993f84ffbb0dd8e8ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/szl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/szl/firefox-140.0b3.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "89c2be0bfcddaa8c44bfca3ab3c91f9c257b1ecebcbeacea203673f4a4e0edb8";
+      sha256 = "e5c40fb83fc68718a38411bf8dd17172546c89328e8a352b6aa4ad81d8946963";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ta/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ta/firefox-140.0b3.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "6df705686cc62e94fff63e1eea2c962e6ac8e45c797755809f4ef7657e97f489";
+      sha256 = "b2ca1cc8d20926557240946aa9ca432c1b24162d8c26be088f95c98a0e2a2697";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/te/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/te/firefox-140.0b3.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "011478d18c5a07bee2dc417a618be95ed94b10f9e97c315c2114405219f4f633";
+      sha256 = "8a3d7b4669dae9648ac2f06a03781578f6803a241fbc5183499fa18a29f46fac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/tg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/tg/firefox-140.0b3.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "bf71f9da12c8060543ebe48ebfdcc6e2e16a8b86b930a138a7a35996d6308974";
+      sha256 = "a65218675b9e62e2a2e72c8bd7a3a78a56cab0ce91426f623b6e6afdea1a04df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/th/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/th/firefox-140.0b3.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "f8c6c9c5a8d51df500f463cab3951addd59a11eda3bc92228d9c42a56c3883a5";
+      sha256 = "9ddb3cae1f4d999d1a7840e019867f1554995cc8bef0a1aa8ac90ba547972722";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/tl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/tl/firefox-140.0b3.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "45c02ae216dfbff769daf7236a31d4efd7aaca3b419ed037d3250b2a5c03658d";
+      sha256 = "a1455aec73754985d65d7b28ffe2897ee9bbde55506fd6d9772277b5346f4092";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/tr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/tr/firefox-140.0b3.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "ff6ab57920b494349951ba85e1e604f135a6b706a89d26a93ec5945ebba7932d";
+      sha256 = "9fbfd677f9a807daba18eb008a183fdf63cad7d42f42cf10311593ccf1e4af93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/trs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/trs/firefox-140.0b3.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "e3999c0c31fa0c1210cbf52ae4a936ee08d1cee6a53e9f6a2b294167317bed99";
+      sha256 = "57a19f4b076bf14db8a83e96559c937e7e848d95621aebc04f8009d614312bfb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/uk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/uk/firefox-140.0b3.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "85af79aed55ab6b5f5f700540bd0a6d382195cbf0f7749e21a9705fc9cc2fc66";
+      sha256 = "ce745304c9068082289893584e10855f022e0b55b974088cd4d2f2d177e949a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/ur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ur/firefox-140.0b3.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "8efb1afcb3555911be2816f62db5d2d2115f416804064f4a7ea016d368605bce";
+      sha256 = "b5fa6ae252d2a39f002d9f61bfca5f4c44322f134f82f6d75736197207ac93ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/uz/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/uz/firefox-140.0b3.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "bbc614544c7b2272e812ea8ebd058adef37bc905bfb989e28259c270d837eda7";
+      sha256 = "d17c250ae08b958bf0c9a3be3953133af69e88855c38dabd5a1f9281ae675b93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/vi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/vi/firefox-140.0b3.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "f6d77d1d12ebcd17795be230395f42f8499ae4fd2c954d96a2fea50102141bcd";
+      sha256 = "45ba1505cc8b64e55ad518c1138e115c7f01c9572a13c2dd07970a479005cd39";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/xh/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/xh/firefox-140.0b3.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "06427fbd032094695659c8aac0b7d48b8ac49207750c72a20bd96516a086e3e9";
+      sha256 = "bc0aea632a700251fbd0359f8fef1b152a86fcad15707b4fb4bcb055c7755c50";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/zh-CN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/zh-CN/firefox-140.0b3.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "afb4e3d700f9c67efe6ca59e1baf98dcbe014f9abcae6aa3326a94f47540556c";
+      sha256 = "4f31a97f9a0eb5677de689c839e61989d40856244d5239707378e5e01fcf0ea6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-i686/zh-TW/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/zh-TW/firefox-140.0b3.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "1eb8189e613d855bdb4da3d929fa59ae00c87c7ce4caf26e242b77dfe4ef9e46";
+      sha256 = "cd397ce84153a60c04457fef2edd31b648eb71476598aca12ff59ddd4f09fe7b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ach/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ach/firefox-140.0b3.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "7cd042bf81247ca4bf869772140a28da2cac0f38336c1b21774753ef0935c252";
+      sha256 = "ca1d393c3f6d8f0b483256bb4dcbbfd87c3e73320acd272125db6a252d225690";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/af/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/af/firefox-140.0b3.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "0b46b672ec0ba920946e8a19b66c4c15618457fa0d70f80283e9339efe919b88";
+      sha256 = "904ce80c145a1d3230081bd7883d2c5e57ed02660b2404bfce3943df0561104f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/an/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/an/firefox-140.0b3.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "cc4e3757e933755b79c35946f87b88a4dd0e9fd68ad8391e2f0a1ec758707c35";
+      sha256 = "a994667975cc8c14d5b768d238a151506e9c9a2bdf6dafa73feba9e43aeab57c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ar/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ar/firefox-140.0b3.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "7ca7a1330d97c5c2d242dcb9b0681768cceabbe931796d78d1db4e434c555cc9";
+      sha256 = "2a9798d1ef0a04664ab9c2683f7fd509c4da5d8129d769c781077c6d45dcc37e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ast/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ast/firefox-140.0b3.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "67976e71bcd80adbfd9e5910708ebba978a1ec02db046b209bee54c0e9fe4e7d";
+      sha256 = "e862943c675f5853709fdf1ca14d2ac28cf732d90d782bd9bada809556f1b654";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/az/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/az/firefox-140.0b3.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "f99cdbb0b61406a82b6d31e87a5ad60cc11b654ba20199eef7e6ff6a0211e0b2";
+      sha256 = "c3e0a2cc6ae0646a5c7497e96b7b47947354f984ba733672fa38a7c14eed8856";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/be/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/be/firefox-140.0b3.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "baa9da20ff4f0cd15f67ca190982a26ab45635a83d6fb2a60a0c537cdf3f0d9e";
+      sha256 = "bd197bc761ba7d16d74ec1eb11f6eb0ea6122919ffba3a775690e3db029e471e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/bg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/bg/firefox-140.0b3.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "493851b1cdeba502582e3f311858296883637763c6b3875c4e2c8fe1832726d0";
+      sha256 = "6dacd9985823ce3ae329eac3fc97530fa405737cac7115a3b56ec6a0db04cfb7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/bn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/bn/firefox-140.0b3.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "7ecad658638c5b4357e06043c33ede20870f50055f3840fa76e0829341e8ed2e";
+      sha256 = "22e0bf169370241de826f2f882c987f01e5cee823dc303d0122e04a210d2b781";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/br/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/br/firefox-140.0b3.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "90cb3c30c226a64ee8e04c89ba4511741b788a08c29305e4bd37f15c568c0790";
+      sha256 = "d3e532791588565ca5aa5dd892cb72298c34efd9a9d07e3b2e89c5df23d41fe6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/bs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/bs/firefox-140.0b3.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "359bce9cb8555fcfd5e3782755345c74a023fd5196629993b9c7ddb4c159d29c";
+      sha256 = "9358ea0b92e59d528873a99bc452bd30c88a2943d23edcd71d47c3dd5521313e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ca-valencia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ca-valencia/firefox-140.0b3.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "d0c0a903e7f49cdd4e7abbc010362ef7f9f94f0ddaede5c073b7d5ed492c8b4b";
+      sha256 = "133b4c9ec4c86a88203c251a5c54e312024d5def03e60e75c80ddbf7868fffaa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ca/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ca/firefox-140.0b3.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "065d8a4d120a5f6bcdc2aaf598e96950b87439b3f091c6ab45ba42c42d9dc493";
+      sha256 = "b4a6e4975dd731eff8f7a70f1b9fbfc33dcc53f76efa3061232df7b0270f803a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/cak/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/cak/firefox-140.0b3.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "f1e95e51e3c73a2c28632e3f23d53d3aaf1211d9db640b8c110eaed94a97ff8b";
+      sha256 = "9c647560a9a1f5012002cdf619f50e10c8f16b8e03e37d34a2aa312f714f9ae2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/cs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/cs/firefox-140.0b3.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "1cabba2333c315ec8a8ffa64609ffdaf3664428b6f109dfbb3f9bcefe6a08326";
+      sha256 = "5b81394b51d29a85677439bf4f91794b1daf5b878e920d1c0e6913fdb8c3fd73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/cy/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/cy/firefox-140.0b3.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "aeaea449bd1427315022606358eda4907a611248ee48cf94b8936c68067f93cd";
+      sha256 = "f0e9b6ab15dfeba4e41ac3e540c02917d8b30213fe2a5fa234a43a9bf9580d33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/da/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/da/firefox-140.0b3.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "baccce03f5a023e9c4db5c786416108d1e9a3b34f8e224c11b0c50089b5044b1";
+      sha256 = "fcad12e84319527cfc25f53192cdfadf51703ae1ab721f05c5f70817586f0626";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/de/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/de/firefox-140.0b3.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "cc7f6ce82a0c27854cc0b2c1aded7f589c29e73741746fa3a9dcad685ddd8b62";
+      sha256 = "805b6c414e6a56ff4fcb3d2fff4cb2ff62105e1f3c5476ea61981916111652bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/dsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/dsb/firefox-140.0b3.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "0a3aba29ef00869e8a543e5196188c42ca87331df9b283d61238ba1a8a724f3a";
+      sha256 = "d9a0dc6db5f1a21ef94101b6ddf1e1c644d88f639b9cf1f4baf3d82759914b61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/el/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/el/firefox-140.0b3.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "d87b9a60fa65911acfe8535ccb1c8d4e6cbfad290d9979692cc7899ce0ac6b38";
+      sha256 = "109873f011ac29c4bdc78f27e8a13541aa1b11175b29401197ed3d3512dec72f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/en-CA/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/en-CA/firefox-140.0b3.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "026ad7b1f2b3b746c85a31860910ae1487e0871d406b63ffbdb87e374c517bb4";
+      sha256 = "ab9ed750e684fd405ac3a797e4fb60ead2c64c39aa53d6742e0259930d371adb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/en-GB/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/en-GB/firefox-140.0b3.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "f26d62c55973c679153ad8b2378c00a28b068748db76c38c61c9aee03aa7bf96";
+      sha256 = "c7c9bc00cb6cfe8dc9c4875b049a13d0655c00a3ff171c5647f5bedef107e7ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/en-US/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/en-US/firefox-140.0b3.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "fb8905d9af83f43bb09b453a0fbd85e23adc70eefa07efcf015395a534140450";
+      sha256 = "39261cfe396d7359aebaf6b5f3becd3bdb5c43b292869f544a88e801443c9efb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/eo/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/eo/firefox-140.0b3.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "347cbb9195e8012d39d18cfd8ada8302a5f5746674bcff21c68926d93edcbc35";
+      sha256 = "75179c336ad589676d93d8dd6daa084c82573a621e69e3e8cbd09679c5f00755";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-AR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/es-AR/firefox-140.0b3.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "c3e04df1298513e487072a6bb5eda83e3921f3217408cb0f86f33c6a52bcc7e7";
+      sha256 = "88ca0c23ae377fbea842073192f89fcbe2319ff4944ade3311c722370c166aa1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-CL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/es-CL/firefox-140.0b3.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "040bc8601a976587a173a5d82b4b3ed7474dc6d274e1be504fd516eacb951174";
+      sha256 = "32b6911754837cb979fec837168963f25590d19adc87ca84c3ee0634bc1797a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-ES/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/es-ES/firefox-140.0b3.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "ed4197fe2d0279979e879eda7f51a5f3bc19b161ba0e6a031f6cea2cb22b5229";
+      sha256 = "ae81dada372a60bdfa0f6c48a988c42f23165e1d1c8cee3c7958c95b64c87d2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/es-MX/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/es-MX/firefox-140.0b3.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "290ae698fca93612144db3d7821b38a9a7708ba1bd9aacda09f9efee8e5a2fcd";
+      sha256 = "c8171810252614f5cbc162b5f4dfe3afd897a8d9beec4978126909bad3f76bea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/et/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/et/firefox-140.0b3.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "7b174a91b10efbd8d5628ea29d95a4dc7dbc986ae64dc5c7709df3f7a9aeb113";
+      sha256 = "76fd0607c61228898b9568987523b4a8e1f5a3b15a4b2859296c0e23c4e59585";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/eu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/eu/firefox-140.0b3.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "36ee14d1be91e8aa663439cd08f71ec6bde8e4b13f5aaf4a17f95df4080b4e00";
+      sha256 = "16205f39cffe37ce480d45e17d266c4bbc3ab1844ce2ea2e04485ddfcb647120";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fa/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fa/firefox-140.0b3.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "1b538780607b5fcc3a153c4198a0ea086b245c4c6f246561179d5aec98e6032d";
+      sha256 = "36b1c98577255d88e2f7b01c88cdb1414b2016fa520aae459b66aa47b10f8996";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ff/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ff/firefox-140.0b3.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "64362226245b8694ef956f4bd3d285c45aa5f7a31830c043fe23b96071e09280";
+      sha256 = "2988f2897ef2c643cdfcd79dce0c126c24fccf6e9810aa58776d91a1baf1b453";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fi/firefox-140.0b3.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "1f810aa9a14a0f47c48d2a485397d8164c71f9a833cea682949d582ac30c4091";
+      sha256 = "c8dd76d403209b965f430d3251df3fe9800535074f3ed1c8d1ec3c49a0ef92ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fr/firefox-140.0b3.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "2861e18226f50259f0ec8426e419c93b268c2e9113c0cae1a3d4923dd906c139";
+      sha256 = "7d43f4e963244761ce06e827776dc3037060457f15d806d248e406222b732d03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fur/firefox-140.0b3.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "42e8d9e6582267a374246cd83cb51a71dfb24b5c54d5b8230dcab93d47e89ecc";
+      sha256 = "75fa230906c272d17bccc003d3bd605a16ac21825812a964c78ca6e839365447";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/fy-NL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fy-NL/firefox-140.0b3.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "5ed467f0a335d41d82007f39b078c60e244faa7f7614e3386991f7e687fc10dd";
+      sha256 = "7b40e7c98e5bca1e7a503303d6d47160243bfc81991301c401da056f506469cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ga-IE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ga-IE/firefox-140.0b3.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "edb53eec33ed84ead0b00d90930c9e0d93cf7f95835f003884190a6379d61664";
+      sha256 = "c2fea5545eb58658a6c3e8ef751b1c18372edb052bb66694b13f09fa0044fe1e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gd/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/gd/firefox-140.0b3.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "dabd8721dbe812bfe349d89011317bffeb2eb8578dfd580e97fb962c6b234ccf";
+      sha256 = "d8894d4118e625b7ed8125621e58b561657f03915a7e4acc464c06e2c948f043";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/gl/firefox-140.0b3.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "4c2cedbd7c26cbdc2869a5186ae3e766c27f059a5be4b745f91cb3b7d334c1de";
+      sha256 = "59cee79cd1d2b593b3ab607d7e56314188f2f9d21aa2eafc4e3da19b27e7cd5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/gn/firefox-140.0b3.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "557eb831214ae85f8954b609fc6c381c7334a6c8fe98c98f0b5ab5d6e3afd9d4";
+      sha256 = "9570e9cd008c221d4587ee0ab740a98b74da2e74f2ade874eb96051c7319f60e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/gu-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/gu-IN/firefox-140.0b3.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "937e4455d075a52b5dc546840a7be025ab14266d36c287dbbfa415f9db5edb38";
+      sha256 = "b0ff6954af3e48e2fe996e38bfe72f060f17a7596640b5653893bdee6ee05f24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/he/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/he/firefox-140.0b3.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "2a660ac10700d2d0c8e223a7e7ccc641923e53001a9ed8f523126766919e3694";
+      sha256 = "61db85d5f194b2d6b797765180135949e683142e24a7c2f10872132a3acafeba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hi-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hi-IN/firefox-140.0b3.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "d2714b679ca967305693eb28655127e381ad7a4adf7e8dfc09c4ebb92385ac61";
+      sha256 = "e5c4e8fb08e6a36ee6c72dc0c4aadb5312e04f91cacf3679c89b7963c8d05541";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hr/firefox-140.0b3.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "8c42af036a26589817096562c089d62c035726be61137b04de137e72fbe0f784";
+      sha256 = "85fb4cf83ac75fd1a0e7f44b73f64e4bfa61899df78f0318370f6d232fafa063";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hsb/firefox-140.0b3.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "8233a55b9d57fa591fb5b6ced9163c9e1ad3ac0efc16106f7900e0938b9bc505";
+      sha256 = "05be655775adb1b4e113e047cc9188e7eefc78a4558f87a8176193697138c687";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hu/firefox-140.0b3.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "e36fcfe99e3885cf8eaff441d917f8b714314688484ed31bc82061eba6cb78a5";
+      sha256 = "566fb0b2e78f693ffdfb6b5990bebf7e84fcca396026b11678b8c613673364b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/hy-AM/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hy-AM/firefox-140.0b3.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "caa0557f2ba798d0d0d0b2e1d2b084079baf1203bade06c580062983fa53fde4";
+      sha256 = "6e51cf2be81bd264143fe6d05f5dd0806456a111cb989b130fde546d2e561fcb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ia/firefox-140.0b3.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "66c4626de30fca547e690fbae7ef8d665f138548ed29b973630c1e5fea8cba1a";
+      sha256 = "74af672f73f85d2e7bffbfa346153358fc8418d0eb5a732d86aaf1be0b3627f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/id/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/id/firefox-140.0b3.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "afeb6eb9c996a7f6bfe93c2e0606f29af90b9d46d9a35633ffd6218b76dd367b";
+      sha256 = "1b37065b20cdcc2e7d7793f77fa71fd846779c4ebcd68f489461489b165ba1b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/is/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/is/firefox-140.0b3.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "ddf3e0190f6ded182ed3d9cc80cb3456d2251f5a3a5af42a4eee4d6144cb04d5";
+      sha256 = "782622a22fb4cac4e967c3d7c934c1fa0fc7e9734e8d4fe6738abeedad7b4188";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/it/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/it/firefox-140.0b3.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "cd16a0d3b70e4e746f2d5a19ce448b4c8f3761e1b4879c6fb50902e5779f73b7";
+      sha256 = "a1c05f3d29b77c3274b65f20bfe0a0a7662133382a2080394cfdba0366cdef01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ja/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ja/firefox-140.0b3.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "2761071a3916fdaf81608d12fc7356450c4abc27fe2315d7ae1768b048751a85";
+      sha256 = "a010cfc3fba7877b33666db790d020c13014b98bc6567d9f3c5274d9705681b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ka/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ka/firefox-140.0b3.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "2fa470435b4e3ecd4389639b135f840f2869ba1f997e495d5b7ca3b3b472a14e";
+      sha256 = "1c1beaa5d438a6214dc75ccf5100982ae415d814d5589f6d19c75f3edc8a2fd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/kab/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/kab/firefox-140.0b3.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "23a15e2d7667bb0cad5069a555ce7eb5ebd647d01dcd5b5008df5dd3a25c41f4";
+      sha256 = "5db404895a198a93cadabd73b3e8b7b9707c9b631169a69268799aba8a2e50b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/kk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/kk/firefox-140.0b3.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "c9ab7d7695204eab0aaf2d395484df8331dcdd5a2d3cf7bcc2ea544e5877443f";
+      sha256 = "115ea1a7775f678f6c60342149993c98f107cab03e10b47ceee913a45f66f311";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/km/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/km/firefox-140.0b3.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "6740c9921ea366cae10b37b3c5de4076f1f1710b4169030c68be12b5070c633b";
+      sha256 = "de7a2faadd3072d434f8c5bd1fe62e23616c4097d5286801669ab6db27143332";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/kn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/kn/firefox-140.0b3.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "938558327b5c687bdebc00007467cc911084ed13d347b3dca50bd4064a1ed0a3";
+      sha256 = "713a1bf13d20796677cf3b4712da2e8f45fe01ae8d2428a48aede0ddf0d57cf3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ko/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ko/firefox-140.0b3.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "d610e561841fa970c6be608a25f030e7bebc0812b674c65e1f32e0f3a722f494";
+      sha256 = "e7642bae7805a364e3189c67143c9935188936925fbf5b9a0210141ed64a7587";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/lij/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/lij/firefox-140.0b3.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "3f8a986918ca0504c5f7e16996d62e52a59ae812aa10b521c93f71e5495a26f1";
+      sha256 = "9f65891d625c585c1515a005ce35b6de04c201428c1352efd9215fa033bdcf07";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/lt/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/lt/firefox-140.0b3.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "41c516c24cbdb6c3953cd378272039c8cbd92c4dfcd45e807224dee8ead1edad";
+      sha256 = "3ca4a021fe1782414512fa7610d0eb5f3ace978373632c6a6f4d618c7afb7645";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/lv/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/lv/firefox-140.0b3.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "fee89b89b07fdb6de208967bdfdf0cd09ff47ef4b382b5ff6dad823e2038f3bc";
+      sha256 = "e73d4256ae749209e41861c3bd20de05c5c50035f760c2c9355320d795e1e99d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/mk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/mk/firefox-140.0b3.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "fc713d3a275cb918aac2960e5d02ed55c1e53a588cd1d7b3072ce4ef1d322010";
+      sha256 = "508698c697ab258dfa923e5f63749569f87c070f2cdbc26ee0bc0a36b1996259";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/mr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/mr/firefox-140.0b3.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "9770d1c413bb780ba5734397fc44a4a750759fafbf092baa2dff9b0ca03f3778";
+      sha256 = "99e9e06270e56262f4fc4a95e6dbfb15ba918e57a964b4fadeec2ad7af4829be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ms/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ms/firefox-140.0b3.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "c0b6fcb678b449c2a7341fee0602591178dc3f783ad914f5e2e1fde3b3889dd3";
+      sha256 = "c9c3935bb6814e5dbbbd980a4487d1dcffeba62f14e3e907f38e07dfaae4822a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/my/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/my/firefox-140.0b3.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "af5a3b599a09708b6981cb3079e3b1512ab3f271c09f506c953b39936e6e0952";
+      sha256 = "ca0ec2bdd803a7d0f61a135ea61d706394877508f32c645acb014f52bf4c4a33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/nb-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/nb-NO/firefox-140.0b3.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "0c6dd74781697f69a8cfd7b657e8971d2272f0c2c7c37efb5476a3c6d226e8d4";
+      sha256 = "c74cfbcfcb0a8b50c18f0d0da54d4855d1326aa72718dfa73614ffc276fe07da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ne-NP/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ne-NP/firefox-140.0b3.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "22c46f8ecc726cb41d302149b6ee4816d8e5f4afc3322ce6a38621f0edfcfc55";
+      sha256 = "f6e88a6e38af551c2ec786e2941c9a23451d236bfc9fc7411fd61d58ef02a93d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/nl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/nl/firefox-140.0b3.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "c19785a813e1d190ff83eae04d02c6647e5423d9e3dbfa5bbdbc124aa20c0b01";
+      sha256 = "2a3dfe87d3b94479282f1bd8b700ff91df1d414ed4d9fc3733533f1db7ae2d5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/nn-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/nn-NO/firefox-140.0b3.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "1f5e90790da565b4e661726b11fa2d07a006c25d6ba41557e20cd8fc53972e7f";
+      sha256 = "fbe5608bfeea90d66f0d4f4c9dc8fe012cee2e0a664dc1eda948660e8e71a7fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/oc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/oc/firefox-140.0b3.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "8280752b38cf4e19ea5400ffe96c370888df59999be3ba73a6ff358df55eb973";
+      sha256 = "36e7cfea755d82e8a210841c94c0a95bfee4a7a69cb9464726b08de103f86a01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pa-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/pa-IN/firefox-140.0b3.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "8496cd59b2f13317622e23e3840a086f70217566bade2b749288d884f6d08326";
+      sha256 = "8c5885c4df9b41f70336217ebdc28d4e640dd99731def0546dd0e34879fd1f65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/pl/firefox-140.0b3.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "466931bbf9058183abe611c927a2bf147e254c84f159a9c1c528bae40d8b62e1";
+      sha256 = "24740a98cac566ddbaeac20d6e16d6fa715c63e703cb9b39be40b8cf9a9b18c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pt-BR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/pt-BR/firefox-140.0b3.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "3c9cdc685156255ad8cdc5e557a3c58de63c3d3c1293c92ea816b2abcca69863";
+      sha256 = "cf51d2981a09199f6091cae1242c73560b1aceeaf04207175fc64e546ccc3396";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/pt-PT/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/pt-PT/firefox-140.0b3.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "b89c7c4d38f667b70ea74e66cb052525e692829a001b0415387f806021ceaf54";
+      sha256 = "2b3cb182d876a304b386f1c091c96be21416b93dcae669a9cc93f19d65741585";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/rm/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/rm/firefox-140.0b3.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "47595af5bf7ad9e8ccd76abe627037bad388bb733b625cd9200414fbe385bad1";
+      sha256 = "914f3b9c41e9cf814ba31a671809f4d2daec6c77ea80e70e808f0ad7beee88d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ro/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ro/firefox-140.0b3.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "48cc3b4168318447044806f63dd4ab2d84aff91ed3315846df63ad9dfdf7e0a5";
+      sha256 = "da7893ed953bf77fd859ffaa542a7cd4ad52357fa5797d0b3c2f31d0395b9720";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ru/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ru/firefox-140.0b3.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "2413517aa76e06fcfb7122c949ba8acca175201ae338b8425eb28a5ffc2ad253";
+      sha256 = "bcfedd95d87f9e1bcbde13380f811a59ce5330f0b47668920f0d7319b3c8171f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sat/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sat/firefox-140.0b3.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "802f635513658ff4c9f146b7988763bf363e9676c7c3c8edaad7d15e99baf22f";
+      sha256 = "d36f47b320f19627ae570e7e004d87226687c469d9de70508c721d0e8d0d132c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sc/firefox-140.0b3.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "4b88d2609d1fd79ca3ec2c0e5f6f8313953a79ff321df92a66aadc0150001635";
+      sha256 = "34440b5887d66dfba85fa9fe431d2b30b963125d211518e2dc001b1749711f1f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sco/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sco/firefox-140.0b3.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "b89f86a38a1595d8b4052b74e1f9beb741c859f4015c7dbf9b894a08eca6fdc1";
+      sha256 = "b3c82d814a526e801d2e4cab78b273e69238808bd1a11cb6edb12f730bc1d435";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/si/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/si/firefox-140.0b3.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "cf5854ec14f712d1a12502edd0026288078d81273ee260244c8d09bc45b1f704";
+      sha256 = "32517ad2aa826fd61b2b8450f5da35ebc38b189465d3bf6bbc36797d39e2edb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sk/firefox-140.0b3.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "54f6863f9dd7ca0b48ddd5b1b46b4b3b929fd01349bc5e2933f314388972757a";
+      sha256 = "c90574e5cd3d2fb46cc800d6ab278e5377c921501ed36cf24d509387a1f5cf67";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/skr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/skr/firefox-140.0b3.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "a051e36dbcec29dde148453fd95881c7073cd8ede0ef92e3c1e2263fcb5e1c94";
+      sha256 = "cab10bad18edfad2e656545add6001aff47cc80c551c99dd4b3d4da639854d27";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sl/firefox-140.0b3.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "e18c4b176463416e35438b155748b69714a965f54e87e8cc578c483a2454d30e";
+      sha256 = "a6cec788ebd392dbe0702b21fdb8ef0e35ca6ba2f0d8a9131e7f12fc10741154";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/son/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/son/firefox-140.0b3.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "46461fa15f488234915e4a6f39fc0e241c1256c6ade93d584e686552fae53d49";
+      sha256 = "e52956217c7c3ee45e7f4233beb469cd26fd379785d25c799f0c498664236862";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sq/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sq/firefox-140.0b3.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "b6bb2006bff76cd6fa875e18e0717a357ddfbd09a419126f41ac1f614bf56adc";
+      sha256 = "e06b5bfa27235106a82513ac24070c2a08841751b6a2121d6e24cba96a2079a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sr/firefox-140.0b3.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "f24fb9fdd5ec517efd56a5c539916a756c6ecb1686e0ec1b1437bc30b78b9168";
+      sha256 = "29202d10e74d780a567bf5a6c68d49824723e910c755a4c5687bdd5b03dce536";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/sv-SE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sv-SE/firefox-140.0b3.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "5d25e7d100840d8259a7c9043e14d2e50daef0fe14ef766aec19ca6fe30e8db5";
+      sha256 = "37e53d6d434776d3d99356a408d4fb4887c080476d1f6c30e1e8fb744a61d521";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/szl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/szl/firefox-140.0b3.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "0ebdd8c0dc4f1d1f6567a9319688c7b71aff30a6999d4d57bb6ca3e50fb66031";
+      sha256 = "66a989f4abed1ce9cbedb76a4d9d9e5d4f5f8a13311da63576531fb99678553a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ta/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ta/firefox-140.0b3.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "e89ad50eb57568f223fc96751b6b426741826a41f1895fde4e0b1d3e3e48a0ef";
+      sha256 = "945ed46a39471bc841582e54a7d1d0a9c9aa142071d7285973768f29fe089432";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/te/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/te/firefox-140.0b3.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "e2e94525844616c4f9f3c51ae82a7c6b1cb4ca39272f76fc77c0c21bd1ef2278";
+      sha256 = "ccb22037cb8be01a0814daf27c3a53e49cafcd148f686dae99df59a93a0cf00a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/tg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/tg/firefox-140.0b3.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "bf8d5f5ea4c8ecc6e6764560966affcc969acacb0a6015153b2c46688b165574";
+      sha256 = "256cef45a12bb6635a74553c4e0666837ca801fbc0b2c3472cd3d322d4dd71d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/th/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/th/firefox-140.0b3.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "23046863b1c3405f5ecd184a0ba82207f46c4489e1672e43110c47f5d6a522bc";
+      sha256 = "3c07a430511b639288beb38a5396c9bf47e0035af9d9809105d412c1a1348fe7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/tl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/tl/firefox-140.0b3.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "0955e3bbc514eccf2774d3e70ec94d890be12b50c555787937ab38b2b30e1eb2";
+      sha256 = "8c13b2df39361cb03719249be3a1ee25ce2b76fb24e427a40577efa49165b492";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/tr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/tr/firefox-140.0b3.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "a99c19d94963709c38ab298199263643f9e5f55459648d4ce9a98ec46f087db9";
+      sha256 = "0481e7ab0f1a35659b669aa97a6c6fcd976b6d7654aa2e7c4ab19f1f12e45b71";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/trs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/trs/firefox-140.0b3.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "e4f033ccdf9ff353d4de0a5fd5aaf239f95c7340a90873a35ca51ad1730f6e5c";
+      sha256 = "2f42057e425350ab0c570638de750efa9a0d72cbe2f54270bcccf84832673596";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/uk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/uk/firefox-140.0b3.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "d16f97ed40b919d179a530d344a16520cf957141d3cbb68987ccffcb7a69fa62";
+      sha256 = "b1905f0d4cf2005cfb2043fa93201ccb5a5cdb6735d0e0ad7abf3a33d5d1383f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/ur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ur/firefox-140.0b3.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "0eee3a71fdbedcdadf3ffe9025c3436a0e551e7596a0b2f386175d196d3dc73a";
+      sha256 = "d2a04cd00dcc36383febec0aa54e5dfb829b0957c46cb73a98b75fa9426c5825";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/uz/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/uz/firefox-140.0b3.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "b7e3707e6c76bdf87c83ca237895c651b9137b83814e8975569512c2c5c9cb10";
+      sha256 = "c8574ade0135845ff83bb0e4cda0889018e504182c75c255dbd58219d1b2a35a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/vi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/vi/firefox-140.0b3.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "2ddbdf7c755241c1400656f65a181e6c117b08743d52127943882f3f0172c405";
+      sha256 = "707d5664f07614223f01de9d5bdf4b9e9da56094b8f7b86c0db95fb2b3165574";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/xh/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/xh/firefox-140.0b3.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "b4fadd9165a04b491c81273273e894a81667de20e06479d166cf36942edd6ccc";
+      sha256 = "2412b00ddda9df5fbfd19b61a1d38eb859287ae0fe7702bd78f508fcaa6788dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/zh-CN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/zh-CN/firefox-140.0b3.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "0e6b7ff8960f0cbbc1b34a3a44bb7d8bef6a832d40f6d9bd85e8d8a54f03b9f6";
+      sha256 = "1404f86ca8c153daa32aaa64f2762e530f54da743dbd088a4ac269710b735bd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/linux-aarch64/zh-TW/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/zh-TW/firefox-140.0b3.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "fbc5b78a7b6e022d8e6784c741d29d0adb6bad2afed4c5b3ff878b26f6dcdd00";
+      sha256 = "43b9ffa8ba86eb6087dd7c4e7a876caf8817958691591adcf70e2d55c47ff927";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ach/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ach/Firefox%20140.0b3.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "1c2d490bbe1ec81a70cc42fd9474f980771b64f8c8142d73001d18a5e74a2f45";
+      sha256 = "f8f307c3ae6b6ec25ff249cd9a244c5f37c724f93d4c69fd0f1a2df9e5ac370b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/af/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/af/Firefox%20140.0b3.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "d841a2fb6679761f95697ed1252c765220ca226774881153ab709f8da13339cf";
+      sha256 = "81fb685411cac7060c66d52089c36e35385d3b29b250847a3c120096c0c26517";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/an/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/an/Firefox%20140.0b3.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "3ebec1ccb2d8a5050ad2920c53016c02f50dbaeb4249fbc65f72aa50463799ee";
+      sha256 = "e4e627d9d160d2edae3b40f30aff3e2e8001bf92e3cda600c4a7990c7329edea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ar/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ar/Firefox%20140.0b3.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "2d40019da859a502af6d3e48112509cdc4fca031901c299dd7f0734bb6ca5de0";
+      sha256 = "12c23cfbe39e045769232288bfde570ca4736003e1fb79d54d254859a5414398";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ast/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ast/Firefox%20140.0b3.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "0f69deb4c3b87c4696d34852d9e7bd956b728d3802403929ec3ba733d174635f";
+      sha256 = "1b94a5428889e602826e387c2c92242aca7c9cd5f8ef6faacb77cd6748e61fa1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/az/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/az/Firefox%20140.0b3.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "de80d2c96e6106aff495e91dda2dc66c98b49082627fc9b73e6cb541418e01bf";
+      sha256 = "dffdd05848f2dd592bb449c98333817fc0b47f53823e2139bb4ce908668d7461";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/be/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/be/Firefox%20140.0b3.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "6d1561f7858485628a4d75340d7f24e6d912703594b4c9d7bca49fd5c0b9a792";
+      sha256 = "3343fcaf79d016a39fe7b53e4558b77dfddbb2c837cfa213375de1242bc55e7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/bg/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/bg/Firefox%20140.0b3.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "59e34ca3ced32f81b26e1a03aa9872c8a9a6247c7c660b146f787f29f53ee4a7";
+      sha256 = "9a561c7716e48b632f9f6893380a8d4abda5175e2d4f6e77b17a56d1b7709ab4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/bn/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/bn/Firefox%20140.0b3.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "3f14512645552b8fd4added4ac10995449e7e01dbfc5fb2dba8923d95298b54d";
+      sha256 = "788a256ef5bc70861d84b0e54fe06f8877dcfd325ab6a4e87748c6ae5ea230f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/br/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/br/Firefox%20140.0b3.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "7793a491f9fa9a417408685ca1d8dcf2b9a2bb1048f4ee95e4aaec3dfa6b2168";
+      sha256 = "fc113a5fb3d3e04f5ae6ae2c9430f024b57f7dcce688b412042df3d808f4d9e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/bs/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/bs/Firefox%20140.0b3.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "8e1e58ae603650f447244b20da467a987bc5663f7805eaa87c108aea0dfe8629";
+      sha256 = "1f4e0e5ad0644c6cdedeb4cb98bbefc5963e91e1a2b7d94875a6a7c331dabd81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ca-valencia/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ca-valencia/Firefox%20140.0b3.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "0fcc15e68a06f56e3aa8f52833652570d2e2c80386b4d468f119d9b2f5d63cc6";
+      sha256 = "659c2b8c92033241ac3d4c0ae0574ed9d451d613da73266196f8b72b7f7267e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ca/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ca/Firefox%20140.0b3.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "a4cd0c1f124a8997182dbdccaee61f03d688e10c2c9f4f46076ef62c88bc2ebc";
+      sha256 = "018db90dfb122a6623398aec698eb8b75d242da2d1f04c16dc1e8c61b3b7729e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/cak/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/cak/Firefox%20140.0b3.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "ba76bb6afbbb6f72538d1a0b50d5f95cd2a14421a321ae013984ee880017031b";
+      sha256 = "ac8c6b24f2dd76d4afc789404737c9cf86a4b12a86b9a72e8ae6522459af8f2d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/cs/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/cs/Firefox%20140.0b3.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "005862a68ec16e926e9e888a73fa27314da31519e38ce0fd6656ad924b6c296c";
+      sha256 = "cae8956a1b6be0bcc22d406eef7a1d27012e31dcbd3340b03c8ccd923ec43d64";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/cy/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/cy/Firefox%20140.0b3.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "d71f2f3f678b5289023089482107772a448848db26e75908e8cde58087aaf1d1";
+      sha256 = "a3bc30cc4d9109bda4ee5cda25a7563fbf6251e2a8bdb85c9921ec2ae7b67581";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/da/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/da/Firefox%20140.0b3.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "a2ca0b54a7324acc16e9d2ee6831e3bf25cabf36e1f4ec69c4034795c1519185";
+      sha256 = "5519c55dd95147ba7924d7eaf64f43672b3e5d0af3c356215e1f4f3a9b8384e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/de/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/de/Firefox%20140.0b3.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "24cbff457b1bdba5c44a473f7d65e247727df35a28ece5ab2b685a92f24cb4db";
+      sha256 = "a449db92f8e9238184aca1afa2714ead4eee5c957d8064b85a06ee28ae71ebe5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/dsb/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/dsb/Firefox%20140.0b3.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "0af7cec5144e91bd7c42b3ac6e1bf1b73724853e0c0a67b4d1800aa5a7ef9218";
+      sha256 = "08d0480a1ef2a1fb17eb48369fd4fa9d0ec5a9a53346822a7e8ebf160e7eb3b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/el/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/el/Firefox%20140.0b3.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "4fe53f17a96dcaa91ae4e630222a8311c4b63c8d627ba7fecafab3cb66ae8bc8";
+      sha256 = "84b4fd07308ea4fae6c0293d54e6d98482d65e72c3e832732676424c0d959c62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/en-CA/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/en-CA/Firefox%20140.0b3.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "5671afd041943c805d0115bb235636c656966b79b37b8ff622318b08dc66f23d";
+      sha256 = "e887c18a43b67075de0950fbee2ceab00d3dec82c7581921daa61291fd9a1f15";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/en-GB/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/en-GB/Firefox%20140.0b3.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "27899bd86fe738877c78e9c95dfed10f84f1d99865caf1c8e377a285f7539742";
+      sha256 = "e7eb6732d1e971838d7cd2aa953fad9a60fa40bab42f0d0fb5777a7c6ba93099";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/en-US/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/en-US/Firefox%20140.0b3.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "e60b906321e4e8f6479d87e02314fdf804e3b461028f8d70552d88911a693a0e";
+      sha256 = "81e8db159fff06cc947413698ed7e1a28cfde271ab4758844f25ce42d4b04699";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/eo/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/eo/Firefox%20140.0b3.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "e5513b3584e0e07ab2efbbc3b1acb531cd19fe88decc460fdef0b8bab1ba45ec";
+      sha256 = "dc6152d2c34ba3c831bfc0059393e3688ba1bc7c6bce7fd7667b5429dc34d4f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/es-AR/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/es-AR/Firefox%20140.0b3.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "e70de7f34a08c75c8ca81e041033fda21f8af581f30705ccd1708666a69ed993";
+      sha256 = "ff2cc539f933981687541f36aa33c9c0f50fe024a570ad5ef956a848c1d03986";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/es-CL/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/es-CL/Firefox%20140.0b3.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "f93f379e3953b56cf32f1e7d71df9fd6d0e898a41cb10c1af8fb0c83fd953c64";
+      sha256 = "2ee8c11f6cc821e7b5cf04a8171031efcc035b319ef668f05e1219cfeaae06de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/es-ES/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/es-ES/Firefox%20140.0b3.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "d7275c44b957fe378e949d0c47f8eba8792b5cbc0bacfaa98a4f26795c0f4bef";
+      sha256 = "9cccd63e810c6dc2485c819c9ca575d071d278c25d303c7e06644f3f1afd8b4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/es-MX/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/es-MX/Firefox%20140.0b3.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "529a01a430b6fd03e8de52f7fad75243d53fd042d39dba676b285156f7279a89";
+      sha256 = "5f16013792bab14181e8d945e63b28cac4ad2d449001b4013d37719f1185cd29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/et/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/et/Firefox%20140.0b3.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "c4e67c20198d278dc784212f765c638f25137d3654ccb3cdb49564c599a0d074";
+      sha256 = "b8353d19f3e7db6828d8f9c525af0493912b7e7fef0edf4376c49804fbf16f17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/eu/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/eu/Firefox%20140.0b3.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "5a2cdbf4aef80735073adf761ca7ebeafee4ec68868c1b19580dc0a3d73d3d4c";
+      sha256 = "4c5c47c1a5985c1bf4fa1a377cf8e35eb9942fd6c1d9fe9b62e1ba4a69d81911";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fa/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/fa/Firefox%20140.0b3.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "57e1d9990fbc724eca8b9bc3f2bd8b2b63c30d99788859d4cdf6c94104dc0713";
+      sha256 = "3ee414921a5d45ddea0ac1426a41e97ccfdbb01524fe1f56dd29a39cbf239fc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ff/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ff/Firefox%20140.0b3.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "2b5bcf6057d17ef408cdcb198198d67a9f27a0bea5f3bc682a167d958b2bbf54";
+      sha256 = "e0fb0c4432c152102cbba9478661870d9c6ca704b9b1b712287f07f13ee53f85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fi/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/fi/Firefox%20140.0b3.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "392ce242ddef92bf02dff3f7ce26f7dfc5358a259a3679ebc2333294650e91cb";
+      sha256 = "fd4d87e350a76e4b27a1a7137372776878b079f61fa8652372edfe274082fffc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/fr/Firefox%20140.0b3.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "c07d5671bef18729205554a881e2055c2d4af04c1109210ba8ea5b5e33c0c553";
+      sha256 = "bef5925b6ccbb6540fb223042acce4613f7f51a937f7d9214313521b16920978";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fur/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/fur/Firefox%20140.0b3.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "baeb0ab73c5b288c67fb87a57f9b3866071051e7e04e68c9f554b30640aa988f";
+      sha256 = "ba7b39bced83e20ac07b045cc0f34bfd6635a211309441c6133c86907742bc13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/fy-NL/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/fy-NL/Firefox%20140.0b3.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "57d0713b6c1eca3460bbeb1f9cc6a769db2bb01036054a5538cca93c6fbb5225";
+      sha256 = "c691224f862a2ba7306bbf30252c6c69dfa9317d251d025c07c69e5bb8362ed8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ga-IE/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ga-IE/Firefox%20140.0b3.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "82fd3bf162cf641549c2a98fe88393d3caa1a41ebdd9fef15e3aff278b24cf5f";
+      sha256 = "2c0aa58a2950d25e376e2850b91cde4d14e3d1fc346f79e87e0dfe514002f0a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/gd/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/gd/Firefox%20140.0b3.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "b15a9124f3c4a138adaf497109467d242b7eb706f7ba904c53e9073fa5b40068";
+      sha256 = "92ac30054f35f414d8c1c9d4f5da9c47d45e7276c81399526fcf3025f16f7e7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/gl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/gl/Firefox%20140.0b3.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "be63b8dabc4673022dd0c69577d202efea303ef3d9204bebbe86b09c80913602";
+      sha256 = "bbbfad7dab740d3ed8de731dedfd6e490a5e67a2015bda75b453f4505f0d3e21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/gn/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/gn/Firefox%20140.0b3.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "0fd5f6cf33ea00c65c1e37c2b5b27e6e28b1e804f873ed2a81862639697fb6da";
+      sha256 = "052f306c7cb17c95f31e433b609126639952699974da2cae143b21fe84fc805b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/gu-IN/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/gu-IN/Firefox%20140.0b3.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "a72071f5897b9de30fe23ab448751d88b0943a1ce12bbac525fc25e0d06ca824";
+      sha256 = "1dd713964bdbf17f6475e54ff32c3742e3c1637444695e0c61100f21fbdad168";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/he/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/he/Firefox%20140.0b3.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "8f5873c677ffa3bf8f3c03c1cdd56c9d532f5576b1d45e3eaddc4ca63a4c84d7";
+      sha256 = "2f36e822da58f09ec8f2d18c2de8cc33b4208db066aaf3753dca426f121a8108";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hi-IN/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/hi-IN/Firefox%20140.0b3.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "ef2a4cb4a0822afd273713265b2bd12199cd5754876205435a996af6bd08e7db";
+      sha256 = "6fc182be1a8a96dd5a5dab5edf9bcd6272709f5954c0b97fc6f0390f56fe5ac2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/hr/Firefox%20140.0b3.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "19f7a517502a8cf46cb802fd428688b2f9733a4b29c6bd69ffb42ead7078c823";
+      sha256 = "51146afa8f1a8c7c04f0b8e629f1dfad49622c024df2380af012f5b9466e0c21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hsb/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/hsb/Firefox%20140.0b3.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "43b7bed183606c1ea212fde9cd996ec7b0c227e2e827ca7f0ac11a11a46c1f46";
+      sha256 = "a5ace3b21b9ecc94fb5449f38e70d463cbace509a240062985a5a0ad1f6dab33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hu/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/hu/Firefox%20140.0b3.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "97998fce9f91f25ae8354c274cd0a8e29145935163e1b0d723818d939bfe0434";
+      sha256 = "d67467bf4cc780c6aa8ead5dc362b88a4e1839fdcd4e059c94c53ec851a711be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/hy-AM/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/hy-AM/Firefox%20140.0b3.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "26fdba87a2584afba336c3e388abf0bcaf75352694415954644b3300a482fd88";
+      sha256 = "6a3c5095e3402fac2eb4d4b39b605312e723e608510c0417f278a393af12bf51";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ia/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ia/Firefox%20140.0b3.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "a714bf43aa173d5d4ef29ee5e406f09fe137ab1d9a311299604dbd6a63653238";
+      sha256 = "bf271c5ece7ee47055fbc6eb8d34fa9736afa4e7408f7345ef352d4ed2d0a4d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/id/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/id/Firefox%20140.0b3.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "883a1081b0a0bb03fbf5ab735520b241f9f6d46f05ff7492750223ba1388bfde";
+      sha256 = "41301f061f84a594cbfc28dcbd87aa9bc714a384ee41f4b766186d17c8207b9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/is/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/is/Firefox%20140.0b3.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "411ac5c44cca622d542e568ead74f6192c4dfe717ac16863554b1d6da11755c5";
+      sha256 = "27592a8d3eef8a9d252927f64fba236cf6b7d420eb1e3f5501b6efa366f79691";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/it/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/it/Firefox%20140.0b3.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "fb088f8cdcaf8ea9aced69ca2892fb776dcf48b746f0abef6975e99854c55a79";
+      sha256 = "20e01876b7a2eda3a586bbd658d04672e400e2c0207083620a2ea2910b71a9f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ja-JP-mac/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ja-JP-mac/Firefox%20140.0b3.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "9258d8f492c8c64695af53960fcdbeee60a6bb82a37d71abc77abe1002f98f09";
+      sha256 = "a140e19cb6c43f334d416494e3faf181c3c3d09933b25e8bea3d8671c768e384";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ka/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ka/Firefox%20140.0b3.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "0f486c5bbcc0af6a9bdb4e1b706c303501284848d3fcfd4000c1bfca71bc0300";
+      sha256 = "75eaf79b48b1b2640cdf39c4b75b4c6f44c69ea289909bb6a85392e40a7023dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/kab/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/kab/Firefox%20140.0b3.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "ccbda4ad3d59661a897a1b47ac77e0c48144802575f6740aec95d788227e1028";
+      sha256 = "076aea0ff89b228814d74860b3139a8694c5b660a09f000c07bf7925b15f0a5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/kk/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/kk/Firefox%20140.0b3.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "e55c667813ee5b15f79c5d623cb33eebd1eec5ac4d57f2a8bb9c3466794b746d";
+      sha256 = "9852eddf1ab5078e8dff92699ecebff9d7fa7e4466de87ba090e5d71e4415b57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/km/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/km/Firefox%20140.0b3.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "5774f04b93c6863b27514a2eae504bcfc1ef8ccfc068a953e4d3e270dedf7b93";
+      sha256 = "860b3a552f2f47b1188e1f77da82a1805af2437c43b2b6b9a6b600cd36681136";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/kn/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/kn/Firefox%20140.0b3.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "7c376799a36ce1cd8f89798ebdd777f7886a99693c5f98729684252d340ba2d4";
+      sha256 = "8d85e36fb0c36243f6c97e8211fa92b16da0e3afbe3a91ebec3baf10546fe938";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ko/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ko/Firefox%20140.0b3.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "5f3d2829512178f393b9a665ebeea9cf4f18e9afa042839b7f53e2b620c5db8e";
+      sha256 = "7bfbba2a109c1494dab5e65e67490280d66c2a6a6b739641e2b78ffff8d81276";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/lij/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/lij/Firefox%20140.0b3.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "30ec59741eb1324d18f995d1b94fe5928421002bfc0d8876cfff257148eda97e";
+      sha256 = "bc752a6c3416a2e60365931d1363e87a432e3f7cf4ec1be8d24bd26eeda5cf6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/lt/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/lt/Firefox%20140.0b3.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "0fe2982d361f6beffd4d61f55fd81843943a9fb4daeb1c2df872191cb1bc6a17";
+      sha256 = "148ed3dae888edfbe5c8a7c47431fd1ec0477af9d56e7e2d519abb50dd940002";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/lv/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/lv/Firefox%20140.0b3.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "7914c9bcf07701a2978c0ff417e14a23078ae2cd6ec6315b4be8979ab09e9823";
+      sha256 = "14a68b53617eaf2d1e78ad934e1c927c8dfec155e0f239289d262073664365c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/mk/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/mk/Firefox%20140.0b3.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "244798bc32bd4429eb230b4aa7d7a6192c5456cb95faee5bf66f09ad8013517b";
+      sha256 = "e1695c52a02f2b051de16ab2b7952895bfed6b23b6e440ae308daf31ae6f3580";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/mr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/mr/Firefox%20140.0b3.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "67a2d6ce2ac921d47d01ef7cee9543014eeb4f2db0394ba3b459114b5e65c23d";
+      sha256 = "464bdb5629c5da032248eaedf583c6d2c14654b8e2f919d06edc9a1fd429246c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ms/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ms/Firefox%20140.0b3.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "d74083626dfccd8d628ef0326ff7f2865cad8c0c32aada246d4cbd9edd6cdefa";
+      sha256 = "d65005ab7af62c83662a07aaeb7d4d57e07ee81a0c9db7e87fe2fa1620260434";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/my/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/my/Firefox%20140.0b3.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "61a501809b50a3006a362eeb76f3c4d49bad778cee9fe35b6dd072c53e7be210";
+      sha256 = "5d39e9cbdab4e72fb66df452ab1de1dec8d7e6f29fb4f2d1c562efacc5d2c691";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/nb-NO/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/nb-NO/Firefox%20140.0b3.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "7b1fbd6ed0aaa7865997be627bc7c89622f872c2c5c7725393620404bb6660c5";
+      sha256 = "e56923023c4fe6fc25731dbf551f21f9636bcc6d1a8359e2121a6589c4db5ab2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ne-NP/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ne-NP/Firefox%20140.0b3.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "e16d0769328870f6b964ffc209b6c0b2cdfa015a83ef1b7744cedbaf91f7ed29";
+      sha256 = "31c9d56a2776ebe63eacf955e46df7065b3e97f99f554fdb1a627767b1324f62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/nl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/nl/Firefox%20140.0b3.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "92bade0cb93b3aa2bafee685b671f4284144f554a3910fe6c3d125a58fd1c830";
+      sha256 = "b5541303b09157e6979f5368c2840c51dab29ff841f02b9dc0bee9813a918060";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/nn-NO/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/nn-NO/Firefox%20140.0b3.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "0ee61fda7d45de9c3a85a88514aef5fa2d7ef9c33e839657257da3804c33e488";
+      sha256 = "7fb516ececa5f586536f8811490b7e71e1e5af25d5884d70334d6f403ee0f362";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/oc/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/oc/Firefox%20140.0b3.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "9b549cec47785c84ed77694f21efa1c8a39eecb76bddfa191e43e54ebd798adf";
+      sha256 = "a55a0693d6b7f39053db3741befbc445c820ca547f42b7c295971d81a795b152";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/pa-IN/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/pa-IN/Firefox%20140.0b3.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "271b013e5388416b2d0956b72d68191cd51857d0ab92595a2ff2f7a0aad95462";
+      sha256 = "6689f4363099fbd3a01f809b1439554ca08f0f404ff8a769e45ef84c1f404666";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/pl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/pl/Firefox%20140.0b3.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "04554a10737ed4c2862a3b9e20c82de6e22b6053a55e4ef34b62bc977a8e1ef3";
+      sha256 = "c084fd8619af8ea6c72d7cd44bb20a9d4f058d3dc082fab5f868e48671d1aac2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/pt-BR/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/pt-BR/Firefox%20140.0b3.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "cf56901b76d04c7ed54827e07d11ef8556cabaf7fc9657b83fbc3d86b051a104";
+      sha256 = "2291d282eaa74bdfb225d2f48e968eed1a48808bb6a7eb08290f6e7889a02036";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/pt-PT/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/pt-PT/Firefox%20140.0b3.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "07d160fbc743da7aff2f3501c4861abb300d509549ad46d8230a298f62e57b99";
+      sha256 = "2dff246a5a5cedfa71b5d22fb7db891bf27e8835970ac21adeaecf73a384835f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/rm/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/rm/Firefox%20140.0b3.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "2bf8142a9034bd15ea15e625788d7dd2aeeb378df54b1e64330a99d6d8fb84e0";
+      sha256 = "ddd1cf01753ce22f577ebed4693fee2352b208d5c522e131f225fc3238bd8e2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ro/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ro/Firefox%20140.0b3.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "c739d147056f2fe970b53977e58139580c6200d414d5a07c656bd33386f8d1f9";
+      sha256 = "321ce0a38b5ec5a5cc81b2b62f8cdb4c48db017accec3ee887b79f5bb1e99c27";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ru/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ru/Firefox%20140.0b3.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "a52b9100ed56fdeb1d3fcb96741e379d96062a89d27a52dc3e1b56ee9d295941";
+      sha256 = "771e6eea536f0fe44c213c03adbfda1126e077b04a3400fcef152e952db62f6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sat/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/sat/Firefox%20140.0b3.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "593a800e5993a1d64b25de417e21b86604bf00a5a46b3bdabeda86ab04876a31";
+      sha256 = "564202f15ded2336241f1baeecc251842e608f24e8923c9212e3b78d14b8604f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sc/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/sc/Firefox%20140.0b3.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "195f0e203e720b40024ccfe65e98b9c3fe485e5f27ab10aeb7f01145f129be2c";
+      sha256 = "6e6598ff2ac53d8c1fc9e63bd9393703b59cf26b8ab4abe011d9b501a17eaeec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sco/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/sco/Firefox%20140.0b3.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "dfceefc189afb27e80659e38446433b9cf92fb81c92b783ff9ae1533a0ca950c";
+      sha256 = "99f6c0d9c7301dbd8a58ae03458bcf5d093a54ad30e2960aa0fbe02c81656dc4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/si/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/si/Firefox%20140.0b3.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "70c88ca3c07759e59add1e057020f7bc18a9b2dd582178727bd6c0c9a74ff407";
+      sha256 = "df763722f9a8c41d15f06f8dbf23eaeb868566488feecf396686daf08073433a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sk/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/sk/Firefox%20140.0b3.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "ce352af03817432c6f8da15ffa2c57ecd2fde59729140ac0f7cd59439d677185";
+      sha256 = "afc30e2f4beab9c64ff597178558a0c28da0c53f311b4f3cd70516ed84ec4c80";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/skr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/skr/Firefox%20140.0b3.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "6205c5cc529b43747cbbb3931e828dd273cac01c1cb4413c8dccf8a3f37b075e";
+      sha256 = "0cf03ef8ccf6889ea45d5c3c01bf0f8538280ad0a0b4ba0d62d0cb880fa70079";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/sl/Firefox%20140.0b3.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "74cb297c6f9fc2fef69bfa7f8a0f7c846e6980ef980b40b8479ca843caf20fc2";
+      sha256 = "c43cb64d9398081fd7b5253d7cfcf4cf2f187f3b6df55558370e08a49da606f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/son/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/son/Firefox%20140.0b3.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "d0972c1cf8c89153daaa8fecea950802dc3c15d93e53eb0549f33e31178dc51f";
+      sha256 = "09b827b23e0578dc465b1e33c2c35ad611665c8487e6b37671f7c2a27a09ea60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sq/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/sq/Firefox%20140.0b3.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "cf89a59786a888726616aae73c8b1a3ba783e64fbcfda3b383d66ec72a6b1d8d";
+      sha256 = "9dcb230c1b926cbd53b5474007148b254a3063b3893cd0bb6e297314e264916e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/sr/Firefox%20140.0b3.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "91ebceddc8280c6c7fb35306abdc551ca4671944f7caceb493a5dab8f200a563";
+      sha256 = "8538c307eda6362bbb88b300f74a6db401d969a6a90cf6c0c0f515aed07e5078";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/sv-SE/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/sv-SE/Firefox%20140.0b3.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "864e8427329b950ad42ead7d0044c51a5bc5595f1f94038093b0fbc6eaeee2f3";
+      sha256 = "4885cf3ba66f3e9f562349bfe9dae07d54331a13d8ec55dc875f51d18ba5c410";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/szl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/szl/Firefox%20140.0b3.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "92dae8cb9b2f3388a070672cbe74e2f2399cd416374f78ac7201ac6389bf5865";
+      sha256 = "17441b0d020fa3d308294563475e6195f143997e0b978a3ede06f68f05ebfd43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ta/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ta/Firefox%20140.0b3.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "3998a4b1d8eedce4789b33fbdfe887bb6c434ef668d45d8cc12445351de18ad9";
+      sha256 = "4f81bf6a7ad7dc6f9dfd50c985156e94d28edde7e2b1d2517786d155c6132bf7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/te/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/te/Firefox%20140.0b3.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "b47d181b75916c505795aa612cfd44708f4fdf99e2c47d95ad8b01fd92eff35a";
+      sha256 = "56a4a194e1dfc3a1abf7b9c28cdc1fd4f5613658d80c1801425e8e32dce4abd0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/tg/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/tg/Firefox%20140.0b3.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "a149324442209694df3a229d00ccb2f67c7589a601dccf4a263f7e9ab5b80425";
+      sha256 = "104a63204b38ab9d82c80e788750a9ca2553000e2084b01d7d8c0227e5777e51";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/th/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/th/Firefox%20140.0b3.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "5391f60c1322ad8ae87436317ac6b95c1c1d3d5f112d5b3d23e82af45118caf8";
+      sha256 = "9a05c4049d84f7f6b0172195f34a98f69aeacdd5a5d80d935fad49052bb8d759";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/tl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/tl/Firefox%20140.0b3.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "c2a5ee86077abe59ae4acf0ce3d1d4ba2c86511fac1ec44a21bde5c1a714509e";
+      sha256 = "3b24fa93c80889bdfe3375340f33d7220800c48256509dcb86366d9c274a4226";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/tr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/tr/Firefox%20140.0b3.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "799ec56efb3bd5fa7e5f76f9cf7683711c79f342fbf02fd69037d8141887f682";
+      sha256 = "e4ea76861425944db62f6befd078d75308d493a85162f1211f9081a95e9c9317";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/trs/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/trs/Firefox%20140.0b3.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "9f6123302bcf9b18344260e3dfab6839087ea41a42daf9c2fed7df04e3362ff4";
+      sha256 = "6caf872e4204661d93f98c1f6c83ed04f506b387d416e89937e45d6413b9af1e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/uk/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/uk/Firefox%20140.0b3.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "f2e58fb4bae53bd8dc03cd5c29e9d5676dced99a2376322a0ba013eaa5154bb4";
+      sha256 = "7364e3a29e2b412e705779342341028abec59f9e88f80ae98d036e362cdb56da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/ur/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/ur/Firefox%20140.0b3.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "a4db73f4a8b98557ceb77f1f491e48bd783f0f4f5941d5234309d618a0221a7d";
+      sha256 = "7d2cb1a3a42b1c5e4fd70b38683243bea376a7f8a44719d96ed1ce0c2ddde982";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/uz/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/uz/Firefox%20140.0b3.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "0446e4a59da6f5e3fb242c2a9e3adb781832c2729f64167a12351638f3d00d8a";
+      sha256 = "66cd768b169964d3509bf2f6de345ba12944498206857161a1afda4e35bd7876";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/vi/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/vi/Firefox%20140.0b3.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "e6f47ff4cc809313f928fb365ccd716f7c8de8a5e914e7afdc774c7f3fbd03f4";
+      sha256 = "c978392a737c19328f374e018ebbce779f61ed3e7b7f61d549fc9d3dcf1bf92e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/xh/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/xh/Firefox%20140.0b3.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "c4ee8e4849fa4334757c2068f9eb94341bba22b7298c767f7fffa8cde8341c6b";
+      sha256 = "780f47c26ac2f447758a27396d9f5e4dfe979037a3471a9e5dfda36b2db05c9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/zh-CN/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/zh-CN/Firefox%20140.0b3.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "f22948993a7882ef1e244bcda91b0cd9ef4c814d17f4f54af2b9911e44f0899f";
+      sha256 = "4530f0a24d355a124470f9bb913e4664785fda206b449ceb5ff4679277396f4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b2/mac/zh-TW/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/mac/zh-TW/Firefox%20140.0b3.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "c95699dca04392bf80ecd477514e74804614765d53029a9be80e9ea6b821a90c";
+      sha256 = "26191d7fd1fb4083f4bf79e5287c47f024606786a56c6f87cfaf4a12e5b93ffe";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/developer-edition_sources.nix
@@ -1,2477 +1,2477 @@
 {
-  version = "140.0b2";
+  version = "140.0b3";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ach/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ach/firefox-140.0b3.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "6304038c471eb73b1c8581f0d0812ba328de0f8d7db7f2b17f587e194754d2a0";
+      sha256 = "bb3f74c91d3b6e87f8446317f52676c307d2ae6fe4b28e0ce0a736460a12b316";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/af/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/af/firefox-140.0b3.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "8cd9c38cce4f6672d7c1017e1309f65481af918314a4ceb43c6acd20ac1bba2e";
+      sha256 = "3c742108cc29a6d065b8296b4d9a71470703e88a62a611366448390868dbf77d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/an/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/an/firefox-140.0b3.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "2380b688d5f54edb3b0a5ec3fa7adc5f6f01513551a3d02bfed1a0ada05ddc05";
+      sha256 = "6bf6ded7f7d9dfc3e01c02155f1b6e49ca6a1bcb4742ac99b533f0c050c4813f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ar/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ar/firefox-140.0b3.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "fde74a9a25843aa6141c796958f9cef020b3265a9578aa63a268365cc1be8e69";
+      sha256 = "29df6cebc687ed6b776b715d315b11c00f551c62641b6d55e080ee2d2ad21eb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ast/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ast/firefox-140.0b3.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "3112d67a4d293f672694661266791521d16e3cde918eedf65f3157e9a2b9f008";
+      sha256 = "7b54f6306df1d779f7c692c4cbf1060cc0f443c9234d0aecb09e1bc78e1de22c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/az/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/az/firefox-140.0b3.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "1904894b09994f8f9ffccc32a295237ffb94779787ff04e2f427416d0912f319";
+      sha256 = "45e2236c7e83eda417a0245f80601eaf087e8f310ba676761a8ed288faa46fbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/be/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/be/firefox-140.0b3.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "9393160070ed056e5d1568e90f68ebdd13323e894b79fd05afea64f207231131";
+      sha256 = "7e46760ae218ca80e46c522a434ddc271032f0b889b13dd4073b5d93fbba5f6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/bg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/bg/firefox-140.0b3.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "c521605cfd30f37dffb5b1063d18f40c35d843782480befa7b4e3a91c9960b80";
+      sha256 = "d11e32569be7aeafba8311125bb3e780d368884da19aaf361f96715598e50af3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/bn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/bn/firefox-140.0b3.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "3d31bd1fbd7d9cac8ce4c4a9f1ed2595d17319dbe640aa8d07b96fce80abba28";
+      sha256 = "f307138cb195a25fccfad8690cd9df89ed8628e9b231fa2b21dd1a656d74e5a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/br/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/br/firefox-140.0b3.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "39c1e6cfca4001c63698e066753269d29328fd3188f9fd2ee8c89a35b72da079";
+      sha256 = "5b4c27e5808a1d19b510d5a931717ac55293a6cc02252f4c270bc0777e64595f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/bs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/bs/firefox-140.0b3.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "406e850b89cf20211936221b208bc164a8a73b02fc5d6a9bf791cdf7a7e9c439";
+      sha256 = "8ca82eddb17ecb7a541164be9a734b54f44e6feeea1e3462aa20fffee1467af5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ca-valencia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ca-valencia/firefox-140.0b3.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "0093fcdc460bc29b826f66da5711bba2b70fe584c41c830e2555f71f33111baf";
+      sha256 = "8e0e1e0f6aa9c491c6c25bb4d8e6c854f586a3a9a0440543cadfcb09143d1086";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ca/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ca/firefox-140.0b3.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "9ed9e2eeb261926aa79faa89122887e7ad0a07b2dd764f05ef140e709a413779";
+      sha256 = "101b5dc2694ce773c9d628706645bc27cf608345a1b8bf3894353764c1a13864";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/cak/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/cak/firefox-140.0b3.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "1b4b3619ef9114b3713a64aa5afec1f33861dc6335bcce5449b86676f4b6a0ee";
+      sha256 = "028afcc9ed2a40bf4535ee2bf331b36574dc159409b32b412748b2157bc2aced";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/cs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/cs/firefox-140.0b3.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "89ada949f223c2579be305656a3dcbdead12465bde6d6ee2a464bb3c92455e77";
+      sha256 = "730515c63ad7fbd3543dcfae768a2495ada40402d78c44c3463965af3878a01f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/cy/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/cy/firefox-140.0b3.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "4c18ce881a44473dd2e4e5ad1b7732bfafbac5519d92e036ee59f61319d2de4e";
+      sha256 = "fb73eaa612722e786bdcaf323bf6aff9103e0456b6f8287405d6ebb5f92d5fdb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/da/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/da/firefox-140.0b3.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "d00cecaa47c94d895a6b94e155e8e24fa43abdd83d9f96aacdc34a1c70b2d6eb";
+      sha256 = "3e8c814920f3877ec2f64fb717485c00afa09c9643b9db8a5607aa8d1e8c5838";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/de/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/de/firefox-140.0b3.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "6039041822411f42a6757c4f53f85f1036c2094b8e8a8d8ec6a26f3c1abe521e";
+      sha256 = "2f2dd73b28f425a3754cbb684c16ba1a9c60b30381bf4736d2bf7ef7fc37d445";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/dsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/dsb/firefox-140.0b3.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "9845539a1db4a76ce1f31047471815f2a2ca4adef51d2b56c6fe487f7b9eafb5";
+      sha256 = "2825a53c1b516060f4bcb833576fe1f76ad33000508ff32a87e7c00848f75d92";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/el/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/el/firefox-140.0b3.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "b468c6b5ca6163aeb94ec45ef16fb856cc02a75fc55d939d2aab6181a777d8f8";
+      sha256 = "2afe5eb918e04946370312bca943c95dc61e325bc377b1505d187e08e0c93dce";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/en-CA/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/en-CA/firefox-140.0b3.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ebadf4008439945b4909f0b4bc68515e89837ea871fe09c76dfd78e194469797";
+      sha256 = "119a7459fca0b0b7c628bc92768094a4a3fb3b178d22e68e85b976c69b55b766";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/en-GB/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/en-GB/firefox-140.0b3.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "f73ac36adeae16e5b0a383dd65ccde3946072de55094b52259cf96b5ee78d732";
+      sha256 = "b0d8aff50786434a3b6b80edff341d41d9ed818304d751edd7c7d53170648260";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/en-US/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/en-US/firefox-140.0b3.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "ab17cf4f447bc681649903aca837c950f62e7fee004eaaa9fc2c894f6d001891";
+      sha256 = "8f54302d625b89f1db74c8f3d5025ffe8971e3a43b39a3cecd7c32c37f3b4725";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/eo/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/eo/firefox-140.0b3.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "6f61eb153692e3de7bf83da4670c44d524aee1761aec5c8e54c9fef3ac843d72";
+      sha256 = "4529ff104a621c97840449faab5b03fb8f3916997423ee63db602225c8372ec9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-AR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/es-AR/firefox-140.0b3.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "1ad06fdea8283a58544922066eedb16801d07ad7ed72cc6fc817a33f36741e69";
+      sha256 = "9a0e3cd09ad714af64d65afae373ef239f9c4c469d6293d3c57d8abfb1b3027c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-CL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/es-CL/firefox-140.0b3.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "79963ea997d12e82e245364556fd7c4deceacdaeb1e0c7e4376c7e10df6d5eca";
+      sha256 = "03c07d9194c3ee8fe333277c6db6aedbb31a5fe7de6fc220ef874ca01ccc38fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-ES/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/es-ES/firefox-140.0b3.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "cc966099a59e66bfddfae99a9a5874490ed5716fd5af99b9db03e3f13125dd80";
+      sha256 = "8f78062de562b3ad21380d2f83025d9becdeb690067e349e2f4a8d91444c929e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/es-MX/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/es-MX/firefox-140.0b3.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "ad8b1bf472d0a377fea8e0f5b532a144b397d1447ae85c7c14f871d9029cab19";
+      sha256 = "fadb26f00d4242ab739c7a7882694334334f2f302daafd6cc27f1501cacc7b09";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/et/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/et/firefox-140.0b3.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "296e93456cc6e9027d187ca7b59923acd330066b36829f8140ca16d4ec423d20";
+      sha256 = "a7914688687d6af80ace9d06f25c94c61de73b2503cc159218d7aaf72e32d033";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/eu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/eu/firefox-140.0b3.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "9269d0e584c4d004d6cb2c6f3d3859329947fada0413141b77cab3e4270e594d";
+      sha256 = "c6f2b792311d762f65705850224ed4c602506d015e09f8a7111600228f9d1b62";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fa/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/fa/firefox-140.0b3.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "02a5f409e51ec0010f551afde246a7b405a642fbdc9c85e8e021c7bbacc298b0";
+      sha256 = "03ea78dba2c87986d50969b290efad780cda9489446f85ac1ba2bb0ad6296288";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ff/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ff/firefox-140.0b3.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "89a1e5d4e8d81ed4c3e2b0db3cb82acfe85f00c7875a993d9ef97a895a2c1e8e";
+      sha256 = "ea9c38f732307ad4754efe2c226339f89c0c6b5769e5fc268a72ffae7cde9ac7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/fi/firefox-140.0b3.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "feb7014dad2848a0e70bf2cb6f59fd7cbe4526566e9517ca636c7f81af1fd227";
+      sha256 = "c531eb2057c40f2d455f14436e6cf16a034cf49a1b4b90c5faba395914c03128";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/fr/firefox-140.0b3.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "d8c21f84f555a7ed705d7a21098151195a18a1ceeb8838a6204aa8b346e3b77e";
+      sha256 = "4708706d7c14f88d3817396b707efbb6d2f1e89a86a883ee4696f1cbbefdb16d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/fur/firefox-140.0b3.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "df6870ff18a549566f89c864349f6e1b1be1e996af61a23f6ba8c8ebdc43ea99";
+      sha256 = "839db9631d3c62afb20e01021f6b40a0e363a0769b3aaa8ada93a54a6e7eeb59";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/fy-NL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/fy-NL/firefox-140.0b3.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "800b0a1ca94fdb9bf745c163053816152a62bfc374682fcb46920c281de24c7b";
+      sha256 = "da0eaeba745c98c328dfdffbbcdb736592e2d954cdb4fdd7cfb118022cf41589";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ga-IE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ga-IE/firefox-140.0b3.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "60d3d9b322ed276db8495119171dbc822dac0720fa67d6e0e2417d5f7d903303";
+      sha256 = "f6450fe5f26a8982d203f40ede0c4078616aa64b4e38cdc3469d0761c66b6a42";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gd/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/gd/firefox-140.0b3.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "fdc316f98f0b7c6c58e11a85df0596763276f506b224a79c17314bbcedd76b18";
+      sha256 = "f8ed572d188f31f3eed7611e066d5cc69cc3bedb7343f363636d69de90d7232d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/gl/firefox-140.0b3.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "3f541084a75bfd470f9684ff0e9c64566ae1ae70ec6cab992f641d1ea711f56f";
+      sha256 = "c6b70f14ef92d23bb6cebbf5dcaf02109de4c394aa1cafc31e40debbcbb1bff5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/gn/firefox-140.0b3.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "403181843d5b8b0a511fb1c8526ac04938750ea19ce5bea725c6f6e67aab4cd9";
+      sha256 = "8dd15122d585c9fdf62e8e621f57aa23a836735c2d9c4fb9fafae0b70f6df657";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/gu-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/gu-IN/firefox-140.0b3.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "a0a75e18c30ba231bbb8696d47f203f35800bfa945b010e4b67102e9ea995a57";
+      sha256 = "601ac9297c27b22c4cd98418dda1c74aeddf053370e23b81350f36a0b205f0e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/he/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/he/firefox-140.0b3.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "da0a1845ead82dbec393b3951ddfb050ea7b1eddf07d1dd52c6ea3941629373c";
+      sha256 = "e824e40a538a6a0edde1829356553068adc5e45ca374ac85872f08db0e6486c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hi-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/hi-IN/firefox-140.0b3.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "9cfca47a6e5c5ce56679575657cc52da56a04cbdfeba9fdde7eed2f7dca21e01";
+      sha256 = "d6702ab83ff039ebb36fe821f2d709db2931ac4eb548962b040efc198e259733";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/hr/firefox-140.0b3.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "e2412f9401f913fb3f78c68c242ed2bc7727e4798145f6d78e7ea7bb1e2330b4";
+      sha256 = "7bfca4956e083d6f38d3933ab86a10148e0cc03778c3b2f6c9e3d61612a99b1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/hsb/firefox-140.0b3.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "eef6641537eb1902fb5c80f85c028012151a864a011d87dfabdfff4860adcdea";
+      sha256 = "eba453fc2a0e9aec31ba386075e7f7cf242f4fb2833405c8afe698541d636b4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/hu/firefox-140.0b3.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "338ce874b6b6e7c18c805488eddbaae60cc0070dede2768e1fe8bd807efa858c";
+      sha256 = "f9fac27391f5153cb58d346b82bc4573fd57d5c7ed07e7b72c6a11e7acfc2ac8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/hy-AM/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/hy-AM/firefox-140.0b3.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "fce3954dab579911bc3f3f2daa4139b6567ec48ba209119fa7a890835abb25b8";
+      sha256 = "1ffeb772517aa1e6f9e6f08d555af0971c4b9fcf3cb8bfc5bebaf29a338cda4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ia/firefox-140.0b3.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "cd252dfb69f3c202f6a10a1f94a3958474b281c5648c86fe1fd7058f1cc0daf4";
+      sha256 = "1aa3caf5120a9820b9edcacb6298c878581caf93b302ac4220e4728ede2ccf8d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/id/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/id/firefox-140.0b3.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "c4110ddcbb1ffe4ef89423626887c8f2f093c26e449f109eeec04e23c8f86f82";
+      sha256 = "2980f208cf2aa93820ae71ac0b2e6fdde04f1415696d3f567df0493a24808450";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/is/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/is/firefox-140.0b3.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "27093bd2b6373dc87174473b087afa19fb9073978819157adca9afac9c1b01a7";
+      sha256 = "183bb6118e8662225778d20e17913afa0879940a5999a0460bf9ba9ae68d5f2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/it/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/it/firefox-140.0b3.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "d7cd7f8f77550be23ac2f834ec892711bdfd40301eb60eb8041b6373881a8063";
+      sha256 = "f416fe140d45ed47aa0c02360293d523aafb1492807685b3cc2dc4bc09420272";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ja/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ja/firefox-140.0b3.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "547d409c2fae32d519b85a0ecaa4fa798035de83a99a24b8679841450816e918";
+      sha256 = "b6a34c1e539480a7b8ca0c4bd090860b5015a34640682b160a39d69cdb5673c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ka/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ka/firefox-140.0b3.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "7c8283de2bd1b175da442f54374737d1c483714ff5a65614393a831d87da5587";
+      sha256 = "793231033ad0ad9fcce4e8aa4ee879cc17633141e1c20a1fe90882206725df95";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/kab/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/kab/firefox-140.0b3.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "f79764adead47510e6af35e084c4bc23e550a07d700e9bf315825eaab019da2e";
+      sha256 = "087e30c622398a27a3e347f9f459e6848c20f2597cfa4c4c98c8fec80693f656";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/kk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/kk/firefox-140.0b3.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "efafd746dbcc752c401d19475513a567cbd334f6ea3f9d64470bb5e1f67bf443";
+      sha256 = "52b8b0c10f32c536812c0cf845c41d7c95c4b8c8f9d9a3dede5d825f1ec8c0f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/km/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/km/firefox-140.0b3.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "5f06885bc54c63e176f521e39030a5cc6efa850a49b1329a06332881143d9d56";
+      sha256 = "4e7fcf965198dd9baee10c5b63dcea3216d1a2b83c020983dae93cdf5ced4d0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/kn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/kn/firefox-140.0b3.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "2af7d765a6093ad174cfb34b89782d6c0ce17555d6b12650ac9e17f4fd383d87";
+      sha256 = "a89e05fc8332f57dbf410ba11decf426bf10f3b71e1163956f7f7c404da51d6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ko/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ko/firefox-140.0b3.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "7ebf5fda02c87f0eeae2036ba3ef26f166cddc131ee165ae4e18c50e69ed676f";
+      sha256 = "4ca7970f60c7a95fd5c58f53cf68906034ef1ca262927eb73cb1cb0d216500fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/lij/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/lij/firefox-140.0b3.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "c864a48999305e753d72ece78900eb7a97a3dad8eedfc8a72374c58f1d5227ba";
+      sha256 = "748419cd7a0dd5581c7d47834eac40137230b2f463fda146719101f01c664336";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/lt/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/lt/firefox-140.0b3.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "04d711be33f1fae9366442584a7f2bbffd74fc3b3854728db5dcce37e50f31c1";
+      sha256 = "0bbb8a4755356624b4aa9eedf6c483ff6dac7117ad1eceeac01a85960c9b8f02";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/lv/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/lv/firefox-140.0b3.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "1568ed415833621077555b9c9ab1341882ec1f8f1ba17c596d51bbf40bace3bf";
+      sha256 = "391c3656a3656666d85f84b2130ec5946bea5b70e409bf500ded2f375944a683";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/mk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/mk/firefox-140.0b3.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "f7fab263b90e197038ced58d845c8ff1220d4b7b10dc2afa3265ad0027856353";
+      sha256 = "07dd87129e2c65cc05f8c300b4e2d9ad23f6dc3e3a9f7cc0b7851b4cfbf23808";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/mr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/mr/firefox-140.0b3.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "6e7b7b1d9977bc6d4462e08ed6e2a49ce22dcc8ae408dcc832f63d04b878e5e8";
+      sha256 = "143796cc2bbc47cd13ca690b3c3538f0699a677d9019bb05d613543fb8d5723f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ms/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ms/firefox-140.0b3.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "17306a80a5bbbaa00ca9c1bb3717f25c49ed94c18c58c751c01292e8a92e8a03";
+      sha256 = "f6af941b3f4acfb38e6ada2fe3f79ec1c8870c70420ad3e1ef21247fa4970225";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/my/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/my/firefox-140.0b3.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "eff89fa784ad8b0f039fa182ed67159aca185093402ddbf33752ef327bb4dd43";
+      sha256 = "cbe571d5680cc82942da8c7271c2a3432198664338680ae39d436823f526bd55";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/nb-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/nb-NO/firefox-140.0b3.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "cddb858d97fd0206ad5b138d41d29acff16199b35cd6fcbe1c70d3ca126da3e5";
+      sha256 = "279bc36eb72990932f211ea33903708d883481df7167a84b87e8f2c6153f575b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ne-NP/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ne-NP/firefox-140.0b3.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "291570b761874ce5146d1282972abde6da445c7cf63be89f3d4a2abb5ae52369";
+      sha256 = "311345680b6d327992c6e18c26e6d38dffc07b85194c8a7d3b9b2fc49989c755";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/nl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/nl/firefox-140.0b3.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "00139cb8cc6c4c5f6f478c476ffc00450d57ba239288462bd296b72aee205562";
+      sha256 = "8c67cfc7478113cd961771ef3c0d2be125c64f002dc10458bef7f17d83543fee";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/nn-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/nn-NO/firefox-140.0b3.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "1c3f80cd5e39d450564a7266a58104e117f892243a5166ba6a5c79a12371cb66";
+      sha256 = "2831b4d2d63a1e3029bc8a29b4cf35b011a43ee46b2d2ab8ab50abbc16d95d82";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/oc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/oc/firefox-140.0b3.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "6fafc879c80e60d49c32b7752dce41906213132e3a19e3eaef5edeccb2d6b389";
+      sha256 = "79cdcdad5622b3a3ac4742b8021146554e7f6a6f1cd86a6c48b7e9505f85e0dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pa-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/pa-IN/firefox-140.0b3.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "c7bf8f30d961adcd6b560d855357a0503bfb5ffa0295ced4f92f6e7b6f0c63b2";
+      sha256 = "a21f05f7753ca70cd08d60ebad30cdeb32e64e135a401072f415fd76599e9606";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/pl/firefox-140.0b3.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "43345fd177e16fda3bead11b3e6c094ce947b4913d401c2d849b13607d8f1474";
+      sha256 = "eeebfc01a29a2bd07adc10f4921adc892e558b1704cc4d8f0d739ebb715ad90f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pt-BR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/pt-BR/firefox-140.0b3.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "8d20b449e1f5dec93f7526bddcb01682478df46b7d6b647235f94d86ff47327d";
+      sha256 = "a90b73e1e8857201a633d70e520796b6db1f52f6ef5e59cbd76b39d491a02179";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/pt-PT/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/pt-PT/firefox-140.0b3.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "0f9febcfb684ea28734508fa27dcbb89282174c8ab04fca0d99adb2596b1bb08";
+      sha256 = "f4bb8f65e03fedb3b17771d55c4c0906e2902f1dfa6a93d8d0c7a7f2a32990a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/rm/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/rm/firefox-140.0b3.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "505a664aa0b5eb7fb919437655f807f87224ca346bdde982eaa6bc755e14bae1";
+      sha256 = "3b0e0ccea7d9cef4a3fe1daff20d1e3902b9efeb08c8a9aa406ca2be2602de48";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ro/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ro/firefox-140.0b3.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "fe1317999e0d07e634f4da7813e25d553844339ef484d055115be201d351c94d";
+      sha256 = "2571da74920d477bf003120dc5a654544037374d0373697417433f6caf82ded5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ru/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ru/firefox-140.0b3.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "45808d9eaff267c7aa5263291352f459e30988e00a3ec867ac0e4eb9e3fa5828";
+      sha256 = "030badf2ca2e23a9a475c1327c50547c7284eef1597a615caa8409c492b66bc8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sat/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/sat/firefox-140.0b3.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "e2ddcf9086a5aab8039b2ee40264ea5349bf27f424c8cebfd8d3f8be64b4812c";
+      sha256 = "85c67e09291d12003e6460059537e24d037a955e9f3a747b1adddcce9826d2dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/sc/firefox-140.0b3.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "6c10bf086c38c7f030cd1ac37ddeee3e7900262367a26d873f1130f1b1a3fa1a";
+      sha256 = "ef28329016e4f2cb0ada2aa55e915bc1bf5b4be18c837fb7cdf029e445fff7f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sco/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/sco/firefox-140.0b3.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "fc5a205155469cdd157423b526c5ddbb8ef6619518543d0a13138e4548902c98";
+      sha256 = "d033ac9b10892677a03d6988c2eeb0812da47dab91b82f4c6b4a47748fe9078a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/si/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/si/firefox-140.0b3.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "f0165747a086b031eaed9fe6d56a6a664d48cc2cc1fcb4acf4cb2980680bbb18";
+      sha256 = "a44e640322041416b8f74ecf4b775bd83e420d27b42bc7c601a3e8388935106d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/sk/firefox-140.0b3.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "3139af3d80de44cabe66907b1ff1a0c9abd6d4dcce7cb8f6a8a4c64cc96d0d6e";
+      sha256 = "05607a7cc2d353b5b2a2dd969fce56a4665d1096b9f1e9210618a071be495a23";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/skr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/skr/firefox-140.0b3.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "4bfd49af3b1a4af17b4830ddad90e3d4742baf9ad3b296ad82c186e46e002c43";
+      sha256 = "26e27c88122c2f5ea3f6ade3c6dcfb8f2c9b24f9a81a5ec5df4b02efb07a1553";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/sl/firefox-140.0b3.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "e58e08c08ce875647350c17919a247d1d959e9aa7cf090b9e1f631e3904e1c49";
+      sha256 = "3797ca5f36bda1fa5a44da7dd5dd44d8a139cdedf2a7d29477450a54d0e8a47b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/son/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/son/firefox-140.0b3.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "df8df3a9d363721f5d7284c95e690938a9669bad7d1cbc659318e71807bfef61";
+      sha256 = "d8bcb22d5e108eafb114e8c1ad2b7e00817227a9ad012132a2cdc04628e1fbcb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sq/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/sq/firefox-140.0b3.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "78c45ef74932ad3264ceffa6ca2a3d5863642b8febd784016b5dbe4ad515ce3f";
+      sha256 = "331c9cc72370af2514dfa9ad7596cedadcaa868d9536d4946812cdbf4c492d91";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/sr/firefox-140.0b3.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "9a3b7e25cd80c19c9ee0ebf2b9cd7fb956969b1a699348859193bb3d138a16f5";
+      sha256 = "f05ef459482485ab76693e9cdec8d5c0a5e97f3185f103801c3041e8719a17bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/sv-SE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/sv-SE/firefox-140.0b3.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "864703a7933ca315ef1dcaf1e978b9fa61035a160cc3017bb6df53d50e42cfe9";
+      sha256 = "c564461b75d461ebd1cec29ef55fb9afbe6477032027e6c42696d7174c5a7508";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/szl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/szl/firefox-140.0b3.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "e63cd0f41501fccf3d6da7779e6926971122b9a40509cb57719ca987417d6231";
+      sha256 = "d54288f9a2da27cb4d384ff8375608ba4fe367c98870cc5ce3f9df910178d8ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ta/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ta/firefox-140.0b3.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "8d45af2c0e6cf88a02c25b7c5fb31dc844bb90ddc8aeec774ad8c700ec12919c";
+      sha256 = "caf68d1283bc14b907b77cc8a25d84188209401ab723f37dcec1a0f05812d140";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/te/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/te/firefox-140.0b3.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "0d0868ec91ad13430488eba13840a0fdb238a355a0b74ede0bd536c6cdc2d013";
+      sha256 = "bf49e26c1082e3413fae86190646f46d66db7d39d93e9a3685812d526e136ff4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/tg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/tg/firefox-140.0b3.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "2112d847a6377c3f4b6fddc2064891f17348a0639a6341833cc6a8681aca2496";
+      sha256 = "970548c941dbee501ccafd78d8634a0e1a542fd9af2bad3ae114bf91d7bea2cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/th/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/th/firefox-140.0b3.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "a49f6e380f2ee83e08b9bce632ac9adc8863eff92f043886e6dff361af0d9fd6";
+      sha256 = "a45a478b45c9843a9132ae8a302a196936ca976f4266da357c3c4577f7235d22";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/tl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/tl/firefox-140.0b3.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "a05dc7b3b86eb5c6c8e8bbd405c356ce6716ff7f57048c502a16dba1dc616778";
+      sha256 = "82f642d104b0c23499d0052caf2266fba054d29f69623d21a6bf8ec8884f8435";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/tr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/tr/firefox-140.0b3.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "be4ff7df882a6bbbb82426868abd07b3bc31328b72faab12c50f44910a04157b";
+      sha256 = "bb413e267dfe2a90ab6ac139cbf277a0a02f937918be3d004cb3231b7148f5d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/trs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/trs/firefox-140.0b3.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "b59cd940914a1dc6034648cb4d2eb98a27db282a63f549670112c005a4fc2c22";
+      sha256 = "aeb33928b53ba8a8a32e147a85588ae49d9bd284dfc14f86976d37def2b6efc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/uk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/uk/firefox-140.0b3.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "cd723b22c8bf8d857e68ba7b7101a42451fd4e0e9216898165194dba6f66600c";
+      sha256 = "ec630f7e731bcc4b4bd8a25cfbf1de8671f2635eedbb5af3a649cdd81c7a07af";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/ur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/ur/firefox-140.0b3.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "23307a580138e4f1e8de9de441c1dfa274b871daa68274510683ce02d1bc4554";
+      sha256 = "44ed4d0fb735987ce4545ef1b5b3b9682580a5380ba11926ebdc6dc37c50eafb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/uz/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/uz/firefox-140.0b3.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "75554e0cb06a1244106e2cab513286d0a48c4b5c5c2645b373e20245d8163d5d";
+      sha256 = "911e95a576aa3263f96772c4902ab20411ec07e958db87a409f3b13f7dfcb938";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/vi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/vi/firefox-140.0b3.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "a502e8408f00db0089081072b813debb97bc5c60e31c632b460cdc3d1f9f3d71";
+      sha256 = "06d4ddff9472adb30394fbd615d6865ca97efed1cbc4df760e2512af606582a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/xh/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/xh/firefox-140.0b3.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a87cb0aff09dfd91acac6931f5f8ff1bd000533448f8e79950dee7baa29f072b";
+      sha256 = "359c74677ee36bbb05b610c16b9bdef325214d908ab6d3bc8452f48581be354e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/zh-CN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/zh-CN/firefox-140.0b3.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "7616247e8ee73956d925b4a4d4b3ba1b269db286390250ff04ffd066c37e6323";
+      sha256 = "9a4f770e862f9adfccd8894bcd25d528753712f95a4a1d08c2bc02468b199e5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-x86_64/zh-TW/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-x86_64/zh-TW/firefox-140.0b3.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "1070fc52e45b0827958fc4ebe74f4fd4643738a1d20a9647b37620066cf18896";
+      sha256 = "bbe5ed8be757ba3da19a1f67e41817684dbb0be5494d7bff79da53370c158934";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ach/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ach/firefox-140.0b3.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "15dd9a2a6103f8b4e11d558aa1b5def0119929f304fe330f14fec35452ba88fe";
+      sha256 = "2f5d0939b594d6e1545c729fb154bf48aedc522d5d000489880c746e80d4bedf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/af/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/af/firefox-140.0b3.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "076016952832f1f9923426ccabc14fdce0016572134be4413c323f04929d2b7a";
+      sha256 = "adcf63fd00fe53ee56901a570ba6c8520e844f8e29e3dc3f45e389df1fa075a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/an/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/an/firefox-140.0b3.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "55e43ac6458d7be27db5aeeef0a4e25732555645faba647f379140b5b18f1cca";
+      sha256 = "29c0f898c8e45fe1f1b86e959c0881d0123f4cc3f9c6942fc5e9e776afefca2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ar/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ar/firefox-140.0b3.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "1640b262104f1f637240480cb5d7727aadc003ce320f444fa7446b2345239a8b";
+      sha256 = "70f34c3c1bc6f4151a2b00372b8cbebf7a5a8ac7f671de68e14f13fe6b9c042f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ast/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ast/firefox-140.0b3.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "726dad49420e6f8f6f48b00df01419fa1e25022e1a9034c917732f591d899ab5";
+      sha256 = "1bcb73e4f19995c8404e9bfc3d1463f5fe38da1d0a42cba2cf05d554d0c82c9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/az/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/az/firefox-140.0b3.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "32f38f9452d6bfe9ed0059402286ba86b8e7d49767b84ef68a807009b3928a71";
+      sha256 = "73ce010c00e10e630cfee1935ea038f6938623ae8e705edc2d65b2821d301ef4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/be/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/be/firefox-140.0b3.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "d205be69a64a92dd2dd4938cbe3804e41f9370bd572b0e6bde337feaacc7c80a";
+      sha256 = "3e88c90944e72a6f69a583cfa79637cefe8707f268013d67128b201f7f975082";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/bg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/bg/firefox-140.0b3.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "a6a8a3d4b40853a7bcbcae6c142896b69632720d1cd8ff0ef38944dee718110d";
+      sha256 = "6f3e2829f93ee12e727b6e0bb0819212e06e49f089be627f213dada909d69439";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/bn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/bn/firefox-140.0b3.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "b1ee7cd72876760977922e48ac38cbf55f45bdd191015fd98b72b9169f88c905";
+      sha256 = "8ecc981475148fd74bdcdb50e2beb1718f562087202dc7a940eabefb3aef51ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/br/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/br/firefox-140.0b3.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "df82db0effa2010c5c90fb0795ba63cd8985716d68649d97e15408dc37c6c84e";
+      sha256 = "45979503bb0596668ed7f8946cf0d4cb88518862b538ad97c60795a8c31a0b6f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/bs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/bs/firefox-140.0b3.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "87c0752bd5b5a9c2b87c6e538621c2626b4464bd585f906e305e4c5715f97c86";
+      sha256 = "9ecd5a38c385219847134169839e72a61b266fc065f6a9299649fa3afe82942c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ca-valencia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ca-valencia/firefox-140.0b3.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "632893b5ad32cc730ade803beef2b413b4df144ea80f233e2b24574092a8036c";
+      sha256 = "5def0002175b68518305b15adc03b87dffd3249ee73ae79d384e3a6c68ff7a9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ca/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ca/firefox-140.0b3.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "000cfb032ec853d10c5130b04e88da02998fd57bf70a07844390cbff55f9885f";
+      sha256 = "eaace9c3e8cd44549fcd91a207a1762b426a77eb5d299ccd0f7e619021f382b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/cak/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/cak/firefox-140.0b3.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "009ba5baaa7d454aa9dcfde0b2b4e6940590b6fd6ad7d5a90003ebaf450a93f0";
+      sha256 = "cfbfd5f3372ecc352a55a64844984ad93d2a756bdfcb822f9333f5a739659f31";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/cs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/cs/firefox-140.0b3.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "67ebd37c779ce36133ccac10894ced3faf9d1131a6d0a71a9f35d73bf4bbae36";
+      sha256 = "0b7e0c0bc0f5f679eafcb89f3a22bb153ccf3bec2c439b86ea17ecc23d604528";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/cy/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/cy/firefox-140.0b3.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "baad091e481f7e3c3e7affc3261a22a5a390e3cb739875af53b4fd09f8995ec6";
+      sha256 = "aae377897d7da3520d8f9baf4e318cb45fd40df79139095d7c8afd49396b7d2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/da/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/da/firefox-140.0b3.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "62315dee7ee9cbe3eef1b01359ccfd45ef7348d526fb6adf35077c74178dbacd";
+      sha256 = "644debcd7c8e8317e03ed1ee62ee3c9d83c7d253d4f7e90599004dc41d09e2b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/de/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/de/firefox-140.0b3.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "c32d7e2e8f07db2c92c876f835d506568d5aa5df587742aac5b5b38b1d741224";
+      sha256 = "0f53204b76af95ea05659875470512488e86850adcd8fff704c6c6e328549326";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/dsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/dsb/firefox-140.0b3.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "9bfbe5c14cc47de7c04d89fc8d753e8cb07e0722b01e694e40769578ab41f80c";
+      sha256 = "57a567b97d77cc6ba5514731ea0023e6df7024e3fbe7d919237c326158081fb5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/el/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/el/firefox-140.0b3.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "b847df7a731151defb9a7195e52e5170f914df02f125474c44e3aa63c676c34a";
+      sha256 = "d113a78e8660fe9372a68567dadf5b7097a5e650764848fac93d50feaf24f8a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/en-CA/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/en-CA/firefox-140.0b3.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "7812b2ddeda5bc1ed121e8512ba2d019edf1596a0ebd5d1a8349613e1745d685";
+      sha256 = "990dda380aad36bcf0b84e9f78579df2bed59f534f2e57d0f6ea065aa652acff";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/en-GB/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/en-GB/firefox-140.0b3.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "5b7e6a78a8d98b36cf640282e2aec5b34d9d54dc1c244d45e043de18be59ede4";
+      sha256 = "a616cdf4a9363eac7349d90a3a1eb4a488f6114997073dee901c1d5804418cc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/en-US/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/en-US/firefox-140.0b3.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "60ca80fc4bdfbabe6810ba4ffb1b49eb02147fb05134a3c3eb19cbb2d7ef5ff3";
+      sha256 = "8fc9253f882b22e0ba78979b0540998bf042239a5a34ab7e574529d3f057c607";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/eo/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/eo/firefox-140.0b3.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "61947e8887d2f0010de1b1cdd1df5ece9dcf4f9abaa17c76deb48b47a14ef79b";
+      sha256 = "0f685452bdfcc638f70c363a5461aa46dfac06f5f4e42cd8c4f1c74b72c1a696";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-AR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/es-AR/firefox-140.0b3.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "8c0c291f1150c6cc45180dce4d94540c947791aaee2172e2f37b57b002aa1784";
+      sha256 = "41bcd6cbcb68a993ced21131e1f7a4642f8625fed0c58109f420bbbff64d852a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-CL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/es-CL/firefox-140.0b3.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "aa1444a6092cb96637ef7dc9c44506702cb96eaf633a39302673d040f0b2a9ac";
+      sha256 = "af25ac96f6c46a25745d832863b556ce634dbb8f77c40ddc9d3afd005ea28b49";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-ES/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/es-ES/firefox-140.0b3.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "0442ff731adeae06a0ea178098ef17c1d0aca3f34ab854a7807c56d2b1ace7d5";
+      sha256 = "d0201178c6f4b96cc311d142488c0ac4b19d72733249a3656cb3b174ff959a98";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/es-MX/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/es-MX/firefox-140.0b3.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "b260521cef1779ccd7d6b1cbfe66ac2d5cd8ee72f282b6e81110ea40995e9b30";
+      sha256 = "3fb7c4a44ef36efb56ca313f3bd10a0464bd08428cb6d1a709c0cdf558ae07cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/et/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/et/firefox-140.0b3.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "f7b752e18302aeab61df546a0423fbdc297d538c35b2038e6e9dd3f0432d55fe";
+      sha256 = "93961bbdecfd176f097095ba7703fb9ef3cec8d604dd9a012ba4c1bb07e841fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/eu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/eu/firefox-140.0b3.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "e0d403ce1c3fb69e692c0679c7ed65464bd28cdfcb107756bcf66b03bb20f15a";
+      sha256 = "4617edf681e734a814dbbf668092e0a427862dba8fa7bbcfcc6c8b6869ea0bd8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fa/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/fa/firefox-140.0b3.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "75eefefa501b4e46f84672aacd3d8e5c96f4bbee41dd652436624de5bbd837e4";
+      sha256 = "a579ae841de8e29069ba0edc59efbe6430ffd8f13dea1d69ab1592affd9bc871";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ff/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ff/firefox-140.0b3.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "197ccaeb27559a1dd913969a3a8dd011555c8125fcbb55a28caf4a6074b963b5";
+      sha256 = "bc4c4b4f4e01ea125d4141de08c2aa7716b87bdb41566c023dd0e3686dee88cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/fi/firefox-140.0b3.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "61ac2a275d6410f7eb8cc4f9bfd70e1e5e56fd63eaac9447a56f15920221be7e";
+      sha256 = "26b27149b6d4a5960e3d59575e7ca1ed6cbd91dc67c818b7b83fceea42c21dac";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/fr/firefox-140.0b3.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "9322f072928c09b3d45e9e683ef26480f404def390315f46eaad3aa76c5db4a5";
+      sha256 = "477523d6453d808db5d378b62f33c0417ff3595b942945dcec1686942c1aa87f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/fur/firefox-140.0b3.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "4ca712790eb5a98804b6b21e68cf1d875f9dccd5bd729a7f1231cd3d7b4c85a0";
+      sha256 = "3a720b45d5411dc9f83143ec80c70909b013acbb6165fc072887edef1de33705";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/fy-NL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/fy-NL/firefox-140.0b3.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "3ca2c4a2ef1de935d5a3ec0f29314596ef64611fb9025efbee2e809b8bf51da2";
+      sha256 = "7436081cc81d5b0e54560404d8e4c0bdbd5ab91456aba97b8841f29c02608f9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ga-IE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ga-IE/firefox-140.0b3.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "2e43d6679a844f9241110f67a785525b09124f004d697b41400686851a45811a";
+      sha256 = "feaa4b8a1e69bfac278bce8e7ec4baf3a18438fabb2634229b449f4a6a8071e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gd/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/gd/firefox-140.0b3.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "a51f8e4c872a39f307bbd8c71e56a3f90d84163feed7ca79067ab0f51f7eef11";
+      sha256 = "f8ed901391214851f1a82bef8659c54596b9dbd221e5845a9b81e40f46d3dd25";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/gl/firefox-140.0b3.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "24fdfac7aa372ea38d4ce642b5e30cdd49c46428e5431b004f368c40d52a450e";
+      sha256 = "bb166811df4e679eee8aa0e371de27c8473308f3f24d6a4e91310f2700f6a10a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/gn/firefox-140.0b3.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "9f81e0d531c7a9826889328afcd0e8e8c29cf00b253b0b6ef420fb798ea3d2de";
+      sha256 = "9175d366055317304a7af2250fd25fea929314fc360787403b486400bdd1018e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/gu-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/gu-IN/firefox-140.0b3.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "72ca1ecac233a4e8d51a70edc8d39d6bcbf036827e868b14c9d166c70a7140f6";
+      sha256 = "c147e7fc02111c32bb0845e8bebbe4be7f6e009c82d9b75c3ca62830fb4c0c95";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/he/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/he/firefox-140.0b3.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "2cbffa2df9acd1b30b7e96b14e9dd7d9cc9658779fc24d87cf89f5a5989770df";
+      sha256 = "dfc43c4a430407d78b62b1148d6fa2b4aed91899bc337e1f4b879608b43afa70";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hi-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/hi-IN/firefox-140.0b3.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "301469bd1372c6153612dda25c686461d55d5140e65a8f4048d9159b7fba67d9";
+      sha256 = "c8422bf72d6683c4088949622e765d5ad4da33d60dd94ef6ee435935060d22a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/hr/firefox-140.0b3.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "b00411fb0539a1de5a4d025fc938f6352cd38f2a3d586d7c5023cea8d3fc976f";
+      sha256 = "d867c871b0bb1fd87395696dd4be6f4c4264e39ebec31f702f8d94331845fa69";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/hsb/firefox-140.0b3.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "0e9daab014b58ca0b5b065ceb8429b576765ddf692886c0b2709f9cecda54373";
+      sha256 = "cf63b5e01ef1abde07f4c3a729263c4591c38ec20ec5b63da41c322fb9c0d40d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/hu/firefox-140.0b3.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "d1ebe95c9ca85f7ad097a42f01728f7ca4b67e0b0325993cd7a8788bfaacf186";
+      sha256 = "bc5bf7b0485bf4c10c8db8347aae430b8817628c3d681069ba932a6f1d57ebec";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/hy-AM/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/hy-AM/firefox-140.0b3.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "84d00b6cf98ff0a2ffc08ead1b7dc61e74f689d69a946f2ab8c0c7ce96299f3a";
+      sha256 = "c4d9b7c8eabd96bb7aa4a7931f8c824f8697defabf3bc58e9005ec35f932c5fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ia/firefox-140.0b3.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "54fff386745c615db563a7e1344ad4c0dfedbfe9ff1b69311fb96106130eda46";
+      sha256 = "5b7a33988ce0ec4c4cd1a76b19e52584bb90c558e53f0659b0821e17c3b0fa40";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/id/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/id/firefox-140.0b3.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d52a44a22505daf7236e289b1653b991d640c2b2be5a9ac4effe0a819e9ef063";
+      sha256 = "957752a35e35370f60a905a49a52356c50faeefcd786c2b9287e5b70c0e31a5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/is/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/is/firefox-140.0b3.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "f01b7bc84a711c72491dffe4be999cff939ba3fd433572f693d9e3a0a97d2a6a";
+      sha256 = "3c51a6c0cebc848f0995fdfaf09e7f2d9f22070d7f1dd21f3b80512efd053dbd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/it/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/it/firefox-140.0b3.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "b885a44f52597ece4a719245709263626fefdc94702162523d0c6392e95a9817";
+      sha256 = "4f51222201514d7ba5ea82b106879275c193b2efa4bdd33ff1a7794c1e51a165";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ja/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ja/firefox-140.0b3.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "5deaef5a05465c8bfa5f10480f0c0928a498c1b5f495e198bbf5bb187c2139dd";
+      sha256 = "edde8d936d28d02514a05418571fb94fc8ac6d7b6391ac7527e04145e7f639ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ka/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ka/firefox-140.0b3.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "6c8ea6cab65bae0429c9f63b906e63f40233a01dffb061b0c37d60b0c966346d";
+      sha256 = "bdc2d130e7fdd4ec2524537038a1f6f4959417565a0c382af7d882bd8cdafdbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/kab/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/kab/firefox-140.0b3.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "2c1b647450c0e179548aef5794a596e2053322be9c4b36da78616cad106537b6";
+      sha256 = "dbe8a9ebccb41f1b2651518baab3ee626c955b2c499ad059803c8f8360d857c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/kk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/kk/firefox-140.0b3.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "36349bedecc9a5d3cc4eca66232925583b82a5f9b7ec2104259f7e5ab2704041";
+      sha256 = "f21596ce29b3e5cce2aef7a6bdcbf53886e09ca1eb8288a4192f0bc74a6cf31d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/km/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/km/firefox-140.0b3.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "a50643354ee4c99602b2a31c6ab79a651a6a74692eee373c988c0ccba8ae9574";
+      sha256 = "51f013bb4d063cb177a6427c603f7bc6b9b6363549fc7b15088e872078b4adc7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/kn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/kn/firefox-140.0b3.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "bf484b8f53ce0703250f4ae0adca41b327addd29319a99087a930abaf92296d0";
+      sha256 = "109270210f06933d1fcf140c5771c281b21dd91ce31f116774f990da2483ff3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ko/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ko/firefox-140.0b3.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "4297f9355f72fbbddb7a337f0de9877c88cfe6a74b98262791d4eea48a9e8b44";
+      sha256 = "fd8790433e4b98e959d409ae606388106c86d7c2a039445fbc3e82a8e382fec8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/lij/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/lij/firefox-140.0b3.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "d1128743a077f51f9dabfc3b949a64500dbe5936bd29347e0042ce118b5621f6";
+      sha256 = "da2c6890c5cb79d4a122f4b550e7cfec38920c2976ad3ac155d6d735ab0de102";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/lt/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/lt/firefox-140.0b3.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "ca2d1ae064e99bd1cc490b8d47cac1a342419ab23a3dd39919873d102d416d7f";
+      sha256 = "c92278eb5526b2ec381e394bee7229c0a5f7177c6516059cd8dc2636f0d99bb9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/lv/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/lv/firefox-140.0b3.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "cab179bfcd42b5a93311a3b0e7d298ff1130e17c5c5493b8321693b9149b5b48";
+      sha256 = "e4d1a0820c21a00722a5b41df3c559b318108281e6fb552d51320fbf6d7bab54";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/mk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/mk/firefox-140.0b3.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "ddbf2ffebf122e83bc865808782cb3d1e0700cc29467b6ad8506ee03499580bf";
+      sha256 = "119900c5589efbba5c192da8ea7d770dd9184932da0c4bbb6d3213a358c1c055";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/mr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/mr/firefox-140.0b3.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "b7635fbe1baff6f7edeb4b832aabd21d12582a7c66cd086b95b0a02aebba4f56";
+      sha256 = "66a8229b2dd946d4396b3ccd2af55fcab0dcec3468ee2b334e2ad2a2029cbe34";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ms/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ms/firefox-140.0b3.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "953a47f53c007d2cf02b22a787e8c476c763ebc5b15796973cc406d34301440c";
+      sha256 = "215a550a78d4656fde841d2baf4083e3f90a9954fd99ed55c82e5392577de31d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/my/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/my/firefox-140.0b3.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "a6ff85aead2ee5d55bcf055a42452d44439b9a51ae25b5336a3b22a573c0b46a";
+      sha256 = "e4579d6e87b52b690e0fbbf71af53402a9261ab5556ce1284051639a9da2d215";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/nb-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/nb-NO/firefox-140.0b3.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "ae4dadeba15ae17d3307f09392ebb3f85f0212332f9a9a857ba5b6118452c2cf";
+      sha256 = "a051053384c01772340ac9cae9c377d97a6ab59e627f5f1e8c1b8fa2768c92e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ne-NP/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ne-NP/firefox-140.0b3.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "28e20f4d661bd7e95495155249faecf8fbb5e7e654298ed1fbdd62cc971476e0";
+      sha256 = "693c42f47289df67ccfdcce9a3d0da796d8ebe84639cd90c14db5af434f13013";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/nl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/nl/firefox-140.0b3.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "dafc7696a404c8fad558b649677988c076c5eb4685fb801840710657631c5356";
+      sha256 = "5532fcebc2aee242934b40e084e2b8c8f29fbce387bed373bd25564489bedf77";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/nn-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/nn-NO/firefox-140.0b3.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "992fe42be2e1521e85b9f5baed59f0e87ed71bf62c99190801bf9c2f5f5351f9";
+      sha256 = "50292d5b83535f8ff85f2eeb184eef5abf684cc2698766d7454f2a0e1e9297ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/oc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/oc/firefox-140.0b3.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "accf61fd69c7e00bdd48163403b6bbacb37202a2db113983fbaf8dc1a3598b0b";
+      sha256 = "7ae1beeb5c4062d8407e811432eac653615f830d35a90dd8217d31fc98caeaf3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pa-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/pa-IN/firefox-140.0b3.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "6fe0de8669c63d79837ea4dc062f4550b5ee709446c24cdb54572fa9a3916469";
+      sha256 = "c47af05a8d08e396de06697f09e7978eac8fe2c2267187a6337dd124ed5a8f77";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/pl/firefox-140.0b3.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "71d4c24b490678d5941caa81eb9206c8aef0688eb6d134766588b2ba1a4fd808";
+      sha256 = "e05f6d2e4f8489507eb087558a11d59e478f7fd0c9bf6ad4279960e065588fac";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pt-BR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/pt-BR/firefox-140.0b3.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "85a69113a9348f3aea241a7de7439dea2c3ce3768ddd8d4b2a3ca5c1769059fe";
+      sha256 = "8ae07d27437f29333b9e0e90e17240db50edd1fb148da4d6a5cebef31e6cd826";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/pt-PT/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/pt-PT/firefox-140.0b3.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "4586e1e50cb48044075c4128ae7671d23daa9ea186c8d60272aed76ac5d3bc7c";
+      sha256 = "2921ad599cad7a906d9e58cf0822d96eb074915c1729579345426ce0aeca94ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/rm/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/rm/firefox-140.0b3.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "d06072037678bb49711952a3f5c7a082b0a39258bbbc951578110ab7f1314bf8";
+      sha256 = "e02b76f0e858bbc91b90cea52f4385d26e96cb9e1394b765d09310830974029f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ro/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ro/firefox-140.0b3.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "cdc758063dc9dff54e5d4ca6809798e239c7e096ab7c21c91738c86bd50c4499";
+      sha256 = "6fc5c8e17bc5e2fe3fa47e68bfc095e131c491c9db572731ac31a8477a9571ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ru/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ru/firefox-140.0b3.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "094f692ad849c608df35112dcaab251f3710145fd28a6426f578d984de4e2bef";
+      sha256 = "7da9cacabac3247e5e64a0a29932b61c6c7b57028464e3c5d73b9523b48f42af";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sat/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/sat/firefox-140.0b3.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "5922623b038eb20d5e600d1dfe48af7cadf9e731de85abb5fa12f6e11b59629b";
+      sha256 = "fb4ecb61c01b11286b1ceeee25720e85a579ee60b4d3be319b8dc4a8c8d51354";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/sc/firefox-140.0b3.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "922dd68c7737deab349f55f8c978a2408e6d405b5a6add9c9ec0728dac4d8e72";
+      sha256 = "935dff48a2d0c0e5ebaa866c9d3fb7f6e8020afe6abb4a29efb2fb5f9ff56d7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sco/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/sco/firefox-140.0b3.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "b5aa0dc79307853f86a37404d9bc42fbedbd94d94c5d65b2600e4505ff4a8553";
+      sha256 = "e74d5c2e9ea815c3665eddb06d556581365b827c0c5020db818afcebd0935921";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/si/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/si/firefox-140.0b3.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "3b43ce4e8f2ff93ce083d4202269ca316c7f74407b30386b0cb8c290dc88b895";
+      sha256 = "b32f8f8d8a5ab761cf49edeb3272e1348a3afc3304024e208156455068be7bee";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/sk/firefox-140.0b3.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "38d4002072a718b74a479e5c733a572565e761a68b906bd7f0e0bc6fd896366a";
+      sha256 = "ccc9aca453f15affe6b2568a5e99f513ecae3e53c3c6d65c2656d4fcc3f5a692";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/skr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/skr/firefox-140.0b3.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "39bb8166cb65e836fa2d4462c8af2bda38ce896b918304a776f1d2cce1419f98";
+      sha256 = "742dc2b55ccf1f8edf25b238e2a296f0ab93f8391c7ef7f59f8051bc22638284";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/sl/firefox-140.0b3.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "6c72f3e2c35c677ef755e9dfa39ff8c9947a341b4b91d3a8906350fa9395030c";
+      sha256 = "bf44954dc276d5c3713f692d1e95f4abd7fb9b6038a06da6e3adbef9fd7afec1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/son/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/son/firefox-140.0b3.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "2d0711bdbfc89da98a0baa43ce8ef0027c86aa7db78b0a1bd18672b667ab0e30";
+      sha256 = "6a8e296c807ece35c0cdc25ccfe8bbc920cb8db884d528e7abbfe6d7a01fe498";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sq/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/sq/firefox-140.0b3.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "1435a9477d2040a926eae4161026f7d343c15dd154af39c785fd0c69a60ccb10";
+      sha256 = "99303596de408afb5a9a7495841e7a4849e6cbdad6486f03d7ddd8e2478ae939";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/sr/firefox-140.0b3.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "ce3002b8360b73d0ad16175dc65ced8a6a5051b01947ef747bf7aa4bbd2c9ac1";
+      sha256 = "672ce8ba090be9d2eab274bbc6f6209035891a2142891996f84f5ffa340b21b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/sv-SE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/sv-SE/firefox-140.0b3.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "56dbd4190064e6f4e34d85c25771b30decdf97c7050336badb6875137780c70b";
+      sha256 = "feb4a6af8546de1d53d8f69a3f72ea96f30dc3ff73846a86c92ebe603836e8ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/szl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/szl/firefox-140.0b3.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "a3f255842ba2050b100d26ee84a6afb31665f8dbe701db7557449b14672a3c12";
+      sha256 = "d2c4a0d99a6c2442da50c2ee1af11a7d324e822fa4671d19db11a30c51f56f23";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ta/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ta/firefox-140.0b3.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "73f008cf652c7a4453d710674d9d8c635e1feb3187f615a087b3ec87b4b16035";
+      sha256 = "99ba555f100864b97986e92fef81ff241926047361f7da3c4cc903fcd49910c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/te/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/te/firefox-140.0b3.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "4307336f634d2bd01aacaeeab52bc995cbc127bc8fd5d9503dbec7c24a4d2f0d";
+      sha256 = "585bba59996f2db750fab194186aae4f8ddf830de6e02fb903002b9e26899ec9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/tg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/tg/firefox-140.0b3.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "97b28078ce5f731948c1e12f0920fa4a307a03d2ed65efe12019ec29b23ab7a9";
+      sha256 = "6b27c5273af61abb038a30b5c1f13458c6fa887998b33226dada878b8a089fad";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/th/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/th/firefox-140.0b3.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "c159df215ddea3e0372cc738d13897a89470031d4302a0d28612ace823ce1398";
+      sha256 = "d858fb1c0c0e699b02bff7da2561b8c47f8e85b8d7cc5be1880711e902a28df7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/tl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/tl/firefox-140.0b3.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "bd888218d668794483dc75778fbe4afd83443a655b9eaf2c9b367cf32c95d7c7";
+      sha256 = "eb204c1e397ea6832a60948f9a66b56d89270fef2c3953bdfda9815dc6ed86f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/tr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/tr/firefox-140.0b3.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "88b9244ee99bdd1ffd602df92cd25d02b240ff4aa3a45cd931c0bd9f5d4c9893";
+      sha256 = "0f942450baa484c2902471e623966dbae50f8e11c2980fba116b9d7fc594b50a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/trs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/trs/firefox-140.0b3.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "14278135b7debd30d31853d9189ec21f400c2d32cc8a390f1e01675f26aec36c";
+      sha256 = "25be16633f1503c90fcb001f2b126fc62feea6e299bb2d5d9b54d5947eaa1b65";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/uk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/uk/firefox-140.0b3.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "93b22572fdbd3095d8e30deea395625b788fb9a778ac2229cb195ce63bfcfe46";
+      sha256 = "a147c51fc3f14e9e2f23a2f2c0213134b3661c6d4e3ae2efb6ee70cb6a56106d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/ur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/ur/firefox-140.0b3.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "f3917596f5f0ca2afd8faa99e916ee272e99bb969c0532775b4b250492e80065";
+      sha256 = "dd80282fe69e3dca44211bb2304b70b92247b0b888f6c4a36f605dec8c0f7031";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/uz/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/uz/firefox-140.0b3.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "cd5eba259c10496a1febcb3e45af097fef27a1988b46d3da92f41acd2f0ae523";
+      sha256 = "9f73de9442ad1aff0e1818b4e5d17d3121f2b2895b3186cafdc553355afb8f33";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/vi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/vi/firefox-140.0b3.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "f40f814223621311d4e61330aba019463bce28b238176ee241b5182dcd23fd5d";
+      sha256 = "62f156b335177c4b866cfa9cd4c8a69d551b7502daa7b7e8de7c6f2df3bf43e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/xh/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/xh/firefox-140.0b3.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "194e2abca87a28bc6fac3fd8a2e81c2948d82bb02e9a21d77ebbb852d4d3323d";
+      sha256 = "eb956b5ab8350f2be647e5986e37b25513e6ecf72489cdd55412c21e6f369496";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/zh-CN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/zh-CN/firefox-140.0b3.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "19d5bd43ee524ec3a7b4bf7d743c382ab21ad8738f821359fa5b076e38dc71a7";
+      sha256 = "47e7cef2c8a721287927fc756e078c6c7e22737d857d99e5f6584b8b98b0d8f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-i686/zh-TW/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-i686/zh-TW/firefox-140.0b3.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "aae9ed93330ba2097ea3b3281ea5c91dcd21f4577acdc87b368a5b2a30f8e46c";
+      sha256 = "7e31b87ff566892a14b0fb2ec227b28a281c38a41c82b00c1c0372825dd5c146";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ach/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ach/firefox-140.0b3.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "8e333cc92651318838354682396e621d91346f82515106a44645db9d58a3af4d";
+      sha256 = "3387f9e12b9b3d67732873942fd0c6cb93de46d9876daeeef57e3ccb731c256c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/af/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/af/firefox-140.0b3.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "b73650f86928fb676d4a1b4ad13abd48a99b3a87c69099f4e67891f2f16b8916";
+      sha256 = "c44171556bdbe1526866137d37a7ef25bd2d5320d8d89478dfd62561b6540c26";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/an/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/an/firefox-140.0b3.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "0087d94bccd33bf7cd38e5272b4722fc6ce0654c86329e5fa400212ba2deae5d";
+      sha256 = "c6db4cbc69e2ad5d632c43855241bff3669e9cebcbb9b9e843e2e505c9b51065";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ar/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ar/firefox-140.0b3.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "ea37bd6670ac8c1074db798729b2b6372ddc081546f05f5ab492e45edf491280";
+      sha256 = "bb96da12a2b3ce4e9840a69c9cf04dd44371567435f3a3b32d9aa84a50022d7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ast/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ast/firefox-140.0b3.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "048e5268852cbb2882daa7e768b661b0168feadd538068724b771564addafd32";
+      sha256 = "ad799375ecddca509884aebe1d6451348658071e15f3a48655f2266dda8cc486";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/az/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/az/firefox-140.0b3.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "69be7ed2489c62f4d4aabe0b6e0e356ae0708fd963243a43843f098624883218";
+      sha256 = "7e873555eeff30625be0bd276ebe0891a664a93033fa932df5e1020a2614de77";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/be/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/be/firefox-140.0b3.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "831ac7b7469b7a94a63f8687f8c8d1a6626d0555f084602b341b7875100ec6e8";
+      sha256 = "0049c3cb02b2bcd53bde4ebfcbc6ee83d7810bafc27ac42436174ca8dbc89ca6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/bg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/bg/firefox-140.0b3.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "071125d022f167f209c6b5fa6099a1eb4819ac095e44e28c72835af09dfc857d";
+      sha256 = "2ddaa5e9eb35ebab4bdd1335a336f1d26293f0eb84d0523992c1cd1762d50ebf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/bn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/bn/firefox-140.0b3.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "05bdb1c8f3bb8d673b2956471a60b616565d9acdc3ab673004c5fe30d4dd8b03";
+      sha256 = "c59773d2590d548949a8e7faa40eaacf0fc02a7d3c8773a8a3a9e7f42ebcf9fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/br/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/br/firefox-140.0b3.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "cce32f7d6985778559a2559f9dd2d27acee239823176676732869f99fd114ac8";
+      sha256 = "590ef978da456874f975d304321bdad7be2dc0c05c182f2dd0df3db5b778cb0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/bs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/bs/firefox-140.0b3.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "22b677d215dfc64350e9cc08cf77facdf56f2248d0be32136310014fcb8bc4c5";
+      sha256 = "cfa92aa57589089c654e359c673b20542e842559eb9ee0d141bc4cb5040a8880";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ca-valencia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ca-valencia/firefox-140.0b3.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "070138cb5c1576458df1acf2d7c735aeee45fd831cf6a5c058f705a555f08074";
+      sha256 = "454184c456b455cbfd4174b32a1af69aa61cf8d03c52beb30c44c407707e14e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ca/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ca/firefox-140.0b3.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "3397ef999dabaef0f21e9c94597e5c1da632a525aac547635fc39ecdc4f7f8de";
+      sha256 = "d96acaa36c3c1bfb20f15d8f6f9e3ca6772dc6463dd9b79a8156f6288622e1e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/cak/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/cak/firefox-140.0b3.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "f4bdcf93142b268ad5ece77deff6684197acc671c39ec3408269a5636761e9c9";
+      sha256 = "ccc48b287e6916c3e1eb0fc9fe99cc0b57e152a18697ef404f69cf10e12ae11d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/cs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/cs/firefox-140.0b3.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "f93563b2f365be59e77b205cd582fbab900aef88aa954c1bece23a6ee8d01a2a";
+      sha256 = "fe6a598ee9852fc78e161363419988572220bf5274548d8808032a770202eaed";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/cy/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/cy/firefox-140.0b3.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "6ffa2b32e82102eec535998ee3593f9c6bae6290546425ad3d19f6038be42d7c";
+      sha256 = "666fabaabacdffeb54b23e96553f4ba154d423d1cf86492b664de9220e8113e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/da/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/da/firefox-140.0b3.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "4cb2c407cf89df1a1add90caa9aaae5947ae389a322666ac5fc3f4534ab9f3be";
+      sha256 = "e1446c20e9f53545db9e3a602573e07bb2c5944a44815a4ebdb7e8ca7bafaf26";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/de/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/de/firefox-140.0b3.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "25e3d5ff4e13d7b716d664f92bb60bedc0b695700c743cc27badba490df4cc2b";
+      sha256 = "a689221b405f94bec20a779817e3c1cc871d9d94d5b1957080cc8cafd4ea7ba9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/dsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/dsb/firefox-140.0b3.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "a85a8c6d39afb495e1b34a896b3cc1aa930334fa8e720a06ba86620ebcb64641";
+      sha256 = "c6922652b164a79cea4a0c17af82a436a2c776f8447bedfa662d1e74e3d3a0f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/el/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/el/firefox-140.0b3.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "9a2abda0113c66b95d1bade25336432618e0123c3e344b97ed27f59a03257b13";
+      sha256 = "7d42e3baa362000b5445069e7563fa1d5c8b8bb775590423269e74de3f36c216";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/en-CA/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/en-CA/firefox-140.0b3.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "05b6af15963426fbd845b2b43dc45499d366d476ad59cc80a1558009bd1d63a3";
+      sha256 = "75420edaf831b15860e3e78dad64e280463e04cdf671eb0ffb8016c3bd1ab4f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/en-GB/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/en-GB/firefox-140.0b3.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "b1babf23c66ddf5ac23188b272cbc61d0c9821c8d2ce4924b15d7231aaca96cc";
+      sha256 = "10b686fbee88fb4a1ec5acb9329785291a591c27215f6b937360f98d519d089e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/en-US/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/en-US/firefox-140.0b3.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "b6b38968b00781bbc144065f0294947bdcd1f23bfa641f57efb6e88f5905cb40";
+      sha256 = "a1b5c903435a501a196882445546fe52b3866573c36206dfe6235c64a7334e30";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/eo/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/eo/firefox-140.0b3.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "195e8ad6973822bd5f1919a82bdf2206cf9d12baa7ed38e467eb360dc5dd2c42";
+      sha256 = "658a0728a5ae42ce59cbe5783aa8392cbd0c7687df22973558b052a4b2e8b166";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-AR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/es-AR/firefox-140.0b3.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "b4c3d0c5fe505ac5e7c9a38584683ce3c8236ecd497f055c7ffcd7b08604fc3b";
+      sha256 = "7495b7e1968ec676c847c03596baa508dc51bd718533887374a753c721e16b6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-CL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/es-CL/firefox-140.0b3.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "42fdd9a3dc09de733adb19bc07eb40448390a4ae9a32039f695564915fca8537";
+      sha256 = "6ae1058ebd39b8294bef8a1c532ac6d9400cc5271ee7efc1b964aaad39ad5081";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-ES/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/es-ES/firefox-140.0b3.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "8946e80d10fbf064eb6fe4565afbf4b7c320d3e224871c33fd45a4c22c53554d";
+      sha256 = "439ab7bab00c10785aac645684460c619418e2a96b2b9c799a9d0bd9a1165e49";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/es-MX/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/es-MX/firefox-140.0b3.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "2e04c6985567aaec38c91f7d45da067153b12d6d800ff6653356af6a39bde95e";
+      sha256 = "8a08c217f062a333478aa5642e3c8d7f1f1927827db8190a0f910f5cae6e332d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/et/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/et/firefox-140.0b3.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "a331657da8a21a447d94ccf778b766abf845f73f2350fd75b4066a1a97cb7255";
+      sha256 = "357458f42be8175279ba09e7e1a8c598233399bddca2fc0f1cdb731389648a54";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/eu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/eu/firefox-140.0b3.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "1b10be47d311454b148558de6e6a98947286d66b32627fe9da586f6e764b3846";
+      sha256 = "c5679d961ac0d133dd54d040b25b6bce0ae3e6bf54bbb80b63e1cd4283a41ede";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fa/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/fa/firefox-140.0b3.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "61ec0edc1639d7c69f258b4860135955addb730c382cd693faccd07acc9ee59e";
+      sha256 = "c54defcf01f5ff63b2c9718bc26660089abe0230b3808f492f55e1e25403ebcf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ff/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ff/firefox-140.0b3.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "97a5d77fd30cf21502b8b9c8005112180396f26d24dce88f6086671b3711d710";
+      sha256 = "9caa213108d214bd1b37e6cc1f367b29e093fcb98f1f010c8cb68a25c6149457";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/fi/firefox-140.0b3.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "180a4a853a9f03cb5c4b6467b8476edeee17ea5cf324ea4415648dcf3d85b228";
+      sha256 = "8be2a4279373bbe9c74b28175a53f6082cccfbea5918bae208be0c6b6b888944";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/fr/firefox-140.0b3.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "6490b20b7cdb731df9d8e0df8ca46bc834b362c577c235d5397665a617b271ac";
+      sha256 = "9267835f4f5512068ad3ef87b8fa75bfba26db4e2c0d8f6f1e37ef86f17317e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/fur/firefox-140.0b3.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "6d7c83bb94c905b02365b0502cb5d1ed7924eff2ffac575994598d7382aa4635";
+      sha256 = "43b1b42524d772baa72ee7ef0c8b6322949fb2b64796ffbed4fd097a6f2328a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/fy-NL/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/fy-NL/firefox-140.0b3.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "9b11642f4ebd8e27f12d3c244ee467a668976a17edfb12b71e94238eb2a98d6e";
+      sha256 = "385c966b1eb1d2af7a038af9e3aef4323949d431b0f09e4cce3ed5e045b0728a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ga-IE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ga-IE/firefox-140.0b3.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "2fea6d116c6be60aa0a0a46278fe29e29f0ea2d6b48396211d500fdfe5669d29";
+      sha256 = "c0f1ea44c17e2eba13f8c6529b39da7da2bb1f8d5f0c8b9b0b41be53c04ace58";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gd/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/gd/firefox-140.0b3.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "22832b70b7504b7bea490b45a70ed88488951d4b9f4e50cec6869cedf5fdf916";
+      sha256 = "e3857c858010c4a0e23b1b4d77ee74e398ed68d0285797e8e5f5b677f8271aa6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/gl/firefox-140.0b3.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "0fefa4add517fbd4a49ef4305c0a37dab58d5cd1cc579ac9dc4db005fd434e9d";
+      sha256 = "5c097ed389da49c71e6165c6735db6b7195cd52e113d8c1e7f6078105f594565";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/gn/firefox-140.0b3.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "0dd0a13c53de0ff825cb563381ad0fd2956cc1b485f270cd9fd07fb791d7da79";
+      sha256 = "d63959887d0efeaca0d34c731230c23be012b0a0ebcf1c1f9b23a2164c1f5051";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/gu-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/gu-IN/firefox-140.0b3.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "0afc4e0cf35f8668cd41026532b05070f5bfb116213d7f195a9e2458a2538c33";
+      sha256 = "b6e876dd0f29e081ccbce9abb08a7338a6add3ef6c52fb43859933461cc422f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/he/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/he/firefox-140.0b3.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "f53438739efa25fb3bf2e76ea57105005c048ee8f87e3fdbaddb6987bd8b41f1";
+      sha256 = "f150fa1887b7547429d67bf465e18ed9ba35a0eb7b05f98a4f5d87673596d8b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hi-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/hi-IN/firefox-140.0b3.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "e82d7805936223b363613138e1641e7ef042ca6229896b1f261cf9db85095921";
+      sha256 = "76d0f4825b8bcfb9d6d66860cdf8ae0b9c47933037586d896f8f2df752c0cadf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/hr/firefox-140.0b3.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "5ccbd439a15849ab7cf33899e52190d7823042c05ad119e54d968284fd95cbc9";
+      sha256 = "c34b67aa88aa37d0a2e680a7e12e6f61933885f3855f85a7219d3ae2a05174d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hsb/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/hsb/firefox-140.0b3.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "6671d4973471337ff156fb0aa8d8a89026ea001a82a3c39151236e450ba83d11";
+      sha256 = "e80a11c6d279f403e7b4486183e22341904627cdfbe6913731b0d9680a27c624";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hu/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/hu/firefox-140.0b3.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "f2b96cd0724c64b2bb946d03fbe4f689e06aeacfe25546521a85fc823df19190";
+      sha256 = "a19774b3a61039debdd0ecdf1e0eb52880406127728b49eeeb2b557674e26288";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/hy-AM/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/hy-AM/firefox-140.0b3.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "9b57ab8d9dc9cf31b1e8c5983085ca6380b4edabc78c823cc5957862011c14d7";
+      sha256 = "667c51cf291606b1da0964d03bf990d5a8583359b01260ce4d55492a5be04229";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ia/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ia/firefox-140.0b3.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "188793a0c4619be9fafb870583c716f2f71026505312050b38c90ba69a7ecba3";
+      sha256 = "3399278865cab1ae01fae526ca2e7184a1edb3337d1d4fdf39d035f5ae05d35d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/id/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/id/firefox-140.0b3.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "69601bbff0fe4b1719d9f76326ff363aed11404d0cc3b1babd6de85f174beae9";
+      sha256 = "258714f0352e26cf4824a129414cb4d73ebf9a196a1e07606fdd512a73643e1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/is/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/is/firefox-140.0b3.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "a446c41c5055ab8b81d28394aa0c3a204012a7409028a610269d6b8c31cab303";
+      sha256 = "60e0e2590c0a46f183991e9b34b055f148cc9e9611460e4e28574b50775b7e17";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/it/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/it/firefox-140.0b3.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "68ec8352f64a031b2e12f43104822a2fbcd80b4061d8cd8ce87498112fd7e5a9";
+      sha256 = "275184c50ebcb1ed872f468f76ac7db657b83e099c58adbe68bab8d8859854aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ja/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ja/firefox-140.0b3.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "a21480a969ac74e85749a6e2904af86dcbee8a85b799b45e09b23c9e7553b783";
+      sha256 = "50d0351a67bbbe93bb224bd470c6e300c319ff73f51891d0f40e33f2e12c1105";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ka/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ka/firefox-140.0b3.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "279672ac2c1b8d7f0e0d942f027a7fdfa7245c9676a406889f420e6b55131ae7";
+      sha256 = "abf5e0c2f1db38f2295223d9bc6835d2250ddc511d1a6373193cab58eb8b5bef";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/kab/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/kab/firefox-140.0b3.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "502c7aefb553e3dd95dd66ee5c20f3314996e0a9551c6da66b3210a2af3268b2";
+      sha256 = "1e216572e181b2182b4a2e4320675c2ac6d523f27f35227b17772b1454e5ce3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/kk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/kk/firefox-140.0b3.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "71b29a6a4b5d8520c74b4321da341fd7d249396d898535f5ddcabdcb63c3fd05";
+      sha256 = "48e8817330d41757d848a69f95e3a89a0b405f46cef54f61541b2cee47910098";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/km/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/km/firefox-140.0b3.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "dd9e94f1c57b55e16cbeaffa85ad406a9a845b7f67c2675b7f0cce97837b389c";
+      sha256 = "24182bdda0438cc4efb50d9ece8d737cf05e1711d15e871c21dd4049200a064f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/kn/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/kn/firefox-140.0b3.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "9ef46633c7abf9862442181598534019b5da16d64cb0150bfa82a06c85a3410f";
+      sha256 = "4792c242e54c336a33fca76299a712a2ec05196081dc6758f39f07b7e18ef183";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ko/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ko/firefox-140.0b3.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "bcfa77af5b291c24b0c60e730c39dd0217a6ff54818e2728ccbf84e04d20d2f9";
+      sha256 = "cb4a05aea03ed789617c032dcb2669c6c1d4c3692cbde750a1994fc641c4f013";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/lij/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/lij/firefox-140.0b3.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "2ab2cd1914eb0cf2429d9f02e95f5752a5284e12f85e29c54fbfde1ba95bff55";
+      sha256 = "f3964c38e58615d0eb7d0150e0c6920a90788f1477fefd2d762556a174662838";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/lt/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/lt/firefox-140.0b3.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "21854475ae62c250dd11e3265b109ccc755cfe4b7827c6911dd4246f26987318";
+      sha256 = "91d419c2bfa9a03abd18e603158f416ef2fa023b29de4e926bacc5ca1feb9946";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/lv/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/lv/firefox-140.0b3.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "1fb6f3e717bd7f285f1d084fea8be957eb7959c29035c4c1de3b116a21f9af67";
+      sha256 = "a4829aa251cdc8c4873870cf85ce889a088a7f60a669ecac6302f818de2677e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/mk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/mk/firefox-140.0b3.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "9f52a7a077d6578820ae9011936ba436eb121814aeeae80e3c5aae097fc3af28";
+      sha256 = "571039c86835ace41507fbb7e88fb808bab9a3cdba86ecca36a705076f1be6ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/mr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/mr/firefox-140.0b3.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "3f2b240659b7354b2d3cbdd8175f33a2a5884c90133fa394cd15b4f6e86ba4a1";
+      sha256 = "5af4d3f08a05a7fd321678d6f5407ca0b885e72c45b320b8c7a6a7658e127e6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ms/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ms/firefox-140.0b3.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "73a18b565e742dbf56c406f2f1cf729a0dd0cbbb3c8660c8c01b2081cc924fba";
+      sha256 = "84bc3e41e4e72b8202eec681520edcd1fcacdcc20dd256ae26280f0136620da9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/my/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/my/firefox-140.0b3.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "e5e43ede829a329c553e786659e980d5e6e94f5228c42c2a44eb34b399210bb3";
+      sha256 = "c99a18fcb63f901cf4d5cad5ee1278895afa4b9ef8d7cb7e0ac0e084e0d25f3c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/nb-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/nb-NO/firefox-140.0b3.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "bd5feca0d1a34e6ba4cc4839ba50d89bf0beda61ba975a2ef76f1a053d725605";
+      sha256 = "816e39b1c3539e771d8f4d7098dfee49595a0432edf8c76a3766d3b1869ac710";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ne-NP/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ne-NP/firefox-140.0b3.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "864e1ede94813108b75fbd870884f93f77628e6cce0449b76018b9118a2c4b0b";
+      sha256 = "1d8ebc6580cbbe03afc5070228f40a5bf928f9edf904605856ba9c1df81fa665";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/nl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/nl/firefox-140.0b3.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "4bba7f1feaa30adc2bfcc769469eb03361b6193260424d3af0092047c6e777a3";
+      sha256 = "ffa903ab76a6dfeda4cf863fbb7248b4a428d03e686d21790c4647d43653975e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/nn-NO/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/nn-NO/firefox-140.0b3.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "968d80dbeb5418f968d584ce0c51bfd322b1189c2122a1205f64c0ade22b66f9";
+      sha256 = "1c46c79761fa30948b364396d28fdec00628c21e46400e4c812f5433c8fec7e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/oc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/oc/firefox-140.0b3.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "66f45ad09dd4a90a3b0c6d66a73b8833a1f1f62f58719a98905ae57c60805b9c";
+      sha256 = "efd8f41921db93f5d83e10ad7398d393502c650494dde02349434f3f94b245d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pa-IN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/pa-IN/firefox-140.0b3.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "05f4b146691ca748e27b524c7e1889bee07290d417b8bab59c0582d48019f61e";
+      sha256 = "64bd9c1af3f0695122df345a86d98da74b4edd4dc6e033882d31358be30cfc36";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/pl/firefox-140.0b3.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "da9d5833e75feba4034b9b708ff0d17dd93364f0d2f0b5bcb2fcfa5b70717fba";
+      sha256 = "a221d10e8b373bfcb179bb36cd6d0c27779dde66ca5d9fcb89ffe637f1898d8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pt-BR/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/pt-BR/firefox-140.0b3.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "680f083f8dcae74b053214b8a20ff2e253829b3b811212356847f99a108438d1";
+      sha256 = "1b5b0f70cb9db3d3e8a4d6c3712ae8e3f406511ee9fb5c8e2433261c9d46b417";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/pt-PT/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/pt-PT/firefox-140.0b3.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "0a5eb3f4a0c9f0c47fd157a26bc8ea6b70007f912f5e50d38d6ea1487c23f7c1";
+      sha256 = "26182efcafdcdf9dcfaa020f299559d7fcd3ebba62cac5c4622efebfe3435174";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/rm/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/rm/firefox-140.0b3.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "33f73c88fd97ac68c415c9bb55db59c68cc7f482d381ca1a96b235ba2854b9d3";
+      sha256 = "953111cc9b2ae344a6082e95f80960a0bdce0c3b5eb4d667d5b8d749e77b97f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ro/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ro/firefox-140.0b3.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "77c641e73af901a2986661790890dbd831e586b579ae398433ce98117e310b8d";
+      sha256 = "7f52eb2eae1b2f27db938474c0710c28dd7cc5366e88abe37b2f51c644675b1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ru/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ru/firefox-140.0b3.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "cc6994ffc7d98817352c390db1d06cd215acb5459121d657862c15a95f27ce4f";
+      sha256 = "7cd6928d0c0cedc76c06946c0329a13515016e486ad634c9eda1c184215999a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sat/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/sat/firefox-140.0b3.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "f2ca87b4c371399e211874e60e25abbcc320eae84993c066ae9c491d6eece514";
+      sha256 = "0509df8f6e67bf3f0ba3eaa5cdc7f09d2ed52edc2016ba17bdec5dca37dc0215";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sc/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/sc/firefox-140.0b3.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "3703ff4a67d1c503fe90726aa63dfa4cb266350aa4c0b5f29723a57ce677fda1";
+      sha256 = "e90d7babeac42128b88966c89bc27ddcb782bdb11cad278cd844f486da9cb1a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sco/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/sco/firefox-140.0b3.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "963234677f4cd4c3beb7299541700f865132646b39df9e12e89d0f99d2d9e8df";
+      sha256 = "12520f1d6e4a8d4385dc44e8b0455c0946159793adc05ca2e6bdeccd331741a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/si/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/si/firefox-140.0b3.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "3632f156201c1c86b9497e09b45707f3126cb02b0cd93a936f9fbcea47af57e2";
+      sha256 = "ab879762439cabdf676f74ce07fe7ce3303f97a59f3758ebcdd3e139bb6188a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/sk/firefox-140.0b3.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "e5b6158136204fc90b960d1650e5c7f0f8b74ecaa46529f3f48c9a9bf7a9cbe6";
+      sha256 = "412edadc539d8999a707a81591537f0565a26f50ca566581687c2e01d186fd95";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/skr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/skr/firefox-140.0b3.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "ee71bf891c728250978a0d19290ddad63e893a68362f73e47249c8600e496c58";
+      sha256 = "6b03c01a8dbaa8e25dcbfe16b45e75c4c0607edfeb1b8378b6218d9c989fe2e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/sl/firefox-140.0b3.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "1b38a650fd3e2c41e4e20e19468483b4001719741bc2de99ab555784baea34f2";
+      sha256 = "aa9843e770e2ff34c12a21f58cc74025ec2a2fe506f5ec5d1ed39e2a71ef5e99";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/son/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/son/firefox-140.0b3.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "5b0ee6db02cb38b7f340f074d4e454c29babf2bab55282aa29bc51174cebe9fe";
+      sha256 = "0c03dc82f8fe84ad296e928046762f33cba7929cfacc20e58ac3682f641a715b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sq/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/sq/firefox-140.0b3.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "14fcb51691a9a4addb2b4d01c0bfff630359c7e1c94181a1b1f41a0bc64f9a9e";
+      sha256 = "825e766cb6204232462edec2ec637fe3620e021382b7ece7f79122194404f85e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/sr/firefox-140.0b3.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "9297b97dd92c4a9b848a0b59f6490014c323d54c63965512719cb766b5ec98b3";
+      sha256 = "3dab1ce01cbf1e4b051dd0be1cefca6bc6921ea35a28767a9619915bf3fae1a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/sv-SE/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/sv-SE/firefox-140.0b3.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "36c4d22521d6515ef705d59b42cbc86ea385b6713049bac544db89cbe79929f1";
+      sha256 = "9936b4edb5afbc133854bd323ecb9f6de75589903db65b444579139184fe3ed0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/szl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/szl/firefox-140.0b3.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "47cef94cb8d05f1e67fa3c805761bc556181769778d86f91014b01e722da0a95";
+      sha256 = "855d718f0519c19c86380fa72ec6aa0aaf9f82d806fe32bd0b94a2f34f27278c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ta/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ta/firefox-140.0b3.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "eb1ba963923ff35be8d85e2e432db2eea1815e23245006c153616fa643a923af";
+      sha256 = "80e7aa6114c2f8be68a1efc6c73c0b39f0c00679db5f16e8fab65c54c74d2569";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/te/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/te/firefox-140.0b3.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "f20e07229cd5cb062b1ce2c07bce7eace439dee11c1de11b956a2ed3dbbde26b";
+      sha256 = "bcc4e2f3fbba6bc6f01a2453165219ce02eb24852d89b0720ec457396f6d0cf0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/tg/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/tg/firefox-140.0b3.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "b25eac2f5a213045980536b4d5ca04f802f083c0467c56dd02680370ea3c7329";
+      sha256 = "4fa638bb86d4c154a9c98d712641f93cd20b87d57320e39fb0632f64bebed14c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/th/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/th/firefox-140.0b3.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "d2242d267cfa67a147becb147b6ce9540d24049d601a4f00776c0eceac02849b";
+      sha256 = "c36363ce1af201aa457d8a230fd75a5129707ffb75b2c84ad4dd0341314a3df3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/tl/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/tl/firefox-140.0b3.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "74891370d6b308e15b200355152ba34a31a23fcccee53ad2472a4be17a38667f";
+      sha256 = "b87af873d33da71a73bfa3e0523b0f9651df8921afa3c8671d73a33ac4925346";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/tr/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/tr/firefox-140.0b3.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "6ffa80dc70a4b37da1a0dd45ee26512b60352f5f0a7d7753ae0f786dc3ecc120";
+      sha256 = "a7fff70158702ede22335388e1e695f5e7086d4617fc868f7f2c85957820a50e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/trs/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/trs/firefox-140.0b3.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "c34973c0d13355f79461880372fed959c4a5872a72b22f570c8480cee4e403ed";
+      sha256 = "ae65ea701ac7c4d71d7de0d175ca2886002704c66a9540af81c92c9fea1edb61";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/uk/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/uk/firefox-140.0b3.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "f0c0b73f4dddc526b058954b4ad3c6757388646dcad0c1fd694947f7f06bb479";
+      sha256 = "3740e4f2065cbc1cf8e5dd413fb9fb1d735e83f28e036cc70dd17a592a4314db";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/ur/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/ur/firefox-140.0b3.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "7cfa2930a547d9b0b15e6ebc571ec8447c42b6a845fd228ccc023df7ddbce914";
+      sha256 = "7f12a9f9e7fbadc91f363259ab25efdd0eb0e7efe876961c5a55d04528a0a8ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/uz/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/uz/firefox-140.0b3.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "1d86c24fcac2d62b946d9bc957a9dfeeebc7d519b4662f5a973beb509b946cdf";
+      sha256 = "430cb9447c248f780752109176652be758e11ae8be6697d9887b427a93d7f4f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/vi/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/vi/firefox-140.0b3.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "126e1f815c3e57cade53f92fdb57f0f2c8f93436523f5947df4e1bc64ad32263";
+      sha256 = "69cbdc59a993867bda380c425cb8817cd332d9527a234530d418a3390d89571a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/xh/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/xh/firefox-140.0b3.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "e3cf2284986f716bb80eac9bc258af4ad089fcb9f24e20dedbc718da3324370e";
+      sha256 = "63fcd5c3aa54cddc831ff612e5a4a81a2d0dbed209884c2f245f1a36daed2cf6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/zh-CN/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/zh-CN/firefox-140.0b3.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "4b4d6d3dbf2fff5efea5c659d5d95c45b55fbc68d0767f7cbd8c052bfdcc5a0b";
+      sha256 = "df7072dca96da6164e8ce0b523eb0f09b5f68a11d53bd9eab0c81ee158e823e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/linux-aarch64/zh-TW/firefox-140.0b2.tar.xz";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/linux-aarch64/zh-TW/firefox-140.0b3.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "7725257c301afb843517120dbd5f28d2af0e394aa838d56e208680e8a51183ca";
+      sha256 = "5bc5002bf66948e837eaf42a0b397766416f14c539ab1684e1400b2febb59b5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ach/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ach/Firefox%20140.0b3.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "4ed0131e4684690e82a3365020d901921255096dcf3a9d59c9ea6845dad75373";
+      sha256 = "b91a4b800d350b018789a6cb08bbeb6e557ef492b79f03c2479fa931eb5eba55";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/af/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/af/Firefox%20140.0b3.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "b880748c005d6036dd89d9d303976393f3d9ac2a91c185c641ccd647ed056ab8";
+      sha256 = "4cf3232c157eab869704d49f8215f1096f421aa58a5a2653ee6fe186375118f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/an/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/an/Firefox%20140.0b3.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "6b35af1d4cf4965bae7bfa7ed4df969a81f24b490033c59a9e41eea21fc3e730";
+      sha256 = "26b0318f7d6b8e6d4512fbca50df1b0848ac6df708eadb6d35ff557214bed2a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ar/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ar/Firefox%20140.0b3.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "866cfb8c17c8e2382c6ea691187507db00157aaaaf53448d49b95407e18e5c85";
+      sha256 = "3de6a419eeaf8e2b7abd6204856604d52dafbe9457a261d99258a34fd9883d34";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ast/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ast/Firefox%20140.0b3.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "7f6aa9adad62d9991e693775e91ed6826594405f17cdebccb99cb8dcc39bf095";
+      sha256 = "506566a4074aa217fe718145d68f5792310816bef7d03412796925eb2f497b2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/az/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/az/Firefox%20140.0b3.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "6fe3f217f783eb93cd8d84b903a9453893b9f1de3f48f68e5484b351b93ef711";
+      sha256 = "6b4d36108ea50db402e5dde3722c251150037c49e13dce7067119029d831ab38";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/be/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/be/Firefox%20140.0b3.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "aae7e9683edee898fd2c665eb1e11572ac4ba61a4960daaa09c19675fa1a19c1";
+      sha256 = "ed5f409da41108e7315499580a848fbc38b6795dbbb4873c1a49b654d3ebcdb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/bg/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/bg/Firefox%20140.0b3.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "45cdf56dd70258d1c20ed870adfe2772b7a1b30cf834409edf397d0dca6f395f";
+      sha256 = "3d89876f2a64a0a089c835efc068cafa8f0611a393bfda1e700fe174ad97ea67";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/bn/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/bn/Firefox%20140.0b3.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "51e9862caf96e94224efee1300fd54eefdafb03cae20d15b40b02bc9d44ed731";
+      sha256 = "951a928b96768e9223a5cbf15000e6492b6af0fdbdd57ac04a9485dc90750a34";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/br/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/br/Firefox%20140.0b3.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "be935dc3369b54d1cdb61ce4662b45839d4bd97ab7e2e66edf2693c9b6716b56";
+      sha256 = "b0850a643f67d4f426cc4da800265476ceb3073be86a236e2390209a839f6580";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/bs/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/bs/Firefox%20140.0b3.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "2cbe8ca8c678cb81385e657660bd92346dafbebf58b6c73d1f6f77e48f52aa6a";
+      sha256 = "b4eaa6d28e13ac082207160093c89de7338194f821d4568a8d48be94e6029cd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ca-valencia/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ca-valencia/Firefox%20140.0b3.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "3a2312c808f9342b7fac383b075ca13b272861f79f49015fb51ae4d9a01c92f3";
+      sha256 = "16aa9aa41615fa318661e5ad4cb44993edd8ada4c8a8a5ee6ea2d2ccfd80e4e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ca/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ca/Firefox%20140.0b3.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "367bfe9dc9f53f783eb59a2e345a3cf8e65dc4b15f535d8f25be9f2c0ab3ca68";
+      sha256 = "3943715885230fe7fb60b63dae1d6b970ce075f4ede2888d6bc04600afa0cb1e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/cak/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/cak/Firefox%20140.0b3.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "055b667349f3962d352bc29a69e2ce67ff19893d2520e1c70043bbb1248d8c53";
+      sha256 = "0cfd7036ffce0e751df720c2fdc47461904eb75316040237ffa9ec65869e2171";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/cs/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/cs/Firefox%20140.0b3.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "c424df549e13c0a6041b212d9e7e49d09bedd634ad0a35daf5ff8b7f08b705fe";
+      sha256 = "88f59df2a7c7f13766f7ecadd41c27502bc7b1194c29aa700e319e268123e469";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/cy/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/cy/Firefox%20140.0b3.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "4cb05bb577e421bc3004831bf878267edb6f6c98b5d776522acd57600b7813ba";
+      sha256 = "fd1a8b3fe4094b98de891b401fea4eb082a82e0c207ac79fa430624f2d7e3de8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/da/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/da/Firefox%20140.0b3.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "793fa4ff34f9f04d83a6f316b8cfa0099f2228648d6fd8e2f066ed381affe5aa";
+      sha256 = "58ded2505aeeffc23007086e8fa183db81b7a1319a48ee00743aba222f82c43c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/de/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/de/Firefox%20140.0b3.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "9284ff990ecbc6260d82aed6e0ffb3608348c5c084c0ca50d59cd75c84e5f4da";
+      sha256 = "62dc719f46113287868cb898f29b2390ff2ad889613ab7b7cecb15b7c14c020a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/dsb/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/dsb/Firefox%20140.0b3.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "e433105013e8b543ad239f0ca7a0007e40541056c8a3bd57adc6136b0fe1d117";
+      sha256 = "da379eccd174c83b80a88d08f31069b61a687f3bf97536fbaa9815314191a766";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/el/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/el/Firefox%20140.0b3.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "b9b8a5f25aebdc89e672793436e3d1f1c35aa6af0ef13f080c89ec23d66ccdd2";
+      sha256 = "1e21eef746d5a3fac0bed5fdb3f536e705b947796331af0faaa40b7480e6b7bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/en-CA/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/en-CA/Firefox%20140.0b3.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "3f6db147fc75e6d2c3efe2dee4e889ead1b3d46909bfa555da8012d48fc7f418";
+      sha256 = "cf0551a0409ed7283baf68707ec51312a170faab606c9da859143f7e114884fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/en-GB/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/en-GB/Firefox%20140.0b3.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "8328b5267b092e75a646da81563461b6d660cfd1000a2da26ca404acb516badf";
+      sha256 = "a2ef452fff308991e1c18d2ce14d62c2b8ae51b6a57e4c12d04159ccb625bb8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/en-US/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/en-US/Firefox%20140.0b3.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "880d44a98e9232eabf61ed9949047c235d4fc68145a97cf3f3569c8557ac848b";
+      sha256 = "36655b97674d1d06d4beaa9ea6e4a62b9ce8918cde026e3a62d5b72cb8f23d40";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/eo/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/eo/Firefox%20140.0b3.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "ae306283229c379bfc29cf47b3dfc1fcb5a71d038e4e851781206f619fd19023";
+      sha256 = "c264873f843cc4b622a6f21d9608879b317975a06cbb7bf067eb0d67abcab6d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/es-AR/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/es-AR/Firefox%20140.0b3.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "e9d3b45ad4454c8b3ae7b04ad9976b46c9d2b5b96271a58fee55dff00f7044ef";
+      sha256 = "c70701849574b48d56bccff74d68f61d00728021110b5a66fe6c9cd534e8dd43";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/es-CL/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/es-CL/Firefox%20140.0b3.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "1e1fc107c05a73888155a9eb89287a5eb4dd9c4eb61fa54afc096a53b4283fd3";
+      sha256 = "b03e20dcbd79468005bfb5deee8d888aa11d5707d0d9568f8abcfd8d1014adad";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/es-ES/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/es-ES/Firefox%20140.0b3.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "639b027643f251dc168d3b93530d8bd3fcd394f3ff62a3eab964b00f9904a175";
+      sha256 = "af7fb0e75d98fabea29580ee313ed18f49062917d73e272b16812c7ad1ba35e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/es-MX/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/es-MX/Firefox%20140.0b3.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "f9f13f56e74d999c13b17c565087bdc62d38228c49bdebacd2ffe5d972172131";
+      sha256 = "d62b8c0c305ca45ec857f026bc27157482474be06ab3b13180cbe3dfda7e676d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/et/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/et/Firefox%20140.0b3.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "c05c637c4e1e3f5ac941ed86f3eb35a25e910eefd08901322aca5aaef1aa9c3b";
+      sha256 = "595b01bea796801dd3b35256110290a2c746836a57e8a2c7690986bcb96209e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/eu/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/eu/Firefox%20140.0b3.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "38ed25cbd21e84d73408fd4b2a934b0e4a975cd9b67050b2f584f462f6175cc2";
+      sha256 = "4c8f36075976c6de8345bfb7716be26e12bb620d273bff2f951530adfa5b1d3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fa/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/fa/Firefox%20140.0b3.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "781e74251240e31bc03c6453cd912c6b8c1399bde374d9218ed0b4a4fa3be374";
+      sha256 = "cbeedab2fc5fe6c563f49d198aba79007a8e149422e046a2b2ad540d18a80e49";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ff/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ff/Firefox%20140.0b3.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "1e02316b5877b8ac781edb9c97b3341d923d02b04eb0a625cc48220f3fa595dd";
+      sha256 = "1820073e2ee74a85a7811e2cf6e8208aac984304e3a060006a4a9c6092357677";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fi/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/fi/Firefox%20140.0b3.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "444db967472e296569612d6686ac31bd0d13d16c58fa87a05edce7a04d8aa8c8";
+      sha256 = "35b4de1b611bcb11ab46567d8cbc5eb369f12ca6455823115cd0c6c3d0a28f29";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/fr/Firefox%20140.0b3.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "4b8b893500b27eaa571b87f5a02fb2259cc8e0be6dfa11bbbc43635b9656233b";
+      sha256 = "df3c9b89144194e4b20244ef8d42b6a2f1b075f5b0afbaacda153af2aff45df3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fur/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/fur/Firefox%20140.0b3.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "1e049b0c7b303bb59425280c838f5855329b523e092e151323c5f3e4b14b1446";
+      sha256 = "b198f7fc147179514be0ebaaa726cd66fce74cfde162d2d32e1756ee20f7d903";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/fy-NL/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/fy-NL/Firefox%20140.0b3.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "a66abc76de786b262bf98b903ec78509d4bdd760ec4b7664befaf7a34c29ba9f";
+      sha256 = "73abfe375f5f858e82a9aa737f7c07b471f47a21adc861cd7d48643afb6f24dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ga-IE/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ga-IE/Firefox%20140.0b3.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "f3d3846347c1295cdd2ce5f9eedb7924ca3eb58b1dfb62cb941b09166dd5d5fe";
+      sha256 = "28bc935a00b9ffd14077aaf3917e4a8595ae3c629f08af32aab3000504130e3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/gd/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/gd/Firefox%20140.0b3.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "31ffc94d1dd8dd5fe8586cdaf62289f3dfeadb13f98a7253463ad1e31d3b01c4";
+      sha256 = "efca639b23420c79025a977d033a0490ef5577ec993527e9e5780567cbecaf77";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/gl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/gl/Firefox%20140.0b3.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "a35e82b0ea8b3dda94af2250e88fbabe73d1e80c3107a0858510797564e508dd";
+      sha256 = "c689143914019a0c824d5b9ebe079d3d0e42a6f8e61083e873c3b5aeae272e1f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/gn/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/gn/Firefox%20140.0b3.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "027723af70d814b569ed34f3aac20f88b3f240f385c74938cd17c4f51a5d821f";
+      sha256 = "e1abb457c9f144a16baaa01e10c4f3ef1d8d55cfa7c10fe32030af14a889dae6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/gu-IN/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/gu-IN/Firefox%20140.0b3.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "fd90192e423f2ebd31b2fc3cf5489203c64cec7a32e407eefa67d9f855ea9e01";
+      sha256 = "810bdc63fb5527aae67c2039a87ff1cabc5d0af1d81d0a38e5dd6eaf87e4c38d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/he/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/he/Firefox%20140.0b3.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "cf93ebd15ad94671080e7e1cedb89b62269ffea14eb577b6fe0e2bf07850207e";
+      sha256 = "fe8dd8d001ea4ef3ae6d570f177fab07cf66968ca0218c328401030ff673ec46";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hi-IN/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/hi-IN/Firefox%20140.0b3.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "e31224609e571576e63fbc976ef5d19f829cc4f3651079f31da4e2121dccdf4f";
+      sha256 = "b97ea559a077fb24f54ee38b78524d054610f6ddb2dbaf01e0b9efac5aa35073";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/hr/Firefox%20140.0b3.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "db90c833900707d4f4a5774fc63481883ba49dc5fe64a8f6356b3d050d62124e";
+      sha256 = "971d6761f8ede73878b1fe75d5ac054187b4039bd36f462a3120c06c5ae2cc62";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hsb/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/hsb/Firefox%20140.0b3.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "062a1815118ab0b8504f1fe68ef15e989f228ff8cfde50df0ec0cb23bb64edb9";
+      sha256 = "f4c952b27fe8eb5d5aca66ce987ee7fea9fa6a34b4effa1199e29d13dcb8c11a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hu/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/hu/Firefox%20140.0b3.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "0d58e286af8a98faebe766da043523ec6ed558c65284d791e82efc5a1defdad1";
+      sha256 = "bd292cfd5c8dd4134a9f00de09230d76924ae1353ac5b11d51a11ac94208d93d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/hy-AM/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/hy-AM/Firefox%20140.0b3.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "b3129366bab54573c690bece87689f971c33f0255865b57f836d87583241054a";
+      sha256 = "2576beffeed165a63ab65d4abd5890f26b6e5af32b32e9f4cdd4dd0773b605e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ia/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ia/Firefox%20140.0b3.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "af5c9f132655b2a5a64faad3bc5f4334108d5cfbb860313fdbb5959c67f4846f";
+      sha256 = "06af1775920044c5faa89624a1009eeb8e5d9ca7bfcb3502c0ce1b8d38192e11";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/id/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/id/Firefox%20140.0b3.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "159eef1610be0923f99b77ad48ab2bbaf451bb0d8b1e6651ca164ba993e25611";
+      sha256 = "240e6519207b2b9402c2fa66a5837e97f04cd7c6ea421a81e0b3b23fed7ea51b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/is/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/is/Firefox%20140.0b3.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "08569f11b397506b4376ccd634fcdf3c548a78b1ccfb1bbff43704cd73d4fded";
+      sha256 = "e4613a65d2abd33e2eaf260c41a82cf3d1201ed0a11693676d53e448832fd1f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/it/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/it/Firefox%20140.0b3.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "d7469d7f3117ea3ea013df5dec0003a9890504d2f3d70550217dc80b290bf93d";
+      sha256 = "0d5cd0c510d67dd6c672f43105a1d503dddb724f665eb483a35f83e082106bb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ja-JP-mac/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ja-JP-mac/Firefox%20140.0b3.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "2991001790e31d97bd5e7378dc3fd6f78bf496db091dcb7e5e8929980a3ca8c0";
+      sha256 = "a95390e3725fe01ad9baaade9021a418372bea41125c5cccba6f37a5251f61b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ka/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ka/Firefox%20140.0b3.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "053c5217774c857a6dc15007e447dea36dc76d403cd1024938987bd6e15ca8af";
+      sha256 = "faa01d4c9385d3f975fbc79ba7aafe59029e90fd128b03fdc1850752e3ddd507";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/kab/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/kab/Firefox%20140.0b3.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "57a6e16519fa59c2dd902d26308ce1f9bd1e28ab7d20ca55736cfa275192e951";
+      sha256 = "89442f6b6c6a414a909eea9df7d5d1a37e5879532b4d9fe61e94fdb51529084b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/kk/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/kk/Firefox%20140.0b3.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "bc6974ccea65432855aa31f5183578ada6562efce971588c3fc6bfe1b841986a";
+      sha256 = "20ab995aaa826d58223435f3317d8de817a165c9a5440f68e90e1a74e8cf6881";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/km/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/km/Firefox%20140.0b3.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "893979330f94c241f95188b479628e6a3c20f771e778459bdd95cf6e9b6abdc4";
+      sha256 = "8c79bd0ff6a8ef9f30312ff49bd40e5b000343203849ba0e633369ec6873b297";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/kn/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/kn/Firefox%20140.0b3.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "12cd26e5fc8dc9355ac7e75964cff9553ce300949fe0c9646c901b4b31ea8e97";
+      sha256 = "8aa7056147c69bcba2d2c141be79ee89092d6af7c57bb50703260e97d7b1cf03";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ko/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ko/Firefox%20140.0b3.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "f81b961491a67e97ed738a49f1a09dbf42654df0921ee0a7b8b711b72ac906c7";
+      sha256 = "99adc3223525a2901b09d0502a90ab9c0105ac9a961941133e18adb020a4fdf8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/lij/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/lij/Firefox%20140.0b3.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "3ebcf3cf0fa5bfcc742f915aa5c35bf83cd51e9da0e196bc2d8ba66e9692cd9a";
+      sha256 = "a2ee8a7df24b872daadf4706ae669bf038dabea9fe1abe2d65ce9ae9a3ff1924";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/lt/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/lt/Firefox%20140.0b3.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "49f53843360a4b9b5ac9464a5d2a94d795f5dae355d590127e8804229b4e55a9";
+      sha256 = "3392374665a21108f4649c07b6617cf7f7340be0890ebd6e9e254c9a88efbb0f";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/lv/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/lv/Firefox%20140.0b3.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "33506586c4e1672039cf32e62c0558d06ee96d3f0172565f9bd1ecee7ea38f65";
+      sha256 = "637b76a242d6470597e7e6c35775b9989235819c2d4388d908ca09fbd14a004e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/mk/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/mk/Firefox%20140.0b3.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "0798de1794c577af5e0545f4682baa4e72cb700bc153ce23d597fbb58882a32e";
+      sha256 = "413a76f4bb5d2c9b32cae19eca2576bf35f3d63df59c44d5b6d99edbba2700f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/mr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/mr/Firefox%20140.0b3.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "a73d3ae4ebd2e80e4fb7280ca335ad99146d71faabf6dbb0c114f98f088d89f3";
+      sha256 = "7cca5cc2d2efb1f3f083fa4e953202b8108bdd735eb9ae26d71a6a3beacfe2b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ms/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ms/Firefox%20140.0b3.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "73c3351e7e63bbd50b7b9c79c3a604fd31efcf381d1a9c023f9c7bdc6f0f5303";
+      sha256 = "102223dddd89fa88ea6cac413c9154863d3be3dbe1063633d977b01c71d180c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/my/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/my/Firefox%20140.0b3.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "631e0ece9a4af6e8ae1bc447ee433c95cdae9a9c18ae75c49022655ace95395a";
+      sha256 = "61ae243ff4451c581d74ce6f98486d5089bd130e415a6921c972fd5db935121c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/nb-NO/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/nb-NO/Firefox%20140.0b3.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "632a6cafabc4fb5bb579d00938a727e169453bca23727c4f981bc6af49487958";
+      sha256 = "f251c9b9cd5295325884989dd91bd91fcd4eacb69381cda3430ffeec4352ab25";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ne-NP/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ne-NP/Firefox%20140.0b3.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "5fc19a06fdb469fa27246f5541887fb36a5f05826f645fd4dd5941d37ac46ad8";
+      sha256 = "58e3a5927e3cf8d53cf4dd83141562b2fc6957e9725d619fa25e40196d90a232";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/nl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/nl/Firefox%20140.0b3.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "68c88cac72f77231dd4e26a6e1790f13facb0bc37cfc04eb5e17020ad1c6521d";
+      sha256 = "3543c215c31dae3e64dd6dc58661158b8148a64aef0e0f2eb5b6da4fc75f7fb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/nn-NO/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/nn-NO/Firefox%20140.0b3.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "25cd5de92e437b848c83d049380a10d9dce7f26456c20fb3da1e29d7adb98b6c";
+      sha256 = "5be9073b97c6be9ac49214b170408b563a05a1330d7008a7fc5828fba34254df";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/oc/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/oc/Firefox%20140.0b3.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "6a8a2d6a6f85d8583d14abb61b7aba1dadb5830f5d33b80ad1b7ef5ed010341a";
+      sha256 = "90a95fba1b9684b72b11ed5e2455b2880a49ee38af0578238eca50f0f64f5c86";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/pa-IN/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/pa-IN/Firefox%20140.0b3.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "72d017a1115c861d89ba13ffaa673d1a33b459426cf2be7434ac526473e458b5";
+      sha256 = "1d1eb37923276bb744e7317e5a13f754c1c40dcfdde803836096bbab4ad1b73c";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/pl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/pl/Firefox%20140.0b3.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "868b42e0a9752172fe8871a5e74a6ee6d1e6ace89480a2b8f937f57187581d17";
+      sha256 = "2f0fbf132c1bf3020c25b0b4a5d3819c7a8976050a13a78a2ac1a2a7a8d90639";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/pt-BR/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/pt-BR/Firefox%20140.0b3.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "edf314c2893d2a07ae3c0e98fd4faa01a8c70afa1c42bf96f4b908e987d65d30";
+      sha256 = "dbb1b75a4504cd974330b831cf101780479e89128226b3201f835182501a20a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/pt-PT/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/pt-PT/Firefox%20140.0b3.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "7c23718aae1119db08e6225104c3748e7b175eb6c96eb21ff7e098f3b3b457bf";
+      sha256 = "be7accef05071d1e3a3eb91c651a2a230a15a6a34f0b631dbb23dff4ab04c48d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/rm/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/rm/Firefox%20140.0b3.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "0dee6e7eabfb1d2727ae10ffe3efde28e87574573271793f27f4696cc6ed4735";
+      sha256 = "3fc7184d29e01e8d35fe15593b51ac1e2aebafb81efbd0f5f9439c88de92dd43";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ro/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ro/Firefox%20140.0b3.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "258337f48e73793368e35586b22ab61f441eeb5c884fb1fae2a19fe750dee283";
+      sha256 = "bc5bef76b02704e9bddc7789cf2613619b05bb8ef60c468d908a2718f70cdac3";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ru/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ru/Firefox%20140.0b3.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "0d94677e22915b79deddfbfdb80c8be4699fbb47fda59b5e54ea26ab80064210";
+      sha256 = "dc6bd8c1566a001a96d09d363b409e4fe1c4789c68b790c1ae3fcfca78c5bd61";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sat/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/sat/Firefox%20140.0b3.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "78f600da1286888e95132da917f0881e2fb480cdaab5f339914f7a3509b5cb12";
+      sha256 = "538a52ac76c407170f20b8205fe8d9c8d87e0994b0ab317adbdaddd318f59603";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sc/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/sc/Firefox%20140.0b3.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "567c98cf0a6d6c789dce738546e02a8c31574b718e997a9e287abc3eedec8c39";
+      sha256 = "ab2083bb3f0792c9992c06e9f36301d32303d03018e23f0637ddde9be3e25e24";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sco/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/sco/Firefox%20140.0b3.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "d71db15059d870d0dfb7492403342df38f7ec0942f72363914153357141b780b";
+      sha256 = "b9c56f2c5e09fd688cbbdcf3ebc99b4b7f057ab481c1fae0a7a2e5861b7dd762";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/si/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/si/Firefox%20140.0b3.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "894c1f664aacb2dd66ba0428d27bb07918c50fbf5529243591f93447c4a21811";
+      sha256 = "58b8d7fc66556775aae57b4e94c4ec634715b82aa2315af59ca22f398d82ad02";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sk/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/sk/Firefox%20140.0b3.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "29bbcf6c57010f28cbba52d2fffa909387c3660d0fdda5a53486e05a872adf9e";
+      sha256 = "de930af4f10e568f0fea89b8e13db00022b1e2ae2feba92f4b83bd7dcf578a39";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/skr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/skr/Firefox%20140.0b3.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "3d65a2d0b7ae8546feee7720261cbcde1f100adb31305c4f2ffcc26206b475db";
+      sha256 = "636f7e563a3ada0c596f75098ba74880d75e579b70aef876aa8f030066a694d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/sl/Firefox%20140.0b3.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "60f74c2dfaac5b049ffc480ed6fd77280ed839caaa8872d3a30eaf5698f5273a";
+      sha256 = "856d81557b6acd1e238c04dbd8efcbbd0fac05d31df38ca1b6dc05e0b4823920";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/son/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/son/Firefox%20140.0b3.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "513be0645fa2800fdc4f228727fbb9b4f93364caba511673265a8993850100bd";
+      sha256 = "757fde5c9c72658729bdaf03fdeab06606c83286ed06c6a17d5c9c034ccc491b";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sq/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/sq/Firefox%20140.0b3.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "29e2b1ea31394dc37021433220e8962dfa24e146491280a93b97b4bc5a0a4bb1";
+      sha256 = "99ffa29be7c64059386d15ce600fb52f72a3e8a98291f88858092b7577153a69";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/sr/Firefox%20140.0b3.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "df4ecb60378e381c578952e0f3be3adcf7453b21c43a4c2015a596b118c7d683";
+      sha256 = "1e15320ded4438a36166e85fdc57b2101c4a1ae4c2790f9dfaf4a2d623c72cdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/sv-SE/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/sv-SE/Firefox%20140.0b3.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "b0f0d77d48cd31bc6b61253ecec6a99c7b4e5ae79659dad34b937790118e64e9";
+      sha256 = "f102f3daa8d5b231a6d3c88692e676f7a776a7bec7867a3130edb7664d694416";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/szl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/szl/Firefox%20140.0b3.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "460465dc52fb1d8c4776d20b275fa31dd6a6b3c959ae29a17ac0a57570deaeeb";
+      sha256 = "f64c48c0376bc7a3fb78401cde45da6f384938a3cf8dc728afe5f79450f28f7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ta/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ta/Firefox%20140.0b3.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "aa67060f3c84e4691b24e6673e8320031422f4443038fa6534a963c63a60e37c";
+      sha256 = "28b94d98a68653139e4920a428915cfecd230d933d8276122907b98b08880e4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/te/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/te/Firefox%20140.0b3.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "35df147c9ef6d765889ff758c3c5214bc5dc5eff7f9eb0080724bf70d2192a25";
+      sha256 = "3c1aeb66d18f386fdce26b76dd6165b1aba5d3abffbe50518a7bb98cad0b260a";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/tg/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/tg/Firefox%20140.0b3.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "dac6ebb25fe418ffc29811398bdbd2b5ec2c5ac522b1baacc8b0ed15923e18a9";
+      sha256 = "0bfd5977424a287b4dd5b33d3d06ef7a46eab14b9528b4faab9ac5624bcf5a15";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/th/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/th/Firefox%20140.0b3.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "d055912dca60a974f7301ce63599cd685c24a375df4622c28ccbeff67eb1df50";
+      sha256 = "c7b00d9601e0dd1b58cb239a243a9814694517bd72654598c9b1cccbf057fad5";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/tl/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/tl/Firefox%20140.0b3.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "c7f9cb0e805776940e0f33849ff9f321f53b93e21470057432e45ad2638cce43";
+      sha256 = "19a06f0ef997df9fe9231393e2641f162b473eef0973c35428ff1c9acf68e790";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/tr/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/tr/Firefox%20140.0b3.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "97d25c6dc788e64f1857f0c1fec8745a0f3a16cd802dd5af3d3c167d9158e1dc";
+      sha256 = "147e73c10914893790ef2f07929b9b448114f9b6decd42be231883c1b8fc4a98";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/trs/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/trs/Firefox%20140.0b3.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "aed82548580fef5dda24a7b48f301ff7fb23041f9e00f651392e38ef92dc7a80";
+      sha256 = "b7fd70dba59b97246f2a69815b63f3984fbcd0551174bbaa9ba6c767b81a1f65";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/uk/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/uk/Firefox%20140.0b3.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "792e2b27880a62f5eef7b93c36a35d89404b964cd17b879bd14e567e846d55c0";
+      sha256 = "bd812c4b22b71be191a17936371f18ee6a1ffc97a1afe88dd1c3f4b5c0aaa9c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/ur/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/ur/Firefox%20140.0b3.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "1e9c8922a7cf00a080b9e69186136dee0f84d44ab61cb8ac8390f77dfb5d7982";
+      sha256 = "ad42340b285bd9aa28bf5f568d2f559cc2525eb4d3c76750766742503208fe23";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/uz/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/uz/Firefox%20140.0b3.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "674551891bbe01db98fbc843ce035c473a19bb6ea7f9b50cfca6a57d281f4345";
+      sha256 = "1e1325a80bbec8eaa0d0fff8d0fc09adab19c43e51160dc041702768eba63220";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/vi/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/vi/Firefox%20140.0b3.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "14d97055a0487c9a7f82959ff4e0978bc67867c5f969ea90cedf1d18a976a344";
+      sha256 = "fc9f36a9269c990feaba9621dfed49d9df96f0fe20155884e90807ae9d7225b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/xh/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/xh/Firefox%20140.0b3.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "e91833e99b4e8b04f690c1e041e2db288d5f64412e04f34bbc3d8b00123a32b0";
+      sha256 = "af8210bf82898991fd9da3f8e539e09aa6a3995665cbe049558bc9245640e0be";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/zh-CN/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/zh-CN/Firefox%20140.0b3.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "721f621b057bcfea7397b16f8e5da98e0059a742809c8b0d3fd54d3b459ac1bc";
+      sha256 = "ebe8c62854e34ea685d7a49864504faac27453d21c76dad92d96e2eb6f7b6cfc";
     }
     {
-      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b2/mac/zh-TW/Firefox%20140.0b2.dmg";
+      url = "https://archive.mozilla.org/pub/devedition/releases/140.0b3/mac/zh-TW/Firefox%20140.0b3.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "0f0dc4ebad9ff5c09a4c015cff5e76a7ca271dbadf185a23034806976a6dd1e5";
+      sha256 = "7035c1f5ce6358fa450ac6de572b08907a8bb4df4849008fb35e8f492c3cf622";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
@@ -10,13 +10,13 @@
 buildMozillaMach rec {
   pname = "firefox-devedition";
   binaryName = pname;
-  version = "140.0b2";
+  version = "140.0b3";
   applicationName = "Firefox Developer Edition";
   requireSigning = false;
   branding = "browser/branding/aurora";
   src = fetchurl {
     url = "mirror://mozilla/devedition/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "4a369638dab1202f21f071a1eb48552888adf01e49ee4e029dfe7b42919312719004099b203a066057fd4d9ef9a684e5f95b0aa06ecf82cc88df0025f33f6368";
+    sha512 = "f7e2382ba9ad9a6fbea4a99ab541a4b70dcc4dd78d52230f5e600e9812eb796c890d424805b9c4d2ad7c981e3e509d654e9ae4e4c79c6a50880388e1b4c83bbe";
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
