### PR TITLE
[Backport release-24.11] viddy: 1.2.1 -> 1.3.0

### DIFF
--- a/pkgs/by-name/vi/viddy/package.nix
+++ b/pkgs/by-name/vi/viddy/package.nix
@@ -6,21 +6,21 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "viddy";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "sachaos";
     repo = "viddy";
     rev = "v${version}";
-    hash = "sha256-r+zgZutBwNRLYNltdSaIB5lS4qHAhI5XL3iFF+FVd64=";
+    hash = "sha256-ZdDe0ymPkj0ZGiPLo1Y0qMDk2SsUcPsSStay+Tuf4p0=";
   };
 
-  cargoHash = "sha256-rEz3GFfqtSzZa0r4Nwbu3gEf7GhsOkfawaFaNplD/tE=";
+  cargoHash = "sha256-d/wmjvbTITpcGCrMVZrkUcCFPDdas2CDDPlIqoVBl9k=";
 
   # requires nightly features
   env.RUSTC_BOOTSTRAP = 1;
 
-  env.VERGEN_BUILD_DATE = "2024-10-13"; # managed via the update script
+  env.VERGEN_BUILD_DATE = "2024-11-28"; # managed via the update script
   env.VERGEN_GIT_DESCRIBE = "Nixpkgs";
 
   passthru.updateScript.command = [ ./update.sh ];


### PR DESCRIPTION
(cherry picked from commit c6b810292b497980bab1b477e62ded50cf9b6586)

* [ ]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-06-02T17%3A00%3A13Z#changes-acceptable-for-releases).
  * Even as a non-committer, if you find that it is not acceptable, leave a comment.

