### PR TITLE
treewide: replace `stdenv.is` with `stdenv.hostPlatform.is`

### DIFF
--- a/nixos/tests/mattermost/default.nix
+++ b/nixos/tests/mattermost/default.nix
@@ -569,7 +569,7 @@ import ../make-test-python.nix (
             shutdown_queue.task_done()
         threading.Thread(target=shutdown_worker, daemon=True).start()
 
-        ${pkgs.lib.optionalString pkgs.stdenv.isx86_64 ''
+        ${pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isx86_64 ''
           # Only run the MySQL tests on x86_64 so we don't have to debug MySQL ARM issues.
           run_mattermost_tests(
             shutdown_queue,

--- a/pkgs/by-name/ac/actual-server/package.nix
+++ b/pkgs/by-name/ac/actual-server/package.nix
@@ -208,7 +208,7 @@ stdenv.mkDerivation {
     mainProgram = "actual-server";
     license = lib.licenses.mit;
     # https://github.com/NixOS/nixpkgs/issues/403846
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     maintainers = [
       lib.maintainers.oddlama
       lib.maintainers.patrickdag

--- a/pkgs/by-name/ag/age-plugin-se/package.nix
+++ b/pkgs/by-name/ag/age-plugin-se/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Can't find libdispatch without this on NixOS. (swift 5.8)
-  LD_LIBRARY_PATH = lib.optionalString stdenv.isLinux "${swiftPackages.Dispatch}/lib";
+  LD_LIBRARY_PATH = lib.optionalString stdenv.hostPlatform.isLinux "${swiftPackages.Dispatch}/lib";
 
   postPatch =
     let

--- a/pkgs/by-name/ak/akkoma-admin-fe/package.nix
+++ b/pkgs/by-name/ak/akkoma-admin-fe/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     git
     libsass
-  ] ++ lib.optional stdenv.isDarwin xcbuild;
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin xcbuild;
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/by-name/ar/ares-rs/package.nix
+++ b/pkgs/by-name/ar/ares-rs/package.nix
@@ -37,6 +37,6 @@ rustPlatform.buildRustPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
     mainProgram = "ares";
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/ar/arp-scan-rs/package.nix
+++ b/pkgs/by-name/ar/arp-scan-rs/package.nix
@@ -45,6 +45,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "arp-scan";
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/bi/bicep-lsp/package.nix
+++ b/pkgs/by-name/bi/bicep-lsp/package.nix
@@ -34,16 +34,16 @@ buildDotnetModule rec {
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
   dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-  buildInputs = lib.optionals stdenv.isLinux [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     icu
     libkrb5
     openssl
     stdenv.cc.cc.lib
   ];
 
-  doCheck = !(stdenv.isDarwin && stdenv.isAarch64); # mono is not available on aarch64-darwin
+  doCheck = !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64); # mono is not available on aarch64-darwin
 
   meta = {
     description = "Domain Specific Language (DSL) for deploying Azure resources declaratively";

--- a/pkgs/by-name/ca/camilladsp/package.nix
+++ b/pkgs/by-name/ca/camilladsp/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     libpulseaudio
     openssl
-  ] ++ lib.optionals stdenv.isLinux [ alsa-lib ];
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ];
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--generate-lockfile" ]; };
 

--- a/pkgs/by-name/ca/cargo-bazel/package.nix
+++ b/pkgs/by-name/ca/cargo-bazel/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-FS1WFlK0YNq1QCi3S3f5tMN+Bdcfx2dxhDKRLXLcios=";
   };
 
-  buildInputs = lib.optional stdenv.isDarwin libz;
+  buildInputs = lib.optional stdenv.hostPlatform.isDarwin libz;
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-E/yF42Vx9tv8Ik1j23El3+fI19ZGzq6nikVMATY7m3E=";

--- a/pkgs/by-name/cl/cloud-provider-kind/package.nix
+++ b/pkgs/by-name/cl/cloud-provider-kind/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  checkFlags = lib.optional stdenv.isDarwin "-skip=^Test_firstSuccessfulProbe$";
+  checkFlags = lib.optional stdenv.hostPlatform.isDarwin "-skip=^Test_firstSuccessfulProbe$";
 
   meta = {
     description = "Load Balancer implementation for Kubernetes-in-Docker";

--- a/pkgs/by-name/fl/fluent-bit/package.nix
+++ b/pkgs/by-name/fl/fluent-bit/package.nix
@@ -118,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgramArg = "--version";
 
   passthru = {
-    tests = lib.optionalAttrs stdenv.isLinux {
+    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
       inherit (nixosTests) fluent-bit;
     };
 

--- a/pkgs/by-name/gc/gcc-arm-embedded-13/package.nix
+++ b/pkgs/by-name/gc/gcc-arm-embedded-13/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     ./info-fix.patch
   ];
 
-  nativeBuildInputs = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+  nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     makeBinaryWrapper
     darwin.sigtool
   ];
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup =
-    lib.optionalString stdenv.isLinux ''
+    lib.optionalString stdenv.hostPlatform.isLinux ''
       find $out -type f | while read f; do
         patchelf "$f" > /dev/null 2>&1 || continue
         patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
         } "$f" || true
       done
     ''
-    + lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
       find "$out" -executable -type f | while read executable; do
         ( \
           install_name_tool \

--- a/pkgs/by-name/gc/gcc-arm-embedded-14/package.nix
+++ b/pkgs/by-name/gc/gcc-arm-embedded-14/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
       .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   };
 
-  nativeBuildInputs = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+  nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     makeBinaryWrapper
     darwin.sigtool
   ];
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup =
-    lib.optionalString stdenv.isLinux ''
+    lib.optionalString stdenv.hostPlatform.isLinux ''
       find $out -type f | while read f; do
         patchelf "$f" > /dev/null 2>&1 || continue
         patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
         } "$f" || true
       done
     ''
