### PR TITLE
jetbrains: introduce `mirror://`

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -2,556 +2,556 @@
   "x86_64-linux": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
-      "url-template": "https://download.jetbrains.com/aqua/aqua-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/aqua/aqua-{version}.tar.gz",
       "version": "2024.3.2",
       "sha256": "de073e8a3734a2c4ef984b3e1bd68f5de72a6180e73400889510439ac3f419aa",
-      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.2.tar.gz",
+      "url": "mirror://jetbrains/aqua/aqua-2024.3.2.tar.gz",
       "build_number": "243.23654.154"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
-      "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/cpp/CLion-{version}.tar.gz",
       "version": "2025.1.1",
       "sha256": "2f747d7240d70b65ed98d736dbcd6ac2b98ac93aff993a63c5f8bd0f65918ac5",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.1.tar.gz",
+      "url": "mirror://jetbrains/cpp/CLion-2025.1.1.tar.gz",
       "build_number": "251.25410.104"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
-      "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/datagrip/datagrip-{version}.tar.gz",
       "version": "2025.1.2",
       "sha256": "47d1c891a34f12f371aeab2364b9280766e1e99b27933f8d11c3c3832ed865ca",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.2.tar.gz",
+      "url": "mirror://jetbrains/datagrip/datagrip-2025.1.2.tar.gz",
       "build_number": "251.25410.123"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
-      "url-template": "https://download.jetbrains.com/python/dataspell-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/python/dataspell-{version}.tar.gz",
       "version": "2025.1",
       "sha256": "d0078ceae9f7ae8cc6b57223874e3a818383aedf10fa8b73b2d34a522c52e53d",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.tar.gz",
+      "url": "mirror://jetbrains/python/dataspell-2025.1.tar.gz",
       "build_number": "251.23774.439"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/idea/gateway/JetBrainsGateway-{version}.tar.gz",
       "version": "2025.1.1",
       "sha256": "edccd3d877407dfc628d9ba2a8ee767c11a861532dd4e0b1cb2a4d8787476ea8",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.1.tar.gz",
+      "url": "mirror://jetbrains/idea/gateway/JetBrainsGateway-2025.1.1.tar.gz",
       "build_number": "251.25410.139"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
-      "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/go/goland-{version}.tar.gz",
       "version": "2025.1.1",
       "sha256": "fb94d5df43942db47a5506b50e511457cf845b986e70168171b9f5324b7d0d77",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.1.tar.gz",
+      "url": "mirror://jetbrains/go/goland-2025.1.1.tar.gz",
       "build_number": "251.25410.140"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/idea/ideaIC-{version}.tar.gz",
       "version": "2025.1.1.1",
       "sha256": "36b72ac85e8e1536dfccb300b5a435461b1e2953585a90a5d8f06e1b263b0b5c",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.1.1.tar.gz",
+      "url": "mirror://jetbrains/idea/ideaIC-2025.1.1.1.tar.gz",
       "build_number": "251.25410.129"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/idea/ideaIU-{version}.tar.gz",
       "version": "2025.1.1.1",
       "sha256": "337d34b20cdaa8da30d71b98e1b36817bdfe2f2245c491ef38f0cee02f0d0316",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.1.1.tar.gz",
+      "url": "mirror://jetbrains/idea/ideaIU-2025.1.1.1.tar.gz",
       "build_number": "251.25410.129"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
-      "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/mps/{versionMajorMinor}/MPS-{version}.tar.gz",
       "version": "2025.1",
       "sha256": "0b6d8c0964dc18785437c14bd2ac7e000e07e39865680227d201cd9cad0ff8a8",
-      "url": "https://download.jetbrains.com/mps/2025.1/MPS-2025.1.tar.gz",
+      "url": "mirror://jetbrains/mps/2025.1/MPS-2025.1.tar.gz",
       "build_number": "251.23774.423"
     },
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/webide/PhpStorm-{version}.tar.gz",
       "version": "2025.1.1",
       "sha256": "b64722ea715db8566754978af617716016deaa2cda3521cf05e4a049e5bbf6a3",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.1.tar.gz",
