### PR TITLE
code-cursor: use generic vscode package builder

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -53,6 +53,7 @@
   useVSCodeRipgrep ? false,
   ripgrep,
   hasVsceSign ? false,
+  patchVSCodePath ? true,
 }:
 
 stdenv.mkDerivation (
@@ -262,9 +263,13 @@ stdenv.mkDerivation (
             mkdir -p "$out/share/pixmaps"
             cp "$out/lib/${libraryName}/resources/app/resources/linux/code.png" "$out/share/pixmaps/${iconName}.png"
 
+          ''
+          + (lib.optionalString patchVSCodePath ''
             # Override the previously determined VSCODE_PATH with the one we know to be correct
             sed -i "/ELECTRON=/iVSCODE_PATH='$out/lib/${libraryName}'" "$out/bin/${executableName}"
             grep -q "VSCODE_PATH='$out/lib/${libraryName}'" "$out/bin/${executableName}" # check if sed succeeded
+          '')
+          + ''
 
             # Remove native encryption code, as it derives the key from the executable path which does not work for us.
             # The credentials should be stored in a secure keychain already, so the benefit of this is questionable

--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -86,7 +86,10 @@ in
       aspauldingcode
       prince213
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ] ++ lib.platforms.darwin;
     mainProgram = "cursor";
   };
 }).overrideAttrs

--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -1,57 +1,18 @@
 {
   lib,
-  stdenvNoCC,
+  stdenv,
+  callPackage,
+  vscode-generic,
   fetchurl,
-
-  # build
   appimageTools,
-
-  # linux dependencies
-  alsa-lib,
-  at-spi2-atk,
-  autoPatchelfHook,
-  cairo,
-  cups,
-  curlWithGnuTls,
-  egl-wayland,
-  expat,
-  fontconfig,
-  freetype,
-  ffmpeg,
-  glib,
-  glibc,
-  glibcLocales,
-  gtk3,
-  libappindicator-gtk3,
-  libdrm,
-  libgbm,
-  libGL,
-  libnotify,
-  libva-minimal,
-  libxkbcommon,
-  libxkbfile,
-  makeWrapper,
-  nspr,
-  nss,
-  pango,
-  pciutils,
-  pulseaudio,
-  vivaldi-ffmpeg-codecs,
-  vulkan-loader,
-  wayland,
-
-  # linux installation
-  rsync,
-  commandLineArgs ? "",
-
-  # darwin build
   undmg,
+  commandLineArgs ? "",
+  useVSCodeRipgrep ? stdenv.hostPlatform.isDarwin,
 }:
-let
-  pname = "cursor";
-  version = "1.0.0";
 
