### PR TITLE
[Backport release-25.05] dprint-plugins.dprint-plugin-typescript: 0.95.1 -> 0.95.5

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-typescript.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-typescript.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "TypeScript/JavaScript code formatter.";
-  hash = "sha256-IHbpEwTATwAmVa/ihGjQzQL/WwWo8owslJtWYUjVF+g=";
+  hash = "sha256-sn10yaYbp6VWspqEMKCd7HbDvKi35AW5Xn8FGzzN3kM=";
   initConfig = {
     configExcludes = [ "**/node_modules" ];
     configKey = "typescript";
@@ -16,6 +16,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-typescript";
   updateUrl = "https://plugins.dprint.dev/dprint/typescript/latest.json";
-  url = "https://plugins.dprint.dev/typescript-0.95.1.wasm";
-  version = "0.95.1";
+  url = "https://plugins.dprint.dev/typescript-0.95.5.wasm";
+  version = "0.95.5";
 }


### PR DESCRIPTION
(cherry picked from commit f8ce8eb61e388566a439519ff7c2f159f01cbdbe)

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  - Even as a non-committer, if you find that it is not acceptable, leave a comment.