### PR TITLE
audiobookshelf: 2.23.0 -> 2.24.0

### DIFF
--- a/pkgs/by-name/au/audiobookshelf/source.json
+++ b/pkgs/by-name/au/audiobookshelf/source.json
@@ -1,9 +1,9 @@
 {
   "owner": "advplyr",
   "repo": "audiobookshelf",
-  "rev": "077273033657da2345494084dc7a1f399cc1a7ba",
-  "hash": "sha256-6ygJrB7AvOyRLgDrkz/qLXiJXP+0U7uhi1HqZP62+gU=",
-  "version": "2.23.0",
-  "depsHash": "sha256-3ANieZvWxLVDiIZ1oGSB3UQgApZvukXN5OokyUnFyzg=",
-  "clientDepsHash": "sha256-WiMQZwPFo5qTo4kTWZ+LuLKDEorediQ+GhUxAO+nRCc="
+  "rev": "c377b57601f82f76d677b09e6bbabda732c18861",
+  "hash": "sha256-q0Qlslw5e1nHDqLfLi4AvD3vAzoWvz9/0/lMgqn+y8Y=",
+  "version": "2.24.0",
+  "depsHash": "sha256-s4U+Hgace+d+zRaHeJkxh6TWgClY6T+tlmoyZq7L7Rk=",
+  "clientDepsHash": "sha256-fAtr5GW8AInIDgSEjv1JwKW9GNZGYImD3LxerkUqH8k="
 }


### PR DESCRIPTION
https://github.com/advplyr/audiobookshelf/releases/tag/v2.24.0

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
