### PR TITLE
python3Packages.craft-grammar: move pydantic to dependencies

### DIFF
--- a/pkgs/development/python-modules/craft-grammar/default.nix
+++ b/pkgs/development/python-modules/craft-grammar/default.nix
@@ -25,12 +25,14 @@ buildPythonPackage rec {
 
   build-system = [ setuptools-scm ];
 
-  dependencies = [ overrides ];
+  dependencies = [
+    overrides
+    pydantic
+  ];
 
   pythonImportsCheck = [ "craft_grammar" ];
 
   nativeCheckInputs = [
-    pydantic
     pytestCheckHook
     pyyaml
   ];


### PR DESCRIPTION
https://github.com/canonical/craft-grammar/blob/8d6962561b82ea1d0da1adda885c6e0d89918f59/pyproject.toml#L6

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).