### PR TITLE
 [Backport release-24.11] kind: 0.24.0 -> 0.29.0

### DIFF
--- a/pkgs/by-name/ki/kind/package.nix
+++ b/pkgs/by-name/ki/kind/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "kind";
-  version = "0.24.0";
+  version = "0.29.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "kubernetes-sigs";
     repo = "kind";
-    hash = "sha256-vndN3ssiaaJdpPZQ0vBdqr4xPuY2bAHAd+SJamNrX6Q=";
+    hash = "sha256-Dv4I50LQcr8fOaCCdaKkz+pHIG05UBQAdDs7gGngm4Y=";
   };
 
   patches = [
@@ -21,7 +21,7 @@ buildGoModule rec {
     ./kernel-module-path.patch
   ];
 
-  vendorHash = "sha256-VfqNM48M39R2LaUHirKmSXCdvBXUHu09oMzDPmAQC4o=";
+  vendorHash = "sha256-QFDQkl1QuIc0fUK0raVxmPT7AF6fsKlQ4F0dzOM9fcw=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Manual backport of #408589

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?#changes-acceptable-for-releases).
  - Even as a non-committer, if you find that it is not acceptable, leave a comment.
