### PR TITLE
ameba-ls: init at 0.1.0

### DIFF
--- a/pkgs/by-name/am/ameba-ls/package.nix
+++ b/pkgs/by-name/am/ameba-ls/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchFromGitHub,
+  crystal_1_15,
+  versionCheckHook,
+}:
+
+let
+  # Use the same Crystal minor version as specified in upstream
+  crystal = crystal_1_15;
+in
+crystal.buildCrystalPackage rec {
+  pname = "ameba-ls";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "crystal-lang-tools";
+    repo = "ameba-ls";
+    tag = "v${version}";
+    hash = "sha256-TEHjR+34wrq24XJNLhWZCEzcDEMDlmUHv0iiF4Z6JlI=";
+  };
+
+  shardsFile = ./shards.nix;
+
+  crystalBinaries.ameba-ls.src = "src/ameba-ls.cr";
+
+  buildTargets = [
+    "ameba-ls"
+  ];
+
+  # There are no actual tests
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 bin/ameba-ls -t "$out/bin/"
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/ameba-ls";
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "Crystal language server powered by Ameba linter";
+    homepage = "https://github.com/crystal-lang-tools/ameba-ls";
+    changelog = "https://github.com/crystal-lang-tools/ameba-ls/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "ameba-ls";
+  };
+}

--- a/pkgs/by-name/am/ameba-ls/shards.nix
+++ b/pkgs/by-name/am/ameba-ls/shards.nix
@@ -1,0 +1,27 @@
+{
+  ameba = {
+    url = "https://github.com/crystal-ameba/ameba.git";
+    rev = "a21dea0b44642f4fc87429283f8b0dd9f1e47a9f";
+    sha256 = "1kzr4ynd4r5w87y2czzrlir1dvqmv43ijm07804kgsy1g20k00fs";
+  };
+  larimar = {
+    url = "https://github.com/nobodywasishere/larimar.git";
+    rev = "97d37e665f7189a7ec35f54fb65003a8438d6cf0";
+    sha256 = "0s5hnfdybwbfk8sbjzrly2p6xppc5niww14h9cx00xkm8m1rlyj2";
+  };
+  lsprotocol = {
+    url = "https://github.com/nobodywasishere/lsprotocol-crystal.git";
+    rev = "28986890c7657af4aefea8355ca3f3c7fc2bc9dd";
+    sha256 = "0pccgq5g87mnvrhpgw3j22p3wgch8kp1svxcrbz2dha7zvgn65kj";
+  };
+  rwlock = {
+    url = "https://github.com/spider-gazelle/readers-writer.git";
+    rev = "v1.0.7";
+    sha256 = "1cs4ang50cza7sb5zh94rl1ppwcn9z1l8jjcsshhy4w72wkbqyny";
+  };
+  tree_sitter = {
+    url = "https://github.com/crystal-lang-tools/crystal-tree-sitter.git";
+    rev = "1d46ca231a641b30b8e7fbbae7eba050f7717a9f";
+    sha256 = "16g0ii3b3pmpnwmx2iz9dr1865pgfka7a724dfj62csjavqm5i1k";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [ameba-ls](https://github.com/crystal-lang-tools/ameba-ls), a language server for Crystal.
It is powered by the [Ameba](https://github.com/NixOS/nixpkgs/blob/a1ba3c5c21b2424ad0bd13bbbfa50ebfbd54823e/pkgs/by-name/am/ameba/package.nix), which is already available in nixpkgs.

I plan to add the update script after its next release. This will likely require similar changes as seen in https://github.com/NixOS/nixpkgs/pull/400558.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
