### PR TITLE
buildGraalvmNativeImage: switch to lib.extendMkDerivation

### DIFF
--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -2,95 +2,107 @@
   lib,
   stdenv,
   glibcLocales,
-  # The GraalVM derivation to use
-  graalvmDrv,
   removeReferencesTo,
-  executable ? args.pname,
-  # JAR used as input for GraalVM derivation, defaults to src
-  jar ? args.src,
-  dontUnpack ? (jar == args.src),
-  # Default native-image arguments. You probably don't want to set this,
-  # except in special cases. In most cases, use extraNativeBuildArgs instead
-  nativeImageBuildArgs ? [
-    (lib.optionalString stdenv.hostPlatform.isDarwin "-H:-CheckToolchain")
-    (lib.optionalString (
-      stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64
-    ) "-H:PageSize=64K")
-    "-H:Name=${executable}"
-    "-march=compatibility"
-    "--verbose"
-  ],
-  # Extra arguments to be passed to the native-image
-  extraNativeImageBuildArgs ? [ ],
-  # XMX size of GraalVM during build
-  graalvmXmx ? "-J-Xmx6g",
-  meta ? { },
-  LC_ALL ? "en_US.UTF-8",
-  ...
-}@args:
+  graalvmPackages,
+}:
 
-let
-  extraArgs = builtins.removeAttrs args [
-    "lib"
-    "stdenv"
-    "glibcLocales"
-    "jar"
-    "dontUnpack"
-    "LC_ALL"
-    "meta"
-    "buildPhase"
-    "nativeBuildInputs"
-    "installPhase"
-    "postInstall"
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+
+  excludeDrvArgNames = [
+    "executable"
+    "extraNativeImageBuildArgs"
+    "graalvmDrv"
+    "graalvmXmx"
+    "nativeImageBuildArgs"
   ];
-in
-stdenv.mkDerivation (
-  {
-    inherit dontUnpack jar;
 
-    env = { inherit LC_ALL; };
+  extendDrvArgs =
+    finalAttrs:
+    {
+      dontUnpack ? true,
+      strictDeps ? true,
+      __structuredAttrs ? true,
 
-    nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
-      graalvmDrv
-      glibcLocales
-      removeReferencesTo
-    ];
+      # The GraalVM derivation to use
+      graalvmDrv ? graalvmPackages.graalvm-ce,
 
-    nativeImageBuildArgs = nativeImageBuildArgs ++ extraNativeImageBuildArgs ++ [ graalvmXmx ];
+      executable ? finalAttrs.meta.mainProgram,
 
-    buildPhase =
-      args.buildPhase or ''
-        runHook preBuild
+      # Default native-image arguments. You probably don't want to set this,
+      # except in special cases. In most cases, use extraNativeBuildArgs instead
+      nativeImageBuildArgs ? [
+        (lib.optionalString stdenv.hostPlatform.isDarwin "-H:-CheckToolchain")
+        (lib.optionalString (
+          stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64
+        ) "-H:PageSize=64K")
+        "-H:Name=${executable}"
+        "-march=compatibility"
+        "--verbose"
+      ],
 
-        native-image -jar "$jar" ''${nativeImageBuildArgs[@]}
+      # Extra arguments to be passed to the native-image
+      extraNativeImageBuildArgs ? [ ],
 
-        runHook postBuild
+      # XMX size of GraalVM during build
+      graalvmXmx ? "-J-Xmx6g",
+
+      env ? { },
+      meta ? { },
+      passthru ? { },
+      ...
+    }@args:
+    {
+      env = {
+        LC_ALL = "en_US.UTF-8";
+      } // env;
+
+      inherit dontUnpack strictDeps __structuredAttrs;
+
+      nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [
+        graalvmDrv
+        glibcLocales
+        removeReferencesTo
+      ];
+
+      # `nativeBuildInputs` does not allow `graalvmDrv`'s propagatedBuildInput to reach here this package.
+      # As its `propagatedBuildInputs` is required for the build process with `native-image`, we must add it here as well.
+      buildInputs = [ graalvmDrv ];
+
+      nativeImageArgs = nativeImageBuildArgs ++ extraNativeImageBuildArgs ++ [ graalvmXmx ];
+
+      buildPhase =
+        args.buildPhase or ''
+          runHook preBuild
+
+          native-image -jar "$src" ''${nativeImageArgs[@]}
+
+          runHook postBuild
+        '';
+
+      installPhase =
+        args.installPhase or ''
+          runHook preInstall
+
+          install -Dm755 ${executable} -t $out/bin
+
+          runHook postInstall
+        '';
+
+      postInstall = ''
+        remove-references-to -t ${graalvmDrv} $out/bin/${executable}
+        ${args.postInstall or ""}
       '';
 
-    installPhase =
-      args.installPhase or ''
-        runHook preInstall
+      disallowedReferences = [ graalvmDrv ];
 
-        install -Dm755 ${executable} -t $out/bin
+      passthru = {
+        inherit graalvmDrv;
+      } // passthru;
 
-        runHook postInstall
-      '';
-
-    postInstall = ''
-      remove-references-to -t ${graalvmDrv} $out/bin/${executable}
-      ${args.postInstall or ""}
-    '';
-
-    disallowedReferences = [ graalvmDrv ];
-
-    passthru = { inherit graalvmDrv; };
-
-    meta = {
-      # default to graalvm's platforms
-      platforms = graalvmDrv.meta.platforms;
-      # default to executable name
-      mainProgram = executable;
-    } // meta;
-  }
-  // extraArgs
-)
+      meta = {
+        # default to graalvm's platforms
+        inherit (graalvmDrv.meta) platforms;
+      } // meta;
+    };
+}

