### PR TITLE
Mailspring

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20601,6 +20601,13 @@
     githubId = 337811;
     name = "Rehno Lindeque";
   };
+  relief-melone = {
+    email = "relief.melone@proton.me";
+    github = "relief-melone";
+    githubId = 6393439;
+    name = "Relief Melone";
+    keys = [ { fingerprint = "8FA81E61BCA8A9DAA03463AF29AF463035D86E25"; } ];
+  };
   relrod = {
     email = "ricky@elrod.me";
     github = "relrod";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -249,6 +249,7 @@
   ./programs/liboping.nix
   ./programs/light.nix
   ./programs/localsend.nix
+  ./programs/mailspring.nix
   ./programs/mdevctl.nix
   ./programs/mepo.nix
   ./programs/mininet.nix

--- a/nixos/modules/programs/mailspring.nix
+++ b/nixos/modules/programs/mailspring.nix
@@ -1,0 +1,114 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  emptySource = pkgs.runCommand "empty-source" { } ''
+    mkdir $out
+  '';
+  desktopItem = pkgs.makeDesktopItem {
+    name = "mailspring";
+    desktopName = "Mailspring";
+    genericName = "Email Client";
+    exec = "mailspring";
+    terminal = false;
+    type = "Application";
+    categories = [
+      "Network"
+      "Email"
+    ];
+    icon = "mailspring";
+  };
+
+  wrapPackage =
+    { settings }:
+    pkgs.stdenv.mkDerivation rec {
+      pname = "mailspring";
+      version = lib.getVersion pkgs.mailspring;
+      executable = pkgs.writeShellScript "mailspring.sh" ''
+        EXECUTABLE=${lib.getExe pkgs.mailspring}
+        FLAGS=${
+          lib.concatStringsSep " " (
+            [ ]
+            ++ lib.optional (settings.password-store != null) "--password-store=${settings.password-store}"
+            ++ lib.optional (settings.dev != null) "--dev=${toString settings.dev}"
+            ++ lib.optional (settings.log-file != null) "--log-file=${settings.log-file}"
+            ++ lib.optional (settings.background != null) "--background=${toString settings.background}"
+            ++ lib.optional (settings.safe != null) "--safe=${toString settings.safe}"
+          )
+        }
+
+        if [ "$#" -gt 0 ]; then
+          $EXECUTABLE "$@"
+        else
+          $EXECUTABLE $FLAGS
+        fi
+      '';
+      src = emptySource;
+      nativeBuildInputs = [ pkgs.copyDesktopItems ];
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/bin $out/share
+        install -Dm755 ${executable} -T $out/bin/mailspring
+        cp -r ${pkgs.mailspring}/share/icons $out/share
+        cp -r ${desktopItem}/* $out/
+        runHook postInstall
+      '';
+
+      desktopItems = [ "share/applications/mailspring.desktop" ];
+    };
+in
+{
+  options.programs.mailspring = {
+    enable = lib.mkEnableOption "Mailspring E-Mail client";
+
+    settings.password-store = lib.mkOption {
+      type = lib.types.enum [
+        "basic"
+        "gnome-keyring"
+        "gnome-libsecret"
+        "kwallet"
+        "kwallet5"
+        "kwallet6"
+        "pass"
+      ];
+      description = "e.g. kwallet6 or gnome-libsecret";
+    };
+
+    settings.log-file = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Log all test output to file";
+    };
+
+    settings.dev = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Run in development mode";
+    };
+
+    settings.background = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Start Mailspring in the background";
+    };
+
+    settings.safe = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = "Do not load packages from the settings 'packages' or 'dev/packages' folders.";
+    };
+  };
+
+  config = lib.mkIf config.programs.mailspring.enable {
+    environment.systemPackages = with config.programs.mailspring; [
+      (wrapPackage { inherit settings; })
+    ];
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    relief-melone
+  ];
+}

--- a/nixos/modules/programs/mailspring.nix
+++ b/nixos/modules/programs/mailspring.nix
@@ -37,6 +37,9 @@ let
             ++ lib.optional (settings.log-file != null) "--log-file=${settings.log-file}"
             ++ lib.optional (settings.background != null) "--background=${toString settings.background}"
             ++ lib.optional (settings.safe != null) "--safe=${toString settings.safe}"
+            ++ lib.optional (settings.safe != null) "--safe=${toString settings.safe}"
+            ++ lib.optional (settings.enable-features != null) "--enable-features=${settings.enable-features}"
+            ++ lib.optional (settings.ozone-platform != null) "--ozone-platform=${settings.ozone-platform}"
           )
         }
 
@@ -99,6 +102,18 @@ in
       type = lib.types.nullOr lib.types.bool;
       default = null;
       description = "Do not load packages from the settings 'packages' or 'dev/packages' folders.";
+    };
+
+    settings.enable-features = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Enable features flag";
+    };
+
+    settings.ozone-platform = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "OzonePlatform to use";
     };
   };
 

--- a/nixos/modules/programs/mailspring.nix
+++ b/nixos/modules/programs/mailspring.nix
@@ -29,7 +29,7 @@ let
       version = lib.getVersion pkgs.mailspring;
       executable = pkgs.writeShellScript "mailspring.sh" ''
         EXECUTABLE=${lib.getExe pkgs.mailspring}
-        FLAGS=${
+        FLAGS='${
           lib.concatStringsSep " " (
             [ ]
             ++ lib.optional (settings.password-store != null) "--password-store=${settings.password-store}"
@@ -41,7 +41,7 @@ let
             ++ lib.optional (settings.enable-features != null) "--enable-features=${settings.enable-features}"
             ++ lib.optional (settings.ozone-platform != null) "--ozone-platform=${settings.ozone-platform}"
           )
-        }
+        }'
 
         if [ "$#" -gt 0 ]; then
           $EXECUTABLE "$@"


### PR DESCRIPTION
Adding Mailspring to the list of programs

## Things done
- added Mailspring to the module list
- added a configurable module for mailspring
- added relief-melone to the list of maintainers
- no separate package build. uses the previously built mailspring package

- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) -> should not be relevant
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant -> not relevant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module -> not relevant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
