### PR TITLE
nixosTests/fscrypt: f2fs auxiliary mount test

### DIFF
--- a/nixos/tests/fscrypt.nix
+++ b/nixos/tests/fscrypt.nix
@@ -36,19 +36,19 @@
           machine.succeed("echo foobar | fscrypt encrypt --skip-unlock --source=pam_passphrase --user=alice /home/alice")
 
       with subtest("Create file as alice"):
-        login_as_alice()
-        machine.succeed("echo hello > /home/alice/world")
-        logout()
-        # Wait for logout to be processed
-        machine.sleep(1)
+          login_as_alice()
+          machine.succeed("echo hello > /home/alice/world")
+          logout()
+          # Wait for logout to be processed
+          machine.sleep(1)
 
       with subtest("File should not be readable without being logged in as alice"):
-        machine.fail("cat /home/alice/world")
+          machine.fail("cat /home/alice/world")
 
       with subtest("File should be readable again as alice"):
-        login_as_alice()
-        assert "Unlocked: Yes" in machine.succeed("fscrypt status /home/alice")
-        assert "hello" in machine.succeed("cat /home/alice/world")
-        logout()
+          login_as_alice()
+          assert "Unlocked: Yes" in machine.succeed("fscrypt status /home/alice")
+          assert "hello" in machine.succeed("cat /home/alice/world")
+          logout()
     '';
 }

--- a/nixos/tests/fscrypt.nix
+++ b/nixos/tests/fscrypt.nix
@@ -9,44 +9,45 @@
       security.pam.enableFscrypt = true;
     };
 
-  testScript = ''
-    def login_as_alice():
-        machine.wait_until_tty_matches("1", "login: ")
-        machine.send_chars("alice\n")
-        machine.wait_until_tty_matches("1", "Password: ")
-        machine.send_chars("foobar\n")
-        machine.wait_until_tty_matches("1", "alice\@machine")
+  testScript = # python
+    ''
+      def login_as_alice():
+          machine.wait_until_tty_matches("1", "login: ")
+          machine.send_chars("alice\n")
+          machine.wait_until_tty_matches("1", "Password: ")
+          machine.send_chars("foobar\n")
+          machine.wait_until_tty_matches("1", "alice\@machine")
 
 
-    def logout():
-        machine.send_chars("logout\n")
-        machine.wait_until_tty_matches("1", "login: ")
+      def logout():
+          machine.send_chars("logout\n")
+          machine.wait_until_tty_matches("1", "login: ")
 
 
-    machine.wait_for_unit("default.target")
+      machine.wait_for_unit("default.target")
 
-    with subtest("Enable fscrypt on filesystem"):
-        machine.succeed("tune2fs -O encrypt /dev/vda")
-        machine.succeed("fscrypt setup --quiet --force --time=1ms")
+      with subtest("Enable fscrypt on filesystem"):
+          machine.succeed("tune2fs -O encrypt /dev/vda")
+          machine.succeed("fscrypt setup --quiet --force --time=1ms")
 
-    with subtest("Set up alice with an fscrypt-enabled home directory"):
-        machine.succeed("(echo foobar; echo foobar) | passwd alice")
-        machine.succeed("chown -R alice.users ~alice")
-        machine.succeed("echo foobar | fscrypt encrypt --skip-unlock --source=pam_passphrase --user=alice /home/alice")
+      with subtest("Set up alice with an fscrypt-enabled home directory"):
+          machine.succeed("(echo foobar; echo foobar) | passwd alice")
+          machine.succeed("chown -R alice.users ~alice")
+          machine.succeed("echo foobar | fscrypt encrypt --skip-unlock --source=pam_passphrase --user=alice /home/alice")
 
-    with subtest("Create file as alice"):
-      login_as_alice()
-      machine.succeed("echo hello > /home/alice/world")
-      logout()
-      # Wait for logout to be processed
-      machine.sleep(1)
+      with subtest("Create file as alice"):
+        login_as_alice()
+        machine.succeed("echo hello > /home/alice/world")
+        logout()
+        # Wait for logout to be processed
+        machine.sleep(1)
 
-    with subtest("File should not be readable without being logged in as alice"):
-      machine.fail("cat /home/alice/world")
+      with subtest("File should not be readable without being logged in as alice"):
+        machine.fail("cat /home/alice/world")
 
-    with subtest("File should be readable again as alice"):
-      login_as_alice()
-      machine.succeed("cat /home/alice/world")
-      logout()
-  '';
+      with subtest("File should be readable again as alice"):
+        login_as_alice()
+        machine.succeed("cat /home/alice/world")
+        logout()
+    '';
 }

--- a/nixos/tests/fscrypt.nix
+++ b/nixos/tests/fscrypt.nix
@@ -47,7 +47,8 @@
 
       with subtest("File should be readable again as alice"):
         login_as_alice()
-        machine.succeed("cat /home/alice/world")
+        assert "Unlocked: Yes" in machine.succeed("fscrypt status /home/alice")
+        assert "hello" in machine.succeed("cat /home/alice/world")
         logout()
     '';
 }

--- a/nixos/tests/fscrypt.nix
+++ b/nixos/tests/fscrypt.nix
@@ -6,49 +6,81 @@
     { pkgs, ... }:
     {
       imports = [ ./common/user-account.nix ];
-      security.pam.enableFscrypt = true;
+      security.pam = {
+        enableFscrypt = true;
+      };
+      virtualisation.emptyDiskImages = [ 256 ];
+      environment.systemPackages = [
+        pkgs.f2fs-tools
+      ];
+      users.users.bob = {
+        home = "/home2/bob";
+        createHome = false;
+      };
     };
 
   testScript = # python
     ''
