### PR TITLE
hotspot: build and run tests

### DIFF
--- a/pkgs/development/tools/analysis/hotspot/0001-fix-also-support-and-as-branch-visualization-charact.patch
+++ b/pkgs/development/tools/analysis/hotspot/0001-fix-also-support-and-as-branch-visualization-charact.patch
@@ -1,0 +1,48 @@
+From f326ef0d2f651d45ceff36050039cbccb2eac6c7 Mon Sep 17 00:00:00 2001
+From: Milian Wolff <milian.wolff@kdab.com>
+Date: Mon, 2 Sep 2024 10:10:16 +0200
+Subject: [PATCH] fix: also support ' and , as branch visualization characters
+
+My objdump from arch uses these chars now, so let's support them too
+---
+ src/resultsdisassemblypage.cpp             | 2 ++
+ tests/modeltests/tst_disassemblyoutput.cpp | 7 ++++---
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/src/resultsdisassemblypage.cpp b/src/resultsdisassemblypage.cpp
+index 229adbb..dfeb022 100644
+--- a/src/resultsdisassemblypage.cpp
++++ b/src/resultsdisassemblypage.cpp
+@@ -142,9 +142,11 @@ public:
+                 startHorizontalLine(x);
+                 verticalLine();
+                 break;
++            case '\'':
+             case '\\':
+                 topRightEdge();
+                 break;
++            case ',':
+             case '/':
+                 bottomLeftEdge();
+                 break;
+diff --git a/tests/modeltests/tst_disassemblyoutput.cpp b/tests/modeltests/tst_disassemblyoutput.cpp
+index 9a4e4d5..ebfb413 100644
+--- a/tests/modeltests/tst_disassemblyoutput.cpp
++++ b/tests/modeltests/tst_disassemblyoutput.cpp
+@@ -243,9 +243,10 @@ private slots:
+         QVERIFY(result.errorMessage.isEmpty());
+ 
+         auto isValidVisualisationCharacter = [](QChar character) {
+-            const static auto validCharacters = std::initializer_list<QChar> {
+-                QLatin1Char(' '), QLatin1Char('\t'), QLatin1Char('|'), QLatin1Char('/'), QLatin1Char('\\'),
+-                QLatin1Char('-'), QLatin1Char('>'),  QLatin1Char('+'), QLatin1Char('X')};
++            const static auto validCharacters =
++                std::initializer_list<QChar> {QLatin1Char(' '),  QLatin1Char('\t'), QLatin1Char('|'), QLatin1Char('/'),
++                                              QLatin1Char('\\'), QLatin1Char('-'),  QLatin1Char('>'), QLatin1Char('+'),
++                                              QLatin1Char('X'),  QLatin1Char(','),  QLatin1Char('\'')};
+ 
+             return std::any_of(validCharacters.begin(), validCharacters.end(),
+                                [character](auto validCharacter) { return character == validCharacter; });
+-- 
+2.49.0
+

--- a/pkgs/development/tools/analysis/hotspot/0001-fix-install-test-binaries-to-correct-paths.patch
+++ b/pkgs/development/tools/analysis/hotspot/0001-fix-install-test-binaries-to-correct-paths.patch
@@ -1,0 +1,43 @@
+From 28b2866967b78b8aa2d4d8f875ae18c7873e4cfd Mon Sep 17 00:00:00 2001
+From: Peter Collingbourne <peter@pcc.me.uk>
+Date: Sat, 31 May 2025 17:55:01 -0700
+Subject: [PATCH] fix: install test binaries to correct paths
+
+With a non-default KDE_INSTALL_EXECROOTDIR (e.g. when building with Nix)
+the tests are unable to find these binaries, so install them in the
+correct location.
+---
+ tests/modeltests/CMakeLists.txt                 | 4 ++++
+ tests/test-clients/cpp-recursion/CMakeLists.txt | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/tests/modeltests/CMakeLists.txt b/tests/modeltests/CMakeLists.txt
+index 0f667a4..a8af447 100644
+--- a/tests/modeltests/CMakeLists.txt
++++ b/tests/modeltests/CMakeLists.txt
+@@ -5,6 +5,10 @@ add_library(
+     disassembly/fib.cpp
+ )
+ 
++set_target_properties(
++    fib PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${KDE_INSTALL_EXECROOTDIR}/tests/modeltests"
++)
++
+ ecm_add_test(
+     tst_models.cpp
+     LINK_LIBRARIES
+diff --git a/tests/test-clients/cpp-recursion/CMakeLists.txt b/tests/test-clients/cpp-recursion/CMakeLists.txt
+index 53776b4..ef8fe2a 100644
+--- a/tests/test-clients/cpp-recursion/CMakeLists.txt
++++ b/tests/test-clients/cpp-recursion/CMakeLists.txt
+@@ -2,3 +2,7 @@ add_executable(
+     cpp-recursion
+     main.cpp
+ )
++
++set_target_properties(
++    cpp-recursion PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${KDE_INSTALL_EXECROOTDIR}/tests/test-clients/cpp-recursion"
++)
+-- 
+2.49.0
+

--- a/pkgs/development/tools/analysis/hotspot/default.nix
+++ b/pkgs/development/tools/analysis/hotspot/default.nix
@@ -18,6 +18,7 @@
   kparts,
   kwindowsystem,
   libelf,
+  libsForQt5,
   linuxPackages,
   qtbase,
   qtsvg,
@@ -38,6 +39,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-O2wp19scyHIwIY2AzKmPmorGXDH249/OhSg+KtzOYhI=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    ./0001-fix-install-test-binaries-to-correct-paths.patch
+    ./0001-fix-also-support-and-as-branch-visualization-charact.patch
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -67,6 +73,8 @@ stdenv.mkDerivation rec {
     zstd
   ];
 
+  doCheck = true;
+
   qtWrapperArgs = [
     "--suffix PATH : ${
       lib.makeBinPath [
@@ -81,6 +89,12 @@ stdenv.mkDerivation rec {
       --add-rpath ${lib.makeLibraryPath [ rustc-demangle ]} \
       --add-needed librustc_demangle.so \
       $out/libexec/hotspot-perfparser
+  '';
+
+  preConfigure = ''
+    # qt.qpa.plugin: Could not find the Qt platform plugin "minimal"
+    # A workaround is to set QT_PLUGIN_PATH explicitly
+    export QT_PLUGIN_PATH=${libsForQt5.qtbase.bin}/${libsForQt5.qtbase.qtPluginPrefix}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
