### PR TITLE
python3Packages.spherogram: init at 2.2.1

### DIFF
--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  python,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchurl,
+  setuptools,
+  cython,
+  bash,
+  perl,
+  gnum4,
+  texliveBasic,
+}:
+
+let
+  pariVersion = "2.15.4";
+  gmpVersion = "6.3.0";
+
+  pariSrc = fetchurl {
+    url = "https://pari.math.u-bordeaux.fr/pub/pari/OLD/${lib.versions.majorMinor pariVersion}/pari-${pariVersion}.tar.gz";
+    hash = "sha256-w1Rb/uDG37QLd/tLurr5mdguYAabn20ovLbPAEyMXA8=";
+  };
+
+  gmpSrc = fetchurl {
+    url = "https://ftp.gnu.org/gnu/gmp/gmp-${gmpVersion}.tar.bz2";
+    hash = "sha256-rCghGnz7YJuuLiyNYFjWbI/pZDT3QM9v4uR7AA0cIMs=";
+  };
+in
+buildPythonPackage rec {
+  pname = "cypari";
+  version = "2.5.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "3-manifolds";
+    repo = "CyPari";
+    tag = "${version}_as_released";
+    hash = "sha256-RJ9O1KsDHmMkTCIFUrcSUkA5ijTsxmoI939QCsCib0Y=";
+  };
+
+  postPatch = ''
+    substituteInPlace ./setup.py \
+      --replace-fail "/bin/bash" "${lib.getExe bash}"
+    # final character is stripped from PARI error messages for some reason
+    substituteInPlace ./cypari/handle_error.pyx \
+      --replace-fail "not a function in function call" "not a function in function cal"
+    ln -s ${pariSrc} ${pariSrc.name}
+    ln -s ${gmpSrc} ${gmpSrc.name}
+  '';
+
+  build-system = [
+    setuptools
+    cython
+  ];
+
+  NIX_LDFLAGS = "-lc";
+
+  nativeBuildInputs = [
+    gnum4
+    perl
+    texliveBasic
+  ];
+
+  pythonImportsCheck = [ "cypari" ];
+
+  checkPhase = ''
+    runHook preCheck
+    rm -r cypari
+    ${python.interpreter} -m cypari.test
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Sage's PARI extension, modified to stand alone";
+    homepage = "https://github.com/3-manifolds/CyPari";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ noiioiu ];
+    changelog = "https://github.com/3-manifolds/CyPari/releases/tag/${src.tag}";
+  };
+}

--- a/pkgs/development/python-modules/fxrays/default.nix
+++ b/pkgs/development/python-modules/fxrays/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cython,
+}:
+
+buildPythonPackage rec {
+  pname = "fxrays";
+  version = "1.3.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "3-manifolds";
+    repo = "FXrays";
+    tag = "${version}_as_released";
+    hash = "sha256-IwEY54zDXqMci7WRvhueDJidTsbMwv6eqQSGZzFOtnQ";
+  };
+
+  build-system = [
+    setuptools
+    cython
+  ];
+
+  pythonImportsCheck = [ "FXrays" ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m FXrays.test
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Computes extremal rays of polyhedral cones with filtering";
+    changelog = "https://github.com/3-manifolds/FXrays/releases/tag/${src.tag}";
+    homepage = "https://github.com/3-manifolds/FXrays";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ noiioiu ];
+  };
+}

--- a/pkgs/development/python-modules/knot-floer-homology/default.nix
+++ b/pkgs/development/python-modules/knot-floer-homology/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cython,
+}:
+
+buildPythonPackage rec {
+  pname = "knot-floer-homology";
+  version = "1.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "3-manifolds";
+    repo = "knot_floer_homology";
+    tag = "${version}_as_released";
+    hash = "sha256-Gw9k9AaUVTBzE+ERUH8VgS//aVT03DdKozpL8xLG4No=";
+  };
+
+  build-system = [
+    setuptools
+    cython
+  ];
+
+  pythonImportsCheck = [ "knot_floer_homology" ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m knot_floer_homology.test
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Python wrapper for Zoltán Szabó's HFK Calculator";
+    changelog = "https://github.com/3-manifolds/knot_floer_homology/releases/tag/${src.tag}";
+    homepage = "https://github.com/3-manifolds/knot_floer_homology";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ noiioiu ];
+  };
+}