+      "url": "mirror://jetbrains/webide/PhpStorm-2025.1.1.tar.gz",
       "build_number": "251.25410.148",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/python/pycharm-community-{version}.tar.gz",
       "version": "2025.1.1",
       "sha256": "d2df49f8ec2df88039f535e0d8706d35f608db3e58b9411f5e8e726536788237",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.1.tar.gz",
+      "url": "mirror://jetbrains/python/pycharm-community-2025.1.1.tar.gz",
       "build_number": "251.25410.122"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/python/pycharm-professional-{version}.tar.gz",
       "version": "2025.1.1",
       "sha256": "b1e8660b1c947f3bb746d0736e1e9c247635fadedb52f230ef5c64862893ad0b",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.1.tar.gz",
+      "url": "mirror://jetbrains/python/pycharm-professional-2025.1.1.tar.gz",
       "build_number": "251.25410.122"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
-      "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/rider/JetBrains.Rider-{version}.tar.gz",
       "version": "2025.1.2",
       "sha256": "cdf8a824c7daa3247b09d76a29acb31cfa623b90643d3d2a814982cb0a32879d",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2.tar.gz",
+      "url": "mirror://jetbrains/rider/JetBrains.Rider-2025.1.2.tar.gz",
       "build_number": "251.25410.119"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
-      "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/ruby/RubyMine-{version}.tar.gz",
       "version": "2025.1.1",
       "sha256": "f5014b52770be4d1c743c5a60f0e20d0dd1a1c172018180d05c0a22f1ffd1027",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.1.tar.gz",
+      "url": "mirror://jetbrains/ruby/RubyMine-2025.1.1.tar.gz",
       "build_number": "251.25410.120"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
-      "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/rustrover/RustRover-{version}.tar.gz",
       "version": "2025.1.2",
       "sha256": "b2974feb5406153817797b7dc93baaafe35c7b3687d38091d5d1b5d010a03132",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.2.tar.gz",
+      "url": "mirror://jetbrains/rustrover/RustRover-2025.1.2.tar.gz",
       "build_number": "251.25410.115"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/webstorm/WebStorm-{version}.tar.gz",
       "version": "2025.1.1",
       "sha256": "411b6d93e47d7743aa9189f4a3cab3956c573ce406908da5621f8dee0098ad99",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.1.tar.gz",
+      "url": "mirror://jetbrains/webstorm/WebStorm-2025.1.1.tar.gz",
       "build_number": "251.25410.117"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
-      "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/writerside/writerside-{version}.tar.gz",
       "version": "2024.3 EAP",
       "sha256": "d49e58020d51ec4ccdbdffea5d42b5a2d776a809fc00789cef5abda7b23bd3f6",
-      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.371.tar.gz",
+      "url": "mirror://jetbrains/writerside/writerside-243.22562.371.tar.gz",
       "build_number": "243.22562.371"
     }
   },
   "aarch64-linux": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
-      "url-template": "https://download.jetbrains.com/aqua/aqua-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/aqua/aqua-{version}-aarch64.tar.gz",
       "version": "2024.3.2",
       "sha256": "d2a3c781756a83ccea63dc6d9aebf85f819de1edb5bcd4e5a1a161eaa0779c84",
-      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.2-aarch64.tar.gz",
+      "url": "mirror://jetbrains/aqua/aqua-2024.3.2-aarch64.tar.gz",
       "build_number": "243.23654.154"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
-      "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/cpp/CLion-{version}-aarch64.tar.gz",
       "version": "2025.1.1",
       "sha256": "dcd7373dc9dd941703d18ae602dd384ce6d154a90745c37c3358bf1f6b41ed2e",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/cpp/CLion-2025.1.1-aarch64.tar.gz",
       "build_number": "251.25410.104"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