-      def log_in_as_alice():
+      def log_in(user: str, passwd: str = "foobar") -> None:
           machine.wait_until_tty_matches("1", "login: ")
-          machine.send_chars("alice\n")
+          machine.send_chars(f"{user}\n")
           machine.wait_until_tty_matches("1", "Password: ")
-          machine.send_chars("foobar\n")
-          machine.wait_until_tty_matches("1", "alice\@machine")
+          machine.send_chars(f"{passwd}\n")
+          machine.wait_until_tty_matches("1", f"{user}\@machine")
 
 
-      def log_out():
+      def log_out() -> None:
           machine.send_chars("logout\n")
           machine.wait_until_tty_matches("1", "login: ")
-
-
-      machine.wait_for_unit("default.target")
-
-      with subtest("Enable fscrypt on filesystem"):
-          machine.succeed("tune2fs -O encrypt /dev/vda")
-          machine.succeed("fscrypt setup --quiet --force --time=1ms")
-
-      with subtest("Set up alice with an fscrypt-enabled home directory"):
-          machine.succeed("(echo foobar; echo foobar) | passwd alice")
-          machine.succeed("chown -R alice.users ~alice")
-          machine.succeed("echo foobar | fscrypt encrypt --skip-unlock --source=pam_passphrase --user=alice /home/alice")
-
-      with subtest("Create file as alice"):
-          log_in_as_alice()
-          machine.succeed("echo hello > /home/alice/world")
-          log_out()
           # Wait for logout to be processed
           machine.sleep(1)
 
-      with subtest("File should not be readable without being logged in as alice"):
+      machine.wait_for_unit("default.target")
+
+      with subtest("Setup & enable fscrypt on filesystems"):
+          machine.succeed("tune2fs -O encrypt /dev/vda")
+          machine.succeed("fscrypt setup --quiet --force --time=1ms")
+          machine.succeed("mkfs.f2fs -f -l f2fs-fscrypt -O extra_attr,encrypt /dev/vdb")
+          machine.succeed("mount -m -t f2fs /dev/vdb /home2")
+          machine.succeed("chmod 755 /home2")
+          machine.succeed("fscrypt setup --quiet --force --time=1ms /home2")
+
+      with subtest("Set up alice with an fscrypt-enabled home directory"):
+          machine.succeed("(echo foobar; echo foobar) | passwd alice")
+          machine.succeed("chown -R alice /home/alice")
+          machine.succeed("echo foobar | fscrypt encrypt --skip-unlock --source=pam_passphrase --user=alice /home/alice")
+
+      with subtest("Set up bob with an fscrypt-enabled home directory"):
+          machine.succeed("(echo foobar; echo foobar) | passwd bob")
+          machine.succeed("mkdir -p /home2/bob")
+          machine.succeed("chown -R bob /home2/bob")
+          machine.succeed("chmod go-rwx /home2/bob")
+          machine.succeed("echo foobar | fscrypt encrypt --skip-unlock --no-recovery --source=pam_passphrase --user=bob /home2/bob")
+
+      with subtest("Create file as alice"):
+          log_in("alice")
+          machine.succeed("echo hello > /home/alice/world")
+          log_out()
+
+      with subtest("Create file as bob"):
+          log_in("bob")
+          machine.succeed("echo hello > /home2/bob/world")
+          log_out()
+
+      with subtest("Files should not be readable without being logged in as alice or bob"):
           machine.fail("cat /home/alice/world")
+          machine.fail("cat /home2/bob/world")
 
       with subtest("File should be readable again as alice"):
-          log_in_as_alice()
+          log_in("alice")
           assert "Unlocked: Yes" in machine.succeed("fscrypt status /home/alice")
           assert "hello" in machine.succeed("cat /home/alice/world")
+          log_out()
+
+      with subtest("File should be readable again as bob"):
+          log_in("bob")
+          assert "Unlocked: Yes" in machine.succeed("fscrypt status /home2/bob")
+          assert "hello" in machine.succeed("cat /home2/bob/world")
           log_out()
     '';
 }

--- a/nixos/tests/fscrypt.nix
+++ b/nixos/tests/fscrypt.nix
@@ -11,7 +11,7 @@
 
   testScript = # python
     ''
-      def login_as_alice():
+      def log_in_as_alice():
           machine.wait_until_tty_matches("1", "login: ")
           machine.send_chars("alice\n")
           machine.wait_until_tty_matches("1", "Password: ")
@@ -19,7 +19,7 @@
           machine.wait_until_tty_matches("1", "alice\@machine")
 
 
-      def logout():
+      def log_out():
           machine.send_chars("logout\n")
           machine.wait_until_tty_matches("1", "login: ")
 
@@ -36,9 +36,9 @@
           machine.succeed("echo foobar | fscrypt encrypt --skip-unlock --source=pam_passphrase --user=alice /home/alice")
 
       with subtest("Create file as alice"):
-          login_as_alice()
+          log_in_as_alice()
           machine.succeed("echo hello > /home/alice/world")
-          logout()
+          log_out()
           # Wait for logout to be processed
           machine.sleep(1)
 
@@ -46,9 +46,9 @@
           machine.fail("cat /home/alice/world")
 
       with subtest("File should be readable again as alice"):
-          login_as_alice()
+          log_in_as_alice()
           assert "Unlocked: Yes" in machine.succeed("fscrypt status /home/alice")
           assert "hello" in machine.succeed("cat /home/alice/world")
-          logout()
+          log_out()
     '';
 }


### PR DESCRIPTION
I have no idea if this is useful to have, but I was tracking down a potential bug in my setup by making this VM test work testing f2fs support for fscrypt. If it’s not useful, it can be closed but it might hopefully be useful to someone to have the history here for SEO (or the LLMs, & MS will sell it back to us).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
