### PR TITLE
box2d: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/by-name/bo/box2d/cmake_use_system_glfw_and_imgui.patch
+++ b/pkgs/by-name/bo/box2d/cmake_use_system_glfw_and_imgui.patch
@@ -1,8 +1,8 @@
 diff --git a/samples/CMakeLists.txt b/samples/CMakeLists.txt
-index 5020345..97af8c6 100644
+index 46d5a23..7572b0b 100644
 --- a/samples/CMakeLists.txt
 +++ b/samples/CMakeLists.txt
-@@ -17,47 +17,12 @@ set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "GLFW Examples")
+@@ -17,49 +17,12 @@ set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "GLFW Examples")
  set(GLFW_BUILD_TESTS OFF CACHE BOOL "GLFW Tests")
  set(GLFW_INSTALL OFF CACHE BOOL "GLFW Install")
  
@@ -43,6 +43,8 @@ index 5020345..97af8c6 100644
 -target_link_libraries(imgui PUBLIC glfw glad)
 -target_include_directories(imgui PUBLIC ${IMGUI_DIR} ${IMGUI_DIR}/backends)
 -target_compile_definitions(imgui PUBLIC IMGUI_DISABLE_OBSOLETE_FUNCTIONS)
+-# The sample app also uses stb_truetype and this keeps the symbols separate
+-target_compile_definitions(imgui PRIVATE IMGUI_STB_NAMESPACE=imgui_stb)
 -set_target_properties(imgui PROPERTIES
 -	CXX_STANDARD 20
 -    CXX_STANDARD_REQUIRED YES

--- a/pkgs/by-name/bo/box2d/package.nix
+++ b/pkgs/by-name/bo/box2d/package.nix
@@ -30,13 +30,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "box2d";
-  version = "3.1.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "erincatto";
     repo = "box2d";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QTSU1+9x8GoUK3hlTDMh43fc4vbNfFR7syt6xVHIuPs=";
+    hash = "sha256-IqQy9A8fWLG9H8ZPmOXeFZDaaks84miRuzXaFlNwm0g=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/erincatto/box2d/compare/refs/tags/v3.1.0...refs/tags/v3.1.1
Changelog: https://github.com/erincatto/box2d/releases/tag/v3.1.1

cc @7c6f434c

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
