### PR TITLE
nixos: Add meta.tests

### DIFF
--- a/maintainers/nixos-tests-for-files.nix
+++ b/maintainers/nixos-tests-for-files.nix
@@ -4,7 +4,7 @@
   A more detailed structure than a list is available in the `meta.tests` option value.
 
   Example:
-    nix-build maintainers/nixos-tests-for-files.nix --arg files '[ nixos/modules/services/databases/postgresql.nix ]'
+    nix-build maintainers/nixos-tests-for-files.nix --arg files '[ ./nixos/modules/services/databases/postgresql.nix ]'
 */
 {
   files,

--- a/maintainers/nixos-tests-for-files.nix
+++ b/maintainers/nixos-tests-for-files.nix
@@ -1,0 +1,25 @@
+/**
+  Returns a list of tests for a given list of NixOS module files (and/or other files which will be ignored).
+
+  A more detailed structure than a list is available in the `meta.tests` option value.
+
+  Example:
+    nix-build maintainers/nixos-tests-for-files.nix --arg files '[ nixos/modules/services/databases/postgresql.nix ]'
+*/
+{
+  files,
+  system ? builtins.currentSystem,
+}:
+
+let
+  pkgs = import ../. {
+    config = { };
+    overlays = [ ];
+    inherit system;
+  };
+  sample = pkgs.nixos {
+    imports = [ ../nixos/modules/virtualisation/qemu-vm.nix ];
+  };
+in
+# See nixos/modules/misc/meta.nix or :doc on an evaluated NixOS
+sample.config.meta.tests.filterForNixBuild files

--- a/maintainers/scripts/nixos-tests-for-files.nix
+++ b/maintainers/scripts/nixos-tests-for-files.nix
@@ -1,24 +1,27 @@
 /**
   Returns a list of tests for a given list of NixOS module files (and/or other files which will be ignored).
 
+  This is a convenience wrapper for use with `nix-build`.
+
   A more detailed structure than a list is available in the `meta.tests` option value.
 
-  Example:
-    nix-build maintainers/nixos-tests-for-files.nix --arg files '[ ./nixos/modules/services/databases/postgresql.nix ]'
+  Example usage (to be run from the Nixpkgs root):
+    nix-build maintainers/scripts/nixos-tests-for-files.nix --arg files '[ ./nixos/modules/services/databases/postgresql.nix ]'
 */
 {
   files,
   system ? builtins.currentSystem,
+# NOTE: if you need finer control, you are encouraged to use `config.meta.tests` directly
 }:
 
 let
-  pkgs = import ../. {
+  pkgs = import ../.. {
     config = { };
     overlays = [ ];
     inherit system;
   };
   sample = pkgs.nixos {
-    imports = [ ../nixos/modules/virtualisation/qemu-vm.nix ];
+    imports = [ ../../nixos/modules/virtualisation/qemu-vm.nix ];
   };
 in
 # See nixos/modules/misc/meta.nix or :doc on an evaluated NixOS

--- a/maintainers/scripts/nixos-tests-for-files.nix
+++ b/maintainers/scripts/nixos-tests-for-files.nix
@@ -6,7 +6,7 @@
   A more detailed structure than a list is available in the `meta.tests` option value.
 
   Example usage (to be run from the Nixpkgs root):
-    nix-build maintainers/scripts/nixos-tests-for-files.nix --arg files '[ ./nixos/modules/services/databases/postgresql.nix ]'
+    nix-build maintainers/scripts/nixos-tests-for-files.nix --arg files '[ ./nixos/modules/security/acme ]'
 */
 {
   files,

--- a/nixos/modules/misc/meta.nix
+++ b/nixos/modules/misc/meta.nix
@@ -100,8 +100,11 @@ let
       */
       filterForNixBuild =
         paths:
-        # Two calls to `attrValues` because we have exactly two layers to flatten.
-        lib.concatMap lib.attrValues (lib.attrValues (filter paths));
+        let
+          flattenPackageSet = ps: lib.attrValues (lib.removeAttrs ps [ "recurseForDerivations" ]);
+        in
+        # Two calls to `flattenPackageSet` because we have exactly two layers to flatten.
+        lib.concatMap flattenPackageSet (flattenPackageSet (filter paths));
     };
   };
 

--- a/nixos/modules/misc/meta.nix
+++ b/nixos/modules/misc/meta.nix
@@ -42,9 +42,6 @@ let
     merge = loc: defs: defs;
   };
 
-  # TODO: add to lib?
-  resolveDefaultNix = p: if lib.pathType p == "directory" then p + "/default.nix" else p;
-
   /**
     Custom type for `meta.tests` option.
   */

