### PR TITLE
sauerbraten: fix build

### DIFF
--- a/pkgs/by-name/sa/sauerbraten/package.nix
+++ b/pkgs/by-name/sa/sauerbraten/package.nix
@@ -8,9 +8,11 @@
   copyDesktopItems,
 
   # buildInputs
+  libGL,
   SDL2,
   SDL2_image,
   SDL2_mixer,
+  xorg,
   zlib,
 
   makeDesktopItem,
@@ -33,9 +35,11 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
+    libGL
     SDL2
     SDL2_image
     SDL2_mixer
+    xorg.libX11
     zlib
   ];
 


### PR DESCRIPTION
Closes #412963

Add missing build inputs to sauerbraten. Build was failing with:
```bash
In file included from engine/main.cpp:6:
/nix/store/s7f0ckw8pa6yap3a7kbn01lwy4s2a2gc-sdl2-compat-2.32.56-dev/include/SDL2/SDL_syswm.h:68:10: fatal error: X11/Xlib.h: No such file or directory
   68 | #include <X11/Xlib.h>
      |          ^~~~~~~~~~~~
```
And 
```bash
       > g++ -O3 -fomit-frame-pointer -ffast-math -Wall -fsigned-char -fno-exceptions -fno-rtti -o sauer_client shared/crypto.o shared/geom.o shared/glemu.o shared/stream.o shared/tools.o shared/zip.o engine/3dgui.o engine/bih.o engine/blend.o engine/blob.o engine/client.o engine/command.o engine/console.o engine/cubeloader.o engine/decal.o engine/dynlight.o engine/glare.o engine/grass.o engine/lightmap.o engine/main.o engine/material.o engine/menus.o engine/movie.o engine/normal.o engine/octa.o engine/octaedit.o engine/octarender.o engine/physics.o engine/pvs.o engine/rendergl.o engine/rendermodel.o engine/renderparticles.o engine/rendersky.o engine/rendertext.o engine/renderva.o engine/server.o engine/serverbrowser.o engine/shader.o engine/shadowmap.o engine/sound.o engine/texture.o engine/water.o engine/world.o engine/worldio.o fpsgame/ai.o fpsgame/client.o fpsgame/entities.o fpsgame/fps.o fpsgame/monster.o fpsgame/movable.o fpsgame/render.o fpsgame/scoreboard.o fpsgame/server.o fpsgame/waypoint.o fpsgame/weapon.o -Lenet -lenet -L/usr/X11R6/lib -lX11 `sdl2-config --libs` -lSDL2_image -lSDL2_mixer -lz -lGL -lrt
       > /nix/store/v63bxfiacw082c7ijshf60alvvrpfxsq-binutils-2.44/bin/ld: cannot find -lGL: No such file or directory
```

Game seems to work - I was able to start a bot match.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
