### PR TITLE
mumps: 5.7.3->5.8.0

### DIFF
--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -12,6 +12,7 @@
   metis,
   parmetis,
   mpiCheckPhaseHook,
+  static ? stdenv.hostPlatform.isStatic,
   mpiSupport ? false,
   withParmetis ? false, # default to false due to unfree license
   withPtScotch ? mpiSupport,
@@ -85,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       "OPTC=-O3"
       "OPTL=-O3"
       "SCALAP=-lscalapack"
-      "allshared"
+      "${if static then "all" else "allshared"}"
     ];
 
   installPhase =

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -46,14 +46,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   name = "mumps";
-  version = "5.7.3";
+  version = "5.8.0";
   # makeFlags contain space and one should use makeFlagsArray+
   # Setting this magic var is an optional solution
   __structuredAttrs = true;
 
   src = fetchzip {
     url = "https://mumps-solver.org/MUMPS_${finalAttrs.version}.tar.gz";
-    hash = "sha256-ZnIfAuvOBJDYqCtKGlWs0r39nG6X2lAVRuUmeIJenZw=";
+    hash = "sha256-opJW7+Z/YhyUFwYTTTuWZuykz8Z4do6/XTBThHyTVCs=";
   };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
       "LIBEXT_SHARED=.dylib"
     ]
     ++ [
-      "ISCOTCH=-I${scotch.dev}/include"
+      "ISCOTCH=-I${lib.getDev scotch}/include"
       "LMETIS=${LMETIS}"
       "LSCOTCH=${LSCOTCH}"
       "ORDERINGSF=${ORDERINGSF}"
@@ -114,9 +114,12 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   doInstallCheck = true;
+
   nativeInstallCheckInputs = lib.optional mpiSupport mpiCheckPhaseHook;
+
   installCheckPhase = ''
     runHook preInstallCheck
+
     ${lib.optionalString stdenv.hostPlatform.isDarwin "export DYLD_LIBRARY_PATH=$out/lib\n"}
     ${lib.optionalString mpiSupport "export MPIRUN='mpirun -n 2'\n"}
     cd examples
@@ -131,6 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
     $MPIRUN ./csimpletest_save_restore <input_simpletest_cmplx
     $MPIRUN ./zsimpletest_save_restore <input_simpletest_cmplx
     $MPIRUN ./c_example_save_restore
+
     runHook postInstallCheck
   '';
 
@@ -140,7 +144,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "MUltifrontal Massively Parallel sparse direct Solver";
-    homepage = "http://mumps-solver.org/";
+    homepage = "https://mumps-solver.org/";
+    changelog = "https://mumps-solver.org/index.php?page=dwnld#cl";
     license = lib.licenses.cecill-c;
     maintainers = with lib.maintainers; [
       nim65s

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -1,19 +1,19 @@
 {
-  blas,
+  lib,
+  stdenv,
   fetchzip,
   gfortran,
+  fixDarwinDylibNames,
+  blas,
   lapack,
-  lib,
+  scalapack,
+  scotch,
   metis,
   parmetis,
-  withParmetis ? false, # default to false due to unfree license
-  scotch,
-  withPtScotch ? mpiSupport,
-  stdenv,
-  fixDarwinDylibNames,
-  mpiSupport ? false,
   mpiCheckPhaseHook,
-  scalapack,
+  mpiSupport ? false,
+  withParmetis ? false, # default to false due to unfree license
+  withPtScotch ? mpiSupport,
 }:
 assert withParmetis -> mpiSupport;
 assert withPtScotch -> mpiSupport;

--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchzip,
+  mpi,
   gfortran,
   fixDarwinDylibNames,
   blas,
@@ -51,6 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
   # Setting this magic var is an optional solution
   __structuredAttrs = true;
 
+  strictDeps = true;
+
   src = fetchzip {
     url = "https://mumps-solver.org/MUMPS_${finalAttrs.version}.tar.gz";
     hash = "sha256-opJW7+Z/YhyUFwYTTTuWZuykz8Z4do6/XTBThHyTVCs=";
@@ -98,9 +101,12 @@ stdenv.mkDerivation (finalAttrs: {
       ln -s $out/include/mumps_seq/mpi.h $out/include/mumps_mpi.h
     '';
 
-  nativeBuildInputs = [
-    gfortran
-  ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+  nativeBuildInputs =
+    [
+      gfortran
+    ]
+    ++ lib.optional mpiSupport mpi
+    ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
   # Parmetis should be placed before scotch to avoid conflict of header file "parmetis.h"
   buildInputs =


### PR DESCRIPTION
changelog: https://mumps-solver.org/index.php?page=dwnld#cl


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
