### PR TITLE
treewide: migrate `rev = "refs/tags/..."` to `tag`

### DIFF
--- a/pkgs/by-name/an/ansible-doctor/package.nix
+++ b/pkgs/by-name/an/ansible-doctor/package.nix
@@ -13,7 +13,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "thegeeklab";
     repo = "ansible-doctor";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-nZv1PdR0kGrke2AjcDWjDWBdsw64UpHYFNDFAe/UoJo=";
   };
 

--- a/pkgs/by-name/cn/cns11643-kai/package.nix
+++ b/pkgs/by-name/cn/cns11643-kai/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rypervenche";
     repo = "cns11643-fonts";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-A/4iwNvyzOYEpBzxKeq1xM/6aU6EOCATAr0lQlyckKQ=";
   };
 

--- a/pkgs/by-name/co/commitlint-rs/package.nix
+++ b/pkgs/by-name/co/commitlint-rs/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "KeisukeYamashita";
     repo = "commitlint-rs";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-9az7AJ4NXmisRZiCFTdHQBVatgEIdRuKU6ZEKVHEgnQ=";
   };
 
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Lint commit messages with conventional commit messages";
     homepage = "https://keisukeyamashita.github.io/commitlint-rs";
-    changelog = "https://github.com/KeisukeYamashita/commitlint-rs/releases/tag/${src.rev}";
+    changelog = "https://github.com/KeisukeYamashita/commitlint-rs/releases/tag/v${version}";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/co/conduktor-ctl/package.nix
+++ b/pkgs/by-name/co/conduktor-ctl/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "conduktor";
     repo = "ctl";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-u2WnFpVEN5tvVFyzPlIH68eUYVutJl2oTJKOwyxm18M=";
   };
 

--- a/pkgs/by-name/cv/cve-prioritizer/package.nix
+++ b/pkgs/by-name/cv/cve-prioritizer/package.nix
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "TURROKS";
     repo = "CVE_Prioritizer";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-FJN/AM4NFctMszzIBdvww7OtC7fimb++tbtRZ77ll5c=";
   };
 

--- a/pkgs/by-name/di/diffnav/package.nix
+++ b/pkgs/by-name/di/diffnav/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "dlvhdr";
     repo = "diffnav";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-admPiEKyatdUkR89vZP8RYHTqtZVSJ8KSvtpnsBViBw=";
   };
 
@@ -31,7 +31,7 @@ buildGoModule rec {
   '';
 
   meta = {
-    changelog = "https://github.com/dlvhdr/diffnav/releases/tag/${src.rev}";
+    changelog = "https://github.com/dlvhdr/diffnav/releases/tag/v${version}";
     description = "Git diff pager based on delta but with a file tree, à la GitHub";
     homepage = "https://github.com/dlvhdr/diffnav";
     license = lib.licenses.mit;

--- a/pkgs/by-name/do/dovecot-fts-flatcurve/package.nix
+++ b/pkgs/by-name/do/dovecot-fts-flatcurve/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "slusarz";
     repo = "dovecot-fts-flatcurve";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-96sR/pl0G0sSjh/YrXdgVgASJPhrL32xHCbBGrDxzoU=";
   };
 

--- a/pkgs/by-name/mo/mongodb-atlas-cli/package.nix
+++ b/pkgs/by-name/mo/mongodb-atlas-cli/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "mongodb";
     repo = "mongodb-atlas-cli";
-    rev = "refs/tags/atlascli/v${version}";
+    tag = "atlascli/v${version}";
     sha256 = "sha256-RJMcVOP94eFxbvYF20/X+wkf5+/DWSEQ4+dt/LxcDro=";
   };
 

--- a/pkgs/by-name/np/npm-check-updates/package.nix
+++ b/pkgs/by-name/np/npm-check-updates/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "raineorshine";
     repo = "npm-check-updates";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-JVwjjGs1BCQnL9q4zwnQ56JRWL5CZ9cf4FyK2jpfKKE=";
   };
 

--- a/pkgs/by-name/pa/package-version-server/package.nix
+++ b/pkgs/by-name/pa/package-version-server/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "zed-industries";
     repo = "package-version-server";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-/YyJ8+tKrNKVrN+F/oHgtExBBRatIIOvWr9mAyTHA3E=";
   };
 

