### PR TITLE
sdl3: avoid transitive gtk dependency

### DIFF
--- a/pkgs/by-name/ib/ibusMinimal/package.nix
+++ b/pkgs/by-name/ib/ibusMinimal/package.nix
@@ -1,0 +1,1 @@
+{ ibus }: ibus.override { libOnly = true; }

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -8,7 +8,7 @@
   darwinMinVersionHook,
   dbus,
   fetchFromGitHub,
-  ibus,
+  ibusMinimal,
   installShellFiles,
   libGL,
   libayatana-appindicator,
@@ -104,7 +104,11 @@ stdenv.mkDerivation (finalAttrs: {
       apple-sdk_11
     ]
     ++ lib.optionals ibusSupport [
-      ibus
+      # sdl3 only uses some constants of the ibus headers
+      # it never actually loads the library
+      # thus, it also does not have to care about gtk integration,
+      # so using ibusMinimal avoids an unnecessarily large closure here.
+      ibusMinimal
     ]
     ++ lib.optional waylandSupport zenity;
 

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -36,6 +36,8 @@
   buildPackages,
   runtimeShell,
   nixosTests,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 let
@@ -61,14 +63,14 @@ let
       '';
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ibus";
   version = "1.5.32";
 
   src = fetchFromGitHub {
     owner = "ibus";
     repo = "ibus";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Rp2Aw2C2LXMBp8++pnZtPHiPoFDERpkDsKd0E//twuY=";
   };
 
@@ -181,12 +183,14 @@ stdenv.mkDerivation rec {
     ];
 
   enableParallelBuilding = true;
+  strictDeps = true;
 
   doCheck = false; # requires X11 daemon
+
   doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/ibus version
-  '';
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  versionCheckProgram = "${placeholder "out"}/bin/ibus";
 
   postInstall = ''
     # It has some hardcoded FHS paths and also we do not use it
@@ -205,13 +209,15 @@ stdenv.mkDerivation rec {
     tests = {
       installed-tests = nixosTests.installed-tests.ibus;
     };
+    updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/ibus/ibus/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/ibus/ibus";
     description = "Intelligent Input Bus, input method framework";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ ttuegel ];
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ttuegel ];
   };
-}
+})

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -27,8 +27,8 @@
   python3,
   json-glib,
   libnotify ? null,
-  enableUI ? true,
-  withWayland ? true,
+  enableUI ? !libOnly,
+  withWayland ? !libOnly,
   libxkbcommon,
   wayland,
   wayland-protocols,
@@ -38,6 +38,8 @@
   nixosTests,
   versionCheckHook,
   nix-update-script,
+  libX11,
+  libOnly ? false,
 }:
 
 let
