### PR TITLE
fex: Add support for library forwarding

### DIFF
--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -11,8 +11,79 @@
   xxHash,
   fmt,
   nasm,
+  buildEnv,
+  writeText,
+  pkgsCross,
+  libclang,
+  libllvm,
+  alsa-lib,
+  libdrm,
+  libGL,
+  wayland,
+  xorg,
 }:
 
+let
+  pkgsCross32 = pkgsCross.gnu32;
+  pkgsCross64 = pkgsCross.gnu64;
+  devRootFS = buildEnv {
+    name = "fex-dev-rootfs";
+    paths = [
+      pkgsCross64.stdenv.cc.libc_dev
+      pkgsCross32.stdenv.cc.libc_dev
+      pkgsCross64.stdenv.cc.cc
+      pkgsCross32.stdenv.cc.cc
+
+      alsa-lib.dev
+      libdrm.dev
+      libGL.dev
+      wayland.dev
+      xorg.libX11.dev
+      xorg.libxcb.dev
+      xorg.libXrandr.dev
+      xorg.libXrender.dev
+      xorg.xorgproto
+    ];
+    ignoreCollisions = true;
+    pathsToLink = [
+      "/include"
+      "/lib"
+    ];
+
+    postBuild = ''
+      mkdir -p $out/usr
+      ln -s $out/include $out/usr/
+    '';
+  };
+
+  toolchain32 = writeText "toolchain_nix_x86_32.txt" ''
+    set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_SYSTEM_PROCESSOR i686)
+    set(CMAKE_C_COMPILER clang)
+    set(CMAKE_CXX_COMPILER clang++)
+    set(CMAKE_C_COMPILER ${pkgsCross32.buildPackages.clang}/bin/i686-unknown-linux-gnu-clang)
+    set(CMAKE_CXX_COMPILER ${pkgsCross32.buildPackages.clang}/bin/i686-unknown-linux-gnu-clang++)
+    set(CLANG_FLAGS "-nodefaultlibs -nostartfiles -target i686-linux-gnu -msse2 -mfpmath=sse --sysroot=${devRootFS} -iwithsysroot/usr/include")
+    set(CMAKE_C_FLAGS "''${CMAKE_C_FLAGS} ''${CLANG_FLAGS}")
+    set(CMAKE_CXX_FLAGS "''${CMAKE_CXX_FLAGS} ''${CLANG_FLAGS}")
+  '';
+
+  toolchain = writeText "toolchain_nix_x86_64.txt" ''
+    set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    set(CMAKE_SYSTEM_PROCESSOR x86_64)
+    set(CMAKE_C_COMPILER clang)
+    set(CMAKE_CXX_COMPILER clang++)
+    set(CMAKE_C_COMPILER ${pkgsCross64.buildPackages.clang}/bin/x86_64-unknown-linux-gnu-clang)
+    set(CMAKE_CXX_COMPILER ${pkgsCross64.buildPackages.clang}/bin/x86_64-unknown-linux-gnu-clang++)
+    set(CLANG_FLAGS "-nodefaultlibs -nostartfiles -target x86_64-linux-gnu --sysroot=${devRootFS} -iwithsysroot/usr/include")
+    set(CMAKE_C_FLAGS "''${CMAKE_C_FLAGS} ''${CLANG_FLAGS}")
+    set(CMAKE_CXX_FLAGS "''${CMAKE_CXX_FLAGS} ''${CLANG_FLAGS}")
+  '';
+in
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "fex";
   version = "2508.1";
@@ -49,6 +120,35 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     '';
   };
 
