### PR TITLE
[Backport release-24.11] mbedtls_2: 2.28.9 -> 2.28.10

### DIFF
--- a/pkgs/development/libraries/mbedtls/2.nix
+++ b/pkgs/development/libraries/mbedtls/2.nix
@@ -1,6 +1,6 @@
 { callPackage }:
 
 callPackage ./generic.nix {
-  version = "2.28.9";
-  hash = "sha256-/Bm05CvS9t7WSh4qoMconCaD7frlmA/H9YDyJOuGuFE=";
+  version = "2.28.10";
+  hash = "sha256-09XWds45TFH7GORrju8pVQQQQomU8MlFAq1jJXrLW0s=";
 }


### PR DESCRIPTION
(cherry picked from commit ec2b95cf8654a8c1f531f22626a7ffd7a59555e1)

Picked from PR #414320 with trivial/automatic conflict resolution.