### PR TITLE
lighthouse: mark cross as broken

### DIFF
--- a/pkgs/by-name/li/lighthouse/package.nix
+++ b/pkgs/by-name/li/lighthouse/package.nix
@@ -141,6 +141,8 @@ rustPlatform.buildRustPackage rec {
       pmw
     ];
     mainProgram = "lighthouse";
-    broken = stdenv.hostPlatform.isDarwin;
+    # can't compile build script with host libraries
+    broken =
+      stdenv.hostPlatform.isDarwin || !lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform;
   };
 }


### PR DESCRIPTION
Attempted x86_64-linux → aarch64-linux
```
  = note: /nix/store/fpz5h4ar7bi32q1flhkjjkwbkl0zhb9a-binutils-2.44/bin/ld: skipping incompatible /nix/store/ni3k23n2h5w0rh22qr5m6pp3zk28dzrg-openssl-aarch64-unknown-linux-gnu-3.4.1/lib/libssl.so when searching for -lssl
          /nix/store/fpz5h4ar7bi32q1flhkjjkwbkl0zhb9a-binutils-2.44/bin/ld: cannot find -lssl: No such file or directory
          /nix/store/fpz5h4ar7bi32q1flhkjjkwbkl0zhb9a-binutils-2.44/bin/ld: skipping incompatible /nix/store/ni3k23n2h5w0rh22qr5m6pp3zk28dzrg-openssl-aarch64-unknown-linux-gnu-3.4.1/lib/libssl.so when searching for -lssl
          /nix/store/fpz5h4ar7bi32q1flhkjjkwbkl0zhb9a-binutils-2.44/bin/ld: skipping incompatible /nix/store/ni3k23n2h5w0rh22qr5m6pp3zk28dzrg-openssl-aarch64-unknown-linux-gnu-3.4.1/lib/libcrypto.so when searching for -lcrypto
          /nix/store/fpz5h4ar7bi32q1flhkjjkwbkl0zhb9a-binutils-2.44/bin/ld: cannot find -lcrypto: No such file or directory
          /nix/store/fpz5h4ar7bi32q1flhkjjkwbkl0zhb9a-binutils-2.44/bin/ld: skipping incompatible /nix/store/ni3k23n2h5w0rh22qr5m6pp3zk28dzrg-openssl-aarch64-unknown-linux-gnu-3.4.1/lib/libcrypto.so when searching for -lcrypto
          collect2: error: ld returned 1 exit status
error: could not compile `deposit_contract` (build script) due to 1 previous error
```

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).