### PR TITLE
tdf: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/by-name/td/tdf/package.nix
+++ b/pkgs/by-name/td/tdf/package.nix
@@ -10,18 +10,18 @@
 
 rustPlatform.buildRustPackage {
   pname = "tdf";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "itsjunetime";
     repo = "tdf";
     fetchSubmodules = true;
-    rev = "a2b728fae3c5b0addfa64e8d3e44eac6fd50f1d9";
-    hash = "sha256-0as/tKw0nKkZn+5q5PlKwK+LZK0xWXDAdiD3valVjBs=";
+    rev = "e16163efb87e63e692cd2929180ea29def09ba89";
+    hash = "sha256-FezpqyoAtfWoX78APTSWjG9vMJr8FMqy402HuIas3/0=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-krIPfi4SM4uCw7NLauudwh1tgAaB8enDWnMC5X16n48=";
+  cargoHash = "sha256-NynxXp6+SM9R9xfbFeLyCvLxiQyRW6LDvlo6QWPBXvs=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [


### PR DESCRIPTION
updated tdf to newest release version (0.3.0).

Changelog: https://github.com/itsjunetime/tdf/blob/main/CHANGELOG.md

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
  - [X] `sandbox = false`
- [X] Tested, as applicable:
  - [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---