### PR TITLE
ocamlPackages.smtml: init at 0.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/hc/default.nix
+++ b/pkgs/development/ocaml-modules/hc/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildDunePackage,
+  fetchzip,
+}:
+
+buildDunePackage rec {
+  pname = "hc";
+  version = "0.5";
+
+  # upstream git server is misconfigured and cannot be cloned
+  src = fetchzip {
+    url = "https://git.zapashcanon.fr/zapashcanon/hc/archive/${version}.tar.gz";
+    hash = "sha256-oTomFi+e9aCgVpZ9EkxQ/dZz18cW2UcaV0ZIokeBoU0=";
+  };
+
+  doCheck = true;
+
+  meta = {
+    description = "Library for hash consing";
+    homepage = "https://ocaml.org/p/hc/";
+    downloadPage = "https://git.zapashcanon.fr/zapashcanon/hc";
+    changelog = "https://git.zapashcanon.fr/zapashcanon/hc/src/tag/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+  };
+}

--- a/pkgs/development/ocaml-modules/patricia-tree/default.nix
+++ b/pkgs/development/ocaml-modules/patricia-tree/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  findlib,
+  mdx,
+  qcheck-core,
+  ppx_inline_test,
+}:
+
+buildDunePackage rec {
+  pname = "patricia-tree";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "codex-semantics-library";
+    repo = "patricia-tree";
+    tag = "v${version}";
+    hash = "sha256-lpmU0KhsyIHxPBiw38ssA7XFEMsRvOT03MByoJG88Xs=";
+  };
+
+  strictDeps = true;
+
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+
+  checkInputs = [
+    mdx
+    ppx_inline_test
+    qcheck-core
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Patricia Tree data structure in OCaml";
+    homepage = "https://codex.top/api/patricia-tree/";
+    downloadPage = "https://github.com/codex-semantics-library/patricia-tree";
+    changelog = "https://github.com/codex-semantics-library/patricia-tree/releases/tag/v${version}";
+    license = lib.licenses.lgpl21Only;
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+  };
+}

--- a/pkgs/development/ocaml-modules/prelude/default.nix
+++ b/pkgs/development/ocaml-modules/prelude/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildDunePackage,
+  fetchzip,
+}:
+
+buildDunePackage rec {
+  pname = "prelude";
+  version = "0.5";
+
+  # upstream git repo is misconfigured and cannot be cloned
+  src = fetchzip {
+    url = "https://git.zapashcanon.fr/zapashcanon/prelude/archive/${version}.tar.gz";
+    hash = "sha256-lti+q1U/eEasAXo0O5YEu4iw7947V9bdvSHA0IEMS8M=";
+  };
+
+  doCheck = true;
+
+  meta = {
+    description = "Library to enforce good stdlib practices";
+    homepage = "https://ocaml.org/p/prelude/";
+    downloadPage = "https://git.zapashcanon.fr/zapashcanon/prelude";
+    changelog = "https://git.zapashcanon.fr/zapashcanon/prelude/src/tag/${version}/CHANGES.md";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+  };
+}

--- a/pkgs/development/ocaml-modules/processor/default.nix
+++ b/pkgs/development/ocaml-modules/processor/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+}:
+
+buildDunePackage rec {
+  pname = "processor";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "haesbaert";
+    repo = "ocaml-processor";
+    tag = "v${version}";
+    hash = "sha256-eGSNYjVbUIUMelajqZYOd3gvmRKQ9UP3TfMflLR9i7k=";
+  };
+
+  doCheck = true;
+
+  meta = {
+    description = "CPU topology and affinity for ocaml-multicore";
+    homepage = "https://haesbaert.github.io/ocaml-processor/processor/index.html";
+    downloadPage = "https://github.com/haesbaert/ocaml-processor";
+    changelog = "https://github.com/haesbaert/ocaml-processor/releases/tag/v${version}";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+  };
+}

--- a/pkgs/development/ocaml-modules/pyml/default.nix
+++ b/pkgs/development/ocaml-modules/pyml/default.nix
@@ -5,6 +5,7 @@
   utop,
   python3,
   stdcompat,
