### PR TITLE
intune-portal: 1.2405.17-jammy -> 1.2503.10-noble, fix openssl version mismatch

### DIFF
--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -6,7 +6,7 @@
   libuuid,
   xorg,
   curlMinimal,
-  openssl,
+  openssl_3,
   libsecret,
   webkitgtk_4_0,
   libsoup_2_4,
@@ -22,6 +22,11 @@
   dbus,
   nixosTests,
 }:
+let
+  curlMinimal_openssl_3 = curlMinimal.override {
+    openssl = openssl_3;
+  };
+in
 stdenv.mkDerivation rec {
   pname = "intune-portal";
   version = "1.2405.17-jammy";
@@ -40,8 +45,8 @@ stdenv.mkDerivation rec {
           stdenv.cc.cc
           libuuid
           xorg.libX11
-          curlMinimal
-          openssl
+          curlMinimal_openssl_3
+          openssl_3
           libsecret
           webkitgtk_4_0
           libsoup_2_4

--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -8,8 +8,8 @@
   curlMinimal,
   openssl_3,
   libsecret,
-  webkitgtk_4_0,
-  libsoup_2_4,
+  webkitgtk_4_1,
+  libsoup_3,
   gtk3,
   atk,
   pango,
@@ -19,6 +19,7 @@
   systemd,
   msalsdk-dbusclient,
   pam,
+  p11-kit,
   dbus,
   nixosTests,
 }:
@@ -29,11 +30,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "intune-portal";
-  version = "1.2405.17-jammy";
+  version = "1.2503.10-noble";
 
   src = fetchurl {
-    url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/i/intune-portal/intune-portal_${version}_amd64.deb";
-    hash = "sha256-WpVPWzh8jN092MaY2rMXhLfpVXsflMl9hOY9nNGJlLk=";
+    url = "https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/i/intune-portal/intune-portal_${version}_amd64.deb";
+    hash = "sha256-NlJ8m7V1yLErOntprHs3EagPtwSzYWd7NBH0jc72+i4=";
   };
 
   nativeBuildInputs = [ dpkg ];
@@ -48,12 +49,13 @@ stdenv.mkDerivation rec {
           curlMinimal_openssl_3
           openssl_3
           libsecret
-          webkitgtk_4_0
-          libsoup_2_4
+          webkitgtk_4_1
+          libsoup_3
           gtk3
           atk
           glib
           pango
+          p11-kit
           sqlite
           zlib
           systemd


### PR DESCRIPTION
Running `intune-portal` currently fails with `error:05880106:x509 certificate routines:X509_REQ_set_version:passed invalid argument:crypto/x509/x509rset.c:21`. This seems to be due to version mismatch of openssl, as original Ubuntu package expects `openssl 3.0.*` instead of `openssl 3.*.z`.

I'm relatively new to this stuff, so not sure if the override of `curlMinimal` is the correct solution.

Also upgrades package to newest version.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
