### PR TITLE
gzip: register for unpackPhase

### DIFF
--- a/pkgs/tools/compression/gzip/default.nix
+++ b/pkgs/tools/compression/gzip/default.nix
@@ -61,6 +61,8 @@ stdenv.mkDerivation rec {
         --add-flags "\''${GZIP_NO_TIMESTAMPS:+-n}"
     '';
 
+  setupHook = ./setup-hook.sh;
+
   meta = {
     homepage = "https://www.gnu.org/software/gzip/";
     description = "GNU zip compression program";

--- a/pkgs/tools/compression/gzip/setup-hook.sh
+++ b/pkgs/tools/compression/gzip/setup-hook.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+
+# If strictDeps is unset or our host offset belongs to a native platform,
+# we assume that we can run gzip and register with unpackCmdHooks; otherwise,
+# return because we cannot assume gzip can run on this platform.
+[[ -z ${strictDeps-} ]] || (( hostOffset < 0 )) || return 0
+
+# Unpacks a GZIP file to the current directory. The file name is the same as the archive,
+# but without the ".gz" extension. The original file is not deleted.
+_tryUngzip() {
+  [[ "$1" = *.gz ]] && gzip --keep --decompress --stdout "$1" > "$(basename "$1" .gz)"
+}
+
+unpackCmdHooks+=(_tryUngzip)


### PR DESCRIPTION
This PR adds a setup hook to `gzip` so that, when included as a native build input, it can unpack files in `src` or `srcs`.

TODO: Rewrite packages which manually use gzip in a custom `unpackPhase`:

- [ ] [`codeium`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/co/codeium/package.nix)
- [ ] [`dbip-asn-lite`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/db/dbip-asn-lite/package.nix)
- [ ] [`dbip-city-lite`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/db/dbip-city-lite/package.nix)
- [ ] [`dbip-country-lite`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/db/dbip-country-lite/package.nix)
- [ ] [`mb2md`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/mb/mb2md/package.nix)
- [ ] [`scala-cli`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/sc/scala-cli/package.nix)
- [ ] [`mnist-example`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/torch/tests/mnist-example/default.nix)

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).+

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
