### PR TITLE
adios2: doCheck with ctestCheckHook

### DIFF
--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -9,6 +9,7 @@
   pkg-config,
   python3Packages,
   mpi,
+  catalyst,
   bzip2,
   c-blosc2,
   hdf5,
@@ -36,6 +37,9 @@ let
     hdf5 = hdf5.override {
       inherit mpi mpiSupport;
       cppSupport = !mpiSupport;
+    };
+    catalyst = catalyst.override {
+      inherit mpi mpiSupport pythonSupport;
     };
     mpi4py = python3Packages.mpi4py.override { inherit mpi; };
   };
@@ -80,6 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       bzip2
       c-blosc2
+      adios2Packages.catalyst
       adios2Packages.hdf5
       libfabric
       libpng
@@ -95,7 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
       # Todo: add these optional dependencies in nixpkgs.
       # sz
       # mgard
-      # catalyst
     ]
     ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform ucx) ucx
     # openmp required by zfp
@@ -134,7 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ADIOS2_USE_Fortran" true)
     (lib.cmakeBool "ADIOS2_USE_UCX" (lib.meta.availableOn stdenv.hostPlatform ucx))
     (lib.cmakeBool "ADIOS2_USE_Sodium" true)
-    (lib.cmakeBool "ADIOS2_USE_Catalyst" false)
+    (lib.cmakeBool "ADIOS2_USE_Catalyst" true)
     (lib.cmakeBool "ADIOS2_USE_Campaign" true)
     (lib.cmakeBool "ADIOS2_USE_AWSSDK" false)
 

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -24,6 +24,7 @@
   yaml-cpp,
   nlohmann_json,
   llvmPackages,
+  testers,
   pythonSupport ? false,
   withExamples ? false,
 }:
