### PR TITLE
marge-bot: 0.10.1 -> 0.15.3, add updateScript, add lelgenio as maintainer

### DIFF
--- a/pkgs/by-name/ma/marge-bot/package.nix
+++ b/pkgs/by-name/ma/marge-bot/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   git,
   openssh,
+  nix-update-script,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -47,6 +48,8 @@ python3.pkgs.buildPythonApplication rec {
     ];
 
   pythonImportsCheck = [ "marge" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Merge bot for GitLab";

--- a/pkgs/by-name/ma/marge-bot/package.nix
+++ b/pkgs/by-name/ma/marge-bot/package.nix
@@ -56,7 +56,10 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://gitlab.com/marge-org/marge-bot";
     changelog = "https://gitlab.com/marge-org/marge-bot/-/blob/${src.rev}/CHANGELOG.md";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ bcdarwin ];
+    maintainers = with maintainers; [
+      bcdarwin
+      lelgenio
+    ];
     mainProgram = "marge.app";
   };
 }

--- a/pkgs/by-name/ma/marge-bot/package.nix
+++ b/pkgs/by-name/ma/marge-bot/package.nix
@@ -2,55 +2,49 @@
   lib,
   python3,
   fetchFromGitLab,
+  git,
+  openssh,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "marge-bot";
-  version = "0.10.1";
+  version = "0.15.3";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "marge-org";
     repo = "marge-bot";
     rev = version;
-    hash = "sha256-2L7c/NEKyjscwpyf/5GtWXr7Ig14IQlRR5IbDYxp8jA=";
+    hash = "sha256-i/hnfoBxgP1mo4RV4F10+QOOkPP/fkcwqaLKBlOuP0I=";
   };
-
-  postPatch = ''
-    substituteInPlace setup.cfg --replace-fail "--flake8 --pylint" ""
-  '';
 
   nativeBuildInputs = [
     python3.pkgs.setuptools
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
-    configargparse
-    maya
-    pyyaml
-    requests
-  ];
+  propagatedBuildInputs =
+    (with python3.pkgs; [
+      configargparse
+      maya
+      pyyaml
+      requests
+      python-gitlab
+      hatchling
+    ])
+    ++ [
+      git
+      openssh
+    ];
 
-  nativeCheckInputs = with python3.pkgs; [
-    pytest-cov-stub
-    pytestCheckHook
-    pendulum
-  ];
-
-  disabledTests = [
-    # test broken when run under Nix:
-    #   "unittest.mock.InvalidSpecError: Cannot spec a Mock object."
-    "test_get_mr_ci_status"
-    # broken because of an incorrect assertion:
-    #   "AttributeError: 'has_calls' is not a valid assertion."
-    "test_reapprove"
-  ];
-
-  disabledTestPaths = [
-    # test errors due to API mismatch in test setup:
-    #   "ImportError: cannot import name 'set_test_now' from 'pendulum.helpers'"
-    "tests/test_interval.py"
-  ];
+  nativeCheckInputs =
+    (with python3.pkgs; [
+      pytest-cov-stub
+      pytestCheckHook
+      pendulum
+    ])
+    ++ [
+      git
+    ];
 
   pythonImportsCheck = [ "marge" ];
 


### PR DESCRIPTION
Tested this in a self hosted Gitlab instance.

Strangely I needed to add `git` and `openssh` to `propagatedBuildInputs`, otherwise it would fail at runtime. Installing git and `openssh` system-wide, or for the user did not work :thinking:.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
