### PR TITLE
treewide: Leverage new top-level `libc` in bootstrap, and simplify

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -242,7 +242,7 @@ self: super:
         buildPackages.stdenv.cc
       ]
       ++ lib.optionals stdenv.hostPlatform.isStatic [
-        (xorg.buildPackages.stdenv.cc.libc.static or null)
+        (xorg.buildPackages.libc.static or null)
       ];
     preConfigure = ''
       sed 's,^as_dummy.*,as_dummy="\$PATH",' -i configure

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -132,7 +132,7 @@ let
             bintools = prevStage.darwin.binutils;
 
             isClang = true;
-            libc = prevStage.darwin.libSystem;
+            inherit (prevStage) libc;
             inherit (prevStage.llvmPackages) libcxx;
 
             inherit lib;
@@ -582,7 +582,10 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
     assert allDeps isFromNixpkgs [
       (sdkPackagesNoCC prevStage)
-      { inherit (prevStage.darwin) binutils libSystem; }
+      {
+        inherit (prevStage.darwin) binutils libSystem;
+        inherit (prevStage) libc;
+      }
     ];
 
     stageFun prevStage {
@@ -1260,6 +1263,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     assert isBuiltByNixpkgsCompiler prevStage.darwin.sigtool;
 
     assert isFromNixpkgs prevStage.darwin.libSystem;
+    assert isFromNixpkgs prevStage.libc;
     assert isFromNixpkgs prevStage.darwin.binutils-unwrapped;
 
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.clang-unwrapped;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -158,8 +158,6 @@ let
     isFromBootstrapFiles = true;
   };
 
-  getLibc = stage: stage.${localSystem.libc};
-
   # This function builds the various standard environments used during
   # the bootstrap.  In all stages, we build an stdenv and the package
   # set that can be built with that stdenv.
@@ -207,7 +205,7 @@ let
               cc = prevStage.gcc-unwrapped;
               bintools = prevStage.binutils;
               isGNU = true;
-              libc = getLibc prevStage;
+              inherit (prevStage) libc;
               inherit lib;
               inherit (prevStage) coreutils gnugrep;
               stdenvNoCC = prevStage.ccWrapperStdenv;
@@ -221,7 +219,7 @@ let
                   postFixup =
                     (a.postFixup or "")
                     + ''
-                      echo "--sysroot=${lib.getDev (getLibc prevStage)}" >> $out/nix-support/cc-cflags
+                      echo "--sysroot=${lib.getDev prevStage.libc}" >> $out/nix-support/cc-cflags
                     '';
                 }
               );
@@ -293,9 +291,13 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           nativeTools = false;
           nativeLibc = false;
           expand-response-params = "";
-          libc = getLibc self;
           inherit lib;
-          inherit (self) stdenvNoCC coreutils gnugrep;
+          inherit (self)
+            stdenvNoCC
+            coreutils
+            gnugrep
+            libc
+            ;
           bintools = bootstrapTools;
           runtimeShell = "${bootstrapTools}/bin/bash";
         };
@@ -320,6 +322,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     # previous stage0 stdenv:
     assert isFromBootstrapFiles prevStage.binutils.bintools;
     assert isFromBootstrapFiles prevStage."${localSystem.libc}";
+    assert isFromBootstrapFiles prevStage.libc;
     assert isFromBootstrapFiles prevStage.gcc-unwrapped;
     assert isFromBootstrapFiles prevStage.coreutils;
     assert isFromBootstrapFiles prevStage.gnugrep;
@@ -339,7 +342,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           binutils
           ;
 
-        ${localSystem.libc} = getLibc prevStage;
+        ${localSystem.libc} = prevStage.${localSystem.libc};
 
         # A threaded perl build needs glibc/libpthread_nonshared.a,
         # which is not included in bootstrapTools, so disable threading.
@@ -374,6 +377,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     prevStage:
     assert isBuiltByBootstrapFilesCompiler prevStage.binutils-unwrapped;
     assert isFromBootstrapFiles prevStage."${localSystem.libc}";
+    assert isFromBootstrapFiles prevStage.libc;
     assert isFromBootstrapFiles prevStage.gcc-unwrapped;
     assert isFromBootstrapFiles prevStage.coreutils;
     assert isFromBootstrapFiles prevStage.gnugrep;
