### PR TITLE
sqlite: fix CVE-2025-29087

### DIFF
--- a/pkgs/development/libraries/sqlite/CVE-2025-29087.patch
+++ b/pkgs/development/libraries/sqlite/CVE-2025-29087.patch
@@ -1,0 +1,11 @@
+--- 1/sqlite3.c
++++ 2/sqlite3.c
+@@ -130218,7 +130218,7 @@ static void concatFuncCore(
+   for(i=0; i<argc; i++){
+     n += sqlite3_value_bytes(argv[i]);
+   }
+-  n += (argc-1)*nSep;
++  n += (argc-1)*(i64)nSep;
+   z = sqlite3_malloc64(n+1);
+   if( z==0 ){
+     sqlite3_result_error_nomem(context);

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-6WkTH5PKefvGTVdyShA1c1iBVVpSYA2+acaeq3LJ/NE=";
   };
 
+  patches = [ ./CVE-2025-29087.patch ];
+
   outputs = [
     "bin"
     "dev"


### PR DESCRIPTION
Backport upstream fix for CVE-2025-29087.
https://github.com/sqlite/sqlite/commit/f4fc2ee20311a0a5141726c71d318ab52001c974