### PR TITLE
hyprgraphics: revert switch to spng

### DIFF
--- a/pkgs/by-name/hy/hyprgraphics/package.nix
+++ b/pkgs/by-name/hy/hyprgraphics/package.nix
@@ -10,7 +10,6 @@
   hyprutils,
   libjpeg,
   libjxl,
-  libspng,
   libwebp,
   pixman,
 }:
@@ -26,6 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-prQ5JKopXtzCMX2eT3dXbaVvGmzjMRE2bXStQDdazpM=";
   };
 
+  patches = [
+    ./remove-spng.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -37,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     hyprutils
     libjpeg
     libjxl
-    libspng
     libwebp
     pixman
   ];

--- a/pkgs/by-name/hy/hyprgraphics/remove-spng.patch
+++ b/pkgs/by-name/hy/hyprgraphics/remove-spng.patch
@@ -1,0 +1,115 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 958b7c0..6754f89 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,7 +48,7 @@ pkg_check_modules(
+   libjpeg
+   libwebp
+   libmagic
+-  spng)
++)
+ 
+ pkg_check_modules(
+   JXL
+diff --git a/src/image/formats/Png.cpp b/src/image/formats/Png.cpp
+index 9651da8..f572c35 100644
+--- a/src/image/formats/Png.cpp
++++ b/src/image/formats/Png.cpp
+@@ -1,93 +1,17 @@
+ #include "Png.hpp"
+-#include <spng.h>
+-#include <vector>
+-#include <fstream>
++#include <cairo.h>
+ #include <filesystem>
+-#include <cstdint>
+ #include <hyprutils/utils/ScopeGuard.hpp>
+ using namespace Hyprutils::Utils;
+ 
+-static std::vector<unsigned char> readBinaryFile(const std::string& filename) {
+-    std::ifstream f(filename, std::ios::binary);
+-    if (!f.good())
+-        return {};
+-    f.unsetf(std::ios::skipws);
+-    return {std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+-}
+-
+ std::expected<cairo_surface_t*, std::string> PNG::createSurfaceFromPNG(const std::string& path) {
+     if (!std::filesystem::exists(path))
+         return std::unexpected("loading png: file doesn't exist");
+ 
+-    spng_ctx*   ctx = spng_ctx_new(0);
+-
+-    CScopeGuard x([&] { spng_ctx_free(ctx); });
+-
+-    const auto  PNGCONTENT = readBinaryFile(path);
+-
+-    if (PNGCONTENT.empty())
+-        return std::unexpected("loading png: file content was empty (bad file?)");
+-
+-    spng_set_png_buffer(ctx, PNGCONTENT.data(), PNGCONTENT.size());
+-
+-    spng_ihdr ihdr{0};
+-    if (int ret = spng_get_ihdr(ctx, &ihdr); ret)
+-        return std::unexpected(std::string{"loading png: spng_get_ihdr failed: "} + spng_strerror(ret));
+-
+-    int fmt = SPNG_FMT_PNG;
+-    if (ihdr.color_type == SPNG_COLOR_TYPE_INDEXED)
+-        fmt = SPNG_FMT_RGB8;
+-
+-    size_t imageLength = 0;
+-    if (int ret = spng_decoded_image_size(ctx, fmt, &imageLength); ret)
+-        return std::unexpected(std::string{"loading png: spng_decoded_image_size failed: "} + spng_strerror(ret));
+-
+-    uint8_t* imageData = (uint8_t*)malloc(imageLength);
+-
+-    if (!imageData)
+-        return std::unexpected("loading png: mallocing failed, out of memory?");
+-
+-    // TODO: allow proper decode of high bitrate images
+-    bool succeededDecode = false;
+-    int  ret             = spng_decode_image(ctx, imageData, imageLength, SPNG_FMT_RGBA8, 0);
+-    if (!ret)
+-        succeededDecode = true;
+-
+-    if (!succeededDecode && ret == SPNG_EBUFSIZ) {
+-        // hack, but I don't know why decoded_image_size is sometimes wrong
+-        imageLength = ihdr.height * ihdr.width * 4 /* FIXME: this is wrong if we doing >32bpp!!!! */;
+-        imageData   = (uint8_t*)realloc(imageData, imageLength);
+-
+-        ret = spng_decode_image(ctx, imageData, imageLength, SPNG_FMT_RGBA8, 0);
+-    }
+-
+-    if (!ret)
+-        succeededDecode = true;
+-
+-    if (!succeededDecode) {
+-        free(imageData);
+-        return std::unexpected(std::string{"loading png: spng_decode_image failed: "} + spng_strerror(ret) + " (bad image?)");
+-    }
+-
+-    // convert RGBA8888 -> ARGB8888 premult for cairo
+-    for (size_t i = 0; i < imageLength; i += 4) {
+-        uint8_t r, g, b, a;
+-        a = ((*((uint32_t*)(imageData + i))) & 0xFF000000) >> 24;
+-        b = ((*((uint32_t*)(imageData + i))) & 0x00FF0000) >> 16;
+-        g = ((*((uint32_t*)(imageData + i))) & 0x0000FF00) >> 8;
+-        r = (*((uint32_t*)(imageData + i))) & 0x000000FF;
+-
+-        r *= ((float)a / 255.F);
+-        g *= ((float)a / 255.F);
+-        b *= ((float)a / 255.F);
+-
+-        *((uint32_t*)(imageData + i)) = (((uint32_t)a) << 24) | (((uint32_t)r) << 16) | (((uint32_t)g) << 8) | (uint32_t)b;
+-    }
+-
+-    auto CAIROSURFACE = cairo_image_surface_create_for_data(imageData, CAIRO_FORMAT_ARGB32, ihdr.width, ihdr.height, ihdr.width * 4);
++    auto CAIROSURFACE = cairo_image_surface_create_from_png(path.c_str());
+ 
+     if (!CAIROSURFACE)
+         return std::unexpected("loading png: cairo failed");
+ 
+     return CAIROSURFACE;
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
Upstream switched to spng in https://github.com/hyprwm/hyprgraphics/commit/0c11438de462ebafc1d098bb89deb661e5d2dee0. This change was entirely unexplained: cairo supports loading PNGs. More importantly, spng is basically unmaintained.
Adding dependencies on it should be avoided, especially considering the hyprgraphics implementation for loading PNGs has security issues (https://github.com/hyprwm/hyprgraphics/commit/12cd7034e441a5ebfdef1a090c0788413b4a635b).

While this patch might look hacky, upstream introducing unaddressed security issues and additional external libraries without explanation is not exactly good style either. This patch is also partially motivated by libspng finally failing to build on current staging-next.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
