### PR TITLE
tic-80: update to git HEAD and fix build

### DIFF
--- a/pkgs/by-name/ti/tic-80/package.nix
+++ b/pkgs/by-name/ti/tic-80/package.nix
@@ -9,49 +9,36 @@
   fetchFromGitHub,
   libGL,
   libGLU,
-  alsa-lib,
   libX11,
-  libICE,
-  libXi,
-  libXScrnSaver,
-  libXcursor,
-  libXinerama,
-  libXext,
-  libXxf86vm,
-  libXrandr,
-  libxkbcommon,
-  wayland,
-  wayland-protocols,
-  wayland-scanner,
-  dbus,
-  udev,
-  libdecor,
-  pipewire,
-  libpulseaudio,
+  janet,
+  lua5_3,
+  quickjs,
+  SDL2,
   # Whether to build TIC-80's "Pro" version, which is an incentive to support the project financially,
   # that enables some additional features. It is, however, fully open source.
   withPro ? false,
 }:
 let
-  major = "1";
-  minor = "1";
-  revision = "2837";
-  year = "2023";
+  # git rev-list HEAD --count
+  revision = "3016";
+  year = "2025";
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "tic-80";
-  version = "${major}.${minor}.${revision}";
+  # use an untagged version until upstream tags a new version. We want
+  # 'PREFER_SYSTEM_LIBRARIES', and without it tic-80 won't build
+  version = "1.1-unstable-2025-05-26";
 
   src = fetchFromGitHub {
     owner = "nesbox";
     repo = "TIC-80";
-    rev = "v" + version;
-    hash = "sha256-p7OyuD/4KxAzylQDlXW681TvEZwKYDD4zq2KDRkcv48=";
-    # TIC-80 vendors its dependencies as submodules, so to use its current build system,
-    # we need to fetch them. Managing the dependencies ourselves would require a lot of
-    # changes in the build system, which doesn't seem worth it right now. In future versions,
-    # TIC-80 is switching to more modular CMake files, at which point we can reconsider.
+    rev = "663d43924abf6fd7620de6bf25c009ce5b30ab83";
+    hash = "sha256-UjBnXxYZ5gfk58sI1qek5fkKpJ7LzOVmrxdjVgONcXc=";
+    # TIC-80 vendors its dependencies as submodules. For the following dependencies,
+    # there are no (or no compatible) packages in nixpkgs yet, so we use the vendored
+    # ones as a fill-in: kubazip, wasm, squirrel, pocketpy, argparse, naett,
+    # sdlgpu, mruby.
     fetchSubmodules = true;
   };
 
@@ -61,7 +48,7 @@ stdenv.mkDerivation rec {
   # To avoid the awkward copyright range of "2017-1980", which would be caused by the
   # sandbox environment, hardcode the year of the release.
   postPatch = ''
-    substituteInPlace CMakeLists.txt \
+    substituteInPlace cmake/version.cmake \
       --replace-fail 'set(VERSION_REVISION 0)' 'set(VERSION_REVISION ${revision})' \
       --replace-fail 'string(TIMESTAMP VERSION_YEAR "%Y")' 'set(VERSION_YEAR "${year}")'
   '';
@@ -72,7 +59,20 @@ stdenv.mkDerivation rec {
     unset LD
   '';
 
-  cmakeFlags = lib.optionals withPro [ "-DBUILD_PRO=On" ] ++ [ "-DBUILD_SDLGPU=On" ];
+  cmakeFlags =
+    let
+      enableCmakeBool = (lib.flip lib.cmakeBool) true;
+    in
+    [
+      (lib.cmakeBool "BUILD_PRO" withPro)
+    ]
+    ++ (map enableCmakeBool [
+      "BUILD_STATIC"
+      "PREFER_SYSTEM_LIBRARIES"
+      "BUILD_SDLGPU"
+      "BUILD_WITH_ALL"
+    ]);
+
   nativeBuildInputs = [
     cmake
     curl
@@ -81,53 +81,14 @@ stdenv.mkDerivation rec {
     rake
   ];
   buildInputs = [
-    alsa-lib
-    dbus
-    libdecor
     libGL
     libGLU
-    libICE
-    libpulseaudio
     libX11
-    libXcursor
-    libXext
-    libXi
-    libXinerama
-    libxkbcommon
-    libXrandr
-    libXScrnSaver
-    libXxf86vm
-    pipewire
-    udev
-    wayland
-    wayland-protocols
-    wayland-scanner
+    janet
+    (lua5_3.withPackages (ps: [ ps.fennel ]))
+    quickjs
+    SDL2
   ];
-
-  # This package borrows heavily from pkgs/development/libraries/SDL2/default.nix
-  # because TIC-80 vendors SDL2, which means we need to take care and implement
-  # a similar environment in TIC-80's vendored copy of SDL2.
-  #
-  # SDL is weird in that instead of just dynamically linking with
-  # libraries when you `--enable-*` (or when `configure` finds) them
-  # it `dlopen`s them at runtime. In principle, this means it can
-  # ignore any missing optional dependencies like alsa, pulseaudio,
-  # some x11 libs, wayland, etc if they are missing on the system
-  # and/or work with wide array of versions of said libraries. In
-  # nixpkgs, however, we don't need any of that. Moreover, since we
-  # don't have a global ld-cache we have to stuff all the propagated
-  # libraries into rpath by hand or else some applications that use
-  # SDL API that requires said libraries will fail to start.
-  #
-  # You can grep SDL sources with `grep -rE 'SDL_(NAME|.*_SYM)'` to
-  # list the symbols used in this way.
-  postFixup =
-    let
-      rpath = lib.makeLibraryPath buildInputs;
-    in
-    ''
-      patchelf --set-rpath "$(patchelf --print-rpath $out/bin/tic80):${rpath}" "$out/bin/tic80"
-    '';
 
   meta = with lib; {
     description = "A free and open source fantasy computer for making, playing and sharing tiny games";
@@ -151,7 +112,5 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "tic80";
     maintainers = with maintainers; [ blinry ];
-    # /build/source/vendor/sdl2/src/audio/pipewire/SDL_pipewire.c:623:37: error: passing argument 1 of 'pw_node_enum_params' from incompatible pointer type [-Wincompatible-pointer-types]
-    broken = true;
   };
 }


### PR DESCRIPTION
The breakage before was due to the bundled SDL2.

Upstream, as of https://github.com/nesbox/TIC-80/pull/2758, there's an option to use system libraries instead... which unfortunately isn't released in any tagged version.

To get that upstream change, this bumps the version to the latest git revision.

This then further updates the build to use nixpkg's version of SDL2, as well as lua5_3 and a few others, which is enough to unbreak the build.

Some of the dependent libraries aren't in nixpkgs, or we only have an incompatible version in nixpkgs, so not all of the libraries are taken from the system.

Still, now it builds and runs, I think that's enough of an improvement we can accept the mix of system and upstream libraries in use here!

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).