### PR TITLE
fetchtor: init

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -945,3 +945,32 @@ fetchtorrent {
 - `config`: When using `transmission` as the `backend`, a json configuration can
   be supplied to transmission. Refer to the [upstream documentation](https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md) for information on how to configure.
 
+## `fetchtor` {#fetchtor}
+
+`fetchtor` proxies HTTP requests over a temporary Tor process, allowing `.onion` addresses to be accessed. By default, it behaves like `fetchgit`, `fetchzip`, or `fetchurl`, depending on parameters, but the underlying fetcher can be any fetcher that handles the `ALL_PROXY` and `NO_PROXY` environment variables the same way that curl does.
+
+::: {.example #ex-fetchtor}
+# `fetchtor` usage example
+```nix
+{ fetchtor }:
+fetchtor {
+  url = "http://eweiibe6tdjsdprb4px6rqrzzcsi22m4koia44kc5pcjr7nec2rlxyad.onion/tpo/core/tor";
+  rev = "933c5491db00c703d5d8264fdabd5a5b10aff96f";
+  hash = "sha256-o6Wpso8GSlQH39GpH3IXZyrVhdP8pEYFxLDq9a7yHX0=";
+}
+```
+:::
+
+### Parameters {#fetchtor-parameters}
+
+- `fetcher`: The underlying fetcher to use over Tor.
+
+   This defaults to `fetchgit` if a `rev` attribute is specified, `fetchzip` if
+   the `url` attribute looks like an archive, and `fetchurl` otherwise.
+
+- `noTor`: A list of domains not to proxy through Tor. Default: `[ ]`.
+
+   This is useful when using `fetchgit` and there are submodules that are
+   accessible from the clearnet.
+
+All other parameters are passed to `fetcher` as-is.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1573,6 +1573,15 @@
   "requirefile": [
     "index.html#requirefile"
   ],
+  "fetchtor": [
+    "index.html#fetchtor"
+  ],
+  "ex-fetchtor": [
+    "index.html#ex-fetchtor"
+  ],
+  "fetchtor-parameters": [
+    "index.html#fetchtor-parameters"
+  ],
   "fetchtorrent": [
     "index.html#fetchtorrent"
   ],

--- a/pkgs/build-support/fetchtor/builder.sh
+++ b/pkgs/build-support/fetchtor/builder.sh
@@ -1,0 +1,14 @@
+torSocket=$NIX_BUILD_TOP/.tor.sock
+torPort=unix:$torSocket
+
+exec {tor_fd}< <(tor --DataDirectory "$NIX_BUILD_TOP/.tor" --SocksPort "$torPort")
+trap "kill '$!'" EXIT
+
+# Wait for Tor to start
+read < <(<&$tor_fd- tee /dev/fd/2 | grep -m 1 -F 'Bootstrapped 100% (done): Done')
+
+export ALL_PROXY="socks5h://localhost$torSocket"
+export http_proxy=$ALL_PROXY # fetchgit insists on this variable even though Git does not
+export NO_PROXY=${noTor// /,}
+
+. "$innerBuilder"

--- a/pkgs/build-support/fetchtor/default.nix
+++ b/pkgs/build-support/fetchtor/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchgit,
+  fetchurl,
+  fetchzip,
+  tor,
+}:
+let
+  defaultFetcherFromUrl =
+    url:
+    if
+      lib.hasSuffix ".tar" url
+      || lib.hasSuffix ".tar.bz" url
+      || lib.hasSuffix ".tar.gz" url
+      || lib.hasSuffix ".tar.xz" url
+      || lib.hasSuffix ".tgz" url
+      || lib.hasSuffix ".zip" url
+    then
+      fetchzip
+    else
+      fetchurl;
+in
+{
+  /**
+    The underlying fetcher to use over Tor.
+
+    This defaults to fetchgit if a rev attribute is specified, fetchzip if
+    the URL looks like an archive, and fetchurl otherwise; but in theory you
+    can set it to any fetcher that honors curl's ALL_PROXY and NO_PROXY
+    environment variables.
+  */
+  fetcher ? if args ? rev then fetchgit else defaultFetcherFromUrl (lib.toLower args.url),
+
+  /**
+    A list of domains not to proxy through Tor.
+
+    This is useful when using fetchgit and there are submodules that are
+    accessible from the clearnet.
+  */
+  noTor ? [ ],
+  ...
+}@args:
+
+(fetcher (
+  removeAttrs args [
+    "fetcher"
+    "noTor"
+  ]
+)).overrideAttrs
+  (prevAttrs: {
+    nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ tor ];
+    builder = ./builder.sh;
+    innerBuilder = prevAttrs.builder;
+    inherit noTor;
+  })

--- a/pkgs/build-support/fetchtor/tests.nix
+++ b/pkgs/build-support/fetchtor/tests.nix
@@ -1,0 +1,40 @@
+{
+  testers,
+  fetchtor,
+  fetchFromGitLab,
+  ...
+}:
+let
+  domain = "eweiibe6tdjsdprb4px6rqrzzcsi22m4koia44kc5pcjr7nec2rlxyad.onion";
+in
+{
+  viaGit = testers.invalidateFetcherByDrvHash fetchtor {
+    name = "fetchgit-tor-source";
+    url = "http://${domain}/tpo/core/tor";
+    rev = "933c5491db00c703d5d8264fdabd5a5b10aff96f";
+    hash = "sha256-o6Wpso8GSlQH39GpH3IXZyrVhdP8pEYFxLDq9a7yHX0=";
+  };
+
+  viaZip = testers.invalidateFetcherByDrvHash fetchtor {
+    name = "fetchzip-tor-source";
+    url = "http://${domain}/tpo/core/tor/-/archive/933c5491db00c703d5d8264fdabd5a5b10aff96f/tor-933c5491db00c703d5d8264fdabd5a5b10aff96f.zip";
+    hash = "sha256-o6Wpso8GSlQH39GpH3IXZyrVhdP8pEYFxLDq9a7yHX0=";
+  };
+
+  viaFetchUrl = testers.invalidateFetcherByDrvHash fetchtor {
+    name = "fetchurl-tor-source";
+    url = "http://${domain}/tpo/core/tor/-/raw/933c5491db00c703d5d8264fdabd5a5b10aff96f/Cargo.lock";
+    hash = "sha256-oX4WbsscLADgJ5o+czpueyAih7ic0u4lZQs7y1vMA3A=";
+  };
+
+  viaFetchFromGitLab = testers.invalidateFetcherByDrvHash fetchtor {
+    name = "gitlab-tor-source";
+    fetcher = fetchFromGitLab;
+    protocol = "http";
+    inherit domain;
+    owner = "tpo/core";
+    repo = "tor";
+    rev = "933c5491db00c703d5d8264fdabd5a5b10aff96f";
+    hash = "sha256-o6Wpso8GSlQH39GpH3IXZyrVhdP8pEYFxLDq9a7yHX0=";
+  };
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -121,6 +121,7 @@ with pkgs;
   compress-drv = callPackage ../build-support/compress-drv/test.nix { };
 
   fetchurl = recurseIntoAttrs (callPackages ../build-support/fetchurl/tests.nix { });
+  fetchtor = recurseIntoAttrs (callPackages ../build-support/fetchtor/tests.nix { });
   fetchtorrent = recurseIntoAttrs (callPackages ../build-support/fetchtorrent/tests.nix { });
   fetchpatch = recurseIntoAttrs (callPackages ../build-support/fetchpatch/tests.nix { });
   fetchpatch2 = recurseIntoAttrs (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -597,6 +597,8 @@ with pkgs;
 
   fetchs3 = callPackage ../build-support/fetchs3 { };
 
+  fetchtor = callPackage ../build-support/fetchtor { };
+
   fetchtorrent = callPackage ../build-support/fetchtorrent { };
 
   fetchsvn =


### PR DESCRIPTION
This is a fetcher that wraps another fetcher and proxies its HTTP requests through Tor. This is useful if the canonical source for a piece of software is not available in the clearnet, but can only be fetched from an `.onion` link.

The wrapped fetcher is selected from `fetchgit`, `fetchzip`, or `fetchurl`, based on whether there is a `rev` attribute or whether the `url` attribute looks like an archive. It can also be explicitly specified if the default selection isn't correct or if a different fetcher is desired. See tests for examples.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
