### PR TITLE
treewide: adjust meta descriptions to avoid definite or indefinite articles

### DIFF
--- a/pkgs/by-name/_2/_2ship2harkinian/package.nix
+++ b/pkgs/by-name/_2/_2ship2harkinian/package.nix
@@ -199,7 +199,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/HarbourMasters/2ship2harkinian";
-    description = "A PC port of Majora's Mask with modern controls, widescreen, high-resolution, and more";
+    description = "PC port of Majora's Mask with modern controls, widescreen, high-resolution, and more";
     mainProgram = "2s2h";
     platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [ qubitnano ];

--- a/pkgs/by-name/ab/abaddon/package.nix
+++ b/pkgs/by-name/ab/abaddon/package.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A discord client reimplementation, written in C++";
+    description = "Discord client reimplementation, written in C++";
     mainProgram = "abaddon";
     homepage = "https://github.com/uowuo/abaddon";
     license = licenses.gpl3Plus;

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://adios2.readthedocs.io/en/latest/";
-    description = "The Adaptable Input/Output System version 2";
+    description = "Adaptable Input/Output System version 2";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ qbisi ];

--- a/pkgs/by-name/ai/air-formatter/package.nix
+++ b/pkgs/by-name/ai/air-formatter/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "An extremely fast R code formatter";
+    description = "Extremely fast R code formatter";
     homepage = "https://posit-dev.github.io/air";
     changelog = "https://github.com/posit-dev/air/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;

--- a/pkgs/by-name/am/amphetype/package.nix
+++ b/pkgs/by-name/am/amphetype/package.nix
@@ -10,7 +10,7 @@
 let
   pname = "amphetype";
   version = "1.0.0";
-  description = "An advanced typing practice program";
+  description = "Advanced typing practice program";
 in
 python3Packages.buildPythonApplication {
   inherit pname version;

--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     changelog = "https://github.com/apache/orc/releases/tag/v${finalAttrs.version}";
-    description = "The smallest, fastest columnar storage for Hadoop workloads";
+    description = "Smallest, fastest columnar storage for Hadoop workloads";
     homepage = "https://github.com/apache/orc/";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ drupol ];

