### PR TITLE
podofo: adopt, clean up version names, change default version, init 1.0, 0.10.4 -> 0.10.5, etc

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -18,6 +18,9 @@
 - `base16-builder` node package has been removed due to lack of upstream maintenance.
 - `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by sil](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.
 
+- `podofo` has been updated from `0.9.8` to `1.0.0`. These releases are by nature very incompatable due to major api changes. The legacy versions can be found under `podofo_0_10` and `podofo_0_9`.
+  Changelog: https://github.com/podofo/podofo/blob/1.0.0/CHANGELOG.md, API-Migration-Guide: https://github.com/podofo/podofo/blob/1.0.0/API-MIGRATION.md.
+
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/applications/misc/krename/default.nix
+++ b/pkgs/applications/misc/krename/default.nix
@@ -11,7 +11,7 @@
   kjsembed,
   taglib,
   exiv2,
-  podofo,
+  podofo_0_9,
   kcrash,
 }:
 
@@ -39,7 +39,7 @@ mkDerivation rec {
   buildInputs = [
     taglib
     exiv2
-    podofo
+    podofo_0_9
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/office/scribus/default.nix
+++ b/pkgs/applications/office/scribus/default.nix
@@ -14,7 +14,7 @@
   libxml2,
   pixman,
   pkg-config,
-  podofo,
+  podofo_0_10,
   poppler,
   poppler_data,
   python3,
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtiff
     libxml2
     pixman
-    podofo
+    podofo_0_10
     poppler
     poppler_data
     pythonEnv

--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -21,7 +21,7 @@
   optipng,
   piper-tts,
   pkg-config,
-  podofo,
+  podofo_0_10,
   poppler-utils,
   python3Packages,
   qt6,
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     libuchardet
     libusb1
     piper-tts
-    podofo
+    podofo_0_10
     poppler-utils
     qt6.qtbase
     qt6.qtwayland
@@ -156,8 +156,8 @@ stdenv.mkDerivation (finalAttrs: {
     export MAGICK_LIB=${imagemagick.out}/lib
     export FC_INC_DIR=${fontconfig.dev}/include/fontconfig
     export FC_LIB_DIR=${fontconfig.lib}/lib
-    export PODOFO_INC_DIR=${podofo.dev}/include/podofo
-    export PODOFO_LIB_DIR=${podofo}/lib
+    export PODOFO_INC_DIR=${podofo_0_10.dev}/include/podofo
+    export PODOFO_LIB_DIR=${podofo_0_10}/lib
     export XDG_DATA_HOME=$out/share
     export XDG_UTILS_INSTALL_MODE="user"
     export PIPER_TTS_DIR=${piper-tts}/bin

--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -157,7 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
     export FC_INC_DIR=${fontconfig.dev}/include/fontconfig
     export FC_LIB_DIR=${fontconfig.lib}/lib
     export PODOFO_INC_DIR=${podofo.dev}/include/podofo
-    export PODOFO_LIB_DIR=${podofo.lib}/lib
+    export PODOFO_LIB_DIR=${podofo}/lib
     export XDG_DATA_HOME=$out/share
     export XDG_UTILS_INSTALL_MODE="user"
     export PIPER_TTS_DIR=${piper-tts}/bin

--- a/pkgs/by-name/ci/cie-middleware-linux/package.nix
+++ b/pkgs/by-name/ci/cie-middleware-linux/package.nix
@@ -15,7 +15,7 @@
   libxml2,
   openssl,
   pcsclite,
-  podofo,
+  podofo_0_10,
   ghostscript,
 }:
 
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
   buildInputs = [
     cryptopp
     fontconfig
-    podofo
+    podofo_0_10
     openssl
     pcsclite
     curl

--- a/pkgs/by-name/gi/gImageReader/package.nix
+++ b/pkgs/by-name/gi/gImageReader/package.nix
@@ -6,7 +6,7 @@
   pkg-config,
   libuuid,
   sane-backends,
-  podofo,
+  podofo_0_10,
   libjpeg,
   djvulibre,
   libxmlxx3,
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
       libzip
       libuuid
       sane-backends
-      podofo
+      podofo_0_10
       libjpeg
       djvulibre
       tesseract

--- a/pkgs/by-name/ho/horizon-eda/base.nix
+++ b/pkgs/by-name/ho/horizon-eda/base.nix
@@ -15,7 +15,7 @@
   ninja,
   opencascade-occt_7_6,
   pkg-config,
-  podofo,
+  podofo_0_10,
   sqlite,
 }:
 let
@@ -51,7 +51,7 @@ rec {
     librsvg
     libuuid
     opencascade-occt
-    podofo
+    podofo_0_10
     sqlite
   ];
 

--- a/pkgs/by-name/po/podofo_0_10/package.nix
+++ b/pkgs/by-name/po/podofo_0_10/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  expat,
   fontconfig,
   freetype,
   libidn,
@@ -11,7 +10,6 @@
   libpng,
   libtiff,
   libxml2,
-  lua5,
   openssl,
   pkg-config,
   zlib,
@@ -19,19 +17,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "podofo";
-  version = "0.10.4";
+  version = "0.10.5";
 
   src = fetchFromGitHub {
     owner = "podofo";
     repo = "podofo";
     rev = finalAttrs.version;
-    hash = "sha256-ZY+kyimLzAeEgvDaflXM7MbyzsGgivOnG1aBD9/ozbk=";
+    hash = "sha256-lYykDGhxFWLwuZhfBIgbw3B0SEhrAP7vLNNXsPKRFZw=";
   };
 
   outputs = [
     "out"
     "dev"
-    "lib"
   ];
 
   nativeBuildInputs = [
@@ -40,7 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    expat
     fontconfig
     freetype
     libidn
@@ -48,7 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     libtiff
     libxml2
-    lua5
     openssl
     zlib
   ];
@@ -66,6 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2Plus
       lgpl2Plus
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      kuflierl
+    ];
   };
 })

--- a/pkgs/by-name/po/podofo_0_9/package.nix
+++ b/pkgs/by-name/po/podofo_0_9/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   cmake,
   zlib,
   freetype,
@@ -13,16 +13,17 @@
   lua5,
   pkg-config,
   libidn,
-  expat,
 }:
 
 stdenv.mkDerivation rec {
   version = "0.9.8";
   pname = "podofo";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/podofo/${pname}-${version}.tar.gz";
-    sha256 = "sha256-XeYH4V8ZK4rZBzgwB1nYjeoPXM3OO/AASKDJMrxkUVQ=";
+  src = fetchFromGitHub {
+    owner = "podofo";
+    repo = "podofo";
+    rev = version;
+    hash = "sha256-VGsACeCC8xKC1n/ackT576ZU3ZR1LAw8H0l/Q9cH27s=";
   };
 
   outputs = [
@@ -45,7 +46,6 @@ stdenv.mkDerivation rec {
     openssl
     libpng
     libidn
-    expat
     lua5
   ];
 
@@ -64,13 +64,16 @@ stdenv.mkDerivation rec {
         -e 's/^libdir=.*/libdir=@CMAKE_INSTALL_LIBDIR@/' -e "$failNoMatches"
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://podofo.sourceforge.net";
     description = "Library to work with the PDF file format";
-    platforms = platforms.all;
-    license = with licenses; [
+    platforms = lib.platforms.all;
+    license = with lib.licenses; [
       gpl2Plus
       lgpl2Plus
+    ];
+    maintainers = with lib.maintainers; [
+      kuflierl
     ];
   };
 }

--- a/pkgs/by-name/po/podofo_1_0/package.nix
+++ b/pkgs/by-name/po/podofo_1_0/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  fontconfig,
+  freetype,
+  libjpeg,
+  libpng,
+  libtiff,
+  libxml2,
+  openssl,
+  pkg-config,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "podofo";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "podofo";
+    repo = "podofo";
+    rev = finalAttrs.version;
+    hash = "sha256-DtbTaPNXjVRl1KU0NH/Sd2j9y3OZlUQGOYYJL3bTQQg=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+    freetype
+    libjpeg
+    libpng
+    libtiff
+    libxml2
+    openssl
+    zlib
+  ];
+
+  cmakeFlags = [
+    "-DPODOFO_BUILD_STATIC=${if stdenv.hostPlatform.isStatic then "ON" else "OFF"}"
+    "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
+  ];
+
+  meta = {
+    homepage = "https://github.com/podofo/podofo";
+    description = "Library to work with the PDF file format";
+    platforms = lib.platforms.all;
+    license = with lib.licenses; [
+      gpl2Plus
+      lgpl2Plus
+    ];
+    maintainers = with lib.maintainers; [
+      kuflierl
+    ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1526,6 +1526,7 @@ mapAliases {
   plots = throw "'plots' has been replaced by 'gnome-graphs'"; # Added 2025-02-05
   pltScheme = racket; # just to be sure
   poac = cabinpkg; # Added 2025-01-22
+  podofo010 = podofo_0_10; # Added 2025-06-01
   polkit-kde-agent = throw ''
     The top-level polkit-kde-agent alias has been removed.
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9291,9 +9291,8 @@ with pkgs;
 
   place-cursor-at = haskell.lib.compose.justStaticExecutables haskellPackages.place-cursor-at;
 
-  podofo = callPackage ../development/libraries/podofo { };
-
   podofo010 = callPackage ../development/libraries/podofo/0.10.x.nix { };
+  podofo = podofo_0_9;
 
   poppler = callPackage ../development/libraries/poppler { lcms = lcms2; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9291,7 +9291,6 @@ with pkgs;
 
   place-cursor-at = haskell.lib.compose.justStaticExecutables haskellPackages.place-cursor-at;
 
-  podofo010 = callPackage ../development/libraries/podofo/0.10.x.nix { };
   podofo = podofo_0_9;
 
   poppler = callPackage ../development/libraries/poppler { lcms = lcms2; };
@@ -12007,7 +12006,7 @@ with pkgs;
   calcmysky = qt6Packages.callPackage ../applications/science/astronomy/calcmysky { };
 
   calibre = callPackage ../by-name/ca/calibre/package.nix {
-    podofo = podofo010;
+    podofo = podofo_0_10;
   };
 
   # calico-felix and calico-node have not been packaged due to libbpf, linking issues

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9291,7 +9291,7 @@ with pkgs;
 
   place-cursor-at = haskell.lib.compose.justStaticExecutables haskellPackages.place-cursor-at;
 
-  podofo = podofo_0_9;
+  podofo = podofo_1_0;
 
   poppler = callPackage ../development/libraries/poppler { lcms = lcms2; };
 
@@ -12004,10 +12004,6 @@ with pkgs;
   breezy = with python3Packages; toPythonApplication breezy;
 
   calcmysky = qt6Packages.callPackage ../applications/science/astronomy/calcmysky { };
-
-  calibre = callPackage ../by-name/ca/calibre/package.nix {
-    podofo = podofo_0_10;
-  };
 
   # calico-felix and calico-node have not been packaged due to libbpf, linking issues
   inherit (callPackage ../applications/networking/cluster/calico { })


### PR DESCRIPTION
## Changes
- podofo_0_9
  - rename attribute from `podofo` to `podofo_0_9` and alias it back for back-compat
  - adopt
  - move package to top-level
  - remove 'with lib'
  - switch deprecated source from sourceforge to github
  - remove unused dependency `expat`
- podofo_0_10
  - rename attribute from `podofo010` to `podofo_0_10` and alias it back for back-compat
  - adopt
  - move package to top-level
  - 0.10.4 -> 0.10.5
  - remove unused deps expat and lua
  - remove unnecessary build output lib
- podofo_1_0: init at 1.0.0
- change default podofo version from 0.9 to 1.0
  - update release notes 25.11 due to breaking change
  - set podofo version for the following packages:
    - krename: 0.9 (will be updated to 0.10 in #413435)
    - scribus: 0.9 -> 0.10
    - calibre: 0.10
    - cie-middleware-linux: 0.9 -> 0.10
    - gImageReader: 0.9 -> 0.10
    - horizon-eda: 0.9 -> 0.10
    - ~~offrss: 0.9~~ (removed in #412816)
  - Implicit podofo version changes:
    - pdfmixtool: 0.9 -> 1.0

## Notes
Completes: #412651
Will backport first 2 commits

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
