### PR TITLE
modemmanager: 1.22.0 -> 1.24.0 / libmbim: 1.30.0 -> 1.32.0

### DIFF
--- a/pkgs/by-name/li/libmbim/package.nix
+++ b/pkgs/by-name/li/libmbim/package.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libmbim";
-  version = "1.30.0";
+  version = "1.32.0";
 
   outputs = [
     "out"
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     owner = "mobile-broadband";
     repo = "libmbim";
     rev = version;
-    hash = "sha256-sHTpu9WeMZroT+1I18ObEHWSzcyj/Relyz8UNe+WawI=";
+    hash = "sha256-+4INXuH2kbKs9C6t4bOJye7yyfYH/BLukmgDVvXo+u0=";
   };
 
   mesonFlags = [

--- a/pkgs/by-name/mo/modemmanager/no-dummy-dirs-in-sysconfdir.patch
+++ b/pkgs/by-name/mo/modemmanager/no-dummy-dirs-in-sysconfdir.patch
@@ -18,3 +18,14 @@ index 5dc3b6a0..25a948a1 100644
  mkdir_cmd = 'mkdir -p ${DESTDIR}@0@'
 -meson.add_install_script('sh', '-c', mkdir_cmd.format(mm_prefix / mm_fccunlockdiruser))
  meson.add_install_script('sh', '-c', mkdir_cmd.format(mm_prefix / mm_fccunlockdirpackage))
+diff --git a/data/dispatcher-modem-setup/meson.build b/data/dispatcher-modem-setup/meson.build
+index 812152a3..7527022b 100644
+--- a/data/dispatcher-modem-setup/meson.build
++++ b/data/dispatcher-modem-setup/meson.build
+@@ -22,5 +22,4 @@ install_data(
+ )
+ 
+ mkdir_cmd = 'mkdir -p ${DESTDIR}@0@'
+-meson.add_install_script('sh', '-c', mkdir_cmd.format(mm_prefix / mm_modemsetupdiruser))
+ meson.add_install_script('sh', '-c', mkdir_cmd.format(mm_prefix / mm_modemsetupdirpackage))
+ 

--- a/pkgs/by-name/mo/modemmanager/package.nix
+++ b/pkgs/by-name/mo/modemmanager/package.nix
@@ -31,26 +31,20 @@
 
 stdenv.mkDerivation rec {
   pname = "modemmanager";
-  version = "1.22.0";
+  version = "1.24.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "mobile-broadband";
     repo = "ModemManager";
     rev = version;
-    hash = "sha256-/D9b2rCCUhpDCUfSNAWR65+3EyUywzFdH1R17eSKRDo=";
+    hash = "sha256-3jI75aR2esmv5dkE4TrdCHIcCvtdOBKnBC5XLEKoVFs=";
   };
 
   patches = [
     # Since /etc is the domain of NixOS, not Nix, we cannot install files there.
     # But these are just placeholders so we do not need to install them at all.
     ./no-dummy-dirs-in-sysconfdir.patch
-
-    (fetchpatch {
-      name = "GI_TYPELIB_PATH.patch";
-      url = "https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/commit/daa829287894273879799a383ed4dc373c6111b0.patch";
-      hash = "sha256-tPQokiZO2SpTlX8xMlkWjP1AIXgoLHW3rJwnmG33z/k=";
-    })
   ];
 
   strictDeps = true;


### PR DESCRIPTION
- upgraded libmbim because required for modemmanager (I hope that is okay to combine)
- removed GI_TYPELIB_PATH.patch as merged upstream into 1.24.0
- expanded patch to remove dummy dirs in sysconfdir

also obsoletes #397359 because of the integrated update of libmbim

I found nothing major or breaking in [Changelog of ModemManager](https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/blob/mm-1-24/NEWS?ref_type=heads).

~I started a nixpkgs-review on one builder host of mine, I am still waiting for it to finish …~ I skipped nixpkgs-review because of storage issues, preventing me from just letting it run.

Closes #397359 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
