### PR TITLE
softhsm: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/so/softhsm/package.nix
+++ b/pkgs/by-name/so/softhsm/package.nix
@@ -22,12 +22,17 @@ stdenv.mkDerivation rec {
     "--with-objectstore-backend-db"
     "--sysconfdir=$out/etc"
     "--localstatedir=$out/var"
+    # The configure script checks for the sqlite3 command, but never uses it.
+    # Provide an arbitrary executable file for cross scenarios.
+    "ac_cv_path_SQLITE3=/"
   ];
 
   buildInputs = [
     botan2
     sqlite
   ];
+
+  strictDeps = true;
 
   postInstall = "rm -rf $out/var";
 


### PR DESCRIPTION
Fixes cross and regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).