### PR TITLE
graphhopper: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/gr/graphhopper/package.nix
+++ b/pkgs/by-name/gr/graphhopper/package.nix
@@ -68,10 +68,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   version = version.patch;
 
-  buildInputs = [
+  nativeBuildInputs = [
     makeWrapper
     maven
   ];
+
+  strictDeps = true;
 
   configurePhase = ''
     runHook preConfigure


### PR DESCRIPTION
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).