### PR TITLE
python3Packages.firedrake: 2025.4.0.post0 -> 2025.4.1

### DIFF
--- a/pkgs/development/python-modules/firedrake/default.nix
+++ b/pkgs/development/python-modules/firedrake/default.nix
@@ -57,32 +57,21 @@ let
 in
 buildPythonPackage rec {
   pname = "firedrake";
-  version = "2025.4.0.post0";
+  version = "2025.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "firedrakeproject";
     repo = "firedrake";
     tag = version;
-    hash = "sha256-wQOS4v/YkIwXdQq6JMvRbmyhnzvx6wj0O6aszNa5ZMw=";
+    hash = "sha256-p/yquIKWynGY7UESDNBCf1cM8zpy8beuuRxSrSMvj7c=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/firedrakeproject/firedrake/commit/b358e33ab12b3c4bc3819c9c6e9ed0930082b750.patch?full_index=1";
-      hash = "sha256-y00GB8njhmHgtAVvlv8ImsJe+hMCU1QFtbB8llEhv/I=";
-    })
-  ];
-
   postPatch =
+    # relax build-dependency petsc4py
     ''
-      # relax build-dependency petsc4py
       substituteInPlace pyproject.toml --replace-fail \
-        "petsc4py==3.23.0" "petsc4py"
-
-      # These scripts are used by official source distribution only,
-      # and do not make sense in our binary distribution.
-      sed -i '/firedrake-\(check\|status\|run-split-tests\)/d' pyproject.toml
+        "petsc4py==3.23.3" "petsc4py"
     ''
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       substituteInPlace firedrake/petsc.py --replace-fail \
@@ -97,6 +86,7 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "decorator"
+    "slepc4py"
   ];
 
   build-system = [
@@ -161,6 +151,11 @@ buildPythonPackage rec {
     mpiCheckPhaseHook
     writableTmpDirAsHomeHook
   ];
+
+  # These scripts are used by official sdist/editable_wheel only
+  postInstall = ''
+    rm $out/bin/firedrake-{check,status,run-split-tests}
+  '';
 
   preCheck = ''
     rm -rf firedrake pyop2 tinyasm tsfc


### PR DESCRIPTION
Changelog: https://github.com/firedrakeproject/firedrake/releases/tag/2025.4.1
Diff: https://github.com/firedrakeproject/firedrake/compare/2025.4.0.post0...2025.4.1

wait for passthru.tests before merge
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
