### PR TITLE
parsedmarc: 8.18.1 -> 8.18.5

### DIFF
--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -1,24 +1,28 @@
 {
   lib,
+  buildPythonPackage,
+  fetchPypi,
+  fetchurl,
+
+  # build-system
+  hatchling,
+
+  # dependencies
   azure-identity,
   azure-monitor-ingestion,
   boto3,
-  buildPythonPackage,
   dateparser,
   dnspython,
   elastic-transport,
-  elasticsearch,
   elasticsearch-dsl,
+  elasticsearch,
   expiringdict,
-  fetchPypi,
-  fetchurl,
   geoip2,
   google-api-core,
   google-api-python-client,
-  google-auth,
   google-auth-httplib2,
   google-auth-oauthlib,
-  hatchling,
+  google-auth,
   imapclient,
   kafka-python-ng,
   lxml,
@@ -28,7 +32,6 @@
   opensearch-py,
   publicsuffixlist,
   pygelf,
-  pythonOlder,
   requests,
   tqdm,
   xmltodict,
@@ -45,14 +48,12 @@ buildPythonPackage rec {
   version = "8.18.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-qE/WMovVlB9u0lyVl3HapHzvhG+fGTC+6DDBUKRU/2w=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
@@ -61,7 +62,7 @@ buildPythonPackage rec {
     "elasticsearch-dsl"
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     azure-identity
     azure-monitor-ingestion
     boto3
@@ -82,12 +83,12 @@ buildPythonPackage rec {
     lxml
     mailsuite
     msgraph-core
+    opensearch-py
     publicsuffixlist
     pygelf
     requests
     tqdm
     xmltodict
-    opensearch-py
   ];
 
   # no tests on PyPI, no tags on GitHub
@@ -101,14 +102,14 @@ buildPythonPackage rec {
     tests = nixosTests.parsedmarc;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Python module and CLI utility for parsing DMARC reports";
     homepage = "https://domainaware.github.io/parsedmarc/";
     changelog = "https://github.com/domainaware/parsedmarc/blob/master/CHANGELOG.md#${
       lib.replaceStrings [ "." ] [ "" ] version
     }";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ talyz ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ talyz ];
     mainProgram = "parsedmarc";
     # https://github.com/domainaware/parsedmarc/issues/464
     broken = lib.versionAtLeast msgraph-core.version "1.0.0";

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -48,14 +48,14 @@ let
 in
 buildPythonPackage rec {
   pname = "parsedmarc";
-  version = "8.18.1";
+  version = "8.18.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "domainaware";
     repo = "parsedmarc";
     tag = version;
-    hash = "sha256-PndhtbZgN4q23v8flPU7uKRsxnN9MR/JaaVfecwEA54=";
+    hash = "sha256-y8wFR9UN1u/IDYiKB+8PrN8c0YCgagxUr7CeAbQWdtg=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   fetchurl,
 
   # build-system
@@ -35,6 +35,9 @@
   requests,
   tqdm,
   xmltodict,
+
+  # test
+  unittestCheckHook,
 }:
 
 let
@@ -48,9 +51,11 @@ buildPythonPackage rec {
   version = "8.18.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-qE/WMovVlB9u0lyVl3HapHzvhG+fGTC+6DDBUKRU/2w=";
+  src = fetchFromGitHub {
+    owner = "domainaware";
+    repo = "parsedmarc";
+    tag = version;
+    hash = "sha256-PndhtbZgN4q23v8flPU7uKRsxnN9MR/JaaVfecwEA54=";
   };
 
   build-system = [
@@ -91,9 +96,9 @@ buildPythonPackage rec {
     xmltodict
   ];
 
-  # no tests on PyPI, no tags on GitHub
-  # https://github.com/domainaware/parsedmarc/issues/426
-  doCheck = false;
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
 
   pythonImportsCheck = [ "parsedmarc" ];
 
@@ -105,9 +110,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python module and CLI utility for parsing DMARC reports";
     homepage = "https://domainaware.github.io/parsedmarc/";
-    changelog = "https://github.com/domainaware/parsedmarc/blob/master/CHANGELOG.md#${
-      lib.replaceStrings [ "." ] [ "" ] version
-    }";
+    changelog = "https://github.com/domainaware/parsedmarc/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ talyz ];
     mainProgram = "parsedmarc";


### PR DESCRIPTION
diff: https://github.com/domainaware/parsedmarc/compare/8.18.1...8.18.5

1. fetchPyPi -> fetchFromGitHub
2. Enabled unit tests (basically smoke tests)
3. Bumped to 8.18.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
