### PR TITLE
rocqPackages.mathcomp: init at 2.5.0

### DIFF
--- a/pkgs/development/rocq-modules/mathcomp/default.nix
+++ b/pkgs/development/rocq-modules/mathcomp/default.nix
@@ -1,0 +1,138 @@
+############################################################################
+# This file mainly provides the `mathcomp` derivation, which is            #
+# essentially a meta-package containing all core mathcomp libraries        #
+# (boot order fingroup algebra solvable field character). They can be      #
+# accessed individually through the passthrough attributes of mathcomp     #
+# bearing the same names (mathcomp.boot, etc).                             #
+############################################################################
+# Compiling a custom version of mathcomp using `mathcomp.override`.        #
+# This is the replacement for the former `mathcomp_ config` function.      #
+# See the documentation at doc/languages-frameworks/coq.section.md.        #
+############################################################################
+
+{
+  lib,
+  ncurses,
+  graphviz,
+  lua,
+  fetchzip,
+  mkRocqDerivation,
+  withDoc ? false,
+  single ? false,
+  rocq-core,
+  hierarchy-builder,
+  version ? null,
+}@args:
+
+let
+  repo = "mathcomp";
+  owner = "math-comp";
+  withDoc = single && (args.withDoc or false);
+  defaultVersion =
+    let
+      case = case: out: { inherit case out; };
+      inherit (lib.versions) range;
+    in
+    lib.switch rocq-core.rocq-version [
+      (case (range "9.0" "9.1") "2.5.0")
+    ] null;
+  release = {
+    "2.5.0".sha256 = "sha256-M/6IP4WhTQ4j2Bc8nXBXjSjWO08QzNIYI+a2owfOh+8=";
+  };
+  releaseRev = v: "mathcomp-${v}";
+
+  # list of core mathcomp packages sorted by dependency order
+  packages = {
+    "boot" = [ ];
+    "order" = [ "boot" ];
+    "fingroup" = [ "boot" ];
+    "algebra" = [
+      "order"
+      "fingroup"
+    ];
+    "solvable" = [ "algebra" ];
+    "field" = [ "solvable" ];
+    "character" = [ "field" ];
+    "all" = [ "character" ];
+  };
+
+  mathcomp_ =
+    package:
+    let
+      mathcomp-deps = lib.optionals (package != "single") (map mathcomp_ packages.${package});
+      pkgpath = if package == "single" then "." else package;
+      pname = if package == "single" then "mathcomp" else "mathcomp-${package}";
+      pkgallMake = ''
+        echo "all.v"  > Make
+        echo "-I ." >>   Make
+        echo "-R . mathcomp.all" >> Make
+      '';
+      derivation = mkRocqDerivation (
+        {
+          inherit
+            version
+            pname
+            defaultVersion
+            release
+            releaseRev
+            repo
+            owner
+            ;
+
+          nativeBuildInputs = lib.optionals withDoc [
+            graphviz
+            lua
+          ];
+          buildInputs = [ ncurses ];
+          propagatedBuildInputs = mathcomp-deps ++ [ hierarchy-builder ];
+
+          buildFlags = lib.optional withDoc "doc";
+
+          preBuild = ''
+            if [[ -f etc/buildlibgraph ]]
+            then patchShebangs etc/buildlibgraph
+            fi
+          ''
+          + ''
+            cd ${pkgpath}
+          ''
+          + lib.optionalString (package == "all") pkgallMake;
+
+          meta = {
+            homepage = "https://math-comp.github.io/";
+            license = lib.licenses.cecill-b;
+            maintainers = with lib.maintainers; [
+              vbgl
+              jwiegley
+              cohencyril
+            ];
+          };
+        }
+        // lib.optionalAttrs (package != "single") { passthru = lib.mapAttrs (p: _: mathcomp_ p) packages; }
+        // lib.optionalAttrs withDoc {
+          htmldoc_template = fetchzip {
+            url = "https://github.com/math-comp/math-comp.github.io/archive/doc-1.12.0.zip";
+            sha256 = "0y1352ha2yy6k2dl375sb1r68r1qi9dyyy7dyzj5lp9hxhhq69x8";
+          };
+          postBuild = ''
+            cp -rf _build_doc/* .
+            rm -r _build_doc
+          '';
+          postInstall =
+            let
+              tgt = "$out/share/coq/${rocq-core.rocq-version}/";
+            in
+            lib.optionalString withDoc ''
+              mkdir -p ${tgt}
+              cp -r htmldoc ${tgt}
+              cp -r $htmldoc_template/htmldoc_template/* ${tgt}/htmldoc/
+            '';
+          buildTargets = "doc";
+          extraInstallFlags = [ "-f Makefile.coq" ];
+        }
+      );
+      # patched-derivation1 = derivation.overrideAttrs ...
+    in
+    derivation;
+in
+mathcomp_ (if single then "single" else "all")

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -37,6 +37,14 @@ let
 
       bignums = callPackage ../development/rocq-modules/bignums { };
       hierarchy-builder = callPackage ../development/rocq-modules/hierarchy-builder { };
+      mathcomp = callPackage ../development/rocq-modules/mathcomp { };
+      mathcomp-boot = self.mathcomp.boot;
+      mathcomp-order = self.mathcomp.order;
+      mathcomp-fingroup = self.mathcomp.fingroup;
+      mathcomp-algebra = self.mathcomp.algebra;
+      mathcomp-solvable = self.mathcomp.solvable;
+      mathcomp-field = self.mathcomp.field;
+      mathcomp-character = self.mathcomp.character;
       parseque = callPackage ../development/rocq-modules/parseque { };
       rocq-elpi = callPackage ../development/rocq-modules/rocq-elpi { };
       stdlib = callPackage ../development/rocq-modules/stdlib { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
