### PR TITLE
nixos/postfix: replace tls cert/key options and allow removing settings from rendered main.cf

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -46,6 +46,11 @@
 
 - `renovate` was updated to v40. See the [upstream release notes](https://github.com/renovatebot/renovate/releases/tag/40.0.0) for breaking changes.
 
+- The Postfix module has been updated and likely requires configuration changes:
+  - The `services.postfix.sslCert` and `sslKey` options were removed and you now need to configure
+    - [services.postfix.config.smtpd_tls_chain_files](#opt-services.postfix.config.smtpd_tls_chain_files) for server certificates,
+    - [services.postfix.config.smtp_tls_chain_files](#opt-services.postfix.config) for client certificates.
+
 ## Other Notable Changes {#sec-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -584,6 +584,41 @@ in
               ])
             );
           options = {
+            smtpd_tls_chain_files = mkOption {
+              type = with types; listOf path;
+              default = [ ];
+              example = [
+                "/var/lib/acme/mail.example.com/privkey.pem"
+                "/var/lib/acme/mail.example.com/fullchain.pem"
+              ];
+              description = ''
+                List of paths to the server private keys and certificates.
+
+                ::: {.caution}
+                The order of items matters and a private key must always be followed by the corresponding certificate.
+                :::
+
+                <https://www.postfix.org/postconf.5.html#smtpd_tls_chain_files>
+              '';
+            };
+
+            smtpd_tls_security_level = mkOption {
+              type = types.enum [
+                "none"
+                "may"
+                "encrypt"
+              ];
+              default = if config.services.postfix.config.smtpd_tls_chain_files != [ ] then "may" else "none";
+              defaultText = lib.literalExpression ''
+                if config.services.postfix.config.smtpd_tls_chain_files != [ ] then "may" else "none"
+              '';
+              example = "may";
+              description = ''
+                The server TLS security level. Enable TLS by configuring at least `may`.
+
+                <https://www.postfix.org/postconf.5.html#smtpd_tls_security_level>
+              '';
+            };
           };
         };
 
@@ -614,18 +649,6 @@ in
         description = ''
           File containing trusted certification authorities (CA) to verify certificates of mailservers contacted for mail delivery. This sets [smtp_tls_CAfile](https://www.postfix.org/postconf.5.html#smtp_tls_CAfile). Defaults to system trusted certificates (see `security.pki.*` options).
         '';
-      };
-
-      sslCert = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = "SSL certificate to use.";
-      };
-
-      sslKey = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = "SSL key to use.";
       };
 
       recipientDelimiter = lib.mkOption {
@@ -991,18 +1014,6 @@ in
           // lib.optionalAttrs (cfg.tlsTrustedAuthorities != "") {
             smtp_tls_CAfile = cfg.tlsTrustedAuthorities;
             smtp_tls_security_level = lib.mkDefault "may";
-          }
-          // lib.optionalAttrs (cfg.sslCert != "") {
-            smtp_tls_cert_file = cfg.sslCert;
-            smtp_tls_key_file = cfg.sslKey;
-
-            smtp_tls_security_level = lib.mkDefault "may";
-
-            smtpd_tls_cert_file = cfg.sslCert;
-            smtpd_tls_key_file = cfg.sslKey;
-
-            smtpd_tls_security_level = lib.mkDefault "may";
-
           };
 
         services.postfix.masterConfig =
@@ -1166,6 +1177,12 @@ in
   imports = [
     (lib.mkRemovedOptionModule [ "services" "postfix" "sslCACert" ]
       "services.postfix.sslCACert was replaced by services.postfix.tlsTrustedAuthorities. In case you intend that your server should validate requested client certificates use services.postfix.extraConfig."
+    )
+    (lib.mkRemovedOptionModule [ "services" "postfix" "sslCert" ]
+      "services.postfix.sslCert was removed. Use services.postfix.config.smtpd_tls_chain_files for the server certificate, or services.postfix.config.smtp_tls_chain_files for the client certificate."
+    )
+    (lib.mkRemovedOptionModule [ "services" "postfix" "sslKey" ]
+      "services.postfix.sslKey was removed. Use services.postfix.config.smtpd_tls_chain_files for server private key, or services.postfix.config.smtp_tls_chain_files for the client private key."
     )
 
     (lib.mkChangedOptionModule

--- a/nixos/tests/postfix.nix
+++ b/nixos/tests/postfix.nix
@@ -14,8 +14,10 @@ import ./make-test-python.nix {
         enableSubmission = true;
         enableSubmissions = true;
         tlsTrustedAuthorities = "${certs.ca.cert}";
-        sslCert = "${certs.${domain}.cert}";
-        sslKey = "${certs.${domain}.key}";
+        config.smtpd_tls_chain_files = [
+          certs.${domain}.key
+          certs.${domain}.cert
+        ];
         submissionsOptions = {
           smtpd_sasl_auth_enable = "yes";
           smtpd_client_restrictions = "permit";


### PR DESCRIPTION
See the individual commits for reasoning.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
