### PR TITLE
python3Packages.google-{auth-httplib2,api-python-client,api-core,search-results,i18n-address,cloud-core}: cleanup, add maintainer

### DIFF
--- a/pkgs/development/python-modules/google-api-core/default.nix
+++ b/pkgs/development/python-modules/google-api-core/default.nix
@@ -12,7 +12,6 @@
   protobuf,
   pytest-asyncio,
   pytestCheckHook,
-  pythonOlder,
   requests,
   setuptools,
 }:
@@ -21,8 +20,6 @@ buildPythonPackage rec {
   pname = "google-api-core";
   version = "2.24.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "googleapis";
@@ -79,15 +76,15 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "google.api_core" ];
 
-  meta = with lib; {
+  meta = {
     description = "Core Library for Google Client Libraries";
     longDescription = ''
       This library is not meant to stand-alone. Instead it defines common
       helpers used by all Google API clients.
     '';
     homepage = "https://github.com/googleapis/python-api-core";
-    changelog = "https://github.com/googleapis/python-api-core/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = [ ];
+    changelog = "https://github.com/googleapis/python-api-core/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.sarahec ];
   };
 }

--- a/pkgs/development/python-modules/google-api-python-client/default.nix
+++ b/pkgs/development/python-modules/google-api-python-client/default.nix
@@ -8,15 +8,12 @@
   httplib2,
   uritemplate,
   setuptools,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "google-api-python-client";
   version = "2.166.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "google_api_python_client";
@@ -39,7 +36,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "googleapiclient" ];
 
-  meta = with lib; {
+  meta = {
     description = "Official Python client library for Google's discovery based APIs";
     longDescription = ''
       These client libraries are officially supported by Google. However, the
@@ -49,7 +46,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/google/google-api-python-client";
     changelog = "https://github.com/googleapis/google-api-python-client/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.sarahec ];
   };
 }

--- a/pkgs/development/python-modules/google-auth-httplib2/default.nix
+++ b/pkgs/development/python-modules/google-auth-httplib2/default.nix
@@ -8,15 +8,12 @@
   mock,
   pytest-localserver,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "google-auth-httplib2";
   version = "0.2.0";
   format = "setuptools";
-
-  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -37,11 +34,16 @@ buildPythonPackage rec {
     pytest-localserver
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Google Authentication Library: httplib2 transport";
+    longDescription = ''
+      The library was created to help clients migrate from oauth2client to google-auth,
+      however this library is no longer maintained. For any new usages please see
+      provided transport layers by google-auth library
+    '';
     homepage = "https://github.com/GoogleCloudPlatform/google-auth-library-python-httplib2";
     changelog = "https://github.com/googleapis/google-auth-library-python-httplib2/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.sarahec ];
   };
 }

--- a/pkgs/development/python-modules/google-cloud-core/default.nix
+++ b/pkgs/development/python-modules/google-cloud-core/default.nix
@@ -49,11 +49,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "google.cloud" ];
 
-  meta = with lib; {
+  meta = {
     description = "API Client library for Google Cloud: Core Helpers";
     homepage = "https://github.com/googleapis/python-cloud-core";
     changelog = "https://github.com/googleapis/python-cloud-core/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = [ ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.sarahec ];
   };
 }

--- a/pkgs/development/python-modules/google-i18n-address/default.nix
+++ b/pkgs/development/python-modules/google-i18n-address/default.nix
@@ -5,15 +5,12 @@
   hatchling,
   requests,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "google-i18n-address";
   version = "3.1.1";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "mirumee";
@@ -30,12 +27,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "i18naddress" ];
 
-  meta = with lib; {
+  meta = {
     description = "Google's i18n address data packaged for Python";
     homepage = "https://github.com/mirumee/google-i18n-address";
-    changelog = "https://github.com/mirumee/google-i18n-address/releases/tag/${version}";
-    license = licenses.bsd3;
-    maintainers = [ ];
+    changelog = "https://github.com/mirumee/google-i18n-address/releases/tag/${src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.sarahec ];
     mainProgram = "update-validation-files";
   };
 }

--- a/pkgs/development/python-modules/google-search-results/default.nix
+++ b/pkgs/development/python-modules/google-search-results/default.nix
@@ -32,6 +32,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/serpapi/google-search-results-python";
     changelog = "https://github.com/serpapi/google-search-results-python/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ natsukium ];
+    maintainers = with lib.maintainers; [
+      natsukium
+      sarahec
+    ];
   };
 }


### PR DESCRIPTION
Removed outdated `pythonOlder` and `with lib;`; modernized builds, added self as maintainer as needed.

No binary changes here, just the start of a systematic review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
