### PR TITLE
fittrackee: 0.9.10 -> 0.10.2

### DIFF
--- a/pkgs/by-name/fi/fittrackee/package.nix
+++ b/pkgs/by-name/fi/fittrackee/package.nix
@@ -97,6 +97,9 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/SamR1/FitTrackee";
     changelog = "https://github.com/SamR1/FitTrackee/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ traxys ];
+    maintainers = with lib.maintainers; [
+      tebriel
+      traxys
+    ];
   };
 }

--- a/pkgs/by-name/fi/fittrackee/package.nix
+++ b/pkgs/by-name/fi/fittrackee/package.nix
@@ -8,14 +8,14 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "fittrackee";
-  version = "0.9.10";
+  version = "0.10.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "SamR1";
     repo = "FitTrackee";
     tag = "v${version}";
-    hash = "sha256-004M7Uhsl0K8BX19eVU4NrvBeAyUJx/mBlC/R27y9jg=";
+    hash = "sha256-ZCQ4Ft2TSjS62DmGDpQ7gG5Spnf82v82i5nnZtg1UmA=";
   };
 
   build-system = [
@@ -24,9 +24,11 @@ python3Packages.buildPythonApplication rec {
 
   pythonRelaxDeps = [
     "authlib"
+    "flask"
     "flask-limiter"
     "flask-migrate"
     "nh3"
+    "lxml"
     "pyopenssl"
     "pytz"
     "sqlalchemy"
@@ -39,6 +41,8 @@ python3Packages.buildPythonApplication rec {
       babel
       click
       dramatiq
+      dramatiq-abort
+      fitdecode
       flask
       flask-bcrypt
       flask-dramatiq
@@ -56,8 +60,9 @@ python3Packages.buildPythonApplication rec {
       pytz
       shortuuid
       sqlalchemy
-      staticmap
+      staticmap3
       ua-parser
+      xmltodict
     ]
     ++ dramatiq.optional-dependencies.redis
     ++ flask-limiter.optional-dependencies.redis;

--- a/pkgs/development/python-modules/dramatiq-abort/default.nix
+++ b/pkgs/development/python-modules/dramatiq-abort/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  gevent,
+  pytestCheckHook,
+  pytest-cov,
+  dramatiq,
+  redis,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "dramatiq-abort";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Flared";
+    repo = "dramatiq-abort";
+    tag = "v${version}";
+    hash = "sha256-i5vL9yjQQambG8m6RDByr7/j8+PhDdLsai3pDrH1A4Q=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    dramatiq
+  ];
+
+  optional-dependencies = {
+    all = lib.flatten (lib.attrValues (lib.filterAttrs (n: v: n != "all") optional-dependencies));
+    gevent = [ gevent ];
+    redis = [ redis ];
+  };
+
+  nativeCheckInputs = [
+    redis
+    pytestCheckHook
+    pytest-cov
+  ];
+
+  pythonImportsCheck = [ "dramatiq_abort" ];
+
+  meta = {
+    changelog = "https://github.com/Flared/dramatiq-abort/releases/tag/v${version}";
+    description = "Dramatiq extension to abort message";
+    homepage = "https://github.com/Flared/dramatiq-abort";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ tebriel ];
+  };
+}

--- a/pkgs/development/python-modules/fitdecode/default.nix
+++ b/pkgs/development/python-modules/fitdecode/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "fitdecode";
+  version = "0.10.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "polyvertex";
+    repo = "fitdecode";
+    tag = "v${version}";
+    hash = "sha256-pW1PgJGqFL2reOYYfpGnQ4WoYFKGMNY8iQJzyHYOly8=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "fitdecode" ];
+
+  meta = {
+    changelog = "https://github.com/polyvertex/fitdecode/blob/${src.tag}/HISTORY.rst";
+    description = "FIT file parsing and decoding library written in Python3";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/polyvertex/fitdecode";
+    maintainers = with lib.maintainers; [ tebriel ];
+  };
+}

--- a/pkgs/development/python-modules/staticmap3/default.nix
+++ b/pkgs/development/python-modules/staticmap3/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cachecontrol,
+  filelock,
+  mypy,
+  pillow,
+  poetry-core,
+  requests,
+  ruff,
+  types-requests,
+  unittestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "staticmap3";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "SamR1";
+    repo = "staticmap";
+    tag = "v${version}";
+    hash = "sha256-SMy4yxHA9Z3BFW6kX8vC7WfsmuZMNqocJ9+dJB6zwSs=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    cachecontrol
+    requests
+    pillow
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  optional-dependencies = {
+    filecache = [ filelock ];
+    dev = [
+      mypy
+      ruff
+      types-requests
+    ];
+  };
+
+  pythonImportsCheck = [ "staticmap3" ];
+
+  meta = {
+    description = "Small, python-based library for creating map images with lines and markers";
+    homepage = "https://github.com/SamR1/staticmap";
+    changelog = "https://github.com/SamR1/staticmap/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ tebriel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16783,6 +16783,8 @@ self: super: with self; {
 
   staticmap = callPackage ../development/python-modules/staticmap { };
 
+  staticmap3 = callPackage ../development/python-modules/staticmap3 { };
+
   staticvectors = callPackage ../development/python-modules/staticvectors { };
 
   statistics = callPackage ../development/python-modules/statistics { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4205,6 +4205,8 @@ self: super: with self; {
 
   dramatiq = callPackage ../development/python-modules/dramatiq { };
 
+  dramatiq-abort = callPackage ../development/python-modules/dramatiq-abort { };
+
   drawille = callPackage ../development/python-modules/drawille { };
 
   drawilleplot = callPackage ../development/python-modules/drawilleplot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5021,6 +5021,8 @@ self: super: with self; {
 
   fitbit = callPackage ../development/python-modules/fitbit { };
 
+  fitdecode = callPackage ../development/python-modules/fitdecode { };
+
   fitfile = callPackage ../development/python-modules/fitfile { };
 
   fivem-api = callPackage ../development/python-modules/fivem-api { };


### PR DESCRIPTION
Changelog:
- https://github.com/SamR1/FitTrackee/releases/tag/v0.9.11
- https://github.com/SamR1/FitTrackee/releases/tag/v0.10.0
- https://github.com/SamR1/FitTrackee/releases/tag/v0.10.1
- https://github.com/SamR1/FitTrackee/releases/tag/v0.10.2

Relaxed deps for
- lxml (update PR: https://github.com/NixOS/nixpkgs/pull/413237)
- flask (update PR: https://github.com/NixOS/nixpkgs/pull/413238)

Introduced libraries:
- python3Packages.staticmap3: init at 0.1.0
- python3packages.fitdecode: init at 0.10.0
- python3Packages.dramatiq-abort: init at 1.2.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