@@ -393,7 +397,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           perl
           patchelf
           ;
-        ${localSystem.libc} = getLibc prevStage;
+        ${localSystem.libc} = prevStage.${localSystem.libc};
         gmp = super.gmp.override { cxx = false; };
         # This stage also rebuilds binutils which will of course be used only in the next stage.
         # We inherit this until stage3, in stage4 it will be rebuilt using the adjacent bash/runtimeShell pkg.
@@ -484,6 +488,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     # previous stage1 stdenv:
     assert isBuiltByBootstrapFilesCompiler prevStage.binutils-unwrapped;
     assert isFromBootstrapFiles prevStage."${localSystem.libc}";
+    assert isFromBootstrapFiles prevStage.libc;
     assert isBuiltByBootstrapFilesCompiler prevStage.gcc-unwrapped;
     assert isFromBootstrapFiles prevStage.coreutils;
     assert isFromBootstrapFiles prevStage.gnugrep;
@@ -507,6 +512,9 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
         dejagnu = super.dejagnu.overrideAttrs (a: {
           doCheck = false;
         });
+
+        # Avoids infinite recursion, as this is in the build-time dependencies of libc.
+        libiconv = self.libcIconv prevStage.libc;
 
         # We need libidn2 and its dependency libunistring as glibc dependency.
         # To avoid the cycle, we build against bootstrap libc, nuke references,
