### PR TITLE
Revert "Update rbtools to the latest version 5.2.1"

### DIFF
--- a/pkgs/development/python-modules/rbtools/default.nix
+++ b/pkgs/development/python-modules/rbtools/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "rbtools";
-  version = "5.2.1";
+  version = "1.0.2";
   format = "setuptools";
 
   disabled = !isPy3k;
 
   src = fetchurl {
     url = "https://downloads.reviewboard.org/releases/RBTools/${lib.versions.majorMinor version}/RBTools-${version}.tar.gz";
-    sha256 = "f2863515ef6ff1cfcd3905d5f409ab8c4d12878b364d6f805ba848dcaecb97f2";
+    sha256 = "577c2f8bbf88f77bda84ee95af0310b59111c156f48a5aab56ca481e2f77eaf4";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#403396, as this [does not build](https://hydra.nixos.org/job/nixpkgs/trunk/python312Packages.rbtools.x86_64-linux).