### PR TITLE
labelife-label-printer: 1.2.1 -> 2.0.0

### DIFF
--- a/pkgs/by-name/la/labelife-label-printer/package.nix
+++ b/pkgs/by-name/la/labelife-label-printer/package.nix
@@ -1,33 +1,49 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchzip,
   cups,
   autoPatchelfHook,
+  detox,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "labelife-label-printer";
-  version = "1.2.1";
+  version = "2.0.0";
 
   arch =
-    if stdenv.hostPlatform.system == "x86_64-linux" then
-      "x86_64"
-    else if stdenv.hostPlatform.system == "i686-linux" then
-      "i386"
-    else
-      throw "Unsupported system: ${stdenv.hostPlatform.system}";
+    {
+      aarch64-linux = "aarch64";
+      armv7l-linux = "armhf";
+      i686-linux = "i386";
+      x86_64-linux = "x86_64";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  src = fetchurl {
-    url = "https://oss.saas.aimocloud.com/saas/Lablife/bag/LabelPrinter-${finalAttrs.version}.tar.gz";
-    hash = "sha256-twnIFMBMyEM3xGlsuk3763C3emz3mgpEnlfvnL0XRWw=";
+  src = fetchzip {
+    url = "https://oss.qu-in.ltd/Labelife/Label_Printer_Driver_Linux.zip";
+    hash = "sha256-0ESZ0EqPh9Wz6ogQ6vTsAogujbn4zINtMh62sEpNRs4=";
   };
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    detox
+  ];
   buildInputs = [ cups ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    tar -xzf ${finalAttrs.src}/LabelPrinter-${finalAttrs.version}.001.tar.gz --strip-components=1
+
+    runHook postUnpack
+  '';
 
   installPhase = ''
     runHook preInstall
+    # Remove spaces from PPD filenames
+    detox ppds
+
     # Install the CUPS filter with executable permissions
     install -Dm755 ./${finalAttrs.arch}/rastertolabeltspl $out/lib/cups/filter/rastertolabeltspl
 
@@ -46,9 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     longDescription = ''
       Supported printer models include:
       - D520 & D520BT
-      - PM-201
       - PM-241 & PM-241-BT
-      - PM-246 & PM-246S
 
       Brands using Labelife drivers include:
       - Phomemo
@@ -58,6 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     maintainers = with lib.maintainers; [ daniel-fahey ];
     platforms = [
+      "aarch64-linux"
+      "armv7l-linux"
       "i686-linux"
       "x86_64-linux"
     ];


### PR DESCRIPTION
I've updated this derivation as Labelife released a new version of their Linux drivers that now include binaries for ARM. Note there's a typo on their ["compatibility chart"](https://labelife.net/#/chart), the driver is version 2.0.0 not 1.2.2.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD --extra-nixpkgs-config '{ allowUnfree = true; }'"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
