### PR TITLE
Revert "libfaketime: 0.9.10 -> 0.9.11"

### DIFF
--- a/pkgs/by-name/li/libfaketime/0001-Remove-unsupported-clang-flags.patch
+++ b/pkgs/by-name/li/libfaketime/0001-Remove-unsupported-clang-flags.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile b/src/Makefile
+index 2af4804..bcff809 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -80,7 +80,7 @@ PREFIX ?= /usr/local
+ LIBDIRNAME ?= /lib/faketime
+ PLATFORM ?=$(shell uname)
+ 
+-CFLAGS += -std=gnu99 -Wall -Wextra -Werror -Wno-nonnull-compare -DFAKE_PTHREAD -DFAKE_STAT -DFAKE_UTIME -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"' $(FAKETIME_COMPILE_CFLAGS)
++CFLAGS += -std=gnu99 -Wall -Wextra -DFAKE_PTHREAD -DFAKE_STAT -DFAKE_UTIME -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"' $(FAKETIME_COMPILE_CFLAGS)
+ ifeq ($(PLATFORM),SunOS)
+ CFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=600
+ endif

--- a/pkgs/by-name/li/libfaketime/package.nix
+++ b/pkgs/by-name/li/libfaketime/package.nix
@@ -6,6 +6,12 @@
   perl,
   coreutils,
 }:
+let
+  hashes = {
+    "0.9.10" = "sha256-DYRuQmIhQu0CNEboBAtHOr/NnWxoXecuPMSR/UQ/VIQ=";
+    "0.9.11" = "sha256-a0TjHYzwbkRQyvr9Sj/DqjgLBnE1Z8kjsTQxTfGqLjE=";
+  };
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libfaketime";
@@ -16,12 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "wolfcw";
     repo = "libfaketime";
-    rev = "v${finalAttrs.version}";
-    sha256 =
-      if stdenv.hostPlatform.isDarwin then
-        "sha256-DYRuQmIhQu0CNEboBAtHOr/NnWxoXecuPMSR/UQ/VIQ="
-      else
-        "sha256-a0TjHYzwbkRQyvr9Sj/DqjgLBnE1Z8kjsTQxTfGqLjE=";
+    tag = "v${finalAttrs.version}";
+    hash = hashes.${finalAttrs.version};
   };
 
   patches =

--- a/pkgs/by-name/li/libfaketime/package.nix
+++ b/pkgs/by-name/li/libfaketime/package.nix
@@ -7,7 +7,7 @@
   coreutils,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libfaketime";
   # 0.9.10 break dict-db-wiktionary and quartus-prime-lite on linux,
   # and 0.9.11 break everything on darwin
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "wolfcw";
     repo = "libfaketime";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 =
       if stdenv.hostPlatform.isDarwin then
         "sha256-DYRuQmIhQu0CNEboBAtHOr/NnWxoXecuPMSR/UQ/VIQ="
@@ -45,11 +45,10 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs test src
-    for a in test/functests/test_exclude_mono.sh src/faketime.c ; do
-      substituteInPlace $a \
-        --replace-fail /bin/bash ${stdenv.shell}
-    done
-    substituteInPlace src/faketime.c --replace-fail @DATE_CMD@ ${coreutils}/bin/date
+    substituteInPlace test/functests/test_exclude_mono.sh src/faketime.c \
+      --replace-fail /bin/bash ${stdenv.shell}
+    substituteInPlace src/faketime.c \
+      --replace-fail @DATE_CMD@ ${lib.getExe' coreutils "date"}
   '';
 
   PREFIX = placeholder "out";
@@ -70,12 +69,12 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Report faked system time to programs without having to change the system-wide time";
     homepage = "https://github.com/wolfcw/libfaketime/";
-    license = licenses.gpl2;
-    platforms = platforms.all;
-    maintainers = [ maintainers.bjornfor ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.bjornfor ];
     mainProgram = "faketime";
   };
-}
+})

--- a/pkgs/by-name/li/libfaketime/package.nix
+++ b/pkgs/by-name/li/libfaketime/package.nix
@@ -9,18 +9,33 @@
 
 stdenv.mkDerivation rec {
   pname = "libfaketime";
-  version = "0.9.11";
+  version = "0.9.10";
 
   src = fetchFromGitHub {
     owner = "wolfcw";
     repo = "libfaketime";
     rev = "v${version}";
-    sha256 = "sha256-a0TjHYzwbkRQyvr9Sj/DqjgLBnE1Z8kjsTQxTfGqLjE=";
+    sha256 = "sha256-DYRuQmIhQu0CNEboBAtHOr/NnWxoXecuPMSR/UQ/VIQ=";
   };
 
-  patches = [
-    ./nix-store-date.patch
-  ];
+  patches =
+    [
+      ./nix-store-date.patch
+      (fetchpatch {
+        name = "0001-libfaketime.c-wrap-timespec_get-in-TIME_UTC-macro.patch";
+        url = "https://github.com/wolfcw/libfaketime/commit/e0e6b79568d36a8fd2b3c41f7214769221182128.patch";
+        sha256 = "sha256-KwwP76v0DXNW73p/YBvwUOPdKMAcVdbQSKexD/uFOYo=";
+      })
+      (fetchpatch {
+        name = "LFS64.patch";
+        url = "https://github.com/wolfcw/libfaketime/commit/f32986867addc9d22b0fab29c1c927f079d44ac1.patch";
+        hash = "sha256-fIXuxxcV9J2IcgwcwSrMo4maObkH9WYv1DC/wdtbq/g=";
+      })
+    ]
+    ++ (lib.optionals stdenv.cc.isClang [
+      # https://github.com/wolfcw/libfaketime/issues/277
+      ./0001-Remove-unsupported-clang-flags.patch
+    ]);
 
   postPatch = ''
     patchShebangs test src


### PR DESCRIPTION
Reverts NixOS/nixpkgs#412913, as it break texlive on darwin
ref. https://github.com/NixOS/nixpkgs/pull/413916