### PR TITLE
ci/eval/compare/get-nixos-module-maintainers.nix: init

### DIFF
--- a/ci/eval/compare/get-nixos-module-maintainers.nix
+++ b/ci/eval/compare/get-nixos-module-maintainers.nix
@@ -1,0 +1,56 @@
+#!/usr/bin/env -S nix-instantiate --eval --strict --json
+/**
+  This script evaluates by default the 'meta.maintainers' and `meta.teams` of the target nixos module file and prints it as json.
+  Pipe the output through `jq '.maintainers + [.teams[].members[]] | .[] | .github' -r` to retrieve github user names
+  This script is a best-effort evaluation and makes no guarantee of being able to extract the maintainers from all files.
+  The only files we require to not cause an evaluation failure are the ones listed in `nixos/modules/module-list.nix`
+
+  Usage:
+
+    ./ci/eval/compare/get-nixos-module-maintainers.nix --arg moduleFname nixos/modules/<SOME_MODULE>
+  or
+    ./ci/eval/compare/get-nixos-module-maintainers.nix --arg moduleFname nixos/modules/<SOME_MODULE> | jq '.maintainers + [.teams[].members[]] | .[] | .github' -r
+*/
+
+{
+  pkgs ? import ../../../. { },
+  lib ? pkgs.lib,
+  # path to the nixos module to eval
+  moduleFname,
+  # change this if you want to retrieve something other than .meta.maintainers/teams
+  attrGetter ? module: {
+    maintainers = module.config.meta.maintainers or module.meta.maintainers or [ ];
+    teams = module.config.meta.teams or module.meta.teams or [ ];
+  },
+}:
+
+let
+  module = (
+    # This evaluator relies heavily on lazy-eval,
+    # and is loosely based on nixos/lib/eval-config.nix
+    lib.fix (
+      config:
+      let
+        moduleFunc = import moduleFname;
+        inputs = {
+          inherit config pkgs lib;
+          modulesPath = ./nixos/modules;
+          options = config.options or { };
+          utils = import nixos/lib/utils.nix { inherit lib config pkgs; };
+          modules = [ ];
+          baseModules = [ ];
+          extraModules = [ ];
+          specialArgs = { };
+          inherit (pkgs) buildEnv;
+        };
+      in
+      if !lib.isFunction moduleFunc then
+        moduleFunc
+      else
+        # The lib.intersectAttrs filtering also enable evaluating many 'runTest'-based nixos tests.
+        # Missing inputs become either "true" or "false" (i.e. the output from lib.functionArgs)
+        moduleFunc (lib.functionArgs moduleFunc // lib.intersectAttrs (lib.functionArgs moduleFunc) inputs)
+    )
+  );
+in
+attrGetter module

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1541,5 +1541,5 @@ in
   ]);
 
   meta.doc = ./nextcloud.md;
-  meta.maintainers = teams.nextcloud;
+  meta.maintainers = teams.nextcloud.members;
 }