-      "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/datagrip/datagrip-{version}-aarch64.tar.gz",
       "version": "2025.1.2",
       "sha256": "fb34b6469c96a54018b3c728f96787d03da0ec92c88a80f52e8f89a0eecc8d01",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.2-aarch64.tar.gz",
+      "url": "mirror://jetbrains/datagrip/datagrip-2025.1.2-aarch64.tar.gz",
       "build_number": "251.25410.123"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
-      "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/python/dataspell-{version}-aarch64.tar.gz",
       "version": "2025.1",
       "sha256": "e55cfc4e3327aff6bd3447e2980cd1e5cbd9223c8e0330688d65031b1e95d0fd",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/python/dataspell-2025.1-aarch64.tar.gz",
       "build_number": "251.23774.439"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
       "version": "2025.1.1",
       "sha256": "869882db293640328f5e1ae80c5cf60183ba850f6087ab1b3cf95ec77b3837be",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/idea/gateway/JetBrainsGateway-2025.1.1-aarch64.tar.gz",
       "build_number": "251.25410.139"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
-      "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/go/goland-{version}-aarch64.tar.gz",
       "version": "2025.1.1",
       "sha256": "949e86c6991e14d90adcaea75c18f679b1ab029ec0c00f00f464a631e999c036",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/go/goland-2025.1.1-aarch64.tar.gz",
       "build_number": "251.25410.140"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/idea/ideaIC-{version}-aarch64.tar.gz",
       "version": "2025.1.1.1",
       "sha256": "7860b836a18b82827fdb54a86cc5601fe8ef28aab4253981f238ef975a982915",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/idea/ideaIC-2025.1.1.1-aarch64.tar.gz",
       "build_number": "251.25410.129"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/idea/ideaIU-{version}-aarch64.tar.gz",
       "version": "2025.1.1.1",
       "sha256": "756baa32d72bd982d9b8c06f86cd42755d2677a9f1ea37bd6ad6a963d17226b2",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/idea/ideaIU-2025.1.1.1-aarch64.tar.gz",
       "build_number": "251.25410.129"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
-      "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}.tar.gz",
+      "url-template": "mirror://jetbrains/mps/{versionMajorMinor}/MPS-{version}.tar.gz",
       "version": "2025.1",
       "sha256": "0b6d8c0964dc18785437c14bd2ac7e000e07e39865680227d201cd9cad0ff8a8",
-      "url": "https://download.jetbrains.com/mps/2025.1/MPS-2025.1.tar.gz",
+      "url": "mirror://jetbrains/mps/2025.1/MPS-2025.1.tar.gz",
       "build_number": "251.23774.423"
     },
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/webide/PhpStorm-{version}-aarch64.tar.gz",
       "version": "2025.1.1",
       "sha256": "6e479318f5627ec1d6ccd47610a93aa9e9a56c9badd2be4d8f935008d0e71b9e",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/webide/PhpStorm-2025.1.1-aarch64.tar.gz",
       "build_number": "251.25410.148",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/python/pycharm-community-{version}-aarch64.tar.gz",
       "version": "2025.1.1",
       "sha256": "d717e039a91587e5396c69d056ebd91f640ae03ddf398e575c8f8eb3817d8afb",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/python/pycharm-community-2025.1.1-aarch64.tar.gz",
       "build_number": "251.25410.122"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/python/pycharm-professional-{version}-aarch64.tar.gz",
       "version": "2025.1.1",
       "sha256": "3f8f8a3773652ec99ea7a05b55dff41b5683548838f009e5e3d132ea644384d9",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/python/pycharm-professional-2025.1.1-aarch64.tar.gz",
       "build_number": "251.25410.122"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
-      "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
       "version": "2025.1.2",
       "sha256": "c1ad139252fd3158aa86e9ac4532db5d9dd653807fc9f1dc4458170f3f1c3de6",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2-aarch64.tar.gz",
+      "url": "mirror://jetbrains/rider/JetBrains.Rider-2025.1.2-aarch64.tar.gz",
       "build_number": "251.25410.119"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
