### PR TITLE
treewide: disable benchmarking

### DIFF
--- a/pkgs/development/python-modules/ahocorasick-rs/default.nix
+++ b/pkgs/development/python-modules/ahocorasick-rs/default.nix
@@ -42,6 +42,8 @@ buildPythonPackage rec {
     hypothesis
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   pythonImportsCheck = [ "ahocorasick_rs" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/automat/default.nix
+++ b/pkgs/development/python-modules/automat/default.nix
@@ -32,6 +32,8 @@ let
       pytestCheckHook
     ];
 
+    pytestFlagsArray = [ "--benchmark-disable" ];
+
     # escape infinite recursion with twisted
     doCheck = false;
 

--- a/pkgs/development/python-modules/boost-histogram/default.nix
+++ b/pkgs/development/python-modules/boost-histogram/default.nix
@@ -58,6 +58,8 @@ buildPythonPackage rec {
     pytest-benchmark
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   disabledTests = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
     # Segfaults: boost_histogram/_internal/hist.py", line 799 in sum
     # Fatal Python error: Segmentation fault

--- a/pkgs/development/python-modules/deltalake/default.nix
+++ b/pkgs/development/python-modules/deltalake/default.nix
@@ -76,7 +76,10 @@ buildPythonPackage rec {
     rm -rf deltalake
   '';
 
-  pytestFlagsArray = [ "-m 'not integration'" ];
+  pytestFlagsArray = [
+    "--benchmark-disable"
+    "-m 'not integration'"
+  ];
 
   meta = with lib; {
     description = "Native Rust library for Delta Lake, with bindings into Python";

--- a/pkgs/development/python-modules/fastcrc/default.nix
+++ b/pkgs/development/python-modules/fastcrc/default.nix
@@ -42,6 +42,8 @@ buildPythonPackage {
     pytest-benchmark
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   # Python source files interfere with testing
   preCheck = ''
     rm -r fastcrc

--- a/pkgs/development/python-modules/gilknocker/default.nix
+++ b/pkgs/development/python-modules/gilknocker/default.nix
@@ -54,6 +54,8 @@ buildPythonPackage rec {
     pytest-rerunfailures
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   meta = {
     description = "Knock on the Python GIL, determine how busy it is";
     homepage = "https://github.com/milesgranger/gilknocker";

--- a/pkgs/development/python-modules/graphql-core/default.nix
+++ b/pkgs/development/python-modules/graphql-core/default.nix
@@ -39,6 +39,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   pythonImportsCheck = [ "graphql" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -144,6 +144,7 @@ buildPythonPackage rec {
   ] ++ lib.concatMap (name: optional-dependencies.${name}) testBackends;
 
   pytestFlagsArray = [
+    "--benchmark-disable"
     "-m"
     "'${lib.concatStringsSep " or " testBackends} or core'"
   ];

--- a/pkgs/development/python-modules/ical/default.nix
+++ b/pkgs/development/python-modules/ical/default.nix
@@ -46,6 +46,8 @@ buildPythonPackage rec {
     syrupy
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   pythonImportsCheck = [ "ical" ];
 
   meta = {

--- a/pkgs/development/python-modules/libipld/default.nix
+++ b/pkgs/development/python-modules/libipld/default.nix
@@ -49,6 +49,8 @@ buildPythonPackage rec {
     pytest-xdist
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   disabledTests = [
     # touches network
     "test_decode_car"

--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -98,6 +98,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   disabledTests = [ "test_moving_window_memcached" ];
 
   pythonImportsCheck = [ "limits" ];

--- a/pkgs/development/python-modules/numbagg/default.nix
+++ b/pkgs/development/python-modules/numbagg/default.nix
@@ -54,6 +54,8 @@ buildPythonPackage rec {
     pytest-benchmark
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   meta = {
     description = "Fast N-dimensional aggregation functions with Numba";
     homepage = "https://github.com/numbagg/numbagg";

--- a/pkgs/development/python-modules/opentelemetry-propagator-aws-xray/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-propagator-aws-xray/default.nix
@@ -26,12 +26,11 @@ buildPythonPackage {
   nativeCheckInputs = [
     opentelemetry-test-utils
     pytestCheckHook
-  ];
-
-  checkInputs = [
     pytest-benchmark
     requests
   ];
+
+  pytestFlagsArray = [ "--benchmark-disable" ];
 
   pythonImportsCheck = [ "opentelemetry.propagators.aws" ];
 

--- a/pkgs/development/python-modules/polars/default.nix
+++ b/pkgs/development/python-modules/polars/default.nix
@@ -235,6 +235,7 @@ buildPythonPackage rec {
     ];
 
     pytestFlagsArray = [
+      "--benchmark-disable"
       "-n auto"
       "--dist loadgroup"
       ''-m "slow or not slow"''

--- a/pkgs/development/python-modules/py7zr/default.nix
+++ b/pkgs/development/python-modules/py7zr/default.nix
@@ -65,6 +65,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   pythonImportsCheck = [
     "py7zr"
   ];

--- a/pkgs/development/python-modules/pyppmd/default.nix
+++ b/pkgs/development/python-modules/pyppmd/default.nix
@@ -35,6 +35,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   pythonImportsCheck = [
     "pyppmd"
   ];

--- a/pkgs/development/python-modules/pystac-client/default.nix
+++ b/pkgs/development/python-modules/pystac-client/default.nix
@@ -47,6 +47,7 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [
+    "--benchmark-disable"
     # Tests accessing Internet
     "-m 'not vcr'"
   ];

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -71,6 +71,8 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   pythonImportsCheck = [ "pytensor" ];
 
   # Ensure that the installed package is used instead of the source files from the current workdir

--- a/pkgs/development/python-modules/python-olm/default.nix
+++ b/pkgs/development/python-modules/python-olm/default.nix
@@ -38,6 +38,8 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   meta = {
     inherit (olm.meta) license maintainers;
     description = "Python bindings for Olm";

--- a/pkgs/development/python-modules/simple-parsing/default.nix
+++ b/pkgs/development/python-modules/simple-parsing/default.nix
@@ -66,6 +66,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pytestFlagsArray = [ "--benchmark-disable" ];
+
   disabledTests = [
     # AssertionError
     # https://github.com/lebrice/SimpleParsing/issues/338


### PR DESCRIPTION
I built the following packages

<details>

py7zr
python312Packages.ahocorasick-rs
python312Packages.automat
python312Packages.boost-histogram
python312Packages.deltalake
python312Packages.fastcrc
python312Packages.gilknocker
python312Packages.graphql-core
python312Packages.ibis-framework
python312Packages.ical
python312Packages.libipld
python312Packages.limits
python312Packages.numbagg
python312Packages.opentelemetry-propagator-aws-xray
python312Packages.polars
python312Packages.py7zr
python312Packages.pyppmd
python312Packages.pystac-client
python312Packages.pytensor
python312Packages.simple-parsing
python313Packages.ahocorasick-rs
python313Packages.automat
python313Packages.boost-histogram
python313Packages.deltalake
python313Packages.fastcrc
python313Packages.gilknocker
python313Packages.graphql-core
python313Packages.ibis-framework
python313Packages.ical
python313Packages.libipld
python313Packages.limits
python313Packages.numbagg
python313Packages.opentelemetry-propagator-aws-xray
python313Packages.polars
python313Packages.py7zr
python313Packages.pyppmd
python313Packages.pystac-client
python313Packages.simple-parsing

</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
