### PR TITLE
az-pim-cli: fix version command, don't use emulator for shell completions

### DIFF
--- a/pkgs/by-name/az/az-pim-cli/package.nix
+++ b/pkgs/by-name/az/az-pim-cli/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   installShellFiles,
   stdenv,
-  buildPackages,
   nix-update-script,
   testers,
 }:
@@ -37,17 +36,12 @@ buildGoModule (finalAttrs: {
     "-X github.com/netr0m/az-pim-cli/cmd.version=v${finalAttrs.version}"
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
-    let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
-    in
-    ''
-      installShellCompletion --cmd az-pim-cli \
-        --bash <(${emulator} $out/bin/az-pim-cli completion bash) \
-        --fish <(${emulator} $out/bin/az-pim-cli completion fish) \
-        --zsh <(${emulator} $out/bin/az-pim-cli completion zsh)
-    ''
-  );
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd az-pim-cli \
+      --bash <($out/bin/az-pim-cli completion bash) \
+      --fish <($out/bin/az-pim-cli completion fish) \
+      --zsh <($out/bin/az-pim-cli completion zsh)
+  '';
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/az/az-pim-cli/version-build-info.patch
+++ b/pkgs/by-name/az/az-pim-cli/version-build-info.patch
@@ -1,0 +1,24 @@
+diff --git a/cmd/version.go b/cmd/version.go
+index 816f044..ef107be 100644
+--- a/cmd/version.go
++++ b/cmd/version.go
+@@ -31,8 +31,7 @@ type BuildInfo struct {
+ }
+
+ func (b BuildInfo) String() string {
+-	return fmt.Sprintf("az-pim-cli version %s (built with %s from %s on %s)",
+-		b.Version, b.GoVersion, b.Commit, b.Date)
++    return fmt.Sprintf("az-pim-cli version %s", b.Version)
+ }
+
+ func printVersion(w io.Writer, info BuildInfo) {
+@@ -47,8 +46,8 @@ func createBuildInfo() BuildInfo {
+ 		Date:      date,
+ 	}
+
+-	buildInfo, available := debug.ReadBuildInfo()
+-	if !available {
++	buildInfo, _ := debug.ReadBuildInfo()
++	if true {
+ 		return info
+ 	}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
