### PR TITLE
ocamlPackages.dns: 10.0.0 → 10.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/dns/cli.nix
+++ b/pkgs/development/ocaml-modules/dns/cli.nix
@@ -5,6 +5,7 @@
   dns-client-lwt,
   dns-server,
   dns-certify,
+  dns-resolver,
   dnssec,
   bos,
   cmdliner,
@@ -13,6 +14,7 @@
   mirage-crypto,
   mirage-crypto-pk,
   mirage-crypto-rng,
+  mirage-mtime,
   ohex,
   ptime,
   mtime,
@@ -39,6 +41,7 @@ buildDunePackage {
     dns-client-lwt
     dns-server
     dns-certify
+    dns-resolver
     dnssec
     bos
     cmdliner
@@ -47,6 +50,7 @@ buildDunePackage {
     mirage-crypto
     mirage-crypto-pk
     mirage-crypto-rng
+    mirage-mtime
     ohex
     ptime
     mtime

--- a/pkgs/development/ocaml-modules/dns/default.nix
+++ b/pkgs/development/ocaml-modules/dns/default.nix
@@ -18,13 +18,13 @@
 
 buildDunePackage rec {
   pname = "dns";
-  version = "10.0.0";
+  version = "10.1.0";
 
   minimalOCamlVersion = "4.13";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-dns/releases/download/v${version}/dns-${version}.tbz";
-    hash = "sha256-dPO9BjvTE0UrpxKrmtgPrgfV/2uG/E9Wd/BNYSMtFwI=";
+    hash = "sha256-XG/qUUzsOccy5xdkZD6PuViN7gOMmRwYSsy+07QeN9I=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/dns/resolver.nix
+++ b/pkgs/development/ocaml-modules/dns/resolver.nix
@@ -14,7 +14,6 @@
   tcpip,
   tls,
   tls-mirage,
-  mirage-crypto-rng-mirage,
   dnssec,
   alcotest,
 }:
@@ -40,7 +39,6 @@ buildDunePackage {
     tcpip
     tls
     tls-mirage
-    mirage-crypto-rng-mirage
   ];
 
   doCheck = true;


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
