### PR TITLE
nixos/networking: deprecate networking.extraHosts

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -46,5 +46,8 @@
 
 - `services.dnscrypt-proxy2` gains a `package` option to specify dnscrypt-proxy package to use.
 
+- [](#opt-networking.extraHosts) has been deprecated in favor of [](#opt-networking.hosts) and is set to be removed in 26.05 release.
+  This allows easier mapping of IP addresses to hostnames.
+
 - `amdgpu` kernel driver overdrive mode can now be enabled by setting [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable) and customized through [hardware.amdgpu.overdrive.ppfeaturemask](#opt-hardware.amdgpu.overdrive.ppfeaturemask).
   This allows for fine-grained control over the GPU's performance and maybe required by overclocking softwares like Corectrl and Lact. These new options replace old options such as {option}`programs.corectrl.gpuOverclock.enable` and {option}`programs.tuxclocker.enableAMD`.

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -53,11 +53,20 @@ in
 
     networking.extraHosts = lib.mkOption {
       type = lib.types.lines;
+      # TODO: Remove this 26.05 to force people to migrate to networking.hosts
+      apply =
+        v:
+        lib.warnIf (v != "")
+          "networking.extraHosts has been deprecated in favor of networking.hosts and is set to be removed in 26.05"
+          v;
       default = "";
       example = "192.168.0.1 lanlocalhost";
       description = ''
         Additional verbatim entries to be appended to {file}`/etc/hosts`.
         For adding hosts from derivation results, use {option}`networking.hostFiles` instead.
+        ::: {.note}
+        This option has been deprecated in favor of {option}`networking.hosts`.
+        :::
       '';
     };
 

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -365,9 +365,12 @@ in
         keyFile = mkDefault key;
         trustedCaFile = mkDefault caCert;
       };
-      networking.extraHosts = mkIf (config.services.etcd.enable) ''
-        127.0.0.1 etcd.${top.addons.dns.clusterDomain} etcd.local
-      '';
+      networking.hosts = mkIf (config.services.etcd.enable) {
+        "127.0.0.1" = [
+          "etcd.${top.addons.dns.clusterDomain}"
+          "etcd.local"
+        ];
+      };
 
       services.flannel = with cfg.certs.flannelClient; {
         kubeconfig = top.lib.mkKubeConfig "flannel" {

--- a/nixos/modules/virtualisation/google-compute-config.nix
+++ b/nixos/modules/virtualisation/google-compute-config.nix
@@ -70,10 +70,12 @@ in
   # Rely on GCP's firewall instead
   networking.firewall.enable = mkDefault false;
 
-  # Configure default metadata hostnames
-  networking.extraHosts = ''
-    169.254.169.254 metadata.google.internal metadata
-  '';
+  networking.hosts = {
+    "169.254.169.254" = [
+      "metadata.google.internal"
+      "metadata"
+    ];
+  };
 
   networking.timeServers = [ "metadata.google.internal" ];
 

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -1084,14 +1084,10 @@ in
           ) config.containers;
 
         # Generate /etc/hosts entries for the containers.
-        networking.extraHosts = concatStrings (
-          mapAttrsToList (
-            name: cfg:
-            optionalString (cfg.localAddress != null) ''
-              ${head (splitString "/" cfg.localAddress)} ${name}.containers
-            ''
-          ) config.containers
-        );
+        networking.hosts = lib.mapAttrs' (name: cfg: {
+          name = head (splitString "/" cfg.localAddress);
+          value = lib.optionals (cfg.localAddress != null) [ "${name}.containers" ];
+        }) config.containers;
 
         networking.dhcpcd.denyInterfaces = [
           "ve-*"


### PR DESCRIPTION
There is already `networking.hosts` that replicates its features with the added benefit of defining multiple hostnames for same IP in a list.

Something like;

```nix
  networking.extraHosts = ''
    169.254.169.254 metadata.google.internal metadata
  '';
```

can be changed to:
```nix
  networking.hosts = {
    "169.254.169.254" = [
      "metadata.google.internal"
      "metadata"
    ];
  };
```

All modules in `nixos/modules/**` has been migrated to `networking.hosts`.
Usage and occurances in tests on Nixpkgs can be migrated in seperate PRs.

After a [discussion on Matrix](https://matrix.to/#/!CTCrFzsBPYmDLmrja4:0upti.me/$3sr1nJxGdSyLgbSLUPdcGyva6pCsB0PmsTMGk2brCaw?via=nixos.org&via=matrix.org&via=tchncs.de) with K900, it's best we deprecate this. This option is set to be removed in 26.05. 1 year of deprecation period allows consumers to be migrated safely.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
