### PR TITLE
nixos/nextcloud: add mail config options

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -116,6 +116,7 @@ let
   runtimeSystemdCredentials =
     [ ]
     ++ (lib.optional (cfg.config.dbpassFile != null) "dbpass:${cfg.config.dbpassFile}")
+    ++ (lib.optional (cfg.config.mail.passFile != null) "mail_password:${cfg.config.mail.passFile}")
     ++ (lib.optional (cfg.config.objectstore.s3.enable) "s3_secret:${cfg.config.objectstore.s3.secretFile}")
     ++ (lib.optional (
       cfg.config.objectstore.s3.sseCKeyFile != null
@@ -221,6 +222,26 @@ let
             ],
           ]
         '';
+      mailConfig =
+        let
+          m = c.mail;
+        in
+        lib.optionalString (m.mode != null) ''
+          'mail_smtpmode' => '${m.mode}',
+          ${lib.optionalString (m.host != null) "'mail_smtphost' => '${m.host}',"}
+          ${lib.optionalString (m.port != null) "'mail_smtpport' => ${toString m.port},"}
+          ${lib.optionalString m.secure "'mail_smtpsecure' => 'ssl',"}
+          ${lib.optionalString (m.timeout != null) "'mail_smtptimeout' => ${toString m.timeout},"}
+          ${lib.optionalString (m.user != null || m.passFile != null) ''
+            'mail_smtpauth' => true,
+            ${lib.optionalString (m.user != null) "'mail_smtpname' => '${m.user}',"}
+            ${lib.optionalString (
+              m.passFile != null
+            ) "'mail_smtppassword' => nix_read_secret('mail_password'),"}
+          ''}
+          ${lib.optionalString (m.fromAddress != null) "'mail_from_address' => '${m.fromAddress}',"}
+          ${lib.optionalString (m.domain != null) "'mail_domain' => '${m.domain}',"}
+        '';
       showAppStoreSetting = cfg.appstoreEnable != null || cfg.extraApps != { };
       renderedAppStoreSetting =
         let
@@ -297,6 +318,7 @@ let
         ${lib.optionalString (c.dbpassFile != null) "'dbpassword' => nix_read_secret('dbpass'),"}
         'dbtype' => '${c.dbtype}',
         ${objectstoreConfig}
+        ${mailConfig}
       ];
 
       $CONFIG = array_replace_recursive($CONFIG, nix_decode_json_file(
@@ -646,6 +668,103 @@ in
           with installations that were originally provisioned with Nextcloud <20.
         '';
       };
+
+      # mail specific config
+      # https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/email_configuration.html
+      mail = {
+        mode = lib.mkOption {
+          type = lib.types.nullOr (
+            lib.types.enum [
+              "smtp"
+              "sendmail"
+              "qmail"
+            ]
+          );
+          default = null;
+          description = ''
+            Mail backend to use for sending emails.
+
+            - smtp: Use SMTP server (recommended)
+            - sendmail: Use local sendmail binary
+            - qmail: Use local qmail binary
+          '';
+        };
+        host = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "smtp.example.com";
+          description = ''
+            SMTP server hostname or IP address.
+            Only used when mode is "smtp".
+          '';
+        };
+        port = lib.mkOption {
+          type = lib.types.nullOr lib.types.port;
+          default = (if cfg.config.mail.secure then 465 else 25);
+          defaultText = lib.literalExpression "(if cfg.config.mail.secure then 465 else 25)";
+          example = 587;
+          description = ''
+            SMTP server port.
+            Defaults to 25 for plain/STARTTLS, 465 for SSL.
+            Only used when mode is "smtp".
+          '';
+        };
+        secure = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            SMTP security mode.
+
+            If required by the SMTP server, a secure SSL/TLS connection can be enforced via the SMTPS protocol.
+          '';
+        };
+        timeout = lib.mkOption {
+          type = lib.types.nullOr lib.types.ints.positive;
+          default = null;
+          example = 30;
+          description = ''
+            SMTP connection timeout in seconds.
+            Useful when malware/SPAM scanners cause delays.
+            Only used when mode is "smtp".
+          '';
+        };
+        user = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "user@example.com";
+          description = ''
+            SMTP username for authentication.
+            Only used when mode is "smtp" and auth is true.
+          '';
+        };
+        passFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "/run/secrets/nextcloud-mail-password";
+          description = ''
+            Path to file containing SMTP password for authentication.
+            Only used when mode is "smtp" and auth is true.
+          '';
+        };
+        fromAddress = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "nextcloud@example.com";
+          description = ''
+            Default "From" address for outgoing emails.
+          '';
+        };
+        domain = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "example.com";
+          description = ''
+            The default domain name used for the sender address is the hostname where your Nextcloud installation is served.
+            If you have a different mail domain name you can override this behavior here.
+          '';
+        };
+      };
+
       adminuser = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = "root";


### PR DESCRIPTION
make it easyer to config mail for nextcloud and also be able to inject the secret as passFile:

from
```nix
settings = {
  # ...
  mail_smtpmode = "smtp";
  mail_smtpsecure = "ssl";
  mail_sendmailmode = "smtp";
  mail_from_address = "cloud";
  mail_domain = "example.com";
  mail_smtphost = "example.com";
  mail_smtpport = 465;
  mail_smtpauth = 1;
  mail_smtpname = "cloud_service@example.com";
  mail_smtppassword = "sehr geheim";
};
```

to:
```nix
config = {
  # ...
  mail = {
    mode = "smtp";
    secure = true;
    host = "example.com";
    domain = "example.com";
    fromAddress = "cloud";
    user = "cloud_service@example.com";
    passFile = "/var/secrets/nextcloud-smtp-password";
  };
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
