### PR TITLE
gradia: init at v1.4.0

### DIFF
--- a/pkgs/by-name/gr/gradia/package.nix
+++ b/pkgs/by-name/gr/gradia/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  gtk4,
+  ninja,
+  meson,
+  libportal,
+  libadwaita,
+  wrapGAppsHook4,
+  fetchFromGitHub,
+  python3Packages,
+  nix-update-script,
+  blueprint-compiler,
+  desktop-file-utils,
+  gobject-introspection,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "gradia";
+  version = "1.4.0";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "AlexanderVanhee";
+    repo = "gradia";
+    tag = "v${version}";
+    hash = "sha256-9iXz4MjgG4VlystZZIKOheK4hYuz6lRXPivy+1K+cYs=";
+  };
+
+  nativeBuildInputs = [
+    gtk4
+    meson
+    ninja
+    wrapGAppsHook4
+    blueprint-compiler
+    desktop-file-utils
+    gobject-introspection
+  ];
+
+  dependencies = with python3Packages; [
+    pillow
+    pycairo
+    pygobject3
+    pygobject-stubs
+  ];
+
+  buildInputs = [
+    libportal
+    libadwaita
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  dontWrapGApps = true;
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
+  meta = {
+    changelog = "https://github.com/AlexanderVanhee/Gradia/releases/tag/${version}";
+    description = "Make your screenshots ready for the world";
+    homepage = "https://github.com/AlexanderVanhee/Gradia";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "gradia";
+    maintainers = with lib.maintainers; [ quadradical ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Adds Gradia, a screenshot editing program: https://github.com/AlexanderVanhee/Gradia
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