-      "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/ruby/RubyMine-{version}-aarch64.tar.gz",
       "version": "2025.1.1",
       "sha256": "00b7526795af4e7eba1c65fc5e10a963e717770e68c5bfd28b10163f9fa37f8c",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/ruby/RubyMine-2025.1.1-aarch64.tar.gz",
       "build_number": "251.25410.120"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
-      "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/rustrover/RustRover-{version}-aarch64.tar.gz",
       "version": "2025.1.2",
       "sha256": "4660f8f2fd37b166bae904385b863157ab596fac35869de17a39df999efde8ce",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.2-aarch64.tar.gz",
+      "url": "mirror://jetbrains/rustrover/RustRover-2025.1.2-aarch64.tar.gz",
       "build_number": "251.25410.115"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/webstorm/WebStorm-{version}-aarch64.tar.gz",
       "version": "2025.1.1",
       "sha256": "0156affae3222afb51cfe8a82e1eabf26f62bd91a74a2822fa821afd1eab9bad",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.1-aarch64.tar.gz",
+      "url": "mirror://jetbrains/webstorm/WebStorm-2025.1.1-aarch64.tar.gz",
       "build_number": "251.25410.117"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
-      "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.tar.gz",
+      "url-template": "mirror://jetbrains/writerside/writerside-{version}-aarch64.tar.gz",
       "version": "2024.3 EAP",
       "sha256": "6067f6f73c4a178e2d0ae42bd18669045d85b5b5ed2c9115c2488ba7aa2a3d88",
-      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.371-aarch64.tar.gz",
+      "url": "mirror://jetbrains/writerside/writerside-243.22562.371-aarch64.tar.gz",
       "build_number": "243.22562.371"
     }
   },
   "x86_64-darwin": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
-      "url-template": "https://download.jetbrains.com/aqua/aqua-{version}.dmg",
+      "url-template": "mirror://jetbrains/aqua/aqua-{version}.dmg",
       "version": "2024.3.2",
       "sha256": "423d492e9849beb7edbbd1771650a04e8df9f469bf1789b41bc5878c84cee393",
-      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.2.dmg",
+      "url": "mirror://jetbrains/aqua/aqua-2024.3.2.dmg",
       "build_number": "243.23654.154"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
-      "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
+      "url-template": "mirror://jetbrains/cpp/CLion-{version}.dmg",
       "version": "2025.1.1",
       "sha256": "e7558d0196390c18e2c11143aa59f2ad56c020d43ebd05057f997fa117abb484",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.1.dmg",
+      "url": "mirror://jetbrains/cpp/CLion-2025.1.1.dmg",
       "build_number": "251.25410.104"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
-      "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
+      "url-template": "mirror://jetbrains/datagrip/datagrip-{version}.dmg",
       "version": "2025.1.2",
       "sha256": "a6b7dadb262813d867281d700456c7bca82b61bea99e52fd54edec05cd07180e",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.2.dmg",
+      "url": "mirror://jetbrains/datagrip/datagrip-2025.1.2.dmg",
       "build_number": "251.25410.123"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
-      "url-template": "https://download.jetbrains.com/python/dataspell-{version}.dmg",
+      "url-template": "mirror://jetbrains/python/dataspell-{version}.dmg",
       "version": "2025.1",
       "sha256": "dd856c72855b0309ea98774a3b4c38cf899b6e307dbd3ced316cd8cc721faa38",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.dmg",
+      "url": "mirror://jetbrains/python/dataspell-2025.1.dmg",
       "build_number": "251.23774.439"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.dmg",
+      "url-template": "mirror://jetbrains/idea/gateway/JetBrainsGateway-{version}.dmg",
       "version": "2025.1.1",
       "sha256": "c849cd16b77b5268ee2e8279bddf02c21a925a25885549d0b1922a785f18120f",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.1.dmg",
