### PR TITLE
megasync: 5.9.0.3 -> 5.12.0.1

### DIFF
--- a/pkgs/by-name/me/megasync/package.nix
+++ b/pkgs/by-name/me/megasync/package.nix
@@ -34,13 +34,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "megasync";
-  version = "5.9.0.3";
+  version = "5.12.0.1";
 
   src = fetchFromGitHub rec {
     owner = "meganz";
     repo = "MEGAsync";
     tag = "v${finalAttrs.version}_Linux";
-    hash = "sha256-anX/zVCKG3azROamIIqG9hrj+2Tcw+sFIE60RDCJjaY=";
+    hash = "sha256-dIva/Xmk7enmRbczfuy1VLAcAMPQ27HUaHEQSTsldaY=";
     fetchSubmodules = false; # DesignTokensImporter cannot be fetched, see #1010 in github:meganz/megasync
     leaveDotGit = true;
     postFetch = ''
@@ -122,6 +122,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "USE_PDFIUM" false) # PDFIUM is not in nixpkgs
     (lib.cmakeBool "USE_FREEIMAGE" false) # freeimage is insecure
     (lib.cmakeBool "ENABLE_DESIGN_TOKENS_IMPORTER" false) # cannot be fetched
+    (lib.cmakeBool "USE_BREAKPAD" false)
+    (lib.cmakeBool "ENABLE_DESKTOP_APP_TESTS" false)
   ];
 
   preFixup = ''


### PR DESCRIPTION
Simply updating the version and hash strings does not build due to the unit tests always being built. The added cmake flags are taken from [the AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=megasync).
