### PR TITLE
firezone-gui-client: 1.4.12 -> 1.5.1

### DIFF
--- a/nixos/modules/services/networking/firezone/gui-client.nix
+++ b/nixos/modules/services/networking/firezone/gui-client.nix
@@ -6,7 +6,6 @@
 }:
 let
   inherit (lib)
-    boolToString
     getExe'
     mkEnableOption
     mkIf
@@ -28,7 +27,7 @@ in
         default = [ ];
         description = ''
           All listed users will become part of the `firezone-client` group so
-          they can control the IPC service. This is a convenience option.
+          they can control the tunnel service. This is a convenience option.
         '';
       };
 
@@ -58,8 +57,8 @@ in
     # Required for the token store in the gui application
     services.gnome.gnome-keyring.enable = true;
 
-    systemd.services.firezone-ipc-service = {
-      description = "GUI IPC service for the Firezone zero-trust access platform";
+    systemd.services.firezone-tunnel-service = {
+      description = "GUI tunnel service for the Firezone zero-trust access platform";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
@@ -73,7 +72,7 @@ in
           export FIREZONE_ID=$(< client_id)
         fi
 
-        exec ${getExe' cfg.package "firezone-client-ipc"} run
+        exec ${getExe' cfg.package "firezone-client-tunnel"} run
       '';
 
       environment = {

--- a/pkgs/by-name/fi/firezone-gui-client/package.nix
+++ b/pkgs/by-name/fi/firezone-gui-client/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  rust,
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
@@ -24,12 +25,12 @@
   copyDesktopItems,
 }:
 let
-  version = "1.4.12";
+  version = "1.5.1";
   src = fetchFromGitHub {
     owner = "firezone";
     repo = "firezone";
     tag = "gui-client-${version}";
-    hash = "sha256-jvrkAbXHFWdNInDCrktC7eMZQ2a/rzUxfCOny7nHQmQ=";
+    hash = "sha256-KozSy44Opx6cukA0QTXeMpI3fP49iyabFzPLIJckOZ4=";
   };
 
   frontend = stdenvNoCC.mkDerivation rec {
@@ -39,9 +40,11 @@ let
     pnpmDeps = pnpm_9.fetchDeps {
       inherit pname version;
       src = "${src}/rust/gui-client";
-      hash = "sha256-bVWpyGwEaxYi3N6BJqOilnHJDgAykKHgRC2QKlvSm4Q=";
+      hash = "sha256-ttbTYBuUv0vyiYzrFATF4x/zngsRXjuLPfL3qW2HEe4=";
     };
     pnpmRoot = "rust/gui-client";
+
+    env.GITHUB_SHA = version;
 
     nativeBuildInputs = [
       pnpm_9.configHook
@@ -52,8 +55,7 @@ let
       runHook preBuild
 
       cd $pnpmRoot
-      cp node_modules/flowbite/dist/flowbite.min.js src/
-      pnpm tailwindcss -i src/input.css -o src/output.css
+      node ./node_modules/flowbite-react/dist/cli/bin.js patch
       node --max_old_space_size=1024000 ./node_modules/vite/bin/vite.js build
 
       runHook postBuild
@@ -73,7 +75,7 @@ rustPlatform.buildRustPackage rec {
   inherit version src;
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-YETCRhECbMTRmNsvOFl7R2YScY6ArjsOYJKdPVuUyGI=";
+  cargoHash = "sha256-TDP1Z4MeQaSER8MGnCEQfIhRsakaSCeJ7boUMBYkkI0=";
   sourceRoot = "${src.name}/rust";
   buildAndTestSubdir = "gui-client";
   RUSTFLAGS = "--cfg system_certs";
@@ -102,6 +104,9 @@ rustPlatform.buildRustPackage rec {
   postPatch = ''
     rm .cargo/config.toml
     ln -s ${frontend} gui-client/dist
+
+    substituteInPlace gui-client/src-tauri/tauri.conf.json \
+      --replace-fail '../../target' '../../target/${rust.envVars.rustHostPlatformSpec}'
   '';
 
   # Tries to compile apple specific crates due to workspace dependencies,


### PR DESCRIPTION
- **firezone-gui-client: 1.4.12 -> 1.5.1**
- **nixos/firezone-gui-client: adjust to renamed tunnel service binary**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
