### PR TITLE
zig: move passthru into a separate file & add fetcher

### DIFF
--- a/pkgs/by-name/bl/blackshades/package.nix
+++ b/pkgs/by-name/bl/blackshades/package.nix
@@ -25,25 +25,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   postUnpack = ''
     ln -s ${
-      runCommand "${finalAttrs.finalPackage.name}-zig-deps"
-        {
-          inherit (finalAttrs) src;
-
-          nativeBuildInputs = [ zig_0_14 ];
-
-          outputHashAlgo = null;
-          outputHashMode = "recursive";
-          outputHash = "sha256-wBIfLeaKtTow2Z7gjEgIFmqcTGWgpRWI+k0t294BslM=";
-        }
-        ''
-          export ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
-
-          runHook unpackPhase
-          cd $sourceRoot
-
-          zig build --fetch
-          mv $ZIG_GLOBAL_CACHE_DIR/p $out
-        ''
+      zig_0_14.fetchDeps {
+        inherit (finalAttrs)
+          src
+          pname
+          version
+          ;
+        hash = "sha256-wBIfLeaKtTow2Z7gjEgIFmqcTGWgpRWI+k0t294BslM=";
+      }
     } $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/development/compilers/zig/fetcher.nix
+++ b/pkgs/development/compilers/zig/fetcher.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  zig,
+  runCommand,
+}:
+{
+  pname,
+  version,
+  name ? "${pname}-${version}",
+  src,
+  hash ? lib.fakeHash,
+}@args:
+runCommand "${name}-zig-deps"
+  {
+    inherit (args) src;
+
+    nativeBuildInputs = [ zig ];
+
+    outputHashAlgo = null;
+    outputHashMode = "recursive";
+    outputHash = hash;
+  }
+  ''
+    export ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
+
+    runHook unpackPhase
+
+    cd $sourceRoot
+    zig build --fetch
+
+    mv $ZIG_GLOBAL_CACHE_DIR/p $out
+  ''

--- a/pkgs/development/compilers/zig/passthru.nix
+++ b/pkgs/development/compilers/zig/passthru.nix
@@ -30,4 +30,6 @@
   };
 
   stdenv = overrideCC stdenv zig.cc;
+
+  fetchDeps = callPackage ./fetcher.nix { inherit zig; };
 }

--- a/pkgs/development/compilers/zig/passthru.nix
+++ b/pkgs/development/compilers/zig/passthru.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  zig,
+  callPackage,
+  wrapCCWith,
+  wrapBintoolsWith,
+  overrideCC,
+  targetPackages,
+}:
+{
+  hook = callPackage ./hook.nix { inherit zig; };
+
+  bintools-unwrapped = callPackage ./bintools.nix { inherit zig; };
+  bintools = wrapBintoolsWith { bintools = zig.bintools-unwrapped; };
+
+  cc-unwrapped = callPackage ./cc.nix { inherit zig; };
+  cc = wrapCCWith {
+    cc = zig.cc-unwrapped;
+    bintools = zig.bintools;
+    extraPackages = [ ];
+    nixSupport.cc-cflags =
+      [
+        "-target"
+        "${stdenv.targetPlatform.system}-${stdenv.targetPlatform.parsed.abi.name}"
+      ]
+      ++ lib.optional (
+        stdenv.targetPlatform.isLinux && !(stdenv.targetPlatform.isStatic or false)
+      ) "-Wl,-dynamic-linker=${targetPackages.stdenv.cc.bintools.dynamicLinker}";
+  };
+
+  stdenv = overrideCC stdenv zig.cc;
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Moves the passthru into a separate file and adds a fetcher. The separate file will be useful for https://github.com/mitchellh/zig-overlay. The fetcher is recommended to fetch zig dependencies.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
