### PR TITLE
cc-wrapper: tidy logic for implied hardening flags

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -18,21 +18,6 @@ if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
   hardeningEnableMap["fortify"]=1
 fi
 
-# Remove unsupported flags.
-for flag in @hardening_unsupported_flags@; do
-  unset -v "hardeningEnableMap[$flag]"
-  # fortify being unsupported implies fortify3 is unsupported
-  if [[ "$flag" = 'fortify' ]] ; then
-    unset -v "hardeningEnableMap['fortify3']"
-  fi
-done
-
-# now make fortify and fortify3 mutually exclusive
-if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
-  unset -v "hardeningEnableMap['fortify']"
-fi
-
-
 # strictflexarrays3 implies strictflexarrays1 enablement - make explicit before
 # we filter unsupported flags because unsupporting strictflexarrays3
 # doesn't mean we should unsupport strictflexarrays1 too
@@ -40,14 +25,25 @@ if [[ -n "${hardeningEnableMap[strictflexarrays3]-}" ]]; then
   hardeningEnableMap["strictflexarrays1"]=1
 fi
 
+
 # Remove unsupported flags.
 for flag in @hardening_unsupported_flags@; do
   unset -v "hardeningEnableMap[$flag]"
+  # fortify being unsupported implies fortify3 is unsupported
+  if [[ "$flag" = 'fortify' ]] ; then
+    unset -v "hardeningEnableMap['fortify3']"
+  fi
   # strictflexarrays1 being unsupported implies strictflexarrays3 is unsupported
   if [[ "$flag" = 'strictflexarrays1' ]] ; then
     unset -v "hardeningEnableMap['strictflexarrays3']"
   fi
 done
+
+
+# now make fortify and fortify3 mutually exclusive
+if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
+  unset -v "hardeningEnableMap['fortify']"
+fi
 
 # now make strictflexarrays1 and strictflexarrays3 mutually exclusive
 if [[ -n "${hardeningEnableMap[strictflexarrays3]-}" ]]; then


### PR DESCRIPTION
I'm not sure my brain was fully working when I wrote this bit of #400408. What's committed works fine, but it makes a lot more sense to combine the "Remove unsupported flags" loops.

Tested `tests.hardeningFlags` on indicated platforms successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
