### PR TITLE
glamoroustoolkit: add .desktop entry

### DIFF
--- a/pkgs/by-name/gl/glamoroustoolkit/package.nix
+++ b/pkgs/by-name/gl/glamoroustoolkit/package.nix
@@ -1,9 +1,11 @@
 {
   lib,
   stdenv,
+  fetchurl,
   fetchzip,
   wrapGAppsHook3,
   cairo,
+  copyDesktopItems,
   dbus,
   fontconfig,
   freetype,
@@ -19,12 +21,18 @@
   libglvnd,
   libuuid,
   libxcb,
+  makeDesktopItem,
   harfbuzz,
   libsoup_3,
   webkitgtk_4_1,
   zenity,
 }:
-
+let
+  gkIcon = fetchurl {
+    url = "https://gist.githubusercontent.com/qbit/cb52e6cd193c410e0b0aee8a216f6574/raw/2b042bde1dc4cbd30457f14c9d18c889444bf3d0/glamoroustoolkit.svg";
+    sha256 = "sha256-Trfo8P01anLq9yTFzwqIfsyidLGyuZDg48YQPrGBkgs=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "glamoroustoolkit";
   version = "1.1.24";
@@ -37,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     wrapGAppsHook3
+    copyDesktopItems
   ];
 
   sourceRoot = ".";
@@ -46,10 +55,21 @@ stdenv.mkDerivation (finalAttrs: {
   dontPatchELF = true;
   dontStrip = true;
 
+  desktopItems = with finalAttrs; [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "GlamorousToolkit";
+      exec = "GlamorousToolkit";
+      icon = "GlamorousToolkit";
+    })
+  ];
+
   installPhase = ''
     runHook preInstall
 
-    install -d $out/bin $out/lib
+    install -d $out/bin $out/lib $out/share/icons/hicolor/scalable/apps
+
+    cp ${gkIcon} $out/share/icons/hicolor/scalable/apps/GlamorousToolkit.svg
     cp -r $src/bin $src/lib $out/
     cp ${./GlamorousToolkit-GetImage} $out/bin/GlamorousToolkit-GetImage
 


### PR DESCRIPTION
Icon was generated with the following code written by Kazunori Kaz Lriya from the "general" discord room:

```
anElement := BlElement new
        size: 256 @ 256;
        layout: BlFrameLayout new;
        addChild: ((BrLabel new
                text: ('g' asRopedText weight: 100) , 't' asRopedText bold;
                aptitude: BrGlamorousLabelAptitude) asScalableElement
                margin: (BlInsets top: -65 left: 0)).
anElement
    exportAsSVG
```

I wanted to have it auto-generated, but adding an image derivation seemed like too much.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