+      "url": "mirror://jetbrains/idea/gateway/JetBrainsGateway-2025.1.1.dmg",
       "build_number": "251.25410.139"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
-      "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
+      "url-template": "mirror://jetbrains/go/goland-{version}.dmg",
       "version": "2025.1.1",
       "sha256": "0b00984d45430b37538bf9c55f8f93f1476f819fba1bdea2588ffd36d7e91cb3",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.1.dmg",
+      "url": "mirror://jetbrains/go/goland-2025.1.1.dmg",
       "build_number": "251.25410.140"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
+      "url-template": "mirror://jetbrains/idea/ideaIC-{version}.dmg",
       "version": "2025.1.1.1",
       "sha256": "ee1577a44930b94112819b200acd617cbb3efdfa039df7911094051e9a10e465",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.1.1.dmg",
+      "url": "mirror://jetbrains/idea/ideaIC-2025.1.1.1.dmg",
       "build_number": "251.25410.129"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
+      "url-template": "mirror://jetbrains/idea/ideaIU-{version}.dmg",
       "version": "2025.1.1.1",
       "sha256": "eccd0ba3f9b1f2f680b946a3658830562fd4369dd11cc618b86671c8e237c375",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.1.1.dmg",
+      "url": "mirror://jetbrains/idea/ideaIU-2025.1.1.1.dmg",
       "build_number": "251.25410.129"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
-      "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}-macos.dmg",
+      "url-template": "mirror://jetbrains/mps/{versionMajorMinor}/MPS-{version}-macos.dmg",
       "version": "2025.1",
       "sha256": "1ddae8569c8a96beeb5e85d20f1eed9115ace532a1154b5624f526cb49ddeaa8",
-      "url": "https://download.jetbrains.com/mps/2025.1/MPS-2025.1-macos.dmg",
+      "url": "mirror://jetbrains/mps/2025.1/MPS-2025.1-macos.dmg",
       "build_number": "251.23774.423"
     },
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
+      "url-template": "mirror://jetbrains/webide/PhpStorm-{version}.dmg",
       "version": "2025.1.1",
       "sha256": "2f7c9b0ec1947c7bb2247fd3a949de9921e82e9a2801e388f6cf9d4421073dbd",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.1.dmg",
+      "url": "mirror://jetbrains/webide/PhpStorm-2025.1.1.dmg",
       "build_number": "251.25410.148",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
+      "url-template": "mirror://jetbrains/python/pycharm-community-{version}.dmg",
       "version": "2025.1.1",
       "sha256": "3d439ad29771d8618b03f28497899f09a6eb696c96c789b54aac9ac1bfb4766c",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.1.dmg",
+      "url": "mirror://jetbrains/python/pycharm-community-2025.1.1.dmg",
       "build_number": "251.25410.122"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
+      "url-template": "mirror://jetbrains/python/pycharm-professional-{version}.dmg",
       "version": "2025.1.1",
       "sha256": "cd56a7e1072f4562e2d3ef67e70f227606376572634120170f5689d3b970b570",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.1.dmg",
+      "url": "mirror://jetbrains/python/pycharm-professional-2025.1.1.dmg",
       "build_number": "251.25410.122"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
-      "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
+      "url-template": "mirror://jetbrains/rider/JetBrains.Rider-{version}.dmg",
       "version": "2025.1.2",
       "sha256": "23f3479d1cff5ee1726726bea866ff755b08930e9da43b7ad250e6cb620c1dcf",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2.dmg",
+      "url": "mirror://jetbrains/rider/JetBrains.Rider-2025.1.2.dmg",
       "build_number": "251.25410.119"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
-      "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
+      "url-template": "mirror://jetbrains/ruby/RubyMine-{version}.dmg",
       "version": "2025.1.1",
       "sha256": "97b154079ef326c9a3ce229129d7d220faee30f266954288f74bf6f27ee43942",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.1.dmg",
+      "url": "mirror://jetbrains/ruby/RubyMine-2025.1.1.dmg",
       "build_number": "251.25410.120"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
