### PR TITLE
python3Packages.anthropic: 0.51.0 -> 0.52.2

### DIFF
--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -30,14 +30,14 @@
 
 buildPythonPackage rec {
   pname = "anthropic";
-  version = "0.51.0";
+  version = "0.52.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anthropics";
     repo = "anthropic-sdk-python";
     tag = "v${version}";
-    hash = "sha256-gD3qZpPKtKZtuoGqnKVgFp0gCxpL0Aq5NGFCMk+z3cQ=";
+    hash = "sha256-vCIS2NDsScKESfYFHDTSRLb9ZhUsrEPHyfuubrbc+44=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/langchain-anthropic/default.nix
+++ b/pkgs/development/python-modules/langchain-anthropic/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-anthropic";
-  version = "0.3.13";
+  version = "0.3.15";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-anthropic==${version}";
-    hash = "sha256-CloIxDPnBnKDUeS4psRvpz8ifK/xR/U62wG+ORHginM=";
+    hash = "sha256-GOD6pMuUDCfrQ6MP+/HXZIg5wHUDRysosEjXjewY/9M=";
   };
 
   sourceRoot = "${src.name}/libs/partners/anthropic";
@@ -52,7 +52,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "tests/unit_tests" ];
+  disabledTestPaths = [
+    "tests/integration_tests"
+  ];
 
   pythonImportsCheck = [ "langchain_anthropic" ];
 

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -10,6 +10,10 @@
   httpx,
   langchain-core,
   syrupy,
+  pytest-benchmark,
+  pytest-codspeed,
+  pytest-recording,
+  vcrpy,
 
   # buildInputs
   pytest,
@@ -26,14 +30,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-tests";
-  version = "0.3.19";
+  version = "0.3.20";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-tests==${version}";
-    hash = "sha256-DSTngWRFseJ6kSAY7Lxxkh77QFr0jhHxG3mH89QmdxA=";
+    hash = "sha256-RMuxWA/n8d71FReFKO3Y/5P0MYk4aZ5WU2/TRxf9UuE=";
   };
 
   sourceRoot = "${src.name}/libs/standard-tests";
@@ -51,8 +55,12 @@ buildPythonPackage rec {
     httpx
     langchain-core
     pytest-asyncio
+    pytest-benchmark
+    pytest-codspeed
+    pytest-recording
     pytest-socket
     syrupy
+    vcrpy
   ];
 
   buildInputs = [ pytest ];


### PR DESCRIPTION
### Bump anthropic SDK

changelog: https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.52.2

diff: https://github.com/anthropics/anthropic-sdk-python/compare/v0.51.0...v0.52.2

### Bump langchain-tests (new version needed by langchain-anthropic)

changelog: https://github.com/langchain-ai/langchain/releases/tag/langchain-tests%3D%3D0.3.20

diff: https://github.com/langchain-ai/langchain/compare/langchain-tests%3D%3D0.3.19...langchain-tests%3D%3D0.3.20

### Bump langchain-anthropic

changelog: https://github.com/langchain-ai/langchain/releases/tag/langchain-anthropic%3D%3D0.3.15

diff: https://github.com/langchain-ai/langchain/compare/langchain-anthropic%3D%3D0.3.13...langchain-anthropic%3D%3D0.3.15

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
