### PR TITLE
unibear: init at 0.4.2

### DIFF
--- a/pkgs/by-name/un/unibear/package.nix
+++ b/pkgs/by-name/un/unibear/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+let
+  os-arch-options = {
+    aarch64-darwin = {
+      name = "unibear-darwin_aarch64-apple-darwin";
+      hash = "sha256-kYfL+ou4SlZChiaNZOscSzGZSIdiZpJ3QnGBPgtpJ5U=";
+    };
+    aarch64-linux = {
+      name = "unibear-linux_aarch64-unknown-linux-gnu";
+      hash = "sha256-BYu4wvv80yThc9O3pUMCAGJQkaVzlVbgIvIXUf6hhro=";
+    };
+    x86_64-darwin = {
+      name = "unibear-darwin_x86_64-apple-darwin";
+      hash = "sha256-u7wDsHiFyRyQiIr05hMmtbEABzRuJsLFLPZdY1SKmG4=";
+    };
+    x86_64-linux = {
+      name = "unibear-linux_x86_64-unknown-linux-gnu";
+      hash = "sha256-4ahYZvdrRBIeI9+xV6SL+03JQALiq83hGmq5ZEZnIPA=";
+    };
+  };
+  name-hash =
+    os-arch-options."${stdenvNoCC.hostPlatform.system}"
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "unibear";
+  version = "0.4.2";
+
+  src = fetchurl {
+    url = "https://github.com/kamilmac/unibear/releases/download/v${finalAttrs.version}/${name-hash.name}";
+    inherit (name-hash) hash;
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install "$src" -Dm755 "$out"/bin/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Lean TUI AI assistant";
+    homepage = "https://github.com/kamilmac/unibear";
+    license = lib.licenses.mit;
+    mainProgram = "unibear";
+    platforms = lib.attrsets.mapAttrsToList (name: value: name) os-arch-options;
+    maintainers = with lib.maintainers; [ arunoruto ];
+  };
+})


### PR DESCRIPTION
[Unibear](https://github.com/kamilmac/unibear) is a [deno](https://deno.com/) project for using LLMs with [helix](https://helix-editor.com/) and [neovim](https://neovim.io/) ([reddit post](https://www.reddit.com/r/HelixEditor/comments/1kllf0m/i_present_you_unibear_magicless_coding_agent_for/)).
Since it is built with deno, building from source isn't as easy as with other JS projects, that is why I opted to use the release files and package them up.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
