### PR TITLE
nixos/stage-1: always include util-linux mount

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -34,9 +34,6 @@ let
   # mounting `/`, like `/` on a loopback).
   fileSystems = filter utils.fsNeededForBoot config.system.build.fileSystems;
 
-  # Determine whether zfs-mount(8) is needed.
-  zfsRequiresMountHelper = any (fs: lib.elem "zfsutil" fs.options) fileSystems;
-
   # A utility for enumerating the shared-library dependencies of a program
   findLibs = pkgs.buildPackages.writeShellScriptBin "find-libs" ''
     set -euo pipefail
@@ -118,24 +115,9 @@ let
           copy_bin_and_libs $BIN
         done
 
-        ${optionalString zfsRequiresMountHelper ''
-          # Filesystems using the "zfsutil" option are mounted regardless of the
-          # mount.zfs(8) helper, but it is required to ensure that ZFS properties
-          # are used as mount options.
-          #
-          # BusyBox does not use the ZFS helper in the first place.
-          # util-linux searches /sbin/ as last path for helpers (stage-1-init.sh
-          # must symlink it to the store PATH).
-          # Without helper program, both `mount`s silently fails back to internal
-          # code, using default options and effectively ignore security relevant
-          # ZFS properties such as `setuid=off` and `exec=off` (unless manually
-          # duplicated in `fileSystems.*.options`, defeating "zfsutil"'s purpose).
-          copy_bin_and_libs ${lib.getOutput "mount" pkgs.util-linux}/bin/mount
-          copy_bin_and_libs ${config.boot.zfs.package}/bin/mount.zfs
-        ''}
-
         # Copy some util-linux stuff.
         copy_bin_and_libs ${pkgs.util-linux}/sbin/blkid
+        copy_bin_and_libs ${lib.getOutput "mount" pkgs.util-linux}/bin/mount
 
         # Copy dmsetup and lvm.
         copy_bin_and_libs ${getBin pkgs.lvm2}/bin/dmsetup
@@ -225,17 +207,7 @@ let
         # Make sure that the patchelf'ed binaries still work.
         echo "testing patched programs..."
         $out/bin/ash -c 'echo hello world' | grep "hello world"
-        ${
-          if zfsRequiresMountHelper then
-            ''
-              $out/bin/mount -V 1>&1 | grep -q "mount from util-linux"
-              $out/bin/mount.zfs -h 2>&1 | grep -q "Usage: mount.zfs"
-            ''
-          else
-            ''
-              $out/bin/mount --help 2>&1 | grep -q "BusyBox"
-            ''
-        }
+        $out/bin/mount -V 2>&1 | grep -q "mount from util-linux"
         $out/bin/blkid -V 2>&1 | grep -q 'libblkid'
         $out/bin/udevadm --version
         $out/bin/dmsetup --version 2>&1 | tee -a log | grep -q "version:"

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -717,6 +717,7 @@ in
         kernelModules = [ "zfs" ];
         extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
           copy_bin_and_libs ${cfgZfs.package}/sbin/zfs
+          copy_bin_and_libs ${cfgZfs.package}/sbin/mount.zfs
           copy_bin_and_libs ${cfgZfs.package}/sbin/zdb
           copy_bin_and_libs ${cfgZfs.package}/sbin/zpool
           copy_bin_and_libs ${cfgZfs.package}/lib/udev/vdev_id
@@ -725,6 +726,7 @@ in
         extraUtilsCommandsTest = lib.mkIf (!config.boot.initrd.systemd.enable) ''
           $out/bin/zfs --help >/dev/null 2>&1
           $out/bin/zpool --help >/dev/null 2>&1
+          $out/bin/mount.zfs -h 2>&1 | grep -q "Usage: mount.zfs"
         '';
         postResumeCommands = lib.mkIf (!config.boot.initrd.systemd.enable) (
           lib.concatStringsSep "\n" (
@@ -796,6 +798,7 @@ in
           extraBin = {
             zpool = "${cfgZfs.package}/sbin/zpool";
             zfs = "${cfgZfs.package}/sbin/zfs";
+            mount.zfs = "${cfgZfs.package}/sbin/mount.zfs";
             awk = "${pkgs.gawk}/bin/awk";
           };
           storePaths = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates stage-1.nix to make enabling util-linux's mount possible for multiple reasons, like the existing ZFS mount helper use case and the new X-mount.subdir use case.

Resolves #414390

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
