### PR TITLE
chromium: add opt-in qt6 support

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -98,6 +98,8 @@
   libgcrypt ? null, # cupsSupport
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
   systemd,
+  qt6Support ? false,
+  qt6,
 }:
 
 buildFun:
@@ -311,7 +313,12 @@ let
       ++ lib.optionals (!isElectron) [
         nodejs
         npmHooks.npmConfigHook
+      ]
+      ++ lib.optionals qt6Support [
+        qt6.qtbase
       ];
+
+    ${if qt6Support then "dontWrapQtApps" else null} = true;
 
     depsBuildBuild =
       [
@@ -815,7 +822,8 @@ let
         if chromiumVersionAtLeast "134" then
           {
             use_qt5 = false;
-            use_qt6 = false;
+            use_qt6 = qt6Support;
+            ${if qt6Support then "moc_qt6_path" else null} = "${qt6.qtbase}/libexec";
           }
         else
           {

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -36,6 +36,8 @@
   commandLineArgs ? "",
   pkgsBuildBuild,
   pkgs,
+  qt6Support ? false,
+  qt6,
 }:
 
 let
@@ -78,6 +80,7 @@ let
         cupsSupport
         pulseSupport
         ungoogled
+        qt6Support
         ;
       gnChromium = buildPackages.gn.overrideAttrs (oldAttrs: {
         version = if (upstream-info.deps.gn ? "version") then upstream-info.deps.gn.version else "0";
@@ -137,7 +140,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     makeWrapper
     ed
-  ];
+  ] ++ lib.optional qt6Support qt6.wrapQtAppsHook;
+
+  ${if qt6Support then "dontWrapQtApps" else null} = true;
 
   buildInputs = [
     # needed for GSETTINGS_SCHEMAS_PATH
@@ -151,7 +156,7 @@ stdenv.mkDerivation {
 
     # Needed for kerberos at runtime
     libkrb5
-  ];
+  ] ++ lib.optional qt6Support qt6.qtbase;
 
   outputs = [
     "out"
@@ -174,7 +179,7 @@ stdenv.mkDerivation {
     ''
       mkdir -p "$out/bin"
 
-      makeWrapper "${browserBinary}" "$out/bin/chromium" \
+      makeShellWrapper "${browserBinary}" "$out/bin/chromium" ${lib.optionalString qt6Support "\${qtWrapperArgs[@]} "}\
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
         --add-flags ${lib.escapeShellArg commandLineArgs}
 


### PR DESCRIPTION
This PR aims to resolve #228751. I have added dependencies for qt6 to the chromium derivation. Further I added the option `qt6Support` to the derivation to make qt6 support optin for chromium and ungoogled-chromium. With `qt6Support=false` no outputs should change nor any rebuilds should occur.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
