### PR TITLE
nixos/lasuite-docs: use systemd bind mount instead of stateful symlink for static directory

### DIFF
--- a/nixos/modules/services/web-apps/lasuite-docs.nix
+++ b/nixos/modules/services/web-apps/lasuite-docs.nix
@@ -264,7 +264,7 @@ in
             type = types.str;
             default = if cfg.enableNginx then "localhost,127.0.0.1,${cfg.domain}" else "";
             defaultText = lib.literalExpression ''
-              if cfg.enableNginx then "localhost,127.0.0.1,$${cfg.domain}" else ""
+              if cfg.enableNginx then "localhost,127.0.0.1,''${cfg.domain}" else ""
             '';
             description = "Comma-separated list of hosts that are able to connect to the server";
           };
@@ -348,8 +348,6 @@ in
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        ln -sfT ${cfg.backendPackage}/share/static /var/lib/lasuite-docs/static
-
         if [ ! -f .version ]; then
           touch .version
         fi
@@ -371,6 +369,8 @@ in
       environment = pythonEnvironment;
 
       serviceConfig = {
+        BindReadOnlyPaths = "${cfg.backendPackage}/share/static:/var/lib/lasuite-docs/static";
+
         ExecStart = utils.escapeSystemdExecArgs (
           [
             (lib.getExe' cfg.backendPackage "gunicorn")


### PR DESCRIPTION
This pull request replaces the creation of symlink in `/var/lib/lasuite-docs/static` to `${cfg.backendPackage}/share/static` with using `BindReadOnlyPaths`, which utilizes the mount namespace of the service instead.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
