### PR TITLE
ubootVisionFive2: init

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -27,6 +27,7 @@
   armTrustedFirmwareRK3568,
   armTrustedFirmwareRK3588,
   armTrustedFirmwareS905,
+  opensbi,
   buildPackages,
 }@pkgs:
 
@@ -807,6 +808,26 @@ in
     # sata init; load sata 0 $loadaddr u-boot-with-nand-spl.imx
     # sf probe; sf update $loadaddr 0 80000
   };
+
+  ubootVisionFive2 =
+    let
+      opensbi_vf2 = opensbi.overrideAttrs (attrs: {
+        makeFlags = attrs.makeFlags ++ [
+          # Matches u-boot documentation: https://docs.u-boot.org/en/latest/board/starfive/visionfive2.html
+          "FW_TEXT_START=0x40000000"
+          "FW_OPTIONS=0"
+        ];
+      });
+    in
+    buildUBoot {
+      defconfig = "starfive_visionfive2_defconfig";
+      extraMeta.platforms = [ "riscv64-linux" ];
+      OPENSBI = "${opensbi_vf2}/share/opensbi/lp64/generic/firmware/fw_dynamic.bin";
+      filesToInstall = [
+        "spl/u-boot-spl.bin.normal.out"
+        "u-boot.itb"
+      ];
+    };
 
   ubootWandboard = buildUBoot {
     defconfig = "wandboard_defconfig";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11552,6 +11552,7 @@ with pkgs;
     ubootSopine
     ubootTuringRK1
     ubootUtilite
+    ubootVisionFive2
     ubootWandboard
     ;
 


### PR DESCRIPTION
A rebased version of https://github.com/NixOS/nixpkgs/pull/333652

Tested by writing it to the SPI and booting NixOS
```
% cat /proc/mtd
dev:    size   erasesize  name
mtd0: 000f0000 00001000 "spl"
mtd1: 00010000 00001000 "uboot-env"
mtd2: 00f00000 00001000 "uboot"
% sudo flashcp -v result/u-boot-spl.bin.normal.out /dev/mtd0
Erasing blocks: 36/36 (100%)
Writing data: 143k/143k (100%)
Verifying data: 143k/143k (100%)
% sudo flashcp -v result/u-boot.itb /dev/mtd2
Erasing blocks: 251/251 (100%)
Writing data: 1002k/1002k (100%)
Verifying data: 1002k/1002k (100%)
```

```
U-Boot SPL 2025.01 (Jan 07 2025 - 00:54:44 +0000)
DDR version: dc2e84f0.
Trying to boot from SPI

OpenSBI v1.6
   ____                    _____ ____ _____
  / __ \                  / ____|  _ \_   _|
 | |  | |_ __   ___ _ __ | (___ | |_) || |
 | |  | | '_ \ / _ \ '_ \ \___ \|  _ < | |
 | |__| | |_) |  __/ | | |____) | |_) || |_
  \____/| .__/ \___|_| |_|_____/|____/_____|
        | |
        |_|

Platform Name               : StarFive VisionFive 2 v1.3B
Platform Features           : medeleg
Platform HART Count         : 5
Platform IPI Device         : aclint-mswi
Platform Timer Device       : aclint-mtimer @ 4000000Hz
Platform Console Device     : uart8250
Platform HSM Device         : ---
Platform PMU Device         : ---
Platform Reboot Device      : pm-reset
Platform Shutdown Device    : pm-reset
Platform Suspend Device     : ---
Platform CPPC Device        : ---
Firmware Base               : 0x40000000
Firmware Size               : 373 KB
Firmware RW Offset          : 0x40000
Firmware RW Size            : 117 KB
Firmware Heap Offset        : 0x50000
Firmware Heap Size          : 53 KB (total), 3 KB (reserved), 13 KB (used), 36 KB (free)
Firmware Scratch Size       : 4096 B (total), 440 B (used), 3656 B (free)
Runtime SBI Version         : 2.0
Standard SBI Extensions     : time,rfnc,ipi,base,hsm,srst,pmu,dbcn,legacy
Experimental SBI Extensions : fwft,dbtr,sse

Domain0 Name                : root
Domain0 Boot HART           : 2
Domain0 HARTs               : 0*,1*,2*,3*,4*
Domain0 Region00            : 0x0000000010000000-0x0000000010000fff M: (I,R,W) S/U: (R,W)
Domain0 Region01            : 0x0000000002000000-0x000000000200ffff M: (I,R,W) S/U: ()
Domain0 Region02            : 0x0000000040040000-0x000000004005ffff M: (R,W) S/U: ()
Domain0 Region03            : 0x0000000040000000-0x000000004003ffff M: (R,X) S/U: ()
Domain0 Region04            : 0x000000000c000000-0x000000000fffffff M: (I,R,W) S/U: (R,W)
Domain0 Region05            : 0x0000000000000000-0xffffffffffffffff M: () S/U: (R,W,X)
Domain0 Next Address        : 0x0000000040200000
Domain0 Next Arg1           : 0x0000000040400000
Domain0 Next Mode           : S-mode
Domain0 SysReset            : yes
Domain0 SysSuspend          : yes

Boot HART ID                : 2
Boot HART Domain            : root
Boot HART Priv Version      : v1.11
Boot HART Base ISA          : rv64imafdcbx
Boot HART ISA Extensions    : zihpm,sdtrig
Boot HART PMP Count         : 8
Boot HART PMP Granularity   : 12 bits
Boot HART PMP Address Bits  : 34
Boot HART MHPM Info         : 2 (0x00000018)
Boot HART Debug Triggers    : 8 triggers
Boot HART MIDELEG           : 0x0000000000000222
Boot HART MEDELEG           : 0x000000000000b109


U-Boot 2025.01 (Jan 07 2025 - 00:54:44 +0000)

CPU:   sifive,u74-mc
Model: StarFive VisionFive 2 v1.3B
DRAM:  8 GiB
Core:  136 devices, 26 uclasses, devicetree: board
WDT:   Not starting watchdog@13070000
MMC:   mmc@16010000: 0, mmc@16020000: 1
Loading Environment from SPIFlash... SF: Detected gd25lq128 with page size 256 Bytes, erase size 4 KiB, total 16 MiB
OK
StarFive EEPROM format v2

--------EEPROM INFO--------
Vendor : StarFive Technology Co., Ltd.
Product full SN: VF7110B1-2253-D008E000-00002367
data version: 0x2
PCB revision: 0xb2
BOM revision: A
Ethernet MAC0 address: 6c:cf:39:00:34:47
Ethernet MAC1 address: 6c:cf:39:00:34:48
--------EEPROM INFO--------

starfive_7110_pcie pcie@2b000000: Starfive PCIe bus probed.
starfive_7110_pcie pcie@2c000000: Starfive PCIe bus probed.
In:    serial@10000000
Out:   serial@10000000
Err:   serial@10000000
Net:   eth0: ethernet@16030000, eth1: ethernet@16040000
starting USB...
Bus xhci_pci: Register 5000420 NbrPorts 5
Starting the controller
USB XHCI 1.00
scanning bus xhci_pci for devices... 2 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Working FDT set to ff72ca10
Hit any key to stop autoboot:  0
```

Closes: https://github.com/NixOS/nixpkgs/pull/333652

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (`pkgsCross.riscv64.ubootVisionFive2`)
  - [X] riscv64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
