### PR TITLE
nixos-containers: Added flake option

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -844,6 +844,16 @@ in
                 '';
               };
 
+              flake = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                example = "github:NixOS/nixpkgs/master";
+                description = ''
+                  The Flake URI of the NixOS configuration to use for the container.
+                  Replaces the option {option}`containers.<name>.path`.
+                '';
+              };
+
               # Removed option. See `checkAssertion` below for the accompanying error message.
               pkgs = mkOption { visible = false; };
             } // networkOptions;
@@ -867,13 +877,18 @@ in
                       - containers.${name}.config.nixpkgs.pkgs
                         This only sets the `pkgs` argument used inside the container modules.
                     ''
+                  else if options.config.isDefined && (options.flake.value != null) then
+                    throw ''
+                      The options 'containers.${name}.path' and 'containers.${name}.flake' cannot both be set.
+                    ''
                   else
                     null;
               in
               {
-                path =
-                  builtins.seq checkAssertion mkIf options.config.isDefined
-                    config.config.system.build.toplevel;
+                path = builtins.seq checkAssertion mkMerge [
+                  (mkIf options.config.isDefined config.config.system.build.toplevel)
+                  (mkIf (config.flake != null) "/nix/var/nix/profiles/per-container/${name}")
+                ];
               };
           }
         )
@@ -1044,7 +1059,12 @@ in
             name: cfg:
             nameValuePair "${configurationDirectoryName}/${name}.conf" {
               text = ''
-                SYSTEM_PATH=${cfg.path}
+                ${optionalString (cfg.flake == null) ''
+                  SYSTEM_PATH=${cfg.path}
+                ''}
+                ${optionalString (cfg.flake != null) ''
+                  FLAKE=${cfg.flake}
+                ''}
                 ${optionalString cfg.privateNetwork ''
                   PRIVATE_NETWORK=1
                   ${optionalString (cfg.hostBridge != null) ''

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -113,6 +113,11 @@ let
 
     cp --remove-destination /etc/resolv.conf "$root/etc/resolv.conf"
 
+    if [ -n "$FLAKE" ] && [ ! -e "/nix/var/nix/profiles/per-container/$INSTANCE/system" ]; then
+      # we create the etc/nixos-container config file, then if we utilize the update function, we can then build all the necessary system files for the container
+      ${lib.getExe nixos-container} update "$INSTANCE"
+    fi
+
     declare -a extraFlags
 
     if [ "$PRIVATE_NETWORK" = 1 ]; then
@@ -944,7 +949,10 @@ in
 
           unitConfig.RequiresMountsFor = "${stateDirectory}/%i";
 
-          path = [ pkgs.iproute2 ];
+          path = [
+            pkgs.iproute2
+            config.nix.package
+          ];
 
           environment = {
             root = "${stateDirectory}/%i";


### PR DESCRIPTION
This PR brings into the nixos-containers module the option to specify a flake instead of a config or a path. This replicates the functionality that `nixos-container create <name> --flake <flake>` preforms, but through a declarative approach.

During my development on my own server, I found the lack of container flake declarative functionality to be time-consuming in my project. Whenever I had to make bigger changes, I often had to run several commands and tinker with .conf files, when most of it was possible with existing config settings. This PR aims to bridge that gap, by allowing a nixos-container utilizing a flake to be specified declaratively.

This is my first time contributing to NixOS, I have tried to follow the Contributing guidelines as closely as possible, however if I have made any mistakes in this process, please let me know so I can correct. Thank you so much.

## Example

Using my own project as an example:

```
{ lib, config, ... }: {
  containers.devhaj-bot = {
    autoStart = true;

    bindMounts = {
      "/data/blahaj-bot" = {
        hostPath = "/data/devhaj-bot";
        isReadOnly = false;
      };
      
      "/etc/blahaj-bot/token" = {
        hostPath = "/run/agenix/blahaj-bot-token";
        isReadOnly = true;
      };
    };

    flake = "github:transgwender/blahaj-bot/db";
  };
}
```

This then results in `/etc/nixos-containers/devhaj-bot.conf` being generated:

```
FLAKE=github:transgwender/blahaj-bot/db
PRIVATE_USERS=no
INTERFACES=""
MACVLANS=""
AUTO_START=1
EXTRA_NSPAWN_FLAGS=" --bind=/data/devhaj-bot:/data/blahaj-bot --bind-ro=/run/agenix/blahaj-bot-token:/etc/blahaj-bot/token"
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
