### PR TITLE
seppo: init at 0-unstable-2025-06-03

### DIFF
--- a/pkgs/by-name/se/seppo/mcdb.nix
+++ b/pkgs/by-name/se/seppo/mcdb.nix
@@ -1,0 +1,26 @@
+{
+  buildDunePackage,
+  camlp-streams,
+  optint,
+  alcotest,
+  uri,
+  base64,
+  seppo,
+}:
+
+buildDunePackage {
+  pname = "mcdb";
+
+  inherit (seppo) version src;
+
+  propagatedBuildInputs = [
+    camlp-streams
+    optint
+  ];
+
+  checkInputs = [
+    alcotest
+    uri
+    base64
+  ];
+}

--- a/pkgs/by-name/se/seppo/package.nix
+++ b/pkgs/by-name/se/seppo/package.nix
@@ -1,0 +1,69 @@
+{
+  ocamlPackages,
+  fetchFromGitea,
+  ocaml-crunch,
+  seppo,
+  lib,
+}:
+
+let
+  mcdb = ocamlPackages.callPackage ./mcdb.nix { inherit seppo; };
+in
+
+ocamlPackages.buildDunePackage {
+  pname = "seppo";
+  version = "0-unstable-2025-06-03";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "seppo";
+    repo = "seppo";
+    rev = "33ae3e9f61d596fb91d3ab1a91fc26ae80981a93";
+    hash = "sha256-tOIIfYBLcZqQzoPxAVkE8RGX0sugUmDGpxIhIZ5Wy+w=";
+  };
+
+  # Provide git sha to avoid git dependency
+  env.GIT_SHA = seppo.src.rev;
+
+  # Static build fails to find correct static libraries
+  postPatch = ''
+    sed -i 's/-static/""/' bin/gen_flags.sh
+  '';
+
+  nativeBuildInputs = [
+    ocaml-crunch
+  ];
+
+  buildInputs = with ocamlPackages; [
+    mcdb
+
+    camlp-streams
+    cohttp-lwt-unix
+    crunch
+    csexp
+    decoders-ezjsonm
+    lambdasoup
+    lwt_ppx
+    mirage-crypto-rng
+    ocaml_sqlite3
+    optint
+    safepass
+    timedesc
+    tls-lwt
+    tyre
+    uucp
+    uuidm
+    uunf
+    uutf
+    x509
+    xmlm
+  ];
+
+  meta = {
+    homepage = "https://seppo.mro.name";
+    description = "Personal Social Web";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ infinidoge ];
+    mainProgram = "seppo";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

#Seppo is a form of social media designed to be a CGI script you install by just placing on a destination server.

This package accomplishes half of that. It isn't a 'true' package because it doesn't build statically. Please let me know if you know how to get it to build statically.

That said, simply linking the binary into place on a webserver works as intended:
![image](https://github.com/user-attachments/assets/a73d2a0c-1a6d-4335-811d-c1c9082e2245)

**Note:** This must be merged after #409636, and will have those commits rebased out after it is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
