### PR TITLE
fmodstudio: init at 2.03.07

### DIFF
--- a/pkgs/by-name/fm/fmodstudio/package.nix
+++ b/pkgs/by-name/fm/fmodstudio/package.nix
@@ -1,0 +1,192 @@
+{
+  stdenv,
+  lib,
+  autoPatchelfHook,
+  makeWrapper,
+  requireFile,
+  alsa-lib,
+  libXcomposite,
+  nss,
+  jq,
+  curl,
+  glib,
+  libglvnd,
+  libdrm,
+  libxkbcommon,
+  fontconfig,
+  xorg,
+  dbus,
+  krb5,
+  xcbutilcursor,
+  xcbutilkeysyms,
+  xcbutilwm,
+  dpkg,
+  fetchMethod ? "requireFile", # "requireFile" or "download"
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fmodstudio";
+  version = "2.03.08";
+  hash = "sha256-FSz4y+MevllXKyNeyoABLtcLzyePSTBNWOLB53TFyzg=";
+
+  src =
+    if fetchMethod == "download" then
+      stdenv.mkDerivation {
+        pname = "${finalAttrs.pname}-src";
+        version = finalAttrs.version;
+
+        dontUnpack = true;
+
+        nativeBuildInputs = [
+          jq
+          curl
+        ];
+
+        impureEnvVars = [
+          "NIX_FMOD_USERNAME"
+          "NIX_FMOD_PASSWORD"
+        ];
+
+        outputHashAlgo = "sha256";
+        outputHashMode = "flat";
+        outputHash = finalAttrs.hash;
+
+        buildPhase = ''
+          set -euo pipefail
+
+          if [ -z "''${NIX_FMOD_USERNAME-}" ] || [ -z "''${NIX_FMOD_PASSWORD-}" ]; then
+              echo "Error: Downloading FMOD Studio requires FMOD credentials." >&2
+              echo "Please set the following environment variables:" >&2
+              echo "  NIX_FMOD_USERNAME - Your FMOD account username/email" >&2
+              echo "  NIX_FMOD_PASSWORD - Your FMOD account password" >&2
+              echo "" >&2
+              echo "You can create an account at https://fmod.com/ if you don't have one." >&2
+              echo "" >&2
+              echo "When using the Nix daemon, add these to your configuration:" >&2
+              echo "  systemd.services.nix-daemon.serviceConfig.Environment = [" >&2
+              echo "      \"NIX_FMOD_USERNAME=xxx\"" >&2
+              echo "      \"NIX_FMOD_PASSWORD=xxx\"" >&2
+              echo "  ];" >&2
+              exit 1
+            fi
+
+          echo "Logging in to fmod.com..."
+          token=$(
+            curl --silent -k -X POST https://fmod.com/api-login \
+              --user "$NIX_FMOD_USERNAME:$NIX_FMOD_PASSWORD" \
+            | jq -r '.token // empty'
+          )
+
+          if [ -z "$token" ]; then
+            echo "Login failed to fmod.com." >&2
+            exit 1
+          fi
+
+          echo "Fetching download link..."
+          download_url=$(
+            curl -k -G "https://fmod.com/api-get-download-link" \
+              --data-urlencode path="files/fmodstudio/tool/Linux/" \
+              --data-urlencode filename="fmodstudio${
+                lib.replaceStrings [ "." ] [ "" ] finalAttrs.version
+              }linux64-installer.deb" \
+              -H "Authorization: FMOD $token" \
+            | jq -r '.url // empty'
+          )
+
+          if [ -z "$download_url" ]; then
+            echo "Failed to get download url." >&2
+            exit 1
+          fi
+
+          echo "Downloading FMOD Studio..."
+          curl -k --fail --location --output "$out" "$download_url"
+        '';
+      }
+    else
+      requireFile rec {
+        name = "fmodstudio${lib.replaceStrings [ "." ] [ "" ] finalAttrs.version}linux64-installer.deb";
+        url = "https://fmod.com/";
+        hash = finalAttrs.hash;
+        message = ''
+          FMOD Studio is available from ${url} and requires a free account.
+
+          Please:
+          1. Create an account at https://fmod.com/ if you don't have one
+          2. Log in and navigate to the download page
+          3. Download the Linux installer (.deb): ${name}
+          4. Add it to the nix store using either:
+             nix-store --add-fixed sha256 ${name}
+             or
+             nix-prefetch-url --type sha256 file:///path/to/${name}
+
+          Alternatively, you can use automatic download by overriding with:
+          fmodstudio.override { fetchMethod = "download"; }
+          (requires setting NIX_FMOD_USERNAME and NIX_FMOD_PASSWORD environment variables)
+        '';
+      };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    dpkg
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libXcomposite
+    nss
+    glib
+    libglvnd
+    libdrm
+    libxkbcommon
+    fontconfig
+    xorg.libXdamage
+    xorg.libXrandr
+    xorg.libXtst
+    xorg.libxshmfence
+    xorg.libxkbfile
+    dbus
+    krb5
+    xcbutilcursor
+    xcbutilkeysyms
+    xcbutilwm
+  ];
+
+  unpackCmd = "dpkg-deb -x $src .";
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/fmodstudio
+    cp -r opt/fmodstudio/* $out/share/fmodstudio/
+    chmod +x $out/share/fmodstudio/fmodstudio
+    chmod +x $out/share/fmodstudio/fmodstudiocl
+    chmod +x $out/share/fmodstudio/libexec/QtWebEngineProcess
+
+    mkdir -p $out/bin
+    ln -s $out/share/fmodstudio/fmodstudio $out/bin/fmodstudio
+    ln -s $out/share/fmodstudio/fmodstudiocl $out/bin/fmodstudiocl
+
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons/hicolor
+
+    if [ -e usr/share/applications/fmodstudio.desktop ]; then
+      install -Dm644 usr/share/applications/fmodstudio.desktop $out/share/applications/
+      # Update paths in desktop file
+      substituteInPlace $out/share/applications/fmodstudio.desktop \
+        --replace-fail "/opt/fmodstudio" "$out/share/fmodstudio"
+    fi
+
+    cp -r usr/share/icons/hicolor $out/share/icons/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Proprietary sound effects engine and authoring tool";
+    homepage = "https://fmod.com";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ eymeric ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Things done

Init fmodstudio.
Mainly inspired by [AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=fmodstudio) and [pianoteq package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/audio/pianoteq/default.nix)

Warning: To build it you need to set env var to access the software ("NIX_FMOD_USERNAME" "NIX_FMOD_PASSWORD").

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@undermirrors can you please test it more deeply than what I can do with my knowledge of the software.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