--- a/pkgs/by-name/ce/certificate-ripper/package.nix
+++ b/pkgs/by-name/ce/certificate-ripper/package.nix
@@ -5,18 +5,18 @@
   buildGraalvmNativeImage,
 }:
 
-let
+buildGraalvmNativeImage (finalAttrs: {
   pname = "certificate-ripper";
   version = "2.4.1";
 
-  jar = maven.buildMavenPackage {
-    pname = "${pname}-jar";
-    inherit version;
+  src = maven.buildMavenPackage {
+    pname = "certificate-ripper-jar";
+    inherit (finalAttrs) version;
 
     src = fetchFromGitHub {
       owner = "Hakky54";
       repo = "certificate-ripper";
-      tag = version;
+      tag = finalAttrs.version;
       hash = "sha256-qQ5BHH+DT1sGNDGzSbclqc6+byBxyP16qvm3k9E/Yks=";
     };
 
@@ -46,13 +46,6 @@ let
       install -Dm644 target/crip.jar $out
     '';
   };
-in
-buildGraalvmNativeImage {
-  inherit pname version;
-
-  src = jar;
-
-  executable = "crip";
 
   # Copied from pom.xml
   extraNativeImageBuildArgs = [
@@ -62,10 +55,11 @@ buildGraalvmNativeImage {
   ];
 
   meta = {
-    changelog = "https://github.com/Hakky54/certificate-ripper/releases/tag/${jar.src.tag}";
+    changelog = "https://github.com/Hakky54/certificate-ripper/releases/tag/${finalAttrs.version}";
     description = "CLI tool to extract server certificates";
     homepage = "https://github.com/Hakky54/certificate-ripper";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ tomasajt ];
+    mainProgram = "crip";
   };
-}
+})

--- a/pkgs/by-name/cl/clj-kondo/package.nix
+++ b/pkgs/by-name/cl/clj-kondo/package.nix
@@ -31,5 +31,6 @@ buildGraalvmNativeImage rec {
       jlesquembre
       bandresen
     ];
+    mainProgram = "clj-kondo";
   };
 }

--- a/pkgs/by-name/cl/clj-kondo/package.nix
+++ b/pkgs/by-name/cl/clj-kondo/package.nix
@@ -1,20 +1,17 @@
 {
   lib,
   buildGraalvmNativeImage,
-  graalvmPackages,
   fetchurl,
 }:
 
-buildGraalvmNativeImage rec {
+buildGraalvmNativeImage (finalAttrs: {
   pname = "clj-kondo";
   version = "2025.06.05";
 
   src = fetchurl {
-    url = "https://github.com/clj-kondo/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
+    url = "https://github.com/clj-kondo/clj-kondo/releases/download/v${finalAttrs.version}/clj-kondo-${finalAttrs.version}-standalone.jar";
     sha256 = "sha256-jmQFiL8MFIuMrHPSxW27E7yZIGf+k8J5nFVXgNGIKoM=";
   };
-
-  graalvmDrv = graalvmPackages.graalvm-ce;
 
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
@@ -26,11 +23,11 @@ buildGraalvmNativeImage rec {
     homepage = "https://github.com/clj-kondo/clj-kondo";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.epl10;
-    changelog = "https://github.com/clj-kondo/clj-kondo/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/clj-kondo/clj-kondo/blob/v${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [
       jlesquembre
       bandresen
     ];
     mainProgram = "clj-kondo";
   };
-}
+})

--- a/pkgs/by-name/cl/cljfmt/package.nix
+++ b/pkgs/by-name/cl/cljfmt/package.nix
@@ -4,15 +4,14 @@
   fetchurl,
   nix-update-script,
   testers,
-  cljfmt,
 }:
 
-buildGraalvmNativeImage rec {
+buildGraalvmNativeImage (finalAttrs: {
   pname = "cljfmt";
   version = "0.13.1";
 
   src = fetchurl {
-    url = "https://github.com/weavejester/cljfmt/releases/download/${version}/cljfmt-${version}-standalone.jar";
+    url = "https://github.com/weavejester/cljfmt/releases/download/${finalAttrs.version}/cljfmt-${finalAttrs.version}-standalone.jar";
     hash = "sha256-Dj1g6hMzRhqm0pJggODVFgEkayB2Wdh3d0z6RglHbgY=";
   };
 
@@ -28,8 +27,8 @@ buildGraalvmNativeImage rec {
   passthru.updateScript = nix-update-script { };
 
   passthru.tests.version = testers.testVersion {
-    inherit version;
-    package = cljfmt;
+    inherit (finalAttrs) version;
+    package = finalAttrs.finalPackage;
     command = "cljfmt --version";
   };
 
@@ -39,7 +38,7 @@ buildGraalvmNativeImage rec {
     homepage = "https://github.com/weavejester/cljfmt";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.epl10;
-    changelog = "https://github.com/weavejester/cljfmt/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/weavejester/cljfmt/blob/${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ sg-qwt ];
   };
-}
+})

--- a/pkgs/by-name/cl/cljstyle/package.nix
+++ b/pkgs/by-name/cl/cljstyle/package.nix
@@ -3,50 +3,44 @@
   buildGraalvmNativeImage,
   fetchMavenArtifact,
   fetchurl,
-  graalvmPackages,
   versionCheckHook,
 }:
 
