### PR TITLE
Revert "nixos/graphical-desktop: add sessions to pathsToLink"

### DIFF
--- a/nixos/modules/services/misc/graphical-desktop.nix
+++ b/nixos/modules/services/misc/graphical-desktop.nix
@@ -45,11 +45,6 @@ in
         nixos-icons # needed for gnome and pantheon about dialog, nixos-manual and maybe more
         xdg-utils
       ];
-      # needed for some display managers to locate desktop manager sessions
-      pathsToLink = [
-        "/share/xsessions"
-        "/share/wayland-sessions"
-      ];
     };
 
     fonts.enableDefaultPackages = lib.mkDefault true;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#411518. 

This is already controlled by `services.displayManager.sessionPackages`, as explained in https://github.com/NixOS/nixpkgs/pull/411518#issuecomment-2936523214.

Because of that PR, now xsessions and wayland session desktop files of every packages in `environment.systemPackages` are now being linked to `/run/current-system/sw/share`. This is highly unwanted behaviour. 