### PR TITLE
openscad-unstable: 2025-05-17 -> 2025-06-04

### DIFF
--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -30,6 +30,7 @@
   libsForQt5,
   libspnav,
   libzip,
+  manifold,
   mesa,
   mpfr,
   python3,
@@ -45,12 +46,12 @@
 # clang consume much less RAM than GCC
 clangStdenv.mkDerivation rec {
   pname = "openscad-unstable";
-  version = "2025-05-17";
+  version = "2025-06-04";
   src = fetchFromGitHub {
     owner = "openscad";
     repo = "openscad";
-    rev = "c76900f9a62fcb98c503dcc5ccce380db8ac564b";
-    hash = "sha256-R2/8T5+BugVTRIUVLaz6SxKQ1YrtyAGbiE4K1Fuc6bg=";
+    rev = "65856c9330f8cc4ffcaccf03d91b4217f2eae28d";
+    hash = "sha256-jozcLFGVSfw8G12oSxHjqUyFtAfENgIByID+omk08mU=";
     fetchSubmodules = true; # Only really need sanitizers-cmake and MCAD and manifold
   };
 
@@ -87,7 +88,6 @@ clangStdenv.mkDerivation rec {
       eigen
       fontconfig
       freetype
-      ghostscript
       glib
       gmp
       opencsg
@@ -96,6 +96,7 @@ clangStdenv.mkDerivation rec {
       lib3mf
       libspnav
       libzip
+      manifold
       mpfr
       qscintilla
       qtbase
@@ -115,9 +116,7 @@ clangStdenv.mkDerivation rec {
     "-DEXPERIMENTAL=ON" # enable experimental options
     "-DSNAPSHOT=ON" # nightly icons
     "-DUSE_BUILTIN_OPENCSG=OFF"
-    # use builtin manifold: 3.1.0 doesn't pass tests, builtin is 7c8fbe1, between 3.0.1 and 3.1.0
-    # FIXME revisit on version update
-    "-DUSE_BUILTIN_MANIFOLD=ON"
+    "-DUSE_BUILTIN_MANIFOLD=OFF"
     "-DUSE_BUILTIN_CLIPPER2=OFF"
     "-DOPENSCAD_VERSION=\"${builtins.replaceStrings [ "-" ] [ "." ] version}\""
     "-DCMAKE_UNITY_BUILD=OFF" # broken compile with unity
@@ -150,14 +149,10 @@ clangStdenv.mkDerivation rec {
   nativeCheckInputs = [
     mesa.llvmpipeHook
     ctestCheckHook
+    ghostscript
   ];
 
   dontUseNinjaCheck = true;
-  checkFlags = [
-    "-E"
-    # some fontconfig issues cause pdf output to have wrong font
-    "pdfexporttest"
-  ];
 
   meta = with lib; {
     description = "3D parametric model compiler (unstable)";


### PR DESCRIPTION
Fixes: #409975
Reverts manifold change of #409444, upstream update is merged: https://github.com/openscad/openscad/pull/5914

I also re-enabled tests that now pass.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).