-let
+buildGraalvmNativeImage (finalAttrs: {
   pname = "cljstyle";
   version = "0.17.642";
 
-  # must be on classpath to build native image
-  graal-build-time = fetchMavenArtifact {
-    repos = [ "https://repo.clojars.org/" ];
-    groupId = "com.github.clj-easy";
-    artifactId = "graal-build-time";
-    version = "1.0.5";
-    hash = "sha256-M6/U27a5n/QGuUzGmo8KphVnNa2K+LFajP5coZiFXoY=";
-  };
-in
-buildGraalvmNativeImage {
-  inherit pname version;
-
   src = fetchurl {
-    url = "https://github.com/greglook/${pname}/releases/download/${version}/${pname}-${version}.jar";
+    url = "https://github.com/greglook/cljstyle/releases/download/${finalAttrs.version}/cljstyle-${finalAttrs.version}.jar";
     hash = "sha256-AkCuTZeDXbNBuwPZEMhYGF/oOGIKq5zVDwL8xwnj+mE=";
   };
-
-  graalvmDrv = graalvmPackages.graalvm-ce;
 
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
     "--no-fallback"
-    "-cp ${graal-build-time.passthru.jar}"
+    "-cp ${finalAttrs.finalPackage.passthru.graal-build-time.passthru.jar}"
   ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = [ "version" ];
 
+  # must be on classpath to build native image
+  passthru.graal-build-time = fetchMavenArtifact {
+    repos = [ "https://repo.clojars.org/" ];
+    groupId = "com.github.clj-easy";
+    artifactId = "graal-build-time";
+    version = "1.0.5";
+    hash = "sha256-M6/U27a5n/QGuUzGmo8KphVnNa2K+LFajP5coZiFXoY=";
+  };
+
   meta = {
     description = "Tool for formatting Clojure code";
     homepage = "https://github.com/greglook/cljstyle";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.epl10;
-    changelog = "https://github.com/greglook/cljstyle/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/greglook/cljstyle/blob/${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ psyclyx ];
     mainProgram = "cljstyle";
   };
-}
+})

--- a/pkgs/by-name/cl/clojure-lsp/package.nix
+++ b/pkgs/by-name/cl/clojure-lsp/package.nix
@@ -80,5 +80,6 @@ buildGraalvmNativeImage rec {
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ericdallo ];
+    mainProgram = "clojure-lsp";
   };
 }

--- a/pkgs/by-name/cl/clojure-lsp/package.nix
+++ b/pkgs/by-name/cl/clojure-lsp/package.nix
@@ -1,27 +1,20 @@
 {
   lib,
+  stdenvNoCC,
   buildGraalvmNativeImage,
   fetchurl,
   fetchFromGitHub,
   writeScript,
   testers,
-  clojure-lsp,
 }:
 
