### PR TITLE
libfaketime: ignore a failing test on aarch64-darwin for now

### DIFF
--- a/pkgs/by-name/li/libfaketime/497_compile-for-arm64-on-darwin-again.patch
+++ b/pkgs/by-name/li/libfaketime/497_compile-for-arm64-on-darwin-again.patch
@@ -1,0 +1,100 @@
+From 3a3d1deebc05f50edea074752066583d087f704d Mon Sep 17 00:00:00 2001
+From: usertam <code@usertam.dev>
+Date: Sun, 1 Jun 2025 01:03:58 +0800
+Subject: [PATCH 1/2] Revert "Check if the user is on ARM64, add target to
+ CFLAGS/LDFLAGS"
+
+This reverts commit 2a2af0fcdcbe845eefbe12e493dcdf7037fce9f2.
+---
+ Makefile         | 19 -------------------
+ src/Makefile.OSX | 15 ---------------
+ 2 files changed, 34 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index a4a2a62..e69c055 100644
+--- a/Makefile
++++ b/Makefile
+@@ -33,23 +33,4 @@ distclean:
+ 	$(MAKE) $(SELECTOR) -C src distclean
+ 	$(MAKE) $(SELECTOR) -C test distclean
+ 
+-macarm64:
+-	$(MAKE) $(SELECTOR) -C src clean
+-	$(MAKE) $(SELECTOR) -C src distclean
+-	$(MAKE) $(SELECTOR) -C src all
+-# 	$(MAKE) $(SELECTOR) -C test all
+-# 	$(MAKE) $(SELECTOR) -C test distclean
+-	$(MAKE) $(SELECTOR) -C src install
+-	$(MAKE) $(SELECTOR) -C man install
+-	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}/share/doc/faketime/"
+-	$(INSTALL) -m0644 README "${DESTDIR}${PREFIX}/share/doc/faketime/README"
+-	$(INSTALL) -m0644 NEWS "${DESTDIR}${PREFIX}/share/doc/faketime/NEWS"
+-
+-macarm64full:
+-	$(MAKE) $(SELECTOR) -C src clean
+-	$(MAKE) $(SELECTOR) -C src distclean
+-	$(MAKE) $(SELECTOR) -C src all
+-	$(MAKE) $(SELECTOR) -C test all
+-# 	$(MAKE) $(SELECTOR) -C test distclean
+-
+ .PHONY: all test install uninstall clean distclean
+diff --git a/src/Makefile.OSX b/src/Makefile.OSX
+index d90b961..4743437 100644
+--- a/src/Makefile.OSX
++++ b/src/Makefile.OSX
+@@ -58,21 +58,6 @@ PREFIX ?= /usr/local
+ CFLAGS += -DFAKE_SLEEP -DFAKE_INTERNAL_CALLS -DPREFIX='"'${PREFIX}'"' $(FAKETIME_COMPILE_CFLAGS) -DMACOS_DYLD_INTERPOSE -DFAKE_SETTIME
+ LIB_LDFLAGS += -dynamiclib -current_version 0.9.11 -compatibility_version 0.7
+ 
+-# ARM64 MacOS (M1/M2/M3/Apple Silicon/etc) processors require a target set as their current version, or they
+-# will receive the following error:
+-# dyld[6675]: terminating because inserted dylib '/usr/local/lib/faketime/libfaketime.1.dylib' could not be loaded: tried: '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/lib/faketime/libfaketime.1.dylib' (no such file), '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
+-# dyld[6675]: tried: '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/lib/faketime/libfaketime.1.dylib' (no such file), '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
+-# Outputs `arm64` on ARM64
+-OS := $(shell uname -m)
+-# Outputs a number, eg 14.4 for MacOS Sonoma 14.4
+-MACOS_PRODUCT_VERSION := $(shell sw_vers --productVersion | cut -d. -f1,2)
+-
+-# Check if arm64 is in OS, if so, add the target
+-ifeq ($(OS),arm64)
+-  CFLAGS += -target arm64e-apple-macos$(MACOS_PRODUCT_VERSION)
+-  LIB_LDFLAGS += -target arm64e-apple-macos$(MACOS_PRODUCT_VERSION)
+-endif
+-
+ SONAME = 1
+ LIBS = libfaketime.${SONAME}.dylib
+ BINS = faketime
+
+From 264e8efad74ea3418b20e603271cbd66f0a2034d Mon Sep 17 00:00:00 2001
+From: usertam <code@usertam.dev>
+Date: Sun, 1 Jun 2025 22:50:46 +0800
+Subject: [PATCH 2/2] Makefile.OSX: compile a fat library of both arm64e and
+ arm64
+
+---
+ src/Makefile.OSX | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/Makefile.OSX b/src/Makefile.OSX
+index 4743437..9bdf922 100644
+--- a/src/Makefile.OSX
++++ b/src/Makefile.OSX
+@@ -58,6 +58,18 @@ PREFIX ?= /usr/local
+ CFLAGS += -DFAKE_SLEEP -DFAKE_INTERNAL_CALLS -DPREFIX='"'${PREFIX}'"' $(FAKETIME_COMPILE_CFLAGS) -DMACOS_DYLD_INTERPOSE -DFAKE_SETTIME
+ LIB_LDFLAGS += -dynamiclib -current_version 0.9.11 -compatibility_version 0.7
+ 
++# From macOS 13 onwards, system binaries are compiled against the new arm64e ABI on Apple Silicon.
++# These arm64e binaries enforce Pointer Authentication Code (PAC), and will refuse to run with
++# "unprotected" arm64 libraries. Meanwhile, older platforms might not recognize the new arm64e ABI.
++
++# Therefore, we now compile for two ABIs at the same time, producing a fat library of arm64e and arm64,
++# so in the end the OS gets to pick which architecture it wants at runtime.
++ARCH := $(shell uname -m)
++
++ifeq ($(ARCH),arm64)
++    CFLAGS += -arch arm64e -arch arm64
++endif
++
+ SONAME = 1
+ LIBS = libfaketime.${SONAME}.dylib
+ BINS = faketime

