### PR TITLE
lttng-ust: 2.13.8 -> 2.13.9, modernize

### DIFF
--- a/pkgs/by-name/lt/lttng-ust/package.nix
+++ b/pkgs/by-name/lt/lttng-ust/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "lttng-ust";
-  version = "2.13.8";
+  version = "2.13.9";
 
   src = fetchurl {
     url = "https://lttng.org/files/lttng-ust/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-1O+Y2rmjetT1JMyv39UK9PJmA5tSjdWvq8545JAk2Tc=";
+    sha256 = "sha256-KtbWmlSh2STBikqnojPbEE48wzK83SQOGWv3rb7T9xI=";
   };
 
   outputs = [

--- a/pkgs/by-name/lt/lttng-ust/package.nix
+++ b/pkgs/by-name/lt/lttng-ust/package.nix
@@ -51,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--disable-examples" ];
 
+  doCheck = true;
+
   strictDeps = true;
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/lt/lttng-ust/package.nix
+++ b/pkgs/by-name/lt/lttng-ust/package.nix
@@ -48,8 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs .
   '';
 
-  hardeningDisable = [ "trivialautovarinit" ];
-
   configureFlags = [ "--disable-examples" ];
 
   strictDeps = true;

--- a/pkgs/by-name/lt/lttng-ust/package.nix
+++ b/pkgs/by-name/lt/lttng-ust/package.nix
@@ -19,13 +19,13 @@
 #
 # Debian builds with std.h (systemtap).
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lttng-ust";
   version = "2.13.9";
 
   src = fetchurl {
-    url = "https://lttng.org/files/lttng-ust/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-KtbWmlSh2STBikqnojPbEE48wzK83SQOGWv3rb7T9xI=";
+    url = "https://lttng.org/files/lttng-ust/lttng-ust-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-KtbWmlSh2STBikqnojPbEE48wzK83SQOGWv3rb7T9xI=";
   };
 
   outputs = [
@@ -36,6 +36,9 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ pkg-config ];
+
+  propagatedBuildInputs = [ liburcu ];
+
   buildInputs = [
     numactl
     python3
@@ -49,21 +52,21 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-examples" ];
 
-  propagatedBuildInputs = [ liburcu ];
+  strictDeps = true;
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "LTTng Userspace Tracer libraries";
     mainProgram = "lttng-gen-tp";
     homepage = "https://lttng.org/";
-    license = with licenses; [
+    changelog = "https://github.com/lttng/lttng-ust/blob/v${finalAttrs.version}/ChangeLog";
+    license = with lib.licenses; [
       lgpl21Only
       gpl2Only
       mit
     ];
-    platforms = lib.intersectLists platforms.linux liburcu.meta.platforms;
-    maintainers = [ maintainers.bjornfor ];
+    platforms = lib.intersectLists lib.platforms.linux liburcu.meta.platforms;
+    maintainers = [ lib.maintainers.bjornfor ];
   };
-
-}
+})

--- a/pkgs/by-name/lt/lttng-ust/package.nix
+++ b/pkgs/by-name/lt/lttng-ust/package.nix
@@ -6,6 +6,7 @@
   liburcu,
   numactl,
   python3,
+  testers,
 }:
 
 # NOTE:
@@ -54,6 +55,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
   meta = {
     description = "LTTng Userspace Tracer libraries";
     mainProgram = "lttng-gen-tp";
@@ -65,6 +70,10 @@ stdenv.mkDerivation (finalAttrs: {
       mit
     ];
     platforms = lib.intersectLists lib.platforms.linux liburcu.meta.platforms;
+    pkgConfigModules = [
+      "lttng-ust-ctl"
+      "lttng-ust"
+    ];
     maintainers = [ lib.maintainers.bjornfor ];
   };
 })


### PR DESCRIPTION
Extended version of https://github.com/NixOS/nixpkgs/pull/406890 .
Seems to fix cross build for `armv7l-hf-multiplatform`, probably via https://github.com/lttng/lttng-ust/commit/8561d22f7c423f9f0bfdde8ffd2015ea29ad8004 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
