### PR TITLE
lib/types: init types.setWith

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -139,6 +139,13 @@ checkConfigOutput '^true$' config.assertion ./gvariant.nix
 
 checkConfigOutput '"ok"' config.result ./specialArgs-lib.nix
 
+checkConfigOutput 'true' config.result ./set-with-submodule.nix ./set-with-submodule-explicit-keys.nix
+checkConfigOutput 'true' config.result ./set-with-submodule.nix ./set-with-submodule-default-keys.nix
+checkConfigError 'The option .*\[definition 1-entry 1\].* was accessed but has no value defined.*' config.set ./set-with-submodule.nix ./set-with-submodule-key-with-merge-error.nix
+
+checkConfigOutput 'true' config.result ./set-with-str.nix ./set-with-str-mergable.nix
+checkConfigError 'The option .set\."\[definition key:.A.\]". has conflicting definition values' config.set ./set-with-str-non-mergable.nix
+
 # https://github.com/NixOS/nixpkgs/pull/131205
 # We currently throw this error already in `config`, but throwing in `config.wrong1` would be acceptable.
 checkConfigError 'It seems as if you.re trying to declare an option by placing it into .config. rather than .options.' config.wrong1 ./error-mkOption-in-config.nix

--- a/lib/tests/modules/set-with-str-mergable.nix
+++ b/lib/tests/modules/set-with-str-mergable.nix
@@ -1,0 +1,24 @@
+{ config, ... }:
+{
+  imports = [
+    {
+      set = [
+        "foo"
+      ];
+    }
+    {
+      set = [
+        "bar"
+      ];
+    }
+    {
+      result =
+        assert
+          config.set == [
+            "bar"
+            "foo"
+          ];
+        true;
+    }
+  ];
+}

--- a/lib/tests/modules/set-with-str-non-mergable.nix
+++ b/lib/tests/modules/set-with-str-non-mergable.nix
@@ -1,0 +1,29 @@
+{ lib, ... }:
+let
+  inherit (lib) types mkOption;
+in
+{
+  imports = [
+    {
+      options.set = mkOption {
+        apply = v: lib.deepSeq v v;
+        type = types.setWith {
+          elemType = types.str;
+          # Every element has the same key
+          toKey = str: "A";
+        };
+      };
+    }
+    {
+      set = [
+        "foo"
+      ];
+    }
+    {
+      # Cannot merge because "foo" != "bar"
+      set = [
+        "bar"
+      ];
+    }
+  ];
+}

--- a/lib/tests/modules/set-with-str.nix
+++ b/lib/tests/modules/set-with-str.nix
@@ -1,0 +1,17 @@
+{ lib, ... }:
+let
+  inherit (lib) types mkOption;
+in
+{
+  imports = [
+    {
+      options.set = mkOption {
+        type = types.setWith {
+          elemType = types.str;
+          toKey = str: str;
+        };
+      };
+      options.result = mkOption { };
+    }
+  ];
+}

--- a/lib/tests/modules/set-with-submodule-default-keys.nix
+++ b/lib/tests/modules/set-with-submodule-default-keys.nix
@@ -1,0 +1,48 @@
+# Merge submodules by their individual key
+{ config, lib, ... }:
+{
+  imports = [
+    {
+      set = [
+        {
+          bar = "bar";
+          foo = "foo";
+          # -> key = "foobar";
+        }
+      ];
+    }
+    {
+      set = [
+        {
+          foo = "foo";
+          bar = "bar";
+          # -> key = "foobar";
+        }
+        {
+          key = "xx";
+        }
+      ];
+    }
+    {
+      set = lib.types.setRemove [
+        {
+          foo = "x";
+          bar = "x";
+          # -> remove key = "xx";
+        }
+      ];
+    }
+    {
+      result =
+        assert
+          config.set == [
+            {
+              foo = "foofoo";
+              bar = "barbar";
+              key = "foofoobarbar";
+            }
+          ];
+        true;
+    }
+  ];
+}