-    + lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
       find "$out" -executable -type f | while read executable; do
         ( \
           install_name_tool \

--- a/pkgs/by-name/gz/gz-cmake/package.nix
+++ b/pkgs/by-name/gz/gz-cmake/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs examples/test_c_child_requires_c_no_deps.bash
     substituteInPlace examples/CMakeLists.txt --replace-fail \
-      "$""{CMAKE_INSTALL_LIBDIR}" "${if stdenv.isDarwin then "lib" else "lib64"}"
+      "$""{CMAKE_INSTALL_LIBDIR}" "${if stdenv.hostPlatform.isDarwin then "lib" else "lib64"}"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ht/http-scanner/package.nix
+++ b/pkgs/by-name/ht/http-scanner/package.nix
@@ -31,6 +31,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "http-scanner";
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/ja/jai/package.nix
+++ b/pkgs/by-name/ja/jai/package.nix
@@ -37,7 +37,7 @@ let
     ];
   };
 in
-if stdenv.isLinux then
+if stdenv.hostPlatform.isLinux then
   buildFHSEnv {
     inherit meta pname version;
     targetPkgs = pkgs: [ pkgs.zlib ];

--- a/pkgs/by-name/li/libcdio/package.nix
+++ b/pkgs/by-name/li/libcdio/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-izjZk2kz9PkLm9+INUdl1e7jMz3nUsQKdplKI9Io+CM=";
   };
 
-  env = lib.optionalAttrs stdenv.is32bit {
+  env = lib.optionalAttrs stdenv.hostPlatform.is32bit {
     NIX_CFLAGS_COMPILE = "-D_LARGEFILE64_SOURCE";
   };
 

--- a/pkgs/by-name/ma/matrix-brandy/package.nix
+++ b/pkgs/by-name/ma/matrix-brandy/package.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-sMgYgV4/vV1x5xSICXRpW6K8uCdVlJrS7iEg6XzQRo8=";
   };
 
-  patches = lib.optionals stdenv.isDarwin [ ./no-lrt.patch ];
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [ ./no-lrt.patch ];
 
-  makeFlags = lib.optionals stdenv.isDarwin [
+  makeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     "CC=cc"
     "LD=clang"
   ];

--- a/pkgs/by-name/mu/musl-obstack/package.nix
+++ b/pkgs/by-name/mu/musl-obstack/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-oydS7FubUniMHAUWfg84OH9+CZ0JCrTXy7jzwOyJzC8=";
   };
 
-  patches = lib.optionals stdenv.isDarwin [
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
     ./0001-ignore-obstack_free-alias-on-darwin.patch
   ];
 

--- a/pkgs/by-name/mu/muvm/package.nix
+++ b/pkgs/by-name/mu/muvm/package.nix
@@ -39,7 +39,7 @@ let
     dhcpcd
     passt
     (placeholder "out")
