### PR TITLE
easytier-gui: init at 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10730,6 +10730,12 @@
     githubId = 54999;
     name = "Ariel Nunez";
   };
+  initialencounter = {
+    email = "2911583893@qq.com";
+    github = "initialencounter";
+    githubId = 109729945;
+    name = "Wang Zeng";
+  };
   interdependence = {
     email = "git@williamvandervalk.com";
     github = "interdependence";

--- a/pkgs/by-name/ea/easytier-gui/package.nix
+++ b/pkgs/by-name/ea/easytier-gui/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  callPackage,
+  fetchFromGitHub,
+  stdenv,
+  wrapGAppsHook3,
+}:
+let
+  pname = "easytier-gui";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "EasyTier";
+    repo = "EasyTier";
+    tag = "v${version}";
+    hash = "sha256-F///8C7lyJZj5+u80nauDdrPFrEE40s0DeNzQeblImw=";
+  };
+
+  pnpm-hash = "sha256-eXMIa1EzS5E6nAYxQgq2G3J+diw+EFVGA+RKmdwQwFY=";
+  vendor-hash = "sha256-f64tOU8AKC14tqX9Q3MLa7/pmIuI4FeFGOct8ZTAe+k=";
+
+  unwrapped = callPackage ./unwrapped.nix {
+    inherit
+      pname
+      version
+      src
+      pnpm-hash
+      vendor-hash
+      meta
+      ;
+  };
+  meta = {
+    description = "EasyTier GUI based on tauri";
+    homepage = "https://github.com/EasyTier/EasyTier";
+    changelog = "https://github.com/EasyTier/EasyTier/releases/tag/v${version}";
+    longDescription = ''
+      EasyTier GUI based on tauri.
+      EasyTier is a simple, safe and decentralized VPN networking solution implemented
+      with the Rust language and Tokio framework.
+    '';
+    license = lib.licenses.asl20;
+    mainProgram = "easytier-gui";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ initialencounter ];
+  };
+in
+stdenv.mkDerivation {
+  inherit
+    pname
+    src
+    version
+    meta
+    ;
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+    cp -r ${unwrapped}/share/* $out/share
+    cp -r ${unwrapped}/bin/easytier-gui $out/bin/easytier-gui
+    runHook postInstall
+  '';
+}

--- a/pkgs/by-name/ea/easytier-gui/unwrapped.nix
+++ b/pkgs/by-name/ea/easytier-gui/unwrapped.nix
@@ -1,0 +1,71 @@
+{
+  pname,
+  version,
+  src,
+  meta,
+  pnpm-hash,
+  vendor-hash,
+  rustPlatform,
+  cargo-tauri,
+  nodejs,
+  pkg-config,
+  pnpm_9,
+  protobuf,
+  llvmPackages,
+  libayatana-appindicator,
+  libsoup_2_4,
+  openssl,
+  webkitgtk_4_1,
+}:
+rustPlatform.buildRustPackage {
+  inherit version src meta;
+  pname = "${pname}-unwrapped";
+
+  cargoRoot = ".";
+  buildAndTestSubdir = "easytier-gui/src-tauri";
+
+  useFetchCargoVendor = true;
+  cargoHash = vendor-hash;
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit pname version src;
+    hash = pnpm-hash;
+  };
+
+  env = {
+    OPENSSL_NO_VENDOR = 1;
+  };
+
+  postPatch = ''
+    substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
+      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+
+    # Update the build command of Tauri in pnpm workspace to recursively build
+    substituteInPlace easytier-gui/src-tauri/tauri.conf.json \
+      --replace-fail "pnpm build" "pnpm -r build"
+
+    # this file tries to override the linker used when compiling for certain platforms
+    rm .cargo/config.toml
+  '';
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    pkg-config
+    pnpm_9.configHook
+    llvmPackages.libclang
+    protobuf
+    rustPlatform.bindgenHook
+  ];
+
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  doCheck = false; # tests failed due to heavy rely on network
+
+  buildInputs = [
+    libayatana-appindicator
+    libsoup_2_4
+    openssl
+    webkitgtk_4_1
+  ];
+}


### PR DESCRIPTION
## Description of changes

EasyTier GUI based on tauri.
EasyTier is a simple, safe and decentralized VPN networking solution implemented with the Rust language and Tokio framework.
Homepage: https://github.com/EasyTier/EasyTier

The EasyTier Cli version has been merged into the repository (https://github.com/NixOS/nixpkgs/pull/339616), but there is no GUI version. Now, the packaging of the GUI version is provided.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
