### PR TITLE
modsecurity_standalone: 2.9.8 -> 2.9.12

### DIFF
--- a/pkgs/by-name/mo/modsecurity_standalone/package.nix
+++ b/pkgs/by-name/mo/modsecurity_standalone/package.nix
@@ -13,7 +13,6 @@
   luaSupport ? false,
   lua5,
   perl,
-  fetchpatch,
   versionCheckHook,
 }:
 
@@ -24,13 +23,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "modsecurity";
-  version = "2.9.8";
+  version = "2.9.12";
 
   src = fetchFromGitHub {
     owner = "owasp-modsecurity";
     repo = "modsecurity";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fJ5XeO5m5LlImAuzIvXVVWkc9awbaRI3NWWOOwGrshI=";
+    hash = "sha256-scMOiu8oI3+VcXe05gLNQ8ILmnP4iwls8ZZ9r+3ei5Y=";
   };
 
   nativeBuildInputs = [
@@ -61,11 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    # msc_test.c:86:5: error: initialization of 'int' from 'void *' makes integer from pointer without a cast []
-    "-Wno-error=int-conversion"
-  ];
-
   outputs = [
     "out"
     "nginx"
@@ -74,24 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     # by default modsecurity's install script copies compiled output to httpd's modules folder
     # this patch removes those lines
     ./Makefile.am.patch
-    # remove when 2.9.9 is released
-    (fetchpatch {
-      name = "move-id_log";
-      url = "https://github.com/owasp-modsecurity/ModSecurity/commit/149376377ecef9ecc36ee81d5b666fc0ac7e249b.patch";
-      hash = "sha256-KjQGqSBt/u9zPZY1aSIupnYHleJbsOAOk3Y2bNOyRxk=";
-    })
-    # remove when 2.9.9 is released
-    (fetchpatch {
-      name = "gcc-format-security";
-      url = "https://github.com/owasp-modsecurity/ModSecurity/commit/cddd9a7eb5585a9b3be1f9bdcadcace8f60f5808.patch";
-      hash = "sha256-H1wkZQ5bTQIRhlEvvvj7YCBi9qndRgHgKTnE9Cusq3I=";
-    })
-    # remove when 2.9.9 is released
-    (fetchpatch {
-      name = "gcc-incompatible-pointer-type";
-      url = "https://github.com/owasp-modsecurity/ModSecurity/commit/4919814a5cf0e7911f71856ed872b0e73b659a0a.patch";
-      hash = "sha256-9JzCtiLf43xw6i4NqQpok37es+kuWXZWKdJum28Hx4M=";
-    })
   ];
 
   doCheck = true;


### PR DESCRIPTION
Fixes CVE-2025-47947, CVE 2025-48866, CVE-2025-52891 and CVE 2025-54571.
    
https://github.com/owasp-modsecurity/ModSecurity/releases/tag/v2.9.9  
https://github.com/owasp-modsecurity/ModSecurity/releases/tag/v2.9.10  
https://github.com/owasp-modsecurity/ModSecurity/releases/tag/v2.9.11  
https://github.com/owasp-modsecurity/ModSecurity/releases/tag/v2.9.12


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 413034`
Commit: `a665b0aca2b51e394448ad79e8f3791b0f84ca49`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>modsecurity_standalone</li>
    <li>modsecurity_standalone.nginx</li>
  </ul>
</details>

### `aarch64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>modsecurity_standalone</li>
    <li>modsecurity_standalone.nginx</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
