### PR TITLE
[25.05] openscad-unstable: 2025-02-07 -> 2025-06-04

### DIFF
--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -30,7 +30,6 @@
   libsForQt5,
   libspnav,
   libzip,
-  manifold,
   mesa,
   mpfr,
   python3,
@@ -99,7 +98,6 @@ clangStdenv.mkDerivation rec {
       lib3mf
       libspnav
       libzip
-      manifold
       mpfr
       qscintilla
       qtbase
@@ -119,7 +117,9 @@ clangStdenv.mkDerivation rec {
     "-DEXPERIMENTAL=ON" # enable experimental options
     "-DSNAPSHOT=ON" # nightly icons
     "-DUSE_BUILTIN_OPENCSG=OFF"
-    "-DUSE_BUILTIN_MANIFOLD=OFF"
+    # use builtin manifold: 3.1.0 doesn't pass tests, builtin is 7c8fbe1, between 3.0.1 and 3.1.0
+    # FIXME revisit on version update
+    "-DUSE_BUILTIN_MANIFOLD=ON"
     "-DUSE_BUILTIN_CLIPPER2=OFF"
     "-DOPENSCAD_VERSION=\"${builtins.replaceStrings [ "-" ] [ "." ] version}\""
     "-DCMAKE_UNITY_BUILD=OFF" # broken compile with unity

--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -46,12 +46,12 @@
 # clang consume much less RAM than GCC
 clangStdenv.mkDerivation rec {
   pname = "openscad-unstable";
-  version = "2025-02-07";
+  version = "2025-05-17";
   src = fetchFromGitHub {
     owner = "openscad";
     repo = "openscad";
-    rev = "1308a7d476facb466bf9fae1e77666c35c8e3c8f";
-    hash = "sha256-+0cQ5mgRzOPfP6nl/rfC/hnw3V7yvGJCyLU8hOmlGOc=";
+    rev = "c76900f9a62fcb98c503dcc5ccce380db8ac564b";
+    hash = "sha256-R2/8T5+BugVTRIUVLaz6SxKQ1YrtyAGbiE4K1Fuc6bg=";
     # Unfortunately, we can't selectively fetch submodules. It would be good
     # to see that we don't accidentally depend on it.
     fetchSubmodules = true; # Only really need sanitizers-cmake and MCAD

--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -51,9 +51,7 @@ clangStdenv.mkDerivation rec {
     repo = "openscad";
     rev = "c76900f9a62fcb98c503dcc5ccce380db8ac564b";
     hash = "sha256-R2/8T5+BugVTRIUVLaz6SxKQ1YrtyAGbiE4K1Fuc6bg=";
-    # Unfortunately, we can't selectively fetch submodules. It would be good
-    # to see that we don't accidentally depend on it.
-    fetchSubmodules = true; # Only really need sanitizers-cmake and MCAD
+    fetchSubmodules = true; # Only really need sanitizers-cmake and MCAD and manifold
   };
 
   patches = [ ./test.diff ];
@@ -134,6 +132,14 @@ clangStdenv.mkDerivation rec {
 
   # tests rely on sysprof which is not available on darwin
   doCheck = !stdenv.hostPlatform.isDarwin;
+
+  # remove unused submodules, to ensure correct dependency usage
+  postUnpack = ''
+    ( cd $sourceRoot
+      for m in submodules/OpenCSG submodules/mimalloc submodules/Clipper2
+      do rm -r $m
+      done )
+  '';
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir $out/Applications

--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -34,7 +34,7 @@
   mesa,
   mpfr,
   python3,
-  tbb_2021_11,
+  tbb_2022_0,
   wayland,
   wayland-protocols,
   wrapGAppsHook3,
@@ -81,7 +81,7 @@ clangStdenv.mkDerivation rec {
     [
       clipper2
       glm
-      tbb_2021_11
+      tbb_2022_0
       mimalloc
       boost
       cairo

--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -30,6 +30,7 @@
   libsForQt5,
   libspnav,
   libzip,
+  manifold,
   mesa,
   mpfr,
   python3,
@@ -45,12 +46,12 @@
 # clang consume much less RAM than GCC
 clangStdenv.mkDerivation rec {
   pname = "openscad-unstable";
-  version = "2025-05-17";
+  version = "2025-06-04";
   src = fetchFromGitHub {
     owner = "openscad";
     repo = "openscad";
-    rev = "c76900f9a62fcb98c503dcc5ccce380db8ac564b";
-    hash = "sha256-R2/8T5+BugVTRIUVLaz6SxKQ1YrtyAGbiE4K1Fuc6bg=";
+    rev = "65856c9330f8cc4ffcaccf03d91b4217f2eae28d";
+    hash = "sha256-jozcLFGVSfw8G12oSxHjqUyFtAfENgIByID+omk08mU=";
     fetchSubmodules = true; # Only really need sanitizers-cmake and MCAD and manifold
   };
 
@@ -87,7 +88,6 @@ clangStdenv.mkDerivation rec {
       eigen
       fontconfig
       freetype
-      ghostscript
       glib
       gmp
       opencsg
@@ -96,6 +96,7 @@ clangStdenv.mkDerivation rec {
       lib3mf
       libspnav
       libzip
+      manifold
       mpfr
       qscintilla
       qtbase
@@ -115,9 +116,7 @@ clangStdenv.mkDerivation rec {
     "-DEXPERIMENTAL=ON" # enable experimental options
     "-DSNAPSHOT=ON" # nightly icons
     "-DUSE_BUILTIN_OPENCSG=OFF"
-    # use builtin manifold: 3.1.0 doesn't pass tests, builtin is 7c8fbe1, between 3.0.1 and 3.1.0
-    # FIXME revisit on version update
-    "-DUSE_BUILTIN_MANIFOLD=ON"
+    "-DUSE_BUILTIN_MANIFOLD=OFF"
     "-DUSE_BUILTIN_CLIPPER2=OFF"
     "-DOPENSCAD_VERSION=\"${builtins.replaceStrings [ "-" ] [ "." ] version}\""
     "-DCMAKE_UNITY_BUILD=OFF" # broken compile with unity
@@ -150,15 +149,10 @@ clangStdenv.mkDerivation rec {
   nativeCheckInputs = [
     mesa.llvmpipeHook
     ctestCheckHook
+    ghostscript
   ];
 
   dontUseNinjaCheck = true;
-  checkFlags = [
-    "-E"
-    # some fontconfig issues cause pdf output to have wrong font
-    # manifold update caused slight rendering changes
-    "pdfexporttest|amfrendermanifoldtest_(issue1105|bad-stl-pcbvicebar|bad-stl-tardis)"
-  ];
 
   meta = with lib; {
     description = "3D parametric model compiler (unstable)";


### PR DESCRIPTION
The last commit will fail the cherry-pick check (due to #413621)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).