### PR TITLE
python312Packages.granian: don't force a custom allocator

### DIFF
--- a/pkgs/development/python-modules/granian/default.nix
+++ b/pkgs/development/python-modules/granian/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   rustPlatform,
   cacert,
@@ -14,7 +13,6 @@
   pytest-asyncio,
   websockets,
   httpx,
-  rust-jemalloc-sys,
   sniffio,
   nix-update-script,
 }:
@@ -31,6 +29,14 @@ buildPythonPackage rec {
     hash = "sha256-qJ65ILj7xLqOWmpn1UzNQHUnzFg714gntVSmYHpI65I=";
   };
 
+  # Granian forces a custom allocator for all the things it runs,
+  # which breaks some libraries in funny ways. Make it not do that,
+  # and allow the final application to make the allocator decision
+  # via LD_PRELOAD or similar.
+  patches = [
+    ./no-alloc.patch
+  ];
+
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
     hash = "sha256-swfqKp8AsxNAUc7dlce6J4dNQbNGWrCcUDc31AhuMmI=";
@@ -39,22 +45,6 @@ buildPythonPackage rec {
   nativeBuildInputs = with rustPlatform; [
     cargoSetupHook
     maturinBuildHook
-  ];
-
-  buildInputs = lib.optionals (stdenv.hostPlatform.isAarch64) [
-    # fix "Unsupported system page size" on aarch64-linux with 16k pages
-    # https://github.com/NixOS/nixpkgs/issues/410572
-    # only enabled on aarch64 due to https://github.com/NixOS/nixpkgs/pull/410611#issuecomment-2939564567
-    (rust-jemalloc-sys.overrideAttrs (
-      { configureFlags, ... }:
-      {
-        configureFlags = configureFlags ++ [
-          # otherwise import check fails with:
-          # ImportError: {{storeDir}}/lib/libjemalloc.so.2: cannot allocate memory in static TLS block
-          "--disable-initial-exec-tls"
-        ];
-      }
-    ))
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/granian/no-alloc.patch
+++ b/pkgs/development/python-modules/granian/no-alloc.patch
@@ -1,0 +1,50 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 4e6676f..1657d61 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -40,7 +40,6 @@ hyper = { version = "=1.6", features = ["http1", "http2", "server"] }
+ hyper-util = { version = "=0.1", features = ["server-auto", "tokio"] }
+ itertools = "0.14"
+ log = "0.4"
+-mimalloc = { version = "0.1.43", default-features = false, features = ["local_dynamic_tls"], optional = true }
+ mime_guess = "=2.0"
+ pem = "=3.0"
+ percent-encoding = "=2.3"
+@@ -56,15 +55,9 @@ tokio-stream = "0.1"
+ tokio-tungstenite = "=0.26"
+ tokio-util = { version = "0.7", features = ["codec", "rt"] }
+ 
+-[target.'cfg(not(any(target_env = "musl", target_os = "freebsd", target_os = "openbsd", target_os = "windows")))'.dependencies]
+-tikv-jemallocator = { version = "0.6.0", default-features = false, features = ["disable_initial_exec_tls"] }
+-
+ [build-dependencies]
+ pyo3-build-config = "=0.25"
+ 
+-[features]
+-mimalloc = ["dep:mimalloc"]
+-
+ [profile.release]
+ codegen-units = 1
+ debug = false
+diff --git a/src/lib.rs b/src/lib.rs
+index 9172842..6c41005 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,17 +1,3 @@
+-#[cfg(not(any(
+-    target_env = "musl",
+-    target_os = "freebsd",
+-    target_os = "openbsd",
+-    target_os = "windows",
+-    feature = "mimalloc"
+-)))]
+-#[global_allocator]
+-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+-
+-#[cfg(feature = "mimalloc")]
+-#[global_allocator]
+-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+-
+ use pyo3::prelude::*;
+ use std::sync::OnceLock;
+ 


### PR DESCRIPTION
Fixes #414214

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
