### PR TITLE
ch9344: 0-unstable-2024-11-15 -> 2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20780,6 +20780,13 @@
     github = "DaRacci";
     githubId = 90304606;
   };
+  RadxaYuntian = {
+    # This is the work account for @MakiseKurisu
+    name = "ZHANG Yuntian";
+    email = "yt@radxa.com";
+    github = "RadxaYuntian";
+    githubId = 95260730;
+  };
   raehik = {
     email = "thefirstmuffinman@gmail.com";
     github = "raehik";

--- a/pkgs/os-specific/linux/ch9344/default.nix
+++ b/pkgs/os-specific/linux/ch9344/default.nix
@@ -7,17 +7,18 @@
 
 stdenv.mkDerivation rec {
   pname = "ch9344";
-  version = "0-unstable-2024-11-15";
+  version = "2.3";
 
   src = fetchFromGitHub {
     owner = "WCHSoftGroup";
     repo = "ch9344ser_linux";
-    rev = "4ea8973886989d67acdd01dba213e355eacc9088";
-    hash = "sha256-ZZ/8s26o7wRwHy6c0m1vZ/DtRW5od+NgiU6aXZBVfc4=";
+    rev = "e0a38c4f4f9d4c1f5e2e3a352b7b1010b33aa322";
+    hash = "sha256-ldYoGmG9DAjASl3xL8djeZ8jRHlcBQdAt0KYAr53epI=";
   };
 
   patches = [
     ./fix-linux-6-12-build.patch
+    ./fix-linux-6-15-build.patch
   ];
 
   sourceRoot = "${src.name}/driver";
@@ -47,6 +48,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ MakiseKurisu ];
+    maintainers = with maintainers; [ RadxaYuntian ];
   };
 }

--- a/pkgs/os-specific/linux/ch9344/fix-linux-6-15-build.patch
+++ b/pkgs/os-specific/linux/ch9344/fix-linux-6-15-build.patch
@@ -1,0 +1,16 @@
+diff --git a/ch9344.c b/ch9344.c
+index 36402c0..cb3efc2 100644
+--- a/ch9344.c
++++ b/ch9344.c
+@@ -1251,7 +1251,11 @@ static void ch9344_port_shutdown(struct tty_port *port)
+ 	struct ch9344 *ch9344 = tty_get_portdata(ttyport);
+ 	int portnum = ttyport->portnum;
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
++	timer_delete(&ttyport->timer);
++#else
+ 	del_timer(&ttyport->timer);
++#endif
+ 	ch9344_set_control(ch9344, portnum, 0x00);
+ 	ch9344_set_control(ch9344, portnum, 0x10);
+ 	ttyport->isopen = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Bump ch9344 to latest version
* Fix build error on Linux 6.15
* Transfer maintainership from @MakiseKurisu to this work account, since we only use this device at work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
