### PR TITLE
snapcraft: pin Python 3.12

### DIFF
--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -5,14 +5,14 @@
   lib,
   makeWrapper,
   nix-update-script,
-  python3Packages,
+  python312Packages,
   squashfsTools,
   cacert,
   stdenv,
   writableTmpDirAsHomeHook,
 }:
 
-python3Packages.buildPythonApplication rec {
+python312Packages.buildPythonApplication rec {
   pname = "snapcraft";
   version = "8.8.1";
 
@@ -58,7 +58,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
-  dependencies = with python3Packages; [
+  dependencies = with python312Packages; [
     attrs
     catkin-pkg
     click
@@ -102,7 +102,7 @@ python3Packages.buildPythonApplication rec {
     validators
   ];
 
-  build-system = with python3Packages; [ setuptools-scm ];
+  build-system = with python312Packages; [ setuptools-scm ];
 
   pythonRelaxDeps = [
     "click"
@@ -125,7 +125,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   nativeCheckInputs =
-    with python3Packages;
+    with python312Packages;
     [
       pytest-check
       pytest-cov-stub


### PR DESCRIPTION
Snapcraft uses paths as context manager here: https://github.com/canonical/snapcraft/blob/8.9.2/snapcraft/providers.py#L115-L117
This functionality was removed in Python 3.13.

Did not find an upstream issue about this.

staging-next currently defaults to Python 3.13.

On Python 3.12, the tests print:
```
tests/unit/test_providers.py::test_capture_logs_from_instance
  /build/source/snapcraft/providers.py:115: DeprecationWarning: pathlib.Path.__enter__() is deprecated and scheduled for removal in Python 3.13; Path objects as a context manager is a no-op
    with instance.temporarily_pull_file(
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).