### PR TITLE
duplicati: 2.1.0.2 -> 2.1.0.5

### DIFF
--- a/pkgs/by-name/du/duplicati/package.nix
+++ b/pkgs/by-name/du/duplicati/package.nix
@@ -2,44 +2,70 @@
   lib,
   stdenv,
   fetchzip,
-  mono,
-  sqlite,
-  makeWrapper,
+  autoPatchelfHook,
+  gcc-unwrapped,
+  zlib,
+  lttng-ust_2_12,
+  icu,
+  openssl,
+  makeBinaryWrapper,
 }:
 
+let
+  _supportedPlatforms = {
+    "armv7l-linux" = "linux-arm7";
+    "x86_64-linux" = "linux-x64";
+    "aarch64-linux" = "linux-arm64";
+  };
+  _platform = _supportedPlatforms."${stdenv.hostPlatform.system}";
+  # nix hash convert --to sri "sha256:`nix-prefetch-url --unpack https://updates.duplicati.com/stable/duplicati-2.1.0.5_stable_2025-03-04-linux-arm64-cli.zip`"
+  _fileHashForSystem = {
+    "armv7l-linux" = "sha256-FQQ07M0rwvxNkHPW6iK5WBTKgFrZ4LOP4vgINfmtq4k=";
+    "x86_64-linux" = "sha256-1QspF/A3hOtqd8bVbSqClJIHUN9gBrd18J5qvZJLkQE=";
+    "aarch64-linux" = "sha256-mSNInaCkNf1MBZK2M42SjJnYRtB5SyGMvSGSn5oH1Cs=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
+  # TODO build duplicati from source https://github.com/duplicati/duplicati/blob/master/.github/workflows/build-packages.yml
   pname = "duplicati";
-  version = "2.1.0.2";
-  channel = "beta";
-  build_date = "2024-11-29";
+  version = "2.1.0.5";
+  channel = "stable";
+  buildDate = "2025-03-04";
 
   src = fetchzip {
     url =
       with finalAttrs;
-      "https://github.com/duplicati/duplicati/releases/download/v${version}-${version}_${channel}_${build_date}/duplicati-${version}_${channel}_${build_date}.zip";
-    hash = "sha256-LmW6yGutxP33ghFqyOLKrGDNCQdr8DDFn/IHigsLpzA=";
-    stripRoot = false;
+      "https://updates.duplicati.com/stable/duplicati-${version}_${channel}_${buildDate}-${_platform}-cli.zip";
+    hash = _fileHashForSystem."${stdenv.hostPlatform.system}";
+    stripRoot = true;
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeBinaryWrapper
+  ];
+  buildInputs = [
+    gcc-unwrapped
+    zlib
+    lttng-ust_2_12
+  ];
 
   installPhase = ''
-    mkdir -p $out/{bin,share/duplicati-${finalAttrs.version}}
-    cp -r * $out/share/duplicati-${finalAttrs.version}
-    makeWrapper "${lib.getExe mono}" $out/bin/duplicati-cli \
-      --add-flags "$out/share/duplicati-${finalAttrs.version}/Duplicati.CommandLine.exe" \
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+    cp -r * "$out/share/"
+    for file in $out/share/duplicati-*; do
+      makeBinaryWrapper "$file" "$out/bin/$(basename $file)" \
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [
-          sqlite
+          icu
+          openssl
         ]
       }
-    makeWrapper "${lib.getExe mono}" $out/bin/duplicati-server \
-      --add-flags "$out/share/duplicati-${finalAttrs.version}/Duplicati.Server.exe" \
-      --prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath [
-          sqlite
-        ]
-      }
+    done
+
+    runHook postInstall
   '';
 
   meta = {
@@ -51,6 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
       bot-wxt1221
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    platforms = lib.platforms.all;
+    platforms = builtins.attrNames _supportedPlatforms;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates duplicati to 2.1.0.5. duplicati has changed packaging a bit and is now shipping dynamically linked executables, instead of a dotnet-requiring ones.

Also the module was updated to allow specifying parameters file. This is useful when passing secrets to duplicati. Credits to @jack-michaud for original PR.

Includes: 
- https://github.com/NixOS/nixpkgs/pull/128392

Fixes: https://github.com/NixOS/nixpkgs/issues/377835

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
