### PR TITLE
[Backport release-25.05] ente-auth: 4.3.5 -> 4.3.6

### DIFF
--- a/pkgs/by-name/en/ente-auth/git-hashes.json
+++ b/pkgs/by-name/en/ente-auth/git-hashes.json
@@ -1,6 +1,5 @@
 {
   "ente_crypto_dart": "sha256-xBBK9BdXh4+OTj+Jkf3zh5sMZjXtvhyuE1R5LFE8iTY=",
   "flutter_local_authentication": "sha256-r50jr+81ho+7q2PWHLf4VnvNJmhiARZ3s4HUpThCgc0=",
-  "flutter_secure_storage_linux": "sha256-Rp+b6ZRH7F5AnM5UvYzfVjprXkpeeA7V6Ep/oYqDeiM=",
   "sqflite": "sha256-+XTVtkFJ94VifwnutvUuAqqiyWwrcEiZ3Uz0H4D9zWA="
 }

--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -18,14 +18,14 @@ let
 in
 flutter324.buildFlutterApplication rec {
   pname = "ente-auth";
-  version = "4.3.5";
+  version = "4.3.6";
 
   src = fetchFromGitHub {
     owner = "ente-io";
     repo = "ente";
     sparseCheckout = [ "auth" ];
     tag = "auth-v${version}";
-    hash = "sha256-kM1y3Q5Z8J84qHhki9A+I/uY7xYQNMlfh2ZhxzpUBHM=";
+    hash = "sha256-6S0sgxiPrakqtQ/KoEKR10yWxOk6Rs5MOHjFZXkAbcg=";
   };
 
   sourceRoot = "${src.name}/auth";

--- a/pkgs/by-name/en/ente-auth/pubspec.lock.json
+++ b/pkgs/by-name/en/ente-auth/pubspec.lock.json
@@ -4,17 +4,17 @@
       "dependency": "transitive",
       "description": {
         "name": "_fe_analyzer_shared",
-        "sha256": "f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834",
+        "sha256": "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "72.0.0"
+      "version": "76.0.0"
     },
     "_macros": {
       "dependency": "transitive",
       "description": "dart",
       "source": "sdk",
-      "version": "0.3.2"
+      "version": "0.3.3"
     },
     "adaptive_theme": {
       "dependency": "direct main",
@@ -30,11 +30,11 @@
       "dependency": "transitive",
       "description": {
         "name": "analyzer",
-        "sha256": "b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139",
+        "sha256": "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.7.0"
+      "version": "6.11.0"
     },
     "ansicolor": {
       "dependency": "transitive",
@@ -110,11 +110,11 @@
       "dependency": "transitive",
       "description": {
         "name": "async",
-        "sha256": "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c",
+        "sha256": "d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.11.0"
+      "version": "2.12.0"
     },
     "auto_size_text": {
       "dependency": "direct main",
@@ -160,11 +160,11 @@
       "dependency": "transitive",
       "description": {
         "name": "boolean_selector",
-        "sha256": "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66",
+        "sha256": "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.1"
+      "version": "2.1.2"
     },
     "build": {
       "dependency": "transitive",
@@ -250,11 +250,11 @@
       "dependency": "transitive",
       "description": {
         "name": "characters",
-        "sha256": "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605",
+        "sha256": "f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.0"
+      "version": "1.4.0"
     },
     "checked_yaml": {
       "dependency": "transitive",
@@ -290,11 +290,11 @@
       "dependency": "transitive",
       "description": {
         "name": "clock",
-        "sha256": "cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf",
+        "sha256": "fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     "code_builder": {
       "dependency": "transitive",
@@ -310,11 +310,11 @@
       "dependency": "direct main",
       "description": {
         "name": "collection",
-        "sha256": "ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a",
+        "sha256": "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.18.0"
+      "version": "1.19.1"
     },
     "confetti": {
       "dependency": "direct main",
@@ -541,11 +541,11 @@
       "dependency": "transitive",
       "description": {
         "name": "fake_async",
-        "sha256": "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78",
+        "sha256": "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     "ffi": {
       "dependency": "direct main",
@@ -841,15 +841,14 @@
       "version": "9.2.2"
     },
     "flutter_secure_storage_linux": {
-      "dependency": "direct overridden",
+      "dependency": "transitive",
       "description": {
-        "path": "flutter_secure_storage_linux",
-        "ref": "develop",
-        "resolved-ref": "5a5692b609b3886cdd49b2ed06b9c079ecdff996",
-        "url": "https://github.com/mogol/flutter_secure_storage.git"
+        "name": "flutter_secure_storage_linux",
+        "sha256": "be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688",
+        "url": "https://pub.dev"
       },
-      "source": "git",
-      "version": "1.2.1"
+      "source": "hosted",
+      "version": "1.2.3"
     },
     "flutter_secure_storage_macos": {
       "dependency": "transitive",
@@ -1177,21 +1176,21 @@
       "dependency": "transitive",
       "description": {
         "name": "leak_tracker",
-        "sha256": "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05",
+        "sha256": "c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "10.0.5"
+      "version": "10.0.8"
     },
     "leak_tracker_flutter_testing": {
       "dependency": "transitive",
       "description": {
         "name": "leak_tracker_flutter_testing",
-        "sha256": "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806",
+        "sha256": "f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.0.5"
+      "version": "3.0.9"
     },
     "leak_tracker_testing": {
       "dependency": "transitive",
@@ -1277,21 +1276,21 @@
       "dependency": "transitive",
       "description": {
         "name": "macros",
-        "sha256": "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536",
+        "sha256": "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.1.2-main.4"
+      "version": "0.1.3-main.0"
     },
     "matcher": {
       "dependency": "transitive",
       "description": {
         "name": "matcher",
-        "sha256": "d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb",
+        "sha256": "dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.12.16+1"
+      "version": "0.12.17"
     },
     "material_color_utilities": {
       "dependency": "transitive",
@@ -1317,11 +1316,11 @@
       "dependency": "transitive",
       "description": {
         "name": "meta",
-        "sha256": "bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7",
+        "sha256": "e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.15.0"
+      "version": "1.16.0"
     },
     "mime": {
       "dependency": "transitive",
@@ -1457,11 +1456,11 @@
       "dependency": "direct main",
       "description": {
         "name": "path",
-        "sha256": "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af",
+        "sha256": "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.9.0"
+      "version": "1.9.1"
     },
     "path_drawing": {
       "dependency": "transitive",
@@ -1697,21 +1696,21 @@
       "dependency": "direct main",
       "description": {
         "name": "sentry",
-        "sha256": "033287044a6644a93498969449d57c37907e56f5cedb17b88a3ff20a882261dd",
+        "sha256": "599701ca0693a74da361bc780b0752e1abc98226cf5095f6b069648116c896bb",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.9.0"
+      "version": "8.14.2"
     },
     "sentry_flutter": {
       "dependency": "direct main",
       "description": {
         "name": "sentry_flutter",
-        "sha256": "3780b5a0bb6afd476857cfbc6c7444d969c29a4d9bd1aa5b6960aa76c65b737a",
+        "sha256": "5ba2cf40646a77d113b37a07bd69f61bb3ec8a73cbabe5537b05a7c89d2656f8",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "8.9.0"
+      "version": "8.14.2"
     },
     "share_plus": {
       "dependency": "direct main",
@@ -1837,7 +1836,7 @@
       "dependency": "transitive",
       "description": "flutter",
       "source": "sdk",
-      "version": "0.0.99"
+      "version": "0.0.0"
     },
     "sodium": {
       "dependency": "transitive",
@@ -1883,11 +1882,11 @@
       "dependency": "transitive",
       "description": {
         "name": "source_span",
-        "sha256": "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c",
+        "sha256": "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.10.0"
+      "version": "1.10.1"
     },
     "sprintf": {
       "dependency": "transitive",
@@ -1944,11 +1943,11 @@
       "dependency": "transitive",
       "description": {
         "name": "stack_trace",
-        "sha256": "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b",
+        "sha256": "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.11.1"
+      "version": "1.12.1"
     },
     "steam_totp": {
       "dependency": "direct main",
@@ -1974,11 +1973,11 @@
       "dependency": "transitive",
       "description": {
         "name": "stream_channel",
-        "sha256": "ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7",
+        "sha256": "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.2"
+      "version": "2.1.4"
     },
     "stream_transform": {
       "dependency": "transitive",
@@ -1994,11 +1993,11 @@
       "dependency": "transitive",
       "description": {
         "name": "string_scanner",
-        "sha256": "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde",
+        "sha256": "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.2.0"
+      "version": "1.4.1"
     },
     "styled_text": {
       "dependency": "direct main",
@@ -2024,21 +2023,21 @@
       "dependency": "transitive",
       "description": {
         "name": "term_glyph",
-        "sha256": "a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84",
+        "sha256": "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "test_api": {
       "dependency": "transitive",
       "description": {
         "name": "test_api",
-        "sha256": "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb",
+        "sha256": "fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.7.2"
+      "version": "0.7.4"
     },
     "timezone": {
       "dependency": "transitive",
@@ -2244,11 +2243,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vm_service",
-        "sha256": "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d",
+        "sha256": "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "14.2.5"
+      "version": "14.3.1"
     },
     "watcher": {
       "dependency": "transitive",
@@ -2362,7 +2361,7 @@
     }
   },
   "sdks": {
-    "dart": ">=3.5.0 <4.0.0",
+    "dart": ">=3.7.0-0 <4.0.0",
     "flutter": ">=3.24.0"
   }
 }

--- a/pkgs/development/compilers/dart/package-source-builders/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/default.nix
@@ -16,6 +16,7 @@
   pdfrx = callPackage ./pdfrx { };
   printing = callPackage ./printing { };
   rhttp = callPackage ./rhttp { };
+  sentry_flutter = callPackage ./sentry_flutter { };
   sqlcipher_flutter_libs = callPackage ./sqlcipher_flutter_libs { };
   sqlite3 = callPackage ./sqlite3 { };
   sqlite3_flutter_libs = callPackage ./sqlite3_flutter_libs { };

--- a/pkgs/development/compilers/dart/package-source-builders/sentry_flutter/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/sentry_flutter/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   fetchFromGitHub,
 }:
@@ -18,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   inherit version src;
   inherit (src) passthru;
 
-  postPatch = ''
+  postPatch = lib.optionalString (lib.versionAtLeast version "8.10.0") ''
     sed -i "s|GIT_REPOSITORY.*|SOURCE_DIR "${sentry-native}"|" sentry-native/sentry-native.cmake
     sed -i '/GIT_TAG/d' sentry-native/sentry-native.cmake
   '';

--- a/pkgs/development/compilers/dart/package-source-builders/sentry_flutter/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/sentry_flutter/default.nix
@@ -1,0 +1,33 @@
+{
+  stdenv,
+  fetchFromGitHub,
+}:
+
+{ version, src, ... }:
+
+let
+  sentry-native = fetchFromGitHub {
+    owner = "getsentry";
+    repo = "sentry-native";
+    tag = "0.8.4";
+    hash = "sha256-0NLxu+aelp36m3ocPhyYz3LDeq310fkyu8WSpZML3Pc=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sentry_flutter";
+  inherit version src;
+  inherit (src) passthru;
+
+  postPatch = ''
+    sed -i "s|GIT_REPOSITORY.*|SOURCE_DIR "${sentry-native}"|" sentry-native/sentry-native.cmake
+    sed -i '/GIT_TAG/d' sentry-native/sentry-native.cmake
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r . $out
+
+    runHook postInstall
+  '';
+})


### PR DESCRIPTION
Superseeds https://github.com/NixOS/nixpkgs/pull/413174

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
