### PR TITLE
onedrive: 2.5.5 -> 2.5.6

### DIFF
--- a/pkgs/by-name/on/onedrive/package.nix
+++ b/pkgs/by-name/on/onedrive/package.nix
@@ -62,12 +62,15 @@ stdenv.mkDerivation (finalAttrs: {
   # we could also pass --enable-completions to configure but we would then have to
   # figure out the paths manually and pass those along.
   postInstall = ''
-    installShellCompletion --bash --name onedrive contrib/completions/complete.bash
-    installShellCompletion --fish --name onedrive contrib/completions/complete.fish
-    installShellCompletion --zsh --name _onedrive contrib/completions/complete.zsh
+    installShellCompletion --cmd onedrive \
+      --bash contrib/completions/complete.bash \
+      --fish contrib/completions/complete.fish \
+      --zsh contrib/completions/complete.zsh
 
-    substituteInPlace $out/lib/systemd/user/onedrive.service --replace-fail "/usr/bin/sleep" "${coreutils}/bin/sleep"
-    substituteInPlace $out/lib/systemd/system/onedrive@.service --replace-fail "/usr/bin/sleep" "${coreutils}/bin/sleep"
+    for s in $out/lib/systemd/user/onedrive.service $out/lib/systemd/system/onedrive@.service; do
+      substituteInPlace $s \
+        --replace-fail "/usr/bin/sleep" "${coreutils}/bin/sleep"
+    done
   '';
 
   passthru = {

--- a/pkgs/by-name/on/onedrive/package.nix
+++ b/pkgs/by-name/on/onedrive/package.nix
@@ -10,6 +10,7 @@
   pkg-config,
   sqlite,
   stdenv,
+  dbus,
   systemd,
   testers,
   # Boolean flags
@@ -18,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "onedrive";
-  version = "2.5.5";
+  version = "2.5.6";
 
   src = fetchFromGitHub {
     owner = "abraunegg";
     repo = "onedrive";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-SoTkphmxWVAeSfqO7Vqm8bdPAP1hK57zFNR6N5elEOM=";
+    hash = "sha256-AFaz1RkrtsdTZfaWobdcADbzsAhbdCzJPkQX6Pa7hN8=";
   };
 
   outputs = [
@@ -42,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     curl
+    dbus
     libnotify
     sqlite
   ] ++ lib.optionals withSystemd [ systemd ];

--- a/pkgs/by-name/on/onedrive/package.nix
+++ b/pkgs/by-name/on/onedrive/package.nix
@@ -1,18 +1,23 @@
 {
   lib,
-  autoreconfHook,
-  coreutils,
-  curl,
+  stdenv,
   fetchFromGitHub,
+
+  # native
+  autoreconfHook,
   installShellFiles,
   ldc,
-  libnotify,
   pkg-config,
-  sqlite,
-  stdenv,
+
+  # host
+  coreutils,
+  curl,
   dbus,
+  libnotify,
+  sqlite,
   systemd,
   testers,
+
   # Boolean flags
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
