### PR TITLE
rp2040js: init at 1.1.1

### DIFF
--- a/pkgs/by-name/rp/rp2040js/package.nix
+++ b/pkgs/by-name/rp/rp2040js/package.nix
@@ -1,0 +1,71 @@
+{
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  testers,
+
+  buildNpmPackage,
+  typescript,
+  nodejs,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "rp2040js";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "wokwi";
+    repo = "rp2040js";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yra47Rg4xMmRX598LX4SvVhuS/ox5gS+j2mBk7E2nIY=";
+  };
+
+  nativeBuildInputs = [
+    typescript
+    makeWrapper
+  ];
+
+  patches = [ ./tsc-build-demo.patch ];
+
+  buildPhase = ''
+    tsc
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/
+    mkdir -p $out/lib/rp2040js
+
+    cp -R ./dist/. $out/lib/rp2040js/
+    cp -R ./node_modules/ $out/lib/rp2040js/
+
+    makeWrapper ${nodejs}/bin/node $out/bin/rp2040js \
+      --add-flags "$out/lib/rp2040js/demo/emulator-run.js" \
+      --prefix NODE_PATH : "$out/lib/rp2040js/"
+  '';
+
+  dontFixup = true;
+
+  npmDepsHash = "sha256-sNMv/zoNwA+pIpDMNzCXcnLWEuBLgQrkdSeQjCELbqY=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      inherit (finalAttrs) version;
+    };
+  };
+
+  meta = {
+    description = "Raspberry Pi Pico (RP2040) Emulator";
+    homepage = "https://github.com/wokwi/rp2040js";
+    changelog = "https://github.com/wokwi/rp2040js/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.baileylu
+    ];
+    mainProgram = "rp2040js";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+    ];
+  };
+})

--- a/pkgs/by-name/rp/rp2040js/tsc-build-demo.patch
+++ b/pkgs/by-name/rp/rp2040js/tsc-build-demo.patch
@@ -1,0 +1,43 @@
+From 4921fbf7168e82a1405a61008412f01721957879 Mon Sep 17 00:00:00 2001
+From: Luke Bailey <baileylu@tcd.ie>
+Date: Tue, 3 Jun 2025 22:20:12 +0100
+Subject: [PATCH] Include demo folder in build for command line package target
+
+---
+ tsconfig.json | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/tsconfig.json b/tsconfig.json
+index 494c2b4..59018de 100644
+--- a/tsconfig.json
++++ b/tsconfig.json
+@@ -1,9 +1,9 @@
+ {
+   "compilerOptions": {
+-    "rootDir": "src",
++    "rootDir": ".",
+     "target": "es2018",
+     "module": "NodeNext",
+-    "outDir": "./dist/esm" /* Redirect output structure to the directory. */,
++    "outDir": "./dist" /* Redirect output structure to the directory. */,
+     "strict": true /* Enable all strict type-checking options. */,
+     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+     "declaration": true,
+@@ -12,6 +12,12 @@
+     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+     "useDefineForClassFields": false
+   },
+-  "include": ["src/**/*.ts"],
+-  "exclude": ["src/**/*.spec.ts"]
++  "include": [
++    "src/**/*.ts",
++    "demo/**/*.ts"
++  ],
++  "exclude": [
++    "src/**/*.spec.ts",
++    "demo/**/*.spec.ts"
++  ]
+ }
+-- 
+2.49.0
+


### PR DESCRIPTION
Initialized the `rp2040js` package, a [javascript based emulator for the raspberry pi pico rp2040](https://github.com/wokwi/rp2040js).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

It should be mentioned that by default the original repository is mainly geared towards usage as a library. Hence, the main module of `index.ts` is not usable in any fashion from the command line, and instead `demo/emulator-run.ts` is, which is intended by the authors. Hence the `rp2040js` binary provided to this package maps to `npm run start`. This is accomplished via the patch to the `tsconfig.json` file.

Also of note is that when no `--image` flag is provided it will look for a binary file called `hello_uart.hex` in the base of the project to run instead. This was not provided here as I believe it does not make sense to bake into this package considering `--image` makes the most sense for regular use

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
