### PR TITLE
gitea-mcp-server: init at 0.2.0 and add conneroisu as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5055,6 +5055,12 @@
     name = "Changsheng Wu";
     githubId = 2083950;
   };
+  connerohnesorge = {
+    email = "conneroisu@outlook.com";
+    github = "conneroisu";
+    githubId = 88785126;
+    name = "Conner Ohnesorge";
+  };
   conni2461 = {
     email = "simon-hauser@outlook.com";
     github = "Conni2461";

--- a/pkgs/by-name/gi/gitea-mcp-server/package.nix
+++ b/pkgs/by-name/gi/gitea-mcp-server/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitea,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gitea-mcp-server";
+  version = "0.2.0";
+
+  src = fetchFromGitea {
+    domain = "gitea.com";
+    owner = "gitea";
+    repo = "gitea-mcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZUnpE25XIYzSwdEilzXnhqGR676iBQcR2yiT3jhJApc=";
+  };
+
+  vendorHash = "sha256-u9jIjrbDUhnaaeBET+pKQTKhaQLUeQvKOXSBfS0vMJM=";
+
+  subPackages = [ "." ];
+
+  doCheck = false; # no test
+
+  postInstall = ''
+    install -Dm644 README.md LICENSE -t $out/share/doc/gitea-mcp-server
+  '';
+
+  meta = {
+    description = "Gitea Model Context Protocol (MCP) Server";
+    longDescription = ''
+      The Gitea MCP Server is a Model Context Protocol (MCP) server that provides
+      seamless integration with Gitea APIs, enabling advanced automation and
+      interaction capabilities for developers and tools.
+
+      This server allows LLMs to interact with Gitea repositories, issues, pull
+      requests, and other Gitea features through structured API interactions.
+    '';
+    homepage = "https://gitea.com/gitea/gitea-mcp";
+    license = lib.licenses.mit;
+    mainProgram = "gitea-mcp";
+    maintainers = with lib.maintainers; [ connerohnesorge ];
+  };
+})


### PR DESCRIPTION
This pull request introduces a new package for the Gitea MCP Server and adds a new maintainer to the `maintainers` list. Below are the key changes grouped by theme:

### Maintainer Updates:
* Added `connerohnesorge` as a new maintainer with the associated email, GitHub username, GitHub ID, and name in `maintainers/maintainer-list.nix`.

### Package Addition:
* Introduced a new package `gitea-mcp-server` in `pkgs/by-name/gi/gitea-mcp-server/package.nix`. This package is built using `buildGoModule`, fetches its source from Gitea, and includes metadata such as description, homepage, license, and maintainers. The package is designed to provide a Model Context Protocol (MCP) server for seamless integration with Gitea APIs.

[https://gitea.com/gitea/gitea-mcp](https://gitea.com/gitea/gitea-mcp)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
