### PR TITLE
blackhole: init at 0.6.1

### DIFF
--- a/pkgs/by-name/bl/blackhole/package.nix
+++ b/pkgs/by-name/bl/blackhole/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  xcbuildHook,
+  apple-sdk,
+  nix-update-script,
+  channel ? "256ch",
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "blackhole";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "existentialaudio";
+    repo = "BlackHole";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jFKi5LJdTOMFa1mErH6WsjgCtLCKzwpgn2+T3Fp9MtQ=";
+  };
+
+  nativeBuildInputs = [
+    xcbuildHook
+  ];
+
+  buildInputs = [ apple-sdk ];
+
+  bundleId = "audio.existential.BlackHole${channel}";
+  xcbuildFlags = [
+    "-project"
+    "BlackHole.xcodeproj"
+    "-configuration"
+    "Release"
+    "PRODUCT_BUNDLE_IDENTIFIER=${finalAttrs.bundleId}"
+    "GCC_PREPROCESSOR_DEFINITIONS=$GCC_PREPROCESSOR_DEFINITIONS kDriver_Name=\\\"blackhole${channel}\\\" kPlugIn_BundleID=\\\"${finalAttrs.bundleId}\\\" kPlugIn_Icon=\\\"BlackHole.icns\\\""
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Library/Audio/Plug-Ins/HAL
+    mv Products/Release/BlackHole.driver $out/Library/Audio/Plug-Ins/HAL/Blackhole${channel}.driver
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Virtual audio driver for macOS";
+    homepage = "https://existential.audio/blackhole";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ eveeifyeve ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

BlackHole a virtual audio driver to route audio through.

Homepage: https://existential.audio/blackhole/
Github: https://github.com/ExistentialAudio/BlackHole

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
