### PR TITLE
openusd: propagate dependencies OpenGL

### DIFF
--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -72,6 +72,12 @@ buildPythonPackage rec {
       url = "https://github.com/PixarAnimationStudios/OpenUSD/commit/9ea3bc1ab550ec46c426dab04292d9667ccd2518.patch?full_index=1";
       hash = "sha256-QjA3kjUDsSleUr+S/bQLb+QK723SNFvnmRPT+ojjgq8=";
     })
+    (fetchpatch {
+      # https://github.com/PixarAnimationStudios/OpenUSD/pull/3648
+      name = "propagate-dependencies-opengl.patch";
+      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/usd/-/raw/41469f20113d3550c5b42e67d1139dedc1062b8c/usd-find-dependency-OpenGL.patch?full_index=1";
+      hash = "sha256-aUWGKn365qov0ttGOq5GgNxYGIGZ4DfmeMJfakbOugQ=";
+    })
   ];
 
   env.OSL_LOCATION = "${osl}";
@@ -125,7 +131,6 @@ buildPythonPackage rec {
       tbb
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
-      libGL
       libX11
       libXt
     ]
@@ -141,6 +146,9 @@ buildPythonPackage rec {
       opensubdiv
       pyopengl
       distutils
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libGL
     ]
     ++ lib.optionals (withTools || withUsdView) [
       pyside-tools-uic


### PR DESCRIPTION
Part of VTK 9.2.6 → 9.4.2: [https://github.com/NixOS/nixpkgs/pull/407910](https://github.com/NixOS/nixpkgs/pull/407910)

Related upstream pull request: [https://github.com/PixarAnimationStudios/OpenUSD/pull/3648](https://github.com/PixarAnimationStudios/OpenUSD/pull/3648)

### Why OpenUSD should propagate OpenGL and X11:

OpenUSD exports the target `usd_ms`, which links to the target [MaterialXRenderGlsl](https://github.com/PixarAnimationStudios/OpenUSD/blob/3fdaad6b592bae0969d471be3b65e02b5cc4e004/pxr/usdImaging/bin/usdBakeMtlx/CMakeLists.txt#L23), defined in [MaterialX](https://github.com/AcademySoftwareFoundation/MaterialX/blob/97505091af01390b888905237ff6aef432bff2dc/source/MaterialXRenderGlsl/CMakeLists.txt#L84-L86).
As we can see in the [MaterialX](https://github.com/AcademySoftwareFoundation/MaterialX/blob/97505091af01390b888905237ff6aef432bff2dc/source/MaterialXRenderGlsl/CMakeLists.txt#L84-L86) source, `MaterialXRenderGlsl` links to additional OpenGL and X11 targets.

Since not all MaterialX targets defined in `MaterialXTargets.cmake` require OpenGL/X11, it is not the responsibility of MaterialX to propagate these dependencies via `find_dependency(OpenGL/X11)` in their `materialxConfig.cmake` module.

In contrast, `pxrTargets,cmake` (OpenUSD) only defines one target (`usd_ms`) that links to `MaterialXRenderGlsl`. This is why OpenUSD should explicitly propagate the OpenGL and X11 dependencies.

---

### Why OpenUSD is blocking the upgrade of VTK from 9.2.6 to 9.4.2 in the package `f3d`:

VTK > 9.2 uses Glad to find the available OpenGL implementation via `dlopen`, rather than linking to `OpenGL::GL`. As a result, `vtkConfig.cmake` no longer propagates OpenGL via `find_dependency(OpenGL)`.

However, we *do* need the OpenGL target when compiling `f3d` with OpenUSD support. Since OpenUSD does not correctly propagate OpenGL, we miss the `OpenGL::GL` target during the CMake configurePhase.

---

I have tried to contact the OpenUSD upstream to fix this problem first, but they insist on blaming it on `nixpkgs/materialx`.

Therefore, let's fix the problem ourselves.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
