### PR TITLE
haskellPackages: remove patches merged upstream

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -215,27 +215,6 @@ with haskellLib;
     disableCabalFlag "auto" super.ghc-lib-parser-ex
   );
 
-  ghcide = appendPatches [
-    # Support ghc == 9.10.2
-    (pkgs.fetchpatch2 {
-      name = "ghcide-ghc-9.10.2.patch";
-      url = "https://github.com/haskell/haskell-language-server/commit/fb17921128bd56ba74872cae9539767e63b9fd79.patch";
-      sha256 = "161kcpfnv3q0n1fgsc0rx2v1rqf16g3pnjqabayym47yg2kp1qiv";
-      stripLen = 1;
-    })
-    # Support hie-bios >= 0.15 (unreleased to hackage)
-    (pkgs.fetchpatch2 {
-      name = "ghcide-hie-bios-0.15.patch";
-      url = "https://github.com/haskell/haskell-language-server/commit/eb06c6f6ad7d7fcc29ff4b62f679f428897147f8.patch";
-      sha256 = "0im3mf71chsgk787lz942c8zlmq00gfsd5rclprlsncg0zli1whq";
-      includes = [
-        "ghcide.cabal"
-        "**/Diagnostics.hs"
-      ];
-      stripLen = 1;
-    })
-  ] super.ghcide;
-
   ###########################################
   ### END HASKELL-LANGUAGE-SERVER SECTION ###
   ###########################################
@@ -481,15 +460,6 @@ with haskellLib;
 
   # https://github.com/schuelermine/ret/issues/3
   ret = doJailbreak super.ret; # base < 4.19
-
-  # 2025-02-13: This part from https://github.com/haskell/ThreadScope/pull/130 seems to be unreleased:
-  threadscope = appendPatches [
-    (fetchpatch {
-      name = "import-monad.patch";
-      url = "https://github.com/haskell/ThreadScope/commit/8846508e9769a8dfd82b3ff66259ba4d58255932.patch";
-      sha256 = "sha256-wBqDJWmqvmU1sFuw/ZlxHOb8xPhZO2RBuyYFP9bJCVI=";
-    })
-  ] super.threadscope;
 
   # The latest release on hackage has an upper bound on containers which
   # breaks the build, though it works with the version of containers present
@@ -2750,20 +2720,6 @@ with haskellLib;
   tasty-autocollect = dontCheck super.tasty-autocollect;
 
   postgres-websockets = lib.pipe super.postgres-websockets [
-    (appendPatches [
-      (pkgs.fetchpatch {
-        # Needed for the patch below to apply.
-        name = "remove-protolude.patch";
-        url = "https://github.com/diogob/postgres-websockets/commit/8027c0f6dc0c5fe6bab4e3e7730db8653b2c51cc.patch";
-        hash = "sha256-gefVUR+tJLrmpwnc1hf4GjLbGVe1GwNmLn5YU7qW/HY=";
-      })
-      (pkgs.fetchpatch {
-        # Can be removed with the next update.
-        name = "fix-connection-closing-when-no-write-mode-is-present.patch";
-        url = "https://github.com/diogob/postgres-websockets/commit/577a2f0bf4750c682c2c3c63e37d90e0ec6f95eb.patch";
-        hash = "sha256-7PCVbfNiJhWfmQrEjaVqbmCL5jffhofOto1RF2FVYJo=";
-      })
-    ])
     (addTestToolDepends [
       pkgs.postgresql
       pkgs.postgresqlTestHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