--- a/lib/tests/modules/set-with-submodule-explicit-keys.nix
+++ b/lib/tests/modules/set-with-submodule-explicit-keys.nix
@@ -1,0 +1,54 @@
+# Merge partially defined submodules by key
+{ config, lib, ... }:
+{
+  imports = [
+    {
+      set = [
+        # Partial submodule, can evaluate, because we set key explizitly,
+        # the default of the module would throw
+        {
+          key = "A";
+          foo = "foo";
+        }
+      ];
+    }
+    {
+      set = [
+        {
+          key = "A";
+          bar = "bar";
+        }
+      ];
+    }
+    {
+      set = [
+        {
+          key = "B";
+          foo = "foo";
+          bar = "bar";
+        }
+      ];
+    }
+    # Merge remove evaluates lazy
+    {
+      set = lib.types.setRemove [
+        {
+          key = "B";
+          foo = "foo";
+        }
+      ];
+    }
+    {
+      result =
+        assert
+          config.set == [
+            {
+              foo = "foo";
+              bar = "bar";
+              key = "A";
+            }
+          ];
+        true;
+    }
+  ];
+}

--- a/lib/tests/modules/set-with-submodule-key-with-merge-error.nix
+++ b/lib/tests/modules/set-with-submodule-key-with-merge-error.nix
@@ -1,0 +1,13 @@
+{
+  imports = [
+    {
+      set = [
+        # Partial submodule, cannot evaluate
+        # Because the default 'key = config.foo + config.bar;'
+        {
+          foo = "foo";
+        }
+      ];
+    }
+  ];
+}

--- a/lib/tests/modules/set-with-submodule.nix
+++ b/lib/tests/modules/set-with-submodule.nix
@@ -1,0 +1,30 @@
+{ lib, ... }:
+let
+  inherit (lib) types mkOption;
+in
+{
+  imports = [
+    {
+      options.set = mkOption {
+        # Because tests dont pass --strict
+        apply = v: lib.deepSeq v v;
+        type = types.setWith {
+          elemType = types.submodule (
+            { config, ... }:
+            {
+              options.key = mkOption {
+                type = types.str;
+                # Default for the key depends on both 'foo' and ''bar'
+                default = config.foo + config.bar;
+              };
+              options.foo = mkOption { };
+              options.bar = mkOption { };
+            }
+          );
+          toKey = m: m.key;
+        };
+      };
+      options.result = mkOption { };
+    }
+  ];
+}

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -451,6 +451,53 @@ Composed types are types that take a type as parameter. `listOf
 
       Displays the option as `foo.<id>` in the manual.
 
+`types.setWith` { *`elemType`*, *`toKey`* }
+
+:   A list of elements where all the elements are of *`elemType`* type.
+
+    **Parameters**
+
+    `elemType` (Required)
+    : Specifies the type of the values contained in the list.
+
+    `toKey` (value -> str)
+    : A function that gets the value of an element as argument and returns a string that is used for deduplication.
+      The output is produced by merging entries into a single entry using the `key` returned from this function.
+
+    **Interactions**
+
+    ```nix
+    types.setWith {
+      elemType = types.str;
+      toKey = v: v;
+    }
+    ```
+
+    Deduplicates strings by their value.
+
+    **Removing items**
+
+    ```nix
+    # One module defines
+    set = [ "foo" "bar" "bar" ]
+    # Other module defines
+    set = [ "foo" "bar" ]
+    # Another module defines
+    set = lib.types.setRemove [ "foo" ]
+    => [ "bar" ]
+    ```
+
+    **mkOverride**
+
+    Using `mkOveride` such as `mkForce` overrides all prior definitions of the set including `setRemove`
+    When using `mkForce` and `setRemove` together the `setRemove` needs to be defined inside `mkForce`
+
+    Example: `mkForce (setRemove [ "foo" ])`
+
+    **order**
+
+    Using `mkOrder` properties such as `mkBefore` or `mkAfter` is not supported.
+
 
 `types.uniq` *`t`*
 


### PR DESCRIPTION
Create a new set type. Behaves like `listOf` except:
The merged value doesn't contain duplicates. (according to `key`)

Every users must define a `toKey` function which is used for deduplication. This type guarantees  that every `key` exists exactly once.

To remove elements from a set the user can use `setRemove [ elem ]`

All definitions of `set [ elemA elemB ]` and `setRemove [ elemB elemC ]` are merged
Resulting in `set [ elemA ] = Just [ elemA ]`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
