### PR TITLE
nixos/doc: explain how to use the ff sync module with ff android

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -50,6 +50,15 @@
   "module-services-crab-hole-upstream-options": [
     "index.html#module-services-crab-hole-upstream-options"
   ],
+  "module-services-firefox-syncserver-clients": [
+    "index.html#module-services-firefox-syncserver-clients"
+  ],
+  "module-services-firefox-syncserver-clients-android": [
+    "index.html#module-services-firefox-syncserver-clients-android"
+  ],
+  "module-services-firefox-syncserver-clients-desktop": [
+    "index.html#module-services-firefox-syncserver-clients-desktop"
+  ],
   "module-services-opencloud": [
     "index.html#module-services-opencloud"
   ],

--- a/nixos/modules/services/networking/firefox-syncserver.md
+++ b/nixos/modules/services/networking/firefox-syncserver.md
@@ -24,10 +24,8 @@ The absolute minimal configuration for the sync server looks like this:
 }
 ```
 
-This will start a sync server that is only accessible locally. Once the services is
-running you can navigate to `about:config` in your Firefox profile and set
-`identity.sync.tokenserver.uri` to `http://localhost:5000/1.0/sync/1.5`. Your browser
-will now use your local sync server for data storage.
+This will start a sync server that is only accessible locally on the following url: `http://localhost:5000/1.0/sync/1.5`.
+See [the dedicated section](#module-services-firefox-syncserver-clients) to configure your browser to use this sync server.
 
 ::: {.warning}
 This configuration should never be used in production. It is not encrypted and
@@ -55,3 +53,25 @@ be made via TLS.
 
 For actual deployment it is also recommended to store the `secrets` file in a
 secure location.
+
+## Configuring clients to use this server {#module-services-firefox-syncserver-clients}
+
+### Firefox desktop {#module-services-firefox-syncserver-clients-desktop}
+To configure a desktop version of Firefox to use your server, navigate to
+`about:config` in your Firefox profile and set
+`identity.sync.tokenserver.uri` to `https://myhostname:5000/1.0/sync/1.5`.
+
+### Firefox Android {#module-services-firefox-syncserver-clients-android}
+To configure an Android version of Firefox to use your server:
+* First ensure that you are disconnected from you Mozilla account.
+* Go to App Menu > Settings > About Firefox and click the logo 5 times. You
+  should see a “debug menu enabled” notification.
+* Back to the main menu, a new menu "sync debug" should have appeared.
+* In this menu, set "custom sync server" to `https://myhostname:5000/1.0/sync/1.5`.
+
+::: {.warning}
+Changes to this configuration value are ignored if you are currently connected to your account.
+:::
+
+* Restart the application.
+* Log in to your account.


### PR DESCRIPTION
source https://mozilla-services.readthedocs.io/en/latest/howtos/run-sync-1.5.html#howto-run-sync15

Quotation:

```
Firefox for Android (“Daylight”, versions 79 and later) does support using a non-Mozilla-hosted Sync server. Before logging in, go to App Menu > Settings > About Firefox and click the logo 5 times. You should see a “debug menu enabled” notification. Go back to the main menu and you will see two options for a custom account server and a custom Sync server. Set the Sync server to the URL given above and then log in.

To configure Android Firefox 44 up to 78 to talk to your new Sync server, just set the “identity.sync.tokenserver.uri” exactly as above before signing in to Mozilla accounts and Sync on your Android device.

Important: after creating the Android account, changes to “identity.sync.tokenserver.uri” will be ignored. (If you need to change the URI, delete the Android account using the Settings > Sync > Disconnect… menu item, update the pref, and sign in again.) Non-default TokenServer URLs are displayed in the Settings > Sync panel in Firefox for Android, so you should be able to verify your URL there.
```

the /token/ prefix is experimentally wrong.


![image](https://github.com/user-attachments/assets/c2da2b5d-2131-4f0a-880a-e4d0544ecd06)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
