### PR TITLE
workflows/check-cherry-picks: minimize more than one old review after force push

### DIFF
--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -115,16 +115,17 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: context.payload.pull_request.number
               })).filter(review =>
-                review.user.login == 'github-actions[bot]' &&
-                review.state == 'CHANGES_REQUESTED'
+                review.user.login == 'github-actions[bot]'
               ).map(async (review) => {
-                await github.rest.pulls.dismissReview({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: context.payload.pull_request.number,
-                  review_id: review.id,
-                  message: 'All cherry-picks are good now, thank you!'
-                })
+                if (review.state == 'CHANGES_REQUESTED') {
+                  await github.rest.pulls.dismissReview({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: context.payload.pull_request.number,
+                    review_id: review.id,
+                    message: 'All cherry-picks are good now, thank you!'
+                  })
+                }
                 await github.graphql(`mutation($node_id:ID!) {
                   minimizeComment(input: {
                     classifier: RESOLVED,


### PR DESCRIPTION
After we removed the dismissed-review workflow, it can happen that multiple non-minimized reviews exist after a force push. To avoid cluttering the PR's history while it's actively worked on, we minimize all of them instead of only the latest.

## Things done

- [x] Tested in my fork
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
