### PR TITLE
nixos/nextcloud: add option enabledApps

### DIFF
--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -135,6 +135,7 @@ let
       ./with-mysql-and-memcached.nix
       ./with-postgresql-and-redis.nix
       ./with-objectstore.nix
+      ./with-enabled-apps.nix
     ];
 in
 listToAttrs (

--- a/nixos/tests/nextcloud/with-enabled-apps.nix
+++ b/nixos/tests/nextcloud/with-enabled-apps.nix
@@ -1,0 +1,80 @@
+{
+  name,
+  pkgs,
+  testBase,
+  system,
+  ...
+}:
+
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+runTest (
+  { config, lib, ... }:
+  {
+    inherit name;
+    meta.maintainers = lib.teams.nextcloud.members;
+
+    imports = [ testBase ];
+
+    nodes = {
+      nextcloud =
+        { config, pkgs, ... }:
+        {
+          services.nextcloud = {
+            enable = true;
+            config.dbtype = "sqlite";
+            extraApps = with config.services.nextcloud.package.packages.apps; {
+              inherit calendar contacts;
+            };
+            extraAppsEnable = true;
+
+            # Test the enabledApps functionality
+            # only enable extraApps, mandatory and specified ones
+            # This should disable e.g. activity, circles, ...
+            enabledApps = [
+              "federation"
+              "user_ldap"
+            ];
+          };
+        };
+    };
+
+    test-helpers.extraTests = ''
+      with subtest("Test enabledApps functionality"):
+          # Get list of enabled apps
+          enabled_apps_output = nextcloud.succeed("nextcloud-occ app:list --output=json")
+          import json
+          app_status = json.loads(enabled_apps_output)
+          enabled_apps = list(app_status.get("enabled", {}).keys())
+          disabled_apps = list(app_status.get("disabled", {}).keys())
+
+          print(f"Enabled apps: {enabled_apps}")
+          print(f"Disabled apps: {disabled_apps}")
+
+          # Check that contacts and calendar are enabled (from enabledApps list)
+          assert "contacts" in enabled_apps, "contacts app should be enabled, but enabled apps are: {}".format(enabled_apps)
+          assert "calendar" in enabled_apps, "calendar app should be enabled, but enabled apps are: {}".format(enabled_apps)
+
+          # Check that activity is disabled (not in enabledApps list, despite being in extraApps)
+          assert "activity" in disabled_apps, "activity app should be disabled, but disabled apps are: {}".format(disabled_apps)
+
+          # Verify mandatory app files are still enabled (these should never be disabled)
+          assert "files" in enabled_apps, "files app should be enabled, because it is mandatory but enabled apps are: {}".format(enabled_apps)
+
+      with subtest("Test app enabling/disabling persistence across service restarts"):
+          # Manually enable contacts app
+          nextcloud.succeed("nextcloud-occ app:enable activity")
+
+          # Restart nextcloud-setup service to trigger the enabledApps logic again
+          nextcloud.succeed("systemctl restart nextcloud-setup.service")
+
+          # Verify activity is disabled again after restart
+          enabled_apps_output = nextcloud.succeed("nextcloud-occ app:list --output=json")
+          app_status = json.loads(enabled_apps_output)
+          enabled_apps = list(app_status.get("enabled", {}).keys())
+          disabled_apps = list(app_status.get("disabled", {}).keys())
+
+          assert "activity" in disabled_apps, "activity should be disabled again after restart, but disabled apps are: {}".format(disabled_apps)
+          assert "calendar" in enabled_apps, "calendar should still be enabled after restart"
+    '';
+  }
+)


### PR DESCRIPTION
add nextcloud service option witch let you define enabled/disabled apps via nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