-  inherit (stdenvNoCC) hostPlatform;
+let
+  inherit (stdenv) hostPlatform;
+  finalCommandLineArgs = "--update=false " + commandLineArgs;
 
   sources = {
     x86_64-linux = fetchurl {
@@ -73,115 +34,47 @@ let
   };
 
   source = sources.${hostPlatform.system};
-
-  # Linux -- build from AppImage
-  appimageContents = appimageTools.extractType2 {
-    inherit version pname;
-    src = source;
-  };
-
-  wrappedAppimage = appimageTools.wrapType2 {
-    inherit version pname;
-    src = source;
-  };
-
 in
-stdenvNoCC.mkDerivation {
-  inherit pname version;
+(callPackage vscode-generic rec {
+  inherit useVSCodeRipgrep;
+  commandLineArgs = finalCommandLineArgs;
 
-  src = if hostPlatform.isLinux then wrappedAppimage else source;
+  version = "1.0.0";
+  pname = "cursor";
 
-  nativeBuildInputs =
-    lib.optionals hostPlatform.isLinux [
-      autoPatchelfHook
-      glibcLocales
-      makeWrapper
-      rsync
-    ]
-    ++ lib.optionals hostPlatform.isDarwin [ undmg ];
+  # You can find the current VSCode version in the About dialog:
+  # workbench.action.showAboutDialog (Help: About)
+  vscodeVersion = "1.96.2";
 
-  buildInputs = lib.optionals hostPlatform.isLinux [
-    alsa-lib
-    at-spi2-atk
-    cairo
-    cups
-    curlWithGnuTls
-    egl-wayland
-    expat
-    ffmpeg
-    glib
-    gtk3
-    libdrm
-    libgbm
-    libGL
-    libva-minimal
-    libxkbcommon
-    libxkbfile
-    nspr
-    nss
-    pango
-    pulseaudio
-    vivaldi-ffmpeg-codecs
-    vulkan-loader
-    wayland
-  ];
+  executableName = "cursor";
+  longName = "Cursor";
+  shortName = "cursor";
+  libraryName = "cursor";
+  iconName = "cursor";
 
-  runtimeDependencies = lib.optionals hostPlatform.isLinux [
-    egl-wayland
-    ffmpeg
-    glibc
-    libappindicator-gtk3
-    libnotify
-    libxkbfile
-    pciutils
-    pulseaudio
-    wayland
-    fontconfig
-    freetype
-  ];
+  src =
+    if hostPlatform.isLinux then
+      appimageTools.extract {
+        inherit pname version;
+        src = source;
+      }
+    else
+      source;
 
-  sourceRoot = lib.optionalString hostPlatform.isDarwin ".";
+  sourceRoot =
+    if hostPlatform.isLinux then "${pname}-${version}-extracted/usr/share/cursor" else "Cursor.app";
 
-  # Don't break code signing
-  dontUpdateAutotoolsGnuConfigScripts = hostPlatform.isDarwin;
-  dontConfigure = hostPlatform.isDarwin;
-  dontFixup = hostPlatform.isDarwin;
+  tests = { };
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/
+  updateScript = ./update.sh;
 
-    ${lib.optionalString hostPlatform.isLinux ''
-      cp -r bin $out/bin
-      # mkdir -p $out/share/cursor
-      # cp -ar ${appimageContents}/usr/share $out/
+  # Editing the `cursor` binary within the app bundle causes the bundle's signature
+  # to be invalidated, which prevents launching starting with macOS Ventura, because Cursor is notarized.
+  # See https://eclecticlight.co/2022/06/17/app-security-changes-coming-in-ventura/ for more information.
+  dontFixup = stdenv.hostPlatform.isDarwin;
 
-      rsync -a -q ${appimageContents}/usr/share $out/ --exclude "*.so"
-
-      # Fix the desktop file to point to the correct location
-      substituteInPlace $out/share/applications/cursor.desktop --replace-fail "/usr/share/cursor/cursor" "$out/bin/cursor"
-
-      wrapProgram $out/bin/cursor \
-        --add-flags "--update=false" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}} --no-update" \
-        --add-flags ${lib.escapeShellArg commandLineArgs}
-    ''}
-
-    ${lib.optionalString hostPlatform.isDarwin ''
-      APP_DIR="$out/Applications"
-      mkdir -p "$APP_DIR"
-      cp -Rp Cursor.app "$APP_DIR"
-      mkdir -p "$out/bin"
-      ln -s "$APP_DIR/Cursor.app/Contents/Resources/app/bin/cursor" "$out/bin/cursor"
-    ''}
-
-    runHook postInstall
-  '';
-
-  passthru = {
-    inherit sources;
-    updateScript = ./update.sh;
-  };
+  # Cursor has no wrapper script.
+  patchVSCodePath = false;
 
   meta = {
     description = "AI-powered code editor built on vscode";
@@ -196,4 +89,20 @@ stdenvNoCC.mkDerivation {
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "cursor";
   };
-}
+}).overrideAttrs
+  (oldAttrs: {
+    nativeBuildInputs =
+      (oldAttrs.nativeBuildInputs or [ ])
+      ++ lib.optionals hostPlatform.isDarwin [ undmg ];
+
+    preInstall =
+      (oldAttrs.preInstall or "")
+      + lib.optionalString hostPlatform.isLinux ''
+        mkdir -p bin
+        ln -s ../cursor bin/cursor
+      '';
+
+    passthru = (oldAttrs.passthru or { }) // {
+      inherit sources;
+    };
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14408,6 +14408,12 @@ with pkgs;
   vscodium-fhs = vscodium.fhs;
   vscodium-fhsWithPackages = vscodium.fhsWithPackages;
 
+  code-cursor = callPackage ../by-name/co/code-cursor/package.nix {
+    vscode-generic = ../applications/editors/vscode/generic.nix;
+  };
+  code-cursor-fhs = code-cursor.fhs;
+  code-cursor-fhsWithPackages = code-cursor.fhsWithPackages;
+
   windsurf = callPackage ../by-name/wi/windsurf/package.nix {
     vscode-generic = ../applications/editors/vscode/generic.nix;
   };


### PR DESCRIPTION
Updated code-cursor package to use the generic vscode package builder, which it is compatible with (apart from the extra step of unpacking the AppImage archive). This fixes hardware acceleration for me and substantially improves Cursor performance. A few more bonuses: it adds a code-cursor-fhs variant, and cursor is now able to launch in the `/etc/nixos` directory (whereas previously it couldn't).

![image](https://github.com/user-attachments/assets/ec1d3763-9075-4bc8-bbb1-3b86dce18107)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
