### PR TITLE
cup-docker{,-noserver}: init at 3.4.0

### DIFF
--- a/pkgs/by-name/cu/cup-docker/package.nix
+++ b/pkgs/by-name/cu/cup-docker/package.nix
@@ -1,0 +1,98 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  lib,
+  stdenvNoCC,
+  bun,
+  nodejs-slim_latest,
+  nix-update-script,
+  withServer ? true,
+}:
+let
+  pname = "cup-docker";
+  version = "3.4.0";
+  src = fetchFromGitHub {
+    owner = "sergi0g";
+    repo = "cup";
+    tag = "v${version}";
+    hash = "sha256-ciH3t2L2eJhk1+JXTqEJSuHve8OuVod7AuQ3iFWmKRE=";
+  };
+  web = stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "${pname}-web";
+    inherit version src;
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+    sourceRoot = "${finalAttrs.src.name}/web";
+    nativeBuildInputs = [
+      bun
+      nodejs-slim_latest
+    ];
+    configurePhase = ''
+      runHook preConfigure
+      bun install --no-progress --frozen-lockfile
+      substituteInPlace node_modules/.bin/{vite,tsc} \
+        --replace-fail "/usr/bin/env node" "${nodejs-slim_latest}/bin/node"
+      runHook postConfigure
+    '';
+    buildPhase = ''
+      runHook preBuild
+      bun run build
+      runHook postBuild
+    '';
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/dist
+      cp -R ./dist $out
+      runHook postInstall
+    '';
+    outputHash = "sha256-Ac1PJYmTQv9XrmhmF1p77vdXh8252hz0CUKxJA+VQR4=";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  });
+in
+rustPlatform.buildRustPackage {
+  inherit
+    src
+    version
+    pname
+    ;
+
+  cargoHash = "sha256-L9zugOwlPwpdtjV87dT1PH7FAMJYHYFuvfyOfPe5b2k=";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures =
+    [
+      "cli"
+    ]
+    ++ lib.optional withServer [
+      "server"
+    ];
+
+  preConfigure = lib.optionalString withServer ''
+    cp -r ${web}/dist src/static
+  '';
+
+  passthru = {
+    inherit web;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "web"
+      ];
+    };
+  };
+
+  meta = {
+    description = "a lightweight way to check for container image updates. written in Rust";
+    homepage = "https://cup.sergi0g.dev";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    changelog = "https://github.com/sergi0g/cup/releases";
+    mainProgram = "cup";
+    maintainers = with lib.maintainers; [
+      kuflierl
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -377,6 +377,8 @@ with pkgs;
 
   copilot-language-server-fhs = copilot-language-server.fhs;
 
+  cup-docker-noserver = cup-docker.override { withServer = false; };
+
   deck = callPackage ../by-name/de/deck/package.nix {
     buildGoModule = buildGo123Module;
   };


### PR DESCRIPTION
Homepage: https://github.com/sergi0g/cup
Issue: https://github.com/NixOS/nixpkgs/issues/410427
Source: https://github.com/kuflierl/NUR/blob/168edac19787f2fe08e65a208cf4e914726411f0/pkgs/by-name/cu/cup-docker/package.nix
Description: a lightweight way to check for container image updates. written in Rust

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-linux -> aarch64-linux cross
  - [x] x86_64-linux -> x86_64-darwin cross
  - [x] x86_64-linux -> aarch64-darwin cross
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
