### PR TITLE
haskellPackages: use warnIf instead of assert

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -1,13 +1,21 @@
 { pkgs, haskellLib }:
 
+self: super:
+
 with haskellLib;
 
 let
   inherit (pkgs) lib;
 
+  warnAfterVersion =
+    ver: pkg:
+    lib.warnIf (lib.versionOlder ver
+      super.${pkg.pname}.version
+    ) "override for haskell.packages.ghc910.${pkg.pname} may no longer be needed" pkg;
+
 in
 
-self: super: {
+{
   llvmPackages = lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
 
   # Disable GHC core libraries

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -5,19 +5,11 @@ self: super:
 let
   inherit (pkgs) lib;
 
-  versionAtMost = a: b: lib.versionAtLeast b a;
-
-  warnVersion =
-    predicate: ver: pkg:
-    let
-      pname = pkg.pname;
-    in
-    lib.warnIf (predicate ver
-      super.${pname}.version
-    ) "override for haskell.packages.ghc912.${pname} may no longer be needed" pkg;
-
-  warnAfterVersion = warnVersion lib.versionOlder;
-  warnFromVersion = warnVersion versionAtMost;
+  warnAfterVersion =
+    ver: pkg:
+    lib.warnIf (lib.versionOlder ver
+      super.${pkg.pname}.version
+    ) "override for haskell.packages.ghc912.${pkg.pname} may no longer be needed" pkg;
 
 in
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -2,20 +2,10 @@
 
 let
   inherit (pkgs) fetchpatch lib;
-  checkAgainAfter =
-    pkg: ver: msg: act:
-    if builtins.compareVersions pkg.version ver <= 0 then
-      act
-    else
-      builtins.throw "Check if '${msg}' was resolved in ${pkg.pname} ${pkg.version} and update or remove this";
 in
 
 with haskellLib;
-self: super:
-let
-  jailbreakForCurrentVersion = p: v: checkAgainAfter p v "bad bounds" (doJailbreak p);
-in
-{
+self: super: {
   llvmPackages = lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
 
   # Disable GHC core libraries.


### PR DESCRIPTION
After fixing some asserts on versions, I realized that asserts are not good, warnings are better (see commit message). I then proceeded to write a nice helper function for configuration-common.nix to make sure we always do the right thing.

Then.. I realized that a bunch of people had the same idea that I had and wrote similar functions with different names in various files in the past. So I re-invented the wheel, fine.

Thus, I now standardized on the latest one and used it everywhere.

## Things done

- [x] Let's see what eval says.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
