### PR TITLE
netbox_4_3: init at 4.3.2

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -31,6 +31,10 @@
 - `podofo` has been updated from `0.9.8` to `1.0.0`. These releases are by nature very incompatable due to major api changes. The legacy versions can be found under `podofo_0_10` and `podofo_0_9`.
   Changelog: https://github.com/podofo/podofo/blob/1.0.0/CHANGELOG.md, API-Migration-Guide: https://github.com/podofo/podofo/blob/1.0.0/API-MIGRATION.md.
 
+- NetBox was updated to `>= 4.3.0`. Have a look at the breaking changes
+  of the [4.3 release](https://github.com/netbox-community/netbox/releases/tag/v4.2.0),
+  make the required changes to your database, if needed, then upgrade by setting `services.netbox.package = pkgs.netbox_4_3;` in your configuration.
+
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/web-apps/netbox.nix
+++ b/nixos/modules/services/web-apps/netbox.nix
@@ -102,20 +102,18 @@ in
     package = lib.mkOption {
       type = lib.types.package;
       default =
-        if lib.versionAtLeast config.system.stateVersion "25.05" then
+        if lib.versionAtLeast config.system.stateVersion "25.11" then
+          pkgs.netbox_4_3
+        else if lib.versionAtLeast config.system.stateVersion "25.05" then
           pkgs.netbox_4_2
-        else if lib.versionAtLeast config.system.stateVersion "24.11" then
-          pkgs.netbox_4_1
-        else if lib.versionAtLeast config.system.stateVersion "24.05" then
-          pkgs.netbox_3_7
         else
-          pkgs.netbox_3_6;
+          pkgs.netbox_4_1;
       defaultText = lib.literalExpression ''
-        if lib.versionAtLeast config.system.stateVersion "24.11"
-        then pkgs.netbox_4_1
-        else if lib.versionAtLeast config.system.stateVersion "24.05"
-        then pkgs.netbox_3_7
-        else pkgs.netbox_3_6;
+        if lib.versionAtLeast config.system.stateVersion "25.11"
+        then pkgs.netbox_4_3
+        else if lib.versionAtLeast config.system.stateVersion "25.05"
+        then pkgs.netbox_4_2
+        else pkgs.netbox_4_1;
       '';
       description = ''
         NetBox package to use.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -913,9 +913,9 @@ in
   networking.scripted = handleTest ./networking/networkd-and-scripted.nix { networkd = false; };
   networking.networkd = handleTest ./networking/networkd-and-scripted.nix { networkd = true; };
   networking.networkmanager = handleTest ./networking/networkmanager.nix { };
-  netbox_3_7 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_3_7; };
   netbox_4_1 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_1; };
   netbox_4_2 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_2; };
+  netbox_4_3 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_3; };
   netbox-upgrade = runTest ./web-apps/netbox-upgrade.nix;
   # TODO: put in networking.nix after the test becomes more complete
   networkingProxy = runTest ./networking-proxy.nix;

--- a/nixos/tests/web-apps/netbox-upgrade.nix
+++ b/nixos/tests/web-apps/netbox-upgrade.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, ... }:
 let
-  oldNetbox = "netbox_4_1";
-  newNetbox = "netbox_4_2";
+  oldNetbox = "netbox_4_2";
+  newNetbox = "netbox_4_3";
 
   apiVersion =
     version:

