### PR TITLE
{nixos/,}cockpit: add branding + small fixes

### DIFF
--- a/pkgs/by-name/co/cockpit/branding.css
+++ b/pkgs/by-name/co/cockpit/branding.css
@@ -1,0 +1,11 @@
+#badge {
+    inline-size: 225px;
+    block-size: 80px;
+    background-image: url("logo.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
+#brand::before {
+    content: "${PRETTY_NAME}";
+}

--- a/pkgs/by-name/co/cockpit/package.nix
+++ b/pkgs/by-name/co/cockpit/package.nix
@@ -37,6 +37,9 @@
   systemd,
   udev,
   xmlto,
+  # Enables lightweight NixOS branding, replacing the default Cockpit icons
+  withBranding ? true,
+  nixos-icons,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -148,6 +151,17 @@ stdenv.mkDerivation (finalAttrs: {
 
     # hardcode libexecdir, I am assuming that cockpit only use it to find it's binaries
     printf 'def get_libexecdir() -> str:\n\treturn "%s"' "$out/libexec" >> src/cockpit/packages.py
+
+    # patch paths used as visibility conditions in apps
+    substituteInPlace pkg/*/manifest.json \
+      --replace-warn '"/usr/bin' '"/run/current-system/sw/bin' \
+      --replace-warn '"/usr/sbin' '"/run/current-system/sw/bin' \
+      --replace-warn '"/usr/share' '"/run/current-system/sw/share' \
+      --replace-warn '"/lib/systemd' '"/run/current-system/sw/lib/systemd'
+
+    # replace reference to system python interpreter, used for e.g. sosreport
+    substituteInPlace pkg/lib/python.ts \
+      --replace-fail /usr/libexec/platform-python ${python3Packages.python.interpreter}
   '';
 
   configureFlags = [
@@ -200,6 +214,19 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/lib/systemd/*/* \
       --replace-warn /bin /run/current-system/sw/bin
 
+    ${lib.optionalString withBranding ''
+      mkdir -p "$out/share/cockpit/branding/nixos"
+      pushd "$out/share/cockpit/branding/nixos"
+
+      icons="${nixos-icons}/share/icons/hicolor"
+      ln -s "$icons/16x16/apps/nix-snowflake.png" favicon.ico
+      ln -s "$icons/256x256/apps/nix-snowflake.png" logo.png
+      ln -s "$icons/256x256/apps/nix-snowflake.png" apple-touch-icon.png
+      cp "${./branding.css}" branding.css
+
+      popd
+    ''}
+
     runHook postFixup
   '';
 
@@ -219,7 +246,7 @@ stdenv.mkDerivation (finalAttrs: {
     export G_MESSAGES_DEBUG=cockpit-ws,cockpit-wrapper,cockpit-bridge
     export PATH=$PATH:$(pwd)
 
-    make check  -j$NIX_BUILD_CORES || true
+    make check -j$NIX_BUILD_CORES || true
     npm run eslint
     npm run stylelint
   '';
@@ -235,6 +262,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://cockpit-project.org/";
     changelog = "https://cockpit-project.org/blog/cockpit-${finalAttrs.version}.html";
     license = lib.licenses.lgpl21;
-    maintainers = [ lib.maintainers.lucasew ];
+    maintainers = with lib.maintainers; [
+      lucasew
+      andre4ik3
+    ];
   };
 })


### PR DESCRIPTION
This PR contains a bunch of small tweaks and fixes to the Cockpit package and NixOS module that fix some NixOS-specific bugs and improve the experience of using it overall:

<details>
<summary>Add some small NixOS branding and logos</summary>

This matches the way Cockpit branding is done in other distros, e.g. Fedora, Arch, etc. It's just a logo, favicon, and the OS text "NixOS 12.34 (Whatever)".

![Cockpit login page, with NixOS logo and version title](https://github.com/user-attachments/assets/c6d4207b-aa34-4b60-a2df-6d26c531292a)

</details>

<details>
<summary>Patch condition paths to fix some apps not displaying</summary>

Before, it would be checking e.g. for the existence of `/usr/share/...` or `/lib/systemd/...` to determine whether to show some applets. This would lead to e.g. Network and Storage applets never showing, even if `NetworkManager` or `udisks2` was installed, as they weren't in the FHS paths. I added a `substituteInPlace` call to rewrite those paths to their NixOS counterparts, so now they'll show up if the dependencies are installed:

![Storage applet working](https://github.com/user-attachments/assets/dfe52dbb-17a9-4c09-8ae7-96a7bc8d0158)

</details>

<details>
<summary>Fix missing hostname in cockpit issue file</summary>

Fixes `cockpit-issue.service` failing due to missing hostname command. Now `/run/cockpit/issue` will have the proper hostname.

</details>

<details>
<summary>Fix reference to Python at runtime, fixes SoS</summary>

Before, SoS (`sosreport`, "Diagnostic reports") would load forever even if it was installed. If you opened the browser console, there would be an error about trying to run a Python script to read SoS configuration, but it would fail, because it was trying to execute `/usr/libexec/platform-python`. To fix this, I rewrote the `platform-python` reference to point to the Python interpreter in the build inputs. (of course SoS still has to be installed and configured separately)

![SoS/sosreport applet working](https://github.com/user-attachments/assets/7461152e-d0d8-4c0e-9833-bcc99ed9d0b3)

</details>

<details>
<summary>Allow connections to remote hosts</summary>

If the `LoginTo` option is not set, Cockpit does some auto-detection to decide whether to show the "Connect to:" prompt. But this would always fail, as SSH wasn't in its path. To fix this, `programs.ssh.package` is added to `cockpit-ws`'s PATH if `LoginTo` is undefined or set to true (so if it's set to false, it won't be added, as it's unnecessary). So by default, `LoginTo` will be undefined, SSH will be added to its PATH, and the "Connect to:" field will show. (This matches other distro's behavior too)

!["Connect to" field](https://github.com/user-attachments/assets/d3cc61be-a261-4348-a7bb-98615e60f9a4)

</details>

<details>
<summary>Add setting to show Cockpit banner in issue and MOTD (enabled by default)</summary>

Matches behavior of other distros (e.g. Fedora). Can be disabled with `services.cockpit.showBanner = false`

![Cockpit banner on login](https://github.com/user-attachments/assets/1b3fbb4b-f17d-4881-976d-4594cca79464)
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Maintainer ping: @lucasew

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
