### PR TITLE
nixos/netadata: update capabilities

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -367,19 +367,25 @@ in
           # AmbientCapabilities
           AmbientCapabilities = lib.optional isThereAnyWireGuardTunnels "CAP_NET_ADMIN";
           # Capabilities
-          CapabilityBoundingSet = [
-            "CAP_DAC_OVERRIDE" # is required for freeipmi and slabinfo plugins
-            "CAP_DAC_READ_SEARCH" # is required for apps and systemd-journal plugin
-            "CAP_FOWNER" # is required for freeipmi plugin
-            "CAP_SETPCAP" # is required for apps, perf and slabinfo plugins
-            "CAP_SYS_ADMIN" # is required for perf plugin
-            "CAP_SYS_PTRACE" # is required for apps plugin
-            "CAP_SYS_RESOURCE" # is required for ebpf plugin
-            "CAP_NET_RAW" # is required for fping app
-            "CAP_SYS_CHROOT" # is required for cgroups plugin
-            "CAP_SETUID" # is required for cgroups and cgroups-network plugins
-            "CAP_SYSLOG" # is required for systemd-journal plugin
-          ] ++ lib.optional isThereAnyWireGuardTunnels "CAP_NET_ADMIN";
+          CapabilityBoundingSet =
+            [
+              "CAP_DAC_OVERRIDE" # is required for freeipmi and slabinfo plugins
+              "CAP_DAC_READ_SEARCH" # is required for apps and systemd-journal plugin
+              "CAP_NET_RAW" # is required for fping app
+              "CAP_PERFMON" # is required for perf plugin
+              "CAP_SETPCAP" # is required for apps, perf and slabinfo plugins
+              "CAP_SETUID" # is required for cgroups and cgroups-network plugins
+              "CAP_SYSLOG" # is required for systemd-journal plugin
+              "CAP_SYS_ADMIN" # is required for perf plugin
+              "CAP_SYS_CHROOT" # is required for cgroups plugin
+              "CAP_SYS_PTRACE" # is required for apps plugin
+              "CAP_SYS_RESOURCE" # is required for ebpf plugin
+            ]
+            ++ lib.optionals cfg.package.withIpmi [
+              "CAP_FOWNER"
+              "CAP_SYS_RAWIO"
+            ]
+            ++ lib.optional isThereAnyWireGuardTunnels "CAP_NET_ADMIN";
           # Sandboxing
           ProtectSystem = "full";
           ProtectHome = "read-only";
@@ -464,7 +470,7 @@ in
       // lib.optionalAttrs (cfg.package.withIpmi) {
         "freeipmi.plugin" = {
           source = "${cfg.package}/libexec/netdata/plugins.d/freeipmi.plugin.org";
-          capabilities = "cap_dac_override,cap_fowner+ep";
+          capabilities = "cap_dac_override,cap_fowner,cap_sys_rawio+ep";
           owner = cfg.user;
           group = cfg.group;
           permissions = "u+rx,g+x,o-rwx";


### PR DESCRIPTION
Update capabilities for perf and freeipmi plugins.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