--- a/pkgs/by-name/ne/netbox_4_2/package.nix
+++ b/pkgs/by-name/ne/netbox_4_2/package.nix
@@ -121,6 +121,9 @@ py.pkgs.buildPythonApplication rec {
     description = "IP address management (IPAM) and data center infrastructure management (DCIM) tool";
     mainProgram = "netbox";
     license = lib.licenses.asl20;
+    knownVulnerabilities = [
+      "Netbox Version ${version} is EOL; please upgrade by following the current release notes instructions"
+    ];
     maintainers = with lib.maintainers; [
       minijackson
       raitobezarius

--- a/pkgs/by-name/ne/netbox_4_3/custom-static-root.patch
+++ b/pkgs/by-name/ne/netbox_4_3/custom-static-root.patch
@@ -1,0 +1,13 @@
+diff --git a/netbox/netbox/settings.py b/netbox/netbox/settings.py
+index 2de06dd10..00406af48 100644
+--- a/netbox/netbox/settings.py
++++ b/netbox/netbox/settings.py
+@@ -410,7 +412,7 @@ USE_X_FORWARDED_HOST = True
+ X_FRAME_OPTIONS = 'SAMEORIGIN'
+ 
+ # Static files (CSS, JavaScript, Images)
+-STATIC_ROOT = BASE_DIR + '/static'
++STATIC_ROOT = getattr(configuration, 'STATIC_ROOT', os.path.join(BASE_DIR, 'static')).rstrip('/')
+ STATIC_URL = f'/{BASE_PATH}static/'
+ STATICFILES_DIRS = (
+     os.path.join(BASE_DIR, 'project-static', 'dist'),

--- a/pkgs/by-name/ne/netbox_4_3/package.nix
+++ b/pkgs/by-name/ne/netbox_4_3/package.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  plugins ? _ps: [ ],
+  nixosTests,
+  nix-update-script,
+}:
+let
+  py = python3.override {
+    self = py;
+    packageOverrides = _final: prev: { django = prev.django_5_2; };
+  };
+
+  extraBuildInputs = plugins py.pkgs;
+in
+py.pkgs.buildPythonApplication rec {
+  pname = "netbox";
+  version = "4.3.2";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox";
+    tag = "v${version}";
+    hash = "sha256-20X/0k60q2cPsWuz+qpgcfXGkg+A2k5qaWx6zHkmpWc=";
+  };
+
+  patches = [
+    ./custom-static-root.patch
+  ];
+
+  dependencies =
+    (
+      with py.pkgs;
+      [
+        django
+        django-cors-headers
+        django-debug-toolbar
+        django-filter
+        django-graphiql-debug-toolbar
+        django-htmx
+        django-mptt
+        django-pglocks
+        django-prometheus
+        django-redis
+        django-rq
+        django-storages
+        django-tables2
+        django-taggit
+        django-timezone-field
+        djangorestframework
+        drf-spectacular
+        drf-spectacular-sidecar
+        feedparser
+        jinja2
+        markdown
+        netaddr
+        nh3
+        pillow
+        psycopg
+        pyyaml
+        requests
+        social-auth-core
+        social-auth-app-django
+        strawberry-graphql
+        strawberry-django
+        svgwrite
+        tablib
+
+        # Optional dependencies, kept here for backward compatibility
+
+        # for the S3 data source backend
+        boto3
+        # for Git data source backend
+        dulwich
+        # for error reporting
+        sentry-sdk
+      ]
+      ++ psycopg.optional-dependencies.c
+      ++ psycopg.optional-dependencies.pool
+      ++ social-auth-core.optional-dependencies.openidconnect
+    )
+    ++ extraBuildInputs;
+
+  nativeBuildInputs = with py.pkgs; [
+    mkdocs-material
+    mkdocs-material-extensions
+    mkdocstrings
+    mkdocstrings-python
+  ];
+
+  postBuild = ''
+    PYTHONPATH=$PYTHONPATH:netbox/
+    ${py.interpreter} -m mkdocs build
+  '';
+
+  installPhase = ''
+    mkdir -p $out/opt/netbox
+    cp -r . $out/opt/netbox
+    chmod +x $out/opt/netbox/netbox/manage.py
+    makeWrapper $out/opt/netbox/netbox/manage.py $out/bin/netbox \
+      --prefix PYTHONPATH : "$PYTHONPATH"
+  '';
+
+  passthru = {
+    python = py;
+    # PYTHONPATH of all dependencies used by the package
+    pythonPath = py.pkgs.makePythonPath dependencies;
+    inherit (py.pkgs) gunicorn;
+    tests = {
+      netbox = nixosTests.netbox_4_3;
+      inherit (nixosTests) netbox-upgrade;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://github.com/netbox-community/netbox";
+    changelog = "https://github.com/netbox-community/netbox/blob/${src.tag}/docs/release-notes/version-${lib.versions.majorMinor version}.md";
+    description = "IP address management (IPAM) and data center infrastructure management (DCIM) tool";
+    mainProgram = "netbox";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      minijackson
+      raitobezarius
+      transcaffeine
+    ];
+  };
+}

--- a/pkgs/development/python-modules/netbox-attachments/default.nix
+++ b/pkgs/development/python-modules/netbox-attachments/default.nix
@@ -1,9 +1,9 @@
 {
   lib,
   buildPythonPackage,
-  pythonAtLeast,
   fetchFromGitHub,
   setuptools,
+  python,
   netbox,
   django,
   netaddr,
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   version = "7.2.0";
   pyproject = true;
 
-  disabled = pythonAtLeast "3.13";
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
 
   src = fetchFromGitHub {
     owner = "Kani999";

--- a/pkgs/development/python-modules/netbox-attachments/default.nix
+++ b/pkgs/development/python-modules/netbox-attachments/default.nix
@@ -10,7 +10,7 @@
 }:
 buildPythonPackage rec {
   pname = "netbox-attachments";
-  version = "7.2.0";
+  version = "8.0.4";
   pyproject = true;
 
   disabled = python.pythonVersion != netbox.python.pythonVersion;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "Kani999";
     repo = "netbox-attachments";
     tag = version;
-    hash = "sha256-EYf1PbFIFyCb2fYrnn/T8dnXz3dHmDOLI8Wbnef8V8M=";
+    hash = "sha256-wVTI0FAj6RaEaE6FhvHq4ophnCspobqL2SnTYVynlxs=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/netbox-contract/default.nix
+++ b/pkgs/development/python-modules/netbox-contract/default.nix
@@ -11,7 +11,7 @@
 }:
 buildPythonPackage rec {
   pname = "netbox-contract";
-  version = "2.3.2";
+  version = "2.4.0";
   pyproject = true;
 
   disabled = python.pythonVersion != netbox.python.pythonVersion;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "mlebreuil";
     repo = "netbox-contract";
     tag = "v${version}";
-    hash = "sha256-e3N0m+oj2CMUXwI4dF/tXA+Lz+9+ZlbJAy+zHoRDNtw=";
+    hash = "sha256-duA53cuJ3q6CRp239xNMXQhGZHGn7IBIGNLoxt7hZh8=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/netbox-contract/default.nix
+++ b/pkgs/development/python-modules/netbox-contract/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  pythonAtLeast,
+  python,
   fetchFromGitHub,
   setuptools,
   python-dateutil,
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   version = "2.3.2";
   pyproject = true;
 
-  disabled = pythonAtLeast "3.13";
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
 
   src = fetchFromGitHub {
     owner = "mlebreuil";

--- a/pkgs/development/python-modules/netbox-floorplan-plugin/default.nix
+++ b/pkgs/development/python-modules/netbox-floorplan-plugin/default.nix
@@ -10,7 +10,7 @@
 }:
 buildPythonPackage rec {
   pname = "netbox-floorplan-plugin";
-  version = "0.6.0";
+  version = "0.7.0";
   pyproject = true;
 
   disabled = python.pythonVersion != netbox.python.pythonVersion;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "netbox-community";
     repo = "netbox-floorplan-plugin";
     tag = version;
-    hash = "sha256-cJrqSXRCBedZh/pIozz/bHyhQosTy8cFYyji3KJva9Q=";
+    hash = "sha256-ecwPdcVuXU6OIVbafYGaY6+pbBHxhh1AlNmDBlUk1Ss=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/netbox-floorplan-plugin/default.nix
+++ b/pkgs/development/python-modules/netbox-floorplan-plugin/default.nix
@@ -4,16 +4,16 @@
   fetchFromGitHub,
   setuptools,
   netbox,
-  pythonAtLeast,
   django,
   netaddr,
+  python,
 }:
 buildPythonPackage rec {
   pname = "netbox-floorplan-plugin";
   version = "0.6.0";
   pyproject = true;
 
-  disabled = pythonAtLeast "3.13";
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
 
   src = fetchFromGitHub {
     owner = "netbox-community";

--- a/pkgs/development/python-modules/netbox-napalm-plugin/default.nix
+++ b/pkgs/development/python-modules/netbox-napalm-plugin/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   setuptools,
   netbox,
-  pythonAtLeast,
+  python,
   napalm,
   django,
 }:
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   version = "0.3.1";
   pyproject = true;
 
-  disabled = pythonAtLeast "3.13";
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
 
   src = fetchFromGitHub {
     owner = "netbox-community";

--- a/pkgs/development/python-modules/netbox-topology-views/default.nix
+++ b/pkgs/development/python-modules/netbox-topology-views/default.nix
@@ -10,7 +10,7 @@
 }:
 buildPythonPackage rec {
   pname = "netbox-topology-views";
-  version = "4.2.1";
+  version = "4.3.0";
   pyproject = true;
 
   disabled = python.pythonVersion != netbox.python.pythonVersion;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "netbox-community";
     repo = "netbox-topology-views";
     tag = "v${version}";
-    hash = "sha256-ysupqyRFOKVa+evNbfSdW2W57apI0jVEU92afz6+AaE=";
+    hash = "sha256-K8hG2M8uWPk9+7u21z+hmedOovievkMNpn3p7I4+6t4=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/netbox-topology-views/default.nix
+++ b/pkgs/development/python-modules/netbox-topology-views/default.nix
@@ -4,16 +4,16 @@
   fetchFromGitHub,
   setuptools,
   netbox,
-  pythonAtLeast,
   django,
   netaddr,
+  python,
 }:
 buildPythonPackage rec {
   pname = "netbox-topology-views";
   version = "4.2.1";
   pyproject = true;
 
-  disabled = pythonAtLeast "3.13";
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
 
   src = fetchFromGitHub {
     owner = "netbox-community";

--- a/pkgs/development/python-modules/strawberry-django/default.nix
+++ b/pkgs/development/python-modules/strawberry-django/default.nix
@@ -19,6 +19,7 @@
   # check inputs
   pytestCheckHook,
   django-guardian,
+  django-model-utils,
   django-mptt,
   django-polymorphic,
   django-tree-queries,
@@ -33,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "strawberry-django";
-  version = "0.57.1";
+  version = "0.60.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "strawberry-graphql";
     repo = "strawberry-django";
     tag = "v${version}";
-    hash = "sha256-nwqb9AVNQNIRdjYcutTaI3YfwuMDLP4mUirSXFq+WnI=";
+    hash = "sha256-mMI/tPdt9XK6Lz7VmI3uDxcCjIuidUeGHjG+6AQLoeQ=";
   };
 
   build-system = [
@@ -64,6 +65,7 @@ buildPythonPackage rec {
       pytestCheckHook
 
       django-guardian
+      django-model-utils
       django-mptt
       django-polymorphic
       django-tree-queries

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -44,7 +44,7 @@
 
 buildPythonPackage rec {
   pname = "strawberry-graphql";
-  version = "0.263.1";
+  version = "0.271.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     owner = "strawberry-graphql";
     repo = "strawberry";
     tag = version;
-    hash = "sha256-w36KY1zl/OguRFs6sM6K4F17bYQcA+bA6XS62VhRgA8=";
+    hash = "sha256-ypGv0ICGqCisOK0xVLWQXIZb5mF6wt3RukcUo0qM2nQ=";
   };
 
   postPatch = ''
@@ -152,6 +152,7 @@ buildPythonPackage rec {
     "tests/schema/extensions/"
     "tests/schema/test_dataloaders.py"
     "tests/schema/test_lazy/"
+    "tests/sanic/test_file_upload.py"
     "tests/test_dataloaders.py"
     "tests/utils/test_pretty_print.py"
     "tests/websockets/test_graphql_transport_ws.py"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3821,7 +3821,7 @@ with pkgs;
   };
 
   # Not in aliases because it wouldn't get picked up by callPackage
-  netbox = netbox_4_2;
+  netbox = netbox_4_3;
 
   netcap-nodpi = callPackage ../by-name/ne/netcap/package.nix {
     withDpi = false;


### PR DESCRIPTION
## Things done

- Add `netbox_4_3` package
  - Update python dependencies `strawberry-graphql` and `strawberry-django`
- Adjust nixos (upgrade) tests for `netbox_4_3`
- drop the `netbox_3_7` upgrade test, apparently a left-over from https://github.com/NixOS/nixpkgs/pull/401110

Attempting to continue this from https://github.com/NixOS/nixpkgs/pull/405880#issuecomment-2940757749

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
