### PR TITLE
root5: fix building with python 3.13

### DIFF
--- a/pkgs/by-name/ro/root5/package.nix
+++ b/pkgs/by-name/ro/root5/package.nix
@@ -85,6 +85,10 @@ stdenv.mkDerivation rec {
     # Backport Python 3.11 fix to v5 from v6.26
     # https://github.com/root-project/root/commit/484deb056dacf768aba4954073b41105c431bffc
     ./root5-python311-fix.patch
+
+    # Backport Python 3.13 fix to v5 from v6.25
+    # https://github.com/root-project/root/commit/9aa67a863482eef8cf50850b9ac3724e35f58781
+    ./python313-PyCFunction_Call.patch
   ];
 
   # https://github.com/root-project/root/issues/13216

--- a/pkgs/by-name/ro/root5/python313-PyCFunction_Call.patch
+++ b/pkgs/by-name/ro/root5/python313-PyCFunction_Call.patch
@@ -1,0 +1,14 @@
+--- a/bindings/pyroot/src/TCustomPyTypes.cxx
++++ b/bindings/pyroot/src/TCustomPyTypes.cxx
+@@ -240,7 +240,11 @@
+ // the function is globally shared, so set and reset its "self" (ok, b/c of GIL)
+    Py_INCREF( self );
+    func->m_self = self;
++#if PY_VERSION_HEX >= 0x03090000
++   PyObject* result = PyObject_Call( (PyObject*)func, args, kw );
++#else
+    PyObject* result = PyCFunction_Call( (PyObject*)func, args, kw );
++#endif
+    func->m_self = 0;
+    Py_DECREF( self );
+    Py_DECREF( args );


### PR DESCRIPTION
Hydra failure: https://hydra.nixos.org/build/298824290

https://docs.python.org/3/whatsnew/3.13.html#removed-c-apis

PyCFunction_Call was a deprecated alias of PyObject_Call() and has been removed in 3.13.

While the package is being considered for removal in https://github.com/NixOS/nixpkgs/pull/392892, that hasn't happen yet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