--- a/pkgs/by-name/ap/appflowy/package.nix
+++ b/pkgs/by-name/ap/appflowy/package.nix
@@ -101,7 +101,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   meta = with lib; {
-    description = "An open-source alternative to Notion";
+    description = "Open-source alternative to Notion";
     homepage = "https://www.appflowy.io/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.agpl3Only;

--- a/pkgs/by-name/aq/aquamarine/package.nix
+++ b/pkgs/by-name/aq/aquamarine/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     changelog = "https://github.com/hyprwm/aquamarine/releases/tag/v${finalAttrs.version}";
-    description = "A very light linux rendering backend library";
+    description = "Very light linux rendering backend library";
     homepage = "https://github.com/hyprwm/aquamarine";
     license = lib.licenses.bsd3;
     teams = [ lib.teams.hyprland ];

--- a/pkgs/by-name/ar/ares-cli/package.nix
+++ b/pkgs/by-name/ar/ares-cli/package.nix
@@ -25,7 +25,7 @@ buildNpmPackage rec {
 
   meta = {
     homepage = "https://webostv.developer.lge.com/develop/tools/cli-introduction";
-    description = "A collection of commands used for creating, packaging, installing, and launching web apps for LG webOS TV.";
+    description = "Collection of commands used for creating, packaging, installing, and launching web apps for LG webOS TV";
     longDescription = ''
       webOS CLI (Command Line Interface) provides a collection of commands used for creating, packaging, installing,
       and launching web apps in the command line environment. The CLI allows you to develop and test your app without using

--- a/pkgs/by-name/ar/arkenfox-userjs/package.nix
+++ b/pkgs/by-name/ar/arkenfox-userjs/package.nix
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A comprehensive user.js template for configuration and hardening";
+    description = "Comprehensive user.js template for configuration and hardening";
     homepage = "https://github.com/arkenfox/user.js";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "The Astro language server";
+    description = "Astro language server";
     homepage = "https://github.com/withastro/language-tools";
     changelog = "https://github.com/withastro/language-tools/blob/@astrojs/language-server@${finalAttrs.version}/packages/language-server/CHANGELOG.md";
     license = lib.licenses.mit;

--- a/pkgs/by-name/au/authentik/ldap.nix
+++ b/pkgs/by-name/au/authentik/ldap.nix
@@ -14,7 +14,7 @@ buildGoModule {
   subPackages = [ "cmd/ldap" ];
 
   meta = authentik.meta // {
-    description = "The authentik ldap outpost. Needed for the external ldap API.";
+    description = "Authentik ldap outpost. Needed for the external ldap API";
     homepage = "https://goauthentik.io/docs/providers/ldap/";
     mainProgram = "ldap";
   };

--- a/pkgs/by-name/av/avalonia/package.nix
+++ b/pkgs/by-name/av/avalonia/package.nix
@@ -189,7 +189,7 @@ stdenvNoCC.mkDerivation (
         homepage = "https://avaloniaui.net/";
         license = [ lib.licenses.mit ];
         maintainers = with lib.maintainers; [ corngood ];
-        description = "A cross-platform UI framework for dotnet";
+        description = "Cross-platform UI framework for dotnet";
         sourceProvenance = with lib.sourceTypes; [
           fromSource
           binaryNativeCode # npm dependencies contain binaries

--- a/pkgs/by-name/av/avml/package.nix
+++ b/pkgs/by-name/av/avml/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A portable volatile memory acquisition tool for Linux";
+    description = "Portable volatile memory acquisition tool for Linux";
     homepage = "https://github.com/microsoft/avml";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.lesuisse ];

--- a/pkgs/by-name/aw/aws-vault/package.nix
+++ b/pkgs/by-name/aw/aws-vault/package.nix
@@ -53,7 +53,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "A vault for securely storing and accessing AWS credentials in development environments";
+    description = "Vault for securely storing and accessing AWS credentials in development environments";
     mainProgram = "aws-vault";
     homepage = "https://github.com/99designs/aws-vault";
     license = licenses.mit;

--- a/pkgs/by-name/az/azahar/package.nix
+++ b/pkgs/by-name/az/azahar/package.nix
@@ -145,7 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    description = "An open-source 3DS emulator project based on Citra";
+    description = "Open-source 3DS emulator project based on Citra";
     homepage = "https://github.com/azahar-emu/azahar";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ arthsmn ];

--- a/pkgs/by-name/az/azure-cli/extensions-manual.nix
+++ b/pkgs/by-name/az/azure-cli/extensions-manual.nix
@@ -36,7 +36,7 @@
 
   azure-iot = mkAzExtension rec {
     pname = "azure-iot";
-    description = "The Azure IoT extension for Azure CLI.";
+    description = "Azure IoT extension for Azure CLI";
     version = "0.25.0";
     url = "https://github.com/Azure/azure-iot-cli-extension/releases/download/v${version}/azure_iot-${version}-py3-none-any.whl";
     hash = "sha256-fbS8B2Z++oRyUT2eEh+yVR/K6uaCVce8B2itQXfBscY=";

--- a/pkgs/by-name/az/azurite/package.nix
+++ b/pkgs/by-name/az/azurite/package.nix
@@ -30,7 +30,7 @@ buildNpmPackage rec {
   ];
 
   meta = {
-    description = "An open source Azure Storage API compatible server";
+    description = "Open source Azure Storage API compatible server";
     homepage = "https://github.com/Azure/Azurite";
     changelog = "https://github.com/Azure/Azurite/releases/tag/v${version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/ba/balls/package.nix
+++ b/pkgs/by-name/ba/balls/package.nix
@@ -46,7 +46,7 @@ buildNimPackage (finalAttrs: {
     '';
 
   meta = finalAttrs.src.meta // {
-    description = "The testing framework with balls";
+    description = "Testing framework with balls";
     homepage = "https://github.com/disruptek/balls";
     mainProgram = "balls";
     license = lib.licenses.mit;

--- a/pkgs/by-name/ba/basalt-monado/package.nix
+++ b/pkgs/by-name/ba/basalt-monado/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A fork of Basalt improved for tracking XR devices with Monado";
+    description = "Fork of Basalt improved for tracking XR devices with Monado";
     homepage = "https://gitlab.freedesktop.org/mateosss/basalt";
     license = lib.licenses.bsd3;
     mainProgram = "basalt_vio";

--- a/pkgs/by-name/ba/bash-language-server/package.nix
+++ b/pkgs/by-name/ba/bash-language-server/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   meta = with lib; {
-    description = "A language server for Bash";
+    description = "Language server for Bash";
     homepage = "https://github.com/bash-lsp/bash-language-server";
     license = licenses.mit;
     maintainers = with maintainers; [ doronbehar ];

--- a/pkgs/by-name/bi/bitbox-bridge/package.nix
+++ b/pkgs/by-name/bi/bitbox-bridge/package.nix
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "A bridge service that connects web wallets like Rabby to BitBox02";
+    description = "Bridge service that connects web wallets like Rabby to BitBox02";
     homepage = "https://github.com/BitBoxSwiss/bitbox-bridge";
     downloadPage = "https://bitbox.swiss/download/";
     changelog = "https://github.com/BitBoxSwiss/bitbox-bridge/blob/v${finalAttrs.version}/CHANGELOG.md";

--- a/pkgs/by-name/bl/blackvoxel/package.nix
+++ b/pkgs/by-name/bl/blackvoxel/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A Sci-Fi game with industry and automation";
+    description = "Sci-Fi game with industry and automation";
     homepage = "https://www.blackvoxel.com";
     changelog = "https://github.com/Blackvoxel/Blackvoxel/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [

--- a/pkgs/by-name/bl/blastem/package.nix
+++ b/pkgs/by-name/bl/blastem/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "The fast and accurate Genesis emulator";
+    description = "Fast and accurate Genesis emulator";
     homepage = "https://www.retrodev.com/blastem/";
     license = lib.licenses.gpl3Plus;
     mainProgram = "blastem";

--- a/pkgs/by-name/bl/blendfarm/package.nix
+++ b/pkgs/by-name/bl/blendfarm/package.nix
@@ -131,7 +131,7 @@ buildDotnetModule rec {
     '';
 
   meta = with lib; {
-    description = "A open-source, cross-platform, stand-alone, Network Renderer for Blender";
+    description = "Open-source, cross-platform, stand-alone, Network Renderer for Blender";
     homepage = "https://github.com/LogicReinc/LogicReinc.BlendFarm";
     license = with licenses; [ gpl3Plus ];
     maintainers = with maintainers; [ gador ];

--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -146,7 +146,7 @@ buildFHSEnv {
 
   meta = {
     homepage = "https://github.com/Adamcake/Bolt";
-    description = "An alternative launcher for RuneScape.";
+    description = "Alternative launcher for RuneScape";
     longDescription = ''
       Bolt Launcher supports HDOS/RuneLite by default with an optional feature flag for RS3 (enableRS3).
     '';

--- a/pkgs/by-name/br/brainflow/package.nix
+++ b/pkgs/by-name/br/brainflow/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A library to obtain, parse and analyze data (EEG, EMG, ECG) from biosensors";
+    description = "Library to obtain, parse and analyze data (EEG, EMG, ECG) from biosensors";
     homepage = "https://brainflow.org/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/bs/bsky-cli/package.nix
+++ b/pkgs/by-name/bs/bsky-cli/package.nix
@@ -36,7 +36,7 @@ buildGoModule (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A cli application for bluesky social";
+    description = "Cli application for bluesky social";
     homepage = "https://github.com/mattn/bsky";
     changelog = "https://github.com/mattn/bsky/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/bu/buffybox/package.nix
+++ b/pkgs/by-name/bu/buffybox/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
-    description = "A suite of graphical applications for the terminal";
+    description = "Suite of graphical applications for the terminal";
     homepage = "https://gitlab.postmarketos.org/postmarketOS/buffybox";
     license = licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ colinsane ];

--- a/pkgs/by-name/bu/burpsuite/package.nix
+++ b/pkgs/by-name/bu/burpsuite/package.nix
@@ -36,7 +36,7 @@ let
   };
 
   pname = "burpsuite";
-  description = "An integrated platform for performing security testing of web applications";
+  description = "Integrated platform for performing security testing of web applications";
   desktopItem = makeDesktopItem {
     name = "burpsuite";
     exec = pname;

--- a/pkgs/by-name/ca/cabinpkg/package.nix
+++ b/pkgs/by-name/ca/cabinpkg/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
   meta = {
     broken = (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64);
     homepage = "https://cabinpkg.com";
-    description = "A package manager and build system for C++";
+    description = "Package manager and build system for C++";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.qwqawawow ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ca/camunda-modeler/package.nix
+++ b/pkgs/by-name/ca/camunda-modeler/package.nix
@@ -75,7 +75,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/camunda/camunda-modeler";
-    description = "An integrated modeling solution for BPMN, DMN and Forms based on bpmn.io";
+    description = "Integrated modeling solution for BPMN, DMN and Forms based on bpmn.io";
     teams = [ teams.wdz ];
     license = licenses.mit;
     inherit (electron.meta) platforms;

--- a/pkgs/by-name/ca/catamaran/package.nix
+++ b/pkgs/by-name/ca/catamaran/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation {
 
   meta = with lib; {
     homepage = "https://fonts.google.com/specimen/Catamaran";
-    description = "A stylish sans-serif Tamil and Latin typeface";
+    description = "Stylish sans-serif Tamil and Latin typeface";
     longDescription = ''
       Catamaran is a Unicode-compliant Latin and Tamil text type family designed for the digital age.
       The Tamil is monolinear and was designed alongside the sans serif Latin and Devanagari family Palanquin.

--- a/pkgs/by-name/ca/catppuccin-whiskers/package.nix
+++ b/pkgs/by-name/ca/catppuccin-whiskers/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage {
 
   meta = {
     homepage = "https://github.com/catppuccin/whiskers";
-    description = "A templating tool to simplify the creation of Catppuccin ports";
+    description = "Templating tool to simplify the creation of Catppuccin ports";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Name ];
     mainProgram = "whiskers";

--- a/pkgs/by-name/cc/cctools/package.nix
+++ b/pkgs/by-name/cc/cctools/package.nix
@@ -157,7 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "The classic linker for Darwin";
+    description = "Classic linker for Darwin";
     homepage = "https://opensource.apple.com/releases/";
     license = with lib.licenses; [
       apple-psl20

--- a/pkgs/by-name/cf/cfonts/package.nix
+++ b/pkgs/by-name/cf/cfonts/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/dominikwilkowski/cfonts";
-    description = "A silly little command line tool for sexy ANSI fonts in the console";
+    description = "Silly little command line tool for sexy ANSI fonts in the console";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ leifhelm ];
     mainProgram = "cfonts";

--- a/pkgs/by-name/ch/chamber/package.nix
+++ b/pkgs/by-name/ch/chamber/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
-    description = "A tool for managing secrets by storing them in AWS SSM Parameter Store";
+    description = "Tool for managing secrets by storing them in AWS SSM Parameter Store";
     homepage = "https://github.com/segmentio/chamber";
     license = licenses.mit;
     maintainers = with maintainers; [ kalekseev ];

--- a/pkgs/by-name/cl/clang-tidy-sarif/package.nix
+++ b/pkgs/by-name/cl/clang-tidy-sarif/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = {
-    description = "A CLI tool to convert clang-tidy diagnostics into SARIF";
+    description = "CLI tool to convert clang-tidy diagnostics into SARIF";
     homepage = "https://psastras.github.io/sarif-rs";
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "clang-tidy-sarif";

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -36,7 +36,7 @@ buildNpmPackage rec {
   passthru.updateScript = ./update.sh;
 
   meta = {
-    description = "An agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster";
+    description = "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster";
     homepage = "https://github.com/anthropics/claude-code";
     downloadPage = "https://www.npmjs.com/package/@anthropic-ai/claude-code";
     license = lib.licenses.unfree;

--- a/pkgs/by-name/cl/clifm/package.nix
+++ b/pkgs/by-name/cl/clifm/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://github.com/leo-arch/clifm";
     changelog = "https://github.com/leo-arch/clifm/releases/tag/v${finalAttrs.version}";
-    description = "A CLI-based, shell-like, and non-curses terminal file manager";
+    description = "CLI-based, shell-like, and non-curses terminal file manager";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ nadir-ishiguro ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/cl/clippy-sarif/package.nix
+++ b/pkgs/by-name/cl/clippy-sarif/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = {
-    description = "A CLI tool to convert clippy diagnostics into SARIF";
+    description = "CLI tool to convert clippy diagnostics into SARIF";
     homepage = "https://psastras.github.io/sarif-rs";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ getchoo ];

--- a/pkgs/by-name/co/code2prompt/package.nix
+++ b/pkgs/by-name/co/code2prompt/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ];
 
   meta = {
-    description = "A CLI tool that converts your codebase into a single LLM prompt with a source tree, prompt templating, and token counting";
+    description = "CLI tool that converts your codebase into a single LLM prompt with a source tree, prompt templating, and token counting";
     homepage = "https://github.com/mufeedvh/code2prompt";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ heisfer ];

--- a/pkgs/by-name/co/cope/package.nix
+++ b/pkgs/by-name/co/cope/package.nix
@@ -33,7 +33,7 @@ perlPackages.buildPerlPackage {
   '';
 
   meta = {
-    description = "A colourful wrapper for terminal programs";
+    description = "Colourful wrapper for terminal programs";
     homepage = "https://github.com/deftdawg/cope";
     license = with lib.licenses; [
       artistic1

--- a/pkgs/by-name/co/courier-unicode/package.nix
+++ b/pkgs/by-name/co/courier-unicode/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "http://www.courier-mta.org/unicode/";
-    description = "The Courier Unicode Library is used by most other Courier packages";
+    description = "Courier Unicode Library is used by most other Courier packages";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/cp/cppad/package.nix
+++ b/pkgs/by-name/cp/cppad/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    description = "A C++ Algorithmic Differentiation Package";
+    description = "C++ Algorithmic Differentiation Package";
     homepage = "https://github.com/coin-or/CppAD";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/cp/cpu_features/package.nix
+++ b/pkgs/by-name/cp/cpu_features/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}" ];
 
   meta = with lib; {
-    description = "A cross platform C99 library to get cpu features at runtime";
+    description = "Cross platform C99 library to get cpu features at runtime";
     homepage = "https://github.com/google/cpu_features";
     license = licenses.asl20;
     platforms = platforms.all;

--- a/pkgs/by-name/cr/crow/package.nix
+++ b/pkgs/by-name/cr/crow/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   meta = {
-    description = "A Fast and Easy to use microframework for the web";
+    description = "Fast and Easy to use microframework for the web";
     homepage = "https://crowcpp.org/";
     maintainers = with lib.maintainers; [ l33tname ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ct/ctune/package.nix
+++ b/pkgs/by-name/ct/ctune/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [ ./cmake_disable_git_clone.patch ];
 
   meta = {
-    description = "A nice terminal nCurses (tui) internet radio player for Linux, browse and search from api.radio-browser.info";
+    description = "Nice terminal nCurses (tui) internet radio player for Linux, browse and search from api.radio-browser.info";
     homepage = "https://github.com/An7ar35/ctune";
     changelog = "https://github.com/An7ar35/ctune/blob/master/CHANGELOG.md";
     license = lib.licenses.agpl3Plus;

--- a/pkgs/by-name/cu/culvert/package.nix
+++ b/pkgs/by-name/cu/culvert/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     homepage = "https://github.com/amboar/culvert";
-    description = "A Test and Debug Tool for BMC AHB Interfaces ";
+    description = "Test and Debug Tool for BMC AHB Interfaces ";
     mainProgram = "culvert";
     license = licenses.asl20;
     maintainers = [ maintainers.baloo ];

--- a/pkgs/by-name/cu/cutentr/package.nix
+++ b/pkgs/by-name/cu/cutentr/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "A 3DS streaming client for Linux";
+    description = "3DS streaming client for Linux";
     homepage = "https://gitlab.com/BoltsJ/cuteNTR";
     license = lib.licenses.gpl3Plus;
     mainProgram = "cutentr";

--- a/pkgs/by-name/db/dbus-broker/package.nix
+++ b/pkgs/by-name/db/dbus-broker/package.nix
@@ -39,7 +39,7 @@ let
       ];
       inherit buildInputs;
       meta = meta // {
-        description = "The C-Util Project is a collection of utility libraries for the C11 language.";
+        description = "C-Util Project is a collection of utility libraries for the C11 language";
         homepage = "https://c-util.github.io/";
         license = [
           lib.licenses.asl20

--- a/pkgs/by-name/df/dfl-ipc/package.nix
+++ b/pkgs/by-name/df/dfl-ipc/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    description = "A very simple set of IPC classes for inter-process communication";
+    description = "Very simple set of IPC classes for inter-process communication";
     homepage = "https://gitlab.com/desktop-frameworks/ipc";
     changelog = "https://gitlab.com/desktop-frameworks/ipc/-/blob/${finalAttrs.src.rev}/ChangeLog";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/di/di-tui/package.nix
+++ b/pkgs/by-name/di/di-tui/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A simple terminal UI player for di.fm";
+    description = "Simple terminal UI player for di.fm";
     homepage = "https://github.com/acaloiaro/di-tui";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.acaloiaro ];

--- a/pkgs/by-name/di/didder/package.nix
+++ b/pkgs/by-name/di/didder/package.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
   '';
 
   meta = src.meta // {
-    description = "An extensive, fast, and accurate command-line image dithering tool";
+    description = "Extensive, fast, and accurate command-line image dithering tool";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ ehmry ];
     mainProgram = "didder";

--- a/pkgs/by-name/di/dinit/package.nix
+++ b/pkgs/by-name/di/dinit/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A service manager / supervision system, which can (on Linux) also function as a system manager and init";
+    description = "Service manager / supervision system, which can (on Linux) also function as a system manager and init";
     homepage = "https://davmac.org/projects/dinit";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ aanderse ];

--- a/pkgs/by-name/di/distrobox-tui/package.nix
+++ b/pkgs/by-name/di/distrobox-tui/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
 
   meta = {
     changelog = "https://github.com/phanirithvij/distrobox-tui/releases/tag/v${version}";
-    description = "A TUI for DistroBox";
+    description = "TUI for DistroBox";
     homepage = "https://github.com/phanirithvij/distrobox-tui";
     license = lib.licenses.gpl3Plus;
     mainProgram = "distrobox-tui";

--- a/pkgs/by-name/di/dita-ot/package.nix
+++ b/pkgs/by-name/di/dita-ot/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://dita-ot.org";
     changelog = "https://www.dita-ot.org/dev/release-notes/#v${finalAttrs.version}";
-    description = "The open-source publishing engine for content authored in the Darwin Information Typing Architecture";
+    description = "Open-source publishing engine for content authored in the Darwin Information Typing Architecture";
     license = lib.licenses.asl20;
     mainProgram = "dita";
     platforms = openjdk17.meta.platforms;

--- a/pkgs/by-name/dn/dnss/package.nix
+++ b/pkgs/by-name/dn/dnss/package.nix
@@ -17,7 +17,7 @@ buildGoModule {
   vendorHash = "sha256-d9aGSBRblkvH5Ixw3jpbgC8lMW/qEYNJfLTVeUlos7A=";
 
   meta = with lib; {
-    description = "A daemon for using DNS over HTTPS";
+    description = "Daemon for using DNS over HTTPS";
     homepage = "https://blitiri.com.ar/git/r/dnss/";
     license = licenses.asl20;
     mainProgram = "dnss";

--- a/pkgs/by-name/do/dotnet-ef/package.nix
+++ b/pkgs/by-name/do/dotnet-ef/package.nix
@@ -7,7 +7,7 @@ buildDotnetGlobalTool {
   nugetHash = "sha256-Mu+MlsjH/qa4kMb7z/TuG1lSVSKPX9j9S4mJLVRZ2+E=";
 
   meta = {
-    description = "The Entity Framework Core tools help with design-time development tasks.";
+    description = "Tools to help with design-time development tasks";
     longDescription = ''
       The Entity Framework Core tools help with design-time development tasks.
       They're primarily used to manage Migrations and to scaffold a DbContext and entity types by reverse engineering the schema of a database.

--- a/pkgs/by-name/dr/draupnir/package.nix
+++ b/pkgs/by-name/dr/draupnir/package.nix
@@ -98,7 +98,7 @@ mkYarnPackage rec {
   passthru.updateScript = ./update.sh;
 
   meta = with lib; {
-    description = "A moderation tool for Matrix";
+    description = "Moderation tool for Matrix";
     homepage = "https://github.com/the-draupnir-project/Draupnir";
     longDescription = ''
       As an all-in-one moderation tool, it can protect your server from

--- a/pkgs/by-name/du/dut/package.nix
+++ b/pkgs/by-name/du/dut/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   meta = {
     platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin;
-    description = "A disk usage calculator for Linux";
+    description = "Disk usage calculator for Linux";
     homepage = "https://codeberg.org/201984/dut";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ errnoh ];

--- a/pkgs/by-name/ed/edido/package.nix
+++ b/pkgs/by-name/ed/edido/package.nix
@@ -10,7 +10,7 @@
 }:
 writeShellApplication {
   name = "edido";
-  meta.description = "A tool to apply display configuration from `boot.kernelParams`.";
+  meta.description = "Tool to apply display configuration from `boot.kernelParams`";
   runtimeInputs = [
     diffutils
     findutils

--- a/pkgs/by-name/ed/edukai/package.nix
+++ b/pkgs/by-name/ed/edukai/package.nix
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    description = "The MOE Standard Kai Font, a Chinese font by the Ministry of Education, ROC (Taiwan)";
+    description = "MOE Standard Kai Font, a Chinese font by the Ministry of Education, ROC (Taiwan)";
     longDescription = ''
       The MOE Standard Kai Font is a kai (regular srcipt) font
       provided by

--- a/pkgs/by-name/ed/eduli/package.nix
+++ b/pkgs/by-name/ed/eduli/package.nix
@@ -22,7 +22,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    description = "The MOE Li Font, a clerical Chinese font by the Ministry of Education, ROC (Taiwan)";
+    description = "MOE Li Font, a clerical Chinese font by the Ministry of Education, ROC (Taiwan)";
     longDescription = ''
       The MOE Li Font is a li (clerical srcipt) font
       provided by

--- a/pkgs/by-name/ed/edusong/package.nix
+++ b/pkgs/by-name/ed/edusong/package.nix
@@ -20,7 +20,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    description = "The MOE Song font, a Song-style Chinese character typeface";
+    description = "MOE Song font, a Song-style Chinese character typeface";
     longDescription = ''
       A Song-style Chinese character typeface published by the Ministry of Education of the Republic of China (Taiwan). The Song style is also referred to as 宋體, 宋体, sòngtǐ, 明體, 明体, or míngtǐ, in Chinese; 명조체, 明朝體, or myeongjo in Korean; 明朝体, みんちょうたい, or minchōtai in Japanese.
     '';

--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -150,7 +150,7 @@ stdenv.mkDerivation (
     };
 
     meta = with lib; {
-      description = "A feature-rich client for Matrix.org";
+      description = "Feature-rich client for Matrix.org";
       homepage = "https://element.io/";
       changelog = "https://github.com/element-hq/element-desktop/blob/v${finalAttrs.version}/CHANGELOG.md";
       license = licenses.asl20;

--- a/pkgs/by-name/el/elm-land/package.nix
+++ b/pkgs/by-name/el/elm-land/package.nix
@@ -59,7 +59,7 @@ buildNpmPackage rec {
   '';
 
   meta = {
-    description = "A production-ready framework for building Elm applications";
+    description = "Production-ready framework for building Elm applications";
     homepage = "https://github.com/elm-land/elm-land";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/em/ember-cli/package.nix
+++ b/pkgs/by-name/em/ember-cli/package.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     homepage = "https://github.com/ember-cli/ember-cli";
-    description = "The Ember.js command line utility";
+    description = "Ember.js command line utility";
     license = licenses.mit;
     maintainers = with maintainers; [ jfvillablanca ];
     platforms = platforms.all;

--- a/pkgs/by-name/en/encrypted-dns-server/package.nix
+++ b/pkgs/by-name/en/encrypted-dns-server/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     changelog = "https://github.com/DNSCrypt/encrypted-dns-server/releases/tag/${version}";
-    description = "An easy to install, high-performance, zero maintenance proxy to run an encrypted DNS server";
+    description = "Easy to install, high-performance, zero maintenance proxy to run an encrypted DNS server";
     homepage = "https://github.com/DNSCrypt/encrypted-dns-server";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ paepcke ];

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "The other cutest Discord client mod";
+    description = "Other cutest Discord client mod";
     homepage = "https://github.com/Equicord/Equicord";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/er/erlang-language-platform/package.nix
+++ b/pkgs/by-name/er/erlang-language-platform/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "An IDE-first library for the semantic analysis of Erlang code, including LSP server, linting and refactoring tools.";
+    description = "IDE-first library for the semantic analysis of Erlang code, including LSP server, linting and refactoring tools";
     homepage = "https://github.com/WhatsApp/erlang-language-platform/";
     license = with lib.licenses; [
       mit

--- a/pkgs/by-name/ev/everest-mons/package.nix
+++ b/pkgs/by-name/ev/everest-mons/package.nix
@@ -40,7 +40,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://mons.coloursofnoise.ca/";
-    description = "A commandline Everest installer and mod manager for Celeste";
+    description = "Commandline Everest installer and mod manager for Celeste";
     license = licenses.mit;
     maintainers = with lib.maintainers; [ ulysseszhan ];
     mainProgram = "mons";

--- a/pkgs/by-name/f1/f1viewer/package.nix
+++ b/pkgs/by-name/f1/f1viewer/package.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   vendorHash = "sha256-UNeH3zxgssXxFpJws6nAL8EgXt0DRyAQfmlJWz/qyDg=";
 
   meta = with lib; {
-    description = "A TUI to view Formula 1 footage using VLC or another media player";
+    description = "TUI to view Formula 1 footage using VLC or another media player";
     homepage = "https://github.com/SoMuchForSubtlety/f1viewer";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ michzappa ];

--- a/pkgs/by-name/fa/fastfetch/package.nix
+++ b/pkgs/by-name/fa/fastfetch/package.nix
@@ -265,7 +265,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "An actively maintained, feature-rich and performance oriented, neofetch like system information tool";
+    description = "Actively maintained, feature-rich and performance oriented, neofetch like system information tool";
     homepage = "https://github.com/fastfetch-cli/fastfetch";
     changelog = "https://github.com/fastfetch-cli/fastfetch/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/fa/fastqc/package.nix
+++ b/pkgs/by-name/fa/fastqc/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "A quality control application for high throughput sequence data";
+    description = "Quality control application for high throughput sequence data";
     longDescription = ''
       FastQC aims to provide a simple way to do some quality control checks on raw sequence data coming from high throughput sequencing pipelines. It provides a modular set of analyses which you can use to give a quick impression of whether your data has any problems of which you should be aware before doing any further analysis.
 

--- a/pkgs/by-name/fa/faust2/package.nix
+++ b/pkgs/by-name/fa/faust2/package.nix
@@ -126,7 +126,7 @@ let
       '';
 
       meta = meta // {
-        description = "A functional programming language for realtime audio signal processing";
+        description = "Functional programming language for realtime audio signal processing";
         longDescription = ''
           FAUST (Functional Audio Stream) is a functional programming
           language specifically designed for real-time signal processing

--- a/pkgs/by-name/fc/fcitx5-fluent/package.nix
+++ b/pkgs/by-name/fc/fcitx5-fluent/package.nix
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "A fluent-design theme with blur effect and shadow";
+    description = "Fluent-design theme with blur effect and shadow";
     homepage = "https://github.com/Reverier-Xu/Fluent-fcitx5";
     license = licenses.mpl20;
     platforms = platforms.all;

--- a/pkgs/by-name/ff/ffts/package.nix
+++ b/pkgs/by-name/ff/ffts/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   cmakeFlags = [ "-DENABLE_SHARED=ON" ];
 
   meta = {
-    description = "The Fastest Fourier Transform in the South";
+    description = "Fastest Fourier Transform in the South";
     homepage = "https://github.com/linkotec/ffts";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bgamari ];

--- a/pkgs/by-name/fs/fscrypt-experimental/package.nix
+++ b/pkgs/by-name/fs/fscrypt-experimental/package.nix
@@ -46,7 +46,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "A high-level tool for the management of Linux filesystem encryption";
+    description = "High-level tool for the management of Linux filesystem encryption";
     mainProgram = "fscrypt";
     longDescription = ''
       This tool manages metadata, key generation, key wrapping, PAM integration,

--- a/pkgs/by-name/gd/gdmap/package.nix
+++ b/pkgs/by-name/gd/gdmap/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     homepage = "https://gitlab.com/sjohannes/gdmap";
-    description = "A tool to visualize disk space (GTK 3 port of Original)";
+    description = "Tool to visualize disk space (GTK 3 port of Original)";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/by-name/gi/git-toolbelt/package.nix
+++ b/pkgs/by-name/gi/git-toolbelt/package.nix
@@ -40,7 +40,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     changelog = "https://github.com/nvie/git-toolbelt/blob/${finalAttrs.src.rev}/CHANGELOG.md";
-    description = "A suite of useful Git commands that aid with scripting or every day command line usage";
+    description = "Suite of useful Git commands that aid with scripting or every day command line usage";
     homepage = "https://github.com/nvie/git-toolbelt";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ tomasajt ];

--- a/pkgs/by-name/gi/git-wait/package.nix
+++ b/pkgs/by-name/gi/git-wait/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage {
   '';
 
   meta = {
-    description = "A simple git wrapper that waits until index.lock file is removed when present before running the command";
+    description = "Simple git wrapper that waits until index.lock file is removed when present before running the command";
     homepage = "https://github.com/darshanparajuli/git-wait";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pbsds ];

--- a/pkgs/by-name/gi/gitnuro/package.nix
+++ b/pkgs/by-name/gi/gitnuro/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A FOSS Git multiplatform client based on Compose and JGit";
+    description = "FOSS Git multiplatform client based on Compose and JGit";
     homepage = "https://gitnuro.com/";
     license = licenses.gpl3Plus;
     platforms = [

--- a/pkgs/by-name/gl/glasskube/package.nix
+++ b/pkgs/by-name/gl/glasskube/package.nix
@@ -78,7 +78,7 @@ buildGo123Module rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "The missing Package Manager for Kubernetes featuring a GUI and a CLI";
+    description = "Missing Package Manager for Kubernetes featuring a GUI and a CLI";
     homepage = "https://github.com/glasskube/glasskube";
     changelog = "https://github.com/glasskube/glasskube/releases/tag/v${version}";
     maintainers = with lib.maintainers; [ jakuzure ];

--- a/pkgs/by-name/gn/gnome-clocks/package.nix
+++ b/pkgs/by-name/gn/gnome-clocks/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://apps.gnome.org/Clocks/";
-    description = "A simple and elegant clock application for GNOME";
+    description = "Simple and elegant clock application for GNOME";
     longDescription = ''
       A simple and elegant clock application. It includes world clocks, alarms,
       a stopwatch, and timers.

--- a/pkgs/by-name/go/gocatcli/package.nix
+++ b/pkgs/by-name/go/gocatcli/package.nix
@@ -38,7 +38,7 @@ buildGoModule rec {
   meta = {
     homepage = "https://github.com/deadc0de6/gocatcli";
     changelog = "https://github.com/deadc0de6/gocatcli/releases/tag/v${version}";
-    description = "The command line catalog tool for your offline data";
+    description = "Command line catalog tool for your offline data";
     longDescription = ''
       gocatcli is a catalog tool for your offline data. It indexes external
       media in a catalog file and allows to quickly find specific files or even

--- a/pkgs/by-name/go/gomuks/package.nix
+++ b/pkgs/by-name/go/gomuks/package.nix
@@ -60,7 +60,7 @@ buildGoModule rec {
 
   meta = with lib; {
     homepage = "https://maunium.net/go/gomuks/";
-    description = "A terminal based Matrix client written in Go";
+    description = "Terminal based Matrix client written in Go";
     mainProgram = "gomuks";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ chvp ];

--- a/pkgs/by-name/go/gopro-tool/package.nix
+++ b/pkgs/by-name/go/gopro-tool/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "A tool to control GoPro webcam mode in Linux (requires v4l2loopback kernel module and a firewall rule)";
+    description = "Tool to control GoPro webcam mode in Linux (requires v4l2loopback kernel module and a firewall rule)";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ ZMon3y ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gp/gpauth/package.nix
+++ b/pkgs/by-name/gp/gpauth/package.nix
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     changelog = "https://github.com/${src.owner}/${src.repo}/blob/${src.rev}/changelog.md";
-    description = "A CLI for GlobalProtect VPN, based on OpenConnect, supports the SSO authentication method";
+    description = "CLI for GlobalProtect VPN, based on OpenConnect, supports the SSO authentication method";
     longDescription = ''
       A CLI for GlobalProtect VPN, based on OpenConnect, supports the SSO
       authentication method. Inspired by gp-saml-gui.

--- a/pkgs/by-name/gr/gren/generated-package.nix
+++ b/pkgs/by-name/gr/gren/generated-package.nix
@@ -95,7 +95,7 @@ mkDerivation {
   testToolDepends = [ hspec-discover ];
   jailbreak = true;
   homepage = "https://gren-lang.org";
-  description = "The `gren` command line interface";
+  description = "`gren` command line interface";
   license = lib.licenses.bsd3;
   mainProgram = "gren";
 }

--- a/pkgs/by-name/gr/grpc-gateway/package.nix
+++ b/pkgs/by-name/gr/grpc-gateway/package.nix
@@ -39,7 +39,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description = "A gRPC to JSON proxy generator plugin for Google Protocol Buffers";
+    description = "GRPC to JSON proxy generator plugin for Google Protocol Buffers";
     longDescription = ''
       This is a plugin for the Google Protocol Buffers compiler (protoc). It reads
       protobuf service definitions and generates a reverse-proxy server which

--- a/pkgs/by-name/gu/guile-json-rpc/package.nix
+++ b/pkgs/by-name/gu/guile-json-rpc/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "A JSON-RPC implementation for Scheme";
+    description = "JSON-RPC implementation for Scheme";
     homepage = "https://codeberg.org/rgherdt/scheme-json-rpc";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ knightpp ];

--- a/pkgs/by-name/gu/guile-lsp-server/package.nix
+++ b/pkgs/by-name/gu/guile-lsp-server/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://codeberg.org/rgherdt/scheme-lsp-server";
-    description = "An LSP server for Guile";
+    description = "LSP server for Guile";
     mainProgram = "guile-lsp-server";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ knightpp ];

--- a/pkgs/by-name/gu/guile-semver/package.nix
+++ b/pkgs/by-name/gu/guile-semver/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with lib; {
-    description = "A GNU Guile library implementing Semantic Versioning 2.0.0";
+    description = "GNU Guile library implementing Semantic Versioning 2.0.0";
     homepage = "https://ngyro.com/software/guile-semver.html";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ foo-dogsquared ];

--- a/pkgs/by-name/ha/hadolint-sarif/package.nix
+++ b/pkgs/by-name/ha/hadolint-sarif/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = {
-    description = "A CLI tool to convert hadolint diagnostics into SARIF";
+    description = "CLI tool to convert hadolint diagnostics into SARIF";
     homepage = "https://psastras.github.io/sarif-rs";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ getchoo ];

--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -90,7 +90,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   meta = {
-    description = "The SQL IDE for Your Terminal";
+    description = "SQL IDE for Your Terminal";
     homepage = "https://harlequin.sh";
     changelog = "https://github.com/tconbeer/harlequin/releases/tag/v${version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/hd/hdfview/package.nix
+++ b/pkgs/by-name/hd/hdfview/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "A visual tool for browsing and editing HDF4 and HDF5 files";
+    description = "Visual tool for browsing and editing HDF4 and HDF5 files";
     license = lib.licenses.free; # BSD-like
     homepage = "https://www.hdfgroup.org/downloads/hdfview";
     downloadPage = "https://github.com/HDFGroup/hdfview";

--- a/pkgs/by-name/he/headset-charge-indicator/package.nix
+++ b/pkgs/by-name/he/headset-charge-indicator/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/centic9/headset-charge-indicator";
-    description = "A app-indicator for GNOME desktops for controlling some features of various wireless headsets";
+    description = "App-indicator for GNOME desktops for controlling some features of various wireless headsets";
     longDescription = "A simple app-indicator for GNOME desktops to display the battery charge of some wireless headsets which also allows to control some functions like LEDs, sidetone and others.";
     platforms = platforms.linux;
     maintainers = with maintainers; [ zebreus ];

--- a/pkgs/by-name/he/heimdall-proxy/package.nix
+++ b/pkgs/by-name/he/heimdall-proxy/package.nix
@@ -34,7 +34,7 @@ buildGoModule {
   ];
 
   meta = {
-    description = "A cloud native Identity Aware Proxy and Access Control Decision service";
+    description = "Cloud native Identity Aware Proxy and Access Control Decision service";
     homepage = "https://dadrus.github.io/heimdall";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ albertilagan ];

--- a/pkgs/by-name/he/heptabase/package.nix
+++ b/pkgs/by-name/he/heptabase/package.nix
@@ -28,7 +28,7 @@ appimageTools.wrapType2 {
 
   meta = {
     changelog = "https://github.com/heptameta/project-meta/releases/tag/v${version}";
-    description = "A visual note-taking tool for learning complex topics";
+    description = "Visual note-taking tool for learning complex topics";
     homepage = "https://heptabase.com/";
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ luftmensch-luftmensch ];

--- a/pkgs/by-name/he/hexxy/package.nix
+++ b/pkgs/by-name/he/hexxy/package.nix
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A modern and beautiful alternative to xxd and hexdump";
+    description = "Modern and beautiful alternative to xxd and hexdump";
     homepage = "https://github.com/sweetbbak/hexxy";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.NotAShelf ];

--- a/pkgs/by-name/hm/hmcl/package.nix
+++ b/pkgs/by-name/hm/hmcl/package.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     homepage = "https://hmcl.huangyuhui.net";
-    description = "A Minecraft Launcher which is multi-functional, cross-platform and popular";
+    description = "Minecraft Launcher which is multi-functional, cross-platform and popular";
     mainProgram = "hmcl";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Only;

--- a/pkgs/by-name/ho/homer/package.nix
+++ b/pkgs/by-name/ho/homer/package.nix
@@ -63,7 +63,7 @@ stdenvNoCC.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "A very simple static homepage for your server.";
+    description = "Very simple static homepage for your server";
     homepage = "https://homer-demo.netlify.app/";
     changelog = "https://github.com/bastienwirtz/homer/releases";
     license = licenses.asl20;

--- a/pkgs/by-name/ho/honggfuzz/package.nix
+++ b/pkgs/by-name/ho/honggfuzz/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A security oriented, feedback-driven, evolutionary, easy-to-use fuzzer";
+    description = "Security oriented, feedback-driven, evolutionary, easy-to-use fuzzer";
     longDescription = ''
       Honggfuzz is a security oriented, feedback-driven, evolutionary,
       easy-to-use fuzzer with interesting analysis options. It is

--- a/pkgs/by-name/ht/hterm/package.nix
+++ b/pkgs/by-name/ht/hterm/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://www.der-hammer.info/pages/terminal.html";
     changelog = "https://www.der-hammer.info/terminal/CHANGELOG.txt";
-    description = "A terminal program for serial communication";
+    description = "Terminal program for serial communication";
     # See https://www.der-hammer.info/terminal/LICENSE.txt
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/hy/hyprland-qt-support/package.nix
+++ b/pkgs/by-name/hy/hyprland-qt-support/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    description = "A Qt6 QML provider for hypr* apps";
+    description = "Qt6 QML provider for hypr* apps";
     homepage = "https://github.com/hyprwm/hyprland-qt-support";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/hy/hyprprop/package.nix
+++ b/pkgs/by-name/hy/hyprprop/package.nix
@@ -62,7 +62,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
   meta = {
-    description = "An xprop replacement for Hyprland";
+    description = "Xprop replacement for Hyprland";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     teams = [ lib.teams.hyprland ];

--- a/pkgs/by-name/hy/hyprsysteminfo/package.nix
+++ b/pkgs/by-name/hy/hyprsysteminfo/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "A tiny qt6/qml application to display information about the running system";
+    description = "Tiny qt6/qml application to display information about the running system";
     homepage = "https://github.com/hyprwm/hyprsysteminfo";
     license = lib.licenses.bsd3;
     teams = [ lib.teams.hyprland ];

--- a/pkgs/by-name/im/imsprog/package.nix
+++ b/pkgs/by-name/im/imsprog/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     changelog = "https://github.com/bigbigmdm/IMSProg/releases/tag/v${finalAttrs.version}";
-    description = "A free I2C EEPROM programmer tool for CH341A device";
+    description = "Free I2C EEPROM programmer tool for CH341A device";
     homepage = "https://github.com/bigbigmdm/IMSProg";
     license = with lib.licenses; [
       gpl3Plus

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -229,7 +229,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   };
 
   meta = with lib; {
-    description = "A generic proof assistant";
+    description = "Generic proof assistant";
 
     longDescription = ''
       Isabelle is a generic proof assistant.  It allows mathematical formulas

--- a/pkgs/by-name/jj/jjui/package.nix
+++ b/pkgs/by-name/jj/jjui/package.nix
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A TUI for Jujutsu VCS";
+    description = "TUI for Jujutsu VCS";
     homepage = "https://github.com/idursun/jjui";
     changelog = "https://github.com/idursun/jjui/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/ka/kanidm-provision/package.nix
+++ b/pkgs/by-name/ka/kanidm-provision/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "A small utility to help with kanidm provisioning";
+    description = "Small utility to help with kanidm provisioning";
     homepage = "https://github.com/oddlama/kanidm-provision";
     license = with lib.licenses; [
       asl20

--- a/pkgs/by-name/kc/kcl-language-server/package.nix
+++ b/pkgs/by-name/kc/kcl-language-server/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     changelog = "https://github.com/kcl-lang/kcl/releases/tag/v${version}";
-    description = "A high-performance implementation of KCL written in Rust that uses LLVM as the compiler backend";
+    description = "High-performance implementation of KCL written in Rust that uses LLVM as the compiler backend";
     downloadPage = "https://github.com/kcl-lang/kcl/tree/v${version}/kclvm/tools/src/LSP";
     homepage = "https://www.kcl-lang.io/";
     license = lib.licenses.asl20;

--- a/pkgs/by-name/kc/kcl/package.nix
+++ b/pkgs/by-name/kc/kcl/package.nix
@@ -63,7 +63,7 @@ buildGoModule rec {
   updateScript = nix-update-script { };
 
   meta = {
-    description = "A command line interface for KCL programming language";
+    description = "Command line interface for KCL programming language";
     changelog = "https://github.com/kcl-lang/cli/releases/tag/v${version}";
     homepage = "https://github.com/kcl-lang/cli";
     license = lib.licenses.asl20;

--- a/pkgs/by-name/kc/kclvm/package.nix
+++ b/pkgs/by-name/kc/kclvm/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
   PROTOC_INCLUDE = "${protobuf}/include";
 
   meta = with lib; {
-    description = "A high-performance implementation of KCL written in Rust that uses LLVM as the compiler backend";
+    description = "High-performance implementation of KCL written in Rust that uses LLVM as the compiler backend";
     homepage = "https://github.com/kcl-lang/kcl";
     license = licenses.asl20;
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/by-name/kc/kclvm_cli/package.nix
+++ b/pkgs/by-name/kc/kclvm_cli/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = with lib; {
-    description = "A high-performance implementation of KCL written in Rust that uses LLVM as the compiler backend";
+    description = "High-performance implementation of KCL written in Rust that uses LLVM as the compiler backend";
     homepage = "https://github.com/kcl-lang/kcl";
     license = licenses.asl20;
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/by-name/ki/kitex/package.nix
+++ b/pkgs/by-name/ki/kitex/package.nix
@@ -37,7 +37,7 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    description = "A high-performance and strong-extensibility Golang RPC framework";
+    description = "High-performance and strong-extensibility Golang RPC framework";
     homepage = "https://github.com/cloudwego/kitex";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ aaronjheng ];

--- a/pkgs/by-name/ki/kitty/package.nix
+++ b/pkgs/by-name/ki/kitty/package.nix
@@ -312,7 +312,7 @@ buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://github.com/kovidgoyal/kitty";
-    description = "The fast, feature-rich, GPU based terminal emulator";
+    description = "Fast, feature-rich, GPU based terminal emulator";
     license = licenses.gpl3Only;
     changelog = [
       "https://sw.kovidgoyal.net/kitty/changelog/"

--- a/pkgs/by-name/ko/koreader/package.nix
+++ b/pkgs/by-name/ko/koreader/package.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/koreader/koreader";
     changelog = "https://github.com/koreader/koreader/releases/tag/v${version}";
-    description = "An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats, running on Cervantes, Kindle, Kobo, PocketBook and Android devices";
+    description = "Ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats, running on Cervantes, Kindle, Kobo, PocketBook and Android devices";
     mainProgram = "koreader";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = [

--- a/pkgs/by-name/ku/kube-capacity/package.nix
+++ b/pkgs/by-name/ku/kube-capacity/package.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   vendorHash = "sha256-YME4AXpHvr1bNuc/HoHxam+7ZkwLzjhIvFSfD4hga1A=";
 
   meta = {
-    description = "A simple CLI that provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster";
+    description = "Simple CLI that provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster";
     mainProgram = "kube-capacity";
     homepage = "https://github.com/robscott/kube-capacity";
     changelog = "https://github.com/robscott/kube-capacity/releases/tag/v${version}";

--- a/pkgs/by-name/ku/kubefetch/package.nix
+++ b/pkgs/by-name/ku/kubefetch/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   vendorHash = "sha256-qsncOsCxepySJI+rJnzbIGxSWlxMzqShtzcEoJD2UPw=";
 
   meta = {
-    description = "A neofetch-like tool to show info about your Kubernetes Cluster.";
+    description = "Neofetch-like tool to show info about your Kubernetes Cluster";
     homepage = "https://github.com/jkulzer/kubefetch";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ wrmilling ];

--- a/pkgs/by-name/ku/kuro/package.nix
+++ b/pkgs/by-name/ku/kuro/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     changelog = "https://github.com/davidsmorais/kuro/releases/tag/${src.rev}";
-    description = "An unofficial, featureful, open source, community-driven, free Microsoft To-Do app";
+    description = "Unofficial, featureful, open source, community-driven, free Microsoft To-Do app";
     homepage = "https://github.com/davidsmorais/kuro";
     license = licenses.mit;
     mainProgram = "kuro";

--- a/pkgs/by-name/la/lasuite-docs-collaboration-server/package.nix
+++ b/pkgs/by-name/la/lasuite-docs-collaboration-server/package.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A collaborative note taking, wiki and documentation platform that scales. Built with Django and React. Opensource alternative to Notion or Outline";
+    description = "Collaborative note taking, wiki and documentation platform that scales. Built with Django and React. Opensource alternative to Notion or Outline";
     homepage = "https://github.com/suitenumerique/docs";
     changelog = "https://github.com/suitenumerique/docs/blob/${src.tag}/CHANGELOG.md";
     mainProgram = "docs-collaboration-server";

--- a/pkgs/by-name/la/lasuite-docs-frontend/package.nix
+++ b/pkgs/by-name/la/lasuite-docs-frontend/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A collaborative note taking, wiki and documentation platform that scales. Built with Django and React. Opensource alternative to Notion or Outline";
+    description = "Collaborative note taking, wiki and documentation platform that scales. Built with Django and React. Opensource alternative to Notion or Outline";
     homepage = "https://github.com/suitenumerique/docs";
     changelog = "https://github.com/suitenumerique/docs/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;

--- a/pkgs/by-name/la/lasuite-docs/package.nix
+++ b/pkgs/by-name/la/lasuite-docs/package.nix
@@ -108,7 +108,7 @@ python.pkgs.buildPythonApplication rec {
   };
 
   meta = {
-    description = "A collaborative note taking, wiki and documentation platform that scales. Built with Django and React. Opensource alternative to Notion or Outline";
+    description = "Collaborative note taking, wiki and documentation platform that scales. Built with Django and React. Opensource alternative to Notion or Outline";
     homepage = "https://github.com/suitenumerique/docs";
     changelog = "https://github.com/suitenumerique/docs/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;

--- a/pkgs/by-name/la/lauti/package.nix
+++ b/pkgs/by-name/la/lauti/package.nix
@@ -46,7 +46,7 @@ buildGoModule rec {
   };
 
   meta = {
-    description = "An open source calendar for events, groups and places";
+    description = "Open source calendar for events, groups and places";
     homepage = "https://lauti.org";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ onny ];

--- a/pkgs/by-name/la/lazysql/package.nix
+++ b/pkgs/by-name/la/lazysql/package.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description = "A cross-platform TUI database management tool written in Go";
+    description = "Cross-platform TUI database management tool written in Go";
     homepage = "https://github.com/jorgerojas26/lazysql";
     license = licenses.mit;
     maintainers = with maintainers; [ kanielrkirby ];

--- a/pkgs/by-name/ld/ld64/package.nix
+++ b/pkgs/by-name/ld/ld64/package.nix
@@ -170,7 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   meta = {
-    description = "The classic linker for Darwin";
+    description = "Classic linker for Darwin";
     homepage = "https://opensource.apple.com/releases/";
     license = lib.licenses.apple-psl20;
     mainProgram = "ld";

--- a/pkgs/by-name/le/leetgo/package.nix
+++ b/pkgs/by-name/le/leetgo/package.nix
@@ -36,7 +36,7 @@ buildGoModule rec {
   '';
 
   meta = {
-    description = "A command-line tool for LeetCode";
+    description = "Command-line tool for LeetCode";
     homepage = "https://github.com/j178/leetgo";
     changelog = "https://github.com/j178/leetgo/releases/tag/v${version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/li/liana/package.nix
+++ b/pkgs/by-name/li/liana/package.nix
@@ -84,7 +84,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     mainProgram = "liana-gui";
-    description = "A Bitcoin wallet leveraging on-chain timelocks for safety and recovery";
+    description = "Bitcoin wallet leveraging on-chain timelocks for safety and recovery";
     homepage = "https://wizardsardine.com/liana";
     changelog = "https://github.com/wizardsardine/liana/releases/tag/${src.rev}";
     license = licenses.bsd3;

--- a/pkgs/by-name/li/lib25519/package.nix
+++ b/pkgs/by-name/li/lib25519/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://randombytes.cr.yp.to/";
-    description = "A simple API for applications generating fresh randomness";
+    description = "Simple API for applications generating fresh randomness";
     changelog = "https://randombytes.cr.yp.to/download.html";
     license = with lib.licenses; [
       # Upstream specifies the public domain licenses with the terms here https://cr.yp.to/spdx.html

--- a/pkgs/by-name/li/libetebase/package.nix
+++ b/pkgs/by-name/li/libetebase/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
   passthru.tests.pkgs-config = testers.testMetaPkgConfig libetebase;
 
   meta = with lib; {
-    description = "A C library for Etebase";
+    description = "C library for Etebase";
     homepage = "https://www.etebase.com/";
     license = licenses.bsd3;
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/li/libgen-cli/package.nix
+++ b/pkgs/by-name/li/libgen-cli/package.nix
@@ -38,7 +38,7 @@ buildGoModule rec {
 
   meta = with lib; {
     homepage = "https://github.com/ciehanski/libgen-cli";
-    description = "A CLI tool used to access the Library Genesis dataset; written in Go";
+    description = "CLI tool used to access the Library Genesis dataset; written in Go";
     longDescription = ''
       libgen-cli is a command line interface application which allows users to
       quickly query the Library Genesis dataset and download any of its

--- a/pkgs/by-name/li/libnop/package.nix
+++ b/pkgs/by-name/li/libnop/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "A fast, header-only C++ serialization library";
+    description = "Fast, header-only C++ serialization library";
     homepage = "https://github.com/google/libnop";
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/li/libpisp/package.nix
+++ b/pkgs/by-name/li/libpisp/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     homepage = "https://github.com/raspberrypi/libpisp";
-    description = "A helper library to generate run-time configuration for the Raspberry Pi ISP (PiSP), consisting of the Frontend and Backend hardware components.";
+    description = "Helper library to generate run-time configuration for the Raspberry Pi ISP (PiSP), consisting of the Frontend and Backend hardware components";
     license = licenses.bsd2;
     platforms = platforms.all;
   };

--- a/pkgs/by-name/li/librandombytes/package.nix
+++ b/pkgs/by-name/li/librandombytes/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://randombytes.cr.yp.to/";
-    description = "A simple API for applications generating fresh randomness";
+    description = "Simple API for applications generating fresh randomness";
     changelog = "https://randombytes.cr.yp.to/download.html";
     license = with lib.licenses; [
       # Upstream specifies the public domain licenses with the terms here https://cr.yp.to/spdx.html

--- a/pkgs/by-name/li/librearp-lv2/package.nix
+++ b/pkgs/by-name/li/librearp-lv2/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    description = "A pattern-based arpeggio generator plugin.";
+    description = "Pattern-based arpeggio generator plugin";
     homepage = "https://librearp.gitlab.io/";
     license = licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/li/librearp/package.nix
+++ b/pkgs/by-name/li/librearp/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    description = "A pattern-based arpeggio generator plugin";
+    description = "Pattern-based arpeggio generator plugin";
     homepage = "https://librearp.gitlab.io/";
     license = licenses.gpl3Plus;
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/li/libstudxml/package.nix
+++ b/pkgs/by-name/li/libstudxml/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "A streaming XML pull parser and streaming XML serializer implementation for modern, standard C++";
+    description = "Streaming XML pull parser and streaming XML serializer implementation for modern, standard C++";
     homepage = "https://www.codesynthesis.com/projects/libstudxml/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ tomasajt ];

--- a/pkgs/by-name/li/littlenavmap/atools.nix
+++ b/pkgs/by-name/li/littlenavmap/atools.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   meta = {
-    description = "A static library extending Qt for exception handling, a log4j like logging framework, Flight Simulator related utilities like BGL reader and more";
+    description = "Static library extending Qt for exception handling, a log4j like logging framework, Flight Simulator related utilities like BGL reader and more";
     homepage = "https://github.com/albar965/atools";
     changelog = "https://github.com/albar965/atools/blob/${src.rev}/CHANGELOG.txt";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/li/littlenavmap/package.nix
+++ b/pkgs/by-name/li/littlenavmap/package.nix
@@ -120,7 +120,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   passthru.local-packages = { inherit atools marble; };
 
   meta = {
-    description = "A free flight planner, navigation tool, moving map, airport search and airport information system for Flight Simulator X, Microsoft Flight Simulator 2020, Prepar3D and X-Plane";
+    description = "Free flight planner, navigation tool, moving map, airport search and airport information system for Flight Simulator X, Microsoft Flight Simulator 2020, Prepar3D and X-Plane";
     homepage = "https://github.com/albar965/littlenavmap";
     changelog = "https://github.com/albar965/littlenavmap/blob/${src.rev}/CHANGELOG.txt";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/lo/lorien/package.nix
+++ b/pkgs/by-name/lo/lorien/package.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/mbrlabs/Lorien";
-    description = "An infinite canvas drawing/note-taking app";
+    description = "Infinite canvas drawing/note-taking app";
     longDescription = ''
       An infinite canvas drawing/note-taking app that is focused on performance,
       small savefiles and simplicity

--- a/pkgs/by-name/lp/lprobe/package.nix
+++ b/pkgs/by-name/lp/lprobe/package.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   ];
 
   meta = {
-    description = "A command-line tool to perform Local Health Check Probes inside Container Images (ECS, Docker)";
+    description = "Command-line tool to perform Local Health Check Probes inside Container Images (ECS, Docker)";
     homepage = "https://github.com/fivexl/lprobe";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/by-name/lu/luanti/package.nix
+++ b/pkgs/by-name/lu/luanti/package.nix
@@ -149,7 +149,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     homepage = "https://www.luanti.org/";
-    description = "An open source voxel game engine (formerly Minetest)";
+    description = "Open source voxel game engine (formerly Minetest)";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [

--- a/pkgs/by-name/lu/lumafly/package.nix
+++ b/pkgs/by-name/lu/lumafly/package.nix
@@ -68,7 +68,7 @@ buildDotnetModule rec {
   ];
 
   meta = {
-    description = "A cross platform mod manager for Hollow Knight written in Avalonia";
+    description = "Cross platform mod manager for Hollow Knight written in Avalonia";
     homepage = "https://themulhima.github.io/Lumafly/";
     license = lib.licenses.gpl3Plus;
     mainProgram = "Lumafly";

--- a/pkgs/by-name/ly/lyra-cursors/package.nix
+++ b/pkgs/by-name/ly/lyra-cursors/package.nix
@@ -73,7 +73,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    description = "A cursor theme inspired by macOS and based on capitaine-cursors";
+    description = "Cursor theme inspired by macOS and based on capitaine-cursors";
     homepage = "https://github.com/yeyushengfan258/Lyra-Cursors";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ma/mackup/package.nix
+++ b/pkgs/by-name/ma/mackup/package.nix
@@ -35,7 +35,7 @@ python3Packages.buildPythonApplication rec {
   disabledTests = [ "test_is_process_running" ];
 
   meta = {
-    description = "A tool to keep your application settings in sync (OS X/Linux)";
+    description = "Tool to keep your application settings in sync (OS X/Linux)";
     changelog = "https://github.com/lra/mackup/releases/tag/${version}";
     license = lib.licenses.agpl3Only;
     homepage = "https://github.com/lra/mackup";

--- a/pkgs/by-name/ma/mangl/package.nix
+++ b/pkgs/by-name/ma/mangl/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     homepage = "https://github.com/zigalenarcic/mangl";
-    description = "A graphical man page viewer based on the mandoc library";
+    description = "Graphical man page viewer based on the mandoc library";
     license = licenses.bsd2;
     maintainers = with maintainers; [ nrabulinski ];
     platforms = platforms.linux;

--- a/pkgs/by-name/ma/marble-marcher-ce/package.nix
+++ b/pkgs/by-name/ma/marble-marcher-ce/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    description = "A community-developed version of the original Marble Marcher - a fractal physics game";
+    description = "Community-developed version of the original Marble Marcher - a fractal physics game";
     mainProgram = "marble-marcher-ce";
     homepage = "https://michaelmoroz.itch.io/mmce";
     license = with lib.licenses; [

--- a/pkgs/by-name/ma/markdown-code-runner/package.nix
+++ b/pkgs/by-name/ma/markdown-code-runner/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage {
   dontUseCargoParallelTests = true;
 
   meta = {
-    description = "A configurable Markdown code runner that executes and optionally replaces code blocks using external commands";
+    description = "Configurable Markdown code runner that executes and optionally replaces code blocks using external commands";
     longDescription = ''
       markdown-code-runner is a command-line tool that scans Markdown files for fenced code blocks,
       executes them using per-language configuration, and optionally replaces the block content

--- a/pkgs/by-name/ma/mars-mips/package.nix
+++ b/pkgs/by-name/ma/mars-mips/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "An IDE for programming in MIPS assembly language intended for educational-level use";
+    description = "IDE for programming in MIPS assembly language intended for educational-level use";
     mainProgram = "Mars";
     homepage = "https://courses.missouristate.edu/KenVollmar/MARS/";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];

--- a/pkgs/by-name/ma/maxcso/package.nix
+++ b/pkgs/by-name/ma/maxcso/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/unknownbrackets/maxcso";
-    description = "A fast ISO to CSO compression program for use with PSP and PS2 emulators, which uses multiple algorithms for best compression ratio";
+    description = "Fast ISO to CSO compression program for use with PSP and PS2 emulators, which uses multiple algorithms for best compression ratio";
     maintainers = with maintainers; [ david-sawatzke ];
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.isc;

--- a/pkgs/by-name/mc/mcphost/package.nix
+++ b/pkgs/by-name/mc/mcphost/package.nix
@@ -18,7 +18,7 @@ buildGoModule (finalAttrs: {
   vendorHash = "sha256-yD+83cuOIBFF91Zu4Xi2g+dsP4iUOTrjBOuetowLRQw=";
 
   meta = {
-    description = "A CLI host application that enables Large Language Models (LLMs) to interact with external tools through the Model Context Protocol (MCP";
+    description = "CLI host application that enables Large Language Models (LLMs) to interact with external tools through the Model Context Protocol (MCP";
     homepage = "https://github.com/mark3labs/mcphost";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ drupol ];

--- a/pkgs/by-name/me/melos/package.nix
+++ b/pkgs/by-name/me/melos/package.nix
@@ -36,7 +36,7 @@ buildDartApplication {
 
   meta = {
     homepage = "https://github.com/invertase/melos";
-    description = "A tool for managing Dart projects with multiple packages. With IntelliJ and Vscode IDE support. Supports automated versioning, changelogs & publishing via Conventional Commits. ";
+    description = "Tool for managing Dart projects with multiple packages. With IntelliJ and Vscode IDE support. Supports automated versioning, changelogs & publishing via Conventional Commits. ";
     mainProgram = "melos";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.eymeric ];

--- a/pkgs/by-name/me/mesonlsp/package.nix
+++ b/pkgs/by-name/me/mesonlsp/package.nix
@@ -160,7 +160,7 @@ stdenv'.mkDerivation (finalAttrs: {
   };
 
   meta = with lib; {
-    description = "An unofficial, unendorsed language server for Meson written in C++";
+    description = "Unofficial, unendorsed language server for Meson written in C++";
     homepage = "https://github.com/JCWasmx86/mesonlsp";
     changelog = "https://github.com/JCWasmx86/mesonlsp/releases/tag/v${finalAttrs.version}";
     license = licenses.gpl3Plus;

--- a/pkgs/by-name/mi/min/package.nix
+++ b/pkgs/by-name/mi/min/package.nix
@@ -34,7 +34,7 @@ buildNimPackage (finalAttrs: {
   NIX_LDFLAGS = [ "-lpcre" ];
 
   meta = {
-    description = "A functional, concatenative programming language with a minimalist syntax";
+    description = "Functional, concatenative programming language with a minimalist syntax";
     homepage = "https://min-lang.org/";
     changelog = "https://github.com/h3rald/min/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/mi/mitm-cache/package.nix
+++ b/pkgs/by-name/mi/mitm-cache/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
   passthru.fetch = callPackage ./fetch.nix { };
 
   meta = with lib; {
-    description = "A MITM caching proxy for use in nixpkgs";
+    description = "MITM caching proxy for use in nixpkgs";
     homepage = "https://github.com/chayleaf/mitm-cache#readme";
     license = licenses.mit;
     maintainers = with maintainers; [ chayleaf ];

--- a/pkgs/by-name/mo/moonpalace/package.nix
+++ b/pkgs/by-name/mo/moonpalace/package.nix
@@ -29,7 +29,7 @@ buildGoModule rec {
   };
 
   meta = {
-    description = "An API debugging tool provided by Moonshot AI";
+    description = "API debugging tool provided by Moonshot AI";
     homepage = "https://github.com/MoonshotAI/moonpalace";
     changelog = "https://github.com/MoonshotAI/moonpalace/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/mo/mov-cli/mov-cli-test.nix
+++ b/pkgs/by-name/mo/mov-cli/mov-cli-test.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ setuptools-scm ];
 
   meta = {
-    description = "A mov-cli plugin that let's you test mov-cli's capabilities by watching free films and animations in the creative commons";
+    description = "Mov-cli plugin that let's you test mov-cli's capabilities by watching free films and animations in the creative commons";
     homepage = "https://github.com/mov-cli/mov-cli-test";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ youhaveme9 ];

--- a/pkgs/by-name/mp/mpv-subs-popout/package.nix
+++ b/pkgs/by-name/mp/mpv-subs-popout/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ];
 
   meta = {
-    description = "A little application that makes it possible to display mpv's subs anywhere you want. With translation features";
+    description = "Little application that makes it possible to display mpv's subs anywhere you want. With translation features";
     homepage = "https://github.com/sdaqo/mpv-subs-popout";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.sdaqo ];

--- a/pkgs/by-name/mq/mqtt-explorer/package.nix
+++ b/pkgs/by-name/mq/mqtt-explorer/package.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "An all-round MQTT client that provides a structured topic overview";
+    description = "All-round MQTT client that provides a structured topic overview";
     homepage = "https://github.com/thomasnordquist/MQTT-Explorer";
     changelog = "https://github.com/thomasnordquist/MQTT-Explorer/releases/tag/v${version}";
     license = licenses.cc-by-nd-40;

--- a/pkgs/by-name/mu/music-assistant/frontend.nix
+++ b/pkgs/by-name/mu/music-assistant/frontend.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     changelog = "https://github.com/music-assistant/frontend/releases/tag/${version}";
-    description = "The Music Assistant frontend";
+    description = "Music Assistant frontend";
     homepage = "https://github.com/music-assistant/frontend";
     license = licenses.asl20;
     maintainers = with maintainers; [ hexa ];

--- a/pkgs/by-name/mu/musl-obstack/package.nix
+++ b/pkgs/by-name/mu/musl-obstack/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/void-linux/musl-obstack";
-    description = "An extraction of the obstack functions and macros from GNU libiberty for use with musl-libc";
+    description = "Extraction of the obstack functions and macros from GNU libiberty for use with musl-libc";
     platforms = platforms.unix;
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.pjjw ];

--- a/pkgs/by-name/mv/mvnd/package.nix
+++ b/pkgs/by-name/mv/mvnd/package.nix
@@ -100,7 +100,7 @@ maven.buildMavenPackage rec {
     });
 
   meta = {
-    description = "The Apache Maven Daemon";
+    description = "Apache Maven Daemon";
     homepage = "https://maven.apache.org/";
     license = lib.licenses.asl20;
     platforms = builtins.attrNames platformMap;

--- a/pkgs/by-name/nb/nbsdgames/package.nix
+++ b/pkgs/by-name/nb/nbsdgames/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "A package of 18 text-based modern games";
+    description = "Package of 18 text-based modern games";
     homepage = "https://github.com/abakh/nbsdgames";
     license = lib.licenses.cc0;
     maintainers = with lib.maintainers; [ sarcasticadmin ];

--- a/pkgs/by-name/ne/next-ls/package.nix
+++ b/pkgs/by-name/ne/next-ls/package.nix
@@ -37,7 +37,7 @@ beamPackages.mixRelease rec {
   meta = {
     homepage = "https://www.elixir-tools.dev/next-ls/";
     changelog = "https://github.com/elixir-tools/next-ls/releases/tag/v${version}";
-    description = "The language server for Elixir that just works";
+    description = "Language server for Elixir that just works";
     license = lib.licenses.mit;
     mainProgram = "nextls";
     maintainers = [ lib.maintainers.adamcstephens ];

--- a/pkgs/by-name/ni/nixos-firewall-tool/package.nix
+++ b/pkgs/by-name/ni/nixos-firewall-tool/package.nix
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "A tool to temporarily manipulate the NixOS firewall";
+    description = "Tool to temporarily manipulate the NixOS firewall";
     license = licenses.mit;
     maintainers = with maintainers; [
       clerie

--- a/pkgs/by-name/ni/nixos-install-tools/package.nix
+++ b/pkgs/by-name/ni/nixos-install-tools/package.nix
@@ -28,7 +28,7 @@ in
   extraOutputsToInstall = [ "man" ];
 
   meta = {
-    description = "The essential commands from the NixOS installer as a package";
+    description = "Essential commands from the NixOS installer as a package";
     longDescription = ''
       With this package, you get the commands like nixos-generate-config and
       nixos-install that you would otherwise only find on a NixOS system, such

--- a/pkgs/by-name/nt/ntfy-alertmanager/package.nix
+++ b/pkgs/by-name/nt/ntfy-alertmanager/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   vendorHash = "sha256-8a6dvBERegpFYFHQGJppz5tlQioQAudCe3/Q7vro+ZI=";
 
   meta = with lib; {
-    description = "A bridge between ntfy and Alertmanager";
+    description = "Bridge between ntfy and Alertmanager";
     homepage = "https://git.xenrox.net/~xenrox/ntfy-alertmanager";
     license = licenses.agpl3Only;
     mainProgram = "ntfy-alertmanager";

--- a/pkgs/by-name/nu/nuv/package.nix
+++ b/pkgs/by-name/nu/nuv/package.nix
@@ -71,7 +71,7 @@ buildGoModule {
 
   meta = {
     homepage = "https://nuvolaris.io/";
-    description = "A CLI tool for running tasks using the Nuvolaris serverless engine";
+    description = "CLI tool for running tasks using the Nuvolaris serverless engine";
     license = lib.licenses.asl20;
     mainProgram = "nuv";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/nw/nwjs-ffmpeg-prebuilt/package.nix
+++ b/pkgs/by-name/nw/nwjs-ffmpeg-prebuilt/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "An app runtime based on Chromium and node.js";
+    description = "App runtime based on Chromium and node.js";
     homepage = "https://nwjs.io/";
     platforms = [
       "i686-linux"

--- a/pkgs/by-name/ob/objfw/package.nix
+++ b/pkgs/by-name/ob/objfw/package.nix
@@ -37,7 +37,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "A portable framework for the Objective-C language";
+    description = "Portable framework for the Objective-C language";
     homepage = "https://objfw.nil.im";
     license = lib.licenses.lgpl3;
     maintainers = [ lib.maintainers.steeleduncan ];

--- a/pkgs/by-name/oc/ocelot-desktop/package.nix
+++ b/pkgs/by-name/oc/ocelot-desktop/package.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    description = "An advanced OpenComputers emulator";
+    description = "Advanced OpenComputers emulator";
     homepage = "https://ocelot.fomalhaut.me/desktop";
     changelog = "https://gitlab.com/cc-ru/ocelot/ocelot-desktop/-/releases/v${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/om/omnom/package.nix
+++ b/pkgs/by-name/om/omnom/package.nix
@@ -78,7 +78,7 @@ buildGoModule (finalAttrs: {
   '';
 
   meta = {
-    description = "A webpage bookmarking and snapshotting service";
+    description = "Webpage bookmarking and snapshotting service";
     homepage = "https://github.com/asciimoo/omnom";
     license = lib.licenses.agpl3Only;
     teams = [ lib.teams.ngi ];

--- a/pkgs/by-name/on/oncall/package.nix
+++ b/pkgs/by-name/on/oncall/package.nix
@@ -100,7 +100,7 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   meta = {
-    description = "A calendar web-app designed for scheduling and managing on-call shifts";
+    description = "Calendar web-app designed for scheduling and managing on-call shifts";
     homepage = "http://oncall.tools";
     changelog = "https://github.com/linkedin/oncall/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.bsd2;

--- a/pkgs/by-name/op/opa-envoy-plugin/package.nix
+++ b/pkgs/by-name/op/opa-envoy-plugin/package.nix
@@ -67,7 +67,7 @@ buildGoModule rec {
     mainProgram = "opa";
     homepage = "https://www.openpolicyagent.org/docs/latest/envoy-introduction/";
     changelog = "https://github.com/open-policy-agent/opa-envoy-plugin/blob/v${version}/CHANGELOG.md";
-    description = "A plugin to enforce OPA policies with Envoy";
+    description = "Plugin to enforce OPA policies with Envoy";
     longDescription = ''
       OPA-Envoy extends OPA with a gRPC server that implements the Envoy
       External Authorization API. You can use this version of OPA to enforce

--- a/pkgs/by-name/op/openbgpd/package.nix
+++ b/pkgs/by-name/op/openbgpd/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   env.NIX_CFLAGS_COMPILE = "-fcommon";
 
   meta = with lib; {
-    description = "A free implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol";
+    description = "Free implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol";
     license = licenses.isc;
     homepage = "http://www.openbgpd.org/";
     maintainers = with maintainers; [ kloenk ];

--- a/pkgs/by-name/op/opensupaplex/package.nix
+++ b/pkgs/by-name/op/opensupaplex/package.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    description = "A decompilation of Supaplex in C and SDL";
+    description = "Decompilation of Supaplex in C and SDL";
     homepage = "https://github.com/sergiou87/open-supaplex";
     changelog = "https://github.com/sergiou87/open-supaplex/blob/master/changelog/v${version}.txt";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/op/optional-lite/package.nix
+++ b/pkgs/by-name/op/optional-lite/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "A C++17-like optional, a nullable object for C++98, C++11 and later in a single-file header-only library";
+    description = "C++17-like optional, a nullable object for C++98, C++11 and later in a single-file header-only library";
     homepage = "https://github.com/martinmoene/optional-lite";
     changelog = "https://github.com/martinmoene/optional-lite/blob/v${finalAttrs.version}/CHANGES.txt";
     license = lib.licenses.boost;

--- a/pkgs/by-name/os/osquery/toolchain-bin.nix
+++ b/pkgs/by-name/os/osquery/toolchain-bin.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "A LLVM-based toolchain for Linux designed to build a portable osquery";
+    description = "LLVM-based toolchain for Linux designed to build a portable osquery";
     homepage = "https://github.com/osquery/osquery-toolchain";
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/ov/overskride/package.nix
+++ b/pkgs/by-name/ov/overskride/package.nix
@@ -78,7 +78,7 @@ rustPlatform.buildRustPackage {
   '';
 
   meta = with lib; {
-    description = "A Bluetooth and Obex client that is straight to the point, DE/WM agnostic, and beautiful";
+    description = "Bluetooth and Obex client that is straight to the point, DE/WM agnostic, and beautiful";
     homepage = "https://github.com/${owner}/${name}";
     changelog = "https://github.com/${owner}/${name}/blob/v${version}/CHANGELOG.md";
     license = licenses.gpl3Only;

--- a/pkgs/by-name/ox/oxide-rs/package.nix
+++ b/pkgs/by-name/ox/oxide-rs/package.nix
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = {
-    description = "The Oxide Rust SDK and CLI";
+    description = "Oxide Rust SDK and CLI";
     homepage = "https://github.com/oxidecomputer/oxide.rs";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/pa/patchcil/package.nix
+++ b/pkgs/by-name/pa/patchcil/package.nix
@@ -59,7 +59,7 @@ buildDotnetModule rec {
   };
 
   meta = {
-    description = "A small utility to modify the library paths from PInvoke in .NET assemblies.";
+    description = "Small utility to modify the library paths from PInvoke in .NET assemblies";
     homepage = "https://github.com/GGG-KILLER/patchcil";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ggg ];

--- a/pkgs/by-name/pa/paup-cli/package.nix
+++ b/pkgs/by-name/pa/paup-cli/package.nix
@@ -41,7 +41,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    description = "A software package for inferring evolutionary trees";
+    description = "Software package for inferring evolutionary trees";
     homepage = "http://phylosolutions.com/paup-test/";
     license = lib.licenses.unfree;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];

--- a/pkgs/by-name/pe/peertube-viewer/package.nix
+++ b/pkgs/by-name/pe/peertube-viewer/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage {
   cargoHash = "sha256-Pf8Jj8XGYbNOAyYEBdAysOK92S3S7bZHerQh/2UlrbQ=";
 
   meta = with lib; {
-    description = "A simple CLI browser for the peertube federated video platform";
+    description = "Simple CLI browser for the peertube federated video platform";
     homepage = "https://gitlab.com/peertube-viewer/peertube-viewer-rs";
     license = licenses.agpl3Only;
     maintainers = with maintainers; [ haruki7049 ];

--- a/pkgs/by-name/pe/perses/package.nix
+++ b/pkgs/by-name/pe/perses/package.nix
@@ -119,7 +119,7 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    description = "The CNCF sandbox for observability visualisation";
+    description = "CNCF sandbox for observability visualisation";
     homepage = "https://perses.dev/";
     changelog = "https://github.com/perses/perses/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;

--- a/pkgs/by-name/ph/photini/package.nix
+++ b/pkgs/by-name/ph/photini/package.nix
@@ -40,7 +40,7 @@ python3Packages.buildPythonApplication rec {
   meta = {
     homepage = "https://github.com/jim-easterbrook/Photini";
     changelog = "https://photini.readthedocs.io/en/release-${version}/misc/changelog.html";
-    description = "An easy to use digital photograph metadata (Exif, IPTC, XMP) editing application";
+    description = "Easy to use digital photograph metadata (Exif, IPTC, XMP) editing application";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ zebreus ];
     mainProgram = "photini";

--- a/pkgs/by-name/pi/piano-rs/package.nix
+++ b/pkgs/by-name/pi/piano-rs/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "A multiplayer piano using UDP sockets that can be played using computer keyboard, in the terminal";
+    description = "Multiplayer piano using UDP sockets that can be played using computer keyboard, in the terminal";
     homepage = "https://github.com/ritiek/piano-rs";
     license = licenses.mit;
     mainProgram = "piano-rs";

--- a/pkgs/by-name/pi/pihole/package.nix
+++ b/pkgs/by-name/pi/pihole/package.nix
@@ -232,7 +232,7 @@
     };
 
   meta = {
-    description = "A black hole for Internet advertisements";
+    description = "Black hole for Internet advertisements";
     license = lib.licenses.eupl12;
     maintainers = with lib.maintainers; [ averyvigolo ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/pi/piscope/package.nix
+++ b/pkgs/by-name/pi/piscope/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "http://abyz.me.uk/rpi/pigpio/piscope.html";
-    description = "A logic analyser (digital waveform viewer) for the Raspberry";
+    description = "Logic analyser (digital waveform viewer) for the Raspberry";
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [ doronbehar ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    description = "A graphical tool for developing on containers and Kubernetes";
+    description = "Graphical tool for developing on containers and Kubernetes";
     homepage = "https://podman-desktop.io";
     changelog = "https://github.com/containers/podman-desktop/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;

--- a/pkgs/by-name/po/polarity/package.nix
+++ b/pkgs/by-name/po/polarity/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
-    description = "A Language with Dependent Data and Codata Types";
+    description = "Language with Dependent Data and Codata Types";
     homepage = "https://polarity-lang.github.io/";
     changelog = "https://github.com/polarity-lang/polarity/blob/${src.rev}/CHANGELOG.md";
     license = with lib.licenses; [

--- a/pkgs/by-name/po/popcorntime/package.nix
+++ b/pkgs/by-name/po/popcorntime/package.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/popcorn-official/popcorn-desktop";
-    description = "An application that streams movies and TV shows from torrents";
+    description = "Application that streams movies and TV shows from torrents";
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.gpl3;

--- a/pkgs/by-name/pp/pplatex/package.nix
+++ b/pkgs/by-name/pp/pplatex/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    description = "A tool to reformat the output of latex and friends into readable messages";
+    description = "Tool to reformat the output of latex and friends into readable messages";
     mainProgram = "pplatex";
     homepage = "https://github.com/stefanhepp/pplatex";
     license = licenses.gpl3Plus;

--- a/pkgs/by-name/pr/premid/package.nix
+++ b/pkgs/by-name/pr/premid/package.nix
@@ -155,7 +155,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A simple, configurable utility to show your web activity as playing status on Discord";
+    description = "Simple, configurable utility to show your web activity as playing status on Discord";
     homepage = "https://premid.app";
     downloadPage = "https://premid.app/downloads";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/pr/pretty-php/package.nix
+++ b/pkgs/by-name/pr/pretty-php/package.nix
@@ -25,7 +25,7 @@ php.buildComposerProject2 (finalAttrs: {
   };
 
   meta = {
-    description = "The opinionated PHP code formatter";
+    description = "Opinionated PHP code formatter";
     homepage = "https://github.com/lkrms/pretty-php";
     license = lib.licenses.mit;
     mainProgram = "pretty-php";

--- a/pkgs/by-name/pr/prometheus-jmx-javaagent/package.nix
+++ b/pkgs/by-name/pr/prometheus-jmx-javaagent/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (
 
     meta = {
       homepage = "https://github.com/prometheus/jmx_exporter";
-      description = "A process for exposing JMX Beans via HTTP for Prometheus consumption";
+      description = "Process for exposing JMX Beans via HTTP for Prometheus consumption";
       sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
       license = lib.licenses.asl20;
       maintainers = [ lib.maintainers.srhb ];

--- a/pkgs/by-name/pr/protege/package.nix
+++ b/pkgs/by-name/pr/protege/package.nix
@@ -74,7 +74,7 @@ maven.buildMavenPackage rec {
   meta = {
     homepage = "https://protege.stanford.edu/";
     downloadPage = "https://protege.stanford.edu/software.php#desktop-protege";
-    description = "A free and open-source OWL 2 ontology editor";
+    description = "Free and open-source OWL 2 ontology editor";
     longDescription = ''
       Protégé Desktop is a feature rich ontology editing environment with full
       support for the OWL 2 Web Ontology Language, and direct in-memory

--- a/pkgs/by-name/pr/protoc-gen-elixir/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-elixir/package.nix
@@ -30,7 +30,7 @@ mixRelease rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A protoc plugin to generate Elixir code";
+    description = "Protoc plugin to generate Elixir code";
     mainProgram = "protoc-gen-elixir";
     homepage = "https://github.com/elixir-protobuf/protobuf";
     license = lib.licenses.mit;

--- a/pkgs/by-name/pr/proxsuite/package.nix
+++ b/pkgs/by-name/pr/proxsuite/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
   pythonImportsCheck = [ "proxsuite" ];
 
   meta = {
-    description = "The Advanced Proximal Optimization Toolbox";
+    description = "Advanced Proximal Optimization Toolbox";
     homepage = "https://github.com/Simple-Robotics/proxsuite";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ nim65s ];

--- a/pkgs/by-name/py/pymol/package.nix
+++ b/pkgs/by-name/py/pymol/package.nix
@@ -17,7 +17,7 @@
 }:
 let
   pname = "pymol";
-  description = "A Python-enhanced molecular graphics tool";
+  description = "Python-enhanced molecular graphics tool";
 
   desktopItem = makeDesktopItem {
     name = pname;

--- a/pkgs/by-name/py/pysolfc/package.nix
+++ b/pkgs/by-name/py/pysolfc/package.nix
@@ -98,7 +98,7 @@ python311Packages.buildPythonApplication rec {
   );
 
   meta = with lib; {
-    description = "A collection of more than 1000 solitaire card games";
+    description = "Collection of more than 1000 solitaire card games";
     mainProgram = "pysol.py";
     homepage = "https://pysolfc.sourceforge.io";
     license = licenses.gpl3;

--- a/pkgs/by-name/py/pyzy/package.nix
+++ b/pkgs/by-name/py/pyzy/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
   };
 
   meta = with lib; {
-    description = "The Chinese PinYin and Bopomofo conversion library";
+    description = "Chinese PinYin and Bopomofo conversion library";
     homepage = "https://github.com/openSUSE/pyzy";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ azuwis ];

--- a/pkgs/by-name/qu/quark-goldleaf/package.nix
+++ b/pkgs/by-name/qu/quark-goldleaf/package.nix
@@ -98,7 +98,7 @@ maven.buildMavenPackage rec {
 
   meta = {
     changelog = "https://github.com/XorTroll/Goldleaf/releases/tag/${src.rev}";
-    description = "A GUI tool for transfering files between a computer and a Nintendo Switch running Goldleaf";
+    description = "GUI tool for transfering files between a computer and a Nintendo Switch running Goldleaf";
     homepage = "https://github.com/XorTroll/Goldleaf#quark-and-remote-browsing";
     longDescription = ''
       ${meta.description}

--- a/pkgs/by-name/ra/rainfrog/package.nix
+++ b/pkgs/by-name/ra/rainfrog/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage {
 
   meta = {
     changelog = "https://github.com/achristmascarl/rainfrog/releases/tag/v${version}";
-    description = "A database management TUI for postgres";
+    description = "Database management TUI for postgres";
     homepage = "https://github.com/achristmascarl/rainfrog";
     license = lib.licenses.mit;
     mainProgram = "rainfrog";

--- a/pkgs/by-name/ra/raygui/package.nix
+++ b/pkgs/by-name/ra/raygui/package.nix
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "A simple and easy-to-use immediate-mode gui library";
+    description = "Simple and easy-to-use immediate-mode gui library";
     homepage = "https://github.com/raysan5/raygui";
     license = lib.licenses.zlib;
     maintainers = with lib.maintainers; [ sigmanificient ];

--- a/pkgs/by-name/re/realm/package.nix
+++ b/pkgs/by-name/re/realm/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = with lib; {
-    description = "A simple, high performance relay server written in rust";
+    description = "Simple, high performance relay server written in rust";
     homepage = "https://github.com/zhboner/realm";
     mainProgram = "realm";
     license = licenses.mit;

--- a/pkgs/by-name/re/redact/package.nix
+++ b/pkgs/by-name/re/redact/package.nix
@@ -49,7 +49,7 @@ appimageTools.wrapType2 {
       '';
 
   meta = {
-    description = "The only platform that allows you to automatically clean up your old posts from services like Twitter, Reddit, Facebook, Discord, and more, all in one place.";
+    description = "Only platform that allows you to automatically clean up your old posts from services like Twitter, Reddit, Facebook, Discord, and more, all in one place";
     homepage = "https://redact.dev/";
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ reputable2772 ];

--- a/pkgs/by-name/re/restic-browser/package.nix
+++ b/pkgs/by-name/re/restic-browser/package.nix
@@ -61,7 +61,7 @@ rustPlatform.buildRustPackage rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A GUI to browse and restore restic backup repositories";
+    description = "GUI to browse and restore restic backup repositories";
     homepage = "https://github.com/emuell/restic-browser";
     changelog = "https://github.com/emuell/restic-browser/releases/tag/v${version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/re/rewritefs/package.nix
+++ b/pkgs/by-name/re/rewritefs/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   preConfigure = "substituteInPlace Makefile --replace /usr/local $out";
 
   meta = with lib; {
-    description = "A FUSE filesystem intended to be used like Apache mod_rewrite";
+    description = "FUSE filesystem intended to be used like Apache mod_rewrite";
     homepage = "https://github.com/sloonz/rewritefs";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ rnhmjoj ];

--- a/pkgs/by-name/rp/rpm-sequoia/package.nix
+++ b/pkgs/by-name/rp/rpm-sequoia/package.nix
@@ -71,7 +71,7 @@ rustPlatform.buildRustPackage rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "An OpenPGP backend for rpm using Sequoia PGP";
+    description = "OpenPGP backend for rpm using Sequoia PGP";
     homepage = "https://sequoia-pgp.org/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ baloo ];

--- a/pkgs/by-name/ru/rundeck-cli/package.nix
+++ b/pkgs/by-name/ru/rundeck-cli/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "The official CLI tool for Rundeck";
+    description = "Official CLI tool for Rundeck";
     longDescription = ''
       The rd command provides command line access to the Rundeck HTTP API,
       allowing you to access and control your Rundeck server from the

--- a/pkgs/by-name/ru/rush-parallel/package.nix
+++ b/pkgs/by-name/ru/rush-parallel/package.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
   ];
 
   meta = {
-    description = "A cross-platform command-line tool for executing jobs in parallel";
+    description = "Cross-platform command-line tool for executing jobs in parallel";
     homepage = "https://github.com/shenwei356/rush";
     changelog = "https://github.com/shenwei356/rush/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;

--- a/pkgs/by-name/ru/rustmission/package.nix
+++ b/pkgs/by-name/ru/rustmission/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   meta = {
-    description = "A TUI for the Transmission daemon";
+    description = "TUI for the Transmission daemon";
     homepage = "https://github.com/intuis/rustmission";
     changelog = "https://github.com/intuis/rustmission/releases/tag/v${version}";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/sa/sarif-fmt/package.nix
+++ b/pkgs/by-name/sa/sarif-fmt/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = {
-    description = "A CLI tool to pretty print SARIF diagnostics";
+    description = "CLI tool to pretty print SARIF diagnostics";
     homepage = "https://psastras.github.io/sarif-rs";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ getchoo ];

--- a/pkgs/by-name/sa/satdump/package.nix
+++ b/pkgs/by-name/sa/satdump/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A generic satellite data processing software";
+    description = "Generic satellite data processing software";
     homepage = "https://www.satdump.org/";
     changelog = "https://github.com/SatDump/SatDump/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;

--- a/pkgs/by-name/sb/sbom4python/package.nix
+++ b/pkgs/by-name/sb/sbom4python/package.nix
@@ -44,7 +44,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     changelog = "https://github.com/anthonyharrison/sbom4python/releases/tag/${src.tag}";
-    description = "A tool to generate a SBOM (Software Bill of Materials) for an installed Python module";
+    description = "Tool to generate a SBOM (Software Bill of Materials) for an installed Python module";
     homepage = "https://github.com/anthonyharrison/sbom4python";
     license = lib.licenses.asl20;
     mainProgram = "sbom4python";

--- a/pkgs/by-name/sb/sbt-extras/package.nix
+++ b/pkgs/by-name/sb/sbt-extras/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "A more featureful runner for sbt, the simple/scala/standard build tool";
+    description = "More featureful runner for sbt, the simple/scala/standard build tool";
     homepage = "https://github.com/paulp/sbt-extras";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/sc/scitokens-cpp/package.nix
+++ b/pkgs/by-name/sc/scitokens-cpp/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     homepage = "https://github.com/scitokens/scitokens-cpp/";
-    description = "A C++ implementation of the SciTokens library with a C library interface";
+    description = "C++ implementation of the SciTokens library with a C library interface";
     platforms = platforms.unix;
     license = licenses.asl20;
     maintainers = with maintainers; [ evey ];

--- a/pkgs/by-name/se/seq-cli/package.nix
+++ b/pkgs/by-name/se/seq-cli/package.nix
@@ -32,7 +32,7 @@ buildDotnetModule (finalAttrs: {
   };
 
   meta = {
-    description = "The Seq command-line client. Administer, log, ingest, search, from any OS";
+    description = "Seq command-line client. Administer, log, ingest, search, from any OS";
     homepage = "https://github.com/datalust/seqcli";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ hausken ];

--- a/pkgs/by-name/se/serie/package.nix
+++ b/pkgs/by-name/se/serie/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   passthru.tests.version = testers.testVersion { package = serie; };
 
   meta = with lib; {
-    description = "A rich git commit graph in your terminal, like magic";
+    description = "Rich git commit graph in your terminal, like magic";
     homepage = "https://github.com/lusingander/serie";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ matthiasbeyer ];

--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -155,7 +155,7 @@ rustPlatform.buildRustPackage {
   };
 
   meta = {
-    description = "The embeddable, independent, memory-safe, modular, parallel web rendering engine";
+    description = "Embeddable, independent, memory-safe, modular, parallel web rendering engine";
     homepage = "https://servo.org";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "A shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion";
+    description = "Shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion";
     homepage = "https://github.com/shader-slang/slang";
     license = with lib.licenses; [
       asl20

--- a/pkgs/by-name/sh/shellspec/package.nix
+++ b/pkgs/by-name/sh/shellspec/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   meta = with lib; {
-    description = "A full-featured BDD unit testing framework for bash, ksh, zsh, dash and all POSIX shells";
+    description = "Full-featured BDD unit testing framework for bash, ksh, zsh, dash and all POSIX shells";
     homepage = "https://shellspec.info/";
     changelog = "https://github.com/shellspec/shellspec/releases/tag/${version}";
     license = licenses.mit;

--- a/pkgs/by-name/sh/shipwright/package.nix
+++ b/pkgs/by-name/sh/shipwright/package.nix
@@ -276,7 +276,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/HarbourMasters/Shipwright";
-    description = "A PC port of Ocarina of Time with modern controls, widescreen, high-resolution, and more";
+    description = "PC port of Ocarina of Time with modern controls, widescreen, high-resolution, and more";
     mainProgram = "soh";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/sl/sleqp/package.nix
+++ b/pkgs/by-name/sl/sleqp/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    description = "An active set-based NLP solver";
+    description = "Active set-based NLP solver";
     homepage = "https://github.com/chrhansk/sleqp";
     changelog = "https://github.com/chrhansk/sleqp/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.lgpl3Only;

--- a/pkgs/by-name/sm/smartdns/package.nix
+++ b/pkgs/by-name/sm/smartdns/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "A local DNS server to obtain the fastest website IP for the best Internet experience";
+    description = "Local DNS server to obtain the fastest website IP for the best Internet experience";
     longDescription = ''
       SmartDNS is a local DNS server. SmartDNS accepts DNS query requests from local clients, obtains DNS query results from multiple upstream DNS servers, and returns the fastest access results to clients.
       Avoiding DNS pollution and improving network access speed, supports high-performance ad filtering.

--- a/pkgs/by-name/sn/snapdragon-profiler/package.nix
+++ b/pkgs/by-name/sn/snapdragon-profiler/package.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://developer.qualcomm.com/software/snapdragon-profiler";
-    description = "An profiler for Android devices running Snapdragon chips";
+    description = "Profiler for Android devices running Snapdragon chips";
     license = licenses.unfree;
     maintainers = [ ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/so/source-meta-json-schema/package.nix
+++ b/pkgs/by-name/so/source-meta-json-schema/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/sourcemeta/jsonschema";
-    description = "The CLI for working with JSON Schema. Covers formatting, linting, testing, bundling, and more for both local development and CI/CD pipelines ";
+    description = "CLI for working with JSON Schema. Covers formatting, linting, testing, bundling, and more for both local development and CI/CD pipelines ";
     changelog = "https://github.com/sourcemeta/jsonschema/releases";
     license = with lib.licenses; [
       agpl3Plus

--- a/pkgs/by-name/sp/sparrow3d/package.nix
+++ b/pkgs/by-name/sp/sparrow3d/package.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/theZiz/sparrow3d";
-    description = "A software renderer for different open handhelds like the gp2x, wiz, caanoo and pandora";
+    description = "Software renderer for different open handhelds like the gp2x, wiz, caanoo and pandora";
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ colinsane ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/sp/spip/package.nix
+++ b/pkgs/by-name/sp/spip/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "A random forest model for splice prediction in genomics";
+    description = "Random forest model for splice prediction in genomics";
     license = licenses.mit;
     homepage = "https://github.com/raphaelleman/SPiP";
     maintainers = with maintainers; [ apraga ];

--- a/pkgs/by-name/sp/splash/package.nix
+++ b/pkgs/by-name/sp/splash/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   meta = {
-    description = "An interactive visualisation and plotting tool using kernel interpolation, mainly used for Smoothed Particle Hydrodynamics simulations";
+    description = "Interactive visualisation and plotting tool using kernel interpolation, mainly used for Smoothed Particle Hydrodynamics simulations";
     inherit (finalAttrs.src.meta) homepage;
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [ doronbehar ];

--- a/pkgs/by-name/sr/srgn/package.nix
+++ b/pkgs/by-name/sr/srgn/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "A code surgeon for precise text and code transplantation";
+    description = "Code surgeon for precise text and code transplantation";
     license = licenses.mit;
     maintainers = with maintainers; [ magistau ];
     mainProgram = "srgn";

--- a/pkgs/by-name/st/stardust-xr-flatland/package.nix
+++ b/pkgs/by-name/st/stardust-xr-flatland/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = {
-    description = "A flat window for Stardust XR";
+    description = "Flat window for Stardust XR";
     homepage = "https://stardustxr.org";
     license = lib.licenses.mit;
     mainProgram = "flatland";

--- a/pkgs/by-name/st/stardust-xr-kiara/package.nix
+++ b/pkgs/by-name/st/stardust-xr-kiara/package.nix
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = {
-    description = "A 360-degree app shell / DE for Stardust XR using Niri";
+    description = "360-degree app shell / DE for Stardust XR using Niri";
     homepage = "https://stardustxr.org/";
     license = lib.licenses.mit;
     mainProgram = "kiara";

--- a/pkgs/by-name/st/stm32cubemx/package.nix
+++ b/pkgs/by-name/st/stm32cubemx/package.nix
@@ -86,7 +86,7 @@ let
     '';
 
     meta = with lib; {
-      description = "A graphical tool for configuring STM32 microcontrollers and microprocessors";
+      description = "Graphical tool for configuring STM32 microcontrollers and microprocessors";
       longDescription = ''
         A graphical tool that allows a very easy configuration of STM32
         microcontrollers and microprocessors, as well as the generation of the

--- a/pkgs/by-name/st/string-view-lite/package.nix
+++ b/pkgs/by-name/st/string-view-lite/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "A C++17-like string_view for C++98, C++11 and later in a single-file header-only library";
+    description = "C++17-like string_view for C++98, C++11 and later in a single-file header-only library";
     homepage = "https://github.com/martinmoene/string-view-lite";
     changelog = "https://github.com/martinmoene/string-view-lite/blob/v${finalAttrs.version}/CHANGES.txt";
     license = lib.licenses.boost;

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -62,7 +62,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A stylelint Language Server";
+    description = "Stylelint Language Server";
     homepage = "https://github.com/bmatcuk/stylelint-lsp";
     license = lib.licenses.mit;
     mainProgram = "stylelint-lsp";

--- a/pkgs/by-name/su/subtitleedit/package.nix
+++ b/pkgs/by-name/su/subtitleedit/package.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
-    description = "A subtitle editor";
+    description = "Subtitle editor";
     longDescription = ''
       With Subtitle Edit you can easily adjust a subtitle if it is out of sync with
       the video in several different ways. You can also use it for making

--- a/pkgs/by-name/su/supermariowar/package.nix
+++ b/pkgs/by-name/su/supermariowar/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {
-    description = "A fan-made multiplayer Super Mario Bros. style deathmatch game";
+    description = "Fan-made multiplayer Super Mario Bros. style deathmatch game";
     homepage = "https://github.com/mmatyas/supermariowar";
     changelog = "https://github.com/mmatyas/supermariowar/blob/${finalAttrs.src.rev}/CHANGELOG";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/by-name/su/supersonic/package.nix
+++ b/pkgs/by-name/su/supersonic/package.nix
@@ -95,7 +95,7 @@ buildGoModule rec {
 
   meta = with lib; {
     mainProgram = "supersonic" + lib.optionalString waylandSupport "-wayland";
-    description = "A lightweight cross-platform desktop client for Subsonic music servers";
+    description = "Lightweight cross-platform desktop client for Subsonic music servers";
     homepage = "https://github.com/dweymouth/supersonic";
     platforms = platforms.linux ++ platforms.darwin;
     license = licenses.gpl3Plus;

--- a/pkgs/by-name/su/sus-compiler/package.nix
+++ b/pkgs/by-name/su/sus-compiler/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   updateScript = nix-update-script { extraArgs = [ "--generate-lockfile" ]; };
 
   meta = {
-    description = "A new Hardware Design Language that keeps you in the driver's seat";
+    description = "New Hardware Design Language that keeps you in the driver's seat";
     homepage = "https://github.com/pc2/sus-compiler";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ pbsds ];

--- a/pkgs/by-name/sv/svix-cli/package.nix
+++ b/pkgs/by-name/sv/svix-cli/package.nix
@@ -39,7 +39,7 @@ buildGoModule rec {
   ];
 
   meta = with lib; {
-    description = "A CLI for interacting with the Svix API";
+    description = "CLI for interacting with the Svix API";
     homepage = "https://github.com/svix/svix-cli/";
     license = licenses.gpl3;
     maintainers = with maintainers; [ techknowlogick ];

--- a/pkgs/by-name/sw/swiftlint/package.nix
+++ b/pkgs/by-name/sw/swiftlint/package.nix
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation rec {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A tool to enforce Swift style and conventions";
+    description = "Tool to enforce Swift style and conventions";
     homepage = "https://realm.github.io/SwiftLint/";
     license = lib.licenses.mit;
     mainProgram = "swiftlint";

--- a/pkgs/by-name/sw/swiftshader/package.nix
+++ b/pkgs/by-name/sw/swiftshader/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "A high-performance CPU-based implementation of the Vulkan 1.3 graphics API";
+    description = "High-performance CPU-based implementation of the Vulkan 1.3 graphics API";
     homepage = "https://opensource.google/projects/swiftshader";
     license = licenses.asl20;
     # Should be possible to support Darwin by changing the install phase with

--- a/pkgs/by-name/sy/symfpu/package.nix
+++ b/pkgs/by-name/sy/symfpu/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A (concrete or symbolic) implementation of IEEE-754 / SMT-LIB floating-point";
+    description = "(concrete or symbolic) implementation of IEEE-754 / SMT-LIB floating-point";
     homepage = "https://github.com/martin-cs/symfpu";
     license = licenses.gpl3Only;
     platforms = platforms.unix;

--- a/pkgs/by-name/sy/synthesia/package.nix
+++ b/pkgs/by-name/sy/synthesia/package.nix
@@ -69,7 +69,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A fun way to learn how to play the piano";
+    description = "Fun way to learn how to play the piano";
     homepage = "https://synthesiagame.com/";
     downloadPage = "https://synthesiagame.com/download";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/tc/tcld/package.nix
+++ b/pkgs/by-name/tc/tcld/package.nix
@@ -39,7 +39,7 @@ buildGoModule (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "The temporal cloud cli.";
+    description = "Temporal cloud cli";
     homepage = "https://www.github.com/temporalio/tcld";
     license = lib.licenses.mit;
     teams = [ lib.teams.mercury ];

--- a/pkgs/by-name/te/techmino/package.nix
+++ b/pkgs/by-name/te/techmino/package.nix
@@ -15,7 +15,7 @@
 
 let
   pname = "techmino";
-  description = "A modern Tetris clone with many features";
+  description = "Modern Tetris clone with many features";
 
   desktopItem = makeDesktopItem {
     name = pname;

--- a/pkgs/by-name/te/ted/package.nix
+++ b/pkgs/by-name/te/ted/package.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "An easy rich text processor";
+    description = "Easy rich text processor";
     longDescription = ''
       Ted is a text processor running under X Windows on Unix/Linux systems.
       Ted was developed as a standard easy light weight word processor, having

--- a/pkgs/by-name/tf/tfmigrate/package.nix
+++ b/pkgs/by-name/tf/tfmigrate/package.nix
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A Terraform / OpenTofu state migration tool for GitOps ";
+    description = "Terraform / OpenTofu state migration tool for GitOps ";
     homepage = "https://github.com/minamijoyo/tfmigrate";
     changelog = "https://github.com/minamijoyo/tfmigrate/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/tf/tfswitch/package.nix
+++ b/pkgs/by-name/tf/tfswitch/package.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "A command line tool to switch between different versions of terraform";
+    description = "Command line tool to switch between different versions of terraform";
     mainProgram = "tfswitch";
     homepage = "https://github.com/warrensbox/terraform-switcher";
     license = licenses.mit;

--- a/pkgs/by-name/tg/tg-archive/package.nix
+++ b/pkgs/by-name/tg/tg-archive/package.nix
@@ -39,7 +39,7 @@ python3.pkgs.buildPythonApplication {
   ];
 
   meta = {
-    description = "A tool for exporting Telegram group chats into static websites like mailing list archives";
+    description = "Tool for exporting Telegram group chats into static websites like mailing list archives";
     homepage = "https://github.com/knadh/tg-archive";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ euxane ];

--- a/pkgs/by-name/ti/tic-80/package.nix
+++ b/pkgs/by-name/ti/tic-80/package.nix
@@ -130,7 +130,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with lib; {
-    description = "A free and open source fantasy computer for making, playing and sharing tiny games";
+    description = "Free and open source fantasy computer for making, playing and sharing tiny games";
     longDescription = ''
       TIC-80 is a free and open source fantasy computer for making, playing and
       sharing tiny games.

--- a/pkgs/by-name/to/tome2/package.nix
+++ b/pkgs/by-name/to/tome2/package.nix
@@ -11,7 +11,7 @@
 
 let
   pname = "tome2";
-  description = "A dungeon crawler similar to Angband, based on the works of Tolkien";
+  description = "Dungeon crawler similar to Angband, based on the works of Tolkien";
 
   desktopItem = makeDesktopItem {
     desktopName = pname;

--- a/pkgs/by-name/tr/transgui/package.nix
+++ b/pkgs/by-name/tr/transgui/package.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    description = "A cross platform front-end for the Transmission BitTorrent client";
+    description = "Cross platform front-end for the Transmission BitTorrent client";
     homepage = "https://sourceforge.net/p/transgui";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ ramkromberg ];

--- a/pkgs/by-name/tr/trrntzip/package.nix
+++ b/pkgs/by-name/tr/trrntzip/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ zlib ];
 
   meta = with lib; {
-    description = "The goal of the program is to use standard values when creating zips to create identical files over multiple systems";
+    description = "Goal of the program is to use standard values when creating zips to create identical files over multiple systems";
     longDescription = ''
       Torrentzip converts zip archives to a standard format with some
       pre-defined values, sorting the files, and using particular compression

--- a/pkgs/by-name/ts/tscli/package.nix
+++ b/pkgs/by-name/ts/tscli/package.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
   '';
 
   meta = {
-    description = "A CLI tool to interact with the Tailscale API";
+    description = "CLI tool to interact with the Tailscale API";
     homepage = "https://github.com/jaxxstorm/tscli";
     changelog = "https://github.com/jaxxstorm/tscli/releases/tag/${src.tag}/CHANGELOG.md";
     mainProgram = "tscli";

--- a/pkgs/by-name/ty/typship/package.nix
+++ b/pkgs/by-name/ty/typship/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "A Typst package CLI tool";
+    description = "Typst package CLI tool";
     homepage = "https://github.com/sjfhsjfh/typship";
     license = lib.licenses.mit;
     changelog = "https://github.com/sjfhsjfh/typship/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/tz/tzf-rs/package.nix
+++ b/pkgs/by-name/tz/tzf-rs/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A fast timezone finder for Rust";
+    description = "Fast timezone finder for Rust";
     homepage = "https://github.com/ringsaturn/tzf-rs";
     changelog = "https://github.com/ringsaturn/tzf-rs/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/u-/u-root/package.nix
+++ b/pkgs/by-name/u-/u-root/package.nix
@@ -55,7 +55,7 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    description = "A fully Go userland with Linux bootloaders";
+    description = "Fully Go userland with Linux bootloaders";
     longDescription = ''
       u-root can create a one-binary root file system (initramfs) containing a busybox-like set of tools written in Go.
 

--- a/pkgs/by-name/un/unflac/package.nix
+++ b/pkgs/by-name/un/unflac/package.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "A command line tool for fast frame accurate audio image + cue sheet splitting";
+    description = "Command line tool for fast frame accurate audio image + cue sheet splitting";
     homepage = "https://sr.ht/~ft/unflac/";
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/by-name/un/unnamed-sdvx-clone/package.nix
+++ b/pkgs/by-name/un/unnamed-sdvx-clone/package.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "A game based on K-Shoot MANIA and Sound Voltex";
+    description = "Game based on K-Shoot MANIA and Sound Voltex";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sako ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/us/usbkvm/package.nix
+++ b/pkgs/by-name/us/usbkvm/package.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "https://github.com/carrotIndustries/usbkvm";
-    description = "An open-source USB KVM (Keyboard, Video and Mouse) adapter";
+    description = "Open-source USB KVM (Keyboard, Video and Mouse) adapter";
     changelog = "https://github.com/carrotIndustries/usbkvm/releases/tag/v${version}";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ lschuermann ];

--- a/pkgs/by-name/va/vacuum-go/package.nix
+++ b/pkgs/by-name/va/vacuum-go/package.nix
@@ -37,7 +37,7 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    description = "The world's fastest OpenAPI & Swagger linter";
+    description = "World's fastest OpenAPI & Swagger linter";
     homepage = "https://quobix.com/vacuum";
     changelog = "https://github.com/daveshanley/vacuum/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/va/vangers/package.nix
+++ b/pkgs/by-name/va/vangers/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "The video game that combines elements of the racing and role-playing genres";
+    description = "Video game that combines elements of the racing and role-playing genres";
     homepage = "https://github.com/KranX/Vangers";
     mainProgram = "vangers";
     platforms = lib.platforms.all;

--- a/pkgs/by-name/va/variant-lite/package.nix
+++ b/pkgs/by-name/va/variant-lite/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "A C++17-like variant, a type-safe union for C++98, C++11 and later in a single-file header-only library";
+    description = "C++17-like variant, a type-safe union for C++98, C++11 and later in a single-file header-only library";
     homepage = "https://github.com/martinmoene/variant-lite";
     changelog = "https://github.com/martinmoene/variant-lite/blob/v${finalAttrs.version}/CHANGES.txt";
     license = lib.licenses.boost;

--- a/pkgs/by-name/ve/veloren/package.nix
+++ b/pkgs/by-name/ve/veloren/package.nix
@@ -101,7 +101,7 @@ rustPlatform.buildRustPackage {
   '';
 
   meta = with lib; {
-    description = "An open world, open source voxel RPG";
+    description = "Open world, open source voxel RPG";
     homepage = "https://www.veloren.net";
     license = licenses.gpl3;
     mainProgram = "veloren-voxygen";

--- a/pkgs/by-name/vi/vimcats/package.nix
+++ b/pkgs/by-name/vi/vimcats/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   passthru.tests.version = testers.testVersion { package = vimcats; };
 
   meta = with lib; {
-    description = "A CLI to generate vim/nvim help doc from LuaCATS. Forked from lemmy-help";
+    description = "CLI to generate vim/nvim help doc from LuaCATS. Forked from lemmy-help";
     longDescription = ''
       `vimcats` is a LuaCATS parser as well as a CLI which takes that parsed tree and converts it into vim help docs.
       It is a fork of lemmy-help that aims to support more recent LuaCATS features.

--- a/pkgs/by-name/vi/vis/package.nix
+++ b/pkgs/by-name/vi/vis/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A vim like editor";
+    description = "Vim like editor";
     homepage = "https://github.com/martanne/vis";
     license = licenses.isc;
     maintainers = with maintainers; [ ramkromberg ];

--- a/pkgs/by-name/vk/vkd3d-proton/package.nix
+++ b/pkgs/by-name/vk/vkd3d-proton/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/HansKristian-Work/vkd3d-proton";
-    description = "A fork of VKD3D, which aims to implement the full Direct3D 12 API on top of Vulkan";
+    description = "Fork of VKD3D, which aims to implement the full Direct3D 12 API on top of Vulkan";
     license = with lib.licenses; [ lgpl21Plus ];
     maintainers = with lib.maintainers; [ ];
     inherit (wine.meta) platforms;

--- a/pkgs/by-name/vo/volatility2-bin/package.nix
+++ b/pkgs/by-name/vo/volatility2-bin/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     homepage = "https://volatilityfoundation.org/";
     mainProgram = "volatility2";
-    description = "An advanced memory forensics framework";
+    description = "Advanced memory forensics framework";
     platforms = [
       "x86_64-linux"
       "x86_64-darwin"

--- a/pkgs/by-name/vs/vscode-js-debug/package.nix
+++ b/pkgs/by-name/vs/vscode-js-debug/package.nix
@@ -75,7 +75,7 @@ buildNpmPackage rec {
       '';
 
   meta = with lib; {
-    description = "A DAP-compatible JavaScript debugger";
+    description = "DAP-compatible JavaScript debugger";
     longDescription = ''
       This is a [DAP](https://microsoft.github.io/debug-adapter-protocol/)-based
       JavaScript debugger. It debugs Node.js, Chrome, Edge, WebView2, VS Code

--- a/pkgs/by-name/vs/vst2-sdk/package.nix
+++ b/pkgs/by-name/vs/vst2-sdk/package.nix
@@ -16,7 +16,7 @@ fetchzip rec {
   '';
 
   meta = {
-    description = "The VST2 source development kit";
+    description = "VST2 source development kit";
     longDescription = ''
       VST2 is proprietary, and deprecated by Steinberg.
       As such, it should only be used for legacy reasons.

--- a/pkgs/by-name/vz/vzic/package.nix
+++ b/pkgs/by-name/vz/vzic/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://github.com/libical/vzic";
-    description = "A program to convert the IANA timezone database files into VTIMEZONE files compatible with the iCalendar specification";
+    description = "Program to convert the IANA timezone database files into VTIMEZONE files compatible with the iCalendar specification";
     changelog = "https://github.com/libical/vzic/blob/${src.rev}/ChangeLog";
     mainProgram = "vzic";
     license = with lib.licenses; [ gpl2Plus ];

--- a/pkgs/by-name/wc/wchisp/package.nix
+++ b/pkgs/by-name/wc/wchisp/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = {
-    description = "A command-line implementation of WCHISPTool, for flashing ch32 MCUs";
+    description = "Command-line implementation of WCHISPTool, for flashing ch32 MCUs";
     homepage = "https://ch32-rs.github.io/wchisp/";
     changelog = "https://github.com/ch32-rs/wchisp/releases/tag/v${version}";
     license = with lib.licenses; [ gpl2Only ];

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A Beautiful Private and Secure Desktop Investment Tracking Application";
+    description = "Beautiful Private and Secure Desktop Investment Tracking Application";
     homepage = "https://wealthfolio.app/";
     license = lib.licenses.agpl3Only;
     mainProgram = "wealthfolio";

--- a/pkgs/by-name/we/webcord/package.nix
+++ b/pkgs/by-name/we/webcord/package.nix
@@ -80,7 +80,7 @@ buildNpmPackage rec {
   passthru.updateScript = ./update.sh;
 
   meta = {
-    description = "A Discord and SpaceBar electron-based client implemented without Discord API";
+    description = "Discord and SpaceBar electron-based client implemented without Discord API";
     homepage = "https://github.com/SpacingBat3/WebCord";
     downloadPage = "https://github.com/SpacingBat3/WebCord/releases";
     changelog = "https://github.com/SpacingBat3/WebCord/releases/tag/v${version}";

--- a/pkgs/by-name/wg/wg-access-server/package.nix
+++ b/pkgs/by-name/wg/wg-access-server/package.nix
@@ -66,7 +66,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description = "An all-in-one WireGuard VPN solution with a web ui for connecting devices";
+    description = "All-in-one WireGuard VPN solution with a web ui for connecting devices";
     homepage = "https://github.com/freifunkMUC/wg-access-server";
     license = licenses.mit;
     maintainers = with maintainers; [ xanderio ];

--- a/pkgs/by-name/wh/whoogle-search/package.nix
+++ b/pkgs/by-name/wh/whoogle-search/package.nix
@@ -69,7 +69,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     homepage = "https://github.com/benbusby/whoogle-search";
-    description = "A self-hosted, ad-free, privacy-respecting metasearch engine";
+    description = "Self-hosted, ad-free, privacy-respecting metasearch engine";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ malte-v ];
     mainProgram = "whoogle-search";

--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -188,7 +188,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "An OpenXR streaming application to a standalone headset";
+    description = "OpenXR streaming application to a standalone headset";
     homepage = "https://github.com/WiVRn/WiVRn/";
     changelog = "https://github.com/WiVRn/WiVRn/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/wl/wl-crosshair/package.nix
+++ b/pkgs/by-name/wl/wl-crosshair/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage {
   '';
 
   meta = {
-    description = "A crosshair overlay for wlroots compositor";
+    description = "Crosshair overlay for wlroots compositor";
     homepage = "https://github.com/lelgenio/wl-crosshair";
     license = lib.licenses.unfree; # didn't found a license
     mainProgram = "wl-crosshair";

--- a/pkgs/by-name/wv/wvdial/package.nix
+++ b/pkgs/by-name/wv/wvdial/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
   ];
 
   meta = {
-    description = "A dialer that automatically recognises the modem";
+    description = "Dialer that automatically recognises the modem";
     homepage = "https://gitea.osmocom.org/retronetworking/wvdial";
     license = lib.licenses.lgpl2;
     maintainers = with lib.maintainers; [ flokli ];

--- a/pkgs/by-name/xa/xar/package.nix
+++ b/pkgs/by-name/xa/xar/package.nix
@@ -181,7 +181,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/apple-oss-distributions/xar";
-    description = "An easily extensible archive format";
+    description = "Easily extensible archive format";
     license = lib.licenses.bsd3;
     maintainers = lib.attrValues { inherit (lib.maintainers) tie; };
     teams = [ lib.teams.darwin ];

--- a/pkgs/by-name/yg/yggdrasil/package.nix
+++ b/pkgs/by-name/yg/yggdrasil/package.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
   passthru.tests.basic = nixosTests.yggdrasil;
 
   meta = with lib; {
-    description = "An experiment in scalable routing as an encrypted IPv6 overlay network";
+    description = "Experiment in scalable routing as an encrypted IPv6 overlay network";
     homepage = "https://yggdrasil-network.github.io/";
     license = licenses.lgpl3;
     maintainers = with maintainers; [

--- a/pkgs/by-name/yt/ytmdesktop/package.nix
+++ b/pkgs/by-name/yt/ytmdesktop/package.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     changelog = "https://github.com/ytmdesktop/ytmdesktop/tag/v${finalAttrs.version}";
-    description = "A Desktop App for YouTube Music";
+    description = "Desktop App for YouTube Music";
     downloadPage = "https://github.com/ytmdesktop/ytmdesktop/releases";
     homepage = "https://ytmdesktop.app/";
     license = lib.licenses.gpl3Only;

--- a/pkgs/by-name/z8/z88dk/package.nix
+++ b/pkgs/by-name/z8/z88dk/package.nix
@@ -25,7 +25,7 @@ let
       hash = "sha256-NbQIy9d4ZcMnRJJApPBSej+W6e/aJ8rkb5E7rD7GVgs=";
     };
     meta = {
-      description = "A date object with as little code as possible (and rw accessors)";
+      description = "Date object with as little code as possible (and rw accessors)";
       license = with lib.licenses; [
         artistic1
         gpl1Plus

--- a/pkgs/by-name/ze/zenoh-plugin-mqtt/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-mqtt/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   meta = {
-    description = "A Zenoh plug-in that allows to integrate and/or route MQTT pub/sub with Eclipse Zenoh";
+    description = "Zenoh plug-in that allows to integrate and/or route MQTT pub/sub with Eclipse Zenoh";
     homepage = "https://github.com/eclipse-zenoh/zenoh-plugin-mqtt";
     license = with lib.licenses; [
       epl20

--- a/pkgs/by-name/ze/zeronsd/package.nix
+++ b/pkgs/by-name/ze/zeronsd/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "A DNS server for ZeroTier users";
+    description = "DNS server for ZeroTier users";
     homepage = "https://github.com/zerotier/zeronsd";
     license = licenses.bsd3;
     maintainers = [ maintainers.dstengele ];

--- a/pkgs/by-name/zi/zimfw/package.nix
+++ b/pkgs/by-name/zi/zimfw/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "The Zsh configuration framework with blazing speed and modular extensions";
+    description = "Zsh configuration framework with blazing speed and modular extensions";
     homepage = "https://zimfw.sh";
     license = licenses.mit;
     maintainers = [ maintainers.joedevivo ];

--- a/pkgs/by-name/zs/zsh-zhooks/package.nix
+++ b/pkgs/by-name/zs/zsh-zhooks/package.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   meta = {
-    description = "A tool for displaying the code for all Zsh hook functions";
+    description = "Tool for displaying the code for all Zsh hook functions";
     homepage = "https://github.com/agkozak/zhooks";
     license = lib.licenses.mit;
     longDescription = ''

--- a/pkgs/by-name/zt/ztools/package.nix
+++ b/pkgs/by-name/zt/ztools/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "An essential set of Z-machine tools for interpreter authors, experienced Inform programmers, and Z-code hackers.";
+    description = "Essential set of Z-machine tools for interpreter authors, experienced Inform programmers, and Z-code hackers";
     homepage = "http://inform-fiction.org/zmachine/ztools.html";
     license = lib.licenses.cc-by-sa-40;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
We avoid these articles to conform to [this style guide entry](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#meta-attributes):

    meta.description must:
        Be short, just one sentence.
        Be capitalized.
        Not start with the definite or an indefinite article.
        Not start with the package name.
            More generally, it should not refer to the package name.
        Not end with a period (or any punctuation for that matter).
        Provide factual information.
            Avoid subjective language.


Inspired by a comment by @dotlambda on [`tscli`](https://github.com/NixOS/nixpkgs/pull/413709/files/e32cdad1e8153475ce0157031dc32e32a2cd23e5#r2125239601), which made me think that this would be fairly widespread (as it was.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).