### PR TITLE
dsf2flac: fix build, clean up & unstable-2021-07-31 -> unstable-2025-01-31

### DIFF
--- a/pkgs/by-name/ds/dsf2flac/package.nix
+++ b/pkgs/by-name/ds/dsf2flac/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   preConfigure = ''
-    export LIBS="$LIBS -lz"
+    export LIBS="$LIBS -lz -lboost_timer"
   '';
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ];

--- a/pkgs/by-name/ds/dsf2flac/package.nix
+++ b/pkgs/by-name/ds/dsf2flac/package.nix
@@ -43,11 +43,11 @@ stdenv.mkDerivation {
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ];
 
-  meta = with lib; {
+  meta = {
     description = "DSD to FLAC transcoding tool";
     homepage = "https://github.com/hank/dsf2flac";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ artemist ];
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ artemist ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "dsf2flac";
   };

--- a/pkgs/by-name/ds/dsf2flac/package.nix
+++ b/pkgs/by-name/ds/dsf2flac/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation {
   pname = "dsf2flac";
-  version = "unstable-2021-07-31";
+  version = "0-unstable-2025-01-31";
 
   src = fetchFromGitHub {
     owner = "hank";
     repo = "dsf2flac";
-    rev = "6b109cd276ec7c7901f96455c77cf2d2ebfbb181";
-    sha256 = "sha256-VlXfywgYhI2QuGQvpD33BspTTgT0jOKUV3gENq4HiBU=";
+    rev = "39d43901ce27d0cc53b5a4eb277a65082e9906f0";
+    hash = "sha256-I8BupNE49+9oExR/GhoZUVbCHhDJEz3hhvQnbi8ZVGs=";
   };
 
   buildInputs = [
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
   meta = {
     description = "DSD to FLAC transcoding tool";
     homepage = "https://github.com/hank/dsf2flac";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ artemist ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "dsf2flac";


### PR DESCRIPTION
Hydra failure: https://hydra.nixos.org/build/297283428

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
