### PR TITLE
mupdf: fix Darwin build

### DIFF
--- a/pkgs/by-name/mu/mupdf/fix-darwin-system-deps.patch
+++ b/pkgs/by-name/mu/mupdf/fix-darwin-system-deps.patch
@@ -1,0 +1,240 @@
+diff --git a/Makefile b/Makefile
+index a16a69968..aa741b037 100644
+--- a/Makefile
++++ b/Makefile
+@@ -454,8 +454,10 @@ install-libs: libs install-headers
+ ifeq ($(shared),yes)
+ 	install -m $(SO_INSTALL_MODE) $(OUT)/libmupdf.$(SO)$(SO_VERSION) $(DESTDIR)$(libdir)/libmupdf.$(SO)$(SO_VERSION)
+   ifneq ($(OS),OpenBSD)
+-	ln -sf libmupdf.$(SO)$(SO_VERSION) $(DESTDIR)$(libdir)/libmupdf.$(SO)$(SO_VERSION_MAJOR)
+-	ln -sf libmupdf.$(SO)$(SO_VERSION) $(DESTDIR)$(libdir)/libmupdf.$(SO)
++    ifneq ($(OS),Darwin)
++		ln -sf libmupdf.$(SO)$(SO_VERSION) $(DESTDIR)$(libdir)/libmupdf.$(SO)$(SO_VERSION_MAJOR)
++		ln -sf libmupdf.$(SO)$(SO_VERSION) $(DESTDIR)$(libdir)/libmupdf.$(SO)
++    endif
+   endif
+ else
+ 	install -m 644 $(MUPDF_LIB) $(DESTDIR)$(libdir)
+diff --git a/Makerules b/Makerules
+index ba4df2189..8eb62622a 100644
+--- a/Makerules
++++ b/Makerules
+@@ -212,101 +212,82 @@ ifneq "$(CLUSTER)" ""
+   CFLAGS += -DCLUSTER
+ endif
+ 
+-ifeq ($(OS),Darwin)
+-  HAVE_GLUT := yes
+-  SYS_GLUT_CFLAGS := -Wno-deprecated-declarations
+-  SYS_GLUT_LIBS := -framework GLUT -framework OpenGL
+-  CC = xcrun cc
+-  AR = xcrun ar
+-  LD = xcrun ld
+-  RANLIB = xcrun ranlib
+-
+-  ifneq ($(ARCHFLAGS),)
+-    $(warning "MacOS with ARCHFLAGS set. Assuming we are building for arm64, and setting HAVE_LIBCRYPTO to no.")
+-    HAVE_LIBCRYPTO := no
+-  else ifeq (, $(shell command -v pkg-config))
+-    $(warning "No pkg-config found, install it for proper integration of libcrypto")
+-  else
+-    HAVE_LIBCRYPTO := $(shell pkg-config --exists 'libcrypto >= 1.1.0' && echo yes)
+-    ifeq ($(HAVE_LIBCRYPTO),yes)
+-      LIBCRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto) -DHAVE_LIBCRYPTO
+-      LIBCRYPTO_LIBS := $(shell pkg-config --libs libcrypto)
+-    endif
+-  endif
+-
+-else
+-
+-  ifeq ($(OS),Linux)
+-    HAVE_OBJCOPY := yes
+-  endif
++ifeq ($(OS),Linux)
++  HAVE_OBJCOPY := yes
++endif
+ 
+-  ifeq ($(OS),OpenBSD)
+-    LDFLAGS += -pthread
+-  endif
++ifeq ($(OS),OpenBSD)
++  LDFLAGS += -pthread
++endif
+ 
+-  ifeq ($(shell pkg-config --exists 'freetype2 >= 18.3.12' && echo yes),yes)
+-    SYS_FREETYPE_CFLAGS := $(shell pkg-config --cflags freetype2)
+-    SYS_FREETYPE_LIBS := $(shell pkg-config --libs freetype2)
+-  endif
+-  ifeq ($(shell pkg-config --exists 'gumbo >= 0.10.0' && echo yes),yes)
+-    SYS_GUMBO_CFLAGS := $(shell pkg-config --cflags gumbo)
+-    SYS_GUMBO_LIBS := $(shell pkg-config --libs gumbo)
+-  endif
+-  ifeq ($(shell pkg-config --exists 'harfbuzz >= 2.0.0' && echo yes),yes)
+-    SYS_HARFBUZZ_CFLAGS := $(shell pkg-config --cflags harfbuzz)
+-    SYS_HARFBUZZ_LIBS := $(shell pkg-config --libs harfbuzz)
+-  endif
+-  ifeq ($(shell pkg-config --exists lcms2 && echo yes),yes)
+-    SYS_LCMS2_CFLAGS := $(shell pkg-config --cflags lcms2)
+-    SYS_LCMS2_LIBS := $(shell pkg-config --libs lcms2)
+-  endif
+-  ifeq ($(shell pkg-config --exists libjpeg && echo yes),yes)
+-    SYS_LIBJPEG_CFLAGS := $(shell pkg-config --cflags libjpeg)
+-    SYS_LIBJPEG_LIBS := $(shell pkg-config --libs libjpeg)
+-  endif
+-  ifeq ($(shell pkg-config --exists 'libopenjp2 >= 2.1.0' && echo yes),yes)
+-    SYS_OPENJPEG_CFLAGS := $(shell pkg-config --cflags libopenjp2)
+-    SYS_OPENJPEG_LIBS := $(shell pkg-config --libs libopenjp2)
+-  endif
+-  ifeq ($(shell pkg-config --exists 'zlib >= 1.2.6' && echo yes),yes)
+-    SYS_ZLIB_CFLAGS := $(shell pkg-config --cflags zlib)
+-    SYS_ZLIB_LIBS := $(shell pkg-config --libs zlib)
+-  endif
+-  ifeq ($(shell pkg-config --exists 'libbrotlidec libbrotlienc >= 0.6.0' && echo yes),yes)
+-    SYS_BROTLI_CFLAGS := $(shell pkg-config --cflags libbrotlidec libbrotlienc)
+-    SYS_BROTLI_LIBS := $(shell pkg-config --libs libbrotlidec libbrotlienc)
+-  endif
++ifeq ($(shell pkg-config --exists 'freetype2 >= 18.3.12' && echo yes),yes)
++  SYS_FREETYPE_CFLAGS := $(shell pkg-config --cflags freetype2)
++  SYS_FREETYPE_LIBS := $(shell pkg-config --libs freetype2)
++endif
++ifeq ($(shell pkg-config --exists 'gumbo >= 0.10.0' && echo yes),yes)
++  SYS_GUMBO_CFLAGS := $(shell pkg-config --cflags gumbo)
++  SYS_GUMBO_LIBS := $(shell pkg-config --libs gumbo)
++endif
++ifeq ($(shell pkg-config --exists 'harfbuzz >= 2.0.0' && echo yes),yes)
++  SYS_HARFBUZZ_CFLAGS := $(shell pkg-config --cflags harfbuzz)
++  SYS_HARFBUZZ_LIBS := $(shell pkg-config --libs harfbuzz)
++endif
++ifeq ($(shell pkg-config --exists lcms2 && echo yes),yes)
++  SYS_LCMS2_CFLAGS := $(shell pkg-config --cflags lcms2)
++  SYS_LCMS2_LIBS := $(shell pkg-config --libs lcms2)
++endif
++ifeq ($(shell pkg-config --exists libjpeg && echo yes),yes)
++  SYS_LIBJPEG_CFLAGS := $(shell pkg-config --cflags libjpeg)
++  SYS_LIBJPEG_LIBS := $(shell pkg-config --libs libjpeg)
++endif
++ifeq ($(shell pkg-config --exists 'libopenjp2 >= 2.1.0' && echo yes),yes)
++  SYS_OPENJPEG_CFLAGS := $(shell pkg-config --cflags libopenjp2)
++  SYS_OPENJPEG_LIBS := $(shell pkg-config --libs libopenjp2)
++endif
++ifeq ($(shell pkg-config --exists 'zlib >= 1.2.6' && echo yes),yes)
++  SYS_ZLIB_CFLAGS := $(shell pkg-config --cflags zlib)
++  SYS_ZLIB_LIBS := $(shell pkg-config --libs zlib)
++endif
++ifeq ($(shell pkg-config --exists 'libbrotlidec libbrotlienc >= 0.6.0' && echo yes),yes)
++  SYS_BROTLI_CFLAGS := $(shell pkg-config --cflags libbrotlidec libbrotlienc)
++  SYS_BROTLI_LIBS := $(shell pkg-config --libs libbrotlidec libbrotlienc)
++endif
+ 
+-  HAVE_SYS_LEPTONICA := $(shell pkg-config --exists 'lept >= 1.7.4' && echo yes)
+-  ifeq ($(HAVE_SYS_LEPTONICA),yes)
+-    SYS_LEPTONICA_CFLAGS := $(shell pkg-config --cflags lept)
+-    SYS_LEPTONICA_LIBS := $(shell pkg-config --libs lept)
+-  endif
++HAVE_SYS_LEPTONICA := $(shell pkg-config --exists 'lept >= 1.7.4' && echo yes)
++ifeq ($(HAVE_SYS_LEPTONICA),yes)
++  SYS_LEPTONICA_CFLAGS := $(shell pkg-config --cflags lept)
++  SYS_LEPTONICA_LIBS := $(shell pkg-config --libs lept)
++endif
+ 
+-  HAVE_SYS_TESSERACT := $(shell pkg-config --exists 'tesseract >= 4.0.0' && echo yes)
+-  ifeq ($(HAVE_SYS_TESSERACT),yes)
+-    SYS_TESSERACT_CFLAGS := $(shell pkg-config --cflags tesseract)
+-    SYS_TESSERACT_LIBS := $(shell pkg-config --libs tesseract)
+-  endif
++HAVE_SYS_TESSERACT := $(shell pkg-config --exists 'tesseract >= 4.0.0' && echo yes)
++ifeq ($(HAVE_SYS_TESSERACT),yes)
++  SYS_TESSERACT_CFLAGS := $(shell pkg-config --cflags tesseract)
++  SYS_TESSERACT_LIBS := $(shell pkg-config --libs tesseract)
++endif
+ 
+-  HAVE_SYS_LIBARCHIVE := $(shell pkg-config --exists 'libarchive' && echo yes)
+-  ifeq ($(HAVE_SYS_LIBARCHIVE),yes)
+-    SYS_LIBARCHIVE_CFLAGS := $(shell pkg-config --cflags libarchive)
+-    SYS_LIBARCHIVE_LIBS := $(shell pkg-config --libs libarchive)
+-  endif
++HAVE_SYS_LIBARCHIVE := $(shell pkg-config --exists 'libarchive' && echo yes)
++ifeq ($(HAVE_SYS_LIBARCHIVE),yes)
++  SYS_LIBARCHIVE_CFLAGS := $(shell pkg-config --cflags libarchive)
++  SYS_LIBARCHIVE_LIBS := $(shell pkg-config --libs libarchive)
++endif
+ 
+-  HAVE_SYS_ZXINGCPP := $(shell pkg-config --exists 'zxing >= 2.0.0' && echo yes)
+-  ifeq ($(HAVE_SYS_ZXINGCPP),yes)
+-    SYS_ZXINGCPP_CFLAGS := $(shell pkg-config --cflags zxing)
+-    SYS_ZXINGCPP_LIBS := $(shell pkg-config --libs zxing)
+-  endif
++HAVE_SYS_ZXINGCPP := $(shell pkg-config --exists 'zxing >= 2.0.0' && echo yes)
++ifeq ($(HAVE_SYS_ZXINGCPP),yes)
++  SYS_ZXINGCPP_CFLAGS := $(shell pkg-config --cflags zxing)
++  SYS_ZXINGCPP_LIBS := $(shell pkg-config --libs zxing)
++endif
+ 
+-  HAVE_SYS_CURL := $(shell pkg-config --exists libcurl && echo yes)
+-  ifeq ($(HAVE_SYS_CURL),yes)
+-    SYS_CURL_CFLAGS := $(shell pkg-config --cflags libcurl)
+-    SYS_CURL_LIBS := $(shell pkg-config --libs libcurl)
+-  endif
++HAVE_SYS_CURL := $(shell pkg-config --exists libcurl && echo yes)
++ifeq ($(HAVE_SYS_CURL),yes)
++  SYS_CURL_CFLAGS := $(shell pkg-config --cflags libcurl)
++  SYS_CURL_LIBS := $(shell pkg-config --libs libcurl)
++endif
+ 
++ifeq ($(OS),Darwin)
++    HAVE_GLUT := yes
++    SYS_GLUT_CFLAGS := -Wno-deprecated-declarations
++    SYS_GLUT_LIBS := -framework GLUT -framework OpenGL
++else
+   ifeq ($(HAVE_GLUT),)
+     HAVE_GLUT := $(shell pkg-config --exists gl x11 xrandr && echo yes)
+   endif
+@@ -321,29 +302,28 @@ else
+       SYS_GLUT_LIBS := -lglut
+     endif
+   endif
++endif
+ 
+-  ifeq ($(HAVE_X11),)
+-    HAVE_X11 := $(shell pkg-config --exists x11 xext && echo yes)
+-  endif
+-  ifeq ($(HAVE_X11),yes)
+-    X11_CFLAGS := $(shell pkg-config --cflags x11 xext)
+-    X11_LIBS := $(shell pkg-config --libs x11 xext)
+-  endif
+-
+-  ifeq ($(HAVE_LIBCRYPTO),)
+-    HAVE_LIBCRYPTO := $(shell pkg-config --exists 'libcrypto >= 1.1.0' && echo yes)
+-  endif
+-  ifeq ($(HAVE_LIBCRYPTO),yes)
+-    LIBCRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto) -DHAVE_LIBCRYPTO
+-    LIBCRYPTO_LIBS := $(shell pkg-config --libs libcrypto)
+-  endif
++ifeq ($(HAVE_X11),)
++  HAVE_X11 := $(shell pkg-config --exists x11 xext && echo yes)
++endif
++ifeq ($(HAVE_X11),yes)
++  X11_CFLAGS := $(shell pkg-config --cflags x11 xext)
++  X11_LIBS := $(shell pkg-config --libs x11 xext)
++endif
+ 
+-  HAVE_PTHREAD := yes
+-  ifeq ($(HAVE_PTHREAD),yes)
+-    PTHREAD_CFLAGS :=
+-    PTHREAD_LIBS := -lpthread
+-  endif
++ifeq ($(HAVE_LIBCRYPTO),)
++  HAVE_LIBCRYPTO := $(shell pkg-config --exists 'libcrypto >= 1.1.0' && echo yes)
++endif
++ifeq ($(HAVE_LIBCRYPTO),yes)
++  LIBCRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto) -DHAVE_LIBCRYPTO
++  LIBCRYPTO_LIBS := $(shell pkg-config --libs libcrypto)
++endif
+ 
++HAVE_PTHREAD := yes
++ifeq ($(HAVE_PTHREAD),yes)
++  PTHREAD_CFLAGS :=
++  PTHREAD_LIBS := -lpthread
+ endif
+ 
+ # The following section has various cross compilation configurations.


### PR DESCRIPTION
I broke builds of mupdf on Darwin in #410552. This should fix it -- I don't have a Darwin box myself, but it seems to build on GitHub Actions.

Current staging-next iteration: #412425


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
