### PR TITLE
ocamlPackages.encore: 0.8 -> 0.8.1

### DIFF
--- a/pkgs/development/ocaml-modules/encore/default.nix
+++ b/pkgs/development/ocaml-modules/encore/default.nix
@@ -10,13 +10,13 @@
 
 buildDunePackage rec {
   pname = "encore";
-  version = "0.8";
+  version = "0.8.1";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.07";
 
   src = fetchurl {
-    url = "https://github.com/mirage/encore/releases/download/v${version}/encore-v${version}.tbz";
-    sha256 = "a406bc9863b04bb424692045939d6c170a2bb65a98521ae5608d25b0559344f6";
+    url = "https://github.com/mirage/encore/releases/download/v${version}/encore-${version}.tbz";
+    hash = "sha256-qg6heSBc6OSfb7vZxEi4rrKh+nx+ffnsCfVvhVR3yY0=";
   };
 
   duneVersion = "3";

--- a/pkgs/development/ocaml-modules/encore/default.nix
+++ b/pkgs/development/ocaml-modules/encore/default.nix
@@ -19,8 +19,6 @@ buildDunePackage rec {
     hash = "sha256-qg6heSBc6OSfb7vZxEi4rrKh+nx+ffnsCfVvhVR3yY0=";
   };
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     angstrom
     fmt
@@ -32,6 +30,12 @@ buildDunePackage rec {
   meta = {
     homepage = "https://github.com/mirage/encore";
     description = "Library to generate encoder/decoder which ensure isomorphism";
+    longDescription = ''
+      Encore is a little library to provide an interface to generate an angstrom decoder and
+      an internal encoder from a shared description. The goal is to ensure a dual isomorphism
+      between them.
+    '';
+    changelog = "https://raw.githubusercontent.com/mirage/encore/refs/tags/v${version}/CHANGES.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.vbgl ];
   };


### PR DESCRIPTION
Diff: https://github.com/mirage/encore@v0.8...v0.8.1
Changelog: https://github.com/mirage/encore/releases/tag/v0.8.1

I ran "nix-shell -p nixpkgs-review --run 'nixpkgs-review rev HEAD'" and received the following error: The build failure of ocaml5.3.0-mirage-crypto-rng caused it, however. Updating this package should be irrelevant.

```
--------- Report for 'aarch64-darwin' ---------
8 packages failed to build:
ocamlPackages.git-mirage ocamlPackages.git-paf ocamlPackages.git-unix ocamlPackages.irmin-git ocamlPackages.irmin-graphql ocamlPackages.irmin-mirage-git ocamlPackages.irmin-mirage-graphql ocamlPackages.plotkicadsch

2 packages built:
ocamlPackages.encore ocamlPackages.git
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