--- a/nixos/modules/misc/meta.nix
+++ b/nixos/modules/misc/meta.nix
@@ -192,7 +192,11 @@ in
 
   config.meta = {
     # Make the option value valid even if not loaded into e.g. a NixOS with real definitions.
-    tests = _: { };
+    tests =
+      { nixosTests }:
+      {
+        inherit (nixosTests) meta;
+      };
   };
 
   meta.maintainers = [

--- a/nixos/modules/misc/meta.nix
+++ b/nixos/modules/misc/meta.nix
@@ -1,5 +1,7 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 let
+  inherit (lib.filesystem) resolveDefaultNix;
+
   maintainer = lib.mkOptionType {
     name = "maintainer";
     check = email: lib.elem email (lib.attrValues lib.maintainers);
@@ -39,6 +41,67 @@ let
     #   { file = "module location"; value = <path/to/doc.xml>; }
     merge = loc: defs: defs;
   };
+
+  /**
+    Custom type for `meta.tests` option.
+  */
+  testsType = lib.mkOptionType {
+    name = "tests";
+    check = lib.isFunction;
+    merge = _loc: defs: rec {
+      byModulePath =
+        lib.zipAttrsWith
+          (
+            _fileName: values:
+            # These are per file, so we don't need to merge definitions.
+            # We could, but it's not implemented yet.
+            assert (lib.length values == 1);
+            lib.head values { inherit (pkgs) nixosTests; }
+          )
+          (
+            map (
+              { file, value, ... }:
+              {
+                "${toString file}" = value;
+              }
+            ) defs
+          );
+      /**
+        Given a list of file names, return a nested attribute set of tests to run, in an efficient lexicographic order.
+      */
+      filter =
+        paths:
+        let
+          pathSet = lib.genAttrs (map toString paths) (_path: null);
+          relevant = builtins.intersectAttrs pathSet byModulePath;
+
+          # Optimize evaluation order by sorting by test name. This way, even
+          # if multiple files reference the same tests, and if you split
+          # evaluation, you can likely resume from a given point in the nested
+          # attrset without encountering already evaluated tests again. (or
+          # split work across multiple processes)
+          /**
+            An attrset structure of <testName>.<fileName> = derivation;
+          */
+          transposed = lib.zipAttrsWith (_k: lib.mergeAttrsList) (
+            lib.mapAttrsToList (fileName: values: lib.mapAttrs (k: v: { "${fileName}" = v; }) values) relevant
+          );
+
+        in
+        transposed;
+
+      /**
+        Given a list of file names, return a list of test derivations for `nix-build`.
+
+        This is like `filter`, but solves the problem that `nix-build` ignores attributes with `.` in their names.
+      */
+      filterForNixBuild =
+        paths:
+        # Two calls to `attrValues` because we have exactly two layers to flatten.
+        lib.concatMap lib.attrValues (lib.attrValues (filter paths));
+    };
+  };
+
 in
 
 {
@@ -81,8 +144,56 @@ in
         '';
       };
 
+      tests = lib.mkOption {
+        type = testsType;
+        description = ''
+          Tests for particular modules.
+
+          Definitions are tied to the location of the module, so the definition syntax is distinct from the option value format.
+
+          For example, this definition:
+          ```nix
+          # module.nix
+          {
+            meta.tests =
+              { nixosTests }:
+              {
+                inherit (nixosTests) foo;
+              };
+          }
+          ```
+
+          ... produces the option value:
+
+          ```nix
+          { nixosTests }:
+          {
+            byPath = {
+              "/path/to/module.nix" = {
+                foo = nixosTests.foo;
+              };
+              # ...
+            };
+            filter = paths: { ... };
+            filterForNixBuild = paths: [ ... ];
+          }
+          ```
+
+          The filter functions have `nix repl` `:doc` documentation.
+
+          This can be used for tooling to figure out which tests are relevant, given a set of changed files.
+        '';
+      };
     };
   };
 
-  meta.maintainers = lib.singleton lib.maintainers.pierron;
+  config.meta = {
+    # Make the option value valid even if not loaded into e.g. a NixOS with real definitions.
+    tests = _: { };
+  };
+
+  meta.maintainers = [
+    lib.maintainers.pierron
+    lib.maintainers.roberth
+  ];
 }

--- a/nixos/modules/misc/meta.nix
+++ b/nixos/modules/misc/meta.nix
@@ -42,6 +42,9 @@ let
     merge = loc: defs: defs;
   };
 
+  # TODO: add to lib?
+  resolveDefaultNix = p: if lib.pathType p == "directory" then p + "/default.nix" else p;
+
   /**
     Custom type for `meta.tests` option.
   */
@@ -62,7 +65,7 @@ let
             map (
               { file, value, ... }:
               {
-                "${toString file}" = value;
+                "${toString (resolveDefaultNix file)}" = value;
               }
             ) defs
           );
@@ -72,7 +75,7 @@ let
       filter =
         paths:
         let
