### PR TITLE
feishin: 0.12.6 -> 0.17.0

### DIFF
--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -1,134 +1,123 @@
 {
   lib,
   stdenv,
-  buildNpmPackage,
+  pnpm_10,
+  nodejs_24,
   fetchFromGitHub,
   electron_36,
   darwin,
   copyDesktopItems,
   makeDesktopItem,
-  ...
+  makeWrapper,
 }:
-let
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "feishin";
-  version = "0.12.6";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "jeffvli";
     repo = "feishin";
     rev = "v${version}";
-    hash = "sha256-cnlPks/sJdcxHdIppHn8Q8d2tkwVlPMofQxjdAlBreg=";
+    hash = "sha256-4gcS7Vd7LSpEByO2Hlk6nb8V2adBPh5XwWGCu2lwOA4=";
+  };
+
+  pnpmDeps = pnpm_10.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    hash = "sha256-1MGxrUcfvazxAubaYAsQuulUKm05opWOIC7oaLzjr7o=";
   };
 
   electron = electron_36;
-in
-buildNpmPackage {
-  inherit pname version;
 
-  inherit src;
-  npmDepsHash = "sha256-lThh29prT/cHRrp2mEtUW4eeVfCtkk+54EPNUyGHyq8=";
-
-  npmFlags = [ "--legacy-peer-deps" ];
   makeCacheWritable = true;
 
-  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
-  nativeBuildInputs =
-    lib.optionals (stdenv.hostPlatform.isLinux) [ copyDesktopItems ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
+  nativeBuildInputs = [
+    nodejs_24
+    pnpm_10.configHook
+    makeWrapper
+    electron
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux) [ copyDesktopItems ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
 
-  postPatch =
-    ''
-      # release/app dependencies are installed on preConfigure
-      substituteInPlace package.json \
-        --replace-fail "electron-builder install-app-deps &&" ""
+  postPatch = ''
+    substituteInPlace package.json \
+      --replace-fail "electron-builder install-app-deps" ""
 
-      # Don't check for updates.
-      substituteInPlace src/main/main.ts \
-        --replace-fail "autoUpdater.checkForUpdatesAndNotify();" ""
-    ''
-    + lib.optionalString stdenv.hostPlatform.isLinux ''
-      # https://github.com/electron/electron/issues/31121
-      substituteInPlace src/main/main.ts \
-        --replace-fail "process.resourcesPath" "'$out/share/feishin/resources'"
-    '';
+    # Don't check for updates.
+    substituteInPlace src/main/index.ts \
+      --replace-fail "autoUpdater.checkForUpdatesAndNotify();" ""
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    # https://github.com/electron/electron/issues/31121
+    substituteInPlace src/main/index.ts \
+      --replace-fail "process.resourcesPath" "'$out/share/feishin/resources'"
+  '';
 
-  preConfigure =
-    let
-      releaseAppDeps = buildNpmPackage {
-        pname = "${pname}-release-app";
-        inherit version;
+  buildPhase = ''
+    runHook preBuild
 
-        src = "${src}/release/app";
-        npmDepsHash = "sha256-kEe5HH/oslH8vtAcJuWTOLc0ZQPxlDVMS4U0RpD8enE=";
+    pnpm --offline electron-vite build
 
-        npmFlags = [ "--ignore-scripts" ];
-        dontNpmBuild = true;
-
-        env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-      };
-      releaseNodeModules = "${releaseAppDeps}/lib/node_modules/feishin/node_modules";
-    in
-    ''
-      for release_module_path in "${releaseNodeModules}"/*; do
-        rm -rf node_modules/"$(basename "$release_module_path")"
-        ln -s "$release_module_path" node_modules/
-      done
-    '';
+    runHook postBuild
+  '';
 
   postBuild =
     lib.optionalString stdenv.hostPlatform.isDarwin ''
       # electron-builder appears to build directly on top of Electron.app, by overwriting the files in the bundle.
       cp -r ${electron.dist}/Electron.app ./
       find ./Electron.app -name 'Info.plist' | xargs -d '\n' chmod +rw
-
       # Disable code signing during build on macOS.
       # https://github.com/electron-userland/electron-builder/blob/fa6fc16/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
       export CSC_IDENTITY_AUTO_DISCOVERY=false
       sed -i "/afterSign/d" package.json
     ''
     + ''
-      npm exec electron-builder -- \
-        --dir \
-        -c.electronDist=${if stdenv.hostPlatform.isDarwin then "./" else electron.dist} \
-        -c.electronVersion=${electron.version} \
-        -c.npmRebuild=false
+      pnpm --offline electron-builder \
+      --dir \
+      -c.electronDist=${if stdenv.hostPlatform.isDarwin then "./" else electron.dist} \
+      -c.electronVersion=${electron.version} \
+      -c.npmRebuild=false
     '';
 
-  installPhase =
-    ''
-      runHook preInstall
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      mkdir -p $out/{Applications,bin}
-      cp -r release/build/**/Feishin.app $out/Applications/
-      makeWrapper $out/Applications/Feishin.app/Contents/MacOS/Feishin $out/bin/feishin
-    ''
-    + lib.optionalString stdenv.hostPlatform.isLinux ''
-      mkdir -p $out/share/feishin
-      pushd release/build/*/
-      cp -r locales resources{,.pak} $out/share/feishin
-      popd
+  installPhase = ''
+    runHook preInstall
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/{Applications,bin}
+    cp -r dist/**/Feishin.app $out/Applications/
+    makeWrapper $out/Applications/Feishin.app/Contents/MacOS/Feishin $out/bin/feishin
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out/share/feishin
+    pushd dist/*/
+    cp -r locales resources{,.pak} $out/share/feishin
+    popd
 
-      # Code relies on checking app.isPackaged, which returns false if the executable is electron.
-      # Set ELECTRON_FORCE_IS_PACKAGED=1.
-      # https://github.com/electron/electron/issues/35153#issuecomment-1202718531
-      makeWrapper ${lib.getExe electron} $out/bin/feishin \
-        --add-flags $out/share/feishin/resources/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
-        --set ELECTRON_FORCE_IS_PACKAGED=1 \
-        --inherit-argv0
+    for size in 32 64 128 256 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      ln -s \
+        $out/share/feishin/resources/assets/icons/"$size"x"$size".png \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/feishin.png
+    done
+  ''
+  + ''
+    runHook postInstall
+  '';
 
-      for size in 32 64 128 256 512 1024; do
-        mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-        ln -s \
-          $out/share/feishin/resources/assets/icons/"$size"x"$size".png \
-          $out/share/icons/hicolor/"$size"x"$size"/apps/feishin.png
-      done
-    ''
-    + ''
-      runHook postInstall
-    '';
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    makeWrapper ${lib.getExe electron} $out/bin/feishin \
+      --add-flags $out/share/feishin/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+  '';
 
   desktopItems = [
     (makeDesktopItem {
@@ -158,4 +147,4 @@ buildNpmPackage {
       jlbribeiro
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- upgrade [feishin](https://github.com/jeffvli/feishin) to [v0.17.0](https://github.com/jeffvli/feishin/releases/tag/v0.17.0)
- change from electron-builder to electron-vite to match package changes
- change from `buildNpmPackage` to `mkDerivation` with `pnpm`
- use `dart-sass` to patch `sass-embedded` required by package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
