### PR TITLE
[24.11] curlMinimal: backport patch for CVE-2025-5399

### DIFF
--- a/pkgs/by-name/cu/curlMinimal/fix-CVE-2025-5399.patch
+++ b/pkgs/by-name/cu/curlMinimal/fix-CVE-2025-5399.patch
@@ -1,0 +1,25 @@
+From d1145df24de8f80e6b167fbc4f28b86bcd0c6832 Mon Sep 17 00:00:00 2001
+From: z2_ <88509734+z2-2z@users.noreply.github.com>
+Date: Sat, 31 May 2025 14:22:00 +0200
+Subject: [PATCH] ws: handle blocked sends better
+
+Closes #17496
+---
+ lib/ws.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/ws.c b/lib/ws.c
+index 93ec3a785ad9..61ab5019fd81 100644
+--- a/lib/ws.c
++++ b/lib/ws.c
+@@ -1384,6 +1384,10 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *d, const void *buffer_arg,
+       if(n < 0 && (result != CURLE_AGAIN))
+         goto out;
+       ws->sendbuf_payload += Curl_bufq_len(&ws->sendbuf) - prev_len;
++      if(!ws->sendbuf_payload) {
++        result = CURLE_AGAIN;
++        goto out;
++      }
+     }
+ 
+     /* flush, blocking when in callback */

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -98,22 +98,26 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-A0Hx7ZeibIEauuvTfWK4M5VnkrdgfqPxXQAWE8dt4gI=";
   };
 
-  patches = lib.optionals wolfsslSupport [
-    (fetchpatch {
-      # https://curl.se/docs/CVE-2025-4947.html backported to 8.13. Remove when version is bumped to 8.14.
-      # Note that this works since fetchpatch uses curl, but does not use WolfSSL.
-      name = "curl-CVE-2025-4947.patch";
-      url = "https://github.com/curl/curl/commit/a85f1df4803bbd272905c9e7125.diff";
-      hash = "sha256-zxwcboJwHjpcVciJXoCiSLrkAi0V9GtSEBf14V6cfvQ=";
+  patches =
+    [
+      ./fix-CVE-2025-5399.patch
+    ]
+    ++ lib.optionals wolfsslSupport [
+      (fetchpatch {
+        # https://curl.se/docs/CVE-2025-4947.html backported to 8.13. Remove when version is bumped to 8.14.
+        # Note that this works since fetchpatch uses curl, but does not use WolfSSL.
+        name = "curl-CVE-2025-4947.patch";
+        url = "https://github.com/curl/curl/commit/a85f1df4803bbd272905c9e7125.diff";
+        hash = "sha256-zxwcboJwHjpcVciJXoCiSLrkAi0V9GtSEBf14V6cfvQ=";
 
-      # All the test patches fail to apply (seemingly, they were added for 8.14)
-      includes = [ "lib/vquic/vquic-tls.c" ];
+        # All the test patches fail to apply (seemingly, they were added for 8.14)
+        includes = [ "lib/vquic/vquic-tls.c" ];
 
-      postFetch = ''
-        substituteInPlace $out --replace-fail "ctx->wssl.ssl" "ctx->wssl.handle"
-      '';
-    })
-  ];
+        postFetch = ''
+          substituteInPlace $out --replace-fail "ctx->wssl.ssl" "ctx->wssl.handle"
+        '';
+      })
+    ];
 
   # this could be accomplished by updateAutotoolsGnuConfigScriptsHook, but that causes infinite recursion
   # necessary for FreeBSD code path in configure


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/413896

CVE-2025-5399

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
