### PR TITLE
Xfce updates 2025-06-01

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
@@ -1,7 +1,14 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  glib,
+  meson,
+  ninja,
+  pkg-config,
   wayland-scanner,
+  wrapGAppsHook3,
   exo,
   gtk3,
   libX11,
@@ -18,18 +25,35 @@
   zenity,
   jq,
   xclip,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-screenshooter";
-  version = "1.11.1";
-  odd-unstable = false;
+  version = "1.11.2";
 
-  sha256 = "sha256-/N79YK233k9rVg5fGr27b8AZD9bCXllNQvrN4ghir/M=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "xfce4-screenshooter";
+    tag = "xfce4-screenshooter-${finalAttrs.version}";
+    hash = "sha256-LELPY3SU25e3Dk9/OljWMLIbZYrDiQD1h6dMq+jRaH8=";
+  };
+
+  strictDeps = true;
+
+  depsBuildBuild = [
+    pkg-config
+  ];
 
   nativeBuildInputs = [
+    gettext
+    glib # glib-compile-resources
+    meson
+    ninja
+    pkg-config
     wayland-scanner
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -62,9 +86,14 @@ mkXfceDerivation {
     )
   '';
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "xfce4-screenshooter-"; };
+
+  meta = {
     description = "Screenshot utility for the Xfce desktop";
+    homepage = "https://gitlab.xfce.org/apps/xfce4-screenshooter";
+    license = lib.licenses.gpl2Plus;
     mainProgram = "xfce4-screenshooter";
-    teams = [ teams.xfce ];
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/desktops/xfce/applications/xfce4-taskmanager/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-taskmanager/default.nix
@@ -1,41 +1,65 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
-  exo,
+  fetchFromGitLab,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
   glib,
   gtk3,
   libxfce4ui,
+  libxfce4util,
   xfconf,
   libwnck,
   libX11,
   libXmu,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-taskmanager";
-  version = "1.5.8";
-  odd-unstable = false;
+  version = "1.6.0";
 
-  sha256 = "sha256-A2L41YdIpFnbAjQOp+/sJu1oUX9V7jxLsWY7b21frjY=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "xfce4-taskmanager";
+    tag = "xfce4-taskmanager-${finalAttrs.version}";
+    hash = "sha256-HQsZ7SmOX8Z5yuQUe+AvQFx+HVWNRRHEO7dE5DnfT/8=";
+  };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
-    exo
+    gettext
+    glib # glib-compile-resources
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
   ];
 
   buildInputs = [
     glib
     gtk3
     libxfce4ui
+    libxfce4util
     xfconf
     libwnck
     libX11
     libXmu
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "xfce4-taskmanager-"; };
+
+  meta = {
     description = "Easy to use task manager for Xfce";
+    homepage = "https://gitlab.xfce.org/apps/xfce4-taskmanager";
+    license = lib.licenses.gpl2Plus;
     mainProgram = "xfce4-taskmanager";
-    teams = [ teams.xfce ];
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/desktops/xfce/applications/xfce4-volumed-pulse/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-volumed-pulse/default.nix
@@ -1,19 +1,41 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
   gtk3,
   libnotify,
   libpulseaudio,
   keybinder3,
   xfconf,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-volumed-pulse";
-  version = "0.2.5";
+  version = "0.3.0";
 
-  sha256 = "sha256-A7PM4zHL4hkhsZjYEPuEiujP1ofP7V/QVqDNgGoGIm8=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "xfce4-volumed-pulse";
+    tag = "xfce4-volumed-pulse-${finalAttrs.version}";
+    hash = "sha256-TdvqvlpNDs9i7IzegqGYTdvy2OVMdQUFvuENNmpkqAY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     gtk3
@@ -23,11 +45,15 @@ mkXfceDerivation {
     xfconf
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "xfce4-volumed-pulse-"; };
+
+  meta = {
     description = "Volume keys control daemon for Xfce using pulseaudio";
+    homepage = "https://gitlab.xfce.org/apps/xfce4-volumed-pulse";
     mainProgram = "xfce4-volumed-pulse";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ abbradar ];
-    teams = [ teams.xfce ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ abbradar ];
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/desktops/xfce/applications/xfmpc/default.nix
+++ b/pkgs/desktops/xfce/applications/xfmpc/default.nix
@@ -1,39 +1,67 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
   vala,
+  wrapGAppsHook3,
   libxfce4util,
   libxfce4ui,
   gtk3,
   glib,
   libmpd,
+  gitUpdater,
 }:
 
-mkXfceDerivation rec {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfmpc";
-  version = "0.3.2";
-  sha256 = "sha256-V5YHvhcWv6IUPe8W1VtuPagj3uU3s+ikgu3ZnRF48O4=";
+  version = "0.4.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "xfmpc";
+    tag = "xfmpc-${finalAttrs.version}";
+    hash = "sha256-fYK8JbWFnkzFpgfmSHa6usnlke4G7pxmdSm7kEQsL5M=";
+  };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
     vala
-    libxfce4util
+    wrapGAppsHook3
     # Needed both here and in buildInputs for cross compilation to work
+    # as they failed to find native vapigen and thus not building the
+    # *.vapi files (this should be fixed when these libraries are built
+    # with meson).
     libxfce4ui
+    libxfce4util
   ];
+
   buildInputs = [
     gtk3
     glib
     libxfce4ui
+    libxfce4util
     libmpd
   ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "xfmpc-"; };
 
   meta = with lib; {
     description = "MPD client written in GTK";
     homepage = "https://docs.xfce.org/apps/xfmpc/start";
     changelog = "https://gitlab.xfce.org/apps/xfmpc/-/blob/xfmpc-${version}/NEWS";
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ doronbehar ];
     teams = [ teams.xfce ];
     mainProgram = "xfmpc";
   };
-}
+})


### PR DESCRIPTION
The 7th PR for the mass autotools -> meson transition, previous:

- https://github.com/NixOS/nixpkgs/pull/409074
- https://github.com/NixOS/nixpkgs/pull/409413
- https://github.com/NixOS/nixpkgs/pull/409803
- https://github.com/NixOS/nixpkgs/pull/410534
- https://github.com/NixOS/nixpkgs/pull/411149
- https://github.com/NixOS/nixpkgs/pull/411782

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

