### PR TITLE
gost: 2.12.0 -> 3.0.0

### DIFF
--- a/pkgs/by-name/go/gost/package.nix
+++ b/pkgs/by-name/go/gost/package.nix
@@ -8,44 +8,16 @@
 
 buildGoModule rec {
   pname = "gost";
-  version = "2.12.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
-    owner = "ginuerzh";
+    owner = "go-gost";
     repo = "gost";
     tag = "v${version}";
-    hash = "sha256-kNhWJiPF6DlxxVZvW7HJkvzSuGsrozZBhiVaw+a7mYs=";
+    hash = "sha256-ep3ZjD+eVKl3PuooDuYeur8xDAcyy6ww2I7f3cYG03o=";
   };
 
-  vendorHash = "sha256-7Wmd82sSMVAo1cGUi1EIig8h5drgy85D9FmSNtIBRqY=";
-
-  postPatch = ''
-    substituteInPlace http2_test.go \
-      --replace-fail "TestH2CForwardTunnel" "SkipH2CForwardTunnel" \
-      --replace-fail "TestH2ForwardTunnel" "SkipH2ForwardTunnel"
-
-    substituteInPlace resolver_test.go \
-      --replace-fail '{NameServer{Addr: "1.1.1.1"}, "github", true},' "" \
-      --replace-fail '{NameServer{Addr: "1.1.1.1"}, "github.com", true},' "" \
-      --replace-fail '{NameServer{Addr: "1.1.1.1:53"}, "github.com", true},' "" \
-      --replace-fail '{NameServer{Addr: "1.1.1.1:53", Protocol: "tcp"}, "github.com", true},' "" \
-      --replace-fail '{NameServer{Addr: "1.1.1.1:853", Protocol: "tls"}, "github.com", true},' "" \
-      --replace-fail '{NameServer{Addr: "1.1.1.1:853", Protocol: "tls", Hostname: "cloudflare-dns.com"}, "github.com", true},' "" \
-      --replace-fail '{NameServer{Addr: "https://cloudflare-dns.com/dns-query", Protocol: "https"}, "github.com", true},' "" \
-      --replace-fail '{NameServer{Addr: "https://1.0.0.1/dns-query", Protocol: "https"}, "github.com", true},' ""
-
-    # Skip TestShadowTCP, TestShadowUDP: #70 #71 #72 #78 #83 #85 #86 #87 #93
-    substituteInPlace ss_test.go \
-      --replace-fail '{url.User("xchacha20"), url.UserPassword("xchacha20", "123456"), false},' "" \
-      --replace-fail '{url.UserPassword("xchacha20", "123456"), url.User("xchacha20"), false},' "" \
-      --replace-fail '{url.UserPassword("xchacha20", "123456"), url.UserPassword("xchacha20", "abc"), false},' "" \
-      --replace-fail '{url.UserPassword("CHACHA20-IETF-POLY1305", "123456"), url.UserPassword("CHACHA20-IETF-POLY1305", "123456"), true},' "" \
-      --replace-fail '{url.UserPassword("AES-128-GCM", "123456"), url.UserPassword("AES-128-GCM", "123456"), true},' "" \
-      --replace-fail '{url.User("AES-192-GCM"), url.UserPassword("AES-192-GCM", "123456"), false},' "" \
-      --replace-fail '{url.UserPassword("AES-192-GCM", "123456"), url.User("AES-192-GCM"), false},' "" \
-      --replace-fail '{url.UserPassword("AES-192-GCM", "123456"), url.UserPassword("AES-192-GCM", "abc"), false},' "" \
-      --replace-fail '{url.UserPassword("AES-256-GCM", "123456"), url.UserPassword("AES-256-GCM", "123456"), true},' ""
-  '';
+  vendorHash = "sha256-lzyr6Q8yXsuer6dRUlwHEeBewjwGxDslueuvIiZUW70=";
 
   __darwinAllowLocalNetworking = true;
 
@@ -60,9 +32,12 @@ buildGoModule rec {
 
   meta = {
     description = "Simple tunnel written in golang";
-    homepage = "https://github.com/ginuerzh/gost";
+    homepage = "https://github.com/go-gost/gost";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pmy ];
+    maintainers = with lib.maintainers; [
+      pmy
+      ramblurr
+    ];
     mainProgram = "gost";
   };
 }


### PR DESCRIPTION
- The project has changed from the author's personal profile on github
  to the go-gost github org
- I've added myself as maintainer since pmy hasn't been active since 2022


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->


---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>gost</li>
  </ul>
</details>



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