--- a/nixos/tests/geoserver.nix
+++ b/nixos/tests/geoserver.nix
@@ -19,7 +19,7 @@ in
 
   name = "geoserver";
   meta = {
-    maintainers = with lib; [ teams.geospatial.members ];
+    maintainers = lib.teams.geospatial.members;
   };
 
   nodes = {


### PR DESCRIPTION
Example usage:

```shell
$ ./ci/eval/compare/get-nixos-module-maintainers.nix --arg moduleFnamenixos/modules/services/misc/polaris.nix
{"maintainers":[{"email":"pbsds@hotmail.com","github":"pbsds","githubId":140964,"matrix":"@pederbs:pvv.ntnu.no","name":"Peder Bergebakken Sundt"}],"teams":[]}

$ ./ci/eval/compare/get-nixos-module-maintainers.nix --arg moduleFname nixos/modules/services/misc/polaris.nix  | jq '.maintainers[] | .github' -r
pbsds
```

Tested with:

```shell
rg maintainers nixos/modules/ -l -tnix | xargs -d'\n' grep meta -l | sort | xe -j0 ./ci/eval/compare/get-nixos-module-maintainers/main.sh
```

Failure mode: *`meta.maintainers` does not evaluate*
* `nixos/modules/programs/vivid.nix`
* `nixos/modules/services/development/jupyter/default.nix`

These are handled in https://github.com/NixOS/nixpkgs/pull/413092

Failure mode: *not a module*
* `nixos/modules/services/hardware/sane_extra_backends/brscan4_etc_files.nix`
* `nixos/modules/services/hardware/sane_extra_backends/brscan5_etc_files.nix`
* `nixos/modules/services/x11/display-managers/account-service-util.nix`

_(should these derivations even be in `nixos/modules`?)_


Failure mode: *not a standard module but a module factory*
* `nixos/modules/services/misc/sourcehut/service.nix`

The rest evaluate.

Although this was not initially considered in scope, with the `lib.intersectAttrs` tweak I also managed to make it work for many of the nixos tests that have migrated away from `handleTest` to `runTest`:

```shell
rg maintainers nixos/tests/ -l -tnix | xargs -d'\n' grep meta -l | xargs -d'\n' grep make-test-python.nix -L | sort | xe -j0 ./maintainers/scripts/get-nixos-module-maintainers/main.sh
```

<details>
<summary>
  Eval successes (output not checked) (753)
</summary>

* `nixos/tests/activation/etc-overlay-immutable.nix`
* `nixos/tests/acme/http01-builtin.nix`
* `nixos/tests/3proxy.nix`
* `nixos/tests/acme/caddy.nix`
* `nixos/tests/aaaaxy.nix`
* `nixos/tests/acme/dns01.nix`
* `nixos/tests/activation/etc-overlay-mutable.nix`
* `nixos/tests/activation/perlless.nix`
* `nixos/tests/actual.nix`
* `nixos/tests/agda.nix`
* `nixos/tests/aesmd.nix`
* `nixos/tests/activation/var.nix`
* `nixos/tests/age-plugin-tpm-decrypt.nix`
* `nixos/tests/activation/nix-channel.nix`
* `nixos/tests/agnos.nix`
* `nixos/tests/amazon-init-shell.nix`
* `nixos/tests/airsonic.nix`
* `nixos/tests/all-terminfo.nix`
* `nixos/tests/alloy.nix`
* `nixos/tests/alps.nix`
* `nixos/tests/amazon-ssm-agent.nix`
* `nixos/tests/amd-sev.nix`
* `nixos/tests/angie-api.nix`
* `nixos/tests/anuko-time-tracker.nix`
* `nixos/tests/anubis.nix`
* `nixos/tests/anki-sync-server.nix`
* `nixos/tests/apfs.nix`
* `nixos/tests/apcupsd.nix`
* `nixos/tests/apparmor/default.nix`
* `nixos/tests/appliance-repart-image.nix`
* `nixos/tests/appliance-repart-image-verity-store.nix`
* `nixos/tests/armagetronad.nix`
* `nixos/tests/archi.nix`
* `nixos/tests/artalk.nix`
* `nixos/tests/aria2.nix`
* `nixos/tests/atd.nix`
* `nixos/tests/atuin.nix`
* `nixos/tests/audiobookshelf.nix`
* `nixos/tests/authelia.nix`
* `nixos/tests/autobrr.nix`
* `nixos/tests/auth-mysql.nix`
* `nixos/tests/ayatana-indicators.nix`
* `nixos/tests/avahi.nix`
* `nixos/tests/babeld.nix`
* `nixos/tests/bazarr.nix`
* `nixos/tests/bcachefs.nix`
* `nixos/tests/beanstalkd.nix`
* `nixos/tests/bitcoind.nix`
* `nixos/tests/bitbox-bridge.nix`
* `nixos/tests/bittorrent.nix`
* `nixos/tests/blockbook-frontend.nix`
* `nixos/tests/bootspec.nix`
* `nixos/tests/boot-stage1.nix`
* `nixos/tests/boot-stage2.nix`
* `nixos/tests/breitbandmessung.nix`
* `nixos/tests/borgbackup.nix`
* `nixos/tests/bpftune.nix`
* `nixos/tests/botamusique.nix`
* `nixos/tests/brscan5.nix`
* `nixos/tests/btrbk-doas.nix`
* `nixos/tests/btrbk.nix`
* `nixos/tests/btrbk-no-timer.nix`
* `nixos/tests/budgie.nix`
* `nixos/tests/buildbot.nix`
* `nixos/tests/buildkite-agents.nix`
* `nixos/tests/btrbk-section-order.nix`
* `nixos/tests/c2fmzq.nix`
* `nixos/tests/caddy.nix`
* `nixos/tests/cagebreak.nix`
* `nixos/tests/cage.nix`
* `nixos/tests/castopod.nix`
* `nixos/tests/calibre-web.nix`
* `nixos/tests/canaille.nix`
* `nixos/tests/centrifugo.nix`
* `nixos/tests/cgit.nix`
* `nixos/tests/charliecloud.nix`
* `nixos/tests/chromadb.nix`
* `nixos/tests/chromium.nix`
* `nixos/tests/cinnamon.nix`
* `nixos/tests/cinnamon-wayland.nix`
* `nixos/tests/cjdns.nix`
* `nixos/tests/clatd.nix`
* `nixos/tests/clickhouse.nix`
* `nixos/tests/cloud-init.nix`
* `nixos/tests/cloud-init-hostname.nix`
* `nixos/tests/cntr.nix`
* `nixos/tests/cockpit.nix`
* `nixos/tests/cloudlog.nix`
* `nixos/tests/coder.nix`
* `nixos/tests/code-server.nix`
* `nixos/tests/commafeed.nix`
* `nixos/tests/connman.nix`
* `nixos/tests/containers-bridge.nix`
* `nixos/tests/containers-extra_veth.nix`
* `nixos/tests/containers-ephemeral.nix`
* `nixos/tests/containers-hosts.nix`
* `nixos/tests/containers-custom-pkgs.nix`
* `nixos/tests/containers-imperative.nix`
* `nixos/tests/containers-ip.nix`
* `nixos/tests/containers-macvlans.nix`
* `nixos/tests/containers-names.nix`
* `nixos/tests/containers-nested.nix`
* `nixos/tests/containers-physical_interfaces.nix`
* `nixos/tests/containers-portforward.nix`
* `nixos/tests/containers-require-bind-mounts.nix`
* `nixos/tests/containers-restart_networking.nix`
* `nixos/tests/containers-tmpfs.nix`
* `nixos/tests/containers-unified-hierarchy.nix`
* `nixos/tests/convos.nix`
* `nixos/tests/couchdb.nix`
* `nixos/tests/crabfit.nix`
* `nixos/tests/croc.nix`
* `nixos/tests/cross-seed.nix`
* `nixos/tests/cryptpad.nix`
* `nixos/tests/custom-ca.nix`
* `nixos/tests/curl-impersonate.nix`
* `nixos/tests/cyrus-imap.nix`
* `nixos/tests/dae.nix`
* `nixos/tests/darling-dmg.nix`
* `nixos/tests/davis.nix`
* `nixos/tests/db-rest.nix`
* `nixos/tests/dconf.nix`
* `nixos/tests/ddns-updater.nix`
* `nixos/tests/deconz.nix`
* `nixos/tests/deepin.nix`
* `nixos/tests/deluge.nix`
* `nixos/tests/dependency-track.nix`
* `nixos/tests/devpi-server.nix`
* `nixos/tests/dex-oidc.nix`
* `nixos/tests/doas.nix`
* `nixos/tests/docker.nix`
* `nixos/tests/docker-registry.nix`
* `nixos/tests/docker-rootless.nix`
* `nixos/tests/docker-tools-cross.nix`
* `nixos/tests/docling-serve.nix`
* `nixos/tests/docker-tools-overlay.nix`
* `nixos/tests/documize.nix`
* `nixos/tests/doh-proxy-rust.nix`
* `nixos/tests/docker-tools-nix-shell.nix`
* `nixos/tests/dolibarr.nix`
* `nixos/tests/domination.nix`
* `nixos/tests/drbd-driver.nix`
* `nixos/tests/ec2.nix`
* `nixos/tests/echoip.nix`
* `nixos/tests/drbd.nix`
* `nixos/tests/dublin-traceroute.nix`
* `nixos/tests/emacs-daemon.nix`
* `nixos/tests/endlessh-go.nix`
* `nixos/tests/endlessh.nix`
* `nixos/tests/engelsystem.nix`
* `nixos/tests/enlightenment.nix`
* `nixos/tests/env.nix`
* `nixos/tests/eris-server.nix`
* `nixos/tests/ergo.nix`
* `nixos/tests/etesync-dav.nix`
* `nixos/tests/esphome.nix`
* `nixos/tests/etebase-server.nix`
* `nixos/tests/evcc.nix`
* `nixos/tests/fakeroute.nix`
* `nixos/tests/fancontrol.nix`
* `nixos/tests/fanout.nix`
* `nixos/tests/fastnetmon-advanced.nix`
* `nixos/tests/fenics.nix`
* `nixos/tests/ferm.nix`
* `nixos/tests/fedimintd.nix`
* `nixos/tests/ferretdb.nix`
* `nixos/tests/filesender.nix`
* `nixos/tests/fider.nix`
* `nixos/tests/filesystems-overlayfs.nix`
* `nixos/tests/firefly-iii-data-importer.nix`
* `nixos/tests/firefoxpwa.nix`
* `nixos/tests/firefly-iii.nix`
* `nixos/tests/firejail.nix`
* `nixos/tests/firezone/firezone.nix`
* `nixos/tests/flaresolverr.nix`
* `nixos/tests/flood.nix`
* `nixos/tests/fluidd.nix`
* `nixos/tests/fontconfig-default-fonts.nix`
* `nixos/tests/freenet.nix`
* `nixos/tests/frigate.nix`
* `nixos/tests/frp.nix`
* `nixos/tests/freeswitch.nix`
* `nixos/tests/frr.nix`
* `nixos/tests/ft2-clone.nix`
* `nixos/tests/gancio.nix`
* `nixos/tests/gemstash.nix`
* `nixos/tests/geoserver.nix`
* `nixos/tests/geoclue2.nix`
* `nixos/tests/gatus.nix`
* `nixos/tests/gerrit.nix`
* `nixos/tests/geth.nix`
* `nixos/tests/ghostunnel.nix`
* `nixos/tests/gitdaemon.nix`
* `nixos/tests/gitea.nix`
* `nixos/tests/github-runner.nix`
* `nixos/tests/git/hub.nix`
* `nixos/tests/gitlab.nix`
* `nixos/tests/gitolite-fcgiwrap.nix`
* `nixos/tests/gitolite.nix`
* `nixos/tests/glances.nix`
* `nixos/tests/glance.nix`
* `nixos/tests/glitchtip.nix`
* `nixos/tests/gnome-extensions.nix`
* `nixos/tests/gnome-flashback.nix`
* `nixos/tests/gnome.nix`
* `nixos/tests/gnome-xorg.nix`
* `nixos/tests/gns3-server.nix`
* `nixos/tests/goatcounter.nix`
* `nixos/tests/gnupg.nix`
* `nixos/tests/gobgpd.nix`
* `nixos/tests/go-camo.nix`
* `nixos/tests/gocd-agent.nix`
* `nixos/tests/gocd-server.nix`
* `nixos/tests/gokapi.nix`
* `nixos/tests/go-neb.nix`
* `nixos/tests/gopro-tool.nix`
* `nixos/tests/goss.nix`
* `nixos/tests/gotify-server.nix`
* `nixos/tests/gotenberg.nix`
* `nixos/tests/graylog.nix`
* `nixos/tests/grocy.nix`
* `nixos/tests/greetd-no-shadow.nix`
* `nixos/tests/grow-partition.nix`
* `nixos/tests/grub.nix`
* `nixos/tests/guacamole-server.nix`
* `nixos/tests/hardened.nix`
* `nixos/tests/gvisor.nix`
* `nixos/tests/haste-server.nix`
* `nixos/tests/headscale.nix`
* `nixos/tests/hedgedoc.nix`
* `nixos/tests/herbstluftwm.nix`
* `nixos/tests/hockeypuck.nix`
* `nixos/tests/hledger-web.nix`
* `nixos/tests/home-assistant.nix`
* `nixos/tests/homebox.nix`
* `nixos/tests/homepage-dashboard.nix`
* `nixos/tests/honk.nix`
* `nixos/tests/hostname.nix`
* `nixos/tests/hydra/default.nix`
* `nixos/tests/hound.nix`
* `nixos/tests/i18n.nix`
* `nixos/tests/i3wm.nix`
* `nixos/tests/icingaweb2.nix`
* `nixos/tests/ifm.nix`
* `nixos/tests/iftop.nix`
* `nixos/tests/incron.nix`
* `nixos/tests/influxdb.nix`
* `nixos/tests/influxdb2.nix`
* `nixos/tests/initrd-network.nix`
* `nixos/tests/initrd-secrets.nix`
* `nixos/tests/input-remapper.nix`
* `nixos/tests/installed-tests/default.nix`
* `nixos/tests/installer.nix`
* `nixos/tests/intune.nix`
* `nixos/tests/invidious.nix`
* `nixos/tests/iosched.nix`
* `nixos/tests/ipv6.nix`
* `nixos/tests/invoiceplane.nix`
* `nixos/tests/iscsi-multipath-root.nix`
* `nixos/tests/iscsi-root.nix`
* `nixos/tests/isolate.nix`
* `nixos/tests/isso.nix`
* `nixos/tests/jackett.nix`
* `nixos/tests/jenkins-cli.nix`
* `nixos/tests/jellyfin.nix`
* `nixos/tests/jenkins.nix`
* `nixos/tests/jibri.nix`
* `nixos/tests/jirafeau.nix`
* `nixos/tests/jitsi-meet.nix`
* `nixos/tests/jotta-cli.nix`
* `nixos/tests/kanidm.nix`
* `nixos/tests/kanidm-provisioning.nix`
* `nixos/tests/kavita.nix`
* `nixos/tests/kbd-setfont-decompress.nix`
* `nixos/tests/kea.nix`
* `nixos/tests/keepalived.nix`
* `nixos/tests/keepassxc.nix`
* `nixos/tests/kernel-latest-ath-user-regd.nix`
* `nixos/tests/keter.nix`
* `nixos/tests/kimai.nix`
* `nixos/tests/kexec.nix`
* `nixos/tests/kmonad.nix`
* `nixos/tests/knot.nix`
* `nixos/tests/komga.nix`
* `nixos/tests/ksm.nix`
* `nixos/tests/kthxbye.nix`
* `nixos/tests/kubo/kubo-fuse.nix`
* `nixos/tests/kubo/kubo.nix`
* `nixos/tests/lact.nix`
* `nixos/tests/ladybird.nix`
* `nixos/tests/languagetool.nix`
* `nixos/tests/lanraragi.nix`
* `nixos/tests/lauti.nix`
* `nixos/tests/lavalink.nix`
* `nixos/tests/leaps.nix`
* `nixos/tests/legit.nix`
* `nixos/tests/lemmy.nix`
* `nixos/tests/librenms.nix`
* `nixos/tests/libresprite.nix`
* `nixos/tests/libreswan-nat.nix`
* `nixos/tests/libreswan.nix`
* `nixos/tests/libvirtd.nix`
* `nixos/tests/libuiohook.nix`
* `nixos/tests/lidarr.nix`
* `nixos/tests/lightdm.nix`
* `nixos/tests/lighttpd.nix`
* `nixos/tests/limesurvey.nix`
* `nixos/tests/limine/bios.nix`
* `nixos/tests/limine/checksum.nix`
* `nixos/tests/limine/specialisations.nix`
* `nixos/tests/limine/secure-boot.nix`
* `nixos/tests/limine/uefi.nix`
* `nixos/tests/litellm.nix`
* `nixos/tests/litestream.nix`
* `nixos/tests/locate.nix`
* `nixos/tests/logrotate.nix`
* `nixos/tests/loki.nix`
* `nixos/tests/lomiri-calculator-app.nix`
* `nixos/tests/lomiri-camera-app.nix`
* `nixos/tests/lomiri-calendar-app.nix`
* `nixos/tests/lomiri-clock-app.nix`
* `nixos/tests/lomiri-docviewer-app.nix`
* `nixos/tests/lomiri-filemanager-app.nix`
* `nixos/tests/lomiri-gallery-app.nix`
* `nixos/tests/lomiri-mediaplayer-app.nix`
* `nixos/tests/lomiri-music-app.nix`
* `nixos/tests/lomiri-system-settings.nix`
* `nixos/tests/lxd-image-server.nix`
* `nixos/tests/lxqt.nix`
* `nixos/tests/maestral.nix`
* `nixos/tests/magic-wormhole-mailbox-server.nix`
* `nixos/tests/magnetico.nix`
* `nixos/tests/mailcatcher.nix`
* `nixos/tests/mailhog.nix`
* `nixos/tests/mailpit.nix`
* `nixos/tests/man.nix`
* `nixos/tests/marytts.nix`
* `nixos/tests/mate.nix`
* `nixos/tests/matomo.nix`
* `nixos/tests/mate-wayland.nix`
* `nixos/tests/matrix/appservice-irc.nix`
* `nixos/tests/matrix/continuwuity.nix`
* `nixos/tests/matrix/dendrite.nix`
* `nixos/tests/matrix/lk-jwt-service.nix`
* `nixos/tests/matrix/matrix-alertmanager.nix`
* `nixos/tests/matrix/mautrix-meta-postgres.nix`
* `nixos/tests/matrix/mautrix-meta-sqlite.nix`
* `nixos/tests/matrix/mjolnir.nix`
* `nixos/tests/matrix/pantalaimon.nix`
* `nixos/tests/matrix/synapse.nix`
* `nixos/tests/matter-server.nix`
* `nixos/tests/mealie.nix`
* `nixos/tests/matrix/synapse-workers.nix`
* `nixos/tests/mediamtx.nix`
* `nixos/tests/meilisearch.nix`
* `nixos/tests/merecat.nix`
* `nixos/tests/metabase.nix`
* `nixos/tests/mihomo.nix`
* `nixos/tests/mindustry.nix`
* `nixos/tests/minecraft.nix`
* `nixos/tests/minecraft-server.nix`
* `nixos/tests/minio.nix`
* `nixos/tests/miniflux.nix`
* `nixos/tests/miracle-wm.nix`
* `nixos/tests/miriway.nix`
* `nixos/tests/misc.nix`
* `nixos/tests/mobilizon.nix`
* `nixos/tests/misskey.nix`
* `nixos/tests/mod_perl.nix`
* `nixos/tests/molly-brown.nix`
* `nixos/tests/mollysocket.nix`
* `nixos/tests/monetdb.nix`
* `nixos/tests/moodle.nix`
* `nixos/tests/moonraker.nix`
* `nixos/tests/morty.nix`
* `nixos/tests/morph-browser.nix`
* `nixos/tests/mosquitto.nix`
* `nixos/tests/mpd.nix`
* `nixos/tests/mpv.nix`
* `nixos/tests/mtp.nix`
* `nixos/tests/multipass.nix`
* `nixos/tests/mumble.nix`
* `nixos/tests/munin.nix`
* `nixos/tests/music-assistant.nix`
* `nixos/tests/mutable-users.nix`
* `nixos/tests/n8n.nix`
* `nixos/tests/nar-serve.nix`
* `nixos/tests/nats.nix`
* `nixos/tests/ncdns.nix`
* `nixos/tests/ndppd.nix`
* `nixos/tests/netdata.nix`
* `nixos/tests/netbird.nix`
* `nixos/tests/networking/livekit.nix`
* `nixos/tests/networking/networkmanager.nix`
* `nixos/tests/networking-proxy.nix`
* `nixos/tests/nexus.nix`
* `nixos/tests/nginx-mime.nix`
* `nixos/tests/nginx.nix`
* `nixos/tests/nginx-proxyprotocol/default.nix`
* `nixos/tests/nginx-redirectcode.nix`
* `nixos/tests/nginx-sso.nix`
* `nixos/tests/nginx-status-page.nix`
* `nixos/tests/nimdow.nix`
* `nixos/tests/nitter.nix`
* `nixos/tests/nix/misc.nix`
* `nixos/tests/nixos-generate-config.nix`
* `nixos/tests/nix-required-mounts/default.nix`
* `nixos/tests/nix-serve-ssh.nix`
* `nixos/tests/node-red.nix`
* `nixos/tests/non-default-filesystems.nix`
* `nixos/tests/non-switchable-system.nix`
* `nixos/tests/noto-fonts-cjk-qt-default-weight.nix`
* `nixos/tests/noto-fonts.nix`
* `nixos/tests/nsd.nix`
* `nixos/tests/ntpd.nix`
* `nixos/tests/ntpd-rs.nix`
* `nixos/tests/nvidia-container-toolkit.nix`
* `nixos/tests/nvmetcfg.nix`
* `nixos/tests/nzbget.nix`
* `nixos/tests/nzbhydra2.nix`
* `nixos/tests/oci-containers.nix`
* `nixos/tests/ocis.nix`
* `nixos/tests/octoprint.nix`
* `nixos/tests/olivetin.nix`
* `nixos/tests/ollama-cuda.nix`
* `nixos/tests/ollama.nix`
* `nixos/tests/ollama-rocm.nix`
* `nixos/tests/ombi.nix`
* `nixos/tests/openarena.nix`
* `nixos/tests/openbao.nix`
* `nixos/tests/opencloud.nix`
* `nixos/tests/openresty-lua.nix`
* `nixos/tests/opensnitch.nix`
* `nixos/tests/openssh.nix`
* `nixos/tests/openstack-image.nix`
* `nixos/tests/opentabletdriver.nix`
* `nixos/tests/opentelemetry-collector.nix`
* `nixos/tests/open-webui.nix`
* `nixos/tests/openvscode-server.nix`
* `nixos/tests/orthanc.nix`
* `nixos/tests/osrm-backend.nix`
* `nixos/tests/overlayfs.nix`
* `nixos/tests/outline.nix`
* `nixos/tests/owncast.nix`
* `nixos/tests/pacemaker.nix`
* `nixos/tests/packagekit.nix`
* `nixos/tests/pam/pam-ussh.nix`
* `nixos/tests/pantheon.nix`
* `nixos/tests/pantheon-wayland.nix`
* `nixos/tests/paretosecurity.nix`
* `nixos/tests/paperless.nix`
* `nixos/tests/parsedmarc/default.nix`
* `nixos/tests/pass-secret-service.nix`
* `nixos/tests/pdns-recursor.nix`
* `nixos/tests/password-option-override-ordering.nix`
* `nixos/tests/pds.nix`
* `nixos/tests/peerflix.nix`
* `nixos/tests/peroxide.nix`
* `nixos/tests/pgadmin4.nix`
* `nixos/tests/pgbackrest/posix.nix`
* `nixos/tests/pgbackrest/sftp.nix`
* `nixos/tests/pgbouncer.nix`
* `nixos/tests/pghero.nix`
* `nixos/tests/pgmanage.nix`
* `nixos/tests/pgweb.nix`
* `nixos/tests/phosh.nix`
* `nixos/tests/photonvision.nix`
* `nixos/tests/photoprism.nix`
* `nixos/tests/pict-rs.nix`
* `nixos/tests/pingvin-share.nix`
* `nixos/tests/pinnwand.nix`
* `nixos/tests/plantuml-server.nix`
* `nixos/tests/plasma5.nix`
* `nixos/tests/plasma5-systemd-start.nix`
* `nixos/tests/plasma6.nix`
* `nixos/tests/plausible.nix`
* `nixos/tests/plasma-bigscreen.nix`
* `nixos/tests/playwright-python.nix`
* `nixos/tests/please.nix`
* `nixos/tests/plikd.nix`
* `nixos/tests/plotinus.nix`
* `nixos/tests/pocket-id.nix`
* `nixos/tests/polaris.nix`
* `nixos/tests/podgrab.nix`
* `nixos/tests/portunus.nix`
* `nixos/tests/postfixadmin.nix`
* `nixos/tests/postgrest.nix`
* `nixos/tests/postgres-websockets.nix`
* `nixos/tests/powerdns-admin.nix`
* `nixos/tests/power-profiles-daemon.nix`
* `nixos/tests/pppd.nix`
* `nixos/tests/prefect.nix`
* `nixos/tests/printing.nix`
* `nixos/tests/privatebin.nix`
* `nixos/tests/private-gpt.nix`
* `nixos/tests/prometheus-exporters.nix`
* `nixos/tests/prometheus/alertmanager-ntfy.nix`
* `nixos/tests/privoxy.nix`
* `nixos/tests/prowlarr.nix`
* `nixos/tests/proxy.nix`
* `nixos/tests/pt2-clone.nix`
* `nixos/tests/public-inbox.nix`
* `nixos/tests/pufferpanel.nix`
* `nixos/tests/pyload.nix`
* `nixos/tests/pykms.nix`
* `nixos/tests/qemu-vm-external-disk-image.nix`
* `nixos/tests/qemu-vm-store.nix`
* `nixos/tests/qemu-vm-volatile-root.nix`
* `nixos/tests/qownnotes.nix`
* `nixos/tests/qtile/default.nix`
* `nixos/tests/quake3.nix`
* `nixos/tests/quicktun.nix`
* `nixos/tests/quickwit.nix`
* `nixos/tests/quorum.nix`
* `nixos/tests/rabbitmq.nix`
* `nixos/tests/radarr.nix`
* `nixos/tests/radicale.nix`
* `nixos/tests/radicle.nix`
* `nixos/tests/ragnarwm.nix`
* `nixos/tests/rasdaemon.nix`
* `nixos/tests/rathole.nix`
* `nixos/tests/readarr.nix`
* `nixos/tests/realm.nix`
* `nixos/tests/readeck.nix`
* `nixos/tests/rebuilderd.nix`
* `nixos/tests/redlib.nix`
* `nixos/tests/redmine.nix`
* `nixos/tests/renovate.nix`
* `nixos/tests/reposilite.nix`
* `nixos/tests/restart-by-activation-script.nix`
* `nixos/tests/restic.nix`
* `nixos/tests/retroarch.nix`
* `nixos/tests/rmfakecloud.nix`
* `nixos/tests/robustirc-bridge.nix`
* `nixos/tests/roundcube.nix`
* `nixos/tests/rshim.nix`
* `nixos/tests/rspamd-trainer.nix`
* `nixos/tests/rstudio-server.nix`
* `nixos/tests/rsyncd.nix`
* `nixos/tests/rsyslogd.nix`
* `nixos/tests/rtkit.nix`
* `nixos/tests/rtorrent.nix`
* `nixos/tests/rush.nix`
* `nixos/tests/rustls-libssl.nix`
* `nixos/tests/sabnzbd.nix`
* `nixos/tests/samba.nix`
* `nixos/tests/samba-wsdd.nix`
* `nixos/tests/sanoid.nix`
* `nixos/tests/scrutiny.nix`
* `nixos/tests/saunafs.nix`
* `nixos/tests/sddm.nix`
* `nixos/tests/scx/default.nix`
* `nixos/tests/sdl3.nix`
* `nixos/tests/seafile.nix`
* `nixos/tests/searx.nix`
* `nixos/tests/seatd.nix`
* `nixos/tests/service-runner.nix`
* `nixos/tests/send.nix`
* `nixos/tests/servo.nix`
* `nixos/tests/sftpgo.nix`
* `nixos/tests/sfxr-qt.nix`
* `nixos/tests/sgt-puzzles.nix`
* `nixos/tests/shadps4.nix`
* `nixos/tests/shadow.nix`
* `nixos/tests/shattered-pixel-dungeon.nix`
* `nixos/tests/shiori.nix`
* `nixos/tests/signal-desktop.nix`
* `nixos/tests/silverbullet.nix`
* `nixos/tests/simple.nix`
* `nixos/tests/sing-box.nix`
* `nixos/tests/slimserver.nix`
* `nixos/tests/slurm.nix`
* `nixos/tests/snapcast.nix`
* `nixos/tests/smokeping.nix`
* `nixos/tests/soapui.nix`
* `nixos/tests/soft-serve.nix`
* `nixos/tests/sogo.nix`
* `nixos/tests/soju.nix`
* `nixos/tests/sonarr.nix`
* `nixos/tests/sonic-server.nix`
* `nixos/tests/spiped.nix`
* `nixos/tests/sqlite3-to-mysql.nix`
* `nixos/tests/squid.nix`
* `nixos/tests/ssh-agent-auth.nix`
* `nixos/tests/stalwart-mail.nix`
* `nixos/tests/starship.nix`
* `nixos/tests/strongswan-swanctl.nix`
* `nixos/tests/sudo-rs.nix`
* `nixos/tests/sudo.nix`
* `nixos/tests/sunshine.nix`
* `nixos/tests/suricata.nix`
* `nixos/tests/suwayomi-server.nix`
* `nixos/tests/swayfx.nix`
* `nixos/tests/swap-file-btrfs.nix`
* `nixos/tests/sway.nix`
* `nixos/tests/switch-test.nix`
* `nixos/tests/sx.nix`
* `nixos/tests/sympa.nix`
* `nixos/tests/syncthing-folders.nix`
* `nixos/tests/syncthing-init.nix`
* `nixos/tests/syncthing-many-devices.nix`
* `nixos/tests/syncthing.nix`
* `nixos/tests/syncthing-no-settings.nix`
* `nixos/tests/syncthing-relay.nix`
* `nixos/tests/sysinit-reactivation.nix`
* `nixos/tests/systemd-boot.nix`
* `nixos/tests/systemd-bpf.nix`
* `nixos/tests/systemd-credentials-tpm2.nix`
* `nixos/tests/systemd-coredump.nix`
* `nixos/tests/systemd-cryptenroll.nix`
* `nixos/tests/systemd-initrd-bridge.nix`
* `nixos/tests/systemd-initrd-luks-unl0kr.nix`
* `nixos/tests/systemd-initrd-networkd.nix`
* `nixos/tests/systemd-initrd-networkd-ssh.nix`
* `nixos/tests/systemd-initrd-vlan.nix`
* `nixos/tests/systemd-journal-gateway.nix`
* `nixos/tests/systemd-journal.nix`
* `nixos/tests/systemd-journal-upload.nix`
* `nixos/tests/systemd-lock-handler.nix`
* `nixos/tests/systemd-networkd-bridge.nix`
* `nixos/tests/systemd-networkd-dhcpserver.nix`
* `nixos/tests/systemd-networkd.nix`
* `nixos/tests/systemd-networkd-vrf.nix`
* `nixos/tests/systemd-nspawn-configfile.nix`
* `nixos/tests/systemd-repart.nix`
* `nixos/tests/systemd-resolved.nix`
* `nixos/tests/systemd-ssh-proxy.nix`
* `nixos/tests/systemd-sysupdate.nix`
* `nixos/tests/systemd-sysusers-immutable.nix`
* `nixos/tests/systemd-sysusers-mutable.nix`
* `nixos/tests/systemd-sysusers-password-option-override-ordering.nix`
* `nixos/tests/systemd-user-tmpfiles-rules.nix`
* `nixos/tests/tandoor-recipes.nix`
* `nixos/tests/tandoor-recipes-script-name.nix`
* `nixos/tests/tayga.nix`
* `nixos/tests/tang.nix`
* `nixos/tests/technitium-dns-server.nix`
* `nixos/tests/teeworlds.nix`
* `nixos/tests/telegraf.nix`
* `nixos/tests/teleport.nix`
* `nixos/tests/teleports.nix`
* `nixos/tests/terminal-emulators.nix`
* `nixos/tests/tika.nix`
* `nixos/tests/tigervnc.nix`
* `nixos/tests/timezone.nix`
* `nixos/tests/tinydns.nix`
* `nixos/tests/tinywl.nix`
* `nixos/tests/tomcat.nix`
* `nixos/tests/tor.nix`
* `nixos/tests/traefik.nix`
* `nixos/tests/trafficserver.nix`
* `nixos/tests/transfer-sh.nix`
* `nixos/tests/trickster.nix`
* `nixos/tests/trezord.nix`
* `nixos/tests/tsm-client-gui.nix`
* `nixos/tests/tuptime.nix`
* `nixos/tests/turbovnc-headless-server.nix`
* `nixos/tests/tusd/default.nix`
* `nixos/tests/tuxguitar.nix`
* `nixos/tests/txredisapi.nix`
* `nixos/tests/typesense.nix`
* `nixos/tests/tzupdate.nix`
* `nixos/tests/ucarp.nix`
* `nixos/tests/udisks2.nix`
* `nixos/tests/ulogd/ulogd.nix`
* `nixos/tests/umurmur.nix`
* `nixos/tests/unbound.nix`
* `nixos/tests/unifi.nix`
* `nixos/tests/uptermd.nix`
* `nixos/tests/uptime-kuma.nix`
* `nixos/tests/usbguard.nix`
* `nixos/tests/urn-timer.nix`
* `nixos/tests/user-activation-scripts.nix`
* `nixos/tests/userborn-immutable-etc.nix`
* `nixos/tests/userborn-immutable-users.nix`
* `nixos/tests/userborn-mutable-etc.nix`
* `nixos/tests/userborn-mutable-users.nix`
* `nixos/tests/userborn.nix`
* `nixos/tests/user-home-mode.nix`
* `nixos/tests/uwsgi.nix`
* `nixos/tests/v2ray.nix`
* `nixos/tests/vault-dev.nix`
* `nixos/tests/vault.nix`
* `nixos/tests/vdirsyncer.nix`
* `nixos/tests/vault-postgresql.nix`
* `nixos/tests/velocity.nix`
* `nixos/tests/vengi-tools.nix`
* `nixos/tests/vikunja.nix`
* `nixos/tests/virtualbox.nix`
* `nixos/tests/waagent.nix`
* `nixos/tests/wakapi.nix`
* `nixos/tests/wasabibackend.nix`
* `nixos/tests/warzone2100.nix`
* `nixos/tests/wastebin.nix`
* `nixos/tests/watchdogd.nix`
* `nixos/tests/web-apps/agorakit.nix`
* `nixos/tests/web-apps/froide-govplan.nix`
* `nixos/tests/web-apps/gotosocial.nix`
* `nixos/tests/web-apps/kanboard.nix`
* `nixos/tests/web-apps/healthchecks.nix`
* `nixos/tests/web-apps/lasuite-docs.nix`
* `nixos/tests/web-apps/movim/prosody-nginx.nix`
* `nixos/tests/web-apps/netbox-upgrade.nix`
* `nixos/tests/web-apps/nextjs-ollama-llm-ui.nix`
* `nixos/tests/web-apps/nifi.nix`
* `nixos/tests/web-apps/oncall.nix`
* `nixos/tests/web-apps/open-web-calendar.nix`
* `nixos/tests/web-apps/peering-manager.nix`
* `nixos/tests/web-apps/phylactery.nix`
* `nixos/tests/web-apps/pretalx.nix`
* `nixos/tests/web-apps/pretix.nix`
* `nixos/tests/web-apps/snipe-it.nix`
* `nixos/tests/web-apps/weblate.nix`
* `nixos/tests/web-servers/agate.nix`
* `nixos/tests/web-servers/h2o/mruby.nix`
* `nixos/tests/web-servers/stargazer.nix`
* `nixos/tests/web-servers/static-web-server.nix`
* `nixos/tests/web-servers/ttyd.nix`
* `nixos/tests/web-servers/unit-perl.nix`
* `nixos/tests/web-servers/unit-php.nix`
* `nixos/tests/wg-access-server.nix`
* `nixos/tests/whisparr.nix`
* `nixos/tests/whoogle-search.nix`
* `nixos/tests/whoami.nix`
* `nixos/tests/wiki-js.nix`
* `nixos/tests/without-nix.nix`
* `nixos/tests/wine.nix`
* `nixos/tests/wmderland.nix`
* `nixos/tests/wordpress.nix`
* `nixos/tests/xandikos.nix`
* `nixos/tests/workout-tracker.nix`
* `nixos/tests/xmonad-xdg-autostart.nix`
* `nixos/tests/xmonad.nix`
* `nixos/tests/xmpp/ejabberd.nix`
* `nixos/tests/xpadneo.nix`
* `nixos/tests/xrdp-with-audio-pulseaudio.nix`
* `nixos/tests/xrdp.nix`
* `nixos/tests/xscreensaver.nix`
* `nixos/tests/xterm.nix`
* `nixos/tests/xxh.nix`
* `nixos/tests/yarr.nix`
* `nixos/tests/your_spotify.nix`
* `nixos/tests/zammad.nix`
* `nixos/tests/yggdrasil.nix`
* `nixos/tests/zenohd.nix`
* `nixos/tests/zeronet-conservancy.nix`
* `nixos/tests/zfs.nix`
* `nixos/tests/zipline.nix`
* `nixos/tests/zoneminder.nix`
* `nixos/tests/zookeeper.nix`
* `nixos/tests/zsh-history.nix`
* `nixos/tests/zwave-js.nix`
* `nixos/tests/zwave-js-ui.nix`

</details>


<details>
<summary>
  Eval failures (43)
</summary>

* `nixos/tests/acme/webserver.nix`
* `nixos/tests/binary-cache.nix`
* `nixos/tests/calibre-server.nix`
* `nixos/tests/cosmic.nix`
* `nixos/tests/cups-pdf.nix`
* `nixos/tests/dnsdist.nix`
* `nixos/tests/discourse.nix`
* `nixos/tests/dokuwiki.nix`
* `nixos/tests/envoy.nix`
* `nixos/tests/firefox.nix`
* `nixos/tests/forgejo.nix`
* `nixos/tests/jool.nix`
* `nixos/tests/login.nix`
* `nixos/tests/mongodb.nix`
* `nixos/tests/nextcloud/basic.nix`
* `nixos/tests/nextcloud/with-declarative-redis-and-secrets.nix`
* `nixos/tests/nextcloud/with-mysql-and-memcached.nix`
* `nixos/tests/nextcloud/with-objectstore.nix`
* `nixos/tests/nextcloud/with-postgresql-and-redis.nix`
* `nixos/tests/nginx-http3.nix`
* `nixos/tests/nix/upgrade.nix`
* `nixos/tests/odoo.nix`
* `nixos/tests/php/fpm.nix`
* `nixos/tests/php/httpd.nix`
* `nixos/tests/php/pcre.nix`
* `nixos/tests/postgresql/pgjwt.nix`
* `nixos/tests/postgresql/anonymizer.nix`
* `nixos/tests/postgresql/postgresql-jit.nix`
* `nixos/tests/postgresql/postgresql.nix`
* `nixos/tests/postgresql/postgresql-tls-client-cert.nix`
* `nixos/tests/postgresql/postgresql-wal-receiver.nix`
* `nixos/tests/postgresql/wal2json.nix`
* `nixos/tests/startx.nix`
* `nixos/tests/systemd-analyze.nix`
* `nixos/tests/systemd-shutdown.nix`
* `nixos/tests/varnish.nix`
* `nixos/tests/web-apps/movim/ejabberd-h2o.nix`
* `nixos/tests/web-servers/h2o/basic.nix`
* `nixos/tests/web-servers/h2o/tls-recommendations.nix`
* `nixos/tests/wpa_supplicant.nix`
* `nixos/tests/xautolock.nix`
* `nixos/tests/xss-lock.nix`
* `nixos/tests/yabar.nix`

</details>




<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
