### PR TITLE
python3Packages.coverage: 7.8.0 -> 7.8.2

### DIFF
--- a/pkgs/development/python-modules/coverage/default.nix
+++ b/pkgs/development/python-modules/coverage/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "coverage";
-  version = "7.8.0";
+  version = "7.8.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nedbat";
     repo = "coveragepy";
     tag = version;
-    hash = "sha256-clnwx9Fa75aLfGe/MZVtIzE8Ah5EY7MQf8g11TSkl/c=";
+    hash = "sha256-PCMGxyG5zIc8iigi9BsuhyuyQindZnewqTgxErT/jHw=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/coverage/default.nix
+++ b/pkgs/development/python-modules/coverage/default.nix
@@ -1,10 +1,14 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  mock,
+  fetchFromGitHub,
+  flaky,
+  hypothesis,
+  pytest-xdist,
+  pytestCheckHook,
   pythonOlder,
   setuptools,
+  tomli,
 }:
 
 buildPythonPackage rec {
@@ -12,23 +16,66 @@ buildPythonPackage rec {
   version = "7.8.0";
   pyproject = true;
 
-  # uses f strings
-  disabled = pythonOlder "3.5";
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-ej1is7A7S2/UGghfNXSHTPlGy0YE0rTT6NyozVcMpQE=";
+  src = fetchFromGitHub {
+    owner = "nedbat";
+    repo = "coveragepy";
+    tag = version;
+    hash = "sha256-clnwx9Fa75aLfGe/MZVtIzE8Ah5EY7MQf8g11TSkl/c=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  postPatch = ''
+    # don't write to Nix store
+    substituteInPlace tests/conftest.py \
+      --replace-fail 'if WORKER == "none":' "if False:"
+  '';
 
-  # No tests in archive
-  doCheck = false;
-  nativeCheckInputs = [ mock ];
+  build-system = [ setuptools ];
+
+  optional-dependencies = {
+    toml = lib.optionals (pythonOlder "3.11") [
+      tomli
+    ];
+  };
+
+  nativeCheckInputs = [
+    flaky
+    hypothesis
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export PATH="$PATH:$out/bin"
+    # import from $out
+    rm -r coverage
+  '';
+
+  disabledTests = [
+    "test_all_our_source_files"
+    "test_doctest"
+    "test_files_up_one_level"
+    "test_get_encoded_zip_files"
+    "test_metadata"
+    "test_more_metadata"
+    "test_multi"
+    "test_no_duplicate_packages"
+    "test_xdist_sys_path_nuttiness_is_fixed"
+    "test_zipfile"
+  ];
+
+  disabledTestPaths = [
+    "tests/test_debug.py"
+    "tests/test_plugins.py"
+    "tests/test_process.py"
+    "tests/test_report.py"
+    "tests/test_venv.py"
+  ];
 
   meta = {
-    description = "Code coverage measurement for python";
-    homepage = "https://coverage.readthedocs.io/";
-    license = lib.licenses.bsd3;
+    changelog = "https://github.com/nedbat/coveragepy/blob/${src.tag}/CHANGES.rst";
+    description = "Code coverage measurement for Python";
+    homepage = "https://github.com/nedbat/coveragepy";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dotlambda ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/nedbat/coveragepy/compare/refs/tags/7.8.0...refs/tags/7.8.2

Changelog: https://github.com/nedbat/coveragepy/blob/7.8.2/CHANGES.rst
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
