### PR TITLE
lib.derivations: avoid common double-warn with warnOnInstantiate

### DIFF
--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -216,8 +216,9 @@ in
   /**
     Wrap a derivation such that instantiating it produces a warning.
 
-    All attributes apart from `meta`, `name`, and `type` (which are used by
-    `nix search`) will be wrapped in `lib.warn`.
+    All attributes will be wrapped with `lib.warn` except from `.meta`, `.name`,
+    and `.type` which are used by `nix search`, and `.outputName` which avoids
+    double warnings with `nix-instantiate` and `nix-build`.
 
     # Inputs
 
@@ -246,6 +247,7 @@ in
         "meta"
         "name"
         "type"
+        "outputName"
       ];
     in
     drv // mapAttrs (_: lib.warn msg) drvToWrap;


### PR DESCRIPTION
Before:

    $ nix-build . -A opensycl
    trace: evaluation warning: 'opensycl' has been renamed to 'adaptivecpp'
    trace: evaluation warning: 'opensycl' has been renamed to 'adaptivecpp'
    /nix/store/8g0lfv82s0sprmqgfj146ggkb7bn3rm6-adaptivecpp-25.02.0

    $ nix-instantiate . -A opensycl
    trace: evaluation warning: 'opensycl' has been renamed to 'adaptivecpp'
    trace: evaluation warning: 'opensycl' has been renamed to 'adaptivecpp'
    warning: you did not specify '--add-root'; the result might be removed by the garbage collector
    /nix/store/b8q5xp94s4n7zfn7as5a9xjvylh6y3pi-adaptivecpp-25.02.0.drv

After:

    $ nix-build . -A opensycl
    trace: evaluation warning: 'opensycl' has been renamed to 'adaptivecpp'
    /nix/store/8g0lfv82s0sprmqgfj146ggkb7bn3rm6-adaptivecpp-25.02.0

    $ nix-instantiate . -A opensycl
    trace: evaluation warning: 'opensycl' has been renamed to 'adaptivecpp'
    warning: you did not specify '--add-root'; the result might be removed by the garbage collector
    /nix/store/b8q5xp94s4n7zfn7as5a9xjvylh6y3pi-adaptivecpp-25.02.0.drv


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
