### PR TITLE
nixos/vector: add graceful shutdown limit option

### DIFF
--- a/nixos/modules/services/logging/vector.nix
+++ b/nixos/modules/services/logging/vector.nix
@@ -22,6 +22,15 @@ in
       '';
     };
 
+    gracefulShutdownLimitSecs = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 60;
+      description = ''
+        Set the duration in seconds to wait for graceful shutdown after SIGINT or SIGTERM are received.
+        After the duration has passed, Vector will force shutdown.
+      '';
+    };
+
     settings = lib.mkOption {
       type = (pkgs.formats.json { }).type;
       default = { };
@@ -56,7 +65,7 @@ in
               '';
         in
         {
-          ExecStart = "${lib.getExe cfg.package} --config ${validateConfig conf}";
+          ExecStart = "${lib.getExe cfg.package} --config ${validateConfig conf} --graceful-shutdown-limit-secs ${builtins.toString cfg.gracefulShutdownLimitSecs}";
           DynamicUser = true;
           Restart = "always";
           StateDirectory = "vector";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add an option to the vector module to set the graceful shutdown limit added in https://github.com/vectordotdev/vector/pull/17479. The option default mirrors the default from the vector cli. Alternatively, the option could be null as to be a no-op if it is not specified. 

Eval and ExecStart output testing:

```bash
nix eval .#nixosTests.vector.api.nodes.machineapi.systemd.services.vector.serviceConfig.ExecStart
"/nix/store/870ikdmdf59v51shbrcqb7mpj34ddk4w-vector-0.47.0/bin/vector --config /nix/store/rpvw5mll6miahra8p96l456a6hj0sqhy-validate-vector-conf --graceful-shutdown-limit-secs 60

/nix/store/870ikdmdf59v51shbrcqb7mpj34ddk4w-vector-0.47.0/bin/vector --config /nix/store/rpvw5mll6miahra8p96l456a6hj0sqhy-validate-vector-conf --graceful-shutdown-limit-secs 60
...
^C2025-06-05T18:56:11.497323Z  INFO vector::signal: Signal received. signal="SIGINT"
2025-06-05T18:56:11.497521Z  INFO vector: Vector has stopped.
2025-06-05T18:56:11.499044Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="demo_logs, file" time_remaining="59 seconds left"

/nix/store/870ikdmdf59v51shbrcqb7mpj34ddk4w-vector-0.47.0/bin/vector --config /nix/store/rpvw5mll6miahra8p96l456a6hj0sqhy-validate-vector-conf --graceful-shutdown-limit-secs 1
...
^C2025-06-05T18:56:20.408502Z  INFO vector::signal: Signal received. signal="SIGINT"
2025-06-05T18:56:20.408671Z  INFO vector: Vector has stopped.
2025-06-05T18:56:20.410253Z  INFO vector::topology::running: Shutting down... Waiting on running components. remaining_components="demo_logs, file" time_remaining="0 seconds left"
```

nixosTests:

```bash
nix-build -A nixosTests.vector
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