-      "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
+      "url-template": "mirror://jetbrains/rustrover/RustRover-{version}.dmg",
       "version": "2025.1.2",
       "sha256": "1419d2aac23965838e16c2bedc31851045f8b9d99ccf93594838a4e329059d92",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.2.dmg",
+      "url": "mirror://jetbrains/rustrover/RustRover-2025.1.2.dmg",
       "build_number": "251.25410.115"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
+      "url-template": "mirror://jetbrains/webstorm/WebStorm-{version}.dmg",
       "version": "2025.1.1",
       "sha256": "44363b71b4ad461c07c2c0ae8424f6efabe356b347a2974765f88549a8ee183c",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.1.dmg",
+      "url": "mirror://jetbrains/webstorm/WebStorm-2025.1.1.dmg",
       "build_number": "251.25410.117"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
-      "url-template": "https://download.jetbrains.com/writerside/writerside-{version}.dmg",
+      "url-template": "mirror://jetbrains/writerside/writerside-{version}.dmg",
       "version": "2024.3 EAP",
       "sha256": "0c78b8035497c855aea5666256716778abd46dadf68f51e4f91c0db01f62b280",
-      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.371.dmg",
+      "url": "mirror://jetbrains/writerside/writerside-243.22562.371.dmg",
       "build_number": "243.22562.371"
     }
   },
   "aarch64-darwin": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
-      "url-template": "https://download.jetbrains.com/aqua/aqua-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/aqua/aqua-{version}-aarch64.dmg",
       "version": "2024.3.2",
       "sha256": "43974cdbbb71aaf5bfcfaf2cfd0e69e9920dda3973e64671936c1d52b267494d",
-      "url": "https://download.jetbrains.com/aqua/aqua-2024.3.2-aarch64.dmg",
+      "url": "mirror://jetbrains/aqua/aqua-2024.3.2-aarch64.dmg",
       "build_number": "243.23654.154"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
-      "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/cpp/CLion-{version}-aarch64.dmg",
       "version": "2025.1.1",
       "sha256": "475280e277cc94d18de228bf5f81ebd6ff14084c2e1d2b0db5b4612007dc46fe",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/cpp/CLion-2025.1.1-aarch64.dmg",
       "build_number": "251.25410.104"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
-      "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/datagrip/datagrip-{version}-aarch64.dmg",
       "version": "2025.1.2",
       "sha256": "6d12a59053db3dfa33079ac79b1ea263e5b3ec6fde01d1d803f6d27afea033de",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.2-aarch64.dmg",
+      "url": "mirror://jetbrains/datagrip/datagrip-2025.1.2-aarch64.dmg",
       "build_number": "251.25410.123"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
-      "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/python/dataspell-{version}-aarch64.dmg",
       "version": "2025.1",
       "sha256": "f6dd63c5458ea2adeb76a9042ab3316b124fd9cbdcccd4d4b08c2d90e17b49b8",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1-aarch64.dmg",
+      "url": "mirror://jetbrains/python/dataspell-2025.1-aarch64.dmg",
       "build_number": "251.23774.439"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
       "version": "2025.1.1",
       "sha256": "abad0e061896590bea9bd1d4bead2183be3c1e71d6dfcba89ce2408f34af3536",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/idea/gateway/JetBrainsGateway-2025.1.1-aarch64.dmg",
       "build_number": "251.25410.139"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
-      "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/go/goland-{version}-aarch64.dmg",
       "version": "2025.1.1",
       "sha256": "52e62d5a616b6ab6bf36f0d40d1925e9f477fcf84e187a2a1194d56d5ccae6ec",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/go/goland-2025.1.1-aarch64.dmg",
       "build_number": "251.25410.140"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/idea/ideaIC-{version}-aarch64.dmg",
       "version": "2025.1.1.1",
       "sha256": "92ea35ebfcd9e34cd9bda0103ca036fe1f9eb900c005ae33a9295050ad636dae",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/idea/ideaIC-2025.1.1.1-aarch64.dmg",
       "build_number": "251.25410.129"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
