### PR TITLE
Expose graphics drivers to coolercontrold

### DIFF
--- a/nixos/modules/programs/coolercontrol.nix
+++ b/nixos/modules/programs/coolercontrol.nix
@@ -16,10 +16,10 @@ in
 
       nvidiaSupport = lib.mkOption {
         type = lib.types.bool;
-        default = lib.elem "nvidia" config.services.xserver.videoDrivers;
+        default = false;
         defaultText = lib.literalExpression "lib.elem \"nvidia\" config.services.xserver.videoDrivers";
         description = ''
-          Enable support for Nvidia GPUs.
+          **Deprecated**: Nvidia support is now automatically provided by graphics drivers.
         '';
       };
     };
@@ -54,10 +54,12 @@ in
           let
             nvidiaPkg = config.hardware.nvidia.package;
           in
-          [
-            nvidiaPkg # nvidia-smi
-            nvidiaPkg.settings # nvidia-settings
-          ];
+          lib.warn
+            "programs.coolercontrol.nvidiaSupport is deprecated. Nvidia support is now provided automatically."
+            [
+              nvidiaPkg # nvidia-smi
+              nvidiaPkg.settings # nvidia-settings
+            ];
       })
     ]
   );

--- a/pkgs/applications/system/coolercontrol/coolercontrold.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrold.nix
@@ -4,6 +4,7 @@
   libdrm,
   coolercontrol,
   runtimeShell,
+  addDriverRunpath,
 }:
 
 {
@@ -21,6 +22,7 @@ rustPlatform.buildRustPackage {
   cargoHash = "sha256-ZyYyQcaYd3VZ7FL0Hki33JO3LscPfBT5gl+nw2cXvUs=";
 
   buildInputs = [ libdrm ];
+  nativeBuildInputs = [ addDriverRunpath ];
 
   postPatch = ''
     # copy the frontend static resources to a directory for embedding
@@ -36,6 +38,10 @@ rustPlatform.buildRustPackage {
     install -Dm444 "${src}/packaging/systemd/coolercontrold.service" -t "$out/lib/systemd/system"
     substituteInPlace "$out/lib/systemd/system/coolercontrold.service" \
       --replace-fail '/usr/bin' "$out/bin"
+  '';
+
+  postFixup = ''
+    addDriverRunpath "$out/bin/$pname"
   '';
 
   passthru.tests.version = testers.testVersion {


### PR DESCRIPTION
As of version 1.4.0, coolercontrol has the ability to use the Nvidia drivers directly, rather than relying on CLI tools. See [this feature ticket](https://gitlab.com/coolercontrol/coolercontrol/-/issues/288) for more information.

In order to use this feature, the graphics drivers need to be available at runtime for dynamic loading.

In addition to eliminating the dependency on CLI tools, this also avoids a race at startup where the lack of an xauth cookie can lead to coolercontrol being unable to manage an Nvidia card (until the daemon is restarted).

I have also taken the liberty of marking the `nvidiaSupport` configuration option as deprecated because it is no longer needed with this implementation. I am new at contributing to NixOS, so please let me know if there is a better way to this.

### Testing
I tested locally with my Nvidia card. `journalctl -u coolercontrold --grep="Initialized GPU Devices:"` shows which Nvidia management mode the daemon is using.

Before:
```
Initialized GPU Devices: {"NVIDIA GeForce RTX 3070 Ti":{"locations":[],"driver name":["nvidia-smi;nvidia-settings"],"driver version":[""]}}
```

After:
```
Initialized GPU Devices: {"NVIDIA GeForce RTX 3070 Ti":{"driver version":["570.144"],"driver name":["nvml:12.570.144"],"locations":["00000000:01:00.0"]}}
```

Additionally, the GUI has new options for the card.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
