### PR TITLE
ly: 1.0.3 -> 1.1.0

### DIFF
--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -41,13 +41,11 @@ let
     path = "/run/current-system/sw/bin";
     term_reset_cmd = "${pkgs.ncurses}/bin/tput reset";
     term_restore_cursor_cmd = "${pkgs.ncurses}/bin/tput cnorm";
-    mcookie_cmd = "/run/current-system/sw/bin/mcookie";
     waylandsessions = "${dmcfg.sessionData.desktops}/share/wayland-sessions";
-    wayland_cmd = dmcfg.sessionData.wrapper;
     xsessions = "${dmcfg.sessionData.desktops}/share/xsessions";
     xauth_cmd = lib.optionalString xcfg.enable "${pkgs.xorg.xauth}/bin/xauth";
     x_cmd = lib.optionalString xcfg.enable xserverWrapper;
-    x_cmd_setup = dmcfg.sessionData.wrapper;
+    setup_cmd = dmcfg.sessionData.wrapper;
   };
 
   finalConfig = defaultConfig // cfg.settings;

--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -12,7 +12,7 @@ let
   cfg = config.services.displayManager.ly;
   xEnv = config.systemd.services.display-manager.environment;
 
-  ly = cfg.package;
+  ly = cfg.package.override { x11Support = cfg.x11Support; };
 
   iniFmt = pkgs.formats.iniWithGlobalSection { };
 
@@ -57,6 +57,11 @@ in
   options = {
     services.displayManager.ly = {
       enable = mkEnableOption "ly as the display manager";
+      x11Support = mkOption {
+        description = "Whether to enable support for X11";
+        type = lib.types.bool;
+        default = true;
+      };
 
       package = mkPackageOption pkgs [ "ly" ] { };
 

--- a/pkgs/by-name/ly/ly/deps.nix
+++ b/pkgs/by-name/ly/ly/deps.nix
@@ -89,23 +89,23 @@ let
 in
 linkFarm name [
   {
-    name = "122062d301a203d003547b414237229b09a7980095061697349f8bef41be9c30266b";
+    name = "clap-0.10.0-oBajB434AQBDh-Ei3YtoKIRxZacVPF1iSwp3IX_ZB8f0";
     path = fetchZigArtifact {
       name = "clap";
-      url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.9.1.tar.gz";
-      hash = "sha256-7qxm/4xb+58MGG+iUzssUtR97OG2dRjAqyS0BAet4HY=";
+      url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.10.0.tar.gz";
+      hash = "sha256-cbPGmVlIXwIuRPIfQoFXzwLulT4XEv8rQWcJUl1ueyo=";
     };
   }
   {
-    name = "12209b971367b4066d40ecad4728e6fdffc4cc4f19356d424c2de57f5b69ac7a619a";
+    name = "zigini-0.3.1-BSkB7XJGAAB2E-sKyzhTaQCBlYBL8yqzE4E_jmSY99sC";
     path = fetchZigArtifact {
       name = "zigini";
-      url = "https://github.com/Kawaii-Ash/zigini/archive/0bba97a12582928e097f4074cc746c43351ba4c8.tar.gz";
-      hash = "sha256-OdaJ5tqmk2MPwaAbpK4HRD/CcQCN+Cjj8U63BqUcFMs=";
+      url = "https://github.com/Kawaii-Ash/zigini/archive/2ed3d417f17fab5b0ee8cad8a63c6d62d7ac1042.tar.gz";
+      hash = "sha256-Zj9uU6EEHkNZ1cPIDgDj1E2CEpbmPmpJYjSSFnxxdf0=";
     };
   }
   {
-    name = "1220b0979ea9891fa4aeb85748fc42bc4b24039d9c99a4d65d893fb1c83e921efad8";
+    name = "N-V-__8AAB9qAACwl56piR-krrhXSPxCvEskA52cmaTWXYk_";
     path = fetchZigArtifact {
       name = "ini";
       url = "https://github.com/ziglibs/ini/archive/e18d36665905c1e7ba0c1ce3e8780076b33e3002.tar.gz";

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -5,26 +5,26 @@
   linux-pam,
   libxcb,
   makeBinaryWrapper,
-  zig_0_13,
+  zig_0_14,
   callPackage,
   nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ly";
-  version = "1.0.3";
+  version = "1.1.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "AnErrupTion";
     repo = "ly";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TsEn0kH7j4myjjgwHnbOUmIZjHn8A1d/7IjamoWxpXQ=";
+    hash = "sha256-+rRvrlzV5MDwb/7pr/oZjxxDmE1kbnchyUi70xwp0Cw=";
   };
 
   nativeBuildInputs = [
     makeBinaryWrapper
-    zig_0_13.hook
+    zig_0_14.hook
   ];
   buildInputs = [
     libxcb
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     ln -s ${
       callPackage ./deps.nix {
-        zig = zig_0_13;
+        zig = zig_0_14;
       }
     } $ZIG_GLOBAL_CACHE_DIR/p
   '';

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitHub,
+  fetchFromGitea,
   linux-pam,
   libxcb,
   makeBinaryWrapper,
@@ -10,14 +10,15 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ly";
   version = "1.0.3";
 
-  src = fetchFromGitHub {
-    owner = "fairyglade";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "AnErrupTion";
     repo = "ly";
-    rev = "v1.0.3";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-TsEn0kH7j4myjjgwHnbOUmIZjHn8A1d/7IjamoWxpXQ=";
   };
 
@@ -40,12 +41,12 @@ stdenv.mkDerivation {
 
   passthru.tests = { inherit (nixosTests) ly; };
 
-  meta = with lib; {
+  meta = {
     description = "TUI display manager";
-    license = licenses.wtfpl;
-    homepage = "https://github.com/fairyglade/ly";
-    maintainers = [ maintainers.vidister ];
-    platforms = platforms.linux;
+    license = lib.licenses.wtfpl;
+    homepage = "https://codeberg.org/AnErrupTion/ly";
+    maintainers = [ lib.maintainers.vidister ];
+    platforms = lib.platforms.linux;
     mainProgram = "ly";
   };
-}
+})

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -8,6 +8,7 @@
   zig_0_14,
   callPackage,
   nixosTests,
+  x11Support ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,9 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
     zig_0_14.hook
   ];
   buildInputs = [
-    libxcb
     linux-pam
-  ];
+  ] ++ (lib.optionals x11Support [ libxcb ]);
 
   postPatch = ''
     ln -s ${
@@ -38,6 +38,9 @@ stdenv.mkDerivation (finalAttrs: {
       }
     } $ZIG_GLOBAL_CACHE_DIR/p
   '';
+  zigBuildFlags = [
+    "-Denable_x11_support=${lib.boolToString x11Support}"
+  ];
 
   passthru.tests = { inherit (nixosTests) ly; };
 


### PR DESCRIPTION
Regular version bump with a lot of improvements on upstream, see Changelog at https://codeberg.org/AnErrupTion/ly/releases/tag/v1.1.0

This also moves Ly to Zig 0.14 (as only supported version).

Includes (as separate [commit](e195c0a27978898816dca632f6a88e8c4b69ff1b)) fetching the source from Codeberg instead of GitHub, as the project moved there. I double checked the output has for the source, it was the same whether fetching from GH or Codeberg.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
