### PR TITLE
Fix Flutter Android builds with Gradle 8.9+

### DIFF
--- a/pkgs/development/compilers/flutter/versions/3_29/patches/gradle-flutter-tools-wrapper.patch
+++ b/pkgs/development/compilers/flutter/versions/3_29/patches/gradle-flutter-tools-wrapper.patch
@@ -15,11 +15,9 @@ The intermediate project makes a `settings.gradle` file in `$HOME/.cache/flutter
 This Gradle project will build the actual `packages/flutter_tools/gradle` project by setting
 `rootProject.projectDir = new File("$settingsDir")` and `apply from: new File("$settingsDir/settings.gradle.kts")`.
 
-Now the `.gradle` will be built in `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/`, but `build` doesn't.
-To move `build` to `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/` as well, we need to set `buildDirectory`.
-diff --git a/packages/flutter_tools/gradle/settings.gradle b/packages/flutter_tools/gradle/settings.gradle
-new file mode 100644
-index 0000000000..b2485c94b4
+To move `build` to `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/`, we need to set `buildDirectory`.
+To move `.gradle` as well, the `--project-cache-dir` argument must be passed to the Gradle wrapper.
+Changing the `GradleUtils.getExecutable` function signature is a delibarate choice, to ensure that no new unpatched usages slip in.
 --- /dev/null
 +++ b/packages/flutter_tools/gradle/settings.gradle
 @@ -0,0 +1,19 @@
@@ -44,12 +42,166 @@ index 0000000000..b2485c94b4
 +includeBuild(dir)
 --- a/packages/flutter_tools/gradle/build.gradle.kts
 +++ b/packages/flutter_tools/gradle/build.gradle.kts
-@@ -4,6 +4,8 @@
+@@ -4,6 +4,11 @@
  
  import org.jetbrains.kotlin.gradle.dsl.JvmTarget
  
++// While flutter_tools runs Gradle with a --project-cache-dir, this startParameter
++// is not passed correctly to the Kotlin Gradle plugin for some reason, and so
++// must be set here as well.
 +gradle.startParameter.projectCacheDir = layout.buildDirectory.dir("cache").get().asFile
 +
  plugins {
      `java-gradle-plugin`
      groovy
+--- a/packages/flutter_tools/lib/src/android/gradle.dart
++++ b/packages/flutter_tools/lib/src/android/gradle.dart
+@@ -456,9 +456,9 @@ class AndroidGradleBuilder implements AndroidBuilder {
+     // from the local.properties file.
+     updateLocalProperties(project: project, buildInfo: androidBuildInfo.buildInfo);
+ 
+-    final List<String> options = <String>[];
+-
+-    final String gradleExecutablePath = _gradleUtils.getExecutable(project);
++    final [String gradleExecutablePath, ...List<String> options] = _gradleUtils.getExecutable(
++      project,
++    );
+ 
+     // All automatically created files should exist.
+     if (configOnly) {
+@@ -781,7 +781,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
+       'aar_init_script.gradle',
+     );
+     final List<String> command = <String>[
+-      _gradleUtils.getExecutable(project),
++      ..._gradleUtils.getExecutable(project),
+       '-I=$initScript',
+       '-Pflutter-root=$flutterRoot',
+       '-Poutput-dir=${outputDirectory.path}',
+@@ -896,6 +896,10 @@ class AndroidGradleBuilder implements AndroidBuilder {
+     final List<String> results = <String>[];
+ 
+     try {
++      final [String gradleExecutablePath, ...List<String> options] = _gradleUtils.getExecutable(
++        project,
++      );
++
+       exitCode = await _runGradleTask(
+         _kBuildVariantTaskName,
+         preRunTask: () {
+@@ -911,10 +915,10 @@ class AndroidGradleBuilder implements AndroidBuilder {
+             ),
+           );
+         },
+-        options: const <String>['-q'],
++        options: <String>[...options, '-q'],
+         project: project,
+         localGradleErrors: gradleErrors,
+-        gradleExecutablePath: _gradleUtils.getExecutable(project),
++        gradleExecutablePath: gradleExecutablePath,
+         outputParser: (String line) {
+           if (_kBuildVariantRegex.firstMatch(line) case final RegExpMatch match) {
+             results.add(match.namedGroup(_kBuildVariantRegexGroupName)!);
+@@ -948,6 +952,10 @@ class AndroidGradleBuilder implements AndroidBuilder {
+     late Stopwatch sw;
+     int exitCode = 1;
+     try {
++      final [String gradleExecutablePath, ...List<String> options] = _gradleUtils.getExecutable(
++        project,
++      );
++
+       exitCode = await _runGradleTask(
+         taskName,
+         preRunTask: () {
+@@ -963,10 +971,10 @@ class AndroidGradleBuilder implements AndroidBuilder {
+             ),
+           );
+         },
+-        options: <String>['-q', '-PoutputPath=$outputPath'],
++        options: <String>[...options, '-q', '-PoutputPath=$outputPath'],
+         project: project,
+         localGradleErrors: gradleErrors,
+-        gradleExecutablePath: _gradleUtils.getExecutable(project),
++        gradleExecutablePath: gradleExecutablePath,
+       );
+     } on Error catch (error) {
+       _logger.printError(error.toString());
+--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
++++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
+@@ -240,7 +240,12 @@ final GradleHandledError flavorUndefinedHandler = GradleHandledError(
+     required bool usesAndroidX,
+   }) async {
+     final RunResult tasksRunResult = await globals.processUtils.run(
+-      <String>[globals.gradleUtils!.getExecutable(project), 'app:tasks', '--all', '--console=auto'],
++      <String>[
++        ...globals.gradleUtils!.getExecutable(project),
++        'app:tasks',
++        '--all',
++        '--console=auto',
++      ],
+       throwOnError: true,
+       workingDirectory: project.android.hostAppGradleRoot.path,
+       environment: globals.java?.environment,
+--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
++++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
+@@ -3,6 +3,7 @@
+ // found in the LICENSE file.
+ 
+ import 'package:meta/meta.dart';
++import 'package:path/path.dart';
+ import 'package:process/process.dart';
+ import 'package:unified_analytics/unified_analytics.dart';
+ 
+@@ -154,9 +155,16 @@ class GradleUtils {
+   final Logger _logger;
+   final OperatingSystemUtils _operatingSystemUtils;
+ 
++  List<String> get _requiredArguments => <String>[
++    '--project-cache-dir=${join(switch (globals.platform.environment['XDG_CACHE_HOME']) {
++      final String cacheHome => cacheHome,
++      _ => join(globals.fsUtils.homeDirPath ?? throwToolExit('No cache directory has been specified.'), '.cache'),
++    }, 'flutter', 'nix-flutter-tools-gradle', globals.flutterVersion.engineRevision.substring(0, 10), 'cache')}',
++  ];
++
+   /// Gets the Gradle executable path and prepares the Gradle project.
+   /// This is the `gradlew` or `gradlew.bat` script in the `android/` directory.
+-  String getExecutable(FlutterProject project) {
++  List<String> getExecutable(FlutterProject project) {
+     final Directory androidDir = project.android.hostAppGradleRoot;
+     injectGradleWrapperIfNeeded(androidDir);
+ 
+@@ -167,7 +175,7 @@ class GradleUtils {
+       // If the Gradle executable doesn't have execute permission,
+       // then attempt to set it.
+       _operatingSystemUtils.makeExecutable(gradle);
+-      return gradle.absolute.path;
++      return <String>[gradle.absolute.path, ..._requiredArguments];
+     }
+     throwToolExit(
+       'Unable to locate gradlew script. Please check that ${gradle.path} '
+--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
++++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+@@ -2740,8 +2740,8 @@ Gradle Crashed
+ 
+ class FakeGradleUtils extends Fake implements GradleUtils {
+   @override
+-  String getExecutable(FlutterProject project) {
+-    return 'gradlew';
++  List<String> getExecutable(FlutterProject project) {
++    return const <String>['gradlew'];
+   }
+ }
+ 
+--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
++++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+@@ -1580,8 +1580,8 @@ Platform fakePlatform(String name) {
+ 
+ class FakeGradleUtils extends Fake implements GradleUtils {
+   @override
+-  String getExecutable(FlutterProject project) {
+-    return 'gradlew';
++  List<String> getExecutable(FlutterProject project) {
++    return const <String>['gradlew'];
+   }
+ }
+ 

--- a/pkgs/development/compilers/flutter/versions/3_29/patches/gradle-flutter-tools-wrapper.patch
+++ b/pkgs/development/compilers/flutter/versions/3_29/patches/gradle-flutter-tools-wrapper.patch
@@ -152,16 +152,29 @@ Changing the `GradleUtils.getExecutable` function signature is a delibarate choi
  import 'package:process/process.dart';
  import 'package:unified_analytics/unified_analytics.dart';
  
-@@ -154,9 +155,16 @@ class GradleUtils {
+@@ -154,9 +155,29 @@ class GradleUtils {
    final Logger _logger;
    final OperatingSystemUtils _operatingSystemUtils;
  
-+  List<String> get _requiredArguments => <String>[
-+    '--project-cache-dir=${join(switch (globals.platform.environment['XDG_CACHE_HOME']) {
-+      final String cacheHome => cacheHome,
-+      _ => join(globals.fsUtils.homeDirPath ?? throwToolExit('No cache directory has been specified.'), '.cache'),
-+    }, 'flutter', 'nix-flutter-tools-gradle', globals.flutterVersion.engineRevision.substring(0, 10), 'cache')}',
-+  ];
++  List<String> get _requiredArguments {
++    final String cacheDir = join(
++      switch (globals.platform.environment['XDG_CACHE_HOME']) {
++        final String cacheHome => cacheHome,
++        _ => join(
++          globals.fsUtils.homeDirPath ?? throwToolExit('No cache directory has been specified.'),
++          '.cache',
++        ),
++      },
++      'flutter',
++      'nix-flutter-tools-gradle',
++      globals.flutterVersion.engineRevision.substring(0, 10),
++    );
++
++    return <String>[
++      '--project-cache-dir=${join(cacheDir, 'cache')}',
++      '-Pkotlin.project.persistent.dir=${join(cacheDir, 'kotlin')}',
++    ];
++  }
 +
    /// Gets the Gradle executable path and prepares the Gradle project.
    /// This is the `gradlew` or `gradlew.bat` script in the `android/` directory.
@@ -170,7 +183,7 @@ Changing the `GradleUtils.getExecutable` function signature is a delibarate choi
      final Directory androidDir = project.android.hostAppGradleRoot;
      injectGradleWrapperIfNeeded(androidDir);
  
-@@ -167,7 +175,7 @@ class GradleUtils {
+@@ -167,7 +188,7 @@ class GradleUtils {
        // If the Gradle executable doesn't have execute permission,
        // then attempt to set it.
        _operatingSystemUtils.makeExecutable(gradle);

--- a/pkgs/development/compilers/flutter/versions/3_32/patches/gradle-flutter-tools-wrapper.patch
+++ b/pkgs/development/compilers/flutter/versions/3_32/patches/gradle-flutter-tools-wrapper.patch
@@ -15,11 +15,9 @@ The intermediate project makes a `settings.gradle` file in `$HOME/.cache/flutter
 This Gradle project will build the actual `packages/flutter_tools/gradle` project by setting
 `rootProject.projectDir = new File("$settingsDir")` and `apply from: new File("$settingsDir/settings.gradle.kts")`.
 
