### PR TITLE
zam-plugins: fix some cross builds

### DIFF
--- a/pkgs/by-name/za/zam-plugins/package.nix
+++ b/pkgs/by-name/za/zam-plugins/package.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs ./dpf/utils/generate-ttl.sh
+    for f in plugins/*/Makefile; do
+      substituteInPlace "$f" \
+        --replace-quiet 'pkg-config' '${stdenv.cc.targetPrefix}pkg-config'
+    done
   '';
 
   makeFlags = [
@@ -59,5 +63,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.magnetophon ];
     platforms = platforms.linux;
+    # tries to run dpf/utils/lv2_ttl_generator (built for host)
+    broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };
 }


### PR DESCRIPTION
Fixed package to work in at least some cross-compile scenarios.

## Things done

- Built on platform(s)
  - [x] x86_64-linux (no-op for native builds)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).