-buildGraalvmNativeImage rec {
+buildGraalvmNativeImage (finalAttrs: {
   pname = "clojure-lsp";
-  version = "2025.03.27-20.21.36";
+  version = "2025.05.27-13.56.57";
 
-  src = fetchFromGitHub {
-    owner = "clojure-lsp";
-    repo = "clojure-lsp";
-    rev = version;
-    hash = "sha256-xS/WVTJFCdktYxBvey855PW5Heqlx4EhpDAMHQ5Bj5M=";
-  };
-
-  jar = fetchurl {
-    url = "https://github.com/clojure-lsp/clojure-lsp/releases/download/${version}/clojure-lsp-standalone.jar";
-    hash = "sha256-g8jX+41gojvoJHV/xMcP+4ROc9LewCUTuDTQcpHQ6+E=";
+  src = fetchurl {
+    url = "https://github.com/clojure-lsp/clojure-lsp/releases/download/${finalAttrs.version}/clojure-lsp-standalone.jar";
+    hash = "sha256-CIly8eufuI/ENgiamKfhnFe+0dssDKEl4MYDJf4Sm/k=";
   };
 
   extraNativeImageBuildArgs = [
@@ -33,22 +26,18 @@ buildGraalvmNativeImage rec {
   ];
 
   doCheck = true;
-  checkPhase =
-    ''
-      runHook preCheck
+  checkPhase = ''
+    runHook preCheck
 
-      export HOME="$(mktemp -d)"
-      ./clojure-lsp --version | fgrep -q '${version}'
-    ''
-    # TODO: fix classpath issue per https://github.com/NixOS/nixpkgs/pull/153770
-    #${babashka}/bin/bb integration-test ./clojure-lsp
-    + ''
-      runHook postCheck
-    '';
+    export HOME="$(mktemp -d)"
+    ./clojure-lsp --version | fgrep -q '${finalAttrs.version}'
+
+    runHook postCheck
+  '';
 
   passthru.tests.version = testers.testVersion {
-    inherit version;
-    package = clojure-lsp;
+    inherit (finalAttrs) version;
+    package = finalAttrs.finalPackage;
     command = "clojure-lsp --version";
   };
 
@@ -57,29 +46,33 @@ buildGraalvmNativeImage rec {
     #!nix-shell -i bash -p curl common-updater-scripts gnused jq nix
 
     set -eu -o pipefail
+    source "${stdenvNoCC}/setup"
 
-    latest_version=$(curl -s https://api.github.com/repos/clojure-lsp/clojure-lsp/releases/latest | jq --raw-output .tag_name)
+    old_version="$(nix-instantiate --strict --json --eval -A clojure-lsp.version | jq -r .)"
+    latest_version="$(curl -s https://api.github.com/repos/clojure-lsp/clojure-lsp/releases/latest | jq -r .tag_name)"
 
-    old_jar_hash=$(nix-instantiate --eval --strict -A "clojure-lsp.jar.drvAttrs.outputHash" | tr -d '"' | sed -re 's|[+]|\\&|g')
+    if [[ $latest_version == $old_version ]]; then
+      echo "Already at latest version $old_version"
+      exit 0
+    fi
 
-    curl -o clojure-lsp-standalone.jar -sL https://github.com/clojure-lsp/clojure-lsp/releases/download/$latest_version/clojure-lsp-standalone.jar
-    new_jar_hash=$(nix-hash --flat --type sha256 clojure-lsp-standalone.jar | sed -re 's|[+]|\\&|g')
+    old_jar_hash="$(nix-instantiate --strict --json --eval -A clojure-lsp.jar.drvAttrs.outputHash | jq -r .)"
+
+    curl -o clojure-lsp-standalone.jar -sL "https://github.com/clojure-lsp/clojure-lsp/releases/download/$latest_version/clojure-lsp-standalone.jar"
+    new_jar_hash="$(nix-hash --flat --type sha256 clojure-lsp-standalone.jar | xargs -n1 nix hash convert --hash-algo sha256)"
 
     rm -f clojure-lsp-standalone.jar
 
-    nixFile=$(nix-instantiate --eval --strict -A "clojure-lsp.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
-
-    sed -i "$nixFile" -re "s|\"$old_jar_hash\"|\"$new_jar_hash\"|"
-    update-source-version clojure-lsp "$latest_version"
+    update-source-version clojure-lsp "$latest_version" "$new_jar_hash"
   '';
 
   meta = {
     description = "Language Server Protocol (LSP) for Clojure";
     homepage = "https://github.com/clojure-lsp/clojure-lsp";
-    changelog = "https://github.com/clojure-lsp/clojure-lsp/releases/tag/${version}";
+    changelog = "https://github.com/clojure-lsp/clojure-lsp/releases/tag/${finalAttrs.version}";
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ericdallo ];
     mainProgram = "clojure-lsp";
   };
-}
+})

--- a/pkgs/by-name/cq/cq/package.nix
+++ b/pkgs/by-name/cq/cq/package.nix
@@ -6,42 +6,39 @@
   graalvmPackages,
 }:
 
-buildGraalvmNativeImage rec {
+buildGraalvmNativeImage (finalAttrs: {
   pname = "cq";
   version = "2024.06.24-12.10";
 
   # we need both src (the prebuild jar)
   src = fetchurl {
-    url = "https://github.com/markus-wa/cq/releases/download/${version}/cq.jar";
+    url = "https://github.com/markus-wa/cq/releases/download/${finalAttrs.version}/cq.jar";
     hash = "sha256-iULV+j/AuGVYPYhbOTQTKd3n+VZhWQYBRE6cRiaa1/M=";
   };
 
   # and build-src (for the native-image build process)
-  build-src = fetchFromGitHub {
+  passthru.build-src = fetchFromGitHub {
     owner = "markus-wa";
     repo = "cq";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-yjAC2obipdmh+JlHzVUTMtTXN2VKe4WKkyJyu2Q93c8=";
   };
-
-  graalvmDrv = graalvmPackages.graalvm-ce;
-
-  executable = "cq";
 
   # copied verbatim from the upstream build script https://github.com/markus-wa/cq/blob/main/package/build-native.sh#L5
   extraNativeImageBuildArgs = [
     "--report-unsupported-elements-at-runtime"
     "--initialize-at-build-time"
     "--no-server"
-    "-H:ReflectionConfigurationFiles=${build-src}/package/reflection-config.json"
+    "-H:ReflectionConfigurationFiles=${finalAttrs.finalPackage.build-src}/package/reflection-config.json"
   ];
 
   meta = {
     description = "Clojure Query: A Command-line Data Processor for JSON, YAML, EDN, XML and more";
     homepage = "https://github.com/markus-wa/cq";
-    changelog = "https://github.com/markus-wa/cq/releases/releases/tag/${version}";
+    changelog = "https://github.com/markus-wa/cq/releases/releases/tag/${finalAttrs.version}";
     license = lib.licenses.epl20;
     maintainers = with lib.maintainers; [ farcaller ];
     platforms = lib.platforms.unix;
+    mainProgram = "cq";
   };
-}
+})

--- a/pkgs/by-name/je/jet/package.nix
+++ b/pkgs/by-name/je/jet/package.nix
@@ -34,5 +34,6 @@ buildGraalvmNativeImage rec {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.epl10;
     maintainers = with maintainers; [ ericdallo ];
+    mainProgram = "jet";
   };
 }

--- a/pkgs/by-name/je/jet/package.nix
+++ b/pkgs/by-name/je/jet/package.nix
@@ -3,15 +3,14 @@
   buildGraalvmNativeImage,
   fetchurl,
   testers,
-  jet,
 }:
 
-buildGraalvmNativeImage rec {
+buildGraalvmNativeImage (finalAttrs: {
   pname = "jet";
   version = "0.7.27";
 
   src = fetchurl {
-    url = "https://github.com/borkdude/${pname}/releases/download/v${version}/${pname}-${version}-standalone.jar";
+    url = "https://github.com/borkdude/jet/releases/download/v${finalAttrs.version}/jet-${finalAttrs.version}-standalone.jar";
     sha256 = "sha256-250/1DBNCXlU1b4jjLUUOXI+uSbOyPXtBN1JJRpdmFc=";
   };
 
@@ -23,17 +22,17 @@ buildGraalvmNativeImage rec {
   ];
 
   passthru.tests.version = testers.testVersion {
-    inherit version;
-    package = jet;
+    inherit (finalAttrs) version;
+    package = finalAttrs.finalPackage;
     command = "jet --version";
   };
 
-  meta = with lib; {
+  meta = {
     description = "CLI to transform between JSON, EDN, YAML and Transit, powered with a minimal query language";
     homepage = "https://github.com/borkdude/jet";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.epl10;
-    maintainers = with maintainers; [ ericdallo ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.epl10;
+    maintainers = with lib.maintainers; [ ericdallo ];
     mainProgram = "jet";
   };
-}
+})

--- a/pkgs/by-name/sc/scala-update/package.nix
+++ b/pkgs/by-name/sc/scala-update/package.nix
@@ -1,33 +1,17 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   coursier,
   buildGraalvmNativeImage,
 }:
 
-let
-  baseName = "scala-update";
+buildGraalvmNativeImage (finalAttrs: {
+  pname = "scala-update";
   version = "0.2.2";
-  deps = stdenv.mkDerivation {
-    name = "${baseName}-deps-${version}";
-    buildCommand = ''
-      export COURSIER_CACHE=$(pwd)
-      ${coursier}/bin/cs fetch io.github.kitlangton:scala-update_2.13:${version} > deps
-      mkdir -p $out/share/java
-      cp $(< deps) $out/share/java/
-    '';
-    outputHashMode = "recursive";
-    outputHashAlgo = "sha256";
-    outputHash = "kNnFzzHn+rFq4taqRYjBYaDax0MHW+vIoSFVN3wxA8M=";
-  };
-in
-buildGraalvmNativeImage {
-  pname = baseName;
-  inherit version;
 
-  buildInputs = [ deps ];
+  buildInputs = [ finalAttrs.finalPackage.passthru.deps ];
 
-  src = "${deps}/share/java/${baseName}_2.13-${version}.jar";
+  src = "${finalAttrs.finalPackage.passthru.deps}/share/java/scala-update_2.13-${finalAttrs.version}.jar";
 
   extraNativeImageBuildArgs = [
     "--no-fallback"
@@ -38,20 +22,37 @@ buildGraalvmNativeImage {
   buildPhase = ''
     runHook preBuild
 
-    native-image ''${nativeImageBuildArgs[@]} -cp $(JARS=("${deps}/share/java"/*.jar); IFS=:; echo "''${JARS[*]}")
+    native-image ''${nativeImageArgs[@]} -cp $(JARS=("${finalAttrs.finalPackage.passthru.deps}/share/java"/*.jar); IFS=:; echo "''${JARS[*]}")
 
     runHook postBuild
   '';
 
   installCheckPhase = ''
-    $out/bin/${baseName} --version | grep -q "${version}"
+    runHook preInstallCheck
+
+    $out/bin/scala-update --version | grep -q "${finalAttrs.version}"
+
+    runHook postInstallCheck
   '';
 
-  meta = with lib; {
+  passthru.deps = stdenvNoCC.mkDerivation {
+    name = "scala-update-deps-${finalAttrs.version}";
+    buildCommand = ''
+      export COURSIER_CACHE=$(pwd)
+      ${lib.getExe coursier} fetch io.github.kitlangton:scala-update_2.13:${finalAttrs.version} > deps
+      mkdir -p $out/share/java
+      cp $(< deps) $out/share/java/
+    '';
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "kNnFzzHn+rFq4taqRYjBYaDax0MHW+vIoSFVN3wxA8M=";
+  };
+
+  meta = {
     description = "Update your Scala dependencies interactively";
     homepage = "https://github.com/kitlangton/scala-update";
-    license = licenses.asl20;
-    maintainers = [ maintainers.rtimush ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.rtimush ];
     mainProgram = "scala-update";
   };
-}
+})

--- a/pkgs/by-name/sc/scala-update/package.nix
+++ b/pkgs/by-name/sc/scala-update/package.nix
@@ -52,5 +52,6 @@ buildGraalvmNativeImage {
     homepage = "https://github.com/kitlangton/scala-update";
     license = licenses.asl20;
     maintainers = [ maintainers.rtimush ];
+    mainProgram = "scala-update";
   };
 }

--- a/pkgs/by-name/ya/yamlscript/package.nix
+++ b/pkgs/by-name/ya/yamlscript/package.nix
@@ -4,16 +4,14 @@
   fetchurl,
 }:
 
-buildGraalvmNativeImage rec {
+buildGraalvmNativeImage (finalAttrs: {
   pname = "yamlscript";
   version = "0.1.96";
 
   src = fetchurl {
-    url = "https://github.com/yaml/yamlscript/releases/download/${version}/yamlscript.cli-${version}-standalone.jar";
+    url = "https://github.com/yaml/yamlscript/releases/download/${finalAttrs.version}/yamlscript.cli-${finalAttrs.version}-standalone.jar";
     hash = "sha256-nwqZhGOtNEJ0qzOTFdHFWBSyt4hmLhn6nhdCz2jyUbg=";
   };
-
-  executable = "ys";
 
   extraNativeImageBuildArgs = [
     "--native-image-info"
@@ -30,15 +28,19 @@ buildGraalvmNativeImage rec {
   doInstallCheck = true;
 
   installCheckPhase = ''
-    $out/bin/ys  -e 'say: (+ 1 2)' | fgrep 3
+    runHook preInstallCheck
+
+    $out/bin/ys -e 'say: (+ 1 2)' | fgrep 3
+
+    runHook postInstallCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Programming in YAML";
     homepage = "https://github.com/yaml/yamlscript";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.mit;
     mainProgram = "ys";
-    maintainers = with maintainers; [ sgo ];
+    maintainers = with lib.maintainers; [ sgo ];
   };
-}
+})

--- a/pkgs/by-name/zp/zprint/package.nix
+++ b/pkgs/by-name/zp/zprint/package.nix
@@ -3,15 +3,14 @@
   buildGraalvmNativeImage,
   fetchurl,
   testers,
-  zprint,
 }:
 
-buildGraalvmNativeImage rec {
+buildGraalvmNativeImage (finalAttrs: {
   pname = "zprint";
   version = "1.3.0";
 
   src = fetchurl {
-    url = "https://github.com/kkinnear/${pname}/releases/download/${version}/${pname}-filter-${version}";
+    url = "https://github.com/kkinnear/zprint/releases/download/${finalAttrs.version}/zprint-filter-${finalAttrs.version}";
     sha256 = "sha256-0ogZkC8j+ja0aWvFgNhygof4GZ78aqQA75lRxYfu6do=";
   };
 
@@ -25,12 +24,12 @@ buildGraalvmNativeImage rec {
   ];
 
   passthru.tests.version = testers.testVersion {
-    inherit version;
-    package = zprint;
+    inherit (finalAttrs) version;
+    package = finalAttrs.finalPackage;
     command = "zprint --version";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Clojure/EDN source code formatter and pretty printer";
     longDescription = ''
       Library and command line tool providing a variety of pretty printing capabilities
@@ -38,8 +37,8 @@ buildGraalvmNativeImage rec {
       As such, it supports a number of major source code formatting approaches
     '';
     homepage = "https://github.com/kkinnear/zprint";
-    license = licenses.mit;
-    maintainers = with maintainers; [ stelcodes ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stelcodes ];
     mainProgram = "zprint";
   };
-}
+})

--- a/pkgs/development/interpreters/babashka/default.nix
+++ b/pkgs/development/interpreters/babashka/default.nix
@@ -1,116 +1,113 @@
 {
   lib,
   buildGraalvmNativeImage,
-  graalvmPackages,
   fetchurl,
   writeScript,
   installShellFiles,
 }:
 
-let
-  babashka-unwrapped = buildGraalvmNativeImage rec {
-    pname = "babashka-unwrapped";
-    version = "1.12.200";
+buildGraalvmNativeImage (finalAttrs: {
+  pname = "babashka-unwrapped";
+  version = "1.12.200";
 
-    src = fetchurl {
-      url = "https://github.com/babashka/babashka/releases/download/v${version}/babashka-${version}-standalone.jar";
-      sha256 = "sha256-hxcoVUaL19RM56fG8oxSKQwPHXDzaoSdCdHXSTXQ9fI=";
-    };
-
-    graalvmDrv = graalvmPackages.graalvm-ce;
-
-    executable = "bb";
-
-    nativeBuildInputs = [ installShellFiles ];
-
-    extraNativeImageBuildArgs = [
-      "-H:+ReportExceptionStackTraces"
-      "--no-fallback"
-      "--native-image-info"
-      "--enable-preview"
-    ];
-
-    doInstallCheck = true;
-
-    installCheckPhase = ''
-      $out/bin/bb --version | fgrep '${version}'
-      $out/bin/bb '(+ 1 2)' | fgrep '3'
-      $out/bin/bb '(vec (dedupe *input*))' <<< '[1 1 1 1 2]' | fgrep '[1 2]'
-      $out/bin/bb '(prn "bépo àê")' | fgrep 'bépo àê'
-      $out/bin/bb '(:out (babashka.process/sh "echo" "ä"))' | fgrep 'ä'
-      $out/bin/bb '(into-array [:f])'
-    '';
-
-    postInstall = ''
-      installShellCompletion --cmd bb --bash ${./completions/bb.bash}
-      installShellCompletion --cmd bb --zsh ${./completions/bb.zsh}
-      installShellCompletion --cmd bb --fish ${./completions/bb.fish}
-    '';
-
-    passthru.updateScript = writeScript "update-babashka" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl common-updater-scripts jq libarchive
-
-      set -euo pipefail
-      shopt -s inherit_errexit
-
-      latest_version="$(curl \
-        ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
-        -fsL "https://api.github.com/repos/babashka/babashka/releases/latest" \
-        | jq -r '.tag_name')"
-
-      if [ "$(update-source-version babashka-unwrapped "''${latest_version/v/}" --print-changes)" = "[]" ]; then
-        # no need to update babashka.clojure-tools when babashka-unwrapped wasn't updated
-        exit 0
-      fi
-
-      clojure_tools_version=$(curl \
-        -fsL \
-        "https://github.com/babashka/babashka/releases/download/''${latest_version}/babashka-''${latest_version/v/}-standalone.jar" \
-        | bsdtar -qxOf - borkdude/deps.clj \
-        | ${babashka-unwrapped}/bin/bb -I -o -e "(or (some->> *input* (filter #(= '(def version) (take 2 %))) first last last last) (throw (ex-info \"Couldn't find expected '(def version ...)' form in 'borkdude/deps.clj'.\" {})))")
-
-      update-source-version babashka.clojure-tools "$clojure_tools_version" \
-        --file="pkgs/development/interpreters/babashka/clojure-tools.nix"
-    '';
-
-    meta = with lib; {
-      description = "Clojure babushka for the grey areas of Bash";
-      longDescription = ''
-        The main idea behind babashka is to leverage Clojure in places where you
-        would be using bash otherwise.
-
-        As one user described it:
-
-            I’m quite at home in Bash most of the time, but there’s a substantial
-            grey area of things that are too complicated to be simple in bash, but
-            too simple to be worth writing a clj/s script for. Babashka really
-            seems to hit the sweet spot for those cases.
-
-        Goals:
-
-        - Low latency Clojure scripting alternative to JVM Clojure.
-        - Easy installation: grab the self-contained binary and run. No JVM needed.
-        - Familiarity and portability:
-          - Scripts should be compatible with JVM Clojure as much as possible
-          - Scripts should be platform-independent as much as possible. Babashka
-            offers support for linux, macOS and Windows.
-        - Allow interop with commonly used classes like java.io.File and System
-        - Multi-threading support (pmap, future, core.async)
-        - Batteries included (tools.cli, cheshire, ...)
-        - Library support via popular tools like the clojure CLI
-      '';
-      homepage = "https://github.com/babashka/babashka";
-      changelog = "https://github.com/babashka/babashka/blob/v${version}/CHANGELOG.md";
-      sourceProvenance = with sourceTypes; [ binaryBytecode ];
-      license = licenses.epl10;
-      maintainers = with maintainers; [
-        bandresen
-        bhougland
-        DerGuteMoritz
-        jlesquembre
-      ];
-    };
+  src = fetchurl {
+    url = "https://github.com/babashka/babashka/releases/download/v${finalAttrs.version}/babashka-${finalAttrs.version}-standalone.jar";
+    sha256 = "sha256-hxcoVUaL19RM56fG8oxSKQwPHXDzaoSdCdHXSTXQ9fI=";
   };
-in
-babashka-unwrapped
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  extraNativeImageBuildArgs = [
+    "-H:+ReportExceptionStackTraces"
+    "--no-fallback"
+    "--native-image-info"
+    "--enable-preview"
+  ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/bb --version | fgrep '${finalAttrs.version}'
+    $out/bin/bb '(+ 1 2)' | fgrep '3'
+    $out/bin/bb '(vec (dedupe *input*))' <<< '[1 1 1 1 2]' | fgrep '[1 2]'
+    $out/bin/bb '(prn "bépo àê")' | fgrep 'bépo àê'
+    $out/bin/bb '(:out (babashka.process/sh "echo" "ä"))' | fgrep 'ä'
+    $out/bin/bb '(into-array [:f])'
+
+    runHook postInstallCheck
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd bb --bash ${./completions/bb.bash}
+    installShellCompletion --cmd bb --zsh ${./completions/bb.zsh}
+    installShellCompletion --cmd bb --fish ${./completions/bb.fish}
+  '';
+
+  passthru.updateScript = writeScript "update-babashka" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl common-updater-scripts jq libarchive
+
+    set -euo pipefail
+    shopt -s inherit_errexit
+
+    latest_version="$(curl \
+      ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+      -fsL "https://api.github.com/repos/babashka/babashka/releases/latest" \
+      | jq -r '.tag_name')"
+
+    if [ "$(update-source-version babashka-unwrapped "''${latest_version/v/}" --print-changes)" = "[]" ]; then
+      # no need to update babashka.clojure-tools when babashka-unwrapped wasn't updated
+      exit 0
+    fi
+
+    clojure_tools_version=$(curl \
+      -fsL \
+      "https://github.com/babashka/babashka/releases/download/''${latest_version}/babashka-''${latest_version/v/}-standalone.jar" \
+      | bsdtar -qxOf - borkdude/deps.clj \
+      | ${lib.getExe finalAttrs.finalPackage} -I -o -e "(or (some->> *input* (filter #(= '(def version) (take 2 %))) first last last last) (throw (ex-info \"Couldn't find expected '(def version ...)' form in 'borkdude/deps.clj'.\" {})))")
+
+    update-source-version babashka.clojure-tools "$clojure_tools_version" \
+      --file="pkgs/development/interpreters/babashka/clojure-tools.nix"
+  '';
+
+  meta = {
+    description = "Clojure babushka for the grey areas of Bash";
+    longDescription = ''
+      The main idea behind babashka is to leverage Clojure in places where you
+      would be using bash otherwise.
+
+      As one user described it:
+
+          I’m quite at home in Bash most of the time, but there’s a substantial
+          grey area of things that are too complicated to be simple in bash, but
+          too simple to be worth writing a clj/s script for. Babashka really
+          seems to hit the sweet spot for those cases.
+
+      Goals:
+
+      - Low latency Clojure scripting alternative to JVM Clojure.
+      - Easy installation: grab the self-contained binary and run. No JVM needed.
+      - Familiarity and portability:
+        - Scripts should be compatible with JVM Clojure as much as possible
+        - Scripts should be platform-independent as much as possible. Babashka
+          offers support for linux, macOS and Windows.
+      - Allow interop with commonly used classes like java.io.File and System
+      - Multi-threading support (pmap, future, core.async)
+      - Batteries included (tools.cli, cheshire, ...)
+      - Library support via popular tools like the clojure CLI
+    '';
+    homepage = "https://github.com/babashka/babashka";
+    changelog = "https://github.com/babashka/babashka/blob/v${finalAttrs.version}/CHANGELOG.md";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.epl10;
+    mainProgram = "bb";
+    maintainers = with lib.maintainers; [
+      bandresen
+      bhougland
+      DerGuteMoritz
+      jlesquembre
+    ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5747,10 +5747,7 @@ with pkgs;
   openjdk_headless = jdk_headless;
 
   graalvmPackages = recurseIntoAttrs (callPackage ../development/compilers/graalvm { });
-  buildGraalvmNativeImage =
-    (callPackage ../build-support/build-graalvm-native-image {
-      graalvmDrv = graalvmPackages.graalvm-ce;
-    }).override;
+  buildGraalvmNativeImage = callPackage ../build-support/build-graalvm-native-image { };
 
   openshot-qt = libsForQt5.callPackage ../applications/video/openshot-qt { };
 


### PR DESCRIPTION
#412768's eval breaks because `executable ? args.pname` fails due to `buildGraalvmNativeImage` defaulting `meta.mainProgram` to `executable`.
The error message reads:
```console
>        error: attribute 'pname' missing
>        at /nix/store/9shgmyz0h0sn35l4bw782ij1a4kik0k1-source/pkgs/build-support/build-graalvm-native-image/default.nix:8:16:
>             7|   removeReferencesTo,
>             8|   executable ? args.pname,
```
This is surprising, as every package that uses `buildGraalvmNativeImage` supplies the `pname` field, as it is just a wrapper around `stdenv.mkDerivation`.

I suspect the combination of `lib.intersectAttrs` in `callPackage(With)` at https://github.com/NixOS/nixpkgs/blob/054144e516ca1e3cf5706d5c3427d350eaa107af/lib/customisation.nix#L247 and the `buildGraalvmNativeImage = (callPackage ../build-support/build-graalvm-native-image { }.override)` is to blame, but I cannot be sure.

Due to the change in the `buildGraalvmNativeImage` function, I don't think it's possible to make this a 0-rebuild PR.

I tested this PR by 
1. observing the failure on #412768
2. cherry-picking this commit onto its branch
3. rebuilding the package that broke in said PR
4. rebuilding all packages that this PR influences

I have also applied `diffoscope` to all of the packages that `nixpkgs-review rev HEAD` printed on my system, and all seem to have remained identical, but I'm not entirely confident, as it seems there are minimal changes in some .JAR files, but all files seem to be present.
If anyone has recommendations for options to tweak in `diffoscope`, let me know 😄 


<details>
<summary>Here is the body of the script</summary>

```bash
#! /usr/bin/env nix-shell
#! nix-shell -i bash -p diffoscope

for package in \
  babashka \
  babashka-unwrapped \
  bbin \
  certificate-ripper \
  clj-kondo \
  cljfmt \
  cljstyle \
  clojure-lsp \
  cq \
  jet \
  keylight-cli \
  neil \
  scala-update \
  vscode-extensions.betterthantomorrow.calva \
  yamlscript \
  zprint
do
  echo $package
  diffoscope "$(nix-build -A $package)" $HOME/.cache/nixpkgs-review/rev-7211d31c9a6b6448191643af108b97b93ab0254c/results/$package-aarch64-darwin \
    --html diffs/$package.html \
    --exclude-directory-metadata yes
  # nix-build -A $package
done



```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
