### PR TITLE
hdf5-blosc: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/by-name/hd/hdf5-blosc/no-external-blosc.patch
+++ b/pkgs/by-name/hd/hdf5-blosc/no-external-blosc.patch
@@ -1,12 +1,15 @@
---- a/CMakeLists.txt      2019-10-11 12:12:27.445417039 -0400
-+++ b/CMakeLists.txt      2019-10-11 12:27:26.630691742 -0400
-@@ -22,14 +22,6 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9ec0f23..35953d3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,15 +24,6 @@ message("BLOSC_INSTALL_DIR='${BLOSC_INSTALL_DIR}'")
  message("BLOSC_CMAKE_ARGS='${BLOSC_CMAKE_ARGS}'")
  message("GIT_EXECUTABLE='${GIT_EXECUTABLE}'")
 
 -ExternalProject_Add(project_blosc
 -  PREFIX ${BLOSC_PREFIX}
 -  GIT_REPOSITORY https://github.com/Blosc/c-blosc.git
+-  GIT_TAG main
 -  INSTALL_DIR ${BLOSC_INSTALL_DIR}
 -  CMAKE_ARGS ${BLOSC_CMAKE_ARGS}
 -)
@@ -15,10 +18,10 @@
  # sources
  set(SOURCES src/blosc_filter.c)
  set(PLUGIN_SOURCES src/blosc_filter.c src/blosc_plugin.c )
-@@ -53,7 +45,6 @@
+@@ -56,7 +47,6 @@ include_directories(${HDF5_INCLUDE_DIRS})
  # add blosc libraries
  add_library(blosc_shared SHARED IMPORTED)
- set_property(TARGET blosc_shared PROPERTY IMPORTED_LOCATION ${BLOSC_INSTALL_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}blosc${CMAKE_SHARED_LIBRARY_SUFFIX})
+ set_property(TARGET blosc_shared PROPERTY IMPORTED_LOCATION ${BLOSC_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}blosc${CMAKE_SHARED_LIBRARY_SUFFIX})
 -add_dependencies(blosc_shared project_blosc)
  include_directories(${BLOSC_INSTALL_DIR}/include)
 

--- a/pkgs/by-name/hd/hdf5-blosc/package.nix
+++ b/pkgs/by-name/hd/hdf5-blosc/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hdf5-blosc";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "Blosc";
     repo = "hdf5-blosc";
     rev = "v${version}";
-    sha256 = "1nj2bm1v6ymm3fmyvhbn6ih5fgdiapavlfghh1pvbmhw71cysyqs";
+    sha256 = "sha256-pM438hUEdzdZEGYxoKlBAHi1G27auj9uGSeiXwVPAE8=";
   };
 
   patches = [ ./no-external-blosc.patch ];
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DPLUGIN_INSTALL_PATH=${placeholder "plugin"}/hdf5/lib/plugin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
   ];
 
   postInstall = ''

--- a/pkgs/by-name/hd/hdf5-blosc/package.nix
+++ b/pkgs/by-name/hd/hdf5-blosc/package.nix
@@ -5,6 +5,7 @@
   cmake,
   hdf5,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -33,18 +34,23 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = ''
-    substituteInPlace CMakeLists.txt --replace 'set(BLOSC_INSTALL_DIR "''${CMAKE_CURRENT_BINARY_DIR}/blosc")' 'set(BLOSC_INSTALL_DIR "${c-blosc}")'
+    substituteInPlace CMakeLists.txt --replace-fail 'set(BLOSC_INSTALL_DIR "''${CMAKE_CURRENT_BINARY_DIR}/blosc")' 'set(BLOSC_INSTALL_DIR "${c-blosc}")'
   '';
 
   cmakeFlags = [
     "-DPLUGIN_INSTALL_PATH=${placeholder "plugin"}/hdf5/lib/plugin"
     "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DBUILD_TESTS=ON"
   ];
 
   postInstall = ''
     mkdir -p $out/lib/pkgconfig
     substituteAll ${./blosc_filter.pc.in} $out/lib/pkgconfig/blosc_filter.pc
   '';
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Filter for HDF5 that uses the Blosc compressor";


### PR DESCRIPTION
Changelog: https://github.com/Blosc/hdf5-blosc/releases/tag/v1.0.1

Fixes gcc14 build. I needed to update the patch for it to apply cleanly though.

I also added passthru.updateScript.

Tracking: #388196 #356812

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
