### PR TITLE
python3Packages.mcp: 1.9.1 -> 1.9.3

### DIFF
--- a/pkgs/development/python-modules/fastapi-mcp/default.nix
+++ b/pkgs/development/python-modules/fastapi-mcp/default.nix
@@ -64,6 +64,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     description = "Expose your FastAPI endpoints as Model Context Protocol (MCP) tools, with Auth";
     homepage = "https://github.com/tadata-org/fastapi_mcp";

--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -7,6 +8,7 @@
   hatchling,
 
   # dependencies
+  authlib,
   exceptiongroup,
   httpx,
   mcp,
@@ -14,24 +16,24 @@
   python-dotenv,
   rich,
   typer,
-  websockets,
 
   # tests
   dirty-equals,
   fastapi,
+  pytest-httpx,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "fastmcp";
-  version = "2.4.0";
+  version = "2.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jlowin";
     repo = "fastmcp";
     tag = "v${version}";
-    hash = "sha256-F4lgMm/84svLZo6SZ7AubsC73s4tffqjJcd9gvA7hGA=";
+    hash = "sha256-UQV/hIu96ukpJxUhOux0mos0o6j4kvsFp2NJHa47tbw=";
   };
 
   postPatch = ''
@@ -45,6 +47,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    authlib
     exceptiongroup
     httpx
     mcp
@@ -52,7 +55,6 @@ buildPythonPackage rec {
     python-dotenv
     rich
     typer
-    websockets
   ];
 
   pythonImportsCheck = [ "fastmcp" ];
@@ -60,8 +62,27 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     dirty-equals
     fastapi
+    pytest-httpx
     pytestCheckHook
   ];
+
+  disabledTests = [
+    # AssertionError: assert 'INFO' == 'DEBUG'
+    "test_temporary_settings"
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # RuntimeError: Server failed to start after 10 attempts
+    "tests/auth/providers/test_bearer.py"
+    "tests/auth/test_oauth_client.py"
+    "tests/client/test_openapi.py"
+    "tests/client/test_sse.py"
+    "tests/client/test_streamable_http.py"
+    "tests/server/http/test_http_dependencies.py"
+    "tests/server/http/test_http_dependencies.py"
+  ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "The fast, Pythonic way to build MCP servers and clients";

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -100,22 +101,27 @@ buildPythonPackage rec {
     "ignore::pydantic.warnings.PydanticDeprecatedSince211"
   ];
 
-  disabledTests = [
-    # attempts to run the package manager uv
-    "test_command_execution"
+  disabledTests =
+    [
+      # attempts to run the package manager uv
+      "test_command_execution"
 
-    # performance-dependent test
-    "test_messages_are_executed_concurrently"
+      # performance-dependent test
+      "test_messages_are_executed_concurrently"
 
-    # ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
-    "test_client_session_version_negotiation_failure"
+      # ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
+      "test_client_session_version_negotiation_failure"
 
-    # AttributeError: 'coroutine' object has no attribute 'client_metadata'
-    "TestOAuthClientProvider"
+      # AttributeError: 'coroutine' object has no attribute 'client_metadata'
+      "TestOAuthClientProvider"
 
-    # inline_snapshot._exceptions.UsageError: snapshot value should not change. Use Is(...) for dynamic snapshot parts
-    "test_build_metadata"
-  ];
+      # inline_snapshot._exceptions.UsageError: snapshot value should not change. Use Is(...) for dynamic snapshot parts
+      "test_build_metadata"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Flaky: ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
+      "test_notification_validation_error"
+    ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -27,22 +27,24 @@
   websockets,
 
   # tests
+  inline-snapshot,
   pytest-asyncio,
   pytest-examples,
+  pytest-xdist,
   pytestCheckHook,
   requests,
 }:
 
 buildPythonPackage rec {
   pname = "mcp";
-  version = "1.9.1";
+  version = "1.9.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "modelcontextprotocol";
     repo = "python-sdk";
     tag = "v${version}";
-    hash = "sha256-8u02/tHR2F1CpjcHXHC8sZC+/JrWz1satqYa/zdSGDw=";
+    hash = "sha256-3r7NG2AnxxKgAAd3n+tjjPTz4WJRmc7isfh3p21hUa0=";
   };
 
   postPatch = ''
@@ -85,8 +87,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "mcp" ];
 
   nativeCheckInputs = [
+    inline-snapshot
     pytest-asyncio
     pytest-examples
+    pytest-xdist
     pytestCheckHook
     requests
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
@@ -108,6 +112,9 @@ buildPythonPackage rec {
 
     # AttributeError: 'coroutine' object has no attribute 'client_metadata'
     "TestOAuthClientProvider"
+
+    # inline_snapshot._exceptions.UsageError: snapshot value should not change. Use Is(...) for dynamic snapshot parts
+    "test_build_metadata"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.mcp: 1.9.1 -> 1.9.3**
- **python3Packages.fastmcp: 2.4.0 -> 2.7.0**

cc @josh

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
