### PR TITLE
factorio, factorio-experimental: 2.0.{43,45} -> 2.0.55

### DIFF
--- a/pkgs/by-name/fa/factorio/versions.json
+++ b/pkgs/by-name/fa/factorio/versions.json
@@ -3,25 +3,25 @@
     "alpha": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio_linux_2.0.45.tar.xz"
+          "factorio_linux_2.0.55.tar.xz"
         ],
-        "name": "factorio_alpha_x64-2.0.45.tar.xz",
+        "name": "factorio_alpha_x64-2.0.55.tar.xz",
         "needsAuth": true,
-        "sha256": "32b004a648dfc8b8e2bb6b82f648e5be458a13b7fefad79487a1d663c6f3b711",
+        "sha256": "f9f4821809a2a2a475683e820853f65b1105a6910e72b4a192843244fedc4819",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.45/alpha/linux64",
-        "version": "2.0.45"
+        "url": "https://factorio.com/get-download/2.0.55/alpha/linux64",
+        "version": "2.0.55"
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio_linux_2.0.43.tar.xz"
+          "factorio_linux_2.0.55.tar.xz"
         ],
-        "name": "factorio_alpha_x64-2.0.43.tar.xz",
+        "name": "factorio_alpha_x64-2.0.55.tar.xz",
         "needsAuth": true,
-        "sha256": "971c293f46d2e021be762eb23c45c17746aa5b8ec74e30fef5f46fa32bb7e1aa",
+        "sha256": "f9f4821809a2a2a475683e820853f65b1105a6910e72b4a192843244fedc4819",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.43/alpha/linux64",
-        "version": "2.0.43"
+        "url": "https://factorio.com/get-download/2.0.55/alpha/linux64",
+        "version": "2.0.55"
       }
     },
     "demo": {
@@ -51,51 +51,51 @@
     "expansion": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio-space-age_linux_2.0.45.tar.xz"
+          "factorio-space-age_linux_2.0.55.tar.xz"
         ],
-        "name": "factorio_expansion_x64-2.0.45.tar.xz",
+        "name": "factorio_expansion_x64-2.0.55.tar.xz",
         "needsAuth": true,
-        "sha256": "7a81be62a051b80166c9f6c9e94fca2e19a0ac65f19769f99a624772f87cdab4",
+        "sha256": "4c70f5dba5ad7236b56163e5224bea2bcfa08c16d6e2ea2b55f55dd118517a95",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.45/expansion/linux64",
-        "version": "2.0.45"
+        "url": "https://factorio.com/get-download/2.0.55/expansion/linux64",
+        "version": "2.0.55"
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio-space-age_linux_2.0.43.tar.xz"
+          "factorio-space-age_linux_2.0.55.tar.xz"
         ],
-        "name": "factorio_expansion_x64-2.0.43.tar.xz",
+        "name": "factorio_expansion_x64-2.0.55.tar.xz",
         "needsAuth": true,
-        "sha256": "43d98f9dfa4edc15a622b9881f71673902710ef8aa12cccc7f6e8ccd7962488e",
+        "sha256": "4c70f5dba5ad7236b56163e5224bea2bcfa08c16d6e2ea2b55f55dd118517a95",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.43/expansion/linux64",
-        "version": "2.0.43"
+        "url": "https://factorio.com/get-download/2.0.55/expansion/linux64",
+        "version": "2.0.55"
       }
     },
     "headless": {
       "experimental": {
         "candidateHashFilenames": [
-          "factorio-headless_linux_2.0.45.tar.xz",
-          "factorio_headless_x64_2.0.45.tar.xz"
+          "factorio-headless_linux_2.0.55.tar.xz",
+          "factorio_headless_x64_2.0.55.tar.xz"
         ],
-        "name": "factorio_headless_x64-2.0.45.tar.xz",
+        "name": "factorio_headless_x64-2.0.55.tar.xz",
         "needsAuth": false,
-        "sha256": "4fd7e04bb3ea7d12da8e1c3befc6b53b3c0064775c960a5a9db6a943f2259fc2",
+        "sha256": "ef12a54d1556ae1f84ff99edc23706d13b7ad41f1c02d74ca1dfadf9448fcbae",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.45/headless/linux64",
-        "version": "2.0.45"
+        "url": "https://factorio.com/get-download/2.0.55/headless/linux64",
+        "version": "2.0.55"
       },
       "stable": {
         "candidateHashFilenames": [
-          "factorio-headless_linux_2.0.43.tar.xz",
-          "factorio_headless_x64_2.0.43.tar.xz"
+          "factorio-headless_linux_2.0.55.tar.xz",
+          "factorio_headless_x64_2.0.55.tar.xz"
         ],
-        "name": "factorio_headless_x64-2.0.43.tar.xz",
+        "name": "factorio_headless_x64-2.0.55.tar.xz",
         "needsAuth": false,
-        "sha256": "bde6e167330c4439ce7df3ac519ea445120258ef676f1f6ad31d0c2816d3aee3",
+        "sha256": "ef12a54d1556ae1f84ff99edc23706d13b7ad41f1c02d74ca1dfadf9448fcbae",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/2.0.43/headless/linux64",
-        "version": "2.0.43"
+        "url": "https://factorio.com/get-download/2.0.55/headless/linux64",
+        "version": "2.0.55"
       }
     }
   }


### PR DESCRIPTION
Changelogs:
- [2.0.44](https://wiki.factorio.com/Version_history/2.0.0#2.0.44)
- [2.0.45](https://wiki.factorio.com/Version_history/2.0.0#2.0.45)
- [2.0.46](https://wiki.factorio.com/Version_history/2.0.0#2.0.46)
- [2.0.47](https://wiki.factorio.com/Version_history/2.0.0#2.0.47)
- [2.0.48](https://wiki.factorio.com/Version_history/2.0.0#2.0.48)
- [2.0.49](https://wiki.factorio.com/Version_history/2.0.0#2.0.49)
- [2.0.50](https://wiki.factorio.com/Version_history/2.0.0#2.0.50)
- [2.0.51](https://wiki.factorio.com/Version_history/2.0.0#2.0.51)
- [2.0.52](https://wiki.factorio.com/Version_history/2.0.0#2.0.52)
- [2.0.53](https://wiki.factorio.com/Version_history/2.0.0#2.0.53)
- [2.0.54](https://wiki.factorio.com/Version_history/2.0.0#2.0.54)
- [2.0.55](https://wiki.factorio.com/Version_history/2.0.0#2.0.55)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
