### PR TITLE
 haskellPackages: fix GHC 9.12 on android 

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -291,6 +291,11 @@
           url = "https://gitlab.haskell.org/ghc/ghc/-/commit/39bb6e583d64738db51441a556d499aa93a4fc4a.patch";
           sha256 = "0w5fx413z924bi2irsy1l4xapxxhrq158b5gn6jzrbsmhvmpirs0";
         })
+      ]
+
+      # Missing ELF symbols
+      ++ lib.optionals stdenv.targetPlatform.isAndroid [
+        ./ghc-define-undefined-elf-st-visibility.patch
       ];
 
     stdenv = stdenvNoCC;

--- a/pkgs/development/compilers/ghc/ghc-define-undefined-elf-st-visibility.patch
+++ b/pkgs/development/compilers/ghc/ghc-define-undefined-elf-st-visibility.patch
@@ -1,0 +1,24 @@
+diff --git a/rts/linker/ElfTypes.h b/rts/linker/ElfTypes.h
+index f5e2f819d9..7f75087738 100644
+--- a/rts/linker/ElfTypes.h
++++ b/rts/linker/ElfTypes.h
+@@ -33,6 +33,9 @@
+ #define Elf_Sym     Elf64_Sym
+ #define Elf_Rel     Elf64_Rel
+ #define Elf_Rela    Elf64_Rela
++#if !defined(ELF64_ST_VISIBILITY)
++#define ELF64_ST_VISIBILITY(o) ((o)&0x3)
++#endif
+ #if !defined(ELF_ST_VISIBILITY)
+ #define ELF_ST_VISIBILITY ELF64_ST_VISIBILITY
+ #endif
+@@ -60,6 +63,9 @@
+ #define Elf_Sym     Elf32_Sym
+ #define Elf_Rel     Elf32_Rel
+ #define Elf_Rela    Elf32_Rela
++#if !defined(ELF32_ST_VISIBILITY)
++#define ELF32_ST_VISIBILITY(o) ((o)&0x3)
++#endif
+ #if !defined(ELF_ST_VISIBILITY)
+ #define ELF_ST_VISIBILITY ELF32_ST_VISIBILITY
+ #endif /* ELF_ST_VISIBILITY */

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -85,7 +85,7 @@ in
   enableSharedLibraries ?
     !stdenv.hostPlatform.isStatic
     && (ghc.enableShared or false)
-    && !stdenv.hostPlatform.useAndroidPrebuilt,
+    && !stdenv.hostPlatform.useAndroidPrebuilt, # TODO: figure out why /build leaks into RPATH
   enableDeadCodeElimination ? (!stdenv.hostPlatform.isDarwin), # TODO: use -dead_strip for darwin
   # Disabling this for ghcjs prevents this crash: https://gitlab.haskell.org/ghc/ghc/-/issues/23235
   enableStaticLibraries ?

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -515,8 +515,8 @@ let
                   ;
               };
 
-              haskell.packages.ghc910 = {
-                inherit (packagePlatforms pkgs.pkgsCross.aarch64-android-prebuilt.haskell.packages.ghc910)
+              haskell.packages.ghc912 = {
+                inherit (packagePlatforms pkgs.pkgsCross.aarch64-android-prebuilt.haskell.packages.ghc912)
                   ghc
                   hello
                   microlens

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -482,6 +482,26 @@ let
           };
 
       pkgsCross = {
+        aarch64-android-prebuilt.pkgsStatic =
+          removePlatforms
+            [
+              # Android NDK package doesn't support building on
+              "aarch64-darwin"
+              "aarch64-linux"
+
+              "x86_64-darwin"
+            ]
+            {
+              haskell.packages.ghc912 = {
+                inherit
+                  (packagePlatforms pkgs.pkgsCross.aarch64-android-prebuilt.pkgsStatic.haskell.packages.ghc912)
+                  ghc
+                  hello
+                  microlens
+                  ;
+              };
+            };
+
         ghcjs =
           removePlatforms
             [
@@ -512,14 +532,6 @@ let
                   microlens
                   miso
                   reflex-dom
-                  ;
-              };
-
-              haskell.packages.ghc912 = {
-                inherit (packagePlatforms pkgs.pkgsCross.aarch64-android-prebuilt.haskell.packages.ghc912)
-                  ghc
-                  hello
-                  microlens
                   ;
               };
 


### PR DESCRIPTION
As seen in https://github.com/input-output-hk/haskell.nix/pull/1874/commits/08efe5b3b97d17748771d902955ac469d00f7dfa

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
