### PR TITLE
electron{-source,-bin,-chromedriver}: updates

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -12,14 +12,14 @@
     },
     "34": {
         "hashes": {
-            "aarch64-darwin": "5d9bba193dd522548da5c9289eae79016f053cefad77d0540e8412f1318462a8",
-            "aarch64-linux": "65e4c5fbbf452378664777696727384853ca4de699da7c84ac39463d8d0e7de9",
-            "armv7l-linux": "cd3dbedf798ddfcd28f3931b8d2214ee49af8a753c21b16d4068edad44dba2ef",
+            "aarch64-darwin": "56c27f79c298bd21f6a0434b70776633ce9971667edf22783b4b3f0051646248",
+            "aarch64-linux": "2172a9fa02331ba9c645dd6a6c5c6c07235e902c0aebb61b123d2f6c3ea0121f",
+            "armv7l-linux": "03514c1e42d4215972add90eb828221aec29278113ecf6761ec014aee92b3c4e",
             "headers": "0gxibckgmbvbr84469fvl1f32aw1hbycnsj1lz5cmx196rpdj0r6",
-            "x86_64-darwin": "8171d8f26305eb01001ddb2d8ff6c922a6142378e1cdac8d5cc72f727bd4e6b6",
-            "x86_64-linux": "0ad6461a74c6bb7ef076ee4b2f5c22801ea1efb585d716b01ba499d9158d34e5"
+            "x86_64-darwin": "fb13c7bf7f01529e0084433166f6b66b149407d8f950ca176fde20f023ee64b6",
+            "x86_64-linux": "da78b040068b6f0d41b3ccc5e5d26f1130bcdeba83f23ebbdae416c26bcf80e2"
         },
-        "version": "34.5.7"
+        "version": "34.5.8"
     },
     "35": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -34,13 +34,13 @@
     },
     "36": {
         "hashes": {
-            "aarch64-darwin": "2b51b3001a0e79d9130a379d5276b87c22c054ddf4f19413fd9e0aa2983b4a9e",
-            "aarch64-linux": "0e68a05932d1c662ec8c33a2773aea5575eae1081514cf6ce1c4efe331b772bf",
-            "armv7l-linux": "216d0c8b6a76ef78e7c3b82a45cda251e5d6b038de89bc62f32a7317590d3995",
-            "headers": "1s0didlyil9vzxjkmnf49h7k99319l71m37fdz6zj45v5dnqqj7g",
-            "x86_64-darwin": "460d54a596a3a8a04c6414fb7866e453b7075c1a848bc3230aa01b6d566e8b03",
-            "x86_64-linux": "d124c39544faf125f45f3adccf83e53ca23589d9f35115f69644cfc5c8133e4e"
+            "aarch64-darwin": "33744982d4f182df72b8b22c20fc83942a1bdadcd2358deb83000ca578dd767d",
+            "aarch64-linux": "27bf37e1cecc7683575140730cbcd4e1b0847bace2d5a705c69e6d1bcd1c0f4c",
+            "armv7l-linux": "5953b7f3747d657334b07bc47971cdbfa1b37ef807e21ef5001637aaaa43f635",
+            "headers": "0zww9rwrvi6g5vjpmxsvp1cqqkmx9rnl6yzwba8kyvyapk5daz8d",
+            "x86_64-darwin": "4d33e24a87df1f839053eba4dc8500026df46cc62b7e57c39d5ec2edecddab91",
+            "x86_64-linux": "d2ef32b2bff3fe2594774fca81abda8d617d5f6c0c40529e39900296309e4a3c"
         },
-        "version": "36.3.2"
+        "version": "36.4.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -23,14 +23,14 @@
     },
     "35": {
         "hashes": {
-            "aarch64-darwin": "03b2926356c6cf8718b2d62ee8dd1eaa0812c1f44c5a751c332401dd2867aa47",
-            "aarch64-linux": "9e98b01d5c6611437e8eecece093307e3e59733bb64c068fc3f9bd226b92238d",
-            "armv7l-linux": "3072f6865c6f0202d4059224cb43ecab27f03852025addf09a4fa1b6606cb80c",
-            "headers": "0wspga950dap8wk6ak2idsmp8irjn4xaxq431vxr5ik6r07zn89b",
-            "x86_64-darwin": "3cfff8110bd11d2b3c342b56674d3fd5863698d8413a2a97be80169f61e23ddf",
-            "x86_64-linux": "4e9d927a8edecf59dde02b98fe6bfde64814141898650ca1c69820ae0edbcfa4"
+            "aarch64-darwin": "3d2759f9ba2201a22c9ea2bc2cc2b2392d00b5584a613c82f0fe2493b2c7c108",
+            "aarch64-linux": "d3338afa395d2eb9eef1a96278e6ced8aeec87c59e3eff754efdc02325b27c2f",
+            "armv7l-linux": "d73dbb4e39f21d8fcca98b59b278a3ea53728f5d0c469dcf0b88a67b4b2b50c3",
+            "headers": "00r5swhxsv7bj8k35ymmprp1mvz337f066jhh1xsh437b1abvscp",
+            "x86_64-darwin": "87b6abd92012904e2b8cf96062657e4ab9b93d60194da88f44b7d84ca281e847",
+            "x86_64-linux": "8eeaaf8035e471d4c0f4519765feb383c164168d95659d349f36d906dec02fb5"
         },
-        "version": "35.5.0"
+        "version": "35.5.1"
     },
     "36": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -23,14 +23,14 @@
     },
     "35": {
         "hashes": {
-            "aarch64-darwin": "511a3c6a6b6032985224bcbc1c4884f8673f7573bde7f3919e9797d6645b53c4",
-            "aarch64-linux": "25923b319e958285847d4e5c154eb7877b49380042a20c781185d8b6eb558afa",
-            "armv7l-linux": "d67750b53d37699ade36ebe1912bd72b64af6e825d2d0ac5095531a0b84b191d",
-            "headers": "0wspga950dap8wk6ak2idsmp8irjn4xaxq431vxr5ik6r07zn89b",
-            "x86_64-darwin": "c995faf74d2d7e5b6000b8a1e9551d60e396a19a29796608a090417388a9dd1a",
-            "x86_64-linux": "a1ef549561d64a9d10c1e658f8e86cd735d4261f0c4fc871d8c342240c23d9e0"
+            "aarch64-darwin": "20f78c2d699cdfb676afe06984bce966be143755e5be6b36a7a16ceb950861d4",
+            "aarch64-linux": "1f5442d17ad795ff7e8132b20d0e31dc6c9b275a86011f9827cc1b37c9d7a191",
+            "armv7l-linux": "a384606f04e08ce777d0eb4810cbcda036c4c94fb4ccf5388f9a65a565b28c65",
+            "headers": "00r5swhxsv7bj8k35ymmprp1mvz337f066jhh1xsh437b1abvscp",
+            "x86_64-darwin": "efbc881a7599c5f250f57193d98ad08124e9f678467bc3c0977b694d3a557862",
+            "x86_64-linux": "1929735f9c3c862bad6ed90edce811f25a38daa9e9a77d49c8d39ce309fd499d"
         },
-        "version": "35.5.0"
+        "version": "35.5.1"
     },
     "36": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -12,14 +12,14 @@
     },
     "34": {
         "hashes": {
-            "aarch64-darwin": "f8d82b6fde28011e3fd75410fe0d9141deeac78a9a3754f3e9e517b485f75b52",
-            "aarch64-linux": "1a65ef666f61c695bf92c7beb52ea9ec70e105d822363ade0998277d19e5cd01",
-            "armv7l-linux": "bfa62551c5ef52f907ebb52004504b083a075d6f6582c1ef41dd180873d86518",
+            "aarch64-darwin": "a3078146762ff67f27dd97470a9d2b4b5a04c182c6fcc5c949303e9a666b8d73",
+            "aarch64-linux": "b0a9aa381fb4b12822408d8ca668b64cbc67c1b18b8a4e5dedd2d0ad7b3513f9",
+            "armv7l-linux": "61a62d8b3d5604a098dc03cac7c89a325ff478d896921e286aabfd22735c64b1",
             "headers": "0gxibckgmbvbr84469fvl1f32aw1hbycnsj1lz5cmx196rpdj0r6",
-            "x86_64-darwin": "5dff162e53b4c5200b581cd4e3d93a9d5aec31bd3d69b7ede7d2a697daee7f97",
-            "x86_64-linux": "8fad178d82cc5e65fa18061f213f6d071e2ae1d773824e18703006dab18acf95"
+            "x86_64-darwin": "aa2ac2aa0dbe410ca152e85ceaf5baeb2cccb28bac7b52b866468edd5e6eb113",
+            "x86_64-linux": "1a6b534f65c47d2e839f5da0efeeb449cebe622e731b624ccc8c91f493eeec4f"
         },
-        "version": "34.5.7"
+        "version": "34.5.8"
     },
     "35": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,13 +34,13 @@
     },
     "36": {
         "hashes": {
-            "aarch64-darwin": "dbbfe5a72cdce199204c32039e5cf38992dd4a5bde95d9a1f351a130fadde340",
-            "aarch64-linux": "ffacf585beb157ab6e2607ac0d288d8cac979f73f08355a50c2244a700272ec1",
-            "armv7l-linux": "d7e290f616e8a7ba2d3b9463939e7b48e3b7f49727483424f3b06ecf7d1bebc6",
-            "headers": "1s0didlyil9vzxjkmnf49h7k99319l71m37fdz6zj45v5dnqqj7g",
-            "x86_64-darwin": "d1dbd94952411b0663f9da05c1c5938d87f4498c798b4b90c7db21bc311329f1",
-            "x86_64-linux": "54296abbcc99416528555113ec0871f230eef5492304827a1208591457d6968a"
+            "aarch64-darwin": "54580cb9d22b469c6eedb5a95b0f499c90e5efb79939dbe401a92461bf2ffda2",
+            "aarch64-linux": "05499a412299c811357250d00beb26c72e0e8abe9bb1c2dbbc23262399821a9e",
+            "armv7l-linux": "4296a52873910c65612e45eba86a6967033b4ee5442eb97ffb8d311eab0e5b1e",
+            "headers": "0zww9rwrvi6g5vjpmxsvp1cqqkmx9rnl6yzwba8kyvyapk5daz8d",
+            "x86_64-darwin": "971dcef573297e05befc8c8618ea5ac38501945e9cee5bf7d49e5a66718cf7b5",
+            "x86_64-linux": "215623fd1736752f70a273a2ea591a8ce0a63a3c4305866cc30c80505aadc5ca"
         },
-        "version": "36.3.2"
+        "version": "36.4.0"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -57,10 +57,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-V393R2leEFjj337xVnqo9hlSn7rq44n2PnLcaUrYQ4M=",
+                    "hash": "sha256-ABlVuW0EUsFUyuIaugoI09EsHF+g7fxRSS/bOaOAkjg=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v34.5.7"
+                    "tag": "v34.5.8"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -1274,7 +1274,7 @@
         "electron_yarn_hash": "0gh5bcsh23s3rqxqc2l3jz5vjb553sk0a1jycn94zm821pc3csd2",
         "modules": "132",
         "node": "20.19.1",
-        "version": "34.5.7"
+        "version": "34.5.8"
     },
     "35": {
         "chrome": "134.0.6998.205",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1334,10 +1334,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-+Kj09hzwmAs5UvzV2wkBY4pPJDDNNmdIcjWXAbfrwz0=",
+                    "hash": "sha256-jIEeMTY8D4o2cCmk2RupGKu9HTVFjNI+90QZlXNrOWM=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v35.5.0"
+                    "tag": "v35.5.1"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2583,7 +2583,7 @@
         "electron_yarn_hash": "1p9gs8s1zhwxvvmi9zb76k5nn1wly4yq0i12ibr0wvw5ls8bbars",
         "modules": "133",
         "node": "22.15.1",
-        "version": "35.5.0"
+        "version": "35.5.1"
     },
     "36": {
         "chrome": "136.0.7103.115",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2586,7 +2586,7 @@
         "version": "35.5.1"
     },
     "36": {
-        "chrome": "136.0.7103.115",
+        "chrome": "136.0.7103.149",
         "chromium": {
             "deps": {
                 "gn": {
@@ -2596,15 +2596,15 @@
                     "version": "2025-03-24"
                 }
             },
-            "version": "136.0.7103.115"
+            "version": "136.0.7103.149"
         },
         "chromium_npm_hash": "sha256-QRjk9X4rJW3ofizK33R4T1qym1riqcnpBhDF+FfNZLo=",
         "deps": {
             "src": {
                 "args": {
-                    "hash": "sha256-yUWNV65TshvAMaz1kGOUQuy+J5vXPryjisGN3MxTU9Q=",
+                    "hash": "sha256-qu3+U2o7N0MSx+nifQMAfSEjxTDIBSz/DNkEZdo5uFw=",
                     "postFetch": "rm -r $out/third_party/blink/web_tests; rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                    "tag": "136.0.7103.115",
+                    "tag": "136.0.7103.149",
                     "url": "https://chromium.googlesource.com/chromium/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -2643,10 +2643,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-bMQJfOkWRFE7Qg4kHiwkNcuXOSWU0EzEGSo8U1SuGTQ=",
+                    "hash": "sha256-DwV8hZ6iK1Pc0j/86UnrkJ6FhOXD3eCBiOk5Y14N4jg=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v36.3.2"
+                    "tag": "v36.4.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -3898,8 +3898,8 @@
             },
             "src/v8": {
                 "args": {
-                    "hash": "sha256-Fi4pl6xSXkHF4XaQNfNzULVjQZSzDfaHFIyIxH103go=",
-                    "rev": "5297e56d91816747d539abca52b578e5832135f0",
+                    "hash": "sha256-COlRcmBtuP/XBe9j4Qxikkz7ZSwcQhcWVe5+I0++OOk=",
+                    "rev": "150f01318cda02f1ef63dd79672eae6c81dd3301",
                     "url": "https://chromium.googlesource.com/v8/v8.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3908,6 +3908,6 @@
         "electron_yarn_hash": "10n86jnzcq8kh0nk29ljw9wi1fgj13f07h92b009i1dryagliyrs",
         "modules": "135",
         "node": "22.15.1",
-        "version": "36.3.2"
+        "version": "36.4.0"
     }
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/electron/electron/releases/tag/v34.5.8
https://github.com/electron/electron/releases/tag/v35.5.1
https://github.com/electron/electron/releases/tag/v36.4.0

Security fix for [CVE-2025-5419](https://github.com/advisories/GHSA-x828-wp24-7h9m)

Commands used to update:
```
pkgs/development/tools/electron/update.py update-all --commit
pkgs/development/tools/electron/binary/update.py update-all --commit
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
