### PR TITLE
python3Packages.django_5_2: 5.2.1 -> 5.2.2

### DIFF
--- a/nixos/tests/atticd.nix
+++ b/nixos/tests/atticd.nix
@@ -78,7 +78,7 @@ in
           s3.wait_for_unit("minio.service")
           s3.wait_for_open_port(9000)
           s3.succeed(
-              "mc config host add minio "
+              "mc alias set minio "
               + "http://localhost:9000 "
               + "${accessKey} ${secretKey} --api s3v4",
               "mc mb minio/attic",

--- a/nixos/tests/nextcloud/with-objectstore.nix
+++ b/nixos/tests/nextcloud/with-objectstore.nix
@@ -126,7 +126,7 @@ runTest (
 
         with subtest("Check if file is in S3"):
             nextcloud.succeed(
-                "mc config host add minio https://acme.test ${accessKey} ${secretKey} --api s3v4"
+                "mc alias set minio https://acme.test ${accessKey} ${secretKey} --api s3v4"
             )
             files = nextcloud.succeed('mc ls minio/nextcloud|sort').strip().split('\n')
 

--- a/nixos/tests/outline.nix
+++ b/nixos/tests/outline.nix
@@ -44,7 +44,7 @@ in
 
     # Create a test bucket on the server
     machine.succeed(
-        "mc config host add minio http://localhost:9000 ${accessKey} ${secretKey} --api s3v4"
+        "mc alias set minio http://localhost:9000 ${accessKey} ${secretKey} --api s3v4"
     )
     machine.succeed("mc mb minio/outline")
 

--- a/nixos/tests/thanos.nix
+++ b/nixos/tests/thanos.nix
@@ -234,7 +234,7 @@ import ./make-test-python.nix {
       s3.wait_for_unit("minio.service")
       s3.wait_for_open_port(${toString minioPort})
       s3.succeed(
-          "mc config host add minio "
+          "mc alias set minio "
           + "http://localhost:${toString minioPort} "
           + "${s3.accessKey} ${s3.secretKey} --api s3v4",
           "mc mb minio/thanos-bucket",

--- a/nixos/tests/web-apps/lasuite-docs.nix
+++ b/nixos/tests/web-apps/lasuite-docs.nix
@@ -141,7 +141,7 @@ in
       machine.wait_for_unit("lasuite-docs-collaboration-server.service")
 
     with subtest("Create S3 bucket"):
-      machine.succeed("mc config host add minio http://${s3Domain} ${minioAccessKey} ${minioSecretKey} --api s3v4")
+      machine.succeed("mc alias set minio http://${s3Domain} ${minioAccessKey} ${minioSecretKey} --api s3v4")
       machine.succeed("mc mb lasuite-docs")
 
     with subtest("Wait for web servers to start"):

--- a/pkgs/development/python-modules/django/5_2.nix
+++ b/pkgs/development/python-modules/django/5_2.nix
@@ -44,7 +44,7 @@
 
 buildPythonPackage rec {
   pname = "django";
-  version = "5.2.1";
+  version = "5.2.2";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     owner = "django";
     repo = "django";
     rev = "refs/tags/${version}";
-    hash = "sha256-JmO2IEWrpA7/FXOwESLvIIuHmi2HQgvg28LVNmBXgLA=";
+    hash = "sha256-x5PTE8oYA1VzErYXfuRzT4xNiMRnfEd6H9lEtB+HBkc=";
   };
 
   patches =


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.2/releases/5.2.2/
https://www.djangoproject.com/weblog/2025/jun/04/security-releases/

Fixes: CVE-2025-48432
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
