### PR TITLE
elmPackages.elm: Fix runtime TLS connection to package.elm-lang.org

### DIFF
--- a/pkgs/development/compilers/elm/packages/ghc9_6/default.nix
+++ b/pkgs/development/compilers/elm/packages/ghc9_6/default.nix
@@ -38,6 +38,10 @@ pkgs.haskell.packages.ghc96.override {
 
         inherit fetchElmDeps;
         elmVersion = elmPkgs.elm.version;
+
+        # Fix TLS issues
+        # see https://github.com/elm/compiler/pull/2325
+        tls = self.callPackage ./tls-1.9.0.nix { };
       };
     in
     elmPkgs

--- a/pkgs/development/compilers/elm/packages/ghc9_6/tls-1.9.0.nix
+++ b/pkgs/development/compilers/elm/packages/ghc9_6/tls-1.9.0.nix
@@ -1,0 +1,79 @@
+{
+  mkDerivation,
+  asn1-encoding,
+  asn1-types,
+  async,
+  base,
+  bytestring,
+  cereal,
+  crypton,
+  crypton-x509,
+  crypton-x509-store,
+  crypton-x509-validation,
+  data-default-class,
+  gauge,
+  hourglass,
+  lib,
+  memory,
+  mtl,
+  network,
+  QuickCheck,
+  tasty,
+  tasty-quickcheck,
+  transformers,
+  unix-time,
+}:
+mkDerivation {
+  pname = "tls";
+  version = "1.9.0";
+  sha256 = "5605b9cbe0903b100e9de72800641453f74bf5dade6176dbe10b34ac9353433e";
+  libraryHaskellDepends = [
+    asn1-encoding
+    asn1-types
+    async
+    base
+    bytestring
+    cereal
+    crypton
+    crypton-x509
+    crypton-x509-store
+    crypton-x509-validation
+    data-default-class
+    memory
+    mtl
+    network
+    transformers
+    unix-time
+  ];
+  testHaskellDepends = [
+    asn1-types
+    async
+    base
+    bytestring
+    crypton
+    crypton-x509
+    crypton-x509-validation
+    data-default-class
+    hourglass
+    QuickCheck
+    tasty
+    tasty-quickcheck
+  ];
+  benchmarkHaskellDepends = [
+    asn1-types
+    async
+    base
+    bytestring
+    crypton
+    crypton-x509
+    crypton-x509-validation
+    data-default-class
+    gauge
+    hourglass
+    QuickCheck
+    tasty-quickcheck
+  ];
+  homepage = "https://github.com/haskell-tls/hs-tls";
+  description = "TLS/SSL protocol native implementation (Server and Client)";
+  license = lib.licenses.bsd3;
+}


### PR DESCRIPTION
Resolves #414208 by downgrading version of TLS library used to compile executables.

See upstream issue for more context https://github.com/elm/compiler/pull/2325

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
