### PR TITLE
[staging-next] libspng: disable broken tests

### DIFF
--- a/pkgs/by-name/li/libspng/package.nix
+++ b/pkgs/by-name/li/libspng/package.nix
@@ -21,6 +21,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-BiRuPQEKVJYYgfUsglIuxrBoJBFiQ0ygQmAFrVvCz4Q=";
   };
 
+  # disable two tests broken after libpng update
+  # https://github.com/randy408/libspng/issues/276
+  postPatch = ''
+    cat tests/images/meson.build | grep -v "'ch1n3p04'" | grep -v "'ch2n3p08'" > tests/images/meson.build-patched
+    mv tests/images/meson.build-patched tests/images/meson.build
+  '';
+
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   mesonBuildType = "release";


### PR DESCRIPTION
https://github.com/randy408/libspng/issues/276

https://github.com/NixOS/nixpkgs/pull/404060#issuecomment-2906887228

Didn't think of a better way to disable specific tests than this.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).