### PR TITLE
cope: 0-unstable-2024-03-27 -> 0-unstable-2025-06-20

### DIFF
--- a/pkgs/by-name/co/cope/package.nix
+++ b/pkgs/by-name/co/cope/package.nix
@@ -3,21 +3,23 @@
   fetchFromGitHub,
   perl,
   perlPackages,
+  makeWrapper,
 }:
-
 perlPackages.buildPerlPackage {
   pname = "cope";
-  version = "0-unstable-2024-03-27";
+  version = "0-unstable-2025-06-20";
 
   src = fetchFromGitHub {
     owner = "deftdawg";
     repo = "cope";
-    rev = "ad0c1ebec5684f5ec3e8becf348414292c489175";
-    hash = "sha256-LMAir7tUkjHtKz+KME/Raa9QHGN1g0bzr56fNxfURQY=";
+    rev = "6d0322a8493361ad32e454b97998df715dbe7b97";
+    hash = "sha256-VQveV7avM/4nbLroyujJaSoVAP3pXhwrzqzI3eMzxVo=";
   };
+  nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = with perlPackages; [
     EnvPath
+    ExporterTiny
     FileShareDir
     IOTty
     IOStty
@@ -26,11 +28,37 @@ perlPackages.buildPerlPackage {
     RegexpIPv6
   ];
 
-  postInstall = ''
-    mkdir -p $out/bin
-    mv $out/${perlPackages.perl.libPrefix}/${perlPackages.perl.version}/auto/share/dist/Cope/* $out/bin/
-    rm -r $out/${perlPackages.perl.libPrefix}/${perlPackages.perl.version}/auto
-  '';
+  postInstall =
+    let
+      perlDeps = with perlPackages; [
+        EnvPath
+        ExporterTiny
+        FileShareDir
+        IOTty
+        IOStty
+        ListMoreUtils
+        RegexpCommon
+        RegexpIPv6
+      ];
+      perlPath = perlPackages.makePerlPath perlDeps;
+    in
+    ''
+      mkdir -p $out/bin # $out/libexec
+      mv $out/${perlPackages.perl.libPrefix}/${perlPackages.perl.version}/auto/share/dist/Cope $out/libexec
+      # Wrap all Perl scripts in the Cope directory before moving them
+      for script in $out/libexec/*; do
+        if [[ -f "$script" && -x "$script" ]]; then
+          wrapProgram "$script" \
+            --set PERL5LIB "${perlPath}:$out/lib/perl5/site_perl"
+          sed -i "1s|^#!.*perl|#!${perl}/bin/perl|" "$out/libexec/.''${script##*/}-wrapped"
+        fi
+      done
+      rm -r $out/${perlPackages.perl.libPrefix}/${perlPackages.perl.version}/auto
+
+      # replace cope with a new cope, new-cope is a bash script which doesn't need to be wrapped
+      cp $src/new-cope $out/bin/cope
+      cp -f $src/new-cope $out/libexec/cope
+    '';
 
   meta = {
     description = "Colourful wrapper for terminal programs";


### PR DESCRIPTION
### 2025-06-20 - Darwin now supported

Reworked derivation and new-cope script to make cope work on Darwin

### 2025-06-11 - Shell mode
Update to cope "a new cope" rewrites cope command with help, status, available commands...
Also features 3 new ways to enable cope:
1. `cope cmd args` (i.e. `cope ls -la`) to run a single command using cope colourization 
2. `cope shell` (like nix-shell) to temporarily colourize with cope in a new shell
3. `eval $(cope enable)` to activate cope colourization within the current shell

<img src="https://github.com/user-attachments/assets/5636da62-f6e8-4301-b3c8-f4a85867be15" width=90%/>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
