### PR TITLE
mpv-handler: init at 0.3.16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14345,6 +14345,12 @@
     name = "legendofmiracles";
     keys = [ { fingerprint = "CC50 F82C 985D 2679 0703  AF15 19B0 82B3 DEFE 5451"; } ];
   };
+  lonerOrz = {
+    email = "2788892716@qq.com";
+    name = "lonerOrz";
+    github = "lonerOrz";
+    githubId = 68736947;
+  };
   longer = {
     email = "michal@mieszczak.com.pl";
     name = "Michał Mieszczak";

--- a/pkgs/by-name/mp/mpv-handler/package.nix
+++ b/pkgs/by-name/mp/mpv-handler/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  mpv,
+  yt-dlp,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "mpv-handler";
+  version = "0.3.16";
+
+  src = fetchFromGitHub {
+    owner = "akiirui";
+    repo = "mpv-handler";
+    tag = "v${version}";
+    hash = "sha256-RpfHUVZmhtneeu8PIfxinYG3/groJPA9QveDSvzU6Zo=";
+  };
+
+  cargoHash = "sha256-FrE1PSRc7GTNUum05jNgKnzpDUc3FiS5CEM18It0lYY=";
+  useFetchCargoVendor = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    install -Dm644 share/linux/mpv-handler.desktop -t $out/share/applications/
+    install -Dm644 share/linux/mpv-handler-debug.desktop -t $out/share/applications/
+    install -Dm644 share/linux/config.toml -t $out/share/doc/mpv-handler/
+
+    wrapProgram $out/bin/mpv-handler \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          mpv
+          yt-dlp
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Play website videos and songs with mpv & yt-dlp";
+    homepage = "https://github.com/akiirui/mpv-handler";
+    mainProgram = "mpv-handler";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lonerOrz ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Summary

Add [mpv-handler](https://github.com/kelciour/mpv-handler), a simple URL scheme handler to launch videos directly in `mpv`, e.g. using `mpv://...` or `mpv-debug://...`.

This tool is useful for integrating video playback in `mpv` from browsers or external apps via custom protocol links.

Also added myself to `lib/maintainers.nix`.

## Things done

- Built on platform(s):
  - [x] x86_64-linux
- Tested:
  - [x] Built with `nix build .#mpv-handler`
  - [x] Verified basic functionality (`mpv-handler mpv://...` works)
- [x] Added `meta.maintainers = with maintainers; [ lonerOrz ];`
- [x] Added myself to `lib/maintainers.nix`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)