### PR TITLE
[25.05] qdiskinfo: 0.3-unstable-2025-05-08 -> 0.4

### DIFF
--- a/pkgs/by-name/qd/qdiskinfo/package.nix
+++ b/pkgs/by-name/qd/qdiskinfo/package.nix
@@ -8,7 +8,7 @@
   qt6,
   qdiskinfo,
   themeBundle ? null,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 let
@@ -34,15 +34,15 @@ assert
     && themeBundle' ? rightCharacter
   );
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qdiskinfo";
-  version = "0.3-unstable-2025-05-22";
+  version = "0.4";
 
   src = fetchFromGitHub {
     owner = "edisionnano";
     repo = "QDiskInfo";
-    rev = "9b7f4fb44e888dde7c9d0e82300d275e8671769d";
-    hash = "sha256-GqHDTEeZ+dEmCeyFehaNKB8af5PN8ZTSKxm00mkqouk=";
+    tag = finalAttrs.version;
+    hash = "sha256-FufbF0oEqpYgXnfzUZJ3tTN2jJoIQX4UB3yURRV7y00=";
   };
 
   nativeBuildInputs = [
@@ -104,7 +104,7 @@ stdenv.mkDerivation {
         themeName: themeBundle:
         (qdiskinfo.override { inherit themeBundle; }).overrideAttrs { pname = "qdiskinfo-${themeName}"; }
       );
-      updateScript = unstableGitUpdater { };
+      updateScript = nix-update-script { };
     };
 
   meta = {
@@ -118,4 +118,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     mainProgram = "QDiskInfo";
   };
-}
+})

--- a/pkgs/by-name/qd/qdiskinfo/package.nix
+++ b/pkgs/by-name/qd/qdiskinfo/package.nix
@@ -36,13 +36,13 @@ assert
 
 stdenv.mkDerivation {
   pname = "qdiskinfo";
-  version = "0.3-unstable-2025-05-08";
+  version = "0.3-unstable-2025-05-22";
 
   src = fetchFromGitHub {
     owner = "edisionnano";
     repo = "QDiskInfo";
-    rev = "3416cc7ac19b25bb78eab135cf5e0b281e506de0";
-    hash = "sha256-loL6fzOSoZyCmrs7joHQCsCStLGgKxmMuqFmtADWTW0=";
+    rev = "9b7f4fb44e888dde7c9d0e82300d275e8671769d";
+    hash = "sha256-GqHDTEeZ+dEmCeyFehaNKB8af5PN8ZTSKxm00mkqouk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Backports #411092 and #412168 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
