### PR TITLE
vimPlugins.vectorcode-nvim: init at 0.6.10

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/vectorcode-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/vectorcode-nvim/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  vimUtils,
+  vectorcode,
+  vimPlugins,
+}:
+let
+  inherit (vectorcode) src version;
+in
+vimUtils.buildVimPlugin {
+  inherit src version;
+
+  pname = "vectorcode.nvim";
+
+  # nixpkgs-update: no auto update
+  # This is built from the same source as vectorcode and will rebuild automatically
+
+  sourceRoot = "${src.name}/plugin";
+
+  dependencies = [
+    vimPlugins.plenary-nvim
+  ];
+
+  buildInputs = [ vectorcode ];
+
+  postPatch = ''
+    cp -r ../lua .
+  '';
+
+  meta = {
+    description = "Index and navigate your code repository using vectorcode";
+    homepage = "https://github.com/Davidyz/VectorCode/blob/main/docs/neovim.md";
+    inherit (vectorcode.meta) changelog license;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}


### PR DESCRIPTION
https://github.com/Davidyz/VectorCode can build two things: `vectorcode` and its Neovim plugin.

This PR builds the Neovim plugin. Note that the lua files are in a parallel directory to the plugin, so we have to copy them into the build directory.

Note: The version number matches `pkgs.vectorcode` and embeds a copy of the executable in its closure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
