### PR TITLE
aliases: warnOnInstantiate all aliases if `config.warnAliases=true`

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -9,6 +9,9 @@
   and newer series. However, embedded chips without LSX (Loongson SIMD eXtension), such as 2K0300 SoC, are not
   supported. `pkgsCross.loongarch64-linux-embedded` can be used to build software and systems for these platforms.
 
+- Package aliases now print a warning when used. This behaviour is controlled with the new `config.warnAliases`
+  which by default is `true`.
+
 ## Backward Incompatibilities {#sec-nixpkgs-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1,4 +1,4 @@
-lib: self: super:
+lib: self: _super:
 
 ### Deprecated aliases - for backward compatibility
 ### Please maintain this list in ASCIIbetical ordering.
@@ -16,8 +16,6 @@ lib: self: super:
 # valid examples of what to preserve:
 #   distro aliases such as:
 #     debian-package-name -> nixos-package-name
-
-with self;
 
 let
   # Removing recurseForDerivation prevents derivations of aliased attribute set
@@ -46,7 +44,7 @@ let
     "${p} has been renamed to ${p3} since ${p4} is also available. Note that upgrade caused data loss for some users so backup is recommended (see NixOS 24.11 release notes for details)";
 
   deprecatedPlasma5Packages = {
-    inherit (plasma5Packages)
+    inherit (self.plasma5Packages)
       akonadi
       akregator
       arianna
@@ -178,7 +176,7 @@ let
       zanshin
       ;
 
-    inherit (plasma5Packages.thirdParty)
+    inherit (self.plasma5Packages.thirdParty)
       krohnkite
       krunner-ssh
       krunner-symbols
@@ -188,7 +186,7 @@ let
       plasma-applet-virtual-desktop-bar
       ;
 
-    inherit (libsForQt5)
+    inherit (self.libsForQt5)
       sddm
       ;
   };
@@ -209,7 +207,7 @@ let
   # Make sure that we are not shadowing something from all-packages.nix.
   checkInPkgs =
     n: alias:
-    if builtins.hasAttr n super then throw "Alias ${n} is still in all-packages.nix" else alias;
+    if builtins.hasAttr n _super then throw "Alias ${n} is still in all-packages.nix" else alias;
 
   mapAliases =
     aliases:
@@ -217,6 +215,8 @@ let
       n: alias: removeDistribute (removeRecurseForDerivations (checkInPkgs n alias))
     ) aliases;
 in
+
+with self;
 
 mapAliases {
   # Added 2018-07-16 preserve, reason: forceSystem should not be used directly in Nixpkgs.

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -101,6 +101,23 @@ let
       '';
     };
 
+    warnAliases = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to show warnings when accessing aliases.
+
+        While it is true by default it is perfectly okay to disable
+        this. For example it make sense to disable alias warnings when
+        running `nix search`.
+
+        This is a tool to gently let you know which attributes in your code
+        are aliases. Projects that aren't Nixpkgs should however be cautious
+        of instantly removing all usages of aliases, as migrating too soon
+        can break compatibility with the stable Nixpkgs releases.
+      '';
+    };
+
     allowUnfree = mkOption {
       type = types.bool;
       default = false;


### PR DESCRIPTION
The problem with ever dropping aliases from `aliases.nix` is that downstream users have no idea that certain attributes they rely on have been an alias for years. With warnings however we can expect users to be able to migrate, which in turn enables dropping aliases a lot quicker. With this merged i believe https://github.com/NixOS/nixpkgs/pull/414656 is very much possible

Tested with `nix-env` and on my nixos config.

I wanted to make `config.warnAliases` default to `false` for normal nixpkgs but `true` for nixos, but i could not figure out how to set that default without it then ignoring whatever the user configures in their nixos config.

I took extra care to make sure the implementation is performant and that there are no huge footguns in `aliases.nix`. It is _possible_ for `.__aliasWarningAttrName` to leak, which is the case for `vamp.vampSDK`, but i believe this is not a real issue. 

# Showcase:

The `jami-client` alias is defined as:

```nix
jami-client = jami; # Added 2023-02-10
```

If you try to use it you wouldn't know it is an alias unless you use the nuclear option `allowAliases=false`:

```shell
$ nix-build . -A jami-client
/nix/store/0dz9vmg7r9wnh30kx95m6vc4s240wgb2-jami-20250523.0
$ nix-build . -A jami-client --arg config '{ allowAliases=false; }'
error: attribute 'jami-client' in selection path 'jami-client' not found
```

but with this PR you will instead see

```shell
$ nix-build . -A jami-client
trace: evaluation warning: 'jami-client' has been renamed to/replaced by 'jami'
/nix/store/0dz9vmg7r9wnh30kx95m6vc4s240wgb2-jami-20250523.0
$ nix-build . -A jami-client --arg config '{ warnAliases=false; }'
/nix/store/0dz9vmg7r9wnh30kx95m6vc4s240wgb2-jami-20250523.0
$ nix-build . -A jami-client --arg config '{ allowAliases=false; }'
error: attribute 'jami-client' in selection path 'jami-client' not found
```


Here is the stderr output of `nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f ./. -qaP --json --meta`:

https://gist.github.com/pbsds/bd6b4211086db4d6707cba98e0fcf5c7

_(all of these examples [had `.outputName` and `.system` excluded from `warnOnInstantiate`](https://github.com/NixOS/nixpkgs/pull/414606#issuecomment-2951905070))_




<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
