### PR TITLE
whatsapp-electron: init at 1.1.1

### DIFF
--- a/pkgs/by-name/wh/whatsapp-electron/icon.patch
+++ b/pkgs/by-name/wh/whatsapp-electron/icon.patch
@@ -1,0 +1,13 @@
+diff --git a/src/index.js b/src/index.js
+index cf77b75..4ceb2da 100644
+--- a/src/index.js
++++ b/src/index.js
+@@ -14,7 +14,7 @@ class WhatsAppElectron
+ {
+ 	constructor() {
+ 		this.store    = new Store();
+-		this.baseIcon = isDev ? path.join(__dirname, "../assets/whatsapp-icon-512x512.png") : path.join(process.resourcesPath, "app.asar.unpacked/assets/whatsapp-icon-512x512.png");
++		this.baseIcon = isDev ? path.join(__dirname, "../assets/whatsapp-icon-512x512.png") : path.join(app.getAppPath(), "assets/whatsapp-icon-512x512.png");
+ 		this.isQuit   = false;
+ 
+ 		this.bounds = this.store.get("bounds");

--- a/pkgs/by-name/wh/whatsapp-electron/package.nix
+++ b/pkgs/by-name/wh/whatsapp-electron/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  electron,
+  stdenv,
+  copyDesktopItems,
+  nodejs,
+  fetchNpmDeps,
+  makeDesktopItem,
+  npmHooks,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "whatsapp";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "dagmoller";
+    repo = "whatsapp-electron";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-i3rk/wAr2MtJqXv7Z9uG0YzIsvaxrDvcXsXQhDEmzxw=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-5AlnAtxiQDbJEbxthGT8DQhZG5tdkrFk0+47czalnlU=";
+  };
+
+  patches = [ ./icon.patch ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    npmHooks.npmConfigHook
+  ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ copyDesktopItems ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+
+  buildPhase = ''
+    runHook preBuild
+
+    npm install
+    ./node_modules/.bin/electron-builder \
+      --dir \
+      -c.electronDist=${if stdenv.hostPlatform.isDarwin then "." else electron.dist} \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/share/whatsapp-electron"
+    cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/whatsapp-electron"
+
+    install -D assets/whatsapp-icon-512x512.png $out/share/pixmaps/whatsapp.png
+    install -D assets/whatsapp-icon-512x512.svg $out/share/icons/hicolor/scalable/apps/whatsapp.svg
+    runHook postInstall
+  '';
+
+  postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    makeWrapper ${electron}/bin/electron $out/bin/whatsapp-electron \
+      --add-flags $out/share/whatsapp-electron/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "com.github.dagmoller.whatsapp-electron";
+      exec = "whatsapp-electron %u";
+      icon = "whatsapp";
+      desktopName = "Whatsapp";
+      startupWMClass = "com.github.dagmoller.whatsapp-electron";
+      categories = [
+        "Network"
+        "InstantMessaging"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Electron wrapper around Whatsapp";
+    homepage = "https://github.com/dagmoller/whatsapp-electron";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [
+      rucadi
+    ];
+    mainProgram = "whatsapp-electron";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

While macos has a native version of whatsapp, linux lacks one, however, in archlinux there is the package: https://aur.archlinux.org/packages/whatsapp-electron-bin

Which just wraps the whatsapp web in an electron app.

Since I prefer to have this specific wrapper instead of accessing via web directly or having it "linked" to a browser, I packaged it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
