### PR TITLE
[24.11] teleport_15: 15.4.33 -> 15.5.2; teleport_16: 16.5.9 -> 16.5.11; teleport_17: 17.4.8 -> 17.5.1

### DIFF
--- a/pkgs/development/libraries/sqlite/CVE-2025-29087.patch
+++ b/pkgs/development/libraries/sqlite/CVE-2025-29087.patch
@@ -1,0 +1,11 @@
+--- 1/sqlite3.c
++++ 2/sqlite3.c
+@@ -130218,7 +130218,7 @@ static void concatFuncCore(
+   for(i=0; i<argc; i++){
+     n += sqlite3_value_bytes(argv[i]);
+   }
+-  n += (argc-1)*nSep;
++  n += (argc-1)*(i64)nSep;
+   z = sqlite3_malloc64(n+1);
+   if( z==0 ){
+     sqlite3_result_error_nomem(context);

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-6WkTH5PKefvGTVdyShA1c1iBVVpSYA2+acaeq3LJ/NE=";
   };
 
+  patches = [ ./CVE-2025-29087.patch ];
+
   outputs = [
     "bin"
     "dev"

--- a/pkgs/servers/teleport/15/default.nix
+++ b/pkgs/servers/teleport/15/default.nix
@@ -2,11 +2,11 @@
 import ../generic.nix (
   args
   // {
-    version = "15.4.33";
-    hash = "sha256-glf0JCsUZD0o3C+3lJ9V2wvamZa8bKySVi/sLo11Mvk=";
-    vendorHash = "sha256-J4N2VbiIzfyZJtFvmwW6xZLxB2F9bDRRDfOaWLoHT/4=";
-    yarnHash = "sha256-3Ady46LXa3TSSwmWY+GDiS1j5qR5VIuJ5Z+iW5g0SAA=";
-    cargoHash = "sha256-aXKrUo+Q9gK09TP9W2PQ3TjDwBtIlUopZL6AJVAiszE=";
+    version = "15.5.2";
+    hash = "sha256-+6+OTQ7G3c4xYhTqJIYuV95xjlBjSw7lnts/7/lXXzM=";
+    vendorHash = "sha256-DNyC5duFufWBk0F2mMAMHHTVusCbNKVtZG2UOUQfZMI=";
+    yarnHash = "sha256-TOWqpMaZLGhdUaN3r3fGgviKi9BbZHoLcu3d7oLr2gk=";
+    cargoHash = "sha256-aXKrUo+Q9gK09TP9W2PQ3TjDwBtIlUopZL6AJVAiszE";
 
     wasm-bindgen-cli = wasm-bindgen-cli.override {
       version = "0.2.100";

--- a/pkgs/servers/teleport/16/default.nix
+++ b/pkgs/servers/teleport/16/default.nix
@@ -2,9 +2,9 @@
 import ../generic.nix (
   args
   // {
-    version = "16.5.9";
-    hash = "sha256-lIWJV3AQ+XWApfjtdUL8ZlHAXCyvwVAGsZjjvXul36I=";
-    vendorHash = "sha256-DdVBtMwz0AIGCYj/QLczG8GPP9mqKrdF+M0NqmM6J0I=";
+    version = "16.5.11";
+    hash = "sha256-uLis1oRTr5J2bKaJtnVAIQ0ixYT8BYLo4jQPcdFp82s=";
+    vendorHash = "sha256-OcVHckqxpTVz6Gaemt3+9WxBQc5D5QBxb3IMGOMq4LI=";
     pnpmHash = "sha256-JQca2eFxcKJDHIaheJBg93ivZU95UWMRgbcK7QE4R10=";
     cargoHash = "sha256-04zykCcVTptEPGy35MIWG+tROKFzEepLBmn04mSbt7I";
 

--- a/pkgs/servers/teleport/17/default.nix
+++ b/pkgs/servers/teleport/17/default.nix
@@ -2,9 +2,9 @@
 import ../generic.nix (
   args
   // {
-    version = "17.4.8";
-    hash = "sha256-BMiV4xMDy/21B2kl/vkXD14LKQ9t/qj6K8HFnU9Td7w=";
-    vendorHash = "sha256-/JP0/4fFdCuDFLQ+mh7CQNMJ4n3yDNyvnLfbmRl/TBA=";
+    version = "17.5.1";
+    hash = "sha256-+9Oit7GAUTNv5Z8ZDOuBBRnVvtdA9N0X97UJbLILX50=";
+    vendorHash = "sha256-yeouUrLMfkKSYnS9va59cYWnGCvQatQQrNa1DuHQMug=";
     pnpmHash = "sha256-TZb1nABTbR+SPgykc/KMRkHW7oLawem6KWmdOFAbLbk=";
     cargoHash = "sha256-qz8gkooQTuBlPWC4lHtvBQpKkd+nEZ0Hl7AVg9JkPqs=";
   }


### PR DESCRIPTION
This PR includes multiple things:
- An update of teleport_15, which is removed in master, so no backport could be done.
- Backports of #414047 and #414507, which cannot be done automatically, as I rewrote the structure of the derivations in #403721. As such, I did not attempt to cherry-pick the commits but just wrote new ones.

This needs Go 1.23.9, which did not reach `release-24.11` yet (#404776), which is why  I starget `staging-24.11`.
I tested locally by cherry-picking 55ea775267867a8cdc52c90e6ffd4df2226306fc on current `release-24.11` (which was at 41a58089b2a621c095b7aab771a7cec66b5a083d).
This is the first time I target a staging branch, so please note when this approach is not valid. I wanted to circumvent doing an entire bootstrap of GCC, Node, Rust and Go just for the Go update.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
