### PR TITLE
labels: automatically add labels for 24.11 on CI PRs

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -22,6 +22,13 @@
         - doc/**/*
         - nixos/doc/**/*
 
+"backport release-24.11":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - .github/workflows/*
+        - ci/**/*.*
+
 "backport release-25.05":
   - any:
     - changed-files:


### PR DESCRIPTION
The chained backport unstable -> 25.05 -> 24.11 became too annoying for me.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
