### PR TITLE
treewide: use https when meta.homepage redirects to https

### DIFF
--- a/pkgs/applications/graphics/yacreader/default.nix
+++ b/pkgs/applications/graphics/yacreader/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Comic reader for cross-platform reading and managing your digital comic collection";
-    homepage = "http://www.yacreader.com";
+    homepage = "https://www.yacreader.com";
     license = lib.licenses.gpl3;
     mainProgram = "YACReader";
     maintainers = [ ];

--- a/pkgs/applications/misc/lyx/default.nix
+++ b/pkgs/applications/misc/lyx/default.nix
@@ -54,7 +54,7 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "WYSIWYM frontend for LaTeX, DocBook";
-    homepage = "http://www.lyx.org";
+    homepage = "https://www.lyx.org";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.vcunat ];
     platforms = platforms.linux;

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -72,7 +72,7 @@ callPackage ./generic.nix {
   );
   meta = with lib; {
     description = "Wolfram Mathematica computational software system";
-    homepage = "http://www.wolfram.com/mathematica/";
+    homepage = "https://www.wolfram.com/mathematica/";
     license = licenses.unfree;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [

--- a/pkgs/applications/video/vdr/default.nix
+++ b/pkgs/applications/video/vdr/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://www.tvdr.de/";
+    homepage = "https://www.tvdr.de/";
     description = "Video Disc Recorder";
     maintainers = [ maintainers.ck3d ];
     platforms = platforms.linux;

--- a/pkgs/by-name/ba/bakoma_ttf/package.nix
+++ b/pkgs/by-name/ba/bakoma_ttf/package.nix
@@ -21,6 +21,6 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "TrueType versions of the Computer Modern and AMS TeX Fonts";
-    homepage = "http://www.ctan.org/tex-archive/fonts/cm/ps-type1/bakoma/ttf/";
+    homepage = "https://www.ctan.org/tex-archive/fonts/cm/ps-type1/bakoma/ttf/";
   };
 }