@@ -538,7 +546,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
         binutils = prevStage.binutils.override {
           # Rewrap the binutils with the new glibc, so both the next
           # stage's wrappers use it.
-          libc = getLibc self;
+          inherit (self) libc;
 
           # Unfortunately, when building gcc in the next stage, its LTO plugin
           # would use the final libc but `ld` would use the bootstrap one,
@@ -557,8 +565,8 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               mkdir -p "$out"/bin
               cp -a '${prevStage.bintools.bintools}'/bin/* "$out"/bin/
               chmod +w "$out"/bin/ld.bfd
-              patchelf --set-interpreter '${getLibc self}'/lib/ld*.so.? \
-                --set-rpath "${getLibc self}/lib:$(patchelf --print-rpath "$out"/bin/ld.bfd)" \
+              patchelf --set-interpreter '${self.libc}'/lib/ld*.so.? \
+                --set-rpath "${self.libc}/lib:$(patchelf --print-rpath "$out"/bin/ld.bfd)" \
                 "$out"/bin/ld.bfd
             '';
           };
@@ -589,6 +597,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     # previous stage2 stdenv:
     assert isBuiltByNixpkgsCompiler prevStage.binutils-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.${localSystem.libc};
+    assert isBuiltByNixpkgsCompiler prevStage.libc;
     assert isBuiltByBootstrapFilesCompiler prevStage.gcc-unwrapped;
     assert isFromBootstrapFiles prevStage.coreutils;
     assert isFromBootstrapFiles prevStage.gnugrep;
@@ -625,7 +634,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           gmp = super.gmp.override { cxx = false; };
         }
         // {
-          ${localSystem.libc} = getLibc prevStage;
+          ${localSystem.libc} = prevStage.${localSystem.libc};
           gcc-unwrapped =
             (super.gcc-unwrapped.override (
               commonGccOverrides
@@ -661,6 +670,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     # previous stage3 stdenv:
     assert isBuiltByNixpkgsCompiler prevStage.binutils-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.${localSystem.libc};
+    assert isBuiltByNixpkgsCompiler prevStage.libc;
     assert isBuiltByNixpkgsCompiler prevStage.gcc-unwrapped;
     assert isFromBootstrapFiles prevStage.coreutils;
     assert isFromBootstrapFiles prevStage.gnugrep;
@@ -684,7 +694,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           libidn2
           libunistring
           ;
-        ${localSystem.libc} = getLibc prevStage;
+        ${localSystem.libc} = prevStage.${localSystem.libc};
         # Since this is the first fresh build of binutils since stage2, our own runtimeShell will be used.
         binutils = super.binutils.override {
           # Build expand-response-params with last stage like below
@@ -702,13 +712,13 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           inherit (prevStage) expand-response-params;
           cc = prevStage.gcc-unwrapped;
           bintools = self.binutils;
-          libc = getLibc self;
           inherit lib;
           inherit (self)
             stdenvNoCC
             coreutils
             gnugrep
             runtimeShell
+            libc
             ;
           fortify-headers = self.fortify-headers;
         };
@@ -736,6 +746,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     # which applies here as well.
     assert isBuiltByNixpkgsCompiler prevStage.binutils-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.${localSystem.libc};
+    assert isBuiltByNixpkgsCompiler prevStage.libc;
     assert isBuiltByNixpkgsCompiler prevStage.gcc-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.coreutils;
     assert isBuiltByNixpkgsCompiler prevStage.gnugrep;
@@ -843,7 +854,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
             libunistring
           ]
           # More complicated cases
-          ++ (map (x: lib.getOutput x (getLibc prevStage)) [
+          ++ (map (x: lib.getOutput x (prevStage.libc)) [
             "out"
             "dev"
             "bin"
@@ -893,7 +904,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               libunistring
               ;
             inherit (prevStage.gnugrep) pcre2;
-            ${localSystem.libc} = getLibc prevStage;
+            ${localSystem.libc} = prevStage.${localSystem.libc};
 
             # Hack: avoid libidn2.{bin,dev} referencing bootstrap tools.  There's a logical cycle.
             libidn2 = import ../../development/libraries/libidn2/no-bootstrap-reference.nix {
@@ -925,6 +936,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     # which applies here as well.
     assert isBuiltByNixpkgsCompiler prevStage.binutils-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.${localSystem.libc};
+    assert isBuiltByNixpkgsCompiler prevStage.libc;
     assert isBuiltByNixpkgsCompiler prevStage.gcc-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.coreutils;
     assert isBuiltByNixpkgsCompiler prevStage.gnugrep;

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -3,9 +3,12 @@
 }:
 
 let
-  inherit (pkgs) lib stdenv config;
-
-  libc = pkgs.stdenv.cc.libc;
+  inherit (pkgs)
+    lib
+    stdenv
+    config
+    libc
+    ;
 
   patchelf = pkgs.patchelf.overrideAttrs (previousAttrs: {
     NIX_CFLAGS_COMPILE = (previousAttrs.NIX_CFLAGS_COMPILE or [ ]) ++ [

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -56,8 +56,7 @@ makeScopeWithSplicing' {
       };
 
       binutils = pkgs.wrapBintoolsWith {
-        libc =
-          if stdenv.targetPlatform != stdenv.hostPlatform then targetPackages.libc else pkgs.stdenv.cc.libc;
+        inherit (targetPackages) libc;
         bintools = self.binutils-unwrapped;
       };
 

--- a/pkgs/top-level/unixtools.nix
+++ b/pkgs/top-level/unixtools.nix
@@ -95,7 +95,7 @@ let
       linux = pkgs.util-linux;
     };
     getconf = {
-      linux = if stdenv.hostPlatform.libc == "glibc" then pkgs.stdenv.cc.libc else pkgs.netbsd.getconf;
+      linux = if stdenv.hostPlatform.libc == "glibc" then pkgs.libc else pkgs.netbsd.getconf;
       darwin = pkgs.darwin.system_cmds;
       # I don't see any obvious arg exec in the doc/manpage
       binlore = ''
@@ -103,8 +103,7 @@ let
       '';
     };
     getent = {
-      linux =
-        if stdenv.hostPlatform.libc == "glibc" then pkgs.stdenv.cc.libc.getent else pkgs.netbsd.getent;
+      linux = if stdenv.hostPlatform.libc == "glibc" then pkgs.libc.getent else pkgs.netbsd.getent;
       darwin = pkgs.netbsd.getent;
       freebsd = pkgs.freebsd.getent;
       openbsd = pkgs.openbsd.getent;


### PR DESCRIPTION
Picking up where #414321 left off, we can now simplify some things by using `pkgs.libc` or `targetPackages.libc` consistently.

Individual packages should probably continue using `stdenv.cc.libc`, for now at least, since it is possible they are given a `stdenv.cc` with an alternative libc, but for the treewide code, the top-level `libc` package is preferable and easier to work with.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
