### PR TITLE
python3Packages.meson-python: disable failing Darwin tests

### DIFF
--- a/pkgs/development/python-modules/meson-python/default.nix
+++ b/pkgs/development/python-modules/meson-python/default.nix
@@ -14,6 +14,7 @@
   cython,
   pytestCheckHook,
   pytest-mock,
+  stdenv,
 }:
 
 buildPythonPackage rec {
@@ -45,43 +46,48 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
-  disabledTests = [
-    # Tests require a Git checkout
-    "test_configure_data"
-    "test_contents"
-    "test_contents"
-    "test_contents_license_file"
-    "test_contents_subdirs"
-    "test_contents_unstaged"
-    "test_detect_wheel_tag_module"
-    "test_detect_wheel_tag_script"
-    "test_dynamic_version"
-    "test_editable_install"
-    "test_editable_verbose"
-    "test_editble_reentrant"
-    "test_entrypoints"
-    "test_executable_bit"
-    "test_executable_bit"
-    "test_generated_files"
-    "test_install_subdir"
-    "test_license_pep639"
-    "test_limited_api"
-    "test_link_library_in_subproject"
-    "test_local_lib"
-    "test_long_path"
-    "test_meson_build_metadata"
-    "test_pep621_metadata"
-    "test_pure"
-    "test_purelib_and_platlib"
-    "test_reproducible"
-    "test_rpath"
-    "test_scipy_like"
-    "test_sharedlib_in_package"
-    "test_symlinks"
-    "test_uneeded_rpath"
-    "test_user_args"
-    "test_vendored_meson"
-  ];
+  disabledTests =
+    [
+      # Tests require a Git checkout
+      "test_configure_data"
+      "test_contents"
+      "test_contents_license_file"
+      "test_contents_subdirs"
+      "test_contents_unstaged"
+      "test_detect_wheel_tag_module"
+      "test_detect_wheel_tag_script"
+      "test_dynamic_version"
+      "test_editable_install"
+      "test_editable_verbose"
+      "test_editble_reentrant"
+      "test_entrypoints"
+      "test_executable_bit"
+      "test_generated_files"
+      "test_install_subdir"
+      "test_license_pep639"
+      "test_limited_api"
+      "test_link_library_in_subproject"
+      "test_local_lib"
+      "test_long_path"
+      "test_meson_build_metadata"
+      "test_pep621_metadata"
+      "test_pure"
+      "test_purelib_and_platlib"
+      "test_reproducible"
+      "test_rpath"
+      "test_scipy_like"
+      "test_sharedlib_in_package"
+      "test_symlinks"
+      "test_uneeded_rpath"
+      "test_user_args"
+      "test_vendored_meson"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # See NixOS/nixpkgs#413252 and mesonbuild/meson-python#760
+      "test_tag_platlib_wheel"
+      "test_tag_stable_abi"
+      "test_wheel_tag"
+    ];
 
   setupHooks = [ ./add-build-flags.sh ];
 


### PR DESCRIPTION
Draft, in case the answer in mesonbuild/meson-python's issue 760 is affirmative.

Disables failing tests on Darwin, see #413252 and mesonbuild/meson-python's issue 760.

Closes: #413252


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
