### PR TITLE
nice-dcv-client: 2021.2.3797 -> 2024.0.8004

### DIFF
--- a/pkgs/by-name/ni/nice-dcv-client/package.nix
+++ b/pkgs/by-name/ni/nice-dcv-client/package.nix
@@ -1,82 +1,137 @@
 {
-  lib,
-  stdenv,
-  fetchurl,
-  glib,
-  libX11,
-  gst_all_1,
-  libepoxy,
-  pango,
-  cairo,
-  gdk-pixbuf,
-  e2fsprogs,
-  libkrb5,
-  libva,
-  openssl,
-  pcsclite,
-  gtk3,
-  libselinux,
-  libxml2,
-  libffi,
-  python3Packages,
-  cpio,
   autoPatchelfHook,
-  wrapGAppsHook3,
+  cairo,
+  cups,
+  cyrus_sasl,
+  dpkg,
+  fetchurl,
+  ffmpeg,
+  gdk-pixbuf,
+  glib,
+  glibc,
+  glib-networking,
+  gst_all_1,
+  gtk4,
+  icu74,
+  jbigkit,
+  lib,
+  libepoxy,
+  libfido2,
+  libgcc,
+  libgudev,
+  libjpeg,
+  libpng,
+  libproxy,
+  libpulseaudio,
+  librsvg,
+  libsoup_3,
+  libva,
+  libvdpau,
+  lz4,
+  openssl,
+  pango,
+  pcsclite,
+  protobufc,
+  stdenv,
+  wrapGAppsHook4,
 }:
 
 stdenv.mkDerivation rec {
   pname = "nice-dcv-client";
-  version = "2021.2.3797-1";
+  version = "2024.0.8004-1";
   src = fetchurl {
-    url = "https://d1uj6qtbmh3dt5.cloudfront.net/2021.2/Clients/nice-dcv-viewer-${version}.el8.x86_64.rpm";
-    sha256 = "sha256-iLz25SB5v7ghkAZOMGPmpNaPihd8ikzCQS//r1xBNRU=";
+    url = "https://d1uj6qtbmh3dt5.cloudfront.net/2024.0/Clients/nice-dcv-viewer_${version}_amd64.ubuntu2404.deb";
+    sha256 = "sha256-yCVbwh1C3sq5sSv9JEMCG9J3NOipdZFutmrA3Jn7fps=";
   };
+
+  postPhases = [ "finalPhase" ];
 
   nativeBuildInputs = [
     autoPatchelfHook
-    wrapGAppsHook3
-    python3Packages.rpm
+    dpkg
+    wrapGAppsHook4
   ];
-  unpackPhase = ''
-    rpm2cpio $src | ${cpio}/bin/cpio -idm
-  '';
 
   buildInputs = [
-    libselinux
-    libkrb5
-    libxml2
-    libva
-    e2fsprogs
-    libX11
-    openssl
-    pcsclite
-    gtk3
     cairo
-    libepoxy
-    pango
+    cups
+    cyrus_sasl
+    ffmpeg.lib
     gdk-pixbuf
+    glib
+    glibc
+    glib-networking
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gtk4
+    icu74
+    jbigkit
+    libepoxy
+    libfido2
+    libgcc.lib
+    libgudev
+    libjpeg
+    libpng
+    libproxy
+    libpulseaudio
+    librsvg
+    libsoup_3
+    libva
+    libvdpau
+    lz4.lib
+    openssl
+    pango
+    pcsclite
+    protobufc.lib
   ];
 
   installPhase = ''
-    mkdir -p $out/bin/
-    mkdir -p $out/lib64/
-    mv usr/bin/dcvviewer $out/bin/dcvviewer
-    mv usr/lib64/* $out/lib64/
-    mkdir -p $out/libexec/dcvviewer
-    mv usr/libexec/dcvviewer/dcvviewer $out/libexec/dcvviewer/dcvviewer
-    patchelf \
-      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      $out/libexec/dcvviewer/dcvviewer
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r usr/share $out/share
+    cp -r usr/bin $out/bin
+
+    mkdir -p $out/lib/x86_64-linux-gnu/dcvviewer
+    cp usr/lib/x86_64-linux-gnu/dcvviewer/dcvviewer $out/lib/x86_64-linux-gnu/dcvviewer
+    cp usr/lib/x86_64-linux-gnu/dcvviewer/libdcv.so $out/lib/x86_64-linux-gnu/dcvviewer
+
+    mkdir -p $out/lib/x86_64-linux-gnu/dcvviewer/gio/modules
+    cp usr/lib/x86_64-linux-gnu/dcvviewer/gio/modules/libgioopenssl.so $out/lib/x86_64-linux-gnu/dcvviewer/gio/modules
+
+    mkdir -p $out/lib/x86_64-linux-gnu/dcvviewer/gdk-pixbuf-2.0/2.10.0
+    cp -r usr/lib/x86_64-linux-gnu/dcvviewer/gdk-pixbuf-2.0/2.10.0/loaders $out/lib/x86_64-linux-gnu/dcvviewer/gdk-pixbuf-2.0/2.10.0
+
     # Fix the wrapper script to have the right basedir.
     sed -i "s#basedir=/usr#basedir=$out#" $out/bin/dcvviewer
-    mv usr/share $out/
 
-    ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+    # Remove all the extra env vars that we'll be patching in
+    sed -i "/export GIO_EXTRA_MODULES/d" $out/bin/dcvviewer
+    sed -i "/export GST_PLUGIN_SYSTEM_PATH/d" $out/bin/dcvviewer
+    sed -i "/export GST_PLUGIN_SCANNER/d" $out/bin/dcvviewer
+    sed -i "/export DCV_SASL_PLUGIN_DIR/d" $out/bin/dcvviewer
+    sed -i "/export GTK_PATH/d" $out/bin/dcvviewer
+    sed -i "/export PANGO_LIBDIR/d" $out/bin/dcvviewer
 
-    # we already ship libffi.so.7
-    ln -s ${lib.getLib libffi}/lib/libffi.so $out/lib64/libffi.so.6
+    gtk4-update-icon-cache -t $out/share/icons/hicolor
+    glib-compile-schemas $out/share/glib-2.0/schemas
+    glib-compile-schemas $out/share/dcvviewer/schemas
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix GIO_EXTRA_MODULES : "$out/lib/x86_64-linux-gnu/dcvviewer/gio/modules"
+      --prefix DCV_SASL_PLUGIN_DIR : "${lib.getLib cyrus_sasl}/lib/sasl2"
+      --prefix PANGO_LIBDIR : "${lib.getLib pango}/lib"
+    )
+  '';
+
+  finalPhase = ''
+    gdk-pixbuf-query-loaders $out/lib/x86_64-linux-gnu/dcvviewer/gdk-pixbuf-2.0/2.10.0/loaders/*.so > $out/lib/x86_64-linux-gnu/dcvviewer/gdk-pixbuf-2.0/2.10.0/loaders.cache
   '';
 
   meta = with lib; {


### PR DESCRIPTION
https://docs.aws.amazon.com/dcv/latest/adminguide/doc-history-release-notes.html#dcv-2024-0-19030-1

Would fix #361129

This package has been out of date for a few years now, so I took a blank canvas approach to updating it here... but this is my first contribution to nixpkgs so I'm probably breaking a handful of conventions. Some notes:
- I started banging my head against this in January, poking at it in my free time here and there, brute forcing learning the nix packaging process as I went. The source package updated a handful of times as I was progressing, so each one I had to check with fresh eyes. Hopefully I've trimmed the cruft from the past iterations, but if anything looks off that's probably why.
- The old version used the `.rpm` package source; at the time I started working on this, the latest `.rpm` depended on the unsafe `openssl_1_1`. I swapped to the `.deb` which didn't seem to have this issue, but it's possible the `.rpm` has been updated to remove this dependency -- let me know if there's a reason to go back down that route.
- `dcvviewer` in the `lib` folder is the main executable run by the script in `bin`, not sure if that should have `wrapGApp` run explicitly on it -- the `autoPatchElf` seems to do the job, I'm just not sure if it would be breaking in some subtle way.
- The package as downloaded included a large number of libraries along with it. I'm unsure of the best practice here, and I didn't spot it in the contributing documentation (though I could have missed it). Do I keep all the bundled libraries, or point the patched files to the nixpkg'd equivalents? I opted for the latter here to keep the install size down, and only copied the libs that appeared unique to this package. `buildInputs` only includes the packages that were explicitly called out by `patchelf --print-needed` for those copied libraries. Please let me know if I should bring back those bundled libs, but I was having some build/runtime issues with the mixed nixpkgs and bundled libs which is the other reason I went down the route of primarily nixpkgs.
  - The lib folder from the source package included a bunch of libraries that didn't seem explicitly needed for the program to launch; probably dependencies of the other bundled libraries.
  - <details>
    <summary>nixpgs including libraries that were bundled but didn't appear necessary</summary>

    - dav1d
    - expat
    - libffi
    - fontconfig.lib
    - freetype
    - fribidi
    - graphene
    - harfbuzzFull
    - json-glib
    - lmdb
    - nghttp2.lib
    - orc
    - pcre2
    - pixman
    - libpsl
    - libtiff
    - libvpx
    - kdePackages.wayland
    - a few Xorg packages 
    - webrtc-audio-processing_1 
    - libz
    
    </details>
- I hit some issues around some gstreamer functionality, but I suspect I have some issues with my own system's configuration. I would love is some other folks may be able to verify, the issues are:
  - Webcam passthrough not working (mic and sound is fine otherwise): I have gstreamer debug logs if needed, it appears to be a mismatch of the kind of stream my webcam can provide and what the dcvvclient is expecting
  - Audio passthrough not working when connected to a bluetooth audio device: It appears to play for a half second before going silent
  - I would generally also like some more folks to test for their own use cases. I use this software for a somewhat limited subset of interactions, certainly some workflows I'm not using

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
