### PR TITLE
vscode-extensions.reditorsupport.r: 2.8.5 -> 2.8.6

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
@@ -12,8 +12,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "r";
     publisher = "reditorsupport";
-    version = "2.8.5";
-    hash = "sha256-cZeZdrViEae9sRb9GyB/LeSQ5NRb/fAp3qQW9mPMbsM=";
+    version = "2.8.6";
+    hash = "sha256-T/Qh0WfTfXMzPonbg9NMII5qFptfNoApFFiZCT5rR3Y=";
   };
   nativeBuildInputs = [
     jq


### PR DESCRIPTION

### Automatic Update for `vscode-extensions.reditorsupport.r`
- **Old version**: `2.8.5`
- **New version**: `2.8.6`
- This PR was generated by a GitHub Actions workflow.