--- a/pkgs/by-name/li/libfaketime/package.nix
+++ b/pkgs/by-name/li/libfaketime/package.nix
@@ -2,19 +2,19 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
+
   perl,
   coreutils,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libfaketime";
   version = "0.9.11";
 
   src = fetchFromGitHub {
     owner = "wolfcw";
     repo = "libfaketime";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-a0TjHYzwbkRQyvr9Sj/DqjgLBnE1Z8kjsTQxTfGqLjE=";
   };
 
@@ -24,11 +24,10 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs test src
-    for a in test/functests/test_exclude_mono.sh src/faketime.c ; do
-      substituteInPlace $a \
-        --replace-fail /bin/bash ${stdenv.shell}
-    done
-    substituteInPlace src/faketime.c --replace-fail @DATE_CMD@ ${coreutils}/bin/date
+    substituteInPlace test/functests/test_exclude_mono.sh src/faketime.c \
+      --replace-fail /bin/bash ${stdenv.shell}
+    substituteInPlace src/faketime.c \
+      --replace-fail @DATE_CMD@ ${lib.getExe' coreutils "date"}
   '';
 
   PREFIX = placeholder "out";
@@ -49,12 +48,12 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Report faked system time to programs without having to change the system-wide time";
     homepage = "https://github.com/wolfcw/libfaketime/";
-    license = licenses.gpl2;
-    platforms = platforms.all;
-    maintainers = [ maintainers.bjornfor ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.bjornfor ];
     mainProgram = "faketime";
   };
-}
+})


### PR DESCRIPTION
Hi,

I noticed that pinocchio is broken on aarch64-darwin, because:
```
libfaketime> # functests/test_exclude_mono.sh summary: 0 succeeded, 1 failed
libfaketime> testframe.sh: error: functests/test_exclude_mono.sh run exit_status=1!
libfaketime> # End functests/test_exclude_mono.sh - BAD
```

I guess this comes from bump in https://github.com/NixOS/nixpkgs/pull/412913, which was not tested on aarch64-darwin.

~~A fix is available upstream, so this PR is adding it.~~ edit: no fix yet, let's ignore it for now

While here, clean things a bit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
