### PR TITLE
ci/nixpkgs-vet: fix random errors

### DIFF
--- a/ci/nixpkgs-vet.nix
+++ b/ci/nixpkgs-vet.nix
@@ -25,6 +25,8 @@ runCommand "nixpkgs-vet"
     env.NIXPKGS_VET_NIX_PACKAGE = nix;
   }
   ''
+    export NIX_STATE_DIR=$(mktemp -d)
+
     nixpkgs-vet --base ${filtered base} ${filtered head}
 
     touch $out


### PR DESCRIPTION
Every now and then, the nixpkgs-vet CI job currently fails with one of:

```
error: creating symlink '/build/.local/share/nix/root/nix/var/nix/gcroots/profiles' -> '/build/.local/share/nix/root/nix/var/nix/profiles': File exists
```
or
```
error: SQLite database '/build/.local/share/nix/root/nix/var/nix/db/db.sqlite' is busy
```

It's hard to reproduce for me, so just taking a guess with the required changes.

I bet somebody else seen those already and can tell whether my change here is likely to fix them.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