+  postPatch = ''
+    substituteInPlace ThunkLibs/GuestLibs/CMakeLists.txt ThunkLibs/HostLibs/CMakeLists.txt \
+      --replace-fail "/usr/include/libdrm" "${devRootFS}/include/libdrm" \
+      --replace-fail "/usr/include/wayland" "${devRootFS}/include/wayland"
+
+    # Add include paths for thunkgen invocation
+    substituteInPlace ThunkLibs/HostLibs/CMakeLists.txt \
+      --replace-fail "-- " "-- $(cat ${llvmPackages.stdenv.cc}/nix-support/libc-cflags) $(cat ${llvmPackages.stdenv.cc}/nix-support/libcxx-cxxflags) $NIX_CFLAGS_COMPILE"
+    substituteInPlace ThunkLibs/GuestLibs/CMakeLists.txt \
+      --replace-fail "-- " "-- $(cat ${llvmPackages.stdenv.cc}/nix-support/libcxx-cxxflags)"
+
+    # Patch any references to library wrapper paths
+    substituteInPlace FEXCore/Source/Interface/Config/Config.json.in \
+      --replace-fail "ThunkGuestLibs" "UnusedThunkGuestLibs" \
+      --replace-fail "ThunkHostLibs" "UnusedThunkHostLibs"
+    substituteInPlace FEXCore/Source/Interface/Config/Config.cpp \
+      --replace-fail "FEXCore::Config::CONFIG_THUNKGUESTLIBS" "FEXCore::Config::CONFIG_UNUSEDTHUNKGUESTLIBS" \
+      --replace-fail "FEXCore::Config::CONFIG_THUNKHOSTLIBS" "FEXCore::Config::CONFIG_UNUSEDTHUNKHOSTLIBS"
+    substituteInPlace Source/Tools/LinuxEmulation/VDSO_Emulation.cpp \
+      --replace-fail "FEX_CONFIG_OPT(ThunkGuestLibs, THUNKGUESTLIBS);" "auto ThunkGuestLibs = []() { return \"$out/share/fex-emu/GuestThunks/\"; };"
+    substituteInPlace Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h \
+      --replace-fail "FEX_CONFIG_OPT(ThunkGuestLibs, THUNKGUESTLIBS);" "fextl::string ThunkGuestLibs() { return \"$out/share/fex-emu/GuestThunks/\"; }"
+    substituteInPlace Source/Tools/LinuxEmulation/Thunks.cpp \
+      --replace-fail "FEX_CONFIG_OPT(ThunkHostLibsPath, THUNKHOSTLIBS);" "fextl::string ThunkHostLibsPath() { return \"$out/lib/fex-emu/HostThunks/\"; }"
+    substituteInPlace Source/Tools/FEXConfig/main.qml \
+      --replace-fail "config: \"Thunk" "config: \"UnusedThunk" \
+      --replace-fail "title: qsTr(\"Library forwarding:\")" "visible: false; title: qsTr(\"Library forwarding:\")"
+  '';
+
   nativeBuildInputs = [
     cmake
     ninja
@@ -69,6 +169,21 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     xxHash
     fmt
+    pkgsCross64.buildPackages.clang
+    pkgsCross32.buildPackages.clang
+    libclang
+    libllvm
+
+    # Headers required to build the ThunkLibs subtree
+    alsa-lib.dev
+    libdrm.dev
+    libGL.dev
+    wayland.dev
+    xorg.libX11.dev
+    xorg.libxcb.dev
+    xorg.libXrandr.dev
+    xorg.libXrender.dev
+    xorg.xorgproto
   ]
   ++ (with qt5; [
     qtbase
@@ -83,6 +198,10 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ENABLE_ASSERTIONS" false)
     (lib.cmakeFeature "OVERRIDE_VERSION" finalAttrs.version)
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "BUILD_THUNKS" true)
+    (lib.cmakeFeature "X86_32_TOOLCHAIN_FILE" "${toolchain32}")
+    (lib.cmakeFeature "X86_64_TOOLCHAIN_FILE" "${toolchain}")
+    (lib.cmakeFeature "X86_DEV_ROOTFS" "${devRootFS}")
   ];
 
   strictDeps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Library forwarding (misleadingly often called "thunks") is a FEX feature that redirects API calls to specific ARM64 host libraries instead of emulating the full x86 builds of those libraries.

This has multiple benefits:
* it improves performance due to avoiding translation overhead (particularly in games)
* it enables support for proprietary / non-Mesa GPU drivers
* it's required for compatibility with some specific applications

To test this feature locally, make sure to run FEXConfig and enable the various libraries in the *Libraries* tab.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

The new derivation successfully builds support for all libraries FEX can forward by creating a *development RootFS* containing glibc/stdlibc++ headers and some additional library headers. As far as the build-side is concerned, this is all perfectly working. (I was actually surprised how easy nix makes this!)

Unfortunately there is a fundamental roadblock I'm unsure how to resolve: To enable library forwarding (for example for libvulkan), FEX uses a `libvulkan-host.so` wrapper library that `dlopen()`s the true ARM64 [libvulkan.so](http://libvulkan.so/) installed on the host. Currently that dlopen call fails, since it only searches the nix store. Looking in the nix store doesn't *really* make sense here though, since FEX is more of a runtime and the true library consumer is the emulated application (which itself is typically *not* built by nix).

This problem isn't exclusive to Vulkan but probably applies to all other libraries FEX can forward. I'm guessing there is a "right way" to do this on NixOS, but ideally a non-NixOS nix-shell should be able to just load an externally managed `/usr/lib64/libvulkan.so` without further ado.

Does anyone with more nix experience than me have any advice on how to proceed here?

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
