### PR TITLE
Revert "level-zero: 1.21.9 -> 1.22.3"

### DIFF
--- a/pkgs/by-name/le/level-zero/package.nix
+++ b/pkgs/by-name/le/level-zero/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "level-zero";
-  version = "1.22.3";
+  version = "1.21.9";
 
   src = fetchFromGitHub {
     owner = "oneapi-src";
     repo = "level-zero";
     tag = "v${version}";
-    hash = "sha256-yCrfaAoxvsDngfayw13/HqL4RW/gC+eRls6WgIELWHE=";
+    hash = "sha256-I9jCS4ZDEfOH/2kgIgeNne96Z5YZdzsmUGXza8PmXZI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#409510

The latest release is https://github.com/oneapi-src/level-zero/releases/tag/v1.21.9, 1.22.3 is a prerelease.