--- a/pkgs/by-name/ph/phylophlan/package.nix
+++ b/pkgs/by-name/ph/phylophlan/package.nix
@@ -17,7 +17,7 @@ let
     src = fetchFromGitHub {
       owner = "biobakery";
       repo = "phylophlan";
-      rev = "refs/tags/${finalAttrs.version}";
+      tag = finalAttrs.version;
       hash = "sha256-KlWKt2tH2lQBh/eQ2Hbcu2gXHEFfmFEc6LrybluxINc=";
     };
 

--- a/pkgs/by-name/po/pop-wallpapers/package.nix
+++ b/pkgs/by-name/po/pop-wallpapers/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "wallpapers";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-JST5Rt4Ec1lRu62PUt98S2G1vKthAyOSpyCpuCnkGmw=";
   };
 

--- a/pkgs/by-name/sa/satyrographos/package.nix
+++ b/pkgs/by-name/sa/satyrographos/package.nix
@@ -10,7 +10,7 @@ let
   src = fetchFromGitHub {
     owner = "na4zagin3";
     repo = "satyrographos";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     sha256 = "sha256-f9iJTr4nV7dFCMkI8+zv9qvYWRSw8H/xbbZm2LR9cB4=";
   };
 in
@@ -40,7 +40,7 @@ ocamlPackages.buildDunePackage {
   ];
 
   meta = {
-    changelog = "https://github.com/na4zagin3/satyrographos/releases/tag/${src.rev}";
+    changelog = "https://github.com/na4zagin3/satyrographos/releases/tag/v${version}";
     description = "Package manager for SATySFi";
     homepage = "https://github.com/na4zagin3/satyrographos";
     maintainers = with lib.maintainers; [ momeemt ];

--- a/pkgs/by-name/sk/skyscraper/package.nix
+++ b/pkgs/by-name/sk/skyscraper/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Gemba";
     repo = "skyscraper";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = finalAttrs.version;
     hash = "sha256-VcXa+aI2z+EKJgAtMKsYO/QZ3Ky2acsRYcqDqMFNedg=";
   };
 

--- a/pkgs/by-name/sp/spot/package.nix
+++ b/pkgs/by-name/sp/spot/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "xou816";
     repo = "spot";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-7zWK0wkh53ojnoznv4T/X//JeyKJVKOrfYF0IkvciIY=";
   };
 
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Native Spotify client for the GNOME desktop";
     homepage = "https://github.com/xou816/spot";
-    changelog = "https://github.com/xou816/spot/releases/tag/${src.rev}";
+    changelog = "https://github.com/xou816/spot/releases/tag/${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "spot";

--- a/pkgs/by-name/su/supercell-wx/package.nix
+++ b/pkgs/by-name/su/supercell-wx/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "dpaulat";
     repo = "supercell-wx";
-    rev = "refs/tags/v${finalAttrs.version}-release";
+    tag = "v${finalAttrs.version}-release";
     sha256 = "sha256-3fVUxbGosN4Y4h8BJXUV7DNv7VZTma+IsV94+Zt8DCA=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/tc/tcld/package.nix
+++ b/pkgs/by-name/tc/tcld/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "temporalio";
     repo = "tcld";
-    rev = "refs/tags/v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-bIJSvop1T3yiLs/LTgFxIMmObfkVfvvnONyY4Bsjj8g=";
   };
   vendorHash = "sha256-GOko8nboj7eN4W84dqP3yLD6jK7GA0bANV0Tj+1GpgY=";

--- a/pkgs/by-name/un/unfs3/package.nix
+++ b/pkgs/by-name/un/unfs3/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "unfs3";
     repo = "unfs3";
-    rev = "refs/tags/unfs3-${version}";
+    tag = "unfs3-${version}";
     hash = "sha256-5iAriIutBhwyZVS7AG2fnkrHOI7pNAKfYv062Cy0WXw=";
   };
 

--- a/pkgs/by-name/ur/urlfinder/package.nix
+++ b/pkgs/by-name/ur/urlfinder/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "urlfinder";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-dtCXCRnI05822+a5Os+I+ZAmL/hC884PRCIPlEY3jok=";
   };
 