-Now the `.gradle` will be built in `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/`, but `build` doesn't.
-To move `build` to `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/` as well, we need to set `buildDirectory`.
-diff --git a/packages/flutter_tools/gradle/settings.gradle b/packages/flutter_tools/gradle/settings.gradle
-new file mode 100644
-index 0000000000..b2485c94b4
+To move `build` to `$HOME/.cache/flutter/nix-flutter-tools-gradle/<short engine rev>/`, we need to set `buildDirectory`.
+To move `.gradle` as well, the `--project-cache-dir` argument must be passed to the Gradle wrapper.
+Changing the `GradleUtils.getExecutable` function signature is a delibarate choice, to ensure that no new unpatched usages slip in.
 --- /dev/null
 +++ b/packages/flutter_tools/gradle/settings.gradle
 @@ -0,0 +1,19 @@
@@ -44,12 +42,166 @@ index 0000000000..b2485c94b4
 +includeBuild(dir)
 --- a/packages/flutter_tools/gradle/build.gradle.kts
 +++ b/packages/flutter_tools/gradle/build.gradle.kts
-@@ -4,6 +4,8 @@
+@@ -4,6 +4,11 @@
  
  import org.jetbrains.kotlin.gradle.dsl.JvmTarget
  
++// While flutter_tools runs Gradle with a --project-cache-dir, this startParameter
++// is not passed correctly to the Kotlin Gradle plugin for some reason, and so
++// must be set here as well.
 +gradle.startParameter.projectCacheDir = layout.buildDirectory.dir("cache").get().asFile
 +
  plugins {
      `java-gradle-plugin`
      groovy
+--- a/packages/flutter_tools/lib/src/android/gradle.dart
++++ b/packages/flutter_tools/lib/src/android/gradle.dart
+@@ -456,9 +456,9 @@ class AndroidGradleBuilder implements AndroidBuilder {
+     // from the local.properties file.
+     updateLocalProperties(project: project, buildInfo: androidBuildInfo.buildInfo);
+ 
+-    final List<String> options = <String>[];
+-
+-    final String gradleExecutablePath = _gradleUtils.getExecutable(project);
++    final [String gradleExecutablePath, ...List<String> options] = _gradleUtils.getExecutable(
++      project,
++    );
+ 
+     // All automatically created files should exist.
+     if (configOnly) {
+@@ -781,7 +781,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
+       'aar_init_script.gradle',
+     );
+     final List<String> command = <String>[
+-      _gradleUtils.getExecutable(project),
++      ..._gradleUtils.getExecutable(project),
+       '-I=$initScript',
+       '-Pflutter-root=$flutterRoot',
+       '-Poutput-dir=${outputDirectory.path}',
+@@ -896,6 +896,10 @@ class AndroidGradleBuilder implements AndroidBuilder {
+     final List<String> results = <String>[];
+ 
+     try {
++      final [String gradleExecutablePath, ...List<String> options] = _gradleUtils.getExecutable(
++        project,
++      );
++
+       exitCode = await _runGradleTask(
+         _kBuildVariantTaskName,
+         preRunTask: () {
+@@ -911,10 +915,10 @@ class AndroidGradleBuilder implements AndroidBuilder {
+             ),
+           );
+         },
+-        options: const <String>['-q'],
++        options: <String>[...options, '-q'],
+         project: project,
+         localGradleErrors: gradleErrors,
+-        gradleExecutablePath: _gradleUtils.getExecutable(project),
++        gradleExecutablePath: gradleExecutablePath,
+         outputParser: (String line) {
+           if (_kBuildVariantRegex.firstMatch(line) case final RegExpMatch match) {
+             results.add(match.namedGroup(_kBuildVariantRegexGroupName)!);
+@@ -948,6 +952,10 @@ class AndroidGradleBuilder implements AndroidBuilder {
+     late Stopwatch sw;
+     int exitCode = 1;
+     try {
++      final [String gradleExecutablePath, ...List<String> options] = _gradleUtils.getExecutable(
++        project,
++      );
++
+       exitCode = await _runGradleTask(
+         taskName,
+         preRunTask: () {
+@@ -963,10 +971,10 @@ class AndroidGradleBuilder implements AndroidBuilder {
+             ),
+           );
+         },
+-        options: <String>['-q', '-PoutputPath=$outputPath'],
++        options: <String>[...options, '-q', '-PoutputPath=$outputPath'],
+         project: project,
+         localGradleErrors: gradleErrors,
+-        gradleExecutablePath: _gradleUtils.getExecutable(project),
++        gradleExecutablePath: gradleExecutablePath,
+       );
+     } on Error catch (error) {
+       _logger.printError(error.toString());
+--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
++++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
+@@ -240,7 +240,12 @@ final GradleHandledError flavorUndefinedHandler = GradleHandledError(
+     required bool usesAndroidX,
+   }) async {
+     final RunResult tasksRunResult = await globals.processUtils.run(
+-      <String>[globals.gradleUtils!.getExecutable(project), 'app:tasks', '--all', '--console=auto'],
++      <String>[
++        ...globals.gradleUtils!.getExecutable(project),
++        'app:tasks',
++        '--all',
++        '--console=auto',
++      ],
+       throwOnError: true,
+       workingDirectory: project.android.hostAppGradleRoot.path,
+       environment: globals.java?.environment,
+--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
++++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
+@@ -3,6 +3,7 @@
+ // found in the LICENSE file.
+ 
+ import 'package:meta/meta.dart';
++import 'package:path/path.dart';
+ import 'package:process/process.dart';
+ import 'package:unified_analytics/unified_analytics.dart';
+ 
+@@ -154,9 +155,16 @@ class GradleUtils {
+   final Logger _logger;
+   final OperatingSystemUtils _operatingSystemUtils;
+ 
++  List<String> get _requiredArguments => <String>[
++    '--project-cache-dir=${join(switch (globals.platform.environment['XDG_CACHE_HOME']) {
++      final String cacheHome => cacheHome,
++      _ => join(globals.fsUtils.homeDirPath ?? throwToolExit('No cache directory has been specified.'), '.cache'),
++    }, 'flutter', 'nix-flutter-tools-gradle', globals.flutterVersion.engineRevision.substring(0, 10), 'cache')}',
++  ];
++
+   /// Gets the Gradle executable path and prepares the Gradle project.
+   /// This is the `gradlew` or `gradlew.bat` script in the `android/` directory.
+-  String getExecutable(FlutterProject project) {
++  List<String> getExecutable(FlutterProject project) {
+     final Directory androidDir = project.android.hostAppGradleRoot;
+     injectGradleWrapperIfNeeded(androidDir);
+ 
+@@ -167,7 +175,7 @@ class GradleUtils {
+       // If the Gradle executable doesn't have execute permission,
+       // then attempt to set it.
+       _operatingSystemUtils.makeExecutable(gradle);
+-      return gradle.absolute.path;
++      return <String>[gradle.absolute.path, ..._requiredArguments];
+     }
+     throwToolExit(
+       'Unable to locate gradlew script. Please check that ${gradle.path} '
+--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
++++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+@@ -2740,8 +2740,8 @@ Gradle Crashed
+ 
+ class FakeGradleUtils extends Fake implements GradleUtils {
+   @override
+-  String getExecutable(FlutterProject project) {
+-    return 'gradlew';
++  List<String> getExecutable(FlutterProject project) {
++    return const <String>['gradlew'];
+   }
+ }
+ 
+--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
++++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+@@ -1580,8 +1580,8 @@ Platform fakePlatform(String name) {
+ 
+ class FakeGradleUtils extends Fake implements GradleUtils {
+   @override
+-  String getExecutable(FlutterProject project) {
+-    return 'gradlew';
++  List<String> getExecutable(FlutterProject project) {
++    return const <String>['gradlew'];
+   }
+ }
+ 

--- a/pkgs/development/compilers/flutter/versions/3_32/patches/gradle-flutter-tools-wrapper.patch
+++ b/pkgs/development/compilers/flutter/versions/3_32/patches/gradle-flutter-tools-wrapper.patch
@@ -152,16 +152,29 @@ Changing the `GradleUtils.getExecutable` function signature is a delibarate choi
  import 'package:process/process.dart';
  import 'package:unified_analytics/unified_analytics.dart';
  
-@@ -154,9 +155,16 @@ class GradleUtils {
+@@ -154,9 +155,29 @@ class GradleUtils {
    final Logger _logger;
    final OperatingSystemUtils _operatingSystemUtils;
  
-+  List<String> get _requiredArguments => <String>[
-+    '--project-cache-dir=${join(switch (globals.platform.environment['XDG_CACHE_HOME']) {
-+      final String cacheHome => cacheHome,
-+      _ => join(globals.fsUtils.homeDirPath ?? throwToolExit('No cache directory has been specified.'), '.cache'),
-+    }, 'flutter', 'nix-flutter-tools-gradle', globals.flutterVersion.engineRevision.substring(0, 10), 'cache')}',
-+  ];
++  List<String> get _requiredArguments {
++    final String cacheDir = join(
++      switch (globals.platform.environment['XDG_CACHE_HOME']) {
++        final String cacheHome => cacheHome,
++        _ => join(
++          globals.fsUtils.homeDirPath ?? throwToolExit('No cache directory has been specified.'),
++          '.cache',
++        ),
++      },
++      'flutter',
++      'nix-flutter-tools-gradle',
++      globals.flutterVersion.engineRevision.substring(0, 10),
++    );
++
++    return <String>[
++      '--project-cache-dir=${join(cacheDir, 'cache')}',
++      '-Pkotlin.project.persistent.dir=${join(cacheDir, 'kotlin')}',
++    ];
++  }
 +
    /// Gets the Gradle executable path and prepares the Gradle project.
    /// This is the `gradlew` or `gradlew.bat` script in the `android/` directory.
@@ -170,7 +183,7 @@ Changing the `GradleUtils.getExecutable` function signature is a delibarate choi
      final Directory androidDir = project.android.hostAppGradleRoot;
      injectGradleWrapperIfNeeded(androidDir);
  
-@@ -167,7 +175,7 @@ class GradleUtils {
+@@ -167,7 +188,7 @@ class GradleUtils {
        // If the Gradle executable doesn't have execute permission,
        // then attempt to set it.
        _operatingSystemUtils.makeExecutable(gradle);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Recent versions of Gradle have broken Android builds with our Flutter package.

- Gradle 8.9 started reading the project cache directory earlier, so our existing hack of changing it in `build.gradle.kts` stopped working
- Gradle 8.11 fixes [KT-58223](https://youtrack.jetbrains.com/issue/KT-58223), creating a another dedicated directory in the read-only Flutter plugin project root in the process

This PR solves both of these issues by introducing a `flutter_tools` patch to add Gradle command-line arguments that change these problematic paths. These are harmless on older Gradle versions.

The patch is larger than I would have liked, because `flutter_tools` had no existing concept of common arguments that get applied to every Gradle command. Unfortunately, there isn't really a better way to fix this AFAIK.

Also see https://github.com/flutter/flutter/issues/169824.

Resolves #395096.

CC @NixOS/flutter

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
