### PR TITLE
fluent-bit: 3.2.6 -> 4.0.3

### DIFF
--- a/pkgs/by-name/fl/fluent-bit/package.nix
+++ b/pkgs/by-name/fl/fluent-bit/package.nix
@@ -1,41 +1,41 @@
 {
   lib,
   stdenv,
+  fetchFromGitHub,
+  nixosTests,
+
   arrow-glib,
   bison,
   c-ares,
   cmake,
-  curl,
-  fetchFromGitHub,
   flex,
   jemalloc,
   libbacktrace,
   libbpf,
-  libnghttp2,
   libpq,
   libyaml,
   luajit,
+  msgpack-c,
+  nghttp2,
   nix-update-script,
-  nixosTests,
   openssl,
   pkg-config,
   rdkafka,
+  sqlite,
   systemd,
   versionCheckHook,
-  zlib,
   zstd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fluent-bit";
-  # FIXME: We are deliberately on 3.2.6 as 3.2.7 and above are causing segfaults (https://github.com/fluent/fluent-bit/issues/10139)
-  version = "3.2.6";
+  version = "4.0.3";
 
   src = fetchFromGitHub {
     owner = "fluent";
     repo = "fluent-bit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-S0sb954n17z+zrVNkYd6yiV01aNbOLJLOV+34PRkSXQ=";
+    hash = "sha256-hxlvidzrEE/5xzka414CerGQ/Vi2jXUnNvO/oSxrHQQ=";
   };
 
   # The source build documentation covers some dependencies and CMake options.
@@ -49,15 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Fortunately, there's the undocumented `FLB_PREFER_SYSTEM_LIBS` CMake option to link against system libraries for
   # some dependencies.
   #
-  # See https://github.com/fluent/fluent-bit/blob/v3.2.6/CMakeLists.txt#L211-L218.
-  #
-  # Like `FLB_PREFER_SYSTEM_LIBS`, several CMake options aren't documented.
-  #
-  # See https://github.com/fluent/fluent-bit/blob/v3.2.6/CMakeLists.txt#L111-L157.
-  #
-  # The CMake options may differ across target platforms. We'll stick to the minimum.
-  #
-  # See https://github.com/fluent/fluent-bit/tree/v3.2.6/packaging/distros.
+  # https://github.com/fluent/fluent-bit/blob/v4.0.2/CMakeLists.txt#L245
 
   strictDeps = true;
 
@@ -72,19 +64,16 @@ stdenv.mkDerivation (finalAttrs: {
     [
       arrow-glib
       c-ares
-      # Needed by rdkafka.
-      curl
       jemalloc
       libbacktrace
-      libnghttp2
       libpq
       libyaml
       luajit
+      msgpack-c
+      nghttp2.dev
       openssl
       rdkafka
-      # Needed by rdkafka.
-      zlib
-      # Needed by rdkafka.
+      sqlite.dev
       zstd
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
fluent-bit now dynamically links against libzstd, sqlite and msgpack

This means that we will not run into the issue that caused us to roll back from 3.2.9 to 3.2.6 anymore (https://github.com/NixOS/nixpkgs/pull/395128) as there shouldn't be two incompatible versions of libzstd loaded at the same time.

Fixes https://github.com/fluent/fluent-bit/issues/10139

Is this eligible for back-porting even-though it's a major version bump?  In my opinion: yes.  We can't keep maintaining 3.x as all the builds after 3.2.6 have the same issue so we are missing out on critical vulnerability fixes. In the meantine Non of the following links mention any backwards compatibilities with 3.2.6:

* https://fluentbit.io/announcements/v4.0.0/
* https://fluentbit.io/announcements/v4.0.1/
* https://fluentbit.io/announcements/v4.0.2/
* https://fluentbit.io/announcements/v4.0.3/
* https://docs.fluentbit.io/manual/installation/upgrade-notes/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
