### PR TITLE
wine64Packages.{unstable,staging}: 10.7 -> 10.12

### DIFF
--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -132,9 +132,9 @@ rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the hash for staging as well.
-    version = "10.10";
+    version = "10.11";
     url = "https://dl.winehq.org/wine/source/10.x/wine-${version}.tar.xz";
-    hash = "sha256-52Rmpcoxl/OZ3fgGmwp55est/+Wzt9uetyciiDMMhZY=";
+    hash = "sha256-GFvphpm5FLwp5yRDCUeYa7eKhn5i5CLwDHU0GTK2eM4=";
 
     patches = [
       # Also look for root certificates at $NIX_SSL_CERT_FILE
@@ -144,7 +144,7 @@ rec {
     # see https://gitlab.winehq.org/wine/wine-staging
     staging = fetchFromGitLab {
       inherit version;
-      hash = "sha256-+aZG8VCoeo9sNgZiEnvpRaik/Mvsj95q1uRbRv576xA=";
+      hash = "sha256-TnUqKi4VXaA67UnF2wPULDCO1lPxO6Sk0wgofbvz6L4=";
       domain = "gitlab.winehq.org";
       owner = "wine";
       repo = "wine-staging";

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -132,9 +132,9 @@ rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the hash for staging as well.
-    version = "10.7";
+    version = "10.9";
     url = "https://dl.winehq.org/wine/source/10.x/wine-${version}.tar.xz";
-    hash = "sha256-dRNnoxCZkNcD5ZDi21MBh8Th39Lo5hNzq4S0L+EbGPo=";
+    hash = "sha256-wrruO0SGgicFYFz9EVn5YPMZ8O7jPAqnw4CumDtwzO4=";
 
     patches = [
       # Also look for root certificates at $NIX_SSL_CERT_FILE
@@ -144,7 +144,7 @@ rec {
     # see https://gitlab.winehq.org/wine/wine-staging
     staging = fetchFromGitLab {
       inherit version;
-      hash = "sha256-4doo7B3eEoQaml6KX02OhcLGGiLcgNhYq4ry/iB7kLc=";
+      hash = "sha256-ijHy/Q/FRgWEFLHxZVC8H8IxBZutGrge/3I1zxTWEqU=";
       domain = "gitlab.winehq.org";
       owner = "wine";
       repo = "wine-staging";

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -132,9 +132,9 @@ rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the hash for staging as well.
-    version = "10.9";
+    version = "10.10";
     url = "https://dl.winehq.org/wine/source/10.x/wine-${version}.tar.xz";
-    hash = "sha256-wrruO0SGgicFYFz9EVn5YPMZ8O7jPAqnw4CumDtwzO4=";
+    hash = "sha256-52Rmpcoxl/OZ3fgGmwp55est/+Wzt9uetyciiDMMhZY=";
 
     patches = [
       # Also look for root certificates at $NIX_SSL_CERT_FILE
@@ -144,7 +144,7 @@ rec {
     # see https://gitlab.winehq.org/wine/wine-staging
     staging = fetchFromGitLab {
       inherit version;
-      hash = "sha256-ijHy/Q/FRgWEFLHxZVC8H8IxBZutGrge/3I1zxTWEqU=";
+      hash = "sha256-+aZG8VCoeo9sNgZiEnvpRaik/Mvsj95q1uRbRv576xA=";
       domain = "gitlab.winehq.org";
       owner = "wine";
       repo = "wine-staging";
@@ -167,9 +167,9 @@ rec {
 
     ## see http://wiki.winehq.org/Mono
     mono = fetchurl rec {
-      version = "10.0.0";
+      version = "10.1.0";
       url = "https://dl.winehq.org/wine/wine-mono/${version}/wine-mono-${version}-x86.msi";
-      hash = "sha256-26ynPl0J96OnwVetBCia+cpHw87XAS1GVEpgcEaQK4c=";
+      hash = "sha256-yIwkMYkLwyys7I1+pw5Tpa5LlcjFXKbnXvjbDkzPEHA=";
     };
 
     updateScript = writeShellScript "update-wine-unstable" ''

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -132,9 +132,9 @@ rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the hash for staging as well.
-    version = "10.11";
+    version = "10.12";
     url = "https://dl.winehq.org/wine/source/10.x/wine-${version}.tar.xz";
-    hash = "sha256-GFvphpm5FLwp5yRDCUeYa7eKhn5i5CLwDHU0GTK2eM4=";
+    hash = "sha256-zVcscaPXLof5hJCyKMfCaq6z/eON2eefw7VjkdWZ1r8=";
 
     patches = [
       # Also look for root certificates at $NIX_SSL_CERT_FILE
@@ -144,7 +144,7 @@ rec {
     # see https://gitlab.winehq.org/wine/wine-staging
     staging = fetchFromGitLab {
       inherit version;
-      hash = "sha256-TnUqKi4VXaA67UnF2wPULDCO1lPxO6Sk0wgofbvz6L4=";
+      hash = "sha256-a5Vw9UVawx/vvTeu6SGxf4C1GwvdmpPJDyuW0PCUob8=";
       domain = "gitlab.winehq.org";
       owner = "wine";
       repo = "wine-staging";


### PR DESCRIPTION
Regular bi-weekly development release

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
