### PR TITLE
beammp-launcher: init at 2.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10744,6 +10744,13 @@
     name = "Antoine Labarussias";
     keys = [ { fingerprint = "5CB5 9AA0 D180 1997 2FB3  E0EC 943A 1DE9 372E BE4E"; } ];
   };
+  invertedEcho = {
+    email = "jakob.stechow@pm.me";
+    github = "invertedEcho";
+    githubId = 80119822;
+    name = "Jakob Stechow";
+    keys = [ { fingerprint = "3A1D 9065 FF53 B4EB FB26  BC7A 46C7 6661 69A1 1502"; } ];
+  };
   invokes-su = {
     email = "nixpkgs-commits@deshaw.com";
     github = "invokes-su";

--- a/pkgs/by-name/be/beammp-launcher/package.nix
+++ b/pkgs/by-name/be/beammp-launcher/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  boost,
+  httplib,
+  openssl,
+  nlohmann_json,
+  curl,
+  makeDesktopItem,
+  copyDesktopItems,
+  installShellFiles,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "beammp-launcher";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "BeamMP";
+    repo = "BeamMP-Launcher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aAQmgK03a3BY4YWuDyTmJzcePchD74SXfbkHwnaOYW8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    copyDesktopItems
+    installShellFiles
+  ];
+
+  buildInputs = [
+    boost
+    httplib
+    openssl
+    nlohmann_json
+    curl
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = finalAttrs.pname;
+      exec = finalAttrs.meta.mainProgram;
+      desktopName = finalAttrs.meta.mainProgram;
+      comment = finalAttrs.meta.description;
+      categories = [ "Game" ];
+      terminal = true;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin BeamMP-Launcher
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Launcher for the BeamMP mod for BeamNG.drive";
+    homepage = "https://github.com/BeamMP/BeamMP-Launcher";
+    mainProgram = "BeamMP-Launcher";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ invertedEcho ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This adds BeamMP-Launcher, a launcher for the multiplayer mod "BeamMP", for the game BeamNG.drive.

Homepage: https://beammp.com/
Github: https://github.com/BeamMP/BeamMP

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
