### PR TITLE
horizon-eda: 2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/by-name/ho/horizon-eda/base.nix
+++ b/pkgs/by-name/ho/horizon-eda/base.nix
@@ -24,13 +24,13 @@ in
 # This base is used in horizon-eda and python3Packages.horizon-eda
 rec {
   pname = "horizon-eda";
-  version = "2.6.0";
+  version = "2.7.0";
 
   src = fetchFromGitHub {
     owner = "horizon-eda";
     repo = "horizon";
     rev = "v${version}";
-    hash = "sha256-0ikCR10r/WPb+H+Ut2GO6y4A/9bctJLanL/RR4r9GWs=";
+    hash = "sha256-Y2oopRycYSxtiKuQZSfTBVP7RmpZ0JA+QyZgnrpoAes=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ho/horizon-eda/base.nix
+++ b/pkgs/by-name/ho/horizon-eda/base.nix
@@ -56,9 +56,8 @@ rec {
   ];
 
   env = {
+    CASROOT = opencascade-occt;
   };
-
-  CASROOT = opencascade-occt;
 
   meta = {
     description = "Free EDA software to develop printed circuit boards";

--- a/pkgs/by-name/ho/horizon-eda/base.nix
+++ b/pkgs/by-name/ho/horizon-eda/base.nix
@@ -56,9 +56,6 @@ rec {
   ];
 
   env = {
-    NIX_CFLAGS_COMPILE = toString [
-      "-fpermissive"
-    ];
   };
 
   CASROOT = opencascade-occt;

--- a/pkgs/by-name/ho/horizon-eda/package.nix
+++ b/pkgs/by-name/ho/horizon-eda/package.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation {
     version
     src
     meta
-    CASROOT
     env
     ;
 

--- a/pkgs/development/python-modules/horizon-eda/default.nix
+++ b/pkgs/development/python-modules/horizon-eda/default.nix
@@ -1,5 +1,6 @@
 {
   buildPythonPackage,
+  fetchpatch,
   horizon-eda,
   pycairo,
   python,
@@ -21,6 +22,14 @@ buildPythonPackage {
   pyproject = false;
 
   disabled = pythonOlder "3.9";
+
+  patches = [
+    # Replaces osmesa with EGL_PLATFORM_SURFACELESS_MESA
+    (fetchpatch {
+      url = "https://github.com/horizon-eda/horizon/commit/663a8adaa1cb7eae7a824de07df8909bc33677c3.patch";
+      hash = "sha256-g0rP9NBDdDijh35Y2h4me9N5R/mjCn+2w7uhnv9bweY=";
+    })
+  ];
 
   buildInputs = base.buildInputs ++ [
     python

--- a/pkgs/development/python-modules/horizon-eda/default.nix
+++ b/pkgs/development/python-modules/horizon-eda/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage {
     version
     src
     meta
-    CASROOT
+    env
     ;
 
   pyproject = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Includes and, thus, closes #413089
- Fixes the broken Python package and, thus, closes #412776
- Clean-up environment

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

#413089
#412776

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
