### PR TITLE
Freecad: fix cursor.pcf font load crash

### DIFF
--- a/pkgs/by-name/fr/freecad/0003-FreeCad-fix-font-load-crash.patch
+++ b/pkgs/by-name/fr/freecad/0003-FreeCad-fix-font-load-crash.patch
@@ -1,0 +1,26 @@
+diff --git a/src/Gui/PreferencePages/DlgSettingsEditor.cpp b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+index 0dda987..01568f1 100755
+--- a/src/Gui/PreferencePages/DlgSettingsEditor.cpp
++++ b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+@@ -288,7 +288,9 @@ void DlgSettingsEditor::loadSettings()
+     QStringList fixedFamilyNames;
+     for (const auto& name : familyNames) {
+         if (QFontDatabase().isFixedPitch(name)) {
+-            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0) {
++            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0
++                && name.compare(QLatin1String("cursor.pcf"), Qt::CaseInsensitive) != 0)
++              {
+                 fixedFamilyNames.append(name);
+             }
+         }
+@@ -298,7 +300,9 @@ void DlgSettingsEditor::loadSettings()
+     QStringList fixedFamilyNames;
+     for (const auto& name : familyNames) {
+         if (QFontDatabase::isFixedPitch(name)) {
+-            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0) {
++            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0
++                && name.compare(QLatin1String("cursor.pcf"), Qt::CaseInsensitive) != 0)
++              {
+                 fixedFamilyNames.append(name);
+             }
+         }

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -152,6 +152,9 @@ freecad-utils.makeCustomizable (
     patches = [
       ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
       ./0002-FreeCad-OndselSolver-pkgconfig.patch
+
+      # https://github.com/FreeCAD/FreeCAD/pull/21710
+      ./0003-FreeCad-fix-font-load-crash.patch
       (fetchpatch {
         url = "https://github.com/FreeCAD/FreeCAD/commit/8e04c0a3dd9435df0c2dec813b17d02f7b723b19.patch?full_index=1";
         hash = "sha256-H6WbJFTY5/IqEdoi5N+7D4A6pVAmZR4D+SqDglwS18c=";


### PR DESCRIPTION
See, 

https://github.com/NixOS/nixpkgs/pull/346740
https://github.com/NixOS/nixpkgs/issues/284880
https://discourse.nixos.org/t/freecad-failed-to-compute-left-right-minimum-bearings-for-cursor-pcf/35266
https://github.com/FreeCAD/FreeCAD/issues/10514

This change blacklists the cursor.pcf font from being background saved into the preferences serialization file.
When this font is loaded, extents cannot be computed, and Freecad freezes at 100% cpu,  with errors streamed to stderr. 

A proposed workaround, that involves manually editing ~/.config/FreeCAD/user.cfg, to clear the <FCText Name="Font">cursor.pcf</FCText> field when modified, only goes so far. 

Since some actions that trigger the behavior - such as DXF import and export - don't provide any opportunity to save work, before one has to perform the pkil, and re-edit the user.cfg, so it is not possible to progress the design.

The  change is similar to
https://github.com/FreeCAD/FreeCAD/pull/10555

The proposed fix,
https://github.com/FreeCAD/FreeCAD/commit/9806a463246f5a0daf5d87b323ab8c06a97feba2
(now reverted) did not work for me.

## Things done

 
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
