### PR TITLE
gdbm: backport upstream FreeBSD fix

### DIFF
--- a/pkgs/by-name/gd/gdbm/package.nix
+++ b/pkgs/by-name/gd/gdbm/package.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./upstream-darwin-clock-nanosleep-fix.patch
     ./upstream-lockwait-test-fixes.patch
     ./upstream-musl-ssize_t-fix.patch
+    ./upstream-freebsd-fix.patch
   ];
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];

--- a/pkgs/by-name/gd/gdbm/upstream-freebsd-fix.patch
+++ b/pkgs/by-name/gd/gdbm/upstream-freebsd-fix.patch
@@ -1,0 +1,51 @@
+From 2cb9effa454ca4ce3ebb47d6ce442d6784700c52 Mon Sep 17 00:00:00 2001
+From: Sergey Poznyakoff <gray@gnu.org>
+Date: Fri, 11 Apr 2025 08:36:19 +0300
+Subject: Minor change
+
+* src/lock.c: Don't set errno to ETIME, preserve the original EINTR
+instead.
+---
+ src/lock.c | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/src/lock.c b/src/lock.c
+index cf28478..b1ca7ad 100644
+--- a/src/lock.c
++++ b/src/lock.c
+@@ -73,15 +73,10 @@ try_lock_flock (GDBM_FILE dbf, int nb)
+     {
+       return TRY_LOCK_OK;
+     }
+-  else if (errno == EWOULDBLOCK)
++  else if (errno == EWOULDBLOCK || errno == EINTR)
+     {
+       return TRY_LOCK_FAIL;
+     }
+-  else if (errno == EINTR)
+-    {
+-      errno = ETIME;
+-      return TRY_LOCK_FAIL;
+-    }
+ #endif
+   return TRY_LOCK_NEXT;
+ }
+@@ -116,7 +111,6 @@ try_lock_lockf (GDBM_FILE dbf, int nb)
+       switch (errno)
+ 	{
+ 	case EINTR:
+-	  errno = ETIME;
+ 	case EACCES:
+ 	case EAGAIN:
+ 	case EDEADLK:
+@@ -162,7 +156,6 @@ try_lock_fcntl (GDBM_FILE dbf, int nb)
+   switch (errno)
+     {
+     case EINTR:
+-      errno = ETIME;
+     case EACCES:
+     case EAGAIN:
+     case EDEADLK:
+-- 
+cgit v1.2.3
+


### PR DESCRIPTION
The upstream commit message is a bit short on detail about what their motivation for this change was, but ETIME does not exist on FreeBSD so this fixes the build failure.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
