### PR TITLE
kopia-ui: 0.20.0 -> 0.20.1

### DIFF
--- a/pkgs/by-name/ko/kopia-ui/fix-paths.patch
+++ b/pkgs/by-name/ko/kopia-ui/fix-paths.patch
@@ -1,42 +1,63 @@
 diff --git a/public/utils.js b/public/utils.js
-index 3cd38b63..54152694 100644
+index c5963e41..30f72965 100644
 --- a/public/utils.js
 +++ b/public/utils.js
-@@ -17,7 +17,7 @@ const osShortName = function () {
+@@ -17,7 +17,7 @@ const osShortName = (function () {
  
  export function iconsPath() {
-     if (!app.isPackaged) {
--        return path.join(__dirname, "..", "resources", osShortName, "icons");
-+        return path.join(__dirname, "..", "..", "icons");
-     }
+   if (!app.isPackaged) {
+-    return path.join(__dirname, "..", "resources", osShortName, "icons");
++    return path.join(__dirname, "..", "..", "icons");
+   }
  
-     return path.join(process.resourcesPath, "icons");
-@@ -25,26 +25,14 @@ export function iconsPath() {
+   return path.join(process.resourcesPath, "icons");
+@@ -25,47 +25,14 @@ export function iconsPath() {
  
  export function publicPath() {
-     if (!app.isPackaged) {
--        return path.join(__dirname, "..", "public");
-+        return path.join(__dirname, "..", "..", "public");
-     }
+   if (!app.isPackaged) {
+-    return path.join(__dirname, "..", "public");
++    return path.join(__dirname, "..", "..", "public");
+   }
  
-     return process.resourcesPath;
+   return process.resourcesPath;
  }
  
  export function defaultServerBinary() {
--    if (!app.isPackaged) {
--        return {
--            "mac": path.join(__dirname, "..", "..", "dist", "kopia_darwin_amd64", "kopia"),
--            "win": path.join(__dirname, "..", "..", "dist", "kopia_windows_amd64", "kopia.exe"),
--            "linux": path.join(__dirname, "..", "..", "dist", "kopia_linux_amd64", "kopia"),
--        }[osShortName]
--    }
--
+-  if (!app.isPackaged) {
 -    return {
--        "mac": path.join(process.resourcesPath, "server", "kopia"),
--        "win": path.join(process.resourcesPath, "server", "kopia.exe"),
--        "linux": path.join(process.resourcesPath, "server", "kopia"),
--    }[osShortName]
-+    return "KOPIA"
+-      mac: path.join(
+-        __dirname,
+-        "..",
+-        "..",
+-        "dist",
+-        "kopia_darwin_amd64",
+-        "kopia",
+-      ),
+-      win: path.join(
+-        __dirname,
+-        "..",
+-        "..",
+-        "dist",
+-        "kopia_windows_amd64",
+-        "kopia.exe",
+-      ),
+-      linux: path.join(
+-        __dirname,
+-        "..",
+-        "..",
+-        "dist",
+-        "kopia_linux_amd64",
+-        "kopia",
+-      ),
+-    }[osShortName];
+-  }
+-
+-  return {
+-    mac: path.join(process.resourcesPath, "server", "kopia"),
+-    win: path.join(process.resourcesPath, "server", "kopia.exe"),
+-    linux: path.join(process.resourcesPath, "server", "kopia"),
+-  }[osShortName];
++  return "KOPIA";
  }
  export function selectByOS(x) {
-     return x[osShortName]
+   return x[osShortName];

--- a/pkgs/by-name/ko/kopia-ui/package.nix
+++ b/pkgs/by-name/ko/kopia-ui/package.nix
@@ -10,12 +10,12 @@
   kopia,
 }:
 let
-  version = "0.20.0";
+  version = "0.20.1";
   src = fetchFromGitHub {
     owner = "kopia";
     repo = "kopia";
     tag = "v${version}";
-    hash = "sha256-AM9Mpy+9ZCvEtFtzYC87vqCNpLxO+yWVd4th9DDQ2QI=";
+    hash = "sha256-hKtrHv7MQjA/AQ/frjP2tPT6zqVPPGnBxYuhWtUgIl0=";
   };
 in
 buildNpmPackage {
@@ -24,7 +24,7 @@ buildNpmPackage {
 
   sourceRoot = "${src.name}/app";
 
-  npmDepsHash = "sha256-FXPfZnqpuI6NgHk81HEJ7Hj8xCpXD0BKJgFeQ/Oce04=";
+  npmDepsHash = "sha256-5gXM5aLsUsJhxbt6IKY4Sg4SBI9ATe248K1TyZThg/0=";
   makeCacheWritable = true;
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changelogs:
  - https://github.com/kopia/kopia/releases/tag/v0.20.1

Had to update the fix-paths.patch as there was a recent reformat of the repo. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