--- a/pkgs/development/python-modules/low-index/default.nix
+++ b/pkgs/development/python-modules/low-index/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  python,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "low-index";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "3-manifolds";
+    repo = "low_index";
+    tag = "v${version}_as_released";
+    hash = "sha256-T8hzC9ulikQ1pUdbXgjuKAX5oMJEycPvXWv74rCkQGY=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "low_index" ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m low_index.test
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Enumerates low index subgroups of a finitely presented group";
+    changelog = "https://github.com/3-manifolds/low_index/releases/tag/${src.tag}";
+    homepage = "https://github.com/3-manifolds/low_index";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ noiioiu ];
+  };
+}

--- a/pkgs/development/python-modules/plink/default.nix
+++ b/pkgs/development/python-modules/plink/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  sphinx,
+  tkinter,
+}:
+
+buildPythonPackage rec {
+  pname = "plink";
+  version = "2.4.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "3-manifolds";
+    repo = "plink";
+    tag = "${version}_as_released";
+    hash = "sha256-+WUyQvQY9Fx47GikzJ4gcCpSIjvk5756FP0bDdF6Ack=";
+  };
+
+  build-system = [
+    setuptools
+    sphinx
+  ];
+
+  dependencies = [ tkinter ];
+
+  pythonImportsCheck = [ "plink" ];
+
+  meta = {
+    description = "Full featured Tk-based knot and link editor";
+    mainProgram = "plink";
+    homepage = "https://3-manifolds.github.io/PLink";
+    changelog = "https://github.com/3-manifolds/PLink/releases/tag/${src.tag}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ noiioiu ];
+  };
+}

--- a/pkgs/development/python-modules/snappy-15-knots/default.nix
+++ b/pkgs/development/python-modules/snappy-15-knots/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  snappy-manifolds,
+}:
+
+buildPythonPackage rec {
+  pname = "snappy-15-knots";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "3-manifolds";
+    repo = "snappy_15_knots";
+    tag = "${version}_as_released";
+    hash = "sha256-fhJhHZFf4XuW/0V6LOuV4qoFWke3oFP0KArDpXLWh9g=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ snappy-manifolds ];
+
+  pythonImportsCheck = [ "snappy_15_knots" ];
+
+  meta = with lib; {
+    description = "Database of snappy manifolds";
+    homepage = "https://snappy.computop.org";
+    changelog = "https://github.com/3-manifolds/snappy_15_knots/releases/tag/${src.tag}";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ noiioiu ];
+  };
+}

--- a/pkgs/development/python-modules/snappy-manifolds/default.nix
+++ b/pkgs/development/python-modules/snappy-manifolds/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "snappy-manifolds";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "3-manifolds";
+    repo = "snappy_manifolds";
+    tag = "${version}_as_released";
+    hash = "sha256-vxG3z6zWzG4S11fBxYGn4/c2f2sWOCIrzT+R27TR144=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "snappy_manifolds" ];
+
+  meta = {
+    description = "Database of snappy manifolds";
+    changelog = "https://github.com/3-manifolds/snappy_manifolds/releases/tag/${src.tag}";
+    homepage = "https://snappy.computop.org";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ noiioiu ];
+  };
+}

