### PR TITLE
abiword: 3.0.6 -> 0-unstable-2024-11-02; enable darwin

### DIFF
--- a/pkgs/by-name/ab/abiword/fix-nonnull-implicit-this-build-failure.patch
+++ b/pkgs/by-name/ab/abiword/fix-nonnull-implicit-this-build-failure.patch
@@ -1,0 +1,51 @@
+From b485f663cea55dcd46f1a7f731044ffe53829807 Mon Sep 17 00:00:00 2001
+From: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
+Date: Tue, 3 Jun 2025 21:54:53 -0400
+Subject: [PATCH] fix: Don't ABI_NONNULL implicit this * argument
+
+Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
+---
+ src/af/xap/xp/xap_DialogFactory.h | 4 ++--
+ src/af/xap/xp/xap_Module.h        | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/af/xap/xp/xap_DialogFactory.h b/src/af/xap/xp/xap_DialogFactory.h
+index c533fb274..b8877767e 100644
+--- a/src/af/xap/xp/xap_DialogFactory.h
++++ b/src/af/xap/xp/xap_DialogFactory.h
+@@ -77,7 +77,7 @@ public:
+ 
+ 	XAP_Dialog *		requestDialog(XAP_Dialog_Id id);
+ 	XAP_Dialog *		justMakeTheDialog(XAP_Dialog_Id id);
+-	void				releaseDialog(XAP_Dialog * pDialog) ABI_NONNULL(1, 2);
++	void				releaseDialog(XAP_Dialog * pDialog) ABI_NONNULL(2);
+ 	XAP_Dialog_Id getNextId(void) const;
+ 	XAP_Dialog_Id		registerDialog(XAP_Dialog *(*pStaticConstructor)(XAP_DialogFactory *, XAP_Dialog_Id id),XAP_Dialog_Type iDialogType);
+ 	void				unregisterDialog(XAP_Dialog_Id id);
+@@ -86,7 +86,7 @@ public:
+ 	bool				unregisterNotebookPage(XAP_Dialog_Id dialog, const XAP_NotebookDialog::Page * page);
+ 
+ protected:
+-	bool				_findDialogInTable(XAP_Dialog_Id id, UT_sint32 * pIndex) const ABI_NONNULL(1, 3);
++	bool				_findDialogInTable(XAP_Dialog_Id id, UT_sint32 * pIndex) const ABI_NONNULL(3);
+ 
+ 	XAP_App *			m_pApp;
+ 	XAP_Frame *			m_pFrame;
+diff --git a/src/af/xap/xp/xap_Module.h b/src/af/xap/xp/xap_Module.h
+index d972b1e2f..e05af8285 100644
+--- a/src/af/xap/xp/xap_Module.h
++++ b/src/af/xap/xp/xap_Module.h
+@@ -95,8 +95,8 @@ private:
+ 	bool unregisterThySelf ();
+ 	bool supportsAbiVersion (UT_uint32 major, UT_uint32 minor,
+ 							 UT_uint32 release);
+-	inline void setCreator (XAP_ModuleManager * creator) ABI_NONNULL(1) {m_creator = creator;}
+-	inline void setLoaded (bool bLoaded) ABI_NONNULL(1) {m_bLoaded = bLoaded;}
++	inline void setCreator (XAP_ModuleManager * creator) {m_creator = creator;}
++	inline void setLoaded (bool bLoaded) {m_bLoaded = bLoaded;}
+ 
+ public:
+ 
+-- 
+2.49.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16937,6 +16937,11 @@ with pkgs;
     fltk = fltk13;
   };
 
+  abiword = callPackage ../by-name/ab/abiword/package.nix {
+    # Use an older version of llvm that doesn't error on char_traits violations
+    stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_16.stdenv else stdenv;
+  };
+
   cantata = callPackage ../by-name/ca/cantata/package.nix {
     ffmpeg = ffmpeg_6;
   };


### PR DESCRIPTION
Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
