### PR TITLE
sdcc: Disable broken-on-darwin man pages output

### DIFF
--- a/pkgs/by-name/sd/sdcc/package.nix
+++ b/pkgs/by-name/sd/sdcc/package.nix
@@ -39,11 +39,20 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-1QMEN/tDa7HZOo29v7RrqqYGEzGPT7P1hx1ygV0e7YA=";
   };
 
-  outputs = [
-    "out"
-    "doc"
-    "man"
-  ];
+  # TODO: sdcc version 4.5.0 does not currently produce a man output.
+  # Until the fix to sdcc's makefiles is released, this workaround
+  # conditionally withholds the man output on darwin.
+  #
+  # sdcc's tracking issue:
+  # <https://sourceforge.net/p/sdcc/bugs/3848/>
+  outputs =
+    [
+      "out"
+      "doc"
+    ]
+    ++ lib.optionals (!stdenv.isDarwin) [
+      "man"
+    ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `sdcc` package does not currently build on Darwin. This is due to a change in sdcc's makefiles. 

Once the release is made upstream, I think we can have the man pages either be opt-in, or detect that the release of `sdcc` requested has `.PHONY` in its build scripts (and automatically include or omit the man page output).

This way sdcc-4.5.0 and other affected versions will still be usable on Darwin.

## Things done
Conditionally include the `"man"` output on non-darwin platforms

Several packages on master were not building in sandboxed aarch64 Darwin to begin with (at least with sandbox = true). I ran nixpkgs-review on both the base of this branch and the tip of this branch and found no regressions.
 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable: **N/A** No relevant tests found, none run
  - I did run pulseview which depends on SDCC in a local flake against an override with this change)
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage] (https://github.com/Mic92/nixpkgs-review#usage) (see des
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Ran the binary and got the help menu
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
