### PR TITLE
gnomeExtensions: auto-update

### DIFF
--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -216,4 +216,18 @@ lib.trivial.pipe super [
         --replace "GLib.build_filenamev([GLib.DIR_SEPARATOR_S, 'usr', 'share', 'touchegg', 'touchegg.conf'])" "'${touchegg}/share/touchegg/touchegg.conf'"
     '';
   }))
+
+  (patchExtension "pwcalc@thilomaurer.de" {
+    postPatch = ''
+      # remove unused dangling symlink
+      rm settings-importexport.ui
+    '';
+  })
+
+  (patchExtension "TeaTimer@zener.sbg.at" {
+    postPatch = ''
+      # remove unused dangling symlink
+      rm utilities-teatime.svg
+    '';
+  })
 ]

--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -142,7 +142,6 @@ lib.trivial.pipe super [
         xdg_utils = xdg-utils;
         gtk_update_icon_cache = "${gtk4.out}/bin/gtk4-update-icon-cache";
         update_desktop_database = "${desktop-file-utils.out}/bin/update-desktop-database";
-        xdg_user_dirs = lib.getExe xdg-user-dirs;
         nautilus_gsettings_path = glib.getSchemaPath nautilus;
       })
     ];

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/gtk4-ding_at_smedius.gitlab.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/gtk4-ding_at_smedius.gitlab.com.patch
@@ -26,28 +26,6 @@ index 42cb878c..929ddce2 100755
                      `${GLib.path_get_dirname(appDesktopFile)}`
                  );
  
-diff --git a/app/adwPreferencesWindow.js b/app/adwPreferencesWindow.js
-index 93d53554..8f5bb8fe 100644
---- a/app/adwPreferencesWindow.js
-+++ b/app/adwPreferencesWindow.js
-@@ -540,7 +540,7 @@ const AdwPreferencesWindow = class {
-     }
- 
-     setDesktopFolder(path) {
--        const command = 'xdg-user-dirs-update --set DESKTOP';
-+        const command = '@xdg_user_dirs@/bin/xdg-user-dirs-update --set DESKTOP';
- 
-         try {
-             GLib.spawn_command_line_async(
-@@ -564,7 +564,7 @@ const AdwPreferencesWindow = class {
-     }
- 
-     getCurrentDesktopFolder() {
--        const command = 'xdg-user-dir DESKTOP';
-+        const command = '@xdg_user_dirs@/bin/xdg-user-dir DESKTOP';
-         const decoder = new TextDecoder();
-         const [, out,, status] = GLib.spawn_command_line_sync(command);
- 
 diff --git a/app/enums.js b/app/enums.js
 index 5434fa7a..e36d3670 100644
 --- a/app/enums.js


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes #411564
Closes #413134

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
