### PR TITLE
python312Packages.tree-sitter-sql: init at 0.3.8

### DIFF
--- a/pkgs/development/python-modules/tree-sitter-sql/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-sql/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  tree-sitter-sql,
+
+  #optional-dependencies
+  tree-sitter,
+}:
+buildPythonPackage rec {
+  pname = "tree-sitter-sql";
+  version = "0.3.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "DerekStride";
+    repo = "tree-sitter-sql";
+    tag = "v${version}";
+    hash = "sha256-8gdbbz187sV8I+PJHubFyyQwGUqvo05Yw1DX7rOK4DI=";
+  };
+
+  postUnpack = ''
+    cp -rf ${tree-sitter-sql.passthru.parsers}/* $sourceRoot
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  passthru = {
+    # As mentioned in https://github.com/DerekStride/tree-sitter-sql README
+    # generated tree sitter parser files necessary for compilation
+    # are separately distributed on the gh-pages branch
+    parsers = fetchFromGitHub {
+      owner = "DerekStride";
+      repo = "tree-sitter-sql";
+      rev = "9853b887c5e4309de273922b681cc7bc09e30c78/gh-pages";
+      hash = "sha256-p60nphbSN+O5fOlL06nw0qgQFpmvoNCTmLzDvUC/JGs=";
+    };
+  };
+
+  optional-dependencies = {
+    core = [
+      tree-sitter
+    ];
+  };
+
+  pythonImportsCheck = [ "tree_sitter_sql" ];
+
+  meta = {
+    description = "sql grammar for tree-sitter";
+    homepage = "https://github.com/DerekStride/tree-sitter-sql";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pcboy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17780,6 +17780,8 @@ self: super: with self; {
 
   tree-sitter-rust = callPackage ../development/python-modules/tree-sitter-rust { };
 
+  tree-sitter-sql = callPackage ../development/python-modules/tree-sitter-sql { };
+
   tree-sitter-yaml = callPackage ../development/python-modules/tree-sitter-yaml { };
 
   treelib = callPackage ../development/python-modules/treelib { };


### PR DESCRIPTION
Follow up of https://github.com/NixOS/nixpkgs/pull/409007

The tree-sitter-sql python package is necessary to make it work.
As mentioned in the readme of the original project at https://github.com/derekstride/tree-sitter-sql/ , some generated files necessary for compilation are not part of the repository but instead generated on CI and pushed to gh-pages. This is what I'm trying to get with a fetchUrl.  
If there is a better way, I'm interested. Considering I can see mention of this gh-pages branch [here](https://github.com/NixOS/nixpkgs/blob/46990a57903249ec1c3d63f096484c4489fbdd15/pkgs/development/tools/parsing/tree-sitter/update.nix#L193) I wonder if there is a better way I'm missing.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

