### PR TITLE
microsoft-identity-broker: fix runtime link errors, add sensible JVM memory & GC-options

### DIFF
--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -55,12 +55,14 @@ stdenv.mkDerivation rec {
     makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-broker \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
       --add-flags "-classpath $classpath" \
+      --add-flags "-Xmx256m -Xss256k -XX:+UseParallelGC -XX:ParallelGCThreads=1" \
       --add-flags "-verbose" \
       --add-flags "com.microsoft.identity.broker.service.IdentityBrokerService"
 
     makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-device-broker \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
       --add-flags "-classpath $classpath" \
+      --add-flags "-Xmx256m -Xss256k -XX:+UseParallelGC -XX:ParallelGCThreads=1" \
       --add-flags "-verbose" \
       --add-flags "com.microsoft.identity.broker.service.DeviceBrokerService"
 

--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -6,18 +6,20 @@
   openjdk11,
   jnr-posix,
   makeWrapper,
-  openjfx17,
   zip,
   nixosTests,
   bash,
+  glib,
+  xorg,
+  alsa-lib,
 }:
 stdenv.mkDerivation rec {
   pname = "microsoft-identity-broker";
   version = "2.0.1";
 
   src = fetchurl {
-    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_${version}_amd64.deb";
-    hash = "sha256-v/FxtdvRaUHYqvFSkJIZyicIdcyxQ8lPpY5rb9smnqA=";
+    url = "https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_${version}_amd64.deb";
+    hash = "sha256-JheJnsu1ZxJbcpt0367FqfHVdwWWvPem2fm0i8s7MGE=";
   };
 
   nativeBuildInputs = [
@@ -27,24 +29,15 @@ stdenv.mkDerivation rec {
     zip
   ];
 
+  buildInputs = [
+    glib
+    xorg.libXtst
+    alsa-lib
+  ];
+
   buildPhase = ''
     runHook preBuild
-
     rm opt/microsoft/identity-broker/lib/jnr-posix-3.1.4.jar
-    jar -uf opt/microsoft/identity-broker/lib/javafx-graphics-15-linux.jar -C ${openjfx17}/modules_libs/javafx.graphics/ libglass.so
-    jar -uf opt/microsoft/identity-broker/lib/javafx-graphics-15-linux.jar -C ${openjfx17}/modules_libs/javafx.graphics/ libglassgtk3.so
-    jar -uf opt/microsoft/identity-broker/lib/javafx-graphics-15-linux.jar -C ${openjfx17}/modules_libs/javafx.graphics/ libprism_es2.so
-    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-54.so
-    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-56.so
-    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-57.so
-    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-ffmpeg-56.so
-    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-ffmpeg-57.so
-    zip -d opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar libavplugin-ffmpeg-58.so
-    jar -uf opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar -C ${openjfx17}/modules_libs/javafx.media/ libavplugin.so
-    jar -uf opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar -C ${openjfx17}/modules_libs/javafx.media/ libfxplugins.so
-    jar -uf opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar -C ${openjfx17}/modules_libs/javafx.media/ libgstreamer-lite.so
-    jar -uf opt/microsoft/identity-broker/lib/javafx-media-15-linux.jar -C ${openjfx17}/modules_libs/javafx.media/ libjfxmedia.so
-
     runHook postBuild
   '';
 
@@ -60,13 +53,16 @@ stdenv.mkDerivation rec {
     classpath="$classpath:${jnr-posix}/share/java/jnr-posix-${jnr-posix.version}.jar"
     mkdir -p $out/bin
     makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-broker \
-      --add-flags "-classpath $classpath com.microsoft.identity.broker.service.IdentityBrokerService" \
-      --add-flags "-verbose"
-    makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-device-broker \
-      --add-flags "-verbose" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
       --add-flags "-classpath $classpath" \
-      --add-flags "com.microsoft.identity.broker.service.DeviceBrokerService" \
-      --add-flags "save"
+      --add-flags "-verbose" \
+      --add-flags "com.microsoft.identity.broker.service.IdentityBrokerService"
+
+    makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-device-broker \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
+      --add-flags "-classpath $classpath" \
+      --add-flags "-verbose" \
+      --add-flags "com.microsoft.identity.broker.service.DeviceBrokerService"
 
     runHook postInstall
   '';
@@ -91,7 +87,7 @@ stdenv.mkDerivation rec {
         $out/bin/microsoft-identity-device-broker \
       --replace \
         /usr/lib/jvm/java-11-openjdk-amd64 \
-        ${openjdk11}/bin/java
+        ${openjdk11}
   '';
 
   passthru = {

--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -57,6 +57,7 @@ stdenv.mkDerivation rec {
       --add-flags "-classpath $classpath" \
       --add-flags "-Xmx256m -Xss256k -XX:+UseParallelGC -XX:ParallelGCThreads=1" \
       --add-flags "-verbose" \
+      --add-flags "-Djava.net.useSystemProxies=true" \
       --add-flags "com.microsoft.identity.broker.service.IdentityBrokerService"
 
     makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-device-broker \
@@ -64,6 +65,7 @@ stdenv.mkDerivation rec {
       --add-flags "-classpath $classpath" \
       --add-flags "-Xmx256m -Xss256k -XX:+UseParallelGC -XX:ParallelGCThreads=1" \
       --add-flags "-verbose" \
+      --add-flags "-Djava.net.useSystemProxies=true" \
       --add-flags "com.microsoft.identity.broker.service.DeviceBrokerService"
 
     runHook postInstall


### PR DESCRIPTION
Closes #401875

With the previous version of the package, trying to enroll a device (using `services.intune.enable = true;`) will end up failing, with `journalctl` revealing the following:

```sh
Apr 25 22:03:03 hostname-redacted microsoft-identity-broker[715232]: Exception in thread "JavaFX Application Thread" java.lang.UnsatisfiedLinkError: 'void com.sun.glass.ui.gtk.GtkWindow._setGravity(long, float, float)'
```

This seems to have been due to the previous packaging effort gotten somewhat rotten over time.

This PR also adds sensible JVM memory limits & GC-options to reduce memory usage during use.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
