### PR TITLE
bluebubbles-server: init at 1.9.9

### DIFF
--- a/pkgs/by-name/bl/bluebubbles-server/package.nix
+++ b/pkgs/by-name/bl/bluebubbles-server/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchurl,
+  undmg,
+  stdenvNoCC,
+}:
+let
+  releaseUrl = "https://github.com/BlueBubblesApp/bluebubbles-server/releases/download";
+in
+stdenvNoCC.mkDerivation rec {
+  pname = "bluebubbles-server";
+  version = "1.9.9";
+
+  src =
+    fetchurl
+      {
+        x86_64-darwin = {
+          url = "${releaseUrl}/v${version}/BlueBubbles-${version}.dmg";
+          hash = "sha256-loHmX2AhSmqV870StXvUzIrW2PWM2cHYgRsqRgatfAQ=";
+        };
+        aarch64-darwin = {
+          url = "${releaseUrl}/v${version}/BlueBubbles-${version}-arm64.dmg";
+          hash = "sha256-+v1lDIg/UudJSmYl5FJJ8hRNGXN4pNVxQ8z2GYuy6GI=";
+        };
+      }
+      .${stdenvNoCC.hostPlatform.system}
+        or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = "BlueBubbles.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications/BlueBubbles.app
+    cp -R . $out/Applications/BlueBubbles.app
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Server for the BlueBubbles messaging app";
+    homepage = "https://github.com/BlueBubblesApp/bluebubbles-server";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ zacharyweiss ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
[bluebubbles-server](https://github.com/BlueBubblesApp/bluebubbles-server) is the necessary companion to the [BlueBubbles app](https://bluebubbles.app/) (recently added to nixpkgs in https://github.com/NixOS/nixpkgs/pull/404147), acting as the bridge / forwarder for iMessages.

I've spent the past week fighting with packaging it from source (mainly owing to inexperience with NPM / Electron / Darwin targets, and only owning an extremely underpowered 2012 Mac Mini to build on, causing extremely long build times), and as such opted to simply use the dmg instead for now. ~~My intent is to write~~ I've written a [nix-darwin module](https://github.com/nix-darwin/nix-darwin/pull/1508) depending on this package, allowing completely declarative configuration/deployment of the server. If other contributors believe they can easily package the source, I would gladly welcome it superseding this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
