### PR TITLE
netcap: init at 0.6.11

### DIFF
--- a/pkgs/by-name/li/libflowmanager/package.nix
+++ b/pkgs/by-name/li/libflowmanager/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  bison,
+  flex,
+  libtrace,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libflowmanager";
+  version = "3.0.0-3";
+
+  src = fetchFromGitHub {
+    owner = "LibtraceTeam";
+    repo = "libflowmanager";
+    tag = finalAttrs.version;
+    hash = "sha256-lQo8F4w+tu0DZgt0pnbEpwcL6buVbAuFoxtwGFXuGX4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    bison
+    flex
+  ];
+  buildInputs = [ libtrace ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=^([0-9.-]+)$" ]; };
+
+  meta = {
+    description = "Library for assigning network packets to flows based on the standard 5-tuple";
+    homepage = "https://github.com/LibtraceTeam/libflowmanager";
+    changelog = "https://github.com/LibtraceTeam/libflowmanager/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libprotoident/package.nix
+++ b/pkgs/by-name/li/libprotoident/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  bison,
+  flex,
+  libtrace,
+  libflowmanager,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libprotoident";
+  version = "2.0.15-2";
+
+  src = fetchFromGitHub {
+    owner = "LibtraceTeam";
+    repo = "libprotoident";
+    tag = finalAttrs.version;
+    hash = "sha256-XiZ/UqF11eeeGudNXJqtTfPn5xWvHPKPrgqV7iHii0M=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    bison
+    flex
+  ];
+  buildInputs = [
+    libtrace
+    libflowmanager
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=^([0-9.-]+)$" ]; };
+
+  meta = {
+    description = "Network traffic classification library that requires minimal application payload";
+    homepage = "https://github.com/LibtraceTeam/libprotoident";
+    changelog = "https://github.com/LibtraceTeam/libprotoident/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libtrace/package.nix
+++ b/pkgs/by-name/li/libtrace/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  bison,
+  flex,
+  zlib,
+  bzip2,
+  xz,
+  libpcap,
+  wandio,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libtrace";
+  version = "4.0.28-1";
+
+  src = fetchFromGitHub {
+    owner = "LibtraceTeam";
+    repo = "libtrace";
+    tag = finalAttrs.version;
+    hash = "sha256-impZrZOOORsQaUz04pkCXGxJkXGaCBcJD390hm74peA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    bison
+    flex
+  ];
+  buildInputs = [
+    zlib
+    bzip2
+    xz
+    libpcap
+    wandio
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=^([0-9.-]+)$" ]; };
+
+  meta = {
+    description = "C Library for working with network packet traces";
+    homepage = "https://github.com/LibtraceTeam/libtrace";
+    changelog = "https://github.com/LibtraceTeam/libtrace/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ne/netcap/ndpi_4_0.nix
+++ b/pkgs/by-name/ne/netcap/ndpi_4_0.nix
@@ -1,0 +1,32 @@
+{
+  ndpi,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  autoreconfHook,
+  autoconf,
+  automake,
+  fixDarwinDylibNames,
+}:
+
+ndpi.overrideAttrs (
+  finalAttrs: prevAttrs: {
+    version = "4.0";
+
+    src = fetchFromGitHub {
+      inherit (prevAttrs.src) owner repo;
+      tag = finalAttrs.version;
+      hash = "sha256-vWx6IVyxPJBgOkXpHdnvstvDGJbAtndFPtowpjLd32o=";
+    };
+
+    configureScript = "./autogen.sh";
+
+    nativeBuildInputs =
+      lib.remove autoreconfHook prevAttrs.nativeBuildInputs
+      ++ [
+        autoconf
+        automake
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixDarwinDylibNames ];
+  }
+)

--- a/pkgs/by-name/ne/netcap/package.nix
+++ b/pkgs/by-name/ne/netcap/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  callPackage,
+  buildGoModule,
+  fetchFromGitHub,
+  withDpi ? true,
+  libpcap,
+  libprotoident,
+  libflowmanager,
+  libtrace,
+  versionCheckHook,
+  nix-update-script,
+}:
+let
+  ndpi = callPackage ./ndpi_4_0.nix { };
+in
+buildGoModule (finalAttrs: {
+  pname = "netcap";
+  version = "0.6.11";
+
+  src = fetchFromGitHub {
+    owner = "dreadl0ck";
+    repo = "netcap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SCBKOIC/s+rfrVWmryp9EBp7ARpZZcxymsnZWtEHrhk=";
+  };
+
+  vendorHash = "sha256-MvHrJLhcFA0fEgK+YT0rwI6wIwTGMcLWQt6AYkx1eZM=";
+
+  subPackages = [ "cmd" ];
+
+  buildInputs =
+    [
+      libpcap
+    ]
+    ++ lib.optionals withDpi [
+      ndpi
+      libprotoident
+      libflowmanager
+      libtrace
+    ];
+
+  ldflags = [
+    "-s -w"
+  ];
+
+  tags = lib.optionals (!withDpi) [
+    "nodpi"
+  ];
+
+  CGO_LDFLAGS = lib.optionalString withDpi ''
+    -L${ndpi}/lib -lndpi
+    -L${libprotoident}/lib -lndpi
+  '';
+
+  CGO_CFLAGS = lib.optionalString withDpi ''
+    -I${ndpi}/include
+    -I${libprotoident}/include
+  '';
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/net
+  '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        # couldn't open packet socket: operation not permitted
+        "TestCaptureLive"
+        # requires local test data
+        "TestCapturePCAP"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/net";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Framework for secure and scalable network traffic analysis";
+    homepage = "https://netcap.io";
+    downloadPage = "https://github.com/dreadl0ck/netcap";
+    changelog = "https://github.com/dreadl0ck/netcap/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ felbinger ];
+    mainProgram = "net";
+  };
+})

--- a/pkgs/by-name/wa/wandio/package.nix
+++ b/pkgs/by-name/wa/wandio/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  zlib,
+  bzip2,
+  xz,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wandio";
+  version = "4.2.6-1";
+
+  src = fetchFromGitHub {
+    owner = "LibtraceTeam";
+    repo = "wandio";
+    tag = finalAttrs.version;
+    hash = "sha256-fYSAmuTgik8YeonHQc+GHRQ1lEuWxlE17npVsMpBlOE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [
+    zlib
+    bzip2
+    xz
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=^([0-9.-]+)$" ]; };
+
+  meta = {
+    description = "C library for simple and efficient file IO";
+    homepage = "https://github.com/LibtraceTeam/wandio";
+    changelog = "https://github.com/LibtraceTeam/wandio/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3826,6 +3826,10 @@ with pkgs;
   # Not in aliases because it wouldn't get picked up by callPackage
   netbox = netbox_4_2;
 
+  netcap-nodpi = callPackage ../by-name/ne/netcap/package.nix {
+    withDpi = false;
+  };
+
   netcat = libressl.nc.overrideAttrs (old: {
     meta = old.meta // {
       description = "Utility which reads and writes data across network connections — LibreSSL implementation";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/dreadl0ck/netcap

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
