### PR TITLE
autenticacao-gov-pt-bin: init at 13.3.3

### DIFF
--- a/pkgs/by-name/au/autenticacao-gov-pt-bin/package.nix
+++ b/pkgs/by-name/au/autenticacao-gov-pt-bin/package.nix
@@ -1,0 +1,169 @@
+{
+  autoPatchelfHook,
+  ccid,
+  cjson,
+  copyDesktopItems,
+  curl,
+  doxygen,
+  fetchurl,
+  flatpak,
+  lib,
+  libGL,
+  libgcc,
+  libsForQt5,
+  libzip,
+  makeDesktopItem,
+  makeWrapper,
+  openjpeg,
+  openpace,
+  openssl,
+  ostree,
+  patchelf,
+  pcsclite,
+  pkg-config,
+  proot,
+  qt5,
+  stdenv,
+  xml-security-c,
+}:
+
+let
+  xercesc_3_2 = stdenv.mkDerivation rec {
+    pname = "xerces-c";
+    version = "3.2.3";
+
+    src = fetchurl {
+      url = "mirror://apache/xerces/c/3/sources/xerces-c-${version}.tar.gz";
+      hash = "sha256-+5b8SbH7iS0eZOU6atqKzPbw5tMM4JN5Vuxo05vXLH4=";
+    };
+
+    nativeBuildInputs = [ pkg-config ];
+    configureFlags = [ "--disable-static" ];
+
+    meta = {
+      description = "Validating XML parser written in a portable subset of C++";
+      homepage = "https://xerces.apache.org/xerces-c/";
+      license = lib.licenses.asl20;
+      platforms = lib.platforms.unix;
+    };
+  };
+
+in
+stdenv.mkDerivation rec {
+  pname = "autenticacao-gov-pt-bin";
+  version = "3.13.3";
+
+  src = fetchurl {
+    url = "https://github.com/amagovpt/autenticacao.gov/releases/download/v${version}/pteid-mw-${version}.flatpak";
+    hash = "sha256-kUSUcX3/rPENdyd6ABeqADqK4CcSltwsdnmcgWzw8Fc=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    flatpak
+    makeWrapper
+    ostree
+    patchelf
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    ccid
+    cjson
+    curl
+    doxygen
+    libGL
+    libgcc
+    libsForQt5.poppler
+    libzip
+    openjpeg
+    openpace
+    openssl
+    pcsclite
+    proot
+    qt5.qtbase
+    qt5.qtgraphicaleffects
+    qt5.qtquickcontrols
+    qt5.qtquickcontrols2
+    qt5.qttools
+    xercesc_3_2
+    xml-security-c
+  ];
+
+  unpackPhase = ''
+    ostree init --repo=pteid --mode=archive-z2
+    ostree static-delta apply-offline --repo=pteid ${src}
+    ostree checkout --repo=pteid -U $(cd pteid/objects && echo */*.commit | sed -E "s/\/|\.commit$//g") pteid_out
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      desktopName = "Autenticação.gov";
+      genericName = "Portuguese eID Data";
+      comment = "Middleware for Electronic Identification in Portugal";
+      icon = "pt.gov.autenticacao";
+      terminal = false;
+      startupNotify = true;
+      categories = [ "Office" ];
+    })
+  ];
+
+  preInstall = ''
+    mkdir -p $out/share $out/app/{lib,share}
+    cp -r pteid_out/files/bin $out/app
+    cp -r pteid_out/files/lib/lib{pteid,CMD}* $out/app/lib/
+    cp -r pteid_out/files/share/certs $out/app/share
+    cp -r pteid_out/files/share/icons $out/share
+  '';
+
+  postInstall = ''
+    makeWrapper "${proot}/bin/proot" "$out/bin/${pname}" \
+      --add-flags "-b" \
+      --add-flags "$out/app:/app" \
+      --add-flags "$out/app/bin/eidguiV2" \
+      --argv0 "$out/bin/eidguiV2"
+  '';
+
+  preFixup = ''
+    find $out/app/lib -type f -name '*.so*' | while read lib; do
+      patchelf --replace-needed libxml-security-c.so.20 libxml-security-c.so.30 "$lib"
+    done
+    wrapQtApp $out/app/bin/eidguiV2
+    autoPatchelf $out/app
+  '';
+
+  meta = {
+    description = "Middleware for Electronic Identification in Portugal (with precompiled binaries by AMA)";
+    homepage = "https://www.autenticacao.gov.pt/";
+    license = lib.licenses.eupl12;
+    longDescription = ''
+      This package provides the official Portuguese Citizen Card middleware (Autenticação.gov),
+      extracted from AMA’s Flatpak release. It enables authentication and digital signing using
+      the Portuguese eID system.
+
+      On NixOS, it works with a supported card reader and Citizen Card, as long as
+      `services.pcscd.enable = true` is set in the system configuration.
+
+      Notes:
+        - Depends on xerces-c 3.2.3, which is no longer in nixpkgs. This package includes a version
+          override to restore it for compatibility.
+
+        - The application uses hardcoded paths for libraries and binaries. To accommodate this,
+          `proot` is used at runtime to simulate a traditional filesystem layout. This allows the
+          binary to run unmodified, though it may introduce minor latency.
+
+        - A desktop entry is included for integration with graphical environments.
+
+      Building from source is possible, but upstream disables signing in source builds. Using the
+      official binary avoids this limitation and provides full functionality.
+    '';
+    maintainers = with lib.maintainers; [ vaavaav ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This adds the official Portuguese Citizen Card middleware (Autenticação.gov), distributed by AMA, as a binary package extracted from their official Flatpak release.

Key notes:

- The software depends on xerces-c 3.2.3, which is no longer packaged in nixpkgs. A version override is included to reintroduce it for compatibility.

- The application makes hardcoded assumptions about library and binary paths. To work around this, proot is used during runtime to simulate the expected filesystem structure. This enables the software to run unmodified but may introduce latency for some user interactions.

- If a cleaner method is known to achieve the same path remapping or if upstream support for dynamic prefix configuration is possible, suggestions are welcome.

- A desktop entry is installed to integrate with graphical environments.

This package is intended for users of the Portuguese eID system who need access to authentication and digital signing functionality provided by the official middleware.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
