### PR TITLE
python3Packages.curl-cffi: 0.10.0 -> 0.11.1

### DIFF
--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -7,19 +7,31 @@
   curl-impersonate-chrome,
   cffi,
   certifi,
-  typing-extensions,
+  charset-normalizer,
+  cryptography,
+  fastapi,
+  httpx,
+  proxy-py,
+  pytest-asyncio,
+  pytest-trio,
+  pytestCheckHook,
+  python-multipart,
+  trustme,
+  uvicorn,
+  websockets,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "curl-cffi";
-  version = "0.10.0";
+  version = "0.11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lexiforest";
     repo = "curl_cffi";
     tag = "v${version}";
-    hash = "sha256-h7PPlxjIVT6T9x7gKBSifuWl8wzUNDwRcaUifUS0icM=";
+    hash = "sha256-hpsAga5741oTBT87Rt7XTyxxu7SQ5Usw+2VVr54oA8k=";
   };
 
   patches = [ ./use-system-libs.patch ];
@@ -33,7 +45,6 @@ buildPythonPackage rec {
   dependencies = [
     cffi
     certifi
-    typing-extensions
   ];
 
   env = lib.optionalAttrs stdenv.cc.isGNU {
@@ -42,7 +53,49 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "curl_cffi" ];
 
+  nativeCheckInputs = [
+    charset-normalizer
+    cryptography
+    fastapi
+    httpx
+    proxy-py
+    pytest-asyncio
+    pytest-trio
+    pytestCheckHook
+    python-multipart
+    trustme
+    uvicorn
+    websockets
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    # import from $out
+    rm -r curl_cffi
+  '';
+
+  pytestFlags = [
+    "tests/unittest"
+    # test accesses network
+    "--deselect tests/unittest/test_smoke.py::test_async"
+  ];
+
+  disabledTests = [
+    # FIXME ImpersonateError: Impersonating chrome136 is not supported
+    "test_impersonate_without_version"
+    "test_with_impersonate"
+    # InvalidURL: Invalid URL component 'path'
+    "test_update_params"
+    # tests access network
+    "test_add_handle"
+    "test_socket_action"
+    "test_without_impersonate"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
+    changelog = "https://github.com/lexiforest/curl_cffi/releases/tag/${src.tag}";
     description = "Python binding for curl-impersonate via cffi";
     homepage = "https://curl-cffi.readthedocs.io";
     license = licenses.mit;


### PR DESCRIPTION
Diff: https://github.com/lexiforest/curl_cffi/compare/refs/tags/v0.10.0...refs/tags/v0.11.1

Changelog: https://github.com/lexiforest/curl_cffi/releases/tag/v0.11.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