@@ -88,11 +90,14 @@ stdenv.mkDerivation (finalAttrs: {
     ./build-without-dbus-launch.patch
   ];
 
-  outputs = [
-    "out"
-    "dev"
-    "installedTests"
-  ];
+  outputs =
+    [
+      "out"
+      "dev"
+    ]
+    ++ lib.optionals (!libOnly) [
+      "installedTests"
+    ];
 
   postPatch = ''
     # Maintainer does not want to create separate tarballs for final release candidate and release versions,
@@ -109,29 +114,38 @@ stdenv.mkDerivation (finalAttrs: {
 
   preAutoreconf = "touch ChangeLog";
 
-  configureFlags = [
-    # The `AX_PROG_{CC,CXX}_FOR_BUILD` autoconf macros can pick up unwrapped GCC binaries,
-    # so we set `{CC,CXX}_FOR_BUILD` to override that behavior.
-    # https://github.com/NixOS/nixpkgs/issues/21751
-    "CC_FOR_BUILD=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
-    "CXX_FOR_BUILD=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}c++"
-    "GLIB_COMPILE_RESOURCES=${lib.getDev buildPackages.glib}/bin/glib-compile-resources"
-    "PKG_CONFIG_VAPIGEN_VAPIGEN=${lib.getBin buildPackages.vala}/bin/vapigen"
-    "--disable-memconf"
-    (lib.enableFeature (dconf != null) "dconf")
-    (lib.enableFeature (libnotify != null) "libnotify")
-    (lib.enableFeature withWayland "wayland")
-    (lib.enableFeature enableUI "ui")
-    "--disable-gtk2"
-    "--enable-gtk4"
-    "--enable-install-tests"
-    "--with-unicode-emoji-dir=${unicode-emoji}/share/unicode/emoji"
-    "--with-emoji-annotation-dir=${cldr-annotations}/share/unicode/cldr/common/annotations"
-    "--with-python=${python3BuildEnv.interpreter}"
-    "--with-ucd-dir=${unicode-character-database}/share/unicode"
-  ];
+  configureFlags =
+    [
+      # The `AX_PROG_{CC,CXX}_FOR_BUILD` autoconf macros can pick up unwrapped GCC binaries,
+      # so we set `{CC,CXX}_FOR_BUILD` to override that behavior.
+      # https://github.com/NixOS/nixpkgs/issues/21751
+      "CC_FOR_BUILD=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
+      "CXX_FOR_BUILD=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}c++"
+      "GLIB_COMPILE_RESOURCES=${lib.getDev buildPackages.glib}/bin/glib-compile-resources"
+      "PKG_CONFIG_VAPIGEN_VAPIGEN=${lib.getBin buildPackages.vala}/bin/vapigen"
+      "--disable-memconf"
+      "--disable-gtk2"
+      "--with-python=${python3BuildEnv.interpreter}"
+      (lib.enableFeature (!libOnly && dconf != null) "dconf")
+      (lib.enableFeature (!libOnly && libnotify != null) "libnotify")
+      (lib.enableFeature withWayland "wayland")
+      (lib.enableFeature enableUI "ui")
+      (lib.enableFeature (!libOnly) "gtk3")
+      (lib.enableFeature (!libOnly) "gtk4")
+      (lib.enableFeature (!libOnly) "xim")
+      (lib.enableFeature (!libOnly) "appindicator")
+      (lib.enableFeature (!libOnly) "tests")
+      (lib.enableFeature (!libOnly) "install-tests")
+      (lib.enableFeature (!libOnly) "emoji-dict")
+      (lib.enableFeature (!libOnly) "unicode-dict")
+    ]
+    ++ lib.optionals (!libOnly) [
+      "--with-unicode-emoji-dir=${unicode-emoji}/share/unicode/emoji"
+      "--with-emoji-annotation-dir=${cldr-annotations}/share/unicode/cldr/common/annotations"
+      "--with-ucd-dir=${unicode-character-database}/share/unicode"
+    ];
 
-  makeFlags = [
+  makeFlags = lib.optionals (!libOnly) [
     "test_execsdir=${placeholder "installedTests"}/libexec/installed-tests/ibus"
     "test_sourcesdir=${placeholder "installedTests"}/share/installed-tests/ibus"
   ];
@@ -148,10 +162,13 @@ stdenv.mkDerivation (finalAttrs: {
       makeWrapper
       pkg-config
       python3BuildEnv
-      vala
-      wrapGAppsHook3
       dbus-launch
+      glib # required to satisfy AM_PATH_GLIB_2_0
+      vala
       gobject-introspection
+    ]
+    ++ lib.optionals (!libOnly) [
+      wrapGAppsHook3
     ]
     ++ lib.optionals withWayland [
       wayland-scanner
@@ -166,14 +183,17 @@ stdenv.mkDerivation (finalAttrs: {
       dbus
       systemd
       dconf
-      gdk-pixbuf
       python3.pkgs.pygobject3 # for pygobject overrides
-      gtk3
-      gtk4
       isocodes
       json-glib
-      libnotify
+      libX11
+    ]
+    ++ lib.optionals (!libOnly) [
+      gtk3
+      gtk4
+      gdk-pixbuf
       libdbusmenu-gtk3
+      libnotify
       vala # for share/vala/Makefile.vapigen (PKG_CONFIG_VAPIGEN_VAPIGEN)
     ]
     ++ lib.optionals withWayland [
@@ -192,13 +212,13 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgramArg = "version";
   versionCheckProgram = "${placeholder "out"}/bin/ibus";
 
-  postInstall = ''
+  postInstall = lib.optionalString (!libOnly) ''
     # It has some hardcoded FHS paths and also we do not use it
     # since we set up the environment in NixOS tests anyway.
     moveToOutput "bin/ibus-desktop-testing-runner" "$installedTests"
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString (!libOnly) ''
     # set necessary environment also for tests
     for f in $installedTests/libexec/installed-tests/ibus/*; do
         wrapGApp $f
@@ -206,7 +226,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    tests = {
+    tests = lib.optionalAttrs (!libOnly) {
       installed-tests = nixosTests.installed-tests.ibus;
     };
     updateScript = nix-update-script { };


### PR DESCRIPTION
Motivation: `ibus` carries lots of dependencies on various versions of gtk.
These dependencies become transitive dependencies for sdl3, which causes quite expensive compiles in the sdl3 closure. Particularly, this means gtk (and, in turn, gstreamer and everything else) become part of e.g. ffmpeg.

`sdl3` itself uses ibus almost exclusively via dbus, and reimplements some of the most important features. It does depend on ibus only to use some of the constants defined in headers. It does not actually load ibus libraries.

This means, as long as the headers are identical, all the gtk dependencies can be removed in the ibus for sdl3. This requires this split.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