--- a/pkgs/by-name/bl/bleachbit/package.nix
+++ b/pkgs/by-name/bl/bleachbit/package.nix
@@ -61,7 +61,7 @@ python3Packages.buildPythonApplication rec {
   strictDeps = false;
 
   meta = with lib; {
-    homepage = "http://bleachbit.sourceforge.net";
+    homepage = "https://bleachbit.sourceforge.net";
     description = "Program to clean your computer";
     longDescription = "BleachBit helps you easily clean your computer to free space and maintain privacy.";
     license = licenses.gpl3;

--- a/pkgs/by-name/ca/catdvi/package.nix
+++ b/pkgs/by-name/ca/catdvi/package.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   meta = with lib; {
-    homepage = "http://catdvi.sourceforge.net";
+    homepage = "https://catdvi.sourceforge.net";
     description = "DVI to plain text translator";
     license = licenses.gpl2Plus;
     maintainers = [ ];

--- a/pkgs/by-name/ej/ejs/package.nix
+++ b/pkgs/by-name/ej/ejs/package.nix
@@ -29,7 +29,7 @@ buildNpmPackage {
 
   meta = {
     description = "Embedded JavaScript templates";
-    homepage = "http://ejs.co";
+    homepage = "https://ejs.co";
     license = lib.licenses.asl20;
     mainProgram = "ejs";
     maintainers = with lib.maintainers; [ momeemt ];

--- a/pkgs/by-name/ek/ekho/package.nix
+++ b/pkgs/by-name/ek/ekho/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Chinese text-to-speech software";
-    homepage = "http://www.eguidedog.net/ekho.php";
+    homepage = "https://www.eguidedog.net/ekho.php";
     longDescription = ''
       Ekho (余音) is a free, open source and multilingual text-to-speech (TTS)
       software. It supports Cantonese (Chinese dialect spoken in Hong Kong and

--- a/pkgs/by-name/el/elvis/package.nix
+++ b/pkgs/by-name/el/elvis/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "http://elvis.the-little-red-haired-girl.org/";
+    homepage = "https://elvis.the-little-red-haired-girl.org/";
     description = "Vi clone for Unix and other operating systems";
     license = lib.licenses.free;
     mainProgram = "elvis";

--- a/pkgs/by-name/fl/flamegraph/package.nix
+++ b/pkgs/by-name/fl/flamegraph/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
       cddl
       gpl2Plus
     ];
-    homepage = "http://www.brendangregg.com/flamegraphs.html";
+    homepage = "https://www.brendangregg.com/flamegraphs.html";
     description = "Visualization for profiled code";
     mainProgram = "flamegraph.pl";
     platforms = platforms.unix;

--- a/pkgs/by-name/fl/fluxbox/package.nix
+++ b/pkgs/by-name/fl/fluxbox/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
       fast, desktop experience. It is written in C++ and licensed
       under MIT license.
     '';
-    homepage = "http://fluxbox.org/";
+    homepage = "https://fluxbox.org/";
     license = licenses.mit;
     maintainers = [ ];
     platforms = platforms.linux;

--- a/pkgs/by-name/fu/fusionInventory/package.nix
+++ b/pkgs/by-name/fu/fusionInventory/package.nix
@@ -97,7 +97,7 @@ perlPackages.buildPerlPackage rec {
   outputs = [ "out" ];
 
   meta = with lib; {
-    homepage = "http://www.fusioninventory.org";
+    homepage = "https://www.fusioninventory.org";
     description = "FusionInventory unified Agent for UNIX, Linux, Windows and MacOSX";
     license = lib.licenses.gpl2Only;
     maintainers = [ maintainers.phile314 ];

--- a/pkgs/by-name/ga/galculator/package.nix
+++ b/pkgs/by-name/ga/galculator/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = false;
 
   meta = {
-    homepage = "http://galculator.sourceforge.net/";
+    homepage = "https://galculator.sourceforge.net/";
     description = "GTK algebraic and RPN calculator";
     longDescription = ''
       galculator is a GTK-based calculator. Its main features include:

--- a/pkgs/by-name/ga/galen/package.nix
+++ b/pkgs/by-name/ga/galen/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://galenframework.com";
+    homepage = "https://galenframework.com";
     description = "Automated layout testing for websites";
     mainProgram = "galen";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];

--- a/pkgs/by-name/ga/gambit-project/package.nix
+++ b/pkgs/by-name/ga/gambit-project/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Open-source collection of tools for doing computation in game theory";
-    homepage = "http://www.gambit-project.org";
+    homepage = "https://www.gambit-project.org";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ t4ccer ];
     platforms = with lib.platforms; unix ++ windows;

--- a/pkgs/by-name/ge/geant4/package.nix
+++ b/pkgs/by-name/ge/geant4/package.nix
@@ -147,7 +147,7 @@ stdenv.mkDerivation rec {
       Its areas of application include high energy, nuclear and accelerator physics, as well as studies in medical and space science.
       The two main reference papers for Geant4 are published in Nuclear Instruments and Methods in Physics Research A 506 (2003) 250-303, and IEEE Transactions on Nuclear Science 53 No. 1 (2006) 270-278.
     '';
-    homepage = "http://www.geant4.org";
+    homepage = "https://www.geant4.org";
     license = licenses.g4sl;
     maintainers = with maintainers; [
       omnipotententity

--- a/pkgs/by-name/gf/gfie/package.nix
+++ b/pkgs/by-name/gf/gfie/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Powerful open source image editor, especially suitable for creating icons, cursors, animations and icon libraries";
-    homepage = "http://greenfishsoftware.org/gfie.php";
+    homepage = "https://greenfishsoftware.org/gfie.php";
     license = with lib.licenses; [ gpl3 ];
     maintainers = with lib.maintainers; [ pluiedev ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/gk/gkrellm/package.nix
+++ b/pkgs/by-name/gk/gkrellm/package.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
       supports applying themes to match its appearance to your window
       manager, Gtk, or any other theme.
     '';
-    homepage = "http://gkrellm.srcbox.net";
+    homepage = "https://gkrellm.srcbox.net";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/he/hex-a-hop/package.nix
+++ b/pkgs/by-name/he/hex-a-hop/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Puzzle game based on hexagonal tiles";
     mainProgram = "hex-a-hop";
-    homepage = "http://hexahop.sourceforge.net";
+    homepage = "https://hexahop.sourceforge.net";
     license = with lib.licenses; [
       gpl2Plus # Main code
       cc-by-30 # Assets

--- a/pkgs/by-name/li/libdivecomputer/package.nix
+++ b/pkgs/by-name/li/libdivecomputer/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage = "http://www.libdivecomputer.org";
+    homepage = "https://www.libdivecomputer.org";
     description = "Cross-platform and open source library for communication with dive computers from various manufacturers";
     mainProgram = "dctool";
     maintainers = [ maintainers.mguentner ];

--- a/pkgs/by-name/ma/makemkv/package.nix
+++ b/pkgs/by-name/ma/makemkv/package.nix
@@ -130,7 +130,7 @@ libsForQt5.mkDerivation {
       licenses.unfree
       licenses.lgpl21
     ];
-    homepage = "http://makemkv.com";
+    homepage = "https://makemkv.com";
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ jchw ];
   };

--- a/pkgs/by-name/ma/matrix-brandy/package.nix
+++ b/pkgs/by-name/ma/matrix-brandy/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
-    homepage = "http://brandy.matrixnetwork.co.uk/";
+    homepage = "https://brandy.matrixnetwork.co.uk/";
     description = "Matrix Brandy BASIC VI for Linux, Windows, MacOSX";
     mainProgram = "brandy";
     license = licenses.gpl2Plus;

--- a/pkgs/by-name/me/merkaartor/package.nix
+++ b/pkgs/by-name/me/merkaartor/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "OpenStreetMap editor";
-    homepage = "http://merkaartor.be/";
+    homepage = "https://merkaartor.be/";
     license = lib.licenses.gpl2Plus;
     mainProgram = "merkaartor";
     maintainers = with lib.maintainers; [ sikmir ];

--- a/pkgs/by-name/on/oncall/package.nix
+++ b/pkgs/by-name/on/oncall/package.nix
@@ -101,7 +101,7 @@ python3.pkgs.buildPythonApplication rec {
 
   meta = {
     description = "Calendar web-app designed for scheduling and managing on-call shifts";
-    homepage = "http://oncall.tools";
+    homepage = "https://oncall.tools";
     changelog = "https://github.com/linkedin/oncall/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ onny ];

--- a/pkgs/by-name/pe/perseus/package.nix
+++ b/pkgs/by-name/pe/perseus/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
       around datasets arising from point samples, images, distance
       matrices and so forth.
     '';
-    homepage = "http://people.maths.ox.ac.uk/nanda/perseus/index.html";
+    homepage = "https://people.maths.ox.ac.uk/nanda/perseus/index.html";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ erikryb ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/pi/pixman/package.nix
+++ b/pkgs/by-name/pi/pixman/package.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = with lib; {
-    homepage = "http://pixman.org";
+    homepage = "https://pixman.org";
     description = "Low-level library for pixel manipulation";
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/by-name/po/pocl/package.nix
+++ b/pkgs/by-name/po/pocl/package.nix
@@ -117,7 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "portable open source (MIT-licensed) implementation of the OpenCL standard";
-    homepage = "http://portablecl.org";
+    homepage = "https://portablecl.org";
     changelog = "https://github.com/pocl/pocl/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/se/selendroid/package.nix
+++ b/pkgs/by-name/se/selendroid/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    homepage = "http://selendroid.io/";
+    homepage = "https://selendroid.io/";
     description = "Test automation for native or hybrid Android apps and the mobile web";
     maintainers = with maintainers; [ offline ];
     platforms = platforms.all;

--- a/pkgs/by-name/su/substudy/package.nix
+++ b/pkgs/by-name/su/substudy/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Learn foreign languages using audio and subtitles extracted from video files";
-    homepage = "http://www.randomhacks.net/substudy";
+    homepage = "https://www.randomhacks.net/substudy";
     license = licenses.asl20;
     mainProgram = "substudy";
     maintainers = with maintainers; [ paveloom ];

--- a/pkgs/by-name/sy/synfigstudio/package.nix
+++ b/pkgs/by-name/sy/synfigstudio/package.nix
@@ -148,7 +148,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "2D animation program";
-    homepage = "http://www.synfig.org";
+    homepage = "https://www.synfig.org";
     license = licenses.gpl3Plus;
     maintainers = [ ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/by-name/te/tet/package.nix
+++ b/pkgs/by-name/te/tet/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation ({
 
   meta = {
     description = "Test Environment Toolkit is used in test applications like The Open Group's UNIX Certification program and the Free Standards Group's LSB Certification program";
-    homepage = "http://tetworks.opengroup.org/Products/tet.htm";
+    homepage = "https://tetworks.opengroup.org/Products/tet.htm";
     license = lib.licenses.artistic1;
     platforms = lib.platforms.unix;
     maintainers = [ ];

--- a/pkgs/by-name/wa/wallabag/package.nix
+++ b/pkgs/by-name/wa/wallabag/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
       It extracts content so that you can read it when you have time.
     '';
     license = licenses.mit;
-    homepage = "http://wallabag.org";
+    homepage = "https://wallabag.org";
     changelog = "https://github.com/wallabag/wallabag/releases/tag/${version}";
     maintainers = with maintainers; [ schneefux ];
     platforms = platforms.all;

--- a/pkgs/by-name/xc/xcowsay/package.nix
+++ b/pkgs/by-name/xc/xcowsay/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://www.doof.me.uk/xcowsay";
+    homepage = "https://www.doof.me.uk/xcowsay";
     description = "Tool to display a cute cow and messages";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ das_j ];

--- a/pkgs/development/libraries/cxxtest/default.nix
+++ b/pkgs/development/libraries/cxxtest/default.nix
@@ -43,7 +43,7 @@ buildPythonApplication rec {
   dontWrapPythonPrograms = true;
 
   meta = with lib; {
-    homepage = "http://github.com/CxxTest/cxxtest";
+    homepage = "https://github.com/CxxTest/cxxtest";
     description = "Unit testing framework for C++";
     mainProgram = "cxxtestgen";
     license = licenses.lgpl3;

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = {
-    homepage = "http://www.pcre.org/";
+    homepage = "https://www.pcre.org/";
     description = "Library for Perl Compatible Regular Expressions";
     license = lib.licenses.bsd3;
 

--- a/pkgs/development/python-modules/i-pi/default.nix
+++ b/pkgs/development/python-modules/i-pi/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
       gpl3Only
       mit
     ];
-    homepage = "http://ipi-code.org/";
+    homepage = "https://ipi-code.org/";
     platforms = platforms.linux;
     maintainers = [ maintainers.sheepforce ];
   };

--- a/pkgs/development/python-modules/supervisor/default.nix
+++ b/pkgs/development/python-modules/supervisor/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "System for controlling process state under UNIX";
-    homepage = "http://supervisord.org/";
+    homepage = "https://supervisord.org/";
     changelog = "https://github.com/Supervisor/supervisor/blob/${version}/CHANGES.rst";
     license = licenses.free; # http://www.repoze.org/LICENSE.txt
     maintainers = with maintainers; [ zimbatm ];

--- a/pkgs/development/python-modules/xstatic-bootbox/default.nix
+++ b/pkgs/development/python-modules/xstatic-bootbox/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    homepage = "http://bootboxjs.com";
+    homepage = "https://bootboxjs.com";
     description = "Bootboxjs packaged static files for python";
     license = licenses.mit;
     maintainers = with maintainers; [ makefu ];

--- a/pkgs/development/tools/alloy/default.nix
+++ b/pkgs/development/tools/alloy/default.nix
@@ -58,8 +58,8 @@ let
           finds structures that satisfy them. Structures are displayed graphically,
           and their appearance can be customized for the domain at hand.
         '';
-        homepage = "http://alloytools.org/";
-        downloadPage = "http://alloytools.org/download.html";
+        homepage = "https://alloytools.org/";
+        downloadPage = "https://alloytools.org/download.html";
         sourceProvenance = with sourceTypes; [ binaryBytecode ];
         license = licenses.mit;
         platforms = platforms.unix;

--- a/pkgs/servers/dns/nsd/default.nix
+++ b/pkgs/servers/dns/nsd/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "http://www.nlnetlabs.nl";
+    homepage = "https://www.nlnetlabs.nl";
     description = "Authoritative only, high performance, simple and open source name server";
     license = licenses.bsd3;
     platforms = platforms.unix;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9495,7 +9495,7 @@ with self;
     doCheck = false;
     meta = {
       description = "Code coverage metrics for Perl";
-      homepage = "http://www.pjcj.net/perl.html";
+      homepage = "https://www.pjcj.net/perl.html";
       license = with lib.licenses; [
         artistic1
         gpl1Plus


### PR DESCRIPTION
Based on https://repology.org/repository/nix_unstable/problems

These are not all the packages, only the trivial ones.
There are a select few that need more than a http -> https replacement, I'll do those in another PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
