### PR TITLE
gentium: 6.200 -> 7.000

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -16,6 +16,7 @@
 - The `offrss` package was removed due to lack of upstream maintenance since 2012. It's recommended for users to migrate to another RSS reader
 
 - `base16-builder` node package has been removed due to lack of upstream maintenance.
+- `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by sil](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.
 
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2645,6 +2645,11 @@
     githubId = 9315;
     name = "Zhong Jianxin";
   };
+  b-fein = {
+    github = "b-fein";
+    githubId = 64250573;
+    name = "Benedikt Fein";
+  };
   b-m-f = {
     email = "maximilian@sodawa.com";
     github = "b-m-f";

--- a/nixos/tests/fontconfig-default-fonts.nix
+++ b/nixos/tests/fontconfig-default-fonts.nix
@@ -15,10 +15,10 @@
         cantarell-fonts
         twitter-color-emoji
         source-code-pro
-        gentium-plus
+        gentium
       ];
       fonts.fontconfig.defaultFonts = {
-        serif = [ "Gentium Plus" ];
+        serif = [ "Gentium" ];
         sansSerif = [ "Cantarell" ];
         monospace = [ "Source Code Pro" ];
         emoji = [ "Twitter Color Emoji" ];
@@ -26,7 +26,7 @@
     };
 
   testScript = ''
-    machine.succeed("fc-match serif | grep '\"Gentium Plus\"'")
+    machine.succeed("fc-match serif | grep '\"Gentium\"'")
     machine.succeed("fc-match sans-serif | grep '\"Cantarell\"'")
     machine.succeed("fc-match monospace | grep '\"Source Code Pro\"'")
     machine.succeed("fc-match emoji | grep '\"Twitter Color Emoji\"'")

--- a/nixos/tests/fontconfig-default-fonts.nix
+++ b/nixos/tests/fontconfig-default-fonts.nix
@@ -15,7 +15,7 @@
         cantarell-fonts
         twitter-color-emoji
         source-code-pro
-        gentium
+        gentium-plus
       ];
       fonts.fontconfig.defaultFonts = {
         serif = [ "Gentium Plus" ];

--- a/pkgs/by-name/ge/gentium-book/package.nix
+++ b/pkgs/by-name/ge/gentium-book/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gentium-book";
+  version = "7.000";
+
+  src = fetchzip {
+    url = "http://software.sil.org/downloads/r/gentium/GentiumBook-${finalAttrs.version}.zip";
+    hash = "sha256-A/QZX8OYrifaxChC08SNOaspdnSr8PxOtYgFAwUc5WY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 FONTLOG.txt README.txt -t $out/share/doc/${finalAttrs.pname}-${finalAttrs.version}
+    cp -r documentation $out/share/doc/${finalAttrs.pname}-${finalAttrs.version}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://software.sil.org/gentium/";
+    description = "High-quality typeface family for Latin, Cyrillic, and Greek";
+    longDescription = ''
+      Gentium is a typeface family designed to enable the diverse ethnic groups
+      around the world who use the Latin, Cyrillic and Greek scripts to produce
+      readable, high-quality publications. It supports a wide range of Latin and
+      Cyrillic-based alphabets.
+
+      The design is intended to be highly readable, reasonably compact, and
+      visually attractive. The additional ‘extended’ Latin letters are designed
+      to naturally harmonize with the traditional 26 ones. Diacritics are
+      treated with careful thought and attention to their use. Gentium also
+      supports both polytonic and monotonic Greek.
+
+      This package contains the regular and italic styles for the Gentium Book
+      font family, along with documentation.
+    '';
+    downloadPage = "https://software.sil.org/gentium/download/";
+    maintainers = with lib.maintainers; [
+      b-fein
+      raskin
+      rycee
+    ];
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ge/gentium-plus/package.nix
+++ b/pkgs/by-name/ge/gentium-plus/package.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "gentium";
+  pname = "gentium-plus";
   version = "6.200";
 
   src = fetchzip {

--- a/pkgs/by-name/ge/gentium/package.nix
+++ b/pkgs/by-name/ge/gentium/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gentium";
+  version = "7.000";
+
+  src = fetchzip {
+    url = "http://software.sil.org/downloads/r/gentium/Gentium-${finalAttrs.version}.zip";
+    hash = "sha256-RBBecFdi/yyFfBk1CcQebOuAdKNUczpwOP52zVtbc2o=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 *.ttf -t $out/share/fonts/truetype
+    install -Dm644 FONTLOG.txt README.txt -t $out/share/doc/${finalAttrs.pname}-${finalAttrs.version}
+    cp -r documentation $out/share/doc/${finalAttrs.pname}-${finalAttrs.version}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://software.sil.org/gentium/";
+    description = "High-quality typeface family for Latin, Cyrillic, and Greek";
+    longDescription = ''
+      Gentium is a typeface family designed to enable the diverse ethnic groups
+      around the world who use the Latin, Cyrillic and Greek scripts to produce
+      readable, high-quality publications. It supports a wide range of Latin and
+      Cyrillic-based alphabets.
+
+      The design is intended to be highly readable, reasonably compact, and
+      visually attractive. The additional ‘extended’ Latin letters are designed
+      to naturally harmonize with the traditional 26 ones. Diacritics are
+      treated with careful thought and attention to their use. Gentium also
+      supports both polytonic and monotonic Greek.
+
+      This package contains the regular and italic styles for the Gentium font
+      family, along with documentation.
+    '';
+    downloadPage = "https://software.sil.org/gentium/download/";
+    maintainers = with lib.maintainers; [
+      b-fein
+      raskin
+      rycee
+    ];
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ge/gentium/package.nix
+++ b/pkgs/by-name/ge/gentium/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "gentium";
   version = "6.200";
 
   src = fetchzip {
-    url = "http://software.sil.org/downloads/r/gentium/GentiumPlus-${version}.zip";
+    url = "http://software.sil.org/downloads/r/gentium/GentiumPlus-${finalAttrs.version}.zip";
     hash = "sha256-gpVOtmF4Kp3y1Rm00c4o3WQEskO7mY1Z5SVaYHI0hzg=";
   };
 
@@ -17,8 +17,8 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
 
     install -Dm644 *.ttf -t $out/share/fonts/truetype
-    install -Dm644 FONTLOG.txt README.txt -t $out/share/doc/${pname}-${version}
-    cp -r documentation $out/share/doc/${pname}-${version}
+    install -Dm644 FONTLOG.txt README.txt -t $out/share/doc/${finalAttrs.pname}-${finalAttrs.version}
+    cp -r documentation $out/share/doc/${finalAttrs.pname}-${finalAttrs.version}
 
     runHook postInstall
   '';
@@ -49,4 +49,4 @@ stdenvNoCC.mkDerivation rec {
     license = licenses.ofl;
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ge/gentium/package.nix
+++ b/pkgs/by-name/ge/gentium/package.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://software.sil.org/gentium/";
     description = "High-quality typeface family for Latin, Cyrillic, and Greek";
     longDescription = ''
@@ -42,11 +42,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       font family, along with documentation.
     '';
     downloadPage = "https://software.sil.org/gentium/download/";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       raskin
       rycee
     ];
-    license = licenses.ofl;
-    platforms = platforms.all;
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ho/hottext/package.nix
+++ b/pkgs/by-name/ho/hottext/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildNimPackage,
   fetchFromSourcehut,
-  gentium,
+  gentium-plus,
   makeDesktopItem,
 }:
 
@@ -19,7 +19,7 @@ buildNimPackage (finalAttrs: {
 
   lockFile = ./lock.json;
 
-  HOTTEXT_FONT_PATH = "${gentium}/share/fonts/truetype/GentiumPlus-Regular.ttf";
+  HOTTEXT_FONT_PATH = "${gentium-plus}/share/fonts/truetype/GentiumPlus-Regular.ttf";
 
   desktopItem = makeDesktopItem {
     categories = [ "Utility" ];

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -20,7 +20,7 @@
   libiconv,
   # FONTCONFIG_FILE
   makeFontsConf,
-  gentium,
+  gentium-plus,
 
   # passthru.tests
   runCommand,
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   FONTCONFIG_FILE = makeFontsConf {
     fontDirectories = [
-      gentium
+      gentium-plus
     ];
   };
   strictDeps = true;


### PR DESCRIPTION
Updates the Gentium font package to version 7.
* The upstream package got renamed from ‘Gentium Plus’ to just ‘Gentium’. Our package was named ‘Gentium’ anyway, so no changes here apart from the description.
  * To avoid breaking other packages the depend on the name of the font (hottext, sile), I renamed the old `gentium` package to `gentium-plus` which remains at the previous version (similar to the `gentium-book-basic` package).
* The ‘Gentium Book’ variant of the font was split upstream into a separate download. This is reflected here by a separate package, too.

rel: https://github.com/silnrsi/font-gentium/releases/tag/v7.000

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