--- a/pkgs/by-name/wy/wyoming-faster-whisper/package.nix
+++ b/pkgs/by-name/wy/wyoming-faster-whisper/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "wyoming-faster-whisper";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-Ai28i+2/oWI2Y61x7U5an5MBHfuBaGy6qZZwZydS308=";
   };
 

--- a/pkgs/by-name/wy/wyoming-openwakeword/package.nix
+++ b/pkgs/by-name/wy/wyoming-openwakeword/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "wyoming-openwakeword";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-5suYJ+Z6ofVAysoCdHi5b5K0JTYaqeFZ32Cm76wC5LU=";
   };
 

--- a/pkgs/by-name/yg/yggdrasil-jumper/package.nix
+++ b/pkgs/by-name/yg/yggdrasil-jumper/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "one-d-wide";
     repo = "yggdrasil-jumper";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-Op3KBJ911AjB7BIJuV4xR8KHMxBtQj7hf++tC1g7SlM=";
   };
 

--- a/pkgs/development/octave-modules/video/default.nix
+++ b/pkgs/development/octave-modules/video/default.nix
@@ -14,7 +14,7 @@ buildOctavePackage rec {
   src = fetchFromGitHub {
     owner = "Andy1978";
     repo = "octave-video";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-fn9LNfuS9dSStBfzBjRRkvP50JJ5K+Em02J9+cHqt6w=";
   };
 

--- a/pkgs/development/python-modules/alabaster/default.nix
+++ b/pkgs/development/python-modules/alabaster/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sphinx-doc";
     repo = "alabaster";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-aQEhFZUJs0TptfpjQVoIVI9V9a+xKjE2OfStSaJKHGI=";
   };
 

--- a/pkgs/development/python-modules/ewmhlib/default.nix
+++ b/pkgs/development/python-modules/ewmhlib/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Kalmat";
     repo = "EWMHlib";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-NELOgUV8KuN+CqmoSbLYImguHlp8dyhGmJtoxJjOBkA=";
   };
 

--- a/pkgs/development/python-modules/pymonctl/default.nix
+++ b/pkgs/development/python-modules/pymonctl/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Kalmat";
     repo = "PyMonCtl";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-eFB+HqYBud836VNEA8q8o1KQKA+GHwSC0YfU1KCbDXw=";
   };
 

--- a/pkgs/development/python-modules/pyrevolve/default.nix
+++ b/pkgs/development/python-modules/pyrevolve/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "devitocodes";
     repo = pname;
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-fcIq/zuKO3W7K9N2E4f2Q6ZVcssZwN/n8o9cCOYmr3E=";
   };
 

--- a/pkgs/development/python-modules/pywinbox/default.nix
+++ b/pkgs/development/python-modules/pywinbox/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Kalmat";
     repo = "PyWinBox";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-Z/gedrIFNpQvzRWqGxMEl5MoEIo9znZz/FZLMVl0Eb4=";
   };
 

--- a/pkgs/development/python-modules/temporalio/default.nix
+++ b/pkgs/development/python-modules/temporalio/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "temporalio";
     repo = "sdk-python";
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-942EmFOAYUWq58MW2rIVhDK9dHkzi62fUdOudYP94hU=";
     fetchSubmodules = true;
   };

--- a/pkgs/development/python-modules/zabbix-utils/default.nix
+++ b/pkgs/development/python-modules/zabbix-utils/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "zabbix";
     repo = "python-zabbix-utils";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-rRPen/FzWT0cCnXWiSdoybtXeP1pxYqnjq5b0QPVs1I=";
   };
 

--- a/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
@@ -13,7 +13,7 @@ buildHomeAssistantComponent rec {
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
-    rev = "refs/tags/${version}";
+    tag = version;
     hash = "sha256-sRmf+6rOWnbLZaO5kJw+9Udsyj6fX2BeFh8tN9xkZRk=";
   };
 


### PR DESCRIPTION
Redo of https://github.com/NixOS/nixpkgs/pull/368177, part of https://github.com/NixOS/nixpkgs/issues/346453.
I've modernized the script with what i've learned during other treewides in preparation for adapting it for non `"refs/tags/..."` migrations of `rev`.

