### PR TITLE
nixos/newt: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -40,6 +40,8 @@
 
 - [postfix-tlspol](https://github.com/Zuplu/postfix-tlspol), MTA-STS and DANE resolver and TLS policy server for Postfix. Available as [services.postfix-tlspol](#opt-services.postfix-tlspol.enable).
 
+- [Newt](https://github.com/fosrl/newt), a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. Available as [services.newt](options.html#opt-services.newt.enable).
+
 - [Szurubooru](https://github.com/rr-/szurubooru), an image board engine inspired by services such as Danbooru, dedicated for small and medium communities. Available as [services.szurubooru](#opt-services.szurubooru.enable).
 
 - The [Neat IP Address Planner](https://spritelink.github.io/NIPAP/) (NIPAP) can now be enabled through [services.nipap.enable](#opt-services.nipap.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1241,6 +1241,7 @@
   ./services/networking/netclient.nix
   ./services/networking/networkd-dispatcher.nix
   ./services/networking/networkmanager.nix
+  ./services/networking/newt.nix
   ./services/networking/nextdns.nix
   ./services/networking/nftables.nix
   ./services/networking/nghttpx/default.nix

--- a/nixos/modules/services/networking/newt.nix
+++ b/nixos/modules/services/networking/newt.nix
@@ -1,0 +1,165 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.newt;
+in
+{
+  options = {
+    services.newt = {
+      enable = lib.mkEnableOption "Newt, user space tunnel client for Pangolin";
+      # needs to be changed when newt-go changes to fosrl-newt
+      package = lib.mkPackageOption pkgs "newt-go" { };
+
+      id = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          The Newt Id that will be used to communicate to Pangolin. This is generated on site creation in the dashboard.
+        '';
+      };
+      endpoint = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          The endpoint where both Gerbil and Pangolin reside in order to connect to the websocket. The url of your Pangolin dashboard.
+        '';
+      };
+      logLevel = lib.mkOption {
+        type = lib.types.enum [
+          "DEBUG"
+          "INFO"
+          "WARN"
+          "ERROR"
+          "FATAL"
+        ];
+        default = "INFO";
+        description = "The log level to use.";
+      };
+      # provide path to file to keep secrets out of the nix store
+      environmentFile = lib.mkOption {
+        type = with lib.types; nullOr path;
+        default = null;
+        description = ''
+          Path to a file containing sensitive environment variables for Newt. See https://docs.fossorial.io/Newt/overview#cli-args
+          These will overwrite anything defined in the config.
+          The file should contain environment-variable assignments like:
+          NEWT_ID=2ix2t8xk22ubpfy
+          NEWT_SECRET=nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = cfg.environmentFile != null;
+        message = "services.newt.environmentFile must be provided when Newt is enabled.";
+      }
+    ];
+
+    systemd.services.newt = {
+      description = "Newt, user space tunnel client for Pangolin";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment = {
+        HOME = "/var/lib/private/newt";
+      };
+      # the flag values will all be overwritten if also defined in the env file
+      script = "
+        exec ${lib.getExe pkgs.newt-go} \\\n
+        ${lib.optionalString (
+                !isNull cfg.id
+              ) "--id ${cfg.id} \\\n"}
+        ${lib.optionalString (
+                !isNull cfg.endpoint
+              ) "--endpoint ${cfg.endpoint} \\\n"}
+        --log-level ${cfg.logLevel}
+      ";
+      serviceConfig = {
+        DynamicUser = true;
+        StateDirectory = "newt";
+        StateDirectoryMode = "0700";
+        Restart = "always";
+        RestartSec = "10s";
+        EnvironmentFile = cfg.environmentFile;
+        # hardening
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = "disconnected";
+        PrivateDevices = true;
+        PrivateUsers = true;
+        PrivateMounts = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        ProtectClock = true;
+        ProtectProc = "noaccess";
+        ProtectHostname = true;
+        RemoveIPC = true;
+        NoNewPrivileges = true;
+        RestrictSUIDSGID = true;
+        MemoryDenyWriteExecute = true;
+        SystemCallArchitectures = "native";
+        UMask = "0077";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+          "AF_UNIX"
+        ];
+        CapabilityBoundingSet = [
+          "~CAP_BLOCK_SUSPEND"
+          "~CAP_BPF"
+          "~CAP_CHOWN"
+          "~CAP_MKNOD"
+          "~CAP_NET_RAW"
+          "~CAP_PERFMON"
+          "~CAP_SYS_BOOT"
+          "~CAP_SYS_CHROOT"
+          "~CAP_SYS_MODULE"
+          "~CAP_SYS_NICE"
+          "~CAP_SYS_PACCT"
+          "~CAP_SYS_PTRACE"
+          "~CAP_SYS_TIME"
+          "~CAP_SYS_TTY_CONFIG"
+          "~CAP_SYSLOG"
+          "~CAP_WAKE_ALARM"
+        ];
+        SystemCallFilter = [
+          "~@aio:EPERM"
+          "~@chown:EPERM"
+          "~@clock:EPERM"
+          "~@cpu-emulation:EPERM"
+          "~@debug:EPERM"
+          "~@keyring:EPERM"
+          "~@memlock:EPERM"
+          "~@module:EPERM"
+          "~@mount:EPERM"
+          "~@obsolete:EPERM"
+          "~@pkey:EPERM"
+          "~@privileged:EPERM"
+          "~@raw-io:EPERM"
+          "~@reboot:EPERM"
+          "~@resources:EPERM"
+          "~@sandbox:EPERM"
+          "~@setuid:EPERM"
+          "~@swap:EPERM"
+          "~@sync:EPERM"
+          "~@timer:EPERM"
+        ];
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ jackr ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init of a systemd service to run newt-go. [Newt](https://github.com/fosrl/newt) is a fully user space [WireGuard](https://www.wireguard.com/) tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
