### PR TITLE
stdenv: remove `--preserve=mode` from `cp` in `defaultUnpack`

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1260,7 +1260,7 @@ _defaultUnpack() {
         # We can't preserve hardlinks because they may have been
         # introduced by store optimization, which might break things
         # in the build.
-        cp -r --preserve=mode,timestamps --reflink=auto -- "$fn" "$destination"
+        cp -r --preserve=timestamps --reflink=auto -- "$fn" "$destination"
 
     else
 


### PR DESCRIPTION
`mode` includes acls and xattrs. Those xattrs can include unsupported attrs on the destination file system. I.E. If copying from nfs4 to ext `fsetxattr` can be called with `system.nfs4_acl` which is an unsupported operation on ext4. This will result in `cp: preserving permissions for ...: Operation not supported`.

See, for instance:

https://lists.gnu.org/archive/html/coreutils/2024-09/msg00009.html

In our case we saw the following when adding a strace to the cp:

`lgetxattr("/nix/store/ihas6mzn9h54ldgp90pics0yrlmi6ln7-source", "system.nfs4_acl", NULL, 0) = -1 EOPNOTSUPP (Operation not supported)`

Removing this flag should not effect the resulting umask/permission bits, which I think is all we care about. From the docs:

> In the absence of this option, the permissions of existing
> destination files are unchanged. Each new file is created with the
> mode of the corresponding source file minus the set-user-ID,
> set-group-ID, and sticky bits as the create mode; the operating system
> then applies either the umask or a default ACL, possibly resulting in
> a more restrictive file mode.

https://www.gnu.org/software/coreutils/manual/html_node/cp-invocation.html

So the only real problem I can foresee is if the setuid/setgid or other sticky bits matter to a build. In which case I think an effected build might have bigger issues.

## Things done

I reproduced with my teammate on an NFS4 mount and observed the above EOPNOTSUPP. Removing the `--preserve=mode` flag fixed the problem.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


