### PR TITLE
artichoke: init at 0-unstable-2025-06-01

### DIFF
--- a/pkgs/by-name/ar/artichoke/package.nix
+++ b/pkgs/by-name/ar/artichoke/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  llvmPackages,
+  _experimental-update-script-combinators,
+  unstableGitUpdater,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "artichoke";
+  version = "0-unstable-2025-06-01";
+
+  src = fetchFromGitHub {
+    owner = "artichoke";
+    repo = "artichoke";
+    rev = "7c35392d8c7622cd8ab8eccaee73d57633b2b901";
+    hash = "sha256-7YPExT+5F+5MMk/yLfG4Rk8ZDwsYfVKlkvIroFB22No=";
+  };
+
+  cargoHash = "sha256-cN70yYYKhktUoswow63ZXHvfFbXDo1rUrTWm22LluCM=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    stdout="$("$out/bin/artichoke" -e 'puts "Hello World!"')"
+    [[ "$stdout" == 'Hello World!' ]]
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    updateScript = _experimental-update-script-combinators.sequence [
+      (unstableGitUpdater { })
+      (nix-update-script {
+        # Updating `cargoHash`
+        extraArgs = [ "--version=skip" ];
+      })
+    ];
+  };
+
+  meta = {
+    description = "Ruby implementation written in Rust and Ruby";
+    homepage = "https://www.artichokeruby.org/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "artichoke";
+    platforms = with lib.platforms; unix ++ windows;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Artichoke](https://github.com/artichoke/artichoke) is a Ruby implementation written in Rust and Ruby.
This package builds two executables, `artichoke` and `airb`, which are likely related to Ruby and IRB.

```console
> tree result/
result/
└── bin
    ├── airb
    └── artichoke
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
