### PR TITLE
tree-sitter: 0.25.4 -> 0.25.6, update grammars

### DIFF
--- a/pkgs/development/python-modules/tree-sitter-markdown/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-markdown/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "tree-sitter-markdown";
-  version = "0.4.1";
+  version = "0.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tree-sitter-grammars";
     repo = "tree-sitter-markdown";
     tag = "v${version}";
-    hash = "sha256-Oe2iL5b1Cyv+dK0nQYFNLCCOCe+93nojxt6ukH2lEmU=";
+    hash = "sha256-I9KDE1yZce8KIGPLG5tmv5r/NCWwN95R6fIyvGdx+So=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/tree-sitter-rust/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-rust/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "tree-sitter-rust";
-  version = "0.23.2";
+  version = "0.24.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tree-sitter";
     repo = "tree-sitter-rust";
     tag = "v${version}";
-    hash = "sha256-aT+tlrEKMgWqTEq/NHh8Vj92h6i1aU6uPikDyaP2vfc=";
+    hash = "sha256-y3sJURlSTM7LRRN5WGIAeslsdRZU522Tfcu6dnXH/XQ=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/tree-sitter-yaml/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-yaml/default.nix
@@ -12,19 +12,19 @@
 
 buildPythonPackage rec {
   pname = "tree-sitter-yaml";
-  version = "0.7.0";
+  version = "0.7.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tree-sitter-grammars";
     repo = "tree-sitter-yaml";
     tag = "v${version}";
-    hash = "sha256-23/zcjnQUQt32N2EdQMzWM9srkXfQxlBvOo7FWH6rnw=";
+    hash = "sha256-Z2L/aQWIyZ8cSqbfjm/i10fJP++yZ2tZgho0U3asA0g=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-Rxjimtp5Lg0x8wgWvyyCepMJipPdc0TplxznrF9COtM=";
+    hash = "sha256-QvqvyjnCgSuSiiY4SB5nB9S7LnGP1F+tySxue359SWY=";
   };
 
   build-system = [

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -30,8 +30,8 @@ let
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
   # 3) Set GITHUB_TOKEN env variable to avoid api rate limit (Use a Personal Access Token from https://github.com/settings/tokens It does not need any permissions)
   # 4) run the ./result script that is output by that (it updates ./grammars)
-  version = "0.25.4";
-  hash = "sha256-6qE/LXAGzV68HHr4lB74vmSn6mGF9EV7enjWOyNQjDQ=";
+  version = "0.25.6";
+  hash = "sha256-2/DF2xyiKi5HAqqeGt1TIMvAWFfZgcfVccK4zrTqq88=";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bash.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bash.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-bash",
-  "rev": "487734f87fd87118028a65a4599352fa99c9cde8",
-  "date": "2024-11-11T01:52:16-05:00",
-  "path": "/nix/store/llqfabr73wh33skh2qzhwjh93zc5cy09-tree-sitter-bash",
-  "sha256": "1smlcfkxxknhya1b1h72zj3ccg35szbg9mii2xwh7iq9acnlzpgc",
-  "hash": "sha256-7N1PLVMJxwN5FzHW9NbXZTzGhvziwLCC8tDO3qdjtOo=",
+  "rev": "56b54c61fb48bce0c63e3dfa2240b5d274384763",
+  "date": "2025-06-04T09:38:10-07:00",
+  "path": "/nix/store/zy2ii6304db3z54x2afg8as71wkbgffd-tree-sitter-bash",
+  "sha256": "1488r0lqldy92v8jr3n6w6iv99fdbcnmb1zxfshiz9azcgz8s5mx",
+  "hash": "sha256-vRaN/mNfpR+hdv2HVS1bzaW0o+HGjizRFsk3iinICJE=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-beancount.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bibtex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bibtex.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/latex-lsp/tree-sitter-bibtex",
-  "rev": "ccfd77db0ed799b6c22c214fe9d2937f47bc8b34",
-  "date": "2021-03-26T15:53:50+01:00",
-  "path": "/nix/store/pg00zy53rni7znda2vbyyhkkclgja3kq-tree-sitter-bibtex",
-  "sha256": "0m7f3dkqbmy8x1bhl11m8f4p6n76wfvh99rp46zrqv39355nw1y2",
-  "hash": "sha256-wgduSxlpbJy/ITenBLfj5lhziUM1BApX6MjXhWcb7lQ=",
+  "rev": "8d04ed27b3bc7929f14b7df9236797dab9f3fa66",
+  "date": "2025-04-19T10:23:36+02:00",
+  "path": "/nix/store/cfx6c2nl3vmm29phi5l7yg4mq8hapqji-tree-sitter-bibtex",
+  "sha256": "0pjjk23a3gyz0rpgy99qkal9gs65i15k8bsc37s87x94dxdcdrah",
+  "hash": "sha256-UOXGWm8k9YP0GUwvNEuIxeiXqJo4Jf9uBt+/oYaYUl4=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bitbake.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bitbake.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bqn.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-bqn.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c",
-  "rev": "2a265d69a4caf57108a73ad2ed1e6922dd2f998c",
-  "date": "2025-02-08T10:48:10-06:00",
-  "path": "/nix/store/0xnd082cryjnml9iaibcfgbp3bc5svxb-tree-sitter-c",
-  "sha256": "1vw7jd3wrb4vnigfllfmqxa8fwcpvgp1invswizz0grxv249piza",
-  "hash": "sha256-6sebiNg9P/B/5HrbGO7bl3GHVMfVUepetJuszEeTh+8=",
+  "rev": "7fa1be1b694b6e763686793d97da01f36a0e5c12",
+  "date": "2025-05-24T13:29:12-04:00",
+  "path": "/nix/store/bms26kscizz0zd4x18smicqz5p7va9d4-tree-sitter-c",
+  "sha256": "19yc4g5fdibfqbn49ggywk9k2by78s8lrsjp1cx2lagb1dvxnv42",
+  "hash": "sha256-gmzbdwvrKSo6C1fqTJFGxy8x0+T+vUTswm7F5sojzKc=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/sogaiu/tree-sitter-clojure",
-  "rev": "f4236d4da8aa92bc105d9c118746474c608e6af7",
-  "date": "2024-05-22T23:05:15+09:00",
-  "path": "/nix/store/vl1d7aql1bcvn65khrgs13rfk90q08ik-tree-sitter-clojure",
-  "sha256": "16hnb5d8shz216sv9hj5hxpg63ri86w5pf9bzi5z3f37zh7vlljj",
-  "hash": "sha256-UlK6D/xnuPFL/Cu5W7hBMQ/zbodFwrS1CeJDjVpZFpo=",
+  "rev": "40c5fc2e2a0f511a802a82002553c5de00feeaf4",
+  "date": "2025-05-26T17:10:02+09:00",
+  "path": "/nix/store/lkzsixjxwr6b2gwxsba0qah3k121axgi-tree-sitter-clojure",
+  "sha256": "163jm1qgrh9ha1xbjlbkcffcxkdbhsvj5kplknq4gcb080wlp6dp",
+  "hash": "sha256-t5lLOUBgsUewnfTOIreGq83OnGNzUbl6UDDB/HCocpg=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cmake.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/uyha/tree-sitter-cmake",
-  "rev": "e409ae33f00e04cde30f2bcffb979caf1a33562a",
-  "date": "2024-10-14T03:37:52+03:00",
-  "path": "/nix/store/hgwv6jwacl1md38yccvvvhigyk6h21s2-tree-sitter-cmake",
-  "sha256": "1v2kkxf9w0y9mwwgimgyvn1s9cmmp6jg71ckr001w1w8szyqqf7q",
-  "hash": "sha256-+DiM/deIBx4AyJOF86S5tbKkg93+1fg4r8kDnlyfU+w=",
+  "rev": "cf9799600b2ba5e6620fdabddec3b2db8306bc46",
+  "date": "2025-05-23T09:02:01Z",
+  "path": "/nix/store/20nwq76zin7f8lhaccdhj4jm4yzvqclr-tree-sitter-cmake",
+  "sha256": "0mqkmdqw0x7b2a83is8w8va32s0qzf3dlfzx0hwxfz7rn5dn459v",
+  "hash": "sha256-OxViW7H5fNc5BP072ob7GGgx1EYc6TiQEut0wHGrE1c=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-comment",
-  "rev": "ef429992748f89e176243411e94b8ffc8777d118",
-  "date": "2023-06-03T20:48:17-05:00",
-  "path": "/nix/store/0kg71dvg10f1m2f08z1b2wh1ap4w4hw6-tree-sitter-comment",
-  "sha256": "1d5g69i8jplyg888yr7wzjb46cqnchwf4kdzgb83him7cwfx9wax",
-  "hash": "sha256-XfHUHWenRjjQer9N4jhkFjNDlvz8ZI8Qep5eiWIyr7Q=",
+  "rev": "689be73775bd2dd57b938b8e12bf50fec35a6ca3",
+  "date": "2025-05-03T18:43:55-05:00",
+  "path": "/nix/store/7s2q0ka47nf94kaih3w12572my3r2ksz-tree-sitter-comment",
+  "sha256": "1x0l8phr4x07n739z0ax8faxq0l6irmpkdprrv1z088zqdr43l1v",
+  "hash": "sha256-O9BBcsMfIfDDzvm2eWuOhgLclUNdgZ/GsQd0kuFFFPQ=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-commonlisp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-commonlisp.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-commonlisp",
-  "rev": "25856774aaab983c573bb2f9cc1ebbc97941f7b9",
-  "date": "2024-04-06T22:22:41+02:00",
-  "path": "/nix/store/mlji0h6k2x17jni9q3y571dmk5k4xi85-tree-sitter-commonlisp",
-  "sha256": "12fh2sinasnfp6rfq5d9qq24nfg55bclc5rp8mnw3a2ccyc5icis",
-  "hash": "sha256-OrJYmGdMqMFtRTcXRtkq5TlLBMapFeyyuc5qZaMW0Ik=",
+  "rev": "9db594efb43574c5fe4a1f880568b1f0d0ee6057",
+  "date": "2025-03-16T16:36:54+01:00",
+  "path": "/nix/store/96phqhn770ds8i0j0l88phldl7d03g72-tree-sitter-commonlisp",
+  "sha256": "0xg3ay8l62h7s35abkxi4gjfvndzdvvrpgh1z980q1ib5935sxf0",
+  "hash": "sha256-wHVdRiorBgxQ+gG+m/duv9nt5COxz6XK0AcKQ5FX43U=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-css.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "9cdfe2d453e5f60fd818935a5895f223e2e6feed",
-  "date": "2025-01-25T13:03:37+01:00",
-  "path": "/nix/store/xz5zddyszj1sgr3lp17f021n2x13dmj7-tree-sitter-cuda",
-  "sha256": "0krk5f0g87cp1mkdn2x6sadldqnvhxxy8zsvc8z2bxc50vb4lw9m",
-  "hash": "sha256-NXFK1gaF9SU+Ylt/5HuH2+JGm9KmC9tmDZcd9IArM08=",
+  "rev": "014628ae8d2df391b88ddb9fa0260fd97f770829",
+  "date": "2025-03-16T17:20:16+01:00",
+  "path": "/nix/store/w0cl4ga4bis992vyfmj8l0pq385z0cka-tree-sitter-cuda",
+  "sha256": "1qyh00rapch29czvnqs3364bx0bi4gyapfxb0v8m4r2m8kybnlff",
+  "hash": "sha256-zlG7/ERVZFLRBqu7q/wjcYG+iBlDY7s/SwKyqzIA0OM=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cue.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cue.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dart.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/usernobody14/tree-sitter-dart",
-  "rev": "e81af6ab94a728ed99c30083be72d88e6d56cf9e",
-  "date": "2024-11-16T21:53:35-07:00",
-  "path": "/nix/store/jb7wiv90s78p45pj9mqvmbgk06xhjlj5-tree-sitter-dart",
-  "sha256": "0zl46vkm4p1jmivmnpyyzc58fwhx5frfgi0rfxna43h0qxdv62wy",
-  "hash": "sha256-nguzW8cADqJsdxnE57IrHXKHCvveX1t3rDJcUuc2hH4=",
+  "rev": "80e23c07b64494f7e21090bb3450223ef0b192f4",
+  "date": "2025-02-28T15:18:07-07:00",
+  "path": "/nix/store/7pfv5380h2fwv0rg0ckdjg8h71vzq71f-tree-sitter-dart",
+  "sha256": "00wzdgmi6kph4lk988brpy03j43a8vvfcjx9plnnnk07a14l3hbc",
+  "hash": "sha256-bMFBSVAHTGstvalL5vZGahA5gL95IZQmJfBOE+trnwM=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-devicetree.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-devicetree.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dockerfile.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dockerfile.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-earthfile.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-earthfile.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/glehmann/tree-sitter-earthfile",
-  "rev": "ae378d9d1306e9a967698516041f6f8803db5592",
-  "date": "2025-02-18T21:51:34+01:00",
-  "path": "/nix/store/wy3w667k4gdxvj6rx83f64r7jbmal4dn-tree-sitter-earthfile",
-  "sha256": "112vc8rv5dzvvbhf7n01qnacvjfpyi9kfzdbsm0gzkpnhk52rah4",
-  "hash": "sha256-BKosyoT2zv9A1at9N1P018nNlMUB2OPg2vu3sjNiW4Q=",
+  "rev": "a37c5ee95ce401ca311c0ae1369d9cfb953e151d",
+  "date": "2025-05-13T08:33:41+02:00",
+  "path": "/nix/store/dhmdlbq30jfmsl719k8pawcffs8xpin0-tree-sitter-earthfile",
+  "sha256": "1gld2wrxa9bfhka70pnyapq7agwxh2mgwa7qj5mq8ga73gfi52lm",
+  "hash": "sha256-lYoS3RtHPYRrkfgo/qqAnT918FXeXnDUhG4l1TMXjb4=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-eex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-eex.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elisp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elisp.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-erlang.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-erlang.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-factor.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-factor.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fortran.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fortran.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/stadelmanma/tree-sitter-fortran",
-  "rev": "022b032d31299c5d8336cdfd0ece97de20a609c0",
-  "date": "2025-01-23T13:28:14-05:00",
-  "path": "/nix/store/vncpfx5db12ish9rzf26phj25373nqs4-tree-sitter-fortran",
-  "sha256": "1mncdji60qa9r8jbiywmcid714ylc3gniq25l8mxj1p4zq95nd29",
-  "hash": "sha256-STRbEv7kBtkrokXgaN9g1JNwWmSV+7gkyklhYKJszNY=",
+  "rev": "ab9aa007a8d982a5a7926663a8ab989cea0f5d9e",
+  "date": "2025-05-30T13:36:15-04:00",
+  "path": "/nix/store/rfny2ivglrrr0wqsby82l0yw63d3gdvp-tree-sitter-fortran",
+  "sha256": "13szimmilfd1lps9j73zyp4lmg630ml1gg802lsfxxdjc944yrcc",
+  "hash": "sha256-jGVPSGKy9e40FQC9F2gFw7xKyfV/HJn0paE5GmuNX48=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gdscript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gdscript.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/prestonknopp/tree-sitter-gdscript",
-  "rev": "b5dea4d852db65f0872d849c24533eb121e03c76",
-  "date": "2024-02-21T19:10:52-08:00",
-  "path": "/nix/store/254bkv3lkgp7jk555rmxqxyg4p4g9smy-tree-sitter-gdscript",
-  "sha256": "17m2gdpdya8afm7fqgggi81m71xkiibbqa61vs2sspym6zna1ygx",
-  "hash": "sha256-/fmg7DfVX62F3sEovFaMs4dTA4rvPexOdQop3257op4=",
+  "rev": "e964ce912b5b835f1caedb600df9d5be77e803a8",
+  "date": "2025-05-14T11:22:28-07:00",
+  "path": "/nix/store/ab2prhn6ckp7kyfnxnymx8zvbna4jda2-tree-sitter-gdscript",
+  "sha256": "19rdpyd05x29b7isv8jnc8jlawlpzh91b11yggiqgjz6il0vkdww",
+  "hash": "sha256-nLe5AY3my4fjez6EFRL8l3JFJWJWoq3jWUn0Apq/Lac=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gemini.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gemini.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gleam.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gleam.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/gleam-lang/tree-sitter-gleam",
-  "rev": "af6043419f5aa0f8b6c2a26db0187aefa46c7f5f",
-  "date": "2025-02-07T14:27:03Z",
-  "path": "/nix/store/k54xiiqza536lzgvdw8yizsp6czdalln-tree-sitter-gleam",
-  "sha256": "0b7k2ah7a29simvvzm3f01vna5lzvv1mi7idvzpc056wjbgnvrg8",
-  "hash": "sha256-6OVt35LcFMDu3y2eWMPenxZldwBu1L93jToJdaAS8yw=",
+  "rev": "6ece453acf8b14568c10f629f8cd25d3dde3794f",
+  "date": "2025-05-17T12:51:15Z",
+  "path": "/nix/store/aahaa06y7w5in76pfp787k5gyamx7599-tree-sitter-gleam",
+  "sha256": "00f481cjn1mz0319jq89775a81nlmqnkc6fvv3qblpiq37fplzcz",
+  "hash": "sha256-n3163Rk4Xrrw2NsZNi2u1AakyjkJYZnCAL8GK1lAxAE=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glimmer.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glimmer.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "66aec57f7119c7e8e40665b723cd7af5594f15ee",
-  "date": "2024-09-12T12:52:04+02:00",
-  "path": "/nix/store/xzxngsr3nhs1586c47iwdx9k20yaansc-tree-sitter-glsl",
-  "sha256": "0gp3bn31xz5rq52amx059r9sllk3749f1ajmbs1fkjb833f2kvqh",
-  "hash": "sha256-EO8p3BhoyemCXlWq4BI5Y1KqU04F9KpEwbn8HoZd4z4=",
+  "rev": "e47b8b62b59d0e3529f1c31b03e025d6bd475044",
+  "date": "2025-03-16T18:14:20+01:00",
+  "path": "/nix/store/87vf9kgi9yzzksj0s7h707ky79kckf5f-tree-sitter-glsl",
+  "sha256": "0d0ymklms4a91b310f0vwl80yy50sji4qq9sdgly5qh42kyjnijb",
+  "hash": "sha256-S0Yr/RQE4uLpazphTKLUoHgPEOUbOBDGCkkRXemsHjQ=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-godot-resource.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-godot-resource.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/prestonknopp/tree-sitter-godot-resource",
-  "rev": "479bfc12579ba54ac5b4dcb320fd0cb81eaabe7d",
-  "date": "2025-01-02T02:55:15-08:00",
-  "path": "/nix/store/3mvxmgjpkr02vxr6iwhqivqkajzzywkb-tree-sitter-godot-resource",
-  "sha256": "18fjf4fj3fyfsq6nvmi5qy1ddwlfcz8sxiq8wq8qrvc7fvfwni1q",
-  "hash": "sha256-OETL3XaH7YwR5gjHrtFnjvLWgscl1m0N1s67IR1x0qE=",
+  "rev": "a1a7295b376fbd2531601f4ffff191b031ffc795",
+  "date": "2025-05-14T13:16:54-07:00",
+  "path": "/nix/store/aiffb583jhinm3ph5l0pz70igyskdc4f-tree-sitter-godot-resource",
+  "sha256": "1jhl7fwrjd07y3bcmwc6v3lyq04yma49q575cgld94ssmcp0rmgs",
+  "hash": "sha256-+tUMLqtak9ToY+UUnIiqngDs6diG8crW8Ac0mbk7FMo=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gomod.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gomod.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-gowork.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-graphql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-graphql.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/MichaHoffmann/tree-sitter-hcl",
-  "rev": "636dbe70301ecbab8f353c8c78b3406fe4f185f5",
-  "date": "2023-07-25T19:21:31+02:00",
-  "path": "/nix/store/k5rmjfpgn4vpxxqc05xb5fflcck9645v-tree-sitter-hcl",
-  "sha256": "1yydi61jki7xpabi0aq6ykz4w4cya15g8rp34apb6qq9hm4lm9di",
-  "hash": "sha256-saVKSYUJY7OuIuNm9EpQnhFO/vQGKxCXuv3EKYOJzfs=",
+  "rev": "009def4ae38ec30e5b40beeae26efe93484ab286",
+  "date": "2025-05-16T09:08:19+02:00",
+  "path": "/nix/store/4fzs7sm98lvygqj7ylpfhg9lpkzyz8as-tree-sitter-hcl",
+  "sha256": "01amk7cm968a3i511kzzbyvhbxhk6h1v5g5klap7vh0y11r3ilyy",
+  "hash": "sha256-3tM4cggewH2uorO8sgM0E/YFt1//zxBKHAqZVNmZVQU=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hjson.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hjson.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-html.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-http.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-http.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hyprlang.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hyprlang.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/tree-sitter-grammars/tree-sitter-hyprlang",
-  "rev": "86025136c12cd1058985479a6b1935829077f1af",
-  "date": "2024-02-10T18:00:17+03:00",
-  "path": "/nix/store/q5csx65ydwbz66bgjjpa6c1yvy3zy6vq-tree-sitter-hyprlang",
-  "sha256": "0z84nl1mb77rwqq86ggaiqdd2lwg3nxrlkbhsn8zhcqnaphq0wfl",
-  "hash": "sha256-1HGA4VUWM/iR1XBNmrsdj1PRGo7qPYMw5vmcVQO1BH0=",
+  "rev": "d0441fd4b883ecc0e70140723a1cf5907992639a",
+  "date": "2025-05-09T22:23:24+03:00",
+  "path": "/nix/store/ajpg66r1yvns2rpbspqhgh7b1ggm6jcf-tree-sitter-hyprlang",
+  "sha256": "171p3hj36a1jqflg9xv138445j4m4m16na6bgpm1km3l67jhvl54",
+  "hash": "sha256-pNAN5TF01Bnqfcsoa0IllchCCBph9/SowzIoMyQcN5w=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-janet-simple.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-janet-simple.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/sogaiu/tree-sitter-janet-simple",
-  "rev": "b08b402207fba0037d5152ce7c521351147f4388",
-  "date": "2025-02-03T20:32:35+09:00",
-  "path": "/nix/store/w0rsgjajpifbl7ygy1kwr87l42gcsh52-tree-sitter-janet-simple",
-  "sha256": "0bqk72915yg6vfby7179rxacbla7if8rzq4zhy1d0g98pyx4qqzn",
-  "hash": "sha256-9mNMur8oPdCCh5/gn5GLR9HFVM/phOOX2+b5EpI4Ey8=",
+  "rev": "7e28cbf1ca061887ea43591a2898001f4245fddf",
+  "date": "2025-05-19T21:38:53+09:00",
+  "path": "/nix/store/k9njvidvlpqlri2dsmfvz3h21b1214a6-tree-sitter-janet-simple",
+  "sha256": "05xn760xxax8q2dsvyj3yw90rhnq7nmv54p0i8af34nhjwyi8sx9",
+  "hash": "sha256-qWsUPZfQkuEUiuCSsqs92MIMEvdD+q2bwKir3oE5thc=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-javascript.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsdoc.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsdoc.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json5.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-json5.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsonnet.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-jsonnet.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-julia.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-just.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-just.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-kdl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-kdl.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-koka.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-koka.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-kotlin.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-kotlin.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ledger.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ledger.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/cbarrete/tree-sitter-ledger",
-  "rev": "d313153eef68c557ba4538b20de2d0e92f3ef6f8",
-  "date": "2024-12-01T20:38:56-05:00",
-  "path": "/nix/store/msd18izp2w9lwsz0i7n1r3r007xaqgvx-tree-sitter-ledger",
-  "sha256": "0k880rxgknlr9gfya9fafi3gmv7gcdph5kxqnpbf9kmrm193glgx",
-  "hash": "sha256-/dE3Uqi5zuTWtbjPAm9j7+z6RnTKJeXdS5na+XoGCE0=",
+  "rev": "96c92d4908a836bf8f661166721c98439f8afb80",
+  "date": "2025-05-04T15:50:31-04:00",
+  "path": "/nix/store/jxnv96mxkypk3hkpy14hlw0yv60ryfsm-tree-sitter-ledger",
+  "sha256": "0g4yh8xxmcf7r0acazmzp4j08c6fx3d25b76i7fgchv7id658v1g",
+  "hash": "sha256-L2xUTItnQ/bcieasItrozjAEJLm/fsUUyMex2juCnjw=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-llvm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-llvm.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/benwilliamgraham/tree-sitter-llvm",
-  "rev": "c14cb839003348692158b845db9edda201374548",
-  "date": "2024-10-07T15:28:34-07:00",
-  "path": "/nix/store/aravnn08ip3zggkbww6ap73xb5zvrf6g-tree-sitter-llvm",
-  "sha256": "1fh5nq7war87zrphlv5v2g55gmsbhyv3385va7k1y8gh3czg0x9g",
-  "hash": "sha256-L3XwPhvwIR/mUbugMbaHS9dXyhO7bApv/gdlxQ+2Bbo=",
+  "rev": "1ac83114e71839fa67f4cce2f864ebbbdf6e2a4f",
+  "date": "2025-05-13T09:33:06+02:00",
+  "path": "/nix/store/yqc7r12pmy0y1bxad2cgpss5kpmd9vzr-tree-sitter-llvm",
+  "sha256": "00srqg073ml85zimmj1a1251nka18i04gm0m1jcpa6fmbbrx6knr",
+  "hash": "sha256-2U7T81rVGXWZDBXUR0BEQU0biggqyFrjL4jWccDDWQM=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-lua.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/MunifTanjim/tree-sitter-lua",
-  "rev": "99fc677e6971c425e8d407f59c77ab897e585c92",
-  "date": "2024-09-09T11:10:03-04:00",
-  "path": "/nix/store/iiih0sfdls1h8q7ca12y0rhc7g5jl76w-tree-sitter-lua",
-  "sha256": "0wrbxmb6j8xyckf5jw14jf97cb9fn7yhalap6xxgsag84ypfsqj3",
-  "hash": "sha256-Q2LtrifoKf16N1dRBf2xLi12kpMkcFncZL4jaVbtK3M=",
+  "rev": "4fbec840c34149b7d5fe10097c93a320ee4af053",
+  "date": "2025-05-16T19:32:03+02:00",
+  "path": "/nix/store/3x9qgcifbb12l80kxq57sz8l3xzrq35k-tree-sitter-lua",
+  "sha256": "1fvfbi5csn3w0zjjr29c05gdhjmy6d8cx1d6s38j6qmfasm1gvvw",
+  "hash": "sha256-fO8XqlauYiPR0KaFzlAzvkrYXgEsiSzlB3xYzUpcbrs=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-make.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-make.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "1c8dea73bc0c996d92dd9ebc30dd388716b1c5db",
-  "date": "2024-09-11T16:28:36+03:00",
-  "path": "/nix/store/g4696miy9vzcw0qwd00rar36qn08jn2l-tree-sitter-markdown",
-  "sha256": "13xfyclim1yql6swbk4y12sxgvn799ldbzjl35n5rrkz7wgnwm9s",
-  "hash": "sha256-OlVuHz9/5lxsGVT+1WhKx+7XtQiezMW1odiHGinzro8=",
+  "rev": "afaa4138517363362f54c89330c9d79391e81168",
+  "date": "2025-05-17T18:46:59+02:00",
+  "path": "/nix/store/46fzwyl91h2w34b73sscbjh1ggl3s15l-tree-sitter-markdown",
+  "sha256": "0aprf5kvqcpjx58xwdxh4lsgz6mzcsdipjv3405fywcrbh9q7li3",
+  "hash": "sha256-I9KDE1yZce8KIGPLG5tmv5r/NCWwN95R6fIyvGdx+So=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-netlinx.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-netlinx.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/norgate-av/tree-sitter-netlinx",
-  "rev": "6d3c01e54d150c6d3dcf99cad95a1f5fa0293018",
-  "date": "2025-04-20T17:23:44+01:00",
-  "path": "/nix/store/mnl4bx3006gy841ky2vgyyfx9fnibm2m-tree-sitter-netlinx",
-  "sha256": "13kyl1a0d9x6k6ivcyzbplkcsdjy3kd4raym1zz8c5gs9xwg6vb4",
-  "hash": "sha256-ZG3zeE/6FYb+D9WrTNocXjbNJr3re7ajmaanBlSgfo4=",
+  "rev": "296c0e62cd507fc23cd1f1db06142f808483cf1a",
+  "date": "2025-05-11T11:31:14+01:00",
+  "path": "/nix/store/yi7az5hhp3dmn5mbk2cin6m5pmbp5fby-tree-sitter-netlinx",
+  "sha256": "09q2w9g4bb8v603b4ykxn5g8ndqjfhrgskslsmzhy095r3jysb2q",
+  "hash": "sha256-WCzt5cglAQ9/1VRP/TJ0EjeLXrF9erIGMButRV7iAic=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nickel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nickel.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "b3a88cf3e597d48c33657deca4fda7a75c0069c1",
-  "date": "2025-01-31T17:04:23Z",
-  "path": "/nix/store/lvw6n2174vjd5g7jmylpk84040gpsyj6-tree-sitter-nix",
-  "sha256": "16gkm286jvkv7kygs6ap9h06dvp96akahjdvqrdjzzp1vlsqlf5s",
-  "hash": "sha256-ujiKNd3h/i9bxrtJqKYy6e5mAExXGf38PHtuaZCo85k=",
+  "rev": "cfc53fd287d23ab7281440a8526c73542984669b",
+  "date": "2025-03-10T21:49:48Z",
+  "path": "/nix/store/aqzm346ck43x74b409jiikbbxqchgyr1-tree-sitter-nix",
+  "sha256": "0bmalpgvfcz1zd72wq43r5qvhj3dqqp7zn9kfb6bs0valrxagaks",
+  "hash": "sha256-eqqneqZqA73McjPZfy7GbUi4ccmDYC5O++Ezt9+lqi4=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg-meta.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg-meta.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nu.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nu.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/nushell/tree-sitter-nu",
-  "rev": "2a153c88d5d44d96653057c7cc14292f4e641bef",
-  "date": "2025-02-14T22:21:43-06:00",
-  "path": "/nix/store/di072yk2yrla0fw45sxa0niy5dd7a8gw-tree-sitter-nu",
-  "sha256": "1jyd7xvnxv5c9i7ankxslmgarvmnhaam6ylhzk2v5lcfjk21gzij",
-  "hash": "sha256-Mv4XxJSO0bLF/JB6U5WCtu6sXqW6T6tOTKzsbnc/zcs=",
+  "rev": "100d06e29d13a8ebfc3f29173c07a5c4f2050586",
+  "date": "2025-06-03T11:43:38Z",
+  "path": "/nix/store/3a41rx3rs29c625ywqv0pw7s7am4gwn5-tree-sitter-nu",
+  "sha256": "07aa73flw0z56fqgqv4y7xyf0akh50ydavjyzyczwc7hyl15mak4",
+  "hash": "sha256-ZKpaAvXwMP6Z/15u1TwocCrgfD+ebPywM+UDTt04Sh0=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ocaml.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ocaml",
-  "rev": "a45fda5fe73cda92f2593d16340b3f6bd46674b8",
-  "date": "2025-01-11T22:05:51+01:00",
-  "path": "/nix/store/jl174nzwf7fb982fyfwczc4ilmsis4sd-tree-sitter-ocaml",
-  "sha256": "17g2ynqhjf1nyhdidz9j9s0s12iys3b2vbywxkygwyccj7rb8zdi",
-  "hash": "sha256-sX208pGMef787NyvLdbQPoqggU4y/RYb9DY4CbH14p0=",
+  "rev": "0cc270ff90ca09c29d0f2f9dec69ddfef55a3eff",
+  "date": "2025-05-29T16:15:06+02:00",
+  "path": "/nix/store/796cycklipmf50nxh0431jfdlard661i-tree-sitter-ocaml",
+  "sha256": "1mrqpdzwrj3hkrv0xib3h3fvj9z3iai5gjwry9dilhdjl2n2akvv",
+  "hash": "sha256-e08lrKCyQRpb8pnLV6KK4ye53YBjxQ52nnDIzH+7ONc=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org-nvim.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pgn.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-php.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-php",
-  "rev": "43aad2b9a98aa8e603ea0cf5bb630728a5591ad8",
-  "date": "2024-11-19T21:55:55-06:00",
-  "path": "/nix/store/nl2r9rkvhnhdd3f9zn59nv7k4d1j6m68-tree-sitter-php",
-  "sha256": "0qkjp5n3ys0jckg67zcdf4mkb01ilnkqx61wga13ys2infgd8agq",
-  "hash": "sha256-+CnUnrNRaD+CejyYjqelMYA1K3GN/WPeZBJoP2y5cmI=",
+  "rev": "f7cf7348737d8cff1b13407a0bfedce02ee7b046",
+  "date": "2025-02-27T03:54:39-06:00",
+  "path": "/nix/store/6hwqa10mfcs32cqq5ab48c444yihm106-tree-sitter-php",
+  "sha256": "05qhz14vvqgwpxgdfr1skwgrv041zwc3wxjyx6y679965nn0lrji",
+  "hash": "sha256-UWYKrC0mpWO86V52Phj/gYCdH586ZNdev/zhvUn4EBc=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pioasm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pioasm.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prisma.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prisma.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-proto.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-proto.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pug.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-pug.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-python.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql-dbscheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql-dbscheme.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ql.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/nvim-treesitter/tree-sitter-query",
-  "rev": "0555ac0da902abff06076e40501102cee3ba68bd",
-  "date": "2025-02-02T17:30:49+01:00",
-  "path": "/nix/store/ab5v1pf3vckwhnix7r0c1l5g8x30v4zl-tree-sitter-query",
-  "sha256": "0dqy7i2jdd9dqf1ppqzcmkzd9yndb11r78l0pv1zyl7dm7h5g76q",
-  "hash": "sha256-2JxX4KntUP/DvoCik0NYzfrU/qzs43uDwy21JkU8Hjc=",
+  "rev": "892ebd701a79be0412ff1478177030a725d0c7b7",
+  "date": "2025-05-16T18:22:36+02:00",
+  "path": "/nix/store/rivlmbcc3gn7fqwljgk3z7zhk2s1ivzh-tree-sitter-query",
+  "sha256": "0is8lzj13zz6sq36wrfmhv7mjbgfvlrqnxf5dxzqa2vncj45v0bv",
+  "hash": "sha256-e4FdiGR2C4V/b8V1izPd7i1Zz4bVZW4G1ub/EeSnSEc=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-r.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-r.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rego.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rego.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-river.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-river.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "cad8a206f2e4194676b9699f26f6560d07130d3f",
-  "date": "2024-11-24T13:48:58-05:00",
-  "path": "/nix/store/2xxvslz0q5vl8z94hs1g8cb4x2ri2pan-tree-sitter-rust",
-  "sha256": "1xxxysiwj0r97sp4wsdmm23pcgsngiw39gsa9jm0achan6basgv9",
-  "hash": "sha256-aT+tlrEKMgWqTEq/NHh8Vj92h6i1aU6uPikDyaP2vfc=",
+  "rev": "18b0515fca567f5a10aee9978c6d2640e878671a",
+  "date": "2025-04-01T14:02:57-07:00",
+  "path": "/nix/store/ilgg71axwwq17wcpy3sm5qkqkfh26bgd-tree-sitter-rust",
+  "sha256": "0x7xqxspdfnbgn9nvrsl2rsnrjbs01i5hy8k8p5wwk2j358hjyyb",
+  "hash": "sha256-y3sJURlSTM7LRRN5WGIAeslsdRZU522Tfcu6dnXH/XQ=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scala.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scheme.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/6cdh/tree-sitter-scheme",
-  "rev": "63e25a4a84142ae7ee0ee01fe3a32c985ca16745",
-  "date": "2024-09-08T01:23:30+08:00",
-  "path": "/nix/store/1wk7w5vkxcwqx24qlm203z1z5rw95vn8-tree-sitter-scheme",
-  "sha256": "12p8g2mnd73lanibk16llhbx7xarlcl2ihngcibhpa4bzppcbb8l",
-  "hash": "sha256-FK3F7v2LqAtXZM/CKCijWfXTF6TUhLmiVXScZqt46Io=",
+  "rev": "e35b41a183164f4a12e10da3d0c430e837c3d75a",
+  "date": "2025-05-25T19:18:44+08:00",
+  "path": "/nix/store/lg0zvr4w9pryyz725vd5hdf7gvg7idx1-tree-sitter-scheme",
+  "sha256": "12dclaaj4snar68hcwfc1kmnbww4ykf1ab2q81r3k9989m7f1ckn",
+  "hash": "sha256-drLgTk0opTlyQFgsFdz0hPNl6wzMcQaRycpqIpWirIk=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scss.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-scss.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-smithy.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-smithy.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-solidity.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-solidity.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sparql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sparql.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-sql.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-supercollider.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-supercollider.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-surface.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-svelte.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-talon.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-talon.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-templ.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-templ.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/vrischmann/tree-sitter-templ",
-  "rev": "def9849184de71a797c4e2b2837df85abeccf92c",
-  "date": "2025-02-06T21:56:41+01:00",
-  "path": "/nix/store/qjzb3snk7m49qhfhdd1z7lhjlhwgg4mk-tree-sitter-templ",
-  "sha256": "1035mfjikzy9c6w4wf59z91vyh0m36gdcw8xj4qa5i0k9ma8pq1d",
-  "hash": "sha256-LeCLVE0TxKIwkR1x1p4ZFUC/Q/qpOE64Ycn/GaWrZYA=",
+  "rev": "de35706f89beed5087670a9c4421b7794ef02411",
+  "date": "2025-06-01T21:02:54+02:00",
+  "path": "/nix/store/9m1jydr3j1m876dmazg9kzvs7878a7ly-tree-sitter-templ",
+  "sha256": "0vbhks5879b7bpygxr9zba142zsb760j4im1gzbgcl6yj6q59j30",
+  "hash": "sha256-YMhUsJHeUPbWf6FGIoE5S39Bglo/5f78XWelg4qecG0=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tera.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tera.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/uncenter/tree-sitter-tera",
-  "rev": "284840b9809741c7fe474204c62f687b04da8104",
-  "date": "2025-02-07T10:08:29-05:00",
-  "path": "/nix/store/lzcz6qpp4cz3ki1ray05fgii7m48zf84-tree-sitter-tera",
-  "sha256": "1mrrl47gk8zzi6l9k65h53xpwharni1k6k2bm90is96sxiq883n3",
-  "hash": "sha256-ww6EcOzaJB1BqktMM0O0WUF++yiwmJmoif+j+Q6hOdc=",
+  "rev": "d006172998fa8b81f96b0f2fc7fa2bf25207c46b",
+  "date": "2025-04-16T08:51:56-04:00",
+  "path": "/nix/store/364masbjrvf29v30h4hbzwds1j438k7a-tree-sitter-tera",
+  "sha256": "0cwihdzlm8jk8g006j234pjnw0apv3l8ixn4kmdc60hzh3bb9ypr",
+  "hash": "sha256-+fq01oAfAsNancT2iOjYVwFu5SVDSAPAQ1OiSn+DkTM=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tiger.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tiger.json
@@ -1,12 +1,13 @@
 {
   "url": "https://github.com/ambroisie/tree-sitter-tiger",
-  "rev": "a7f11d946b44244f71df41d2a78af0665d618dae",
-  "date": "2023-08-29T21:54:01+01:00",
-  "path": "/nix/store/ynxdy89llzc9kqqw0h2fmv81dna7wrxq-tree-sitter-tiger",
-  "sha256": "100cpj00w021hk0cgn5qbgqa6yn8ji58hl77qf3054h2jxzxnsnc",
-  "hash": "sha256-zGrbf5cCkgKGw+dQiEqUyHqj8Fu42MfAhEEADoC8DIA=",
+  "rev": "4a77b2d7a004587646bddc4e854779044b6db459",
+  "date": "2025-03-13T19:58:23Z",
+  "path": "/nix/store/ps5vkphx7wqlzzj8j02sqi7hcgmbwh1c-tree-sitter-tiger",
+  "sha256": "0d4rwxi6zc8psy2adw8lhmvvk0f1miv6w517aiqq11njfbg4kdwc",
+  "hash": "sha256-jLdJ3nLShoBxVCcUbnaswYG5d4UU8aaE1xexb2LnmTQ=",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-toml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-toml.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tsq.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tsq.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-turtle.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-turtle.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-twig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-twig.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typst.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-uiua.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-uiua.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-verilog.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vue.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vue.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-wgsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-wgsl.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-wing.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-wing.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yaml.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yang.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-yang.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -8,5 +8,6 @@
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,
+  "fetchTags": false,
   "leaveDotGit": false
 }


### PR DESCRIPTION
Built `tree-sitter{,.grammars}`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