-          pathSet = lib.genAttrs (map toString paths) (_path: null);
+          pathSet = lib.genAttrs (map (p: toString (resolveDefaultNix p)) paths) (_path: null);
           relevant = builtins.intersectAttrs pathSet byModulePath;
 
           # Optimize evaluation order by sorting by test name. This way, even

--- a/nixos/modules/misc/meta/tests.nix
+++ b/nixos/modules/misc/meta/tests.nix
@@ -1,0 +1,41 @@
+{ lib, evalMinimalConfig, ... }:
+
+rec {
+  exampleModule1 = {
+    _file = "/tests/example.nix";
+    meta.tests =
+      { nixosTests }:
+      {
+        qux = nixosTests.foo;
+      };
+  };
+
+  exampleA = evalMinimalConfig {
+    imports = [
+      {
+        _module.args.pkgs = {
+          nixosTests = nixosTestsA;
+        };
+      }
+      ../meta.nix
+      exampleModule1
+    ];
+  };
+  nixosTestsA = {
+    foo = lib.recurseIntoAttrs {
+      bar = "Dummy nixosTestsA.foo.bar";
+    };
+  };
+  testsA = exampleA.config.meta.tests;
+
+  evalTests =
+    ok:
+    assert
+      exampleA.config.meta.tests.byModulePath."/tests/example.nix" == {
+        qux = lib.recurseIntoAttrs {
+          bar = "Dummy nixosTestsA.foo.bar";
+        };
+      };
+    ok;
+
+}

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -1233,6 +1233,7 @@ in
 
   meta = {
     maintainers = lib.teams.acme.members;
+    tests = { nixosTests }: nixosTests.acme;
     doc = ./default.md;
   };
 }

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -944,9 +944,5 @@ in
 
   meta.doc = ./postgresql.md;
   meta.maintainers = pkgs.postgresql.meta.maintainers;
-  meta.tests =
-    { nixosTests }:
-    {
-      inherit (nixosTests) postgresql;
-    };
+  meta.tests = { nixosTests }: nixosTests.postgresql;
 }

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -944,4 +944,9 @@ in
 
   meta.doc = ./postgresql.md;
   meta.maintainers = pkgs.postgresql.meta.maintainers;
+  meta.tests =
+    { nixosTests }:
+    {
+      inherit (nixosTests) postgresql;
+    };
 }

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1542,5 +1542,5 @@ in
   ]);
 
   meta.doc = ./nextcloud.md;
-  meta.maintainers = teams.nextcloud;
+  meta.maintainers = teams.nextcloud.members;
 }

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1472,4 +1472,15 @@ in
 
   # uses types of services/x11/xserver.nix
   meta.buildDocsInSandbox = false;
+
+  meta.tests =
+    { nixosTests }:
+    {
+      inherit (nixosTests)
+        qemu-vm-restrictnetwork
+        qemu-vm-volatile-root
+        qemu-vm-external-disk-image
+        qemu-vm-store
+        ;
+    };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1,6 +1,7 @@
 {
   system,
   pkgs,
+  lib ? pkgs.lib,
 
   # Projects the test configuration into a the desired value; usually
   # the test runner: `config: config.test`.
@@ -140,6 +141,8 @@ let
       _class = "nixosTest";
       node.pkgs = pkgs.pkgsLinux;
     };
+
+  inherit (pkgs) emptyFile;
 
 in
 {
@@ -856,6 +859,9 @@ in
   meilisearch = runTest ./meilisearch.nix;
   memcached = runTest ./memcached.nix;
   merecat = runTest ./merecat.nix;
+  meta =
+    (import ../modules/misc/meta/tests.nix { inherit lib evalMinimalConfig; }).evalTests
+      emptyFile;
   metabase = runTest ./metabase.nix;
   mihomo = runTest ./mihomo.nix;
   mindustry = runTest ./mindustry.nix;


### PR DESCRIPTION
This provides the needed infrastructure to make tooling like ofborg build the relevant tests, given a set of changed files.

Having mandatory CI for modules is not just crucial for DX, but also prerequisite to test-driven expansion of NixOS use cases, such as alternate base module sets. (minimal module list and similar ideas)

The option is documented.
We can provide additional instructional docs elsewhere when this is wired into ofborg.


### Why not infer the mapping automatically?

Basically the same reasons we have `passthru.tests.nixos`.

1. Too costly. We'd have to evaluate all tests to figure out which ones changed.
2. For some modules it is not feasible to run all affected tests, because that set is too large. We need a representative smaller set.
3. This could perhaps be scripted as a one-off or infrequent process that updates the mapping, but then it is *time of all evals* * *number of files under `nixos/`... And then there's still some risk that it's not a good mapping for some reason. Doesn't solve (2)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Context

- Closes #148364

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
