### PR TITLE
turntable: init at 0.3.3

### DIFF
--- a/pkgs/by-name/tu/turntable/package.nix
+++ b/pkgs/by-name/tu/turntable/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  meson,
+  ninja,
+  pkg-config,
+  vala,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  libadwaita,
+  libsoup_3,
+  json-glib,
+  libsecret,
+  glib-networking,
+
+  # Per the upstream request. Key owned by Aleksana
+  lastfmKey ? "b5027c5178ca2abfcc31bd04397c3c0e",
+  lastfmSecret ? "8d375bdee925a2a35f241c04272bc862",
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "turntable";
+  version = "0.3.3";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "GeopJr";
+    repo = "Turntable";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fBduW49eNOEzRVBb72zcB5arTjTiRUy8jE3sSMjPITE=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    libadwaita
+    libsoup_3
+    json-glib
+    libsecret
+    glib-networking
+  ];
+
+  mesonFlags = [
+    (lib.mesonOption "lastfm_key" lastfmKey)
+    (lib.mesonOption "lastfm_secret" lastfmSecret)
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "Scrobbles your music to multiple services with playback controls for MPRIS players";
+    longDescription = ''
+      Keep track of your listening habits by scrobbling them
+      to last.fm, ListenBrainz, Libre.fm and Maloja at the
+      same time using your favorite music app's, favorite
+      music app! Turntable comes with a highly customizable
+      and sleek design that displays information about the
+      currently playing song and allows you to control your
+      music player, allowlist it for scrobbling and manage
+      your scrobbling accounts. All MPRIS-enabled apps are
+      supported.
+    '';
+    homepage = "https://turntable.geopjr.dev";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ aleksana ];
+    mainProgram = "dev.geopjr.Turntable";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/d17ba50a-6018-4f2f-8caa-0204debdd312)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