Done with:
```bash
#!/usr/bin/env nix-shell
#!nix-shell -I nixpkgs=. --pure -i bash -p ripgrep sd jq git git-wait lix util-linux diffutils delta
set -euo pipefail

export NIX_PATH= # no nixpkgs-overlays plz
export NIXPKGS_CONFIG= # no surprises plz

export NIXPKGS_ALLOW_UNFREE=1
export NIXPKGS_ALLOW_INSECURE=1
export NIXPKGS_ALLOW_BROKEN=1

#  === helpers ===

verbose() (
  set -x
  "$@"
)

mk_packages_json() (
  set -x
  time nix-env  \
    --extra-experimental-features no-url-literals  \
    --option system x86_64-linux  \
    -f ./.  \
    -qaP  \
    --json \
    --meta \
    --drv-path \
    --out-path \
    --show-trace \
    --no-allow-import-from-derivation  \
    --arg config '{ allowAliases = false; }' \
    | sd '.nix:[0-9]+"' '.nix:XX"' \
    | sd '"line":[0-9]+,' '"line":"XX",' \
    | sd '"line":[0-9]+}' '"line":"XX"}'
)

list_attrpath_fname_column() {
    jq <packages.json 'to_entries[] | select(.value.meta.position==null|not) | "\(.key)\t\(.value.meta.position)"' -r |
        sed -e "s#\t$(realpath .)/#\t#" |
        sed -E 's#:[^:]+$##' |
        grep . |
        grep -iv haskell |
        grep -iv /top-level/ |
        grep -iv chicken |
        grep -iv build |
        grep -E '/(package|default)\.nix'
}

_eval_json_with_fixup() {
  local expression="$1"
  nix eval \
    --extra-experimental-features nix-command \
    --log-format raw \
    --impure \
    --json \
    --expr '
      let
        pkgs = import ./. { };
        inherit (pkgs) lib;
        fixup = attrs: lib.attrsets.mapAttrs'"'"' (k: v: lib.nameValuePair (if k != "outPath" then k else "outPath_") v) attrs;
      in
        lib.attrsets.filterAttrsRecursive (n: v: !lib.isFunction v) ('"$expression"')
      ' \
    | sd '.nix:[0-9]+"' '.nix:XX"' \
    | sd '"line":[0-9]+,' '"line":"XX",' \
    | sd '"line":[0-9]+}' '"line":"XX"}'
}

eval_package_out_attributes() {
  local attrpath="$1"
  _eval_json_with_fixup '
    fixup {
      inherit (pkgs.'"${attrpath}"') pname version drvPath outPath passthru meta;
      src = fixup { inherit (pkgs.'"${attrpath}"'.src) name owner repo drvPath outPath; };
    }
  ' | sd \
    '"changelog":"https://github.com/([^/]+)/([^/]+)/blob/refs/tags/' \
    '"changelog":"https://github.com/$1/$2/blob/'
}
eval_package_rev_tag() {
  local attrpath="$1"
  _eval_json_with_fixup '
    fixup {
      inherit (pkgs.'"${attrpath}"'.src) owner repo rev tag;
    }
  '
}


# === start ===

git-wait restore .

test -s packages.json || mk_packages_json >packages.json
touch bad-paths.txt

set +e

while IFS=$'\t' read attrpath fname; do
    [[ -n "$attrpath" ]] || continue
    [[ -s "$fname" ]]    || continue
    grep -qE "(fetchgit|fetchFromGitHub)" "$fname" || continue
    grep -qE '\brev = "refs/tags/'        "$fname" || continue
    grep -qE '\btag = "'                  "$fname" && continue ||:

    # skip previous failures
    grep -qxF "$fname" bad-paths.txt && continue ||:

    (
        set -euo pipefail
        echo "$attrpath"

        # === read ===

        pkgdata1a="$(eval_package_rev_tag "$attrpath")"; [[ -n "$pkgdata1a" ]]

        owner="$(jq <<<"$pkgdata1a" .owner -r)"; [[ -n "$owner" ]]
        repo="$( jq <<<"$pkgdata1a" .repo  -r)"; [[ -n "$repo"  ]]
        rev="$(  jq <<<"$pkgdata1a" .rev   -r)"; [[ -n "$rev"   ]]

        grep -qE <<<"$rev" "^refs/tags/"

        pkgdata1b="$(
          eval_package_out_attributes "$attrpath" \
            | sd \
              '"changelog":"https://github.com/([^/]+)/([^/]+)/releases/tag/refs/tags/' \
              '"changelog":"https://github.com/$1/$2/releases/tag/'
        )";
        [[ -n "$pkgdata1b" ]]

        # the nix expression for rev
        tag_expr="$(grep -E '\brev = "refs/tags/(.*)";' "$fname" -o | cut -d'"' -f2 | cut -d/ -f3-)"
        # we have no guarantee of correctness if there are multiple matches
        [[ -n "$tag_expr" ]]
        [[ "$(wc -l <<<"$tag_expr" ||:)" -eq 1 ]]


        # === patch ===

        # convert rev -> tag
        verbose sd '\brev = "refs/tags/(.*)";'  'tag = "$1";'  "$fname"
        verbose sd '\btag = "\$\{(.*)\}";'      'tag = $1;'    "$fname"

        # fix meta changelog (YAGNI)
        prefix="https://github.com/$owner/$repo/releases/tag"
        verbose sd -F "$prefix"'/${self.src.rev}'        "$prefix/$tag_expr"  "$fname"
        verbose sd -F "$prefix"'/${src.rev}'             "$prefix/$tag_expr"  "$fname"
        verbose sd -F "$prefix"'/${finalAttrs.src.rev}'  "$prefix/$tag_expr"  "$fname"
        # undo https://github.com/NixOS/nixpkgs/pull/338301
        verbose sd -F "$prefix"'/${lib.removePrefix "refs/tags/" src.rev}'             "$prefix/$tag_expr"  "$fname"
        verbose sd -F "$prefix"'/${lib.removePrefix "refs/tags/" finalAttrs.src.rev}'  "$prefix/$tag_expr"  "$fname"
        verbose sd -F "$prefix"'/${lib.removePrefix "refs/tags/" self.src.rev}'        "$prefix/$tag_expr"  "$fname"


        # === read and verify ===

        pkgdata2a="$(eval_package_rev_tag "$attrpath")"; [[ -n "$pkgdata2a" ]]

        if [[ "$pkgdata1a" = "$pkgdata2a" ]]; then
            echo >&2 "ERROR: src.tag didn't change"
            git-wait diff "$fname" | delta --paging=never
            false
        fi

        pkgdata2b="$(eval_package_out_attributes "$attrpath")"; [[ -n "$pkgdata2b" ]]

        if [[ "$pkgdata1b" != "$pkgdata2b" ]]; then
            echo >&2 "ERROR: derivations, outputs, passthru or meta has changed"
            git-wait diff "$fname" | delta --paging=never
            diff -u <(cat <<<"$pkgdata1b") <(cat <<<"$pkgdata2b") | delta --paging=never
            false
        fi

        # Test if src builds, this checks the FOD hash.
        # This is not actually needed since all drvPath are unchanged (FODs only fix the outPath)
        #if ! nix-build . -A "$attrpath".src --check ; then
        #    >&2 echo "src doesn't build"
        #    git-wait diff "$fname" | delta --paging=never
        #    false
        #fi


        #  === commit ===

        verbose git-wait add "$fname"

    ) </dev/null

    #  === rollback ===

    if [[ "$?" -ne 0 ]]; then
      verbose git-wait restore "$fname" || verbose git-wait restore .
      # track failures, to faster resume if aborting the script
      echo "$fname" >> bad-paths.txt
    fi

done < <(list_attrpath_fname_column)

# git-wait restore .
mk_packages_json >packages2.json
```

and filtered with `GIT_DIFF_OPTS='--unified=20' git -c interactive.singleKey=true add --patch`.
I the checked `diff -u packages{,2}.json` which only shows changed `meta.changelog`s and the nixos-manual, hence no eval failures (which CI does not report on) are introduced.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