-      "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/idea/ideaIU-{version}-aarch64.dmg",
       "version": "2025.1.1.1",
       "sha256": "5207878b28df2a13e4248c1936ee4fff7c89495e3d4ffdaa3b8da3f21548117e",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/idea/ideaIU-2025.1.1.1-aarch64.dmg",
       "build_number": "251.25410.129"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
-      "url-template": "https://download.jetbrains.com/mps/{versionMajorMinor}/MPS-{version}-macos-aarch64.dmg",
+      "url-template": "mirror://jetbrains/mps/{versionMajorMinor}/MPS-{version}-macos-aarch64.dmg",
       "version": "2025.1",
-      "url": "https://download.jetbrains.com/mps/2025.1/MPS-2025.1-macos-aarch64.dmg",
+      "url": "mirror://jetbrains/mps/2025.1/MPS-2025.1-macos-aarch64.dmg",
       "sha256": "cb2aaa6311252a655ef55f813d3dff78890c2a10cf0aeff885018c316390486b",
       "build_number": "251.23774.423"
     },
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/webide/PhpStorm-{version}-aarch64.dmg",
       "version": "2025.1.1",
       "sha256": "8bb7acf16076e4a32b522107bc359197bb2ee0eeebe0ed5feb1d25d9110830c1",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/webide/PhpStorm-2025.1.1-aarch64.dmg",
       "build_number": "251.25410.148",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/python/pycharm-community-{version}-aarch64.dmg",
       "version": "2025.1.1",
       "sha256": "4e493ce20dd840402ed040f4447d06cab62e59514b5ab2058e94421877f72270",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/python/pycharm-community-2025.1.1-aarch64.dmg",
       "build_number": "251.25410.122"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
-      "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/python/pycharm-professional-{version}-aarch64.dmg",
       "version": "2025.1.1",
       "sha256": "76a97e0d1ca75cbfbcc0acb046154daec1113010c052318077a128ff89fb55a6",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/python/pycharm-professional-2025.1.1-aarch64.dmg",
       "build_number": "251.25410.122"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
-      "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/rider/JetBrains.Rider-{version}-aarch64.dmg",
       "version": "2025.1.2",
       "sha256": "ab6645bba503f0a9d67b2838d1dd88a81ad81dd34e6015ccaea30400c35659e4",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2-aarch64.dmg",
+      "url": "mirror://jetbrains/rider/JetBrains.Rider-2025.1.2-aarch64.dmg",
       "build_number": "251.25410.119"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
-      "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/ruby/RubyMine-{version}-aarch64.dmg",
       "version": "2025.1.1",
       "sha256": "6b8bd9c8ffeec01b0a907604d99cc77ede865aa9abf350e76957d9675ab8a810",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/ruby/RubyMine-2025.1.1-aarch64.dmg",
       "build_number": "251.25410.120"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
-      "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/rustrover/RustRover-{version}-aarch64.dmg",
       "version": "2025.1.2",
       "sha256": "3f12ad41285d6b67dcc577526976b5c394b44caa3f243147143968a505144a79",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.2-aarch64.dmg",
+      "url": "mirror://jetbrains/rustrover/RustRover-2025.1.2-aarch64.dmg",
       "build_number": "251.25410.115"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
-      "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/webstorm/WebStorm-{version}-aarch64.dmg",
       "version": "2025.1.1",
       "sha256": "7acfa46536b598b576775892ac46bb570dd06bc9461cc58c51b9efd4afd09139",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.1-aarch64.dmg",
+      "url": "mirror://jetbrains/webstorm/WebStorm-2025.1.1-aarch64.dmg",
       "build_number": "251.25410.117"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
-      "url-template": "https://download.jetbrains.com/writerside/writerside-{version}-aarch64.dmg",
+      "url-template": "mirror://jetbrains/writerside/writerside-{version}-aarch64.dmg",
       "version": "2024.3 EAP",
       "sha256": "9d86ef50b4c6d2a07d236219e9b05c0557241fb017d52ac395719bdb425130f5",
