### PR TITLE
krename: switch to podofo 0.10, adopt, refactor

### DIFF
--- a/pkgs/by-name/kr/krename/package.nix
+++ b/pkgs/by-name/kr/krename/package.nix
@@ -1,30 +1,20 @@
 {
-  mkDerivation,
+  stdenv,
   fetchurl,
   fetchpatch,
   lib,
   extra-cmake-modules,
-  kdoctools,
-  wrapGAppsHook3,
-  kconfig,
-  kinit,
-  kjsembed,
+  libsForQt5,
   taglib,
   exiv2,
-  podofo_0_9,
-  kcrash,
+  podofo_0_10,
 }:
-
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "krename";
   version = "5.0.2";
 
-in
-mkDerivation rec {
-  name = "${pname}-${version}";
-
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
+    url = "mirror://kde/stable/krename/${finalAttrs.version}/src/krename-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-sjxgp93Z9ttN1/VaxV/MqKVY+miq+PpcuJ4er2kvI+0=";
   };
 
@@ -34,35 +24,44 @@ mkDerivation rec {
       url = "https://invent.kde.org/utilities/krename/-/commit/e7dd767a9a1068ee1fe1502c4d619b57d3b12add.patch";
       hash = "sha256-JpLVbegRHJbXi/Z99nZt9kgNTetBi+L9GfKv5s3LAZw=";
     })
+    (fetchpatch {
+      name = "add-support-for-podofo-0.10.patch";
+      url = "https://invent.kde.org/utilities/krename/-/commit/056d614dc2166cd25749caf264b1b4d9d348f4d4.patch";
+      hash = "sha256-OYjd1QJWIdWBWVlYzmcn7DTpeoToZKjVfVQpFNZX02E=";
+    })
   ];
 
   buildInputs = [
     taglib
     exiv2
-    podofo_0_9
+    podofo_0_10
   ];
 
   nativeBuildInputs = [
     extra-cmake-modules
-    kdoctools
-    wrapGAppsHook3
+    libsForQt5.kdoctools
+    libsForQt5.wrapQtAppsHook
   ];
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with libsForQt5; [
     kconfig
     kcrash
-    kinit
+    qtbase
     kjsembed
+    kio
   ];
 
   NIX_LDFLAGS = "-ltag";
 
-  meta = with lib; {
+  meta = {
     description = "Powerful batch renamer for KDE";
     mainProgram = "krename";
     homepage = "https://kde.org/applications/utilities/krename/";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ peterhoeg ];
-    inherit (kconfig.meta) platforms;
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [
+      peterhoeg
+      kuflierl
+    ];
+    inherit (libsForQt5.kconfig.meta) platforms;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3459,8 +3459,6 @@ with pkgs;
 
   kio-fuse = libsForQt5.callPackage ../tools/filesystems/kio-fuse { };
 
-  krename = libsForQt5.callPackage ../applications/misc/krename { };
-
   krunner-pass = libsForQt5.callPackage ../tools/security/krunner-pass { };
 
   krunner-translator = libsForQt5.callPackage ../tools/misc/krunner-translator { };


### PR DESCRIPTION
Changes:
- adopt
- podofo 0.9 -> 0.10
- switch to explicit qt5 lib
- remove `with lib;`
- migrate to pkgs/by-name
- switch to finalAttrs
- switch to stdenv.mkDerivation from mkDerivation
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
