### PR TITLE
Create Typora repository for Chinese repo

### DIFF
--- a/pkgs/by-name/ty/typoracn/package.nix
+++ b/pkgs/by-name/ty/typoracn/package.nix
@@ -1,0 +1,140 @@
+{
+  stdenv,
+  fetchurl,
+  dpkg,
+  lib,
+  glib,
+  nss,
+  nspr,
+  cups,
+  dbus,
+  libdrm,
+  gtk3,
+  pango,
+  cairo,
+  libxkbcommon,
+  libgbm,
+  expat,
+  alsa-lib,
+  buildFHSEnv,
+  writeTextFile,
+}:
+
+let
+  pname = "typora";
+  version = "1.10.8";
+  src = fetchurl {
+    url = "https://download.typoraio.cn/linux/typora_${version}_amd64.deb";
+    hash = "sha256-7auxTtdVafvM2fIpQVvEey1Q6eLVG3mLdjdZXcqSE/Q=";
+  };
+
+  typoraBase = stdenv.mkDerivation {
+    inherit pname version src;
+
+    nativeBuildInputs = [ dpkg ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/share
+      mv usr/share $out
+      ln -s $out/share/typora/Typora $out/bin/Typora
+
+      runHook postInstall
+    '';
+  };
+
+  typoraFHS = buildFHSEnv {
+    pname = "typora-fhs";
+    inherit version;
+    targetPkgs =
+      pkgs:
+      (with pkgs; [
+        typoraBase
+        udev
+        alsa-lib
+        glib
+        nss
+        nspr
+        atk
+        cups
+        dbus
+        gtk3
+        libdrm
+        pango
+        cairo
+        libgbm
+        libGL
+        expat
+        libxkbcommon
+      ])
+      ++ (with pkgs.xorg; [
+        libX11
+        libXcursor
+        libXrandr
+        libXcomposite
+        libXdamage
+        libXext
+        libXfixes
+        libxcb
+      ]);
+    runScript = ''
+      Typora "$@"
+    '';
+  };
+
+  launchScript = writeTextFile {
+    name = "typora-launcher";
+    executable = true;
+    text = ''
+      #!${stdenv.shell}
+
+      # Configuration directory setup
+      XDG_CONFIG_HOME=''${XDG_CONFIG_HOME:-~/.config}
+      TYPORA_CONFIG_DIR="$XDG_CONFIG_HOME/Typora"
+      TYPORA_DICT_DIR="$TYPORA_CONFIG_DIR/typora-dictionaries"
+
+      # Create config directories with proper permissions
+      mkdir -p "$TYPORA_DICT_DIR"
+      chmod 755 "$TYPORA_CONFIG_DIR"
+      chmod 755 "$TYPORA_DICT_DIR"
+
+      # Read user flags if they exist
+      if [ -f "$XDG_CONFIG_HOME/typora-flags.conf" ]; then
+        TYPORA_USER_FLAGS="$(sed 's/#.*//' "$XDG_CONFIG_HOME/typora-flags.conf" | tr '\n' ' ')"
+      fi
+
+      exec ${typoraFHS}/bin/typora-fhs "$@" $TYPORA_USER_FLAGS
+    '';
+  };
+
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ln -s ${launchScript} $out/bin/typora
+    ln -s ${typoraBase}/share/ $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Markdown editor, a markdown reader, build by Chinese repository.";
+    homepage = "https://typoraio.cn/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ npulidomateo ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "typora";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

### Motivation

This PR adds a new package: `typoracn`, which is a build of Typora using software sources from mainland China. This is intended to improve accessibility and download speed for users in China.

### Things done

- [x] Added a new package definition under `pkgs/by-name/typoracn`
- [x] Used China mainland software sources for all required dependencies and fetches
- [x] Tested installation and launch on NixOS (please specify your test platform if possible)
- [x] Added myself as a maintainer (if applicable)

#### Checklist from the PR template

- [x] Built on platform(s): NixOS (please specify architecture, e.g., x86_64-linux)
- [x] Tested execution of the main binary
- [x] Meets Nixpkgs contribution standards
- [x] Used sandboxing for builds (if possible)
- [x] Checked if dependent packages build with `nixpkgs-review` (if applicable)

#### Further comments

If there are any suggestions for improving the use of regional sources or general packaging practices, please let me know.
