### PR TITLE
lib: Add documentation for `mkOverride`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1377,6 +1377,36 @@ let
   */
   mkDefinition = args@{ file, value, ... }: args // { _type = "definition"; };
 
+  /**
+    Produce a _property_ or "modifier" that assigns the given priority to an option definition.
+
+    The priority mechanism is responsible for ignoring defaults when user-defined definitions are set, and ignoring regular definitions when `mkForce` is used.
+
+    Given a list of definitions, only those with the highest priority (lowest number) are merged (if applicable) to become the option value.
+
+    # Input
+
+    - `priority` (number): How to prioritise the value (high number -> lower priority, low number -> higher priority)
+    - `value` (any): The value to prioritise.
+
+    # Example
+
+     In one file the Nextcloud service could be enabled by default, but depending on some condition that could be overridden.
+
+    **configuration.nix**
+    ```nix
+    {
+      services.nextcloud.enable = lib.mkDefault true;
+    }
+    ```
+
+    **my-module.nix**
+    ```nix
+    {
+      services.nextcloud.enable = lib.mkOverride 50 false;
+    }
+    ```
+  */
   mkOverride = priority: content: {
     _type = "override";
     inherit priority content;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1167,6 +1167,9 @@ let
             mergedOption.type;
       };
 
+      /**
+        See https://nixos.org/manual/nixos/unstable/#sec-option-types-submodule
+      */
       submoduleWith =
         {
           modules,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10236,6 +10236,21 @@ with pkgs;
   apacheHttpd_2_4 = callPackage ../servers/http/apache-httpd/2.4.nix { };
   apacheHttpd = apacheHttpd_2_4;
 
+  /**
+    Create an attribute set of packages built for the specified apache-httpd package.
+    It contains apache-httpd modules such as `auth_mellon`, `ca`, and `crl`.
+
+    # Parameters (positional)
+
+    - `apacheHttpd`: The apache-httpd package to build packages for
+    - `self`: The scope to use when using `pkgs.newScope`. This should generally be the same value as `apacheHttpd`.
+
+    # Examples
+
+    ```nix
+    myApachePackages = apacheHttpdPackagesFor apacheHttpd apacheHttpd
+    ```
+  */
   apacheHttpdPackagesFor =
     apacheHttpd: self:
     let

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -164,9 +164,50 @@ in
 {
   inherit splicePackages;
 
-  # We use `callPackage' to be able to omit function arguments that can be
-  # obtained `pkgs` or `buildPackages` and their `xorg` package sets. Use
-  # `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).
+  /**
+    We use `callPackage' to be able to omit function arguments that can be obtained `pkgs` or `buildPackages` and their `xorg` package sets. Use `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).
+
+    # Inputs (positional)
+
+    - `funcOrPath` - `(AttrSet -> a) | Path`
+
+      Either a function that is expected to build a package from the given attribute set or a file that returns such a function when imported.
+
+    - `args` - `AttrSet`
+
+      Arguments that will be passed to the function, overriding or extending attributes of `pkgs`.
+
+    # Examples
+
+    Define a function that uses attributes from `pkgs`
+
+    :::{.example}
+      **say-hello.nix**
+      ```nix
+      {
+        # Attributes found in `pkgs`
+        hello, lib, writeScript,
+        # An additional attribute not in `pkgs`
+        name,
+        ...
+      }:
+
+      writeScript "say-hello-${name}" ''
+        export PATH=${lib.strings.makeBinPath [hello]}
+        hello -g "Hello ${name}!"
+      ''
+      ```
+
+    In another file, call `say-hello.nix` without worrying about passing all the arguments found in `pkgs`.
+    `name` must be passed though as it is not in the `pkgs` attribute set.
+
+    ```nix
+    { pkgs, ...}:
+    {
+      sayHelloPackage = pkgs.callPackage ./say-hello.nix { name = "Medina"; };
+    }
+    ```
+  */
   callPackage = pkgs.newScope { };
 
   callPackages = lib.callPackagesWith pkgsForCall;


### PR DESCRIPTION
This PR is inspired by the patches posted on Discourse. I asked the author to post the patches on Github, but I got no reply so far. Therefore, I took the initiative to publish them myself.

Links:
- https://discourse.nixos.org/t/patch-lib-add-documentation-for-mkoverride/60253
- https://discourse.nixos.org/t/patch-add-modify-documentation-for-pkgs-callpackage-and-lib-callpackagewith/60315
- https://discourse.nixos.org/t/patch-all-packages-add-documentation-for-apachehttpdpackagesfor/60313
- https://discourse.nixos.org/t/patch-lib-copy-documentation-from-manual-to-types-submoduleswith/60310

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
