### PR TITLE
lowdown: 1.3.2 -> 2.0.2, nixVersions.nix_2_24: fix build against lowdown 2.0.2; lix: apply patches for lowdown >= 1.4

### DIFF
--- a/pkgs/by-name/lo/lowdown/package.nix
+++ b/pkgs/by-name/lo/lowdown/package.nix
@@ -5,6 +5,7 @@
   fixDarwinDylibNames,
   which,
   dieHook,
+  bmake,
   enableShared ? !stdenv.hostPlatform.isStatic,
   enableStatic ? stdenv.hostPlatform.isStatic,
   enableDarwinSandbox ? true,
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec {
   pname = "lowdown${
     lib.optionalString (stdenv.hostPlatform.isDarwin && !enableDarwinSandbox) "-unsandboxed"
   }";
-  version = "1.3.2";
+  version = "2.0.2";
 
   outputs = [
     "out"
@@ -27,12 +28,13 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://kristaps.bsd.lv/lowdown/snapshots/lowdown-${version}.tar.gz";
-    hash = "sha512-IQmgPm2zE+B82Zdg+ldjtU/XI+qab9YRAzwzRMYv32KKjql0YLDEgc/m6DbgyCiNBkulD0dVExCtrTM+nBFHzw==";
+    hash = "sha512-cfzhuF4EnGmLJf5EGSIbWqJItY3npbRSALm+GarZ7SMU7Hr1xw0gtBFMpOdi5PBar4TgtvbnG4oRPh+COINGlA==";
   };
 
   nativeBuildInputs = [
     which
     dieHook
+    bmake # Uses FreeBSD's dialect
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixDarwinDylibNames ];
 
@@ -74,7 +76,7 @@ stdenv.mkDerivation rec {
 
   postInstall =
     let
-      soVersion = "1";
+      soVersion = "2";
     in
 
     # Check that soVersion is up to date even if we are not on darwin

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -9,6 +9,7 @@
   fetchgit,
   fetchFromGitHub,
   fetchFromGitea,
+  fetchpatch2,
   rustPlatform,
   editline,
   ncurses,
@@ -168,6 +169,15 @@ lib.makeExtensible (self: {
         hash = "sha256-b5d+HnPcyHz0ZJW1+LZl4qm4LGTB/TiaDFQVlVL2xpE=";
       };
 
+      patches = [
+        # Support for lowdown >= 1.4, https://gerrit.lix.systems/c/lix/+/3731
+        (fetchpatch2 {
+          name = "lix-2.91-lowdown-1.4.0.patch";
+          url = "https://git.lix.systems/lix-project/lix/commit/ecff59d77371b21fef229c33ebb629bc49a8fad5.patch";
+          sha256 = "sha256-2M5oId5kObwzpw67rddAPI2RbWPEVlGBrMUXZWqqmEo=";
+        })
+      ];
+
       docCargoDeps = rustPlatform.fetchCargoVendor {
         name = "lix-doc-${version}";
         inherit src;
@@ -200,6 +210,15 @@ lib.makeExtensible (self: {
         hash = "sha256-iP2iUDxA99RcgQyZROs7bQw8pqxa1vFudRqjAIHg9Iw=";
       };
 
+      patches = [
+        # Support for lowdown >= 1.4, https://gerrit.lix.systems/c/lix/+/3731
+        (fetchpatch2 {
+          name = "lix-lowdown-1.4.0.patch";
+          url = "https://git.lix.systems/lix-project/lix/commit/858de5f47a1bfd33835ec97794ece339a88490f1.patch";
+          hash = "sha256-FfLO2dFSWV1qwcupIg8dYEhCHir2XX6/Hs89eLwd+SY=";
+        })
+      ];
+
       cargoDeps = rustPlatform.fetchCargoVendor {
         name = "lix-${version}";
         inherit src;
@@ -230,6 +249,15 @@ lib.makeExtensible (self: {
         rev = version;
         hash = "sha256-J4ycLoXHPsoBoQtEXFCelL4xlq5pT8U9tNWNKm43+YI=";
       };
+
+      patches = [
+        # Support for lowdown >= 1.4, https://gerrit.lix.systems/c/lix/+/3731
+        (fetchpatch2 {
+          name = "lix-lowdown-1.4.0.patch";
+          url = "https://git.lix.systems/lix-project/lix/commit/858de5f47a1bfd33835ec97794ece339a88490f1.patch";
+          hash = "sha256-FfLO2dFSWV1qwcupIg8dYEhCHir2XX6/Hs89eLwd+SY=";
+        })
+      ];
 
       cargoDeps = rustPlatform.fetchCargoVendor {
         name = "lix-${version}";

--- a/pkgs/tools/package-management/nix/common-autoconf.nix
+++ b/pkgs/tools/package-management/nix/common-autoconf.nix
@@ -254,6 +254,14 @@ let
       "--enable-lto"
     ];
 
+    env.CXXFLAGS = toString (
+      lib.optionals (lib.versionAtLeast lowdown.version "1.4.0") [
+        # Autotools based build system wasn't updated with the backport of
+        # https://github.com/NixOS/nix/pull/12115, so set the define explicitly.
+        "-DHAVE_LOWDOWN_1_4"
+      ]
+    );
+
     makeFlags = [
       # gcc runs multi-threaded LTO using make and does not yet detect the new fifo:/path style
       # of make jobserver. until gcc adds support for this we have to instruct make to use this


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Supersedes https://github.com/NixOS/nixpkgs/pull/368499. `lowdown` itself needs a switch from gmake to bmake because upstream has started using FreeBSD dialect.

~~Draft because `lix` will fail to build. @RaitoBezarius, @lf- how should we go about this? Would pinning to `lowdown_1_3` be preferable or could lix get a patch similar to @trofi's https://github.com/NixOS/nix/pull/12115 backported?~~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
