### PR TITLE
fediwall: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25536,6 +25536,17 @@
     github = "tpwrules";
     githubId = 208010;
   };
+  transcaffeine = {
+    name = "transcaffeine";
+    email = "transcaffeine@finally.coffee";
+    github = "transcaffeine";
+    githubId = 139544537;
+    keys = [
+      {
+        fingerprint = "5E0A 9CB3 9806 57CB 9AB9  4AE6 790E AEC8 F99A B41F";
+      }
+    ];
+  };
   traverseda = {
     email = "traverse.da@gmail.com";
     github = "traverseda";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -17,6 +17,8 @@
 
 - [Pi-hole](https://pi-hole.net/), a DNS sinkhole for advertisements based on Dnsmasq. Available as [services.pihole-ftl](#opt-services.pihole-ftl.enable), and [services.pihole-web](#opt-services.pihole-web.enable) for the web GUI and API.
 
+- [Fediwall](https://fediwall.social), a web application for live displaying toots from mastodon, inspired by mastowall. Available as [services.fediwall](#opt-services.fediwall.enable).
+
 - [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files. Available as [services.filebrowser](#opt-services.filebrowser.enable).
 
 - Options under [networking.getaddrinfo](#opt-networking.getaddrinfo.enable) are now allowed to declaratively configure address selection and sorting behavior of `getaddrinfo` in dual-stack networks.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1543,6 +1543,7 @@
   ./services/web-apps/eintopf.nix
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ethercalc.nix
+  ./services/web-apps/fediwall.nix
   ./services/web-apps/fider.nix
   ./services/web-apps/filebrowser.nix
   ./services/web-apps/filesender.nix

--- a/nixos/modules/services/web-apps/fediwall.nix
+++ b/nixos/modules/services/web-apps/fediwall.nix
@@ -1,0 +1,128 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.services.fediwall;
+  pkg = cfg.package.override { conf = cfg.settings; };
+  format = pkgs.formats.json { };
+in
+{
+  options.services.fediwall = {
+    enable = lib.mkEnableOption "fediwall, a social media wall for the fediverse";
+    package = lib.mkPackageOption pkgs "fediwall" { };
+    hostName = lib.mkOption {
+      type = lib.types.str;
+      default = config.networking.fqdnOrHostName;
+      defaultText = lib.literalExpression "config.networking.fqdnOrHostName";
+      example = "fediwall.example.org";
+      description = "The hostname to serve fediwall on.";
+    };
+    settings = lib.mkOption {
+      default = { };
+      description = ''
+        Fediwall configuration. See
+        https://github.com/defnull/fediwall/blob/main/public/wall-config.json.example
+        for information on supported values.
+      '';
+      type = lib.types.submodule {
+        freeformType = format.type;
+        options = {
+          servers = lib.mkOption {
+            type = with lib.types; listOf str;
+            default = [ "mastodon.social" ];
+            description = "Servers to load posts from";
+          };
+          tags = lib.mkOption {
+            type = with lib.types; listOf str;
+            default = [ ];
+            example = lib.literalExpression "[ \"cats\" \"dogs\"]";
+            description = "Tags to follow";
+          };
+          loadPublic = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Load public posts";
+          };
+          loadFederated = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Load federated posts";
+          };
+          loadTrends = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Load trending posts";
+          };
+          hideSensitive = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Hide sensitive (potentially NSFW) posts";
+          };
+          hideBots = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Hide posts from bot accounts";
+          };
+          hideReplies = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Hide replies";
+          };
+          hideBoosts = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Hide boosts";
+          };
+          showMedia = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Show media in posts";
+          };
+          playVideos = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Autoplay videos in posts";
+          };
+        };
+      };
+    };
+    nginx = lib.mkOption {
+      type = lib.types.submodule (
+        lib.recursiveUpdate (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) { }
+      );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          serverAliases = [
+            "fedi.''${config.networking.domain}"
+          ];
+          # Enable TLS and use let's encrypt for ACME
+          forceSSL = true;
+          enableACME = true;
+        }
+      '';
+      description = "Allows customizing the nginx virtualHost settings";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.nginx = {
+      enable = lib.mkDefault true;
+      virtualHosts."${cfg.hostName}" = lib.mkMerge [
+        cfg.nginx
+        {
+          root = lib.mkForce "${pkg}";
+          locations = {
+            "/" = {
+              index = "index.html";
+            };
+          };
+        }
+      ];
+    };
+  };
+}

--- a/pkgs/by-name/fe/fediwall-unwrapped/package.nix
+++ b/pkgs/by-name/fe/fediwall-unwrapped/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+}:
+
+let
+  version = "1.4.0";
+in
+buildNpmPackage {
+  pname = "fediwall";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "defnull";
+    repo = "fediwall";
+    tag = "v${version}";
+    hash = "sha256-aEY6mO7Es+H6CNE4shj/jz47nUeEIxGijKbUscIp0pM=";
+  };
+
+  npmDepsHash = "sha256-0VQ/CBqpQNqjg3lug+AQfFVbh0KhEaGwd+cEakBr/Dc=";
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Social media wall for the Fediverse";
+    homepage = "https://fediwall.social";
+    license = lib.licenses.agpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ transcaffeine ];
+  };
+}

--- a/pkgs/by-name/fe/fediwall/package.nix
+++ b/pkgs/by-name/fe/fediwall/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  stdenv,
+  fediwall-unwrapped,
+  conf ? { },
+}:
+
+if (conf == { }) then
+  fediwall-unwrapped
+else
+  stdenv.mkDerivation {
+    pname = "fediwall";
+    inherit (fediwall-unwrapped) version meta;
+
+    dontUnpack = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      ln -s ${fediwall-unwrapped}/* $out
+      echo ${lib.escapeShellArg (builtins.toJSON conf)} \
+          > "$out/wall-config.json"
+      runHook postInstall
+    '';
+  }


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
