### PR TITLE
nixos/vintagestory: init at 1.20.11

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -617,6 +617,7 @@
   ./services/games/quake3-server.nix
   ./services/games/teeworlds.nix
   ./services/games/terraria.nix
+  ./services/games/vintagestory.nix
   ./services/games/xonotic.nix
   ./services/hardware/acpid.nix
   ./services/hardware/actkbd.nix

--- a/nixos/modules/services/games/vintagestory.nix
+++ b/nixos/modules/services/games/vintagestory.nix
@@ -1,0 +1,130 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.vintagestory;
+in
+{
+  options.services.vintagestory = {
+    enable = lib.mkEnableOption "Vintagestory server";
+    package = lib.mkPackageOption pkgs "vintagestory" { };
+
+    openFirewall = lib.mkOption {
+      description = "open the firewall on the specified port";
+      default = false;
+      type = lib.types.bool;
+    };
+
+    host = lib.mkOption {
+      description = "The address that the server will bind to";
+      default = null;
+      example = "127.0.0.1";
+      type = with lib.types; nullOr singleLineStr;
+    };
+
+    port = lib.mkOption {
+      description = "The port that the server will bind to";
+      default = 42420;
+      type = lib.types.port;
+    };
+
+    maxClients = lib.mkOption {
+      description = "The maximum amount of players that are allowed to join";
+      default = 16;
+      type = lib.types.int;
+    };
+
+    dataPath = lib.mkOption {
+      description = "The path under /var/lib to store the server's state in";
+      default = "vintagestory";
+      example = "vintagestory-2";
+      type = lib.types.str;
+    };
+
+    extraFlags = lib.mkOption {
+      description = "Extra flags to pass to the server";
+      default = [ ];
+      type = with lib.types; listOf str;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.groups.vintagestory = { };
+
+    users.users.vintagestory = {
+      isSystemUser = true;
+      group = "vintagestory";
+    };
+
+    systemd.services.vintagestory = {
+      description = "Vintagestory server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      script =
+        let
+          # NOTE: casing is inconsistent in the server CLI, so this is
+          # intentional
+          opts = {
+            inherit (cfg) port;
+            dataPath = "/var/lib/${cfg.dataPath}";
+            ip = cfg.host;
+            maxclients = builtins.toString cfg.maxClients;
+          };
+        in
+        ''
+          ${lib.getExe' cfg.package "vintagestory-server"} \
+            ${lib.cli.toGNUCommandLineShell { } opts} \
+            ${lib.concatStringsSep " " cfg.extraFlags}
+        '';
+
+      serviceConfig = {
+        StateDirectory = cfg.dataPath;
+
+        User = "vintagestory";
+        Group = "vintagestory";
+
+        Sockets = "vintagestory.socket";
+        # HACK: can't send all three over the same socket, because the
+        # vintagestory server doesn't seem to support it
+        StandardInput = "socket";
+        StandardOutput = "journal";
+        StandardError = "journal";
+
+        Restart = "on-failure";
+        RestartSec = 10;
+        StartLimitBurst = 5;
+      };
+    };
+
+    systemd.sockets.vintagestory = {
+      description = "Command input for Vintagestory server";
+      socketConfig = {
+        ListenFIFO = "%t/vintagestory.socket";
+        Service = "vintagestory.service";
+      };
+    };
+
+    environment.systemPackages = [
+      # HACK: read from the journal and pipe stdin to the socket at the same
+      # time, to circumvent vintagestory limitations
+      # At the moment this script is also the only way to make a player an
+      # operator
+      (pkgs.writeShellScriptBin "vintagestory-admin" ''
+        journalctl -o cat -fu vintagestory.service & pid=$!
+        ${lib.getExe pkgs.socat} -u STDIN PIPE:/run/vintagestory.socket
+
+        kill $pid
+      '')
+    ];
+
+    networking.firewall.allowedUDPPorts = lib.optional cfg.openFirewall cfg.port;
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall cfg.port;
+  };
+
+  meta.maintainers = with lib.maintainers; [ dtomvan ];
+}


### PR DESCRIPTION
Adds a module for a [vintagestory](https://www.vintagestory.at) server.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
