### PR TITLE
owi: init at 0.2-unstable-2025-05-05

### DIFF
--- a/pkgs/by-name/ow/owi/package.nix
+++ b/pkgs/by-name/ow/owi/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  ocaml-ng,
+  fetchFromGitHub,
+  llvmPackages,
+  rustc,
+  zig,
+  makeWrapper,
+  unstableGitUpdater,
+}:
+
+let
+  ocamlPackages = ocaml-ng.ocamlPackages_5_1;
+in
+ocamlPackages.buildDunePackage rec {
+  pname = "owi";
+  version = "0.2-unstable-2025-05-05";
+
+  src = fetchFromGitHub {
+    owner = "ocamlpro";
+    repo = "owi";
+    rev = "e4c2e85f1364714a77a925ec29321cf9b8fe90f4";
+    fetchSubmodules = true;
+    hash = "sha256-ewaAkSyxtiiE8WcHusOyZDesqI61kCEN3pMb99R7Dkw=";
+  };
+
+  nativeBuildInputs = with ocamlPackages; [
+    findlib
+    menhir
+    # unwrapped because wrapped tries to enforce a target and the build
+    # script wants to do its own thing
+    llvmPackages.clang-unwrapped
+    # lld + llc isn't included in unwrapped, so we pull it in here
+    llvmPackages.bintools-unwrapped
+    rustc
+    zig
+    makeWrapper
+  ];
+
+  buildInputs = with ocamlPackages; [
+    bos
+    cmdliner
+    digestif
+    dolmen_type
+    dune-build-info
+    dune-site
+    hc
+    integers
+    menhir
+    menhirLib
+    ocaml_intrinsics
+    patricia-tree
+    prelude
+    processor
+    pyml
+    re2
+    scfg
+    sedlex
+    smtml
+    uutf
+    xmlm
+    yojson
+    z3
+    zarith
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/owi \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          llvmPackages.bintools-unwrapped
+          llvmPackages.clang-unwrapped
+          rustc
+          zig
+        ]
+      }
+  '';
+
+  doCheck = false;
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Symbolic execution for Wasm, C, C++, Rust and Zig";
+    homepage = "https://ocamlpro.github.io/owi/";
+    downloadPage = "https://github.com/OCamlPro/owi";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+    teams = with lib.teams; [ ngi ];
+    mainProgram = "owi";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Having trouble getting tests to pass. I may split the Ocaml libraries into a separate PR just to have them merged earlier.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
