### PR TITLE
pd-else: init at 1.0-rc13

### DIFF
--- a/pkgs/by-name/pd/pd-else/package.nix
+++ b/pkgs/by-name/pd/pd-else/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  puredata,
+  pkg-config,
+  cmake,
+  openssl,
+  libogg,
+  libvorbis,
+  opusfile,
+  ffmpeg,
+  zlib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pd-else";
+  version = "1.0-rc13";
+
+  src = fetchFromGitHub {
+    owner = "porres";
+    repo = "pd-else";
+    tag = "v.${version}";
+    hash = "sha256-WebjdozcFup2xk3cS9LPTiA6m0l1sR6sj3hHlt6ScfU=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [
+    puredata
+    openssl
+    libogg
+    libvorbis
+    opusfile
+    ffmpeg
+    zlib
+  ];
+
+  # Set up Pure Data headers and configure with system libraries
+  preConfigure = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'add_subdirectory(Source/Shared/ffmpeg)' '# add_subdirectory(Source/Shared/ffmpeg) - using system FFmpeg' \
+      --replace-fail 'target_link_libraries(play.file_tilde PRIVATE ffmpeg)' 'target_link_libraries(play.file_tilde PRIVATE avformat avcodec avutil swresample z)' \
+      --replace-fail 'target_link_libraries(sfload PRIVATE ffmpeg)' 'target_link_libraries(sfload PRIVATE avformat avcodec avutil swresample z)' \
+      --replace-fail 'target_link_libraries(sfinfo PRIVATE ffmpeg)' 'target_link_libraries(sfinfo PRIVATE avformat avcodec avutil swresample z)'
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_C_FLAGS=-I${puredata}/include/pd"
+    "-DCMAKE_CXX_FLAGS=-I${puredata}/include/pd"
+    "-DUSE_LTO=ON"
+    "-DOPENSSL_CRYPTO_LIBRARY=${lib.getLib openssl}/lib/libcrypto.so"
+    "-DOPENSSL_SSL_LIBRARY=${lib.getLib openssl}/lib/libssl.so"
+  ];
+
+  postInstall = ''
+    mv else/ $out/else/
+    rm -rf $out/include/ $out/lib/
+  '';
+
+  postFixup = ''
+    interpreter=$(cat $NIX_CC/nix-support/dynamic-linker)
+    find $out -type f -executable -exec patchelf --set-interpreter "$interpreter" --set-rpath ${lib.makeLibraryPath buildInputs} {} \;
+  '';
+
+  meta = {
+    description = "EL Locus Solus' Externals for Pure Data";
+    longDescription = ''
+      ELSE is a library of externals and abstractions for Pure Data.
+      It provides a comprehensive set of tools for signal processing,
+      MIDI, GUI, and more in Pure Data.
+    '';
+    homepage = "https://github.com/porres/pd-else";
+    license = lib.licenses.wtfpl;
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
+    maintainers = [ lib.maintainers.kugland ];
+  };
+}


### PR DESCRIPTION
This PR adds the ELSE (EL Locus Solus' Externals) package for Pure Data, which provides a comprehensive set of externals and abstractions for signal processing, MIDI, GUI, and more in Pure Data.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