@@ -63,7 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     [
-      mpi
       bzip2
       c-blosc2
       (hdf5-mpi.override { inherit mpi; })
@@ -87,10 +87,14 @@ stdenv.mkDerivation (finalAttrs: {
     # openmp required by zfp
     ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
-  propagatedBuildInputs = lib.optionals pythonSupport [
-    (python3Packages.mpi4py.override { inherit mpi; })
-    python3Packages.numpy
-  ];
+  propagatedBuildInputs =
+    [
+      mpi
+    ]
+    ++ lib.optionals pythonSupport [
+      (python3Packages.mpi4py.override { inherit mpi; })
+      python3Packages.numpy
+    ];
 
   cmakeFlags = [
     # adios2 builtin modules
@@ -158,6 +162,11 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.pythonImportsCheckHook
     python3Packages.pytestCheckHook
   ];
+
+  passthru.tests.cmake-config = testers.hasCmakeConfigModules {
+    moduleNames = [ "adios2" ];
+    package = finalAttrs.finalPackage;
+  };
 
   meta = {
     homepage = "https://adios2.readthedocs.io/en/latest/";

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals pythonSupport [
       python3Packages.python
       python3Packages.pybind11
+      python3Packages.pythonImportsCheckHook
     ];
 
   buildInputs =
@@ -168,7 +169,6 @@ stdenv.mkDerivation (finalAttrs: {
   pythonImportsCheck = [ "adios2" ];
 
   nativeInstallCheckInputs = lib.optionals pythonSupport [
-    python3Packages.pythonImportsCheckHook
     python3Packages.pytestCheckHook
   ];
 

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -7,7 +7,6 @@
   ninja,
   gfortran,
   pkg-config,
-  python3,
   python3Packages,
   mpi,
   bzip2,
@@ -58,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
       pkg-config
     ]
     ++ lib.optionals pythonSupport [
-      python3
+      python3Packages.python
       python3Packages.pybind11
     ];
 
@@ -130,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
     (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
-    (lib.cmakeFeature "CMAKE_INSTALL_PYTHONDIR" python3.sitePackages)
+    (lib.cmakeFeature "CMAKE_INSTALL_PYTHONDIR" python3Packages.python.sitePackages)
   ];
 
   # required for finding the generated adios2-config.cmake file
@@ -143,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preCheck =
     ''
-      export PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+      export PYTHONPATH=$out/${python3Packages.python.sitePackages}:$PYTHONPATH
     ''
     + lib.optionalString (stdenv.hostPlatform.system == "aarch64-linux") ''
       rm ../testing/adios2/python/TestBPWriteTypesHighLevelAPI.py

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -94,11 +94,39 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
+    # adios2 builtin modules
+    (lib.cmakeBool "ADIOS2_USE_DataMan" true)
+    (lib.cmakeBool "ADIOS2_USE_MHS" true)
+    (lib.cmakeBool "ADIOS2_USE_SST" true)
+
+    # declare thirdparty dependencies explicitly
+    (lib.cmakeBool "ADIOS2_USE_EXTERNAL_DEPENDENCIES" true)
+    (lib.cmakeBool "ADIOS2_USE_Blosc2" true)
+    (lib.cmakeBool "ADIOS2_USE_BZip2" true)
+    (lib.cmakeBool "ADIOS2_USE_ZFP" true)
+    (lib.cmakeBool "ADIOS2_USE_SZ" false)
+    (lib.cmakeBool "ADIOS2_USE_LIBPRESSIO" false)
+    (lib.cmakeBool "ADIOS2_USE_MGARD" false)
+    (lib.cmakeBool "ADIOS2_USE_PNG" true)
+    (lib.cmakeBool "ADIOS2_USE_CUDA" false)
+    (lib.cmakeBool "ADIOS2_USE_Kokkos" false)
+    (lib.cmakeBool "ADIOS2_USE_MPI" true)
+    (lib.cmakeBool "ADIOS2_USE_DAOS" false)
+    (lib.cmakeBool "ADIOS2_USE_DataSpaces" false)
+    (lib.cmakeBool "ADIOS2_USE_ZeroMQ" true)
     (lib.cmakeBool "ADIOS2_USE_HDF5" true)
     (lib.cmakeBool "ADIOS2_USE_HDF5_VOL" true)
+    (lib.cmakeBool "ADIOS2_USE_IME" false)
+    (lib.cmakeBool "ADIOS2_USE_Python" pythonSupport)
+    (lib.cmakeBool "ADIOS2_USE_Fortran" true)
+    (lib.cmakeBool "ADIOS2_USE_UCX" (lib.meta.availableOn stdenv.hostPlatform ucx))
+    (lib.cmakeBool "ADIOS2_USE_Sodium" true)
+    (lib.cmakeBool "ADIOS2_USE_Catalyst" false)
+    (lib.cmakeBool "ADIOS2_USE_Campaign" true)
+    (lib.cmakeBool "ADIOS2_USE_AWSSDK" false)
+
     (lib.cmakeBool "BUILD_TESTING" false)
     (lib.cmakeBool "ADIOS2_BUILD_EXAMPLES" withExamples)
-    (lib.cmakeBool "ADIOS2_USE_EXTERNAL_DEPENDENCIES" true)
     (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
     (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
     (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -134,6 +134,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ADIOS2_USE_Campaign" true)
     (lib.cmakeBool "ADIOS2_USE_AWSSDK" false)
 
+    # Enable support for Little/Big Endian Interoperability
+    (lib.cmakeBool "ADIOS2_USE_Endian_Reverse" true)
+
     (lib.cmakeBool "BUILD_TESTING" false)
     (lib.cmakeBool "ADIOS2_BUILD_EXAMPLES" withExamples)
     (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -105,8 +105,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_INSTALL_PYTHONDIR" python3.sitePackages)
   ];
 
-  # equired for finding the generated adios2-config.cmake file
-  env.adios2_DIR = "${placeholder "out"}/lib/cmake/adios2";
+  # required for finding the generated adios2-config.cmake file
+  preInstall = ''
+    export adios2_DIR=$out/lib/cmake/adios2
+  '';
 
   # Ctest takes too much time, so we only perform some smoke Python tests.
   doInstallCheck = pythonSupport;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -93,7 +93,6 @@ self: super: with self; {
 
   adios2 = toPythonModule (
     pkgs.adios2.override {
-      python3 = python;
       python3Packages = self;
       pythonSupport = true;
     }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
