### PR TITLE
wild: init at 0.7.0

### DIFF
--- a/pkgs/by-name/wi/wild/adapterTest.nix
+++ b/pkgs/by-name/wi/wild/adapterTest.nix
@@ -1,6 +1,10 @@
 {
   lib,
   stdenv,
+  gccStdenv,
+  clangStdenv,
+  buildPackages,
+  runCommandCC,
   makeBinaryWrapper,
   gcc,
   wild,
@@ -8,6 +12,8 @@
   clang,
   lld,
   clang-tools,
+  useWildLinker,
+  hello,
 }:
 let
   # These wrappers are REQUIRED for the Wild test suite to pass
@@ -51,6 +57,38 @@ let
       runHook postBuild
     '';
   };
+
+  # Test helper that takes in a binary and checks that it runs
+  # and was built with Wild
+  helloTest =
+    name: helloWild:
+    let
+      command = "$READELF -p .comment ${lib.getExe helloWild}";
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    runCommandCC "wild-${name}-test" { passthru = { inherit helloWild; }; } ''
+      echo "Testing running the 'hello' binary which should be linked with 'wild'" >&2
+      ${emulator} ${lib.getExe helloWild}
+
+      echo "Checking for wild in the '.comment' section" >&2
+      if output=$(${command} 2>&1); then
+        if grep -Fw -- "Wild" - <<< "$output"; then
+          touch $out
+        else
+          echo "No mention of 'wild' detected in the '.comment' section" >&2
+          echo "The command was:" >&2
+          echo "${command}" >&2
+          echo "The output was:" >&2
+          echo "$output" >&2
+          exit 1
+        fi
+      else
+        echo -n "${command}" >&2
+        echo " returned a non-zero exit code." >&2
+        echo "$output" >&2
+        exit 1
+      fi
+    '';
 in
 {
   testWild = wild.overrideAttrs {
@@ -96,4 +134,18 @@ in
 
     installPhase = "touch $out";
   };
+
+  # Test that the adapter works with a gcc stdenv
+  adapterGcc = helloTest "adapter-gcc" (
+    hello.override (_: {
+      stdenv = useWildLinker gccStdenv;
+    })
+  );
+
+  # Test the adapter works with a clang stdenv
+  adapter-llvm = helloTest "adapter-llvm" (
+    hello.override (_: {
+      stdenv = useWildLinker clangStdenv;
+    })
+  );
 }

