### PR TITLE
efiboots: init at 2.1.0-unstable-2025-06-03

### DIFF
--- a/pkgs/by-name/ef/efiboots/package.nix
+++ b/pkgs/by-name/ef/efiboots/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  gtk4,
+  glib,
+  gobject-introspection,
+  efibootmgr,
+  python3,
+  util-linux,
+  wrapGAppsHook3,
+  desktop-file-utils,
+  hicolor-icon-theme,
+  meson,
+  ninja,
+  pkg-config,
+  gettext,
+  appstream,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "efiboots";
+  version = "2.1.0-unstable-2025-06-03";
+
+  src = fetchFromGitHub {
+    owner = "Elinvention";
+    repo = "efiboots";
+    rev = "3d40c87e7a3711c3b96289ea680e9fa729980051";
+    hash = "sha256-IKFfLsbYd7KDnzEo04Sh39j5qTMYgsRAS5JdbbPPPmA=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+    appstream
+    wrapGAppsHook3
+    python3.pkgs.wrapPython
+    desktop-file-utils # needed for update-desktop-database
+    glib # needed for glib-compile-schemas
+    gobject-introspection # need for gtk namespace to be available
+    hicolor-icon-theme # needed for postinstall script
+  ];
+
+  buildInputs = [
+    gtk4
+    glib
+  ];
+
+  propagatedBuildInputs = [ python3.pkgs.pygobject3 ];
+
+  doCheck = true;
+  checkInputs = finalAttrs.buildInputs;
+
+  # ModuleNotFoundError: No module named 'gi' error
+  # fix found from https://github.com/NixOS/nixpkgs/issues/343134#issuecomment-2453502399
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=( \
+      "''${gappsWrapperArgs[@]}" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          efibootmgr
+          util-linux
+        ]
+      }" \
+    )
+  '';
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  meta = {
+    description = "Manage EFI boot loader entries with this simple GUI";
+    homepage = "https://github.com/Elinvention/efiboots";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    mainProgram = "efiboots";
+    maintainers = with lib.maintainers; [
+      Elinvention
+      phanirithvij
+    ];
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
