### PR TITLE
jpegli: init at 0-unstable-2025-02-11

### DIFF
--- a/pkgs/by-name/jp/jpegli/package.nix
+++ b/pkgs/by-name/jp/jpegli/package.nix
@@ -1,0 +1,84 @@
+{
+  stdenv,
+  lib,
+  asciidoc,
+  brotli,
+  cmake,
+  fetchFromGitHub,
+  giflib,
+  gtest,
+  lcms2,
+  libjpeg,
+  libhwy,
+  libpng,
+  ninja,
+  openexr,
+  pkg-config,
+  python3,
+  unstableGitUpdater,
+}:
+stdenv.mkDerivation {
+  pname = "jpegli";
+  version = "0-unstable-2025-02-11";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "jpegli";
+    rev = "bc19ca2393f79bfe0a4a9518f77e4ad33ce1ab7a";
+    hash = "sha256-8th+QHLOoAIbSJwFyaBxUXoCXwj7K7rgg/cCK7LgOb0=";
+    fetchSubmodules = true;
+  };
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    asciidoc
+    cmake
+    gtest
+    ninja
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    brotli
+    giflib
+    lcms2
+    libhwy
+    libjpeg
+    libpng
+    openexr
+  ];
+
+  cmakeFlags = [
+    "-DJPEGXL_ENABLE_JPEGLI_LIBJPEG=No"
+    "-DJPEGXL_BUNDLE_LIBPNG=No"
+    "-DJPEGXL_FORCE_SYSTEM_BROTLI=Yes"
+    "-DJPEGXL_FORCE_SYSTEM_GTEST=Yes"
+    "-DJPEGXL_FORCE_SYSTEM_LCMS2=Yes"
+    "-DJPEGXL_FORCE_SYSTEM_HWY=Yes"
+    # Enable hardware-dependent optimizations
+    "-DJPEGXL_ENABLE_SIZELESS_VECTORS=Yes"
+    "-DJPEGXL_ENABLE_AVX512=Yes"
+    "-DJPEGXL_ENABLE_AVX512_SPR=Yes"
+    "-DJPEGXL_ENABLE_AVX512_ZEN4=Yes"
+  ];
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+  };
+
+  meta = {
+    description = "Improved JPEG encoder and decoder implementation";
+    homepage = "https://github.com/google/jpegli";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ jwillikers ];
+    mainProgram = "cjpegli";
+  };
+}


### PR DESCRIPTION
[jpegli](https://github.com/google/jpegli) is an improved JPEG encoder and decoder implementation.

Fixes #361872

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