--- a/pkgs/by-name/wi/wild/adapterTest.nix
+++ b/pkgs/by-name/wi/wild/adapterTest.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  makeBinaryWrapper,
+  gcc,
+  wild,
+  binutils-unwrapped-all-targets,
+  clang,
+  lld,
+  clang-tools,
+}:
+let
+  # These wrappers are REQUIRED for the Wild test suite to pass
+  #
+  # Write a wrapper for GCC that passes -B to *unwrapped* binutils.
+  # This ensures that if -fuse-ld=bfd is used, gcc picks up unwrapped ld.bfd
+  # instead of the hardcoded wrapper search directory.
+  # We pass it last because apparently gcc likes picking ld from the *first* -B,
+  # which we want our wild target directory to be if passed.
+  gccWrapper = stdenv.mkDerivation {
+    inherit (gcc) name;
+    dontUnpack = true;
+    dontConfigure = true;
+    dontInstall = true;
+
+    buildInputs = [ makeBinaryWrapper ];
+    buildPhase = ''
+      runHook preBuild
+
+      makeWrapper ${lib.getExe gcc} $out/bin/gcc \
+        --append-flag -B${binutils-unwrapped-all-targets}/bin
+
+      runHook postBuild
+    '';
+
+  };
+
+  gppWrapper = stdenv.mkDerivation {
+    dontUnpack = true;
+    dontConfigure = true;
+    dontInstall = true;
+
+    name = "g++-wrapped";
+    buildInputs = [ makeBinaryWrapper ];
+    buildPhase = ''
+      runHook preBuild
+
+      makeWrapper ${lib.getExe' gcc "g++"} $out/bin/g++ \
+        --append-flag -B${binutils-unwrapped-all-targets}/bin
+
+      runHook postBuild
+    '';
+  };
+in
+{
+  testWild = wild.overrideAttrs {
+    pname = "wild-tests";
+    doCheck = true;
+    doInstallCheck = false;
+    dontBuild = true;
+    buildType = "debug";
+
+    checkInputs = [
+      stdenv.cc.libc.out
+      stdenv.cc.libc.static
+    ];
+
+    # https://github.com/davidlattimore/wild/discussions/832#discussioncomment-14482948
+    checkFlags = lib.optionals stdenv.hostPlatform.isAarch64 [
+      "--skip=integration_test::program_name_71___unresolved_symbols_object_c__"
+    ];
+
+    # wild's tests compare the outputs of several different linkers. nixpkgs's
+    # patching and wrappers change the output behavior, so we must make sure
+    # that their behavior is compatible.
+    #
+    # Does not work if they are put in nativeCheckInputs or checkInputs
+    preCheck = ''
+      export LD_LIBRARY_PATH=${
+        lib.makeLibraryPath [
+          stdenv.cc.cc.lib
+        ]
+      }:$LD_LIBRARY_PATH
+
+      export PATH=${
+        lib.makeBinPath [
+          binutils-unwrapped-all-targets
+          clang
+          gccWrapper
+          gppWrapper
+          lld
+          clang-tools
+        ]
+      }:$PATH
+    '';
+
+    installPhase = "touch $out";
+  };
+}

--- a/pkgs/by-name/wi/wild/package.nix
+++ b/pkgs/by-name/wi/wild/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchFromGitHub,
+  callPackage,
+  versionCheckHook,
+  rustPlatform,
+  pkg-config,
+  zstd,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wild";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "davidlattimore";
+    repo = "wild";
+    tag = finalAttrs.version;
+    hash = "sha256-x0IZuWjj0LRMj4pu2FVaD8SENm/UVtE1e4rl0EOZZZM=";
+  };
+
+  cargoHash = "sha256-5s0qS8y0+EH+R1tgN2W5/+t+GdjbQdRVLlcA2KjpHsE=";
+
+  cargoBuildFlags = [ "-p wild-linker" ];
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    zstd
+  ];
+
+  env.ZSTD_SYS_USE_PKG_CONFIG = true;
+
+  doCheck = false; # Tests are ran in passthru tests
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests = callPackage ./adapterTest.nix { wild = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "Very fast linker for Linux";
+    homepage = "https://github.com/davidlattimore/wild";
+    changelog = "https://github.com/davidlattimore/wild/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = [
+      lib.licenses.asl20 # or
+      lib.licenses.mit
+    ];
+    mainProgram = "wild";
+    maintainers = with lib.maintainers; [ RossSmyth ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -335,6 +335,22 @@ rec {
             }
       );
 
+  useWildLinker =
+    stdenv:
+    if !stdenv.targetPlatform.isLinux then
+      throw "Wild only supports building Linux ELF files from Linux hosts."
+    else
+      stdenv.override (prev: {
+        allowedRequisites = null;
+        cc = prev.cc.override {
+          bintools = prev.cc.bintools.override {
+            extraBuildCommands = ''
+              ln -fs ${pkgs.buildPackages.wild-wrapped}/bin/* "$out/bin"
+            '';
+          };
+        };
+      });
+
   /*
     Modify a stdenv so that it builds binaries optimized specifically
     for the machine they are built on.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6870,6 +6870,20 @@ with pkgs;
 
   vcpkg-tool-unwrapped = vcpkg-tool.override { doWrap = false; };
 
+  wild-wrapped =
+    let
+      ldWrapper = ../build-support/bintools-wrapper/ld-wrapper.sh;
+    in
+    wrapBintoolsWith {
+      bintools = wild;
+      extraBuildCommands = ''
+        wrap wild ${ldWrapper} ${lib.getExe buildPackages.wild}
+        wrap ld.wild ${ldWrapper} ${lib.getExe buildPackages.wild}
+        wrap ${stdenv.cc.bintools.targetPrefix}ld.wild ${ldWrapper} ${lib.getExe buildPackages.wild}
+        wrap ${stdenv.cc.bintools.targetPrefix}ld ${ldWrapper} ${lib.getExe buildPackages.wild}
+      '';
+    };
+
   whatstyle = callPackage ../development/tools/misc/whatstyle {
     inherit (llvmPackages) clang-unwrapped;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Add Wild package
2. Add stdenv adapter for Wild
3. Tests for adapter

Works, see https://github.com/davidlattimore/wild/actions/runs/17930736759

Closes #337924

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
