### PR TITLE
treewide: substitute finalAttrs.pname for strings

### DIFF
--- a/pkgs/by-name/_7/_7zz/package.nix
+++ b/pkgs/by-name/_7/_7zz/package.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     install -Dm555 -t $out/bin b/*/7zz${stdenv.hostPlatform.extensions.executable}
-    install -Dm444 -t $out/share/doc/${finalAttrs.pname} ../../../../DOC/*.txt
+    install -Dm444 -t $out/share/doc/7zz ../../../../DOC/*.txt
 
     runHook postInstall
   '';

--- a/pkgs/by-name/as/as31/package.nix
+++ b/pkgs/by-name/as/as31/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.3.1";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/a/as31/${finalAttrs.pname}_${finalAttrs.version}.orig.tar.gz";
+    url = "mirror://debian/pool/main/a/as31/as31_${finalAttrs.version}.orig.tar.gz";
     name = "${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     hash = "sha256-zSEyWHFon5nyq717Mpmdv1XZ5Hz0e8ZABqsP8M83c1U=";
   };

--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "9.20.9";
 
   src = fetchurl {
-    url = "https://downloads.isc.org/isc/bind9/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    url = "https://downloads.isc.org/isc/bind9/${finalAttrs.version}/bind-${finalAttrs.version}.tar.xz";
     hash = "sha256-PSaQDtnJqFkHP/6puX4pLBJI2tGCebF7BfyyPDCR+G0=";
   };
 

--- a/pkgs/by-name/co/coal/package.nix
+++ b/pkgs/by-name/co/coal/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   postFixup = ''
     moveToOutput share/ament_index "$dev"
-    moveToOutput share/${finalAttrs.pname} "$dev"
+    moveToOutput share/coal "$dev"
   '';
 
   meta = {

--- a/pkgs/by-name/da/davis/package.nix
+++ b/pkgs/by-name/da/davis/package.nix
@@ -21,9 +21,9 @@ php.buildComposerProject2 (finalAttrs: {
   postInstall = ''
     chmod -R u+w $out/share
     # Only include the files needed for runtime in the derivation
-    mv $out/share/php/${finalAttrs.pname}/{migrations,public,src,config,bin,templates,tests,translations,vendor,symfony.lock,composer.json,composer.lock} $out
+    mv $out/share/php/davis/{migrations,public,src,config,bin,templates,tests,translations,vendor,symfony.lock,composer.json,composer.lock} $out
     # Save the upstream .env file for reference, but rename it so it is not loaded
-    mv $out/share/php/${finalAttrs.pname}/.env $out/env-upstream
+    mv $out/share/php/davis/.env $out/env-upstream
     rm -rf "$out/share"
   '';
 

--- a/pkgs/by-name/di/dirdiff/package.nix
+++ b/pkgs/by-name/di/dirdiff/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.1";
 
   src = fetchurl {
-    url = "mirror://samba/paulus/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "mirror://samba/paulus/dirdiff-${finalAttrs.version}.tar.gz";
     hash = "sha256-yzc2VNV4gCeAQ1XjVd8GlYYsO/wfaj/GAUcisxVqklI=";
   };
 

--- a/pkgs/by-name/ef/efibooteditor/package.nix
+++ b/pkgs/by-name/ef/efibooteditor/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [ "-DQT_VERSION_MAJOR=6" ];
 
   postInstall = ''
-    install -Dm644 $src/LICENSE.txt $out/share/licenses/${finalAttrs.pname}/LICENSE
+    install -Dm644 $src/LICENSE.txt $out/share/licenses/efibooteditor/LICENSE
   '';
 
   meta = {

--- a/pkgs/by-name/ex/example-robot-data/package.nix
+++ b/pkgs/by-name/ex/example-robot-data/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   # The package expect to find an `example-robot-data/robots` folder somewhere
   # either in install prefix or in the sources
   # where it can find the meshes for unit tests
-  preCheck = "ln -s source ../../${finalAttrs.pname}";
+  preCheck = "ln -s source ../../example-robot-data";
   pythonImportsCheck = [ "example_robot_data" ];
 
   meta = with lib; {

--- a/pkgs/by-name/fc/fcitx5-material-color/package.nix
+++ b/pkgs/by-name/fc/fcitx5-material-color/package.nix
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     # https://gitlab.archlinux.org/archlinux/packaging/packages/fcitx5-material-color/-/blob/main/PKGBUILD?ref_type=heads#L16
-    install -Dm644 arrow.png radio.png -t $out/share/${finalAttrs.pname}/
+    install -Dm644 arrow.png radio.png -t $out/share/fcitx5-material-color/
     for _variant in black blue brown deepPurple indigo orange pink red sakuraPink teal; do
       _variant_name=Material-Color-$_variant
       install -dm755 $_variant_name $out/share/fcitx5/themes/$_variant_name

--- a/pkgs/by-name/fi/figma-linux/package.nix
+++ b/pkgs/by-name/fi/figma-linux/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = ''
     substituteInPlace $out/share/applications/figma-linux.desktop \
-          --replace "Exec=/opt/figma-linux/figma-linux" "Exec=$out/bin/${finalAttrs.pname}"
+          --replace "Exec=/opt/figma-linux/figma-linux" "Exec=$out/bin/figma-linux"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/fm/fmi-reference-fmus/package.nix
+++ b/pkgs/by-name/fm/fmi-reference-fmus/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.0.38";
   src = fetchFromGitHub {
     owner = "modelica";
-    repo = finalAttrs.pname;
+    repo = "reference-fmus";
     rev = "v${finalAttrs.version}";
     hash = "sha256-FeDKYcm9K670q1FGqy41Tp2Ag8p2JidH4z78zpHOngw=";
   };

--- a/pkgs/by-name/ge/genesys/package.nix
+++ b/pkgs/by-name/ge/genesys/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out
     mv bin lib $out
-    wrapProgram $out/bin/${finalAttrs.pname} \
+    wrapProgram $out/bin/genesys \
       --set JAVA_HOME "${jre.home}" \
       --prefix PATH : "${graphviz}/bin"
 

--- a/pkgs/by-name/go/go-jsonnet/package.nix
+++ b/pkgs/by-name/go/go-jsonnet/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "google";
-    repo = finalAttrs.pname;
+    repo = "go-jsonnet";
     tag = "v${finalAttrs.version}";
     hash = "sha256-J92xNDpCidbiSsN6NveS6BX6Tx+qDQqkgm6pjk1wBTQ=";
   };

--- a/pkgs/by-name/ho/hottext/package.nix
+++ b/pkgs/by-name/ho/hottext/package.nix
@@ -24,9 +24,9 @@ buildNimPackage (finalAttrs: {
   desktopItem = makeDesktopItem {
     categories = [ "Utility" ];
     comment = finalAttrs.meta.description;
-    desktopName = finalAttrs.pname;
-    exec = finalAttrs.pname;
-    name = finalAttrs.pname;
+    desktopName = "hottext";
+    exec = "hottext";
+    name = "hottext";
   };
 
   postInstall = ''

--- a/pkgs/by-name/id/ideamaker/package.nix
+++ b/pkgs/by-name/id/ideamaker/package.nix
@@ -135,10 +135,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     install -D usr/lib/x86_64-linux-gnu/ideamaker/ideamaker \
-      $out/bin/${finalAttrs.pname}
+      $out/bin/ideamaker
 
     patchelf --replace-needed libquazip.so.1 libquazip1-qt5.so \
-      $out/bin/${finalAttrs.pname}
+      $out/bin/ideamaker
 
     mimetypeDir=$out/share/icons/hicolor/128x128/mimetypes
     mkdir -p ''$mimetypeDir
@@ -146,10 +146,10 @@ stdenv.mkDerivation (finalAttrs: {
       mv $file ''$mimetypeDir/''$(basename ''${file%.ico}).png
     done
     install -D ${./mimetypes.xml} \
-      $out/share/mime/packages/${finalAttrs.pname}.xml
+      $out/share/mime/packages/ideamaker.xml
 
     install -D usr/share/ideamaker/icons/ideamaker-icon.png \
-      $out/share/pixmaps/${finalAttrs.pname}.png
+      $out/share/pixmaps/ideamaker.png
 
     ln -s ${finalAttrs.desktopItem}/share/applications $out/share/
 
@@ -157,9 +157,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   desktopItem = makeDesktopItem {
-    name = finalAttrs.pname;
-    exec = finalAttrs.pname;
-    icon = finalAttrs.pname;
+    name = "ideamaker";
+    exec = "ideamaker";
+    icon = "ideamaker";
     desktopName = "Ideamaker";
     comment = "ideaMaker - www.raise3d.com";
     categories = [

--- a/pkgs/by-name/id/idnkit/package.nix
+++ b/pkgs/by-name/id/idnkit/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.3";
 
   src = fetchurl {
-    url = "https://jprs.co.jp/idn/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    url = "https://jprs.co.jp/idn/idnkit-${finalAttrs.version}.tar.bz2";
     hash = "sha256-JtBxF2UAQqtGk/DgCWAnXVihvnc+bRPFA7o4RxDz6X4=";
   };
 

--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -44,8 +44,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   desktopItems = [
     (makeDesktopItem {
-      name = finalAttrs.pname;
-      exec = finalAttrs.pname;
+      name = "irpf";
+      exec = "irpf";
       icon = "rfb64";
       desktopName = "Imposto de Renda Pessoa Física";
       comment = "Programa Oficial da Receita para elaboração do IRPF";
@@ -56,7 +56,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    BASEDIR="$out/share/${finalAttrs.pname}"
+    BASEDIR="$out/share/irpf"
     mkdir -p "$BASEDIR"
 
     cp --no-preserve=mode -r help lib lib-modulos "$BASEDIR"
@@ -64,10 +64,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     install -Dm644 irpf.jar Leia-me.htm offline.png online.png pgd-updater.jar "$BASEDIR"
 
     # make xdg-open overrideable at runtime
-    makeWrapper ${jdk11}/bin/java $out/bin/${finalAttrs.pname} \
+    makeWrapper ${jdk11}/bin/java $out/bin/irpf \
       --add-flags "-Dawt.useSystemAAFontSettings=on" \
       --add-flags "-Dswing.aatext=true" \
-      --add-flags "-jar $BASEDIR/${finalAttrs.pname}.jar" \
+      --add-flags "-jar $BASEDIR/irpf.jar" \
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
       --set _JAVA_AWT_WM_NONREPARENTING 1 \
       --set AWT_TOOLKIT MToolkit

--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -123,7 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    target="$out/lib/dotnet/${finalAttrs.pname}"
+    target="$out/lib/dotnet/keepass"
     mkdir -p "$target"
 
     cp -rv $outputFiles "$target"

--- a/pkgs/by-name/li/libconfig/package.nix
+++ b/pkgs/by-name/li/libconfig/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.8";
 
   src = fetchurl {
-    url = "https://hyperrealm.github.io/${finalAttrs.pname}/dist/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "https://hyperrealm.github.io/libconfig/dist/libconfig-${finalAttrs.version}.tar.gz";
     hash = "sha256-BR4V3Q6QfESQXzF5M/VIcxTypW6MZybIMEzpkIhIUKo=";
   };
 

--- a/pkgs/by-name/mo/movim/package.nix
+++ b/pkgs/by-name/mo/movim/package.nix
@@ -154,7 +154,7 @@ php.buildComposerProject2 (finalAttrs: {
     mkdir -p $out/bin
     cat << EOF > $out/bin/movim
     #!${lib.getExe dash}
-    ${lib.getExe finalAttrs.php} $out/share/php/${finalAttrs.pname}/daemon.php "\$@"
+    ${lib.getExe finalAttrs.php} $out/share/php/movim/daemon.php "\$@"
     EOF
     chmod +x $out/bin/movim
 

--- a/pkgs/by-name/my/mya/package.nix
+++ b/pkgs/by-name/my/mya/package.nix
@@ -44,9 +44,9 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     # Based on the upstream PKGBUILD
-    mkdir -p $out/share/doc/${finalAttrs.pname}
+    mkdir -p $out/share/doc/mya
     cp -a bin $out
-    cp $cmakeDir/README.md $out/share/doc/${finalAttrs.pname}
+    cp $cmakeDir/README.md $out/share/doc/mya
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -126,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "NETGEN_VERSION_GIT" "v${finalAttrs.version}-0")
     (lib.cmakeFeature "NG_INSTALL_DIR_BIN" "bin")
     (lib.cmakeFeature "NG_INSTALL_DIR_LIB" "lib")
-    (lib.cmakeFeature "NG_INSTALL_DIR_CMAKE" "lib/cmake/${finalAttrs.pname}")
+    (lib.cmakeFeature "NG_INSTALL_DIR_CMAKE" "lib/cmake/netgen")
     (lib.cmakeFeature "NG_INSTALL_DIR_PYTHON" python3Packages.python.sitePackages)
     (lib.cmakeFeature "NG_INSTALL_DIR_RES" "share")
     (lib.cmakeFeature "NG_INSTALL_DIR_INCLUDE" "include")
@@ -160,11 +160,11 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall =
     lib.optionalString stdenv.hostPlatform.isDarwin ''
       rm $out/bin/{Netgen1,startup.sh}
-      mkdir -p $out/Applications/${finalAttrs.pname}.app/Contents/{MacOS,Resouces}
+      mkdir -p $out/Applications/netgen.app/Contents/{MacOS,Resouces}
       substituteInPlace $out/Info.plist --replace-fail "Netgen1" "netgen"
-      mv $out/Info.plist $out/Applications/${finalAttrs.pname}.app/Contents
-      mv $out/Netgen.icns $out/Applications/${finalAttrs.pname}.app/Contents/Resouces
-      ln -s $out/bin/netgen $out/Applications/${finalAttrs.pname}.app/Contents/MacOS/netgen
+      mv $out/Info.plist $out/Applications/netgen.app/Contents
+      mv $out/Netgen.icns $out/Applications/netgen.app/Contents/Resouces
+      ln -s $out/bin/netgen $out/Applications/netgen.app/Contents/MacOS/netgen
     ''
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       # Extract pngs from the Apple icon image and create

--- a/pkgs/by-name/oa/oakctl/package.nix
+++ b/pkgs/by-name/oa/oakctl/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/bin
-    install -D -m 0755 $src $out/bin/${finalAttrs.pname}
+    install -D -m 0755 $src $out/bin/oakctl
 
     runHook postInstall
   '';

--- a/pkgs/by-name/oc/ocelot-desktop/package.nix
+++ b/pkgs/by-name/oc/ocelot-desktop/package.nix
@@ -77,14 +77,14 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       runHook preInstall
 
-      mkdir -p $out/{bin,share/${finalAttrs.pname}}
-      install -Dm644 ${finalAttrs.src} $out/share/${finalAttrs.pname}/ocelot-desktop.jar
+      mkdir -p $out/{bin,share/ocelot-desktop}
+      install -Dm644 ${finalAttrs.src} $out/share/ocelot-desktop/ocelot-desktop.jar
 
       makeBinaryWrapper ${jre}/bin/java $out/bin/ocelot-desktop \
         --set JAVA_HOME ${jre.home} \
         --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}" \
         --prefix PATH : "${lib.makeBinPath runtimePrograms}" \
-        --add-flags "-jar $out/share/${finalAttrs.pname}/ocelot-desktop.jar"
+        --add-flags "-jar $out/share/ocelot-desktop/ocelot-desktop.jar"
 
       # copy icons from zip file
       # ocelot/desktop/images/icon*.png
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       for size in 16 32 64 128 256; do
         mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-        unzip -p $out/share/${finalAttrs.pname}/ocelot-desktop.jar \
+        unzip -p $out/share/ocelot-desktop/ocelot-desktop.jar \
           ocelot/desktop/images/icon"$size".png > $out/share/icons/hicolor/"$size"x"$size"/apps/ocelot-desktop.png
       done
 

--- a/pkgs/by-name/pa/payload_dumper/package.nix
+++ b/pkgs/by-name/pa/payload_dumper/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    sitePackages=$out/${python3.sitePackages}/${finalAttrs.pname}
+    sitePackages=$out/${python3.sitePackages}/payload_dumper
 
     install -D ./payload_dumper.py $out/bin/payload_dumper
     install -D ./update_metadata_pb2.py $sitePackages/update_metadata_pb2.py

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "picolibc";
-    repo = finalAttrs.pname;
+    repo = "picolibc";
     tag = finalAttrs.version;
     hash = "sha256-djOZKkinsaaYD4tUEA6mKdo+5em0GP1/+rI0mIm7Vs8=";
   };

--- a/pkgs/by-name/pi/pixelfed/package.nix
+++ b/pkgs/by-name/pi/pixelfed/package.nix
@@ -23,7 +23,7 @@ php.buildComposerProject2 (finalAttrs: {
 
   postInstall = ''
     chmod -R u+w $out/share
-    mv "$out/share/php/${finalAttrs.pname}"/* $out
+    mv "$out/share/php/pixelfed"/* $out
     rm -R $out/bootstrap/cache
     # Move static contents for the NixOS module to pick it up, if needed.
     mv $out/bootstrap $out/bootstrap-static

--- a/pkgs/by-name/sc/scmutils/package.nix
+++ b/pkgs/by-name/sc/scmutils/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "20230902";
 
   src = fetchurl {
-    url = "https://groups.csail.mit.edu/mac/users/gjs/6946/mechanics-system-installation/native-code/${finalAttrs.pname}-src-${finalAttrs.version}.tar.gz";
+    url = "https://groups.csail.mit.edu/mac/users/gjs/6946/mechanics-system-installation/native-code/scmutils-src-${finalAttrs.version}.tar.gz";
     hash = "sha256-9/shOxoKwJ4uDTHmvXqhemgy3W+GUCmoqFm5e1t3W0M=";
   };
 

--- a/pkgs/by-name/sn/snes9x/package.nix
+++ b/pkgs/by-name/sn/snes9x/package.nix
@@ -106,9 +106,9 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     install -Dm755 snes9x -t "$out/bin/"
-    install -Dm644 snes9x.conf.default -t "$out/share/doc/${finalAttrs.pname}/"
+    install -Dm644 snes9x.conf.default -t "$out/share/doc/snes9x/"
     install -Dm644 ../docs/{control-inputs,controls,snapshots}.txt -t \
-      "$out/share/doc/${finalAttrs.pname}/"
+      "$out/share/doc/snes9x/"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/sr/srb2/package.nix
+++ b/pkgs/by-name/sr/srb2/package.nix
@@ -90,8 +90,8 @@ stdenv.mkDerivation (finalAttrs: {
   desktopItems = [
     (makeDesktopItem rec {
       name = "Sonic Robo Blast 2";
-      exec = finalAttrs.pname;
-      icon = finalAttrs.pname;
+      exec = "srb2";
+      icon = "srb2";
       comment = finalAttrs.meta.description;
       desktopName = name;
       genericName = name;

--- a/pkgs/by-name/sr/srb2kart/package.nix
+++ b/pkgs/by-name/sr/srb2kart/package.nix
@@ -73,8 +73,8 @@ stdenv.mkDerivation (finalAttrs: {
   desktopItems = [
     (makeDesktopItem rec {
       name = "Sonic Robo Blast 2 Kart";
-      exec = finalAttrs.pname;
-      icon = finalAttrs.pname;
+      exec = "srb2kart";
+      icon = "srb2kart";
       comment = "Kart racing mod based on SRB2";
       desktopName = name;
       genericName = name;

--- a/pkgs/by-name/st/stardust/package.nix
+++ b/pkgs/by-name/st/stardust/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.13";
 
   src = fetchurl {
-    url = "http://iwar.free.fr/spip/IMG/gz/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "http://iwar.free.fr/spip/IMG/gz/stardust-${finalAttrs.version}.tar.gz";
     hash = "sha256-t5cykB5zHYYj4tlk9QDhL7YQVgEScBZw9OIVXz5NOqc=";
   };
 

--- a/pkgs/by-name/st/stegsolve/package.nix
+++ b/pkgs/by-name/st/stegsolve/package.nix
@@ -23,10 +23,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   desktopItems = [
     (makeDesktopItem {
       type = "Application";
-      name = finalAttrs.pname;
+      name = "stegsolve";
       desktopName = "Stegsolve";
       comment = "A steganographic image analyzer, solver and data extractor for challanges";
-      exec = finalAttrs.pname;
+      exec = "stegsolve";
       categories = [ "Graphics" ];
     })
   ];

--- a/pkgs/by-name/st/stretchly/package.nix
+++ b/pkgs/by-name/st/stretchly/package.nix
@@ -27,21 +27,21 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/share/${finalAttrs.pname}/
-    mv resources/app.asar* $out/share/${finalAttrs.pname}/
+    mkdir -p $out/bin $out/share/stretchly/
+    mv resources/app.asar* $out/share/stretchly/
 
     mkdir -p $out/share/applications
     ln -s ${finalAttrs.desktopItem}/share/applications/* $out/share/applications/
 
-    makeWrapper ${electron}/bin/electron $out/bin/${finalAttrs.pname} \
-      --add-flags $out/share/${finalAttrs.pname}/app.asar
+    makeWrapper ${electron}/bin/electron $out/bin/stretchly \
+      --add-flags $out/share/stretchly/app.asar
 
     runHook postInstall
   '';
 
   desktopItem = makeDesktopItem {
-    name = finalAttrs.pname;
-    exec = finalAttrs.pname;
+    name = "stretchly";
+    exec = "stretchly";
     icon = finalAttrs.icon;
     desktopName = "Stretchly";
     genericName = "Stretchly";

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -51,10 +51,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,lib/${finalAttrs.pname}}
-    mv {dist,node_modules} $out/lib/${finalAttrs.pname}
-    chmod a+x $out/lib/${finalAttrs.pname}/dist/index.js
-    ln -s $out/lib/${finalAttrs.pname}/dist/index.js $out/bin/stylelint-lsp
+    mkdir -p $out/{bin,lib/stylelint-lsp}
+    mv {dist,node_modules} $out/lib/stylelint-lsp
+    chmod a+x $out/lib/stylelint-lsp/dist/index.js
+    ln -s $out/lib/stylelint-lsp/dist/index.js $out/bin/stylelint-lsp
 
     runHook postInstall
   '';

--- a/pkgs/by-name/st/styluslabs-write/package.nix
+++ b/pkgs/by-name/st/styluslabs-write/package.nix
@@ -75,13 +75,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     for i in 16 24 48 64 96 128 256 512; do
       mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
-      magick scribbleres/write_512.png -resize ''${i}x''${i} $out/share/icons/hicolor/''${i}x''${i}/apps/${finalAttrs.pname}.png
+      magick scribbleres/write_512.png -resize ''${i}x''${i} $out/share/icons/hicolor/''${i}x''${i}/apps/styluslabs-write.png
     done
 
     install -Dm444 scribbleres/linux/Write.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/Write.desktop \
         --replace-fail 'Exec=/opt/Write/Write' 'Exec=Write' \
-        --replace-fail 'Icon=Write144x144' 'Icon=${finalAttrs.pname}'
+        --replace-fail 'Icon=Write144x144' 'Icon=styluslabs-write'
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/te/texpresso/package.nix
+++ b/pkgs/by-name/te/texpresso/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    install -Dm0755 -t "$out/bin/" "build/${finalAttrs.pname}"
+    install -Dm0755 -t "$out/bin/" "build/texpresso"
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ti/ticktick/package.nix
+++ b/pkgs/by-name/ti/ticktick/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   unpackPhase = ''
     runHook preUnpack
 
-    mkdir -p "$out/share" "$out/opt/${finalAttrs.pname}" "$out/bin"
+    mkdir -p "$out/share" "$out/opt/ticktick" "$out/bin"
     dpkg-deb --fsys-tarfile "$src" | tar --extract --directory="$out"
 
     runHook postUnpack
@@ -66,13 +66,13 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    cp -av $out/opt/TickTick/* $out/opt/${finalAttrs.pname}
+    cp -av $out/opt/TickTick/* $out/opt/ticktick
     cp -av $out/usr/share/* $out/share
     rm -rf $out/usr $out/opt/TickTick
-    ln -sf "$out/opt/${finalAttrs.pname}/${finalAttrs.pname}" "$out/bin/${finalAttrs.pname}"
+    ln -sf "$out/opt/ticktick/ticktick" "$out/bin/ticktick"
 
-    substituteInPlace "$out/share/applications/${finalAttrs.pname}.desktop" \
-      --replace "Exec=/opt/TickTick/ticktick" "Exec=$out/bin/${finalAttrs.pname}"
+    substituteInPlace "$out/share/applications/ticktick.desktop" \
+      --replace "Exec=/opt/TickTick/ticktick" "Exec=$out/bin/ticktick"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/tt/ttaenc/package.nix
+++ b/pkgs/by-name/tt/ttaenc/package.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     # Copy docs
-    install -dm755 "$out/share/doc/${finalAttrs.pname}"
-    install -m644 "ChangeLog-${finalAttrs.version}" README "$out/share/doc/${finalAttrs.pname}"
+    install -dm755 "$out/share/doc/ttaenc"
+    install -m644 "ChangeLog-${finalAttrs.version}" README "$out/share/doc/ttaenc"
   '';
 
   meta = {

--- a/pkgs/by-name/uf/ufetch/package.nix
+++ b/pkgs/by-name/uf/ufetch/package.nix
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin $out/share/licenses/${finalAttrs.pname}
+    mkdir -p $out/bin $out/share/licenses/ufetch
     ${
       if !full then
         "install -Dm755 ufetch-${osName} $out/bin/ufetch"
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
           ln -s $out/bin/ufetch-${osName} $out/bin/ufetch
         ''
     }
-    install -Dm644 LICENSE $out/share/licenses/${finalAttrs.pname}/LICENSE
+    install -Dm644 LICENSE $out/share/licenses/ufetch/LICENSE
     runHook postInstall
   '';
 

--- a/pkgs/by-name/un/untie/package.nix
+++ b/pkgs/by-name/un/untie/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "untie";
   version = "0.3";
   src = fetchurl {
-    url = "http://guichaz.free.fr/untie/files/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    url = "http://guichaz.free.fr/untie/files/untie-${finalAttrs.version}.tar.bz2";
     sha256 = "1334ngvbi4arcch462mzi5vxvxck4sy1nf0m58116d9xmx83ak0m";
   };
 

--- a/pkgs/by-name/wh/whatsie/package.nix
+++ b/pkgs/by-name/wh/whatsie/package.nix
@@ -24,10 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   desktopItems = [
     (makeDesktopItem {
-      name = finalAttrs.pname;
+      name = "whatsie";
       desktopName = "Whatsie";
-      icon = finalAttrs.pname;
-      exec = finalAttrs.pname;
+      icon = "whatsie";
+      exec = "whatsie";
       comment = finalAttrs.meta.description;
     })
   ];

--- a/pkgs/by-name/xe/xeus/package.nix
+++ b/pkgs/by-name/xe/xeus/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "jupyter-xeus";
-    repo = finalAttrs.pname;
+    repo = "xeus";
     tag = finalAttrs.version;
     hash = "sha256-nR247SGnc3TSj6PCrJmY6ccACvYKeSYFMgoawyYLBNs=";
   };

--- a/pkgs/by-name/zc/zcfan/package.nix
+++ b/pkgs/by-name/zc/zcfan/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    $out/bin/${finalAttrs.pname} -h
+    $out/bin/zcfan -h
 
     runHook postInstallCheck
   '';

--- a/pkgs/by-name/zs/zsh-forgit/package.nix
+++ b/pkgs/by-name/zs/zsh-forgit/package.nix
@@ -40,7 +40,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     install -D bin/git-forgit $out/bin/git-forgit
     install -D completions/_git-forgit $out/share/zsh/site-functions/_git-forgit
-    install -D forgit.plugin.zsh $out/share/zsh/${finalAttrs.pname}/forgit.plugin.zsh
+    install -D forgit.plugin.zsh $out/share/zsh/zsh-forgit/forgit.plugin.zsh
     wrapProgram $out/bin/git-forgit \
       --prefix PATH : ${
         lib.makeBinPath [


### PR DESCRIPTION
Based on https://github.com/NixOS/nixpkgs/pull/410679, this time targeting `finalAttrs.pname`. Limited to `pkgs/by-name`, part of https://github.com/NixOS/nixpkgs/issues/346453
I widened the grep to allow for more patterns where `finalAttrs.pname` are used.

Should be zero rebuilds.

All candidates were made using:

```bash
#!/usr/bin/env nix-shell
#!nix-shell -I nixpkgs=. --pure -i bash -p ripgrep sd jq git git-wait lix util-linux

# not suprises plz
export NIX_PATH= # no nixpkgs-overlays
export NIXPKGS_CONFIG=

export NIXPKGS_ALLOW_UNFREE=1
export NIXPKGS_ALLOW_INSECURE=1
export NIXPKGS_ALLOW_BROKEN=1

git-wait restore .

test -s packages.json || ( set -x;
  time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --drv-path --out-path --show-trace --no-allow-import-from-derivation --arg config '{ allowAliases = false; }' > packages.json
)

list_attrpath_fname_col() {
    jq <packages.json 'to_entries[] | select(.value.meta.position==null|not) | "\(.key)\t\(.value.meta.position)"' -r |
        sed -e "s#\t$(realpath .)/#\t#" |
        sed -e 's#:\([0-9]*\)$#\t\1#' |
        grep . |
        grep -iv haskell |
        grep -iv /top-level/ |
        grep -iv chicken |
        grep pkgs/by-name/ |
        grep -iv build |
        grep -E '/(package|default)\.nix'
}

tmp_uid="ZaeDuash6dae1eochai4quuethie3biemahThe1Aenahng9ied" # pwgen -n 50

while read attrpath fname col; do
    grep -qE '\b(repo|exec|icon) *= *("\$\{finalAttrs\.pname\}"|finalAttrs\.pname);' "$fname" ||
    grep -qF '/${finalAttrs.pname}' "$fname" ||
    grep -qF '${finalAttrs.pname}/' "$fname" || continue

    echo | (

        echo "$attrpath"
        data="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)" || exit
        test -n "$data" || exit
        pname="$(jq <<<"$data" .pname -r)"
        test -n "$pname" || exit

        (set -x
            sd -F '"${finalAttrs.pname}-${finalAttrs.version}' "$tmp_uid" "$fname" # avoid changing this pattern, this is better addressed with more targeted treewides

            sd -F '${finalAttrs.pname}'   "$pname"         "$fname"
            sd -F ' = finalAttrs.pname;'  " = \"$pname\";" "$fname"

            sd -F "$tmp_uid" '"${finalAttrs.pname}-${finalAttrs.version}' "$fname" # revert tmp_uid
        )

        data2="$(nix eval --log-format raw --impure --expr 'with import ./. {}; lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) { inherit ('"$attrpath"') pname drvPath passthru meta; drvPath2='"$attrpath"'.src.drvPath; }' --json)"
        if [[ "$data" = "$data2" ]]; then
            (set -x; git-wait add "$fname")
        else
            (set -x; git-wait restore "$fname")
            exit
        fi

    )

done < <(list_attrpath_fname_col)

git restore .

time nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta --drv-path --out-path --show-trace --no-allow-import-from-derivation --arg config '{ allowAliases = false; }' > packages2.json
```

`diff packages{,2}.json` is empty, indicating that no package nor src derivation has changed, nor have I introduced any eval failures.
I checked and cherry-picked the changes using `GIT_DIFF_OPTS='-u20' git -c interactive.singleKey=true add --patch` along to some music. I then tested merging against master, staging and staging-next


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
