### PR TITLE
sdl{2-compat,3}: clean up dependencies

### DIFF
--- a/pkgs/by-name/sd/sdl2-compat/package.nix
+++ b/pkgs/by-name/sd/sdl2-compat/package.nix
@@ -21,7 +21,11 @@
   ffmpeg,
   qemu,
 }:
-
+let
+  # tray support on sdl3 pulls in gtk3, which is quite an expensive dependency.
+  # sdl2 does not support the tray, so we can just disable that requirement.
+  sdl3' = sdl3.override { traySupport = false; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl2-compat";
   version = "2.32.56";
@@ -39,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    sdl3
+    sdl3'
     libX11
   ];
 
@@ -57,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "SDL2COMPAT_TESTS" finalAttrs.finalPackage.doCheck)
-    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (lib.makeLibraryPath [ sdl3 ]))
+    (lib.cmakeFeature "CMAKE_INSTALL_RPATH" (lib.makeLibraryPath [ sdl3' ]))
   ];
 
   # skip timing-based tests as those are flaky

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -63,11 +63,15 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";
   version = "3.2.12";
 
-  outputs = [
-    "lib"
-    "dev"
-    "out"
-  ];
+  outputs =
+    [
+      "lib"
+      "dev"
+      "out"
+    ]
+    ++ lib.optionals testSupport [
+      "installedTests"
+    ];
 
   src = fetchFromGitHub {
     owner = "libsdl-org";
@@ -78,9 +82,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch =
     # Tests timeout on Darwin
+    # `testtray` loads assets from a relative path, which we are patching to be absolute
     lib.optionalString testSupport ''
       substituteInPlace test/CMakeLists.txt \
         --replace-fail 'set(noninteractive_timeout 10)' 'set(noninteractive_timeout 30)'
+
+      substituteInPlace test/testtray.c \
+        --replace-warn '../test/' '${placeholder "installedTests"}/share/assets/'
     ''
     + lib.optionalString waylandSupport ''
       substituteInPlace src/video/wayland/SDL_waylandmessagebox.c \
@@ -165,6 +173,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SDL_X11" x11Support)
 
     (lib.cmakeBool "SDL_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "SDL_INSTALL_TESTS" testSupport)
   ];
 
   doCheck = testSupport && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
@@ -179,6 +188,12 @@ stdenv.mkDerivation (finalAttrs: {
       stdenv.hostPlatform.hasSharedLibraries && stdenv.hostPlatform.extensions.sharedLibrary == ".so"
     ) "-rpath ${lib.makeLibraryPath (finalAttrs.dlopenBuildInputs)}";
   };
+
+  postInstall = lib.optionalString testSupport ''
+    moveToOutput "share/installed-tests" "$installedTests"
+    moveToOutput "libexec/installed-tests" "$installedTests"
+    install -Dm 444 -t $installedTests/share/assets test/*.bmp
+  '';
 
   passthru = {
     # Building this in its own derivation to make sure the rpath hack above propagate to users

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -59,6 +59,7 @@
 assert lib.assertMsg (
   waylandSupport -> openglSupport
 ) "SDL3 requires OpenGL support to enable Wayland";
+assert lib.assertMsg (ibusSupport -> dbusSupport) "SDL3 requires dbus support to enable ibus";
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -51,6 +51,7 @@
   libudevSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   sndioSupport ? false,
   testSupport ? true,
+  traySupport ? true,
   waylandSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   x11Support ? !stdenv.hostPlatform.isAndroid && !stdenv.hostPlatform.isWindows,
 }:
@@ -121,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
       libusb1
     ]
     ++ lib.optional (
-      stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isDarwin
+      stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isDarwin && traySupport
     ) libayatana-appindicator
     ++ lib.optional alsaSupport alsa-lib
     ++ lib.optional dbusSupport dbus
@@ -168,6 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SDL_PULSEAUDIO" pulseaudioSupport)
     (lib.cmakeBool "SDL_SNDIO" sndioSupport)
     (lib.cmakeBool "SDL_TEST_LIBRARY" testSupport)
+    (lib.cmakeBool "SDL_TRAY_DUMMY" (!traySupport))
     (lib.cmakeBool "SDL_WAYLAND" waylandSupport)
     (lib.cmakeBool "SDL_WAYLAND_LIBDECOR" libdecorSupport)
     (lib.cmakeBool "SDL_X11" x11Support)

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -95,6 +95,8 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString waylandSupport ''
       substituteInPlace src/video/wayland/SDL_waylandmessagebox.c \
         --replace-fail '"zenity"' '"${lib.getExe zenity}"'
+      substituteInPlace src/dialog/unix/SDL_zenitydialog.c \
+        --replace-fail '"zenity"' '"${lib.getExe zenity}"'
     '';
 
   strictDeps = true;


### PR DESCRIPTION
Tray support in sdl3 is nice, but completely unsupported by SDL2. Thus, it makes little sense to pull in all the dependencies needed for tray into sdl2-compat.

Similarly, both sdl2 and sdl3 support `zenity` as a dialog backend. This is optional, and will by default only be used if dbus/portal backend fails. The classic SDL2 technically supported zenity upstream, but we never enabled that support. Similarly, sdl3 supports zenity, but our implementation was broken, always returning zenity was not available. Zenity can still be made available, either by setting the override or adding `zenity` to `$PATH` in a wrapper of a consumer package.

While testing these, i needed the `installed-tests` output to execute the test binaries in an interactive session.
It might make sense to use the `installedTests` output e.g. in a VM test to make sure these override interfaces don't break.

I also found ibus support requires dbus support and added an assertion for that.

This is currently a draft: I am not yet entirely decided on some aspects, and i would *like* to write VM tests for these things. sdl3 also still depends on `libdecor` which in turn pulls in gtk3 into the closure. Arguably this is fine: SDL2_classic also depended on libdecor, and the closure size was still acceptable. But, if there is a reasonable way to drop it, we wouldn't need any gtk for the sdl going into ffmpeg, which could be nice!

cc @NixOS/sdl, feedback welcome

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