--- a/pkgs/development/python-modules/spherogram/default.nix
+++ b/pkgs/development/python-modules/spherogram/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cython,
+  networkx,
+  decorator,
+  knot-floer-homology,
+  snappy-manifolds,
+  snappy-15-knots,
+}:
+
+buildPythonPackage rec {
+  pname = "spherogram";
+  version = "2.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "3-manifolds";
+    repo = "spherogram";
+    tag = "${version}_as_released";
+    hash = "sha256-uqc+3xS4xulXR0tZlNuyC5Zz5OztR6c4PZWpsvU+4Pw=";
+  };
+
+  build-system = [
+    setuptools
+    cython
+  ];
+
+  dependencies = [
+    networkx
+    decorator
+    snappy-manifolds
+    knot-floer-homology
+  ];
+
+  optional-dependencies.snappy-15-knots = [ snappy-15-knots ];
+
+  pythonImportsCheck = [ "spherogram" ];
+
+  meta = {
+    description = "Spherical diagrams for 3-manifold topology";
+    homepage = "https://snappy.computop.org/spherogram.html";
+    changelog = "https://github.com/3-manifolds/Spherogram/releases/tag/${src.tag}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ noiioiu ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8463,6 +8463,8 @@ self: super: with self; {
 
   lottie = callPackage ../development/python-modules/lottie { };
 
+  low-index = callPackage ../development/python-modules/low-index { };
+
   lox = callPackage ../development/python-modules/lox { };
 
   lpc-checksum = callPackage ../development/python-modules/lpc-checksum { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7582,6 +7582,8 @@ self: super: with self; {
 
   knocki = callPackage ../development/python-modules/knocki { };
 
+  knot-floer-homology = callPackage ../development/python-modules/knot-floer-homology { };
+
   knx-frontend = callPackage ../development/python-modules/knx-frontend { };
 
   kombu = callPackage ../development/python-modules/kombu { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16479,6 +16479,8 @@ self: super: with self; {
 
   spglib = callPackage ../development/python-modules/spglib { };
 
+  spherogram = callPackage ../development/python-modules/spherogram { };
+
   sphfile = callPackage ../development/python-modules/sphfile { };
 
   sphinx = callPackage ../development/python-modules/sphinx { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11441,6 +11441,8 @@ self: super: with self; {
 
   plfit = toPythonModule (pkgs.plfit.override { inherit (self) python; });
 
+  plink = callPackage ../development/python-modules/plink { };
+
   plone-testing = callPackage ../development/python-modules/plone-testing { };
 
   ploomber-core = callPackage ../development/python-modules/ploomber-core { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5432,6 +5432,8 @@ self: super: with self; {
 
   fx2 = callPackage ../development/python-modules/fx2 { };
 
+  fxrays = callPackage ../development/python-modules/fxrays { };
+
   fyta-cli = callPackage ../development/python-modules/fyta-cli { };
 
   g2pkk = callPackage ../development/python-modules/g2pkk { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3128,6 +3128,8 @@ self: super: with self; {
 
   cynthion = callPackage ../development/python-modules/cynthion { };
 
+  cypari = callPackage ../development/python-modules/cypari { };
+
   cypari2 = callPackage ../development/python-modules/cypari2 { };
 
   cypherpunkpay = callPackage ../development/python-modules/cypherpunkpay { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16309,6 +16309,8 @@ self: super: with self; {
 
   snapcast = callPackage ../development/python-modules/snapcast { };
 
+  snappy-15-knots = callPackage ../development/python-modules/snappy-15-knots { };
+
   snappy-manifolds = callPackage ../development/python-modules/snappy-manifolds { };
 
   snapshottest = callPackage ../development/python-modules/snapshottest { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16309,6 +16309,8 @@ self: super: with self; {
 
   snapcast = callPackage ../development/python-modules/snapcast { };
 
+  snappy-manifolds = callPackage ../development/python-modules/snappy-manifolds { };
+
   snapshottest = callPackage ../development/python-modules/snapshottest { };
 
   snaptime = callPackage ../development/python-modules/snaptime { };


### PR DESCRIPTION
[Spherogram](https://github.com/3-manifolds/Spherogram) is a python module for dealing with planar diagrams used in 3-dimensional topology, such as link diagrams. It is part of [SnapPy](https://snappy.computop.org/spherogram.html) and can also be used within sage to compute knot polynomials.

This pull request depends on:
[fxrays](https://github.com/NixOS/nixpkgs/pull/411630)
[low-index](https://github.com/NixOS/nixpkgs/pull/411821)
[plink](https://github.com/NixOS/nixpkgs/pull/411057)
[cypari](https://github.com/NixOS/nixpkgs/pull/411812)
[knot-floer-homology](https://github.com/NixOS/nixpkgs/pull/411365)
[snappy-manifolds](https://github.com/NixOS/nixpkgs/pull/412071)
[snappy-15-knots](https://github.com/NixOS/nixpkgs/pull/414018)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
