### PR TITLE
workflows/backport: cancel concurrent runs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,6 +9,10 @@ on:
   pull_request_target:
     types: [closed, labeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION
When backporting a change to 24.11 and 25.05 at the same time by adding the two labels immediately *after* merging the PR, three backport jobs will run concurrently: One for the merge and one for each label added. Each of those jobs will try to create both PRs, which will lead to two of the jobs failing for sure.

With a concurrency group and cancelling in-progress jobs, only one of those jobs will remain. This reduces notification noise.

Example of 3 runs at the same time: #414784.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
