### PR TITLE
quint: init at 0.25.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3802,6 +3802,12 @@
     githubId = 2379774;
     name = "Sean Buckley";
   };
+  bugarela = {
+    email = "gabrielamoreira05@gmail.com";
+    github = "bugarela";
+    githubId = 18356186;
+    name = "Gabriela Moreira";
+  };
   bugworm = {
     email = "bugworm@zoho.com";
     github = "bugworm";

--- a/pkgs/by-name/qu/quint/package.nix
+++ b/pkgs/by-name/qu/quint/package.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  nodejs,
+  nodejs_20,
+  makeWrapper,
+  jre,
+  fetchzip,
+  buildNpmPackage,
+}:
+
+let
+  version = "0.25.1";
+  apalacheVersion = "0.47.2";
+  evaluatorVersion = "0.2.0";
+
+  metaCommon = {
+    description = "Formal specification language with TLA+ semantics";
+    homepage = "https://quint-lang.org";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ bugarela ];
+  };
+
+  src = fetchFromGitHub {
+    owner = "informalsystems";
+    repo = "quint";
+    tag = "v${version}";
+    hash = "sha256-CYQesIoDlIGCKXIJ/hpZqOZBVd19Or5VEKVERchJz68=";
+  };
+
+  # Build the Quint CLI from source
+  quint-cli = buildNpmPackage {
+    pname = "quint-cli";
+    inherit version src;
+
+    nativeBuildInputs = [ nodejs_20 ];
+
+    sourceRoot = "${src.name}/quint";
+
+    npmDepsHash = "sha256-FYNSr5B0/oJ4PbU/HUVqSdPG8kFvq4vRFnYwwdMf+jQ=";
+
+    npmBuildScript = "compile";
+
+    dontNpmPrune = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/quint
+      cp -r node_modules $out/share/quint
+      cp -r dist $out/share/quint
+
+      runHook postInstall
+    '';
+
+    meta = metaCommon // {
+      description = "CLI for the Quint formal specification language";
+    };
+  };
+
+  # Build the Rust evaluator from source
+  quint-evaluator = rustPlatform.buildRustPackage {
+    pname = "quint-evaluator";
+    version = evaluatorVersion;
+    inherit src;
+
+    sourceRoot = "${src.name}/evaluator";
+
+    # Skip tests during build, as many rust tests rely on the Quint CLI
+    doCheck = false;
+
+    cargoHash = "sha256-beWqUDaWWCbGL+V1LNtf35wZrIqWCCbFLYo5HCZF7FI=";
+
+    meta = metaCommon // {
+      description = "Evaluator for the Quint formal specification language";
+    };
+  };
+
+  # Download Apalache. It runs on the JVM, so no need to build it from source.
+  apalacheDist = fetchzip {
+    url = "https://github.com/apalache-mc/apalache/releases/download/v${apalacheVersion}/apalache.tgz";
+    hash = "sha256-P0QOxB14OSlphqBALR1YL9WJ0XYaUYE/R52yZytVzds=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "quint";
+  inherit version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/quint \
+      --add-flags "${quint-cli}/share/quint/dist/src/cli.js" \
+      --set QUINT_HOME "$out/share/quint" \
+      --prefix PATH : ${lib.makeBinPath [ jre ]}
+
+    install -Dm755 ${quint-evaluator}/bin/quint_evaluator -t $out/share/quint/rust-evaluator-v${evaluatorVersion}/
+
+    mkdir -p $out/share/quint/apalache-dist-${apalacheVersion}
+    cp -r ${apalacheDist} $out/share/quint/apalache-dist-${apalacheVersion}/apalache
+    chmod +x $out/share/quint/apalache-dist-${apalacheVersion}/apalache/bin/apalache-mc
+
+    runHook postInstall
+  '';
+
+  meta = metaCommon // {
+    mainProgram = "quint";
+  };
+})


### PR DESCRIPTION
Hello :octocat: 

This adds a package for Quint, a fairly new (3 years old) formal specification language based on TLA+. Quint is not mainstream, but it is actively maintained, has currently [941 GitHub stars](https://github.com/informalsystems/quint/stargazers) and a decent amount of downloads on [NPM](https://www.npmjs.com/package/@informalsystems/quint) and [VSCode](https://marketplace.visualstudio.com/items?itemName=informal.quint-vscode). I work on Quint as my full time job and will be a maintainer for this nix package.

Here's the official website: https://quint-lang.org/

Quint automatically downloads two dependencies (Apalache, the model checker in Scala (JVM) and its alternative evaluator in Rust (binary) - both released under Apache 2.0) if they are not found in the expected folders (under `$QUINT_HOME`). So what I'm doing in this package is building/downloading these dependencies in a nix-compatible way, and then Quint will not perform any automatic downloads.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

The command finishes successfully, but I get this report:
```
--------- Report for 'x86_64-linux' ---------
1 package built:
quint

error: build log of '/nix/store/1jy8bcpgmxsbgdhcmrqgn1mzl84h1cyz-quint-0.25.1.drv^*' is not available
```
I'm not sure how to proceed.

- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
