### PR TITLE
labels: remove automatic backport for CI

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -22,11 +22,4 @@
         - doc/**/*
         - nixos/doc/**/*
 
-"backport release-24.11":
-  - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - .github/workflows/*
-        - ci/**/*.*
-
 # keep-sorted end


### PR DESCRIPTION
This will be done from master directly now. #413280

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
