### PR TITLE
fosrl-pangolin: init at 1.2.0

### DIFF
--- a/pkgs/by-name/fo/fosrl-pangolin/package.nix
+++ b/pkgs/by-name/fo/fosrl-pangolin/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  fetchFromGitHub,
+  esbuild,
+  buildNpmPackage,
+  inter,
+}:
+
+buildNpmPackage rec {
+  pname = "pangolin";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "fosrl";
+    repo = "pangolin";
+    tag = version;
+    hash = "sha256-2yrim4pr8cgIh/FBuGIuK+ycwImpMiz+m21H5qYARmU=";
+  };
+
+  npmDepsHash = "sha256-fi4e79Bk1LC/LizBJ+EhCjDzLR5ZocgVyWbSXsEJKdw=";
+  nativeBuildInputs = [ esbuild ];
+  # Replace the googleapis.com Inter font with a local copy from nixpkgs
+  # based on
+  # https://github.com/NixOS/nixpkgs/blob/f7bf574774e466b984063a44330384cdbca67d6c/pkgs/by-name/ne/nextjs-ollama-llm-ui/package.nix
+  postPatch = ''
+    substituteInPlace src/app/layout.tsx --replace-fail \
+      "{ Figtree, Inter } from \"next/font/google\"" \
+      "localFont from \"next/font/local\""
+
+    substituteInPlace src/app/layout.tsx --replace-fail \
+      "Inter({ subsets: [\"latin\"] })" \
+      "localFont({ src: './Inter.ttf' })"
+
+    cp "${inter}/share/fonts/truetype/InterVariable.ttf" src/app/Inter.ttf
+  '';
+
+  preBuild = ''
+    npx drizzle-kit generate --dialect sqlite --schema ./server/db/schemas/ --out init
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/
+
+    cp -r .next/standalone/* $out/
+    cp -r .next/standalone/.next $out/
+
+    cp -r .next/static $out/.next/static
+    cp -r dist $out/dist
+    cp -r init $out/dist/init
+
+    cp server/db/names.json $out/dist/names.json
+    cp -r public $out/public
+    cp -r node_modules $out/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Tunneled reverse proxy server with identity and access control";
+    homepage = "https://github.com/fosrl/pangolin";
+    changelog = "https://github.com/fosrl/pangolin/releases/tag/${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ jackr ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Package for Pangolin,  a self-hosted tunneled reverse proxy server with identity and access control, designed to securely expose private resources on distributed networks. Service to come soon :)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