-  ] ++ lib.optionals stdenv.isAarch64 [ fex ];
+  ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [ fex ];
   wrapArgs = lib.escapeShellArgs [
     "--prefix"
     "PATH"
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage rec {
         --replace-fail "/sbin/sysctl" "${lib.getExe' procps "sysctl"}"
     ''
     # Only patch FEX path if we're aarch64, otherwise we don't want the derivation to pull in FEX in any way
-    + lib.optionalString stdenv.isAarch64 ''
+    + lib.optionalString stdenv.hostPlatform.isAarch64 ''
       substituteInPlace crates/muvm/src/guest/mount.rs \
         --replace-fail "/usr/share/fex-emu" "${fex}/share/fex-emu"
     '';

--- a/pkgs/by-name/ne/neofetch/package.nix
+++ b/pkgs/by-name/ne/neofetch/package.nix
@@ -5,7 +5,7 @@
   bash,
   makeWrapper,
   pciutils,
-  x11Support ? !stdenvNoCC.isOpenBSD,
+  x11Support ? !stdenvNoCC.hostPlatform.isOpenBSD,
   ueberzug,
   fetchpatch,
 }:
@@ -56,7 +56,9 @@ stdenvNoCC.mkDerivation {
   postInstall = ''
     wrapProgram $out/bin/neofetch \
       --prefix PATH : ${
-        lib.makeBinPath (lib.optional (!stdenvNoCC.isOpenBSD) pciutils ++ lib.optional x11Support ueberzug)
+        lib.makeBinPath (
+          lib.optional (!stdenvNoCC.hostPlatform.isOpenBSD) pciutils ++ lib.optional x11Support ueberzug
+        )
       }
   '';
 

--- a/pkgs/by-name/os/osu-lazer-bin/package.nix
+++ b/pkgs/by-name/os/osu-lazer-bin/package.nix
@@ -55,7 +55,7 @@ let
 
   passthru.updateScript = ./update.sh;
 in
-if stdenvNoCC.isDarwin then
+if stdenvNoCC.hostPlatform.isDarwin then
   stdenvNoCC.mkDerivation {
     inherit
       pname

--- a/pkgs/by-name/ov/ovftool/package.nix
+++ b/pkgs/by-name/ov/ovftool/package.nix
@@ -341,7 +341,7 @@ stdenv.mkDerivation (final: {
     ];
     platforms = builtins.attrNames ovftoolSystems;
     mainProgram = "ovftool";
-    knownVulnerabilities = lib.optionals (stdenv.isDarwin) [
+    knownVulnerabilities = lib.optionals (stdenv.hostPlatform.isDarwin) [
       "The bundled version of openssl 1.0.2zj in ovftool for Darwin has open vulnerabilities."
       "https://openssl-library.org/news/vulnerabilities-1.0.2/"
       "CVE-2024-0727"

--- a/pkgs/by-name/rp/rp/package.nix
+++ b/pkgs/by-name/rp/rp/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     cmake
     ninja
   ];
-  buildInputs = lib.optionals (stdenv.isLinux) [ stdenv.cc.libc.static ];
+  buildInputs = lib.optionals (stdenv.hostPlatform.isLinux) [ stdenv.cc.libc.static ];
 
   src = fetchFromGitHub {
     owner = "0vercl0k";
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp rp-${if stdenv.isDarwin then "osx" else "lin"} $out/bin/rp
+    cp rp-${if stdenv.hostPlatform.isDarwin then "osx" else "lin"} $out/bin/rp
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/ry/ryubing/package.nix
+++ b/pkgs/by-name/ry/ryubing/package.nix
@@ -101,7 +101,7 @@ buildDotnetModule rec {
     "--set SDL_VIDEODRIVER x11"
   ];
 
-  preInstall = lib.optionalString stdenv.isLinux ''
+  preInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     # workaround for https://github.com/Ryujinx/Ryujinx/issues/2349
     mkdir -p $out/lib/sndio-6
     ln -s ${sndio}/lib/libsndio.so $out/lib/sndio-6/libsndio.so.6

--- a/pkgs/by-name/sp/spider/package.nix
+++ b/pkgs/by-name/sp/spider/package.nix
@@ -56,7 +56,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "--skip=pdl_is_fresh"
       "--skip=verify_revision_available"
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # Sandbox limitation: attempted to create a NULL object
       "--skip=website::test_link_duplicates"
       "--skip=website::not_crawl_blacklist"

--- a/pkgs/by-name/yn/ynetd/package.nix
+++ b/pkgs/by-name/yn/ynetd/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-7gioQ0r0LlUftIWKRwTqeZQl0GtskcRKaEE5z6A0S24=";
   };
 
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace Makefile --replace-fail "-Wl,-z,relro,-z,now" ""
   '';
 

--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -57,8 +57,8 @@ let
           in
           "[${lib.concatStringsSep "," options}]";
 
-        LANG = if stdenv.isLinux then "C.UTF-8" else "C";
-        LC_CTYPE = if stdenv.isLinux then "C.UTF-8" else "UTF-8";
+        LANG = if stdenv.hostPlatform.isLinux then "C.UTF-8" else "C";
+        LC_CTYPE = if stdenv.hostPlatform.isLinux then "C.UTF-8" else "UTF-8";
 
         # add to ERL_LIBS so other modules can find at runtime.
         # http://erlang.org/doc/man/code.html#code-path

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -138,8 +138,8 @@ stdenv.mkDerivation (
       in
       "[${lib.concatStringsSep "," options}]";
 
-    LANG = if stdenv.isLinux then "C.UTF-8" else "C";
-    LC_CTYPE = if stdenv.isLinux then "C.UTF-8" else "UTF-8";
+    LANG = if stdenv.hostPlatform.isLinux then "C.UTF-8" else "C";
+    LC_CTYPE = if stdenv.hostPlatform.isLinux then "C.UTF-8" else "UTF-8";
 
     postUnpack =
       ''

--- a/pkgs/development/compilers/dotnet/packages.nix
+++ b/pkgs/development/compilers/dotnet/packages.nix
@@ -162,10 +162,13 @@ let
       runHook postInstall
     '';
 
-    ${if stdenvNoCC.isDarwin && lib.versionAtLeast version "10" then "postInstall" else null} = ''
-      mkdir -p "$out"/nix-support
-      cp "$src"/nix-support/manual-sdk-deps "$out"/nix-support/manual-sdk-deps
-    '';
+    ${
+      if stdenvNoCC.hostPlatform.isDarwin && lib.versionAtLeast version "10" then "postInstall" else null
+    } =
+      ''
+        mkdir -p "$out"/nix-support
+        cp "$src"/nix-support/manual-sdk-deps "$out"/nix-support/manual-sdk-deps
+      '';
 
     passthru = {
       inherit (vmr) icu targetRid hasILCompiler;

--- a/pkgs/development/compilers/elm/packages/node/node-composition.nix
+++ b/pkgs/development/compilers/elm/packages/node/node-composition.nix
@@ -18,7 +18,7 @@ let
       writeShellScript
       ;
     inherit pkgs nodejs;
-    libtool = if pkgs.stdenv.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
+    libtool = if pkgs.stdenv.hostPlatform.isDarwin then pkgs.cctools or pkgs.darwin.cctools else null;
   };
 in
 import ./node-packages.nix {

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -25,7 +25,7 @@ qtModule {
   ];
   strictDeps = true;
 
-  nativeBuildInputs = lib.optionals stdenv.isDarwin [
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.sigtool
   ];
 

--- a/pkgs/development/lisp-modules/imported.nix
+++ b/pkgs/development/lisp-modules/imported.nix
@@ -15922,7 +15922,7 @@ lib.makeScope pkgs.newScope (self: {
       meta = {
         hydraPlatforms = [ ];
         # darwin cannot find libpango.dylib
-        broken = stdenv.isDarwin;
+        broken = stdenv.hostPlatform.isDarwin;
       };
     }
   );
@@ -39541,7 +39541,7 @@ lib.makeScope pkgs.newScope (self: {
       meta = {
         hydraPlatforms = [ ];
         # darwin cannot find libpango.dylib
-        broken = stdenv.isDarwin;
+        broken = stdenv.hostPlatform.isDarwin;
       };
     }
   );

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -23,7 +23,7 @@ deployAndroidPackage {
       pkgs.ncurses5
       pkgs.libcxx
     ]
-    ++ lib.optionals (os == "linux" && stdenv.isx86_64) (
+    ++ lib.optionals (os == "linux" && stdenv.hostPlatform.isx86_64) (
       with pkgsi686Linux;
       [
         glibc

--- a/pkgs/development/php-packages/tideways/default.nix
+++ b/pkgs/development/php-packages/tideways/default.nix
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported platform for tideways-php: ${stdenvNoCC.hostPlatform.system}");
 
-  nativeBuildInputs = lib.optionals stdenvNoCC.isLinux [
+  nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
     autoPatchelfHook
   ];
 

--- a/pkgs/development/python-modules/cut-cross-entropy/default.nix
+++ b/pkgs/development/python-modules/cut-cross-entropy/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage {
       transformers
     ];
     # `deepspeed` is not yet packaged in nixpkgs
-    # ++ lib.optionals (!stdenv.isDarwin) [
+    # ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     #   deepspeed
     # ];
   };

--- a/pkgs/development/python-modules/fmpy/default.nix
+++ b/pkgs/development/python-modules/fmpy/default.nix
@@ -119,7 +119,7 @@ buildPythonPackage rec {
       cmakeConfigurePhase
       cmake --build native/src/build --config Release
     ''
-    + lib.optionalString (enableRemoting && stdenv.isLinux) ''
+    + lib.optionalString (enableRemoting && stdenv.hostPlatform.isLinux) ''
       # reimplementation of native/build_remoting.py
       cmakeFlags="-S native/remoting -B remoting/linux64 -D RPCLIB=${rpclib}"
       cmakeConfigurePhase

--- a/pkgs/development/python-modules/peft/default.nix
+++ b/pkgs/development/python-modules/peft/default.nix
@@ -71,7 +71,7 @@ buildPythonPackage rec {
   pytestFlagsArray = [ "tests" ];
 
   # These tests fail when MPS devices are detected
-  disabledTests = lib.optional stdenv.isDarwin [
+  disabledTests = lib.optional stdenv.hostPlatform.isDarwin [
     "gpu"
   ];
 

--- a/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
+++ b/pkgs/development/python-modules/prometheus-fastapi-instrumentator/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   ];
 
   # numerous test failures on Darwin
-  doCheck = stdenv.isLinux;
+  doCheck = stdenv.hostPlatform.isLinux;
 
   pythonImportsCheck = [ "prometheus_fastapi_instrumentator" ];
 

--- a/pkgs/development/python-modules/pygal/default.nix
+++ b/pkgs/development/python-modules/pygal/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
   __impureHostDeps = [ "/System/Library/Fonts" ];
 
   postCheck = ''
-    export LANG=${if stdenv.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
+    export LANG=${if stdenv.hostPlatform.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/smolagents/default.nix
+++ b/pkgs/development/python-modules/smolagents/default.nix
@@ -132,7 +132,7 @@ buildPythonPackage rec {
       "test_visit_webpage"
       "test_wikipedia_search"
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # Missing dependencies
       "test_get_mlx"
 

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -295,7 +295,7 @@ buildPythonPackage rec {
     lib.optionals cpuSupport [
       oneDNN
     ]
-    ++ lib.optionals (cpuSupport && stdenv.isLinux) [
+    ++ lib.optionals (cpuSupport && stdenv.hostPlatform.isLinux) [
       numactl
     ]
     ++ lib.optionals cudaSupport (

--- a/pkgs/servers/nextcloud/packages/apps/recognize.nix
+++ b/pkgs/servers/nextcloud/packages/apps/recognize.nix
@@ -10,7 +10,7 @@
   ffmpeg-headless,
 
   # Current derivation only supports linux-x86_64 (contributions welcome, without libTensorflow builtin webassembly can be used)
-  useLibTensorflow ? stdenv.isx86_64 && stdenv.isLinux,
+  useLibTensorflow ? stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isLinux,
 
   ncVersion,
 }:

--- a/pkgs/tools/system/uefitool/new-engine.nix
+++ b/pkgs/tools/system/uefitool/new-engine.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     zip
     wrapQtAppsHook
   ];
-  patches = lib.optionals stdenv.isDarwin [ ./bundle-destination.patch ];
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [ ./bundle-destination.patch ];
 
   meta = {
     description = "UEFI firmware image viewer and editor";


### PR DESCRIPTION
Repeat of #341407, part of #346453

I cherry picked this with `--patch`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
