### PR TITLE
[Backport release-24.11] aerc: backport an upstream patch for handling of attachments' filenames

### DIFF
--- a/pkgs/by-name/ae/aerc/basename-temp-file-fixup.patch
+++ b/pkgs/by-name/ae/aerc/basename-temp-file-fixup.patch
@@ -1,0 +1,34 @@
+From 2bbe75fe0bc87ab4c1e16c5a18c6200224391629 Mon Sep 17 00:00:00 2001
+From: Nicole Patricia Mazzuca <nicole@streganil.no>
+Date: Fri, 9 May 2025 09:32:21 +0200
+Subject: [PATCH] open: fix opening text/html messages
+
+This fixes a bug introduced in 93bec0de8ed5ab3d6b1f01026fe2ef20fa154329:
+aerc started using `path.Base(<part>)`, which returns `"."` on an empty
+path, but still checked for `""` two lines later.
+
+On macOS, the result is that aerc attempts to open the directory:
+
+```
+open /var/folders/vn/hs0zvdsx3vq6svvry8s1bnym0000gn/T/aerc-4229266673: is a directory
+```
+
+Signed-off-by: Nicole Patricia Mazzuca <nicole@streganil.no>
+Acked-by: Robin Jarry <robin@jarry.cc>
+---
+ commands/msgview/open.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/commands/msgview/open.go b/commands/msgview/open.go
+index a6e43cb8da5fd49d2aa562d4c25ee2d597deefc3..7c770d4a90b771e3a18dfcb327f5e9306d5b5fa7 100644
+--- a/commands/msgview/open.go
++++ b/commands/msgview/open.go
+@@ -59,7 +59,7 @@ func (o Open) Execute(args []string) error {
+ 		}
+ 		filename := path.Base(part.FileName())
+ 		var tmpFile *os.File
+-		if filename == "" {
++		if filename == "." {
+ 			extension := ""
+ 			if exts, _ := mime.ExtensionsByType(mimeType); len(exts) > 0 {
+ 				extension = exts[0]

--- a/pkgs/by-name/ae/aerc/basename-temp-file.patch
+++ b/pkgs/by-name/ae/aerc/basename-temp-file.patch
@@ -1,0 +1,41 @@
+From 93bec0de8ed5ab3d6b1f01026fe2ef20fa154329 Mon Sep 17 00:00:00 2001
+From: Robin Jarry <robin@jarry.cc>
+Date: Wed, 9 Apr 2025 10:49:24 +0200
+Subject: [PATCH] open: only use part basename for temp file
+
+When an attachment part has a name such as "/tmp/55208186_AllDocs.pdf",
+aerc creates a temp folder and tries to store the file by blindly
+concatenating the path as follows:
+
+	/tmp/aerc-3444057757/tmp/55208186_AllDocs.pdf
+
+And when writing to this path, it gets a "No such file or directory"
+error because the intermediate "tmp" subfolder isn't created.
+
+Reported-by: Erik Colson <eco@ecocode.net>
+Signed-off-by: Robin Jarry <robin@jarry.cc>
+---
+ commands/msgview/open.go | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/commands/msgview/open.go b/commands/msgview/open.go
+index 4293b7e4892c137a7f3fbbe79245ffb6733b2671..a6e43cb8da5fd49d2aa562d4c25ee2d597deefc3 100644
+--- a/commands/msgview/open.go
++++ b/commands/msgview/open.go
+@@ -5,6 +5,7 @@ import (
+ 	"io"
+ 	"mime"
+ 	"os"
++	"path"
+ 	"path/filepath"
+ 
+ 	"git.sr.ht/~rjarry/aerc/app"
+@@ -56,7 +57,7 @@ func (o Open) Execute(args []string) error {
+ 			app.PushError(err.Error())
+ 			return
+ 		}
+-		filename := part.FileName()
++		filename := path.Base(part.FileName())
+ 		var tmpFile *os.File
+ 		if filename == "" {
+ 			extension := ""

--- a/pkgs/by-name/ae/aerc/package.nix
+++ b/pkgs/by-name/ae/aerc/package.nix
@@ -39,6 +39,11 @@ buildGoModule rec {
       url = "https://git.sr.ht/~rjarry/aerc/commit/7346d20.patch";
       hash = "sha256-OCm8BcovYN2IDSgslZklQxkGVkSYQ8HLCrf2+DRB2mM=";
     })
+
+    # TODO remove these with the next release
+    # they resolve a path injection vulnerability when saving attachments (CVE-2025-49466)
+    ./basename-temp-file.patch
+    ./basename-temp-file-fixup.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
The patch is not part of a tagged release yet so we apply it selectively instead of upgrading whole aerc. While it is originally presented as a usability problem only for attachments with absolutes filepaths (they fail to open), there is nothing stopping you from putting a relative path in there therefore forcing aerc to overwriting any path on the host system with sender chosen data. It's been marked as CVE-2025-49466

I decided to inline the patches into nixpkgs as they are very short and the current bot protection of git.sr.ht complicates patch fetching.

(cherry picked from commit a8b64551c5f11f7fe4700c94d50758b4c1baf5d3)

Backports #414181

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