+  writableTmpDirAsHomeHook,
 }:
 
 buildDunePackage rec {
@@ -17,6 +18,10 @@ buildDunePackage rec {
     rev = version;
     sha256 = "sha256-0Yy5T/S3Npwt0XJmEsdXGg5AXYi9vV9UG9nMSzz/CEc=";
   };
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
 
   buildInputs = [
     utop

--- a/pkgs/development/ocaml-modules/scfg/default.nix
+++ b/pkgs/development/ocaml-modules/scfg/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildDunePackage,
+  fetchzip,
+  bos,
+  cmdliner,
+  fmt,
+  fpath,
+  menhir,
+  menhirLib,
+  prelude,
+  sedlex,
+  writableTmpDirAsHomeHook,
+}:
+
+buildDunePackage rec {
+  pname = "scfg";
+  version = "0.5";
+
+  # upstream git repo is misconfigured and cannot be cloned
+  src = fetchzip {
+    url = "https://git.zapashcanon.fr/zapashcanon/scfg/archive/${version}.tar.gz";
+    hash = "sha256-XyNVmI0W0B1JqR+uuojpHe9L5KKLhyoH8vN8+9i7Xcg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    menhir
+  ];
+
+  buildInputs = [
+    bos
+    cmdliner
+    fmt
+    fpath
+    menhir
+    menhirLib
+    prelude
+    sedlex
+  ];
+
+  checkInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Library to work with the scfg configuration file";
+    homepage = "https://ocaml.org/p/scfg/";
+    downloadPage = "https://git.zapashcanon.fr/zapashcanon/scfg";
+    changelog = "https://git.zapashcanon.fr/zapashcanon/scfg/src/tag/${version}/CHANGES.md";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+  };
+}

--- a/pkgs/development/ocaml-modules/smtml/default.nix
+++ b/pkgs/development/ocaml-modules/smtml/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  menhir,
+  bos,
+  cmdliner,
+  dolmen_type,
+  fpath,
+  hc,
+  menhirLib,
+  ocaml_intrinsics,
+  ocaml_intrinsics_kernel,
+  patricia-tree,
+  prelude,
+  scfg,
+  sedlex,
+  yojson,
+  zarith,
+  ounit2,
+}:
+
+buildDunePackage rec {
+  pname = "smtml";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "formalsec";
+    repo = "smtml";
+    tag = "v${version}";
+    hash = "sha256-QxVORnu28mcs54ZEPMxI5Bch/+/gkIfn0bTqrnSKUOw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    menhir
+  ];
+
+  buildInputs = [
+    bos
+    cmdliner
+    dolmen_type
+    fpath
+    hc
+    menhir
+    menhirLib
+    ocaml_intrinsics
+    ocaml_intrinsics_kernel
+    patricia-tree
+    prelude
+    scfg
+    sedlex
+    yojson
+    zarith
+  ];
+
+  checkInputs = [
+    ounit2
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "SMT solver frontend for OCaml";
+    homepage = "https://formalsec.github.io/smtml/smtml/";
+    downloadPage = "https://github.com/formalsec/smtml";
+    changelog = "https://github.com/formalsec/smtml/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -719,6 +719,8 @@ let
 
         hashcons = callPackage ../development/ocaml-modules/hashcons { };
 
+        hc = callPackage ../development/ocaml-modules/hc { };
+
         hex = callPackage ../development/ocaml-modules/hex { };
 
         hidapi = callPackage ../development/ocaml-modules/hidapi { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1769,6 +1769,8 @@ let
 
         pratter = callPackage ../development/ocaml-modules/pratter { };
 
+        prelude = callPackage ../development/ocaml-modules/prelude { };
+
         prettym = callPackage ../development/ocaml-modules/prettym { };
 
         printbox = callPackage ../development/ocaml-modules/printbox { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1781,6 +1781,8 @@ let
 
         process = callPackage ../development/ocaml-modules/process { };
 
+        processor = callPackage ../development/ocaml-modules/processor { };
+
         prometheus = callPackage ../development/ocaml-modules/prometheus { };
 
         progress = callPackage ../development/ocaml-modules/progress { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1952,6 +1952,8 @@ let
 
         slug = callPackage ../development/ocaml-modules/slug { };
 
+        smtml = callPackage ../development/ocaml-modules/smtml { };
+
         sodium = callPackage ../development/ocaml-modules/sodium { };
 
         sosa = callPackage ../development/ocaml-modules/sosa { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1916,6 +1916,8 @@ let
 
         sawja = callPackage ../development/ocaml-modules/sawja { };
 
+        scfg = callPackage ../development/ocaml-modules/scfg { };
+
         secp256k1 = callPackage ../development/ocaml-modules/secp256k1 {
           inherit (pkgs) secp256k1;
         };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1655,6 +1655,8 @@ let
 
         path_glob = callPackage ../development/ocaml-modules/path_glob { };
 
+        patricia-tree = callPackage ../development/ocaml-modules/patricia-tree { };
+
         pbkdf = callPackage ../development/ocaml-modules/pbkdf { };
 
         pbrt = callPackage ../development/ocaml-modules/pbrt { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
OCaml dependies for the `owi` package: https://github.com/NixOS/nixpkgs/pull/414133
The `owi` package only builds on ocaml version 5.3, not 5.1. However, I have to use 5.1 because the `stdcompat` library does not build on 5.3 and I am waiting on upstream to support it. It is in the works. I thought I would add the package deps so that they are in nixpkgs and available for as many people as possible. 

This work is in preparation for Summer of Nix 2025, funded by the NLNet and NixOS Foundation, among others.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