-      "url": "https://download.jetbrains.com/writerside/writerside-243.22562.371-aarch64.dmg",
+      "url": "mirror://jetbrains/writerside/writerside-243.22562.371-aarch64.dmg",
       "build_number": "243.22562.371"
     }
   }

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -123,6 +123,12 @@
     "ftp://ftp.sunet.se/mirror/imagemagick.org/ftp/" # also contains older versions removed from most mirrors
   ];
 
+  # JetBrain's mirrors
+  jetbrains = [
+    "https://download.jetbrains.com/"
+    "https://download-cf.jetbrains.com/"
+  ];
+
   kde = [
     "https://download.kde.org/"
     "https://ftp.funet.fi/pub/mirrors/ftp.kde.org/pub/kde/"

--- a/pkgs/by-name/ij/ijhttp/package.nix
+++ b/pkgs/by-name/ij/ijhttp/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "243.24978.46";
 
   src = fetchurl {
-    url = "https://download.jetbrains.com/resources/intellij/http-client/${finalAttrs.version}/intellij-http-client.zip";
+    url = "mirror://jetbrains/resources/intellij/http-client/${finalAttrs.version}/intellij-http-client.zip";
     hash = "sha256-L9u/Y0pD/OD2I2WX6mgV5riP8y7Ik+6zVcM/WZJs7rE=";
   };
 

--- a/pkgs/by-name/je/jetbrains-toolbox/package.nix
+++ b/pkgs/by-name/je/jetbrains-toolbox/package.nix
@@ -45,7 +45,7 @@ let
         };
       in
       fetchzip {
-        url = "https://download.jetbrains.com/toolbox/jetbrains-toolbox-${version}${arch}.tar.gz";
+        url = "mirror://jetbrains/toolbox/jetbrains-toolbox-${version}${arch}.tar.gz";
         hash = selectSystem {
           x86_64-linux = "sha256-nIvlO313GZhIpgyCUhp2FUzllD3tk0oRrxFzxtHSIQA=";
           aarch64-linux = "sha256-iggrnpjqLEqiteXnmA+eynTB7cs9YeOnNW4DWGP6mk0=";
@@ -87,7 +87,7 @@ let
         };
       in
       fetchurl {
-        url = "https://download.jetbrains.com/toolbox/jetbrains-toolbox-${finalAttrs.version}${arch}.dmg";
+        url = "mirror://jetbrains/toolbox/jetbrains-toolbox-${finalAttrs.version}${arch}.dmg";
         hash = selectSystem {
           x86_64-darwin = "sha256-518Ew3yhj6wrTfPklNTC6La0EOb/XmrFcNmoeNbod8k=";
           aarch64-darwin = "sha256-Enyn4iJn8qLUdrvin44bGLv0dzl5VOL6KPi4AODhtPE=";

--- a/pkgs/by-name/yo/youtrack/package.nix
+++ b/pkgs/by-name/yo/youtrack/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "2025.1.76253";
 
   src = fetchzip {
-    url = "https://download.jetbrains.com/charisma/youtrack-${finalAttrs.version}.zip";
+    url = "mirror://jetbrains/charisma/youtrack-${finalAttrs.version}.zip";
     hash = "sha256-DW3LZAlkfB7Uqy+xj4Oe3LkYD5fQyi4lDcgv/6brSEs=";
   };
 


### PR DESCRIPTION
Replaced `https://download.jetbrains.com/` with `mirror://jetbrains/`, which aliases to the previous url as well as `https://download-cf.jetbrains.com/`. Update according nix files and internal python scripts. Made sure that the scripts are working and the download hashes match.

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

nixpkgs-review eats up to 10+GiBs of RAM and takes 15 minutes to finish even though my change impacted only fixed-output derivations.
This is a major pain point whenever I try to contribute to nixpkgs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
