### PR TITLE
fwupd-efi: 1.6 -> 1.7

### DIFF
--- a/pkgs/by-name/fw/fwupd-efi/package.nix
+++ b/pkgs/by-name/fw/fwupd-efi/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "fwupd";
-    repo = "${finalAttrs.pname}";
+    repo = "fwupd-efi";
     rev = "${finalAttrs.version}";
     hash = "sha256-PcVqnnFrxedkhYgm+8EUF2I65R5gTXqbVrk69Pw1m1g=";
   };

--- a/pkgs/by-name/fw/fwupd-efi/package.nix
+++ b/pkgs/by-name/fw/fwupd-efi/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   pkg-config,
   meson,
   ninja,
@@ -10,13 +10,15 @@
   python3Packages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd-efi";
-  version = "1.6";
+  version = "1.7";
 
-  src = fetchurl {
-    url = "https://github.com/fwupd/fwupd-efi/releases/download/${version}/fwupd-efi-${version}.tar.xz";
-    hash = "sha256-r9CAWirQgafK/y71vABM46AUe1OAFejsqWY0FxaxJg4=";
+  src = fetchFromGitHub {
+    owner = "fwupd";
+    repo = "${finalAttrs.pname}";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-PcVqnnFrxedkhYgm+8EUF2I65R5gTXqbVrk69Pw1m1g=";
   };
 
   nativeBuildInputs = [
@@ -43,9 +45,10 @@ stdenv.mkDerivation rec {
     "-Defi-ldsdir=${gnu-efi}/lib"
     "-Defi_sbat_distro_id=nixos"
     "-Defi_sbat_distro_summary=NixOS"
-    "-Defi_sbat_distro_pkgname=${pname}"
-    "-Defi_sbat_distro_version=${version}"
+    "-Defi_sbat_distro_pkgname=${finalAttrs.pname}"
+    "-Defi_sbat_distro_version=${finalAttrs.version}"
     "-Defi_sbat_distro_url=https://search.nixos.org/packages?channel=unstable&show=fwupd-efi&from=0&size=50&sort=relevance&query=fwupd-efi"
+    "-Dgenpeimg=disabled"
   ];
 
   meta = with lib; {
@@ -54,4 +57,4 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Updates `fwupd-efi` to version `1.7`. The current version (`1.6`) is [not compatible](https://github.com/fwupd/firmware-lenovo/issues/515#issuecomment-2949355743) with `gnu-efi` >= version `4`. In NixOS `25.05` the current version of `gnu-efi` is `4.0.0`, so I believe updating via `fwupdmgr` is mostly broken for people at this time (it was on my Thinkpad.)

Regarding the flag `-Dgenpeimg=disabled` addition, this was [added upstream](https://github.com/fwupd/fwupd-efi/blob/cfd0be286a9b050c1aa4bfa3f0820256903a264a/contrib/fwupd-efi.spec.in#L41) for `1.7` as what appears to be a default. Without it the nix package fails to build due to the missing command `genpeimg`, which seems to be [from here](https://www.mingw-w64.org/tools/genpeimg/) (which is for cross compiling stuff on Windows, so it should be unnecessary.)

Fixes:
https://github.com/fwupd/firmware-lenovo/issues/514
https://github.com/fwupd/firmware-lenovo/issues/515

I will attempt to fulfill the test requirements outlined below and will edit as I have done so. [I used a package overlay](https://github.com/fwupd/firmware-lenovo/issues/515#issuecomment-2950900997) to install version `1.7` locally and was able to successfully update system firmware with that version.

## Things done

- Built on platform(s)
  - [x] x86_64-linux

- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
