### PR TITLE
weather-fetch: init at 1.0.0

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16968,4 +16968,5 @@ with pkgs;
   davis = callPackage ../by-name/da/davis/package.nix {
     php = php83; # https://github.com/tchapi/davis/issues/195
   };
+  weather-fetch = callPackage ../tools/misc/weather-fetch { };
 }


### PR DESCRIPTION
Title: weather-fetch: init at 1.0.0

Description:

This PR adds weather-fetch, a simple command-line tool that retrieves and displays current weather information for a specified location. It's useful for users who prefer accessing weather data directly from the terminal.

Package Details:

    Homepage: https://gitlab.com/laura.sorgente09/weather-fetch

    License: MIT

    Dependencies: python3, colorama, geocodes. requests

Usage:

After installation, you can use weather-fetch as follows:

weather-fetch 

This command will display the current weather information for the fetched location of the user based on ip

Feel free to adjust this template to better fit the specifics of your package. If you have any further questions or need assistance with the PR process, don't hesitate to ask!
