### PR TITLE
qxmpp: clean-up and 1.10.2 -> 1.10.4

### DIFF
--- a/pkgs/by-name/qx/qxmpp/package.nix
+++ b/pkgs/by-name/qx/qxmpp/package.nix
@@ -57,11 +57,11 @@ stdenv.mkDerivation rec {
       "-DBUILD_OMEMO=ON"
     ];
 
-  meta = with lib; {
+  meta = {
     description = "Cross-platform C++ XMPP client and server library";
     homepage = "https://github.com/qxmpp-project/qxmpp";
-    license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ astro ];
-    platforms = with platforms; linux;
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ astro ];
+    platforms = with lib.platforms; linux;
   };
 }

--- a/pkgs/by-name/qx/qxmpp/package.nix
+++ b/pkgs/by-name/qx/qxmpp/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitHub,
+  fetchFromGitLab,
   cmake,
   pkg-config,
   kdePackages,
@@ -15,10 +15,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "qxmpp";
   version = "1.10.2";
 
-  src = fetchFromGitHub {
-    owner = "qxmpp-project";
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "libraries";
     repo = "qxmpp";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-M3F4tNIO3RvDxk/lce8/J6kmQtnsGLILQ15uEzgyfds=";
   };
 
@@ -59,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Cross-platform C++ XMPP client and server library";
-    homepage = "https://github.com/qxmpp-project/qxmpp";
+    homepage = "https://invent.kde.org/libraries/qxmpp";
     license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ astro ];
     platforms = with lib.platforms; linux;

--- a/pkgs/by-name/qx/qxmpp/package.nix
+++ b/pkgs/by-name/qx/qxmpp/package.nix
@@ -13,14 +13,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qxmpp";
-  version = "1.10.2";
+  version = "1.10.4";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "libraries";
     repo = "qxmpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-M3F4tNIO3RvDxk/lce8/J6kmQtnsGLILQ15uEzgyfds=";
+    hash = "sha256-iSsQKVfcH5AjX+bURYK7UPdZKWFX6WaFSrpeRC5IE/0=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/qx/qxmpp/package.nix
+++ b/pkgs/by-name/qx/qxmpp/package.nix
@@ -4,9 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  wrapQtAppsNoGuiHook,
-  qtbase,
-  qca,
+  kdePackages,
   withGstreamer ? true,
   gst_all_1,
   withOmemo ? true,
@@ -27,7 +25,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs =
     [
       cmake
-      wrapQtAppsNoGuiHook
+      kdePackages.wrapQtAppsNoGuiHook
     ]
     ++ lib.optionals (withGstreamer || withOmemo) [
       pkg-config
@@ -43,8 +41,8 @@ stdenv.mkDerivation rec {
       ]
     )
     ++ lib.optionals withOmemo [
-      qtbase
-      qca
+      kdePackages.qtbase
+      kdePackages.qca
       libomemo-c
     ];
   cmakeFlags =

--- a/pkgs/by-name/qx/qxmpp/package.nix
+++ b/pkgs/by-name/qx/qxmpp/package.nix
@@ -11,14 +11,14 @@
   libomemo-c,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qxmpp";
   version = "1.10.2";
 
   src = fetchFromGitHub {
     owner = "qxmpp-project";
-    repo = pname;
-    rev = "v${version}";
+    repo = "qxmpp";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-M3F4tNIO3RvDxk/lce8/J6kmQtnsGLILQ15uEzgyfds=";
   };
 
@@ -64,4 +64,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ astro ];
     platforms = with lib.platforms; linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8327,8 +8327,6 @@ with pkgs;
     }
   );
 
-  qxmpp = qt6Packages.callPackage ../development/libraries/qxmpp { };
-
   gnutls = callPackage ../development/libraries/gnutls {
     util-linux = util-linuxMinimal; # break the cyclic dependency
     autoconf = buildPackages.autoconf269;


### PR DESCRIPTION
Project description at https://github.com/qxmpp-project/qxmpp now points to https://invent.kde.org/libraries/qxmpp.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
