### PR TITLE
[Backport release-24.11] firefox-beta-bin-unwrapped: 140.0b3 -> 140.0b6

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,2477 +1,2477 @@
 {
-  version = "140.0b4";
+  version = "140.0b6";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ach/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ach/firefox-140.0b6.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "79c4bae3ab2ecc83eaaaab31104e117ba66ad82abc4dfae2f5ec76dde47f51ad";
+      sha256 = "0cf9f3c0865a1dc3c327e78cfb2447f64d64a280121c78aeee4046d74116dce4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/af/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/af/firefox-140.0b6.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "699a969d7ab130bc9bda98abf1e5ff47b77dd6de0cbdb0c1201f465ba8cee7e7";
+      sha256 = "6a38e65b960d36ad164e71cbbd2c427ae28e68662f78182cafbccedbdaee86cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/an/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/an/firefox-140.0b6.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "68f2fd1f33a6fd473c53cf0e3574e780cfa9a28c298d2733813676d71650e6ac";
+      sha256 = "93a085d3bcbf1074c309aae8dd0418dbaaa030666c16f732ba21079854f3098b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ar/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ar/firefox-140.0b6.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "16d9b35f06fb47a74a778d64cf7abe219a3624ca4732287970ce9f109cfa688c";
+      sha256 = "b324f71e736da3d7dce96dcae18a19e3a1ed01b2075d68d4662a740c2011662f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ast/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ast/firefox-140.0b6.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "8063552de94d50d73b2adfe01eed122e50c399aeacf4944769e27ac51af5ca5c";
+      sha256 = "4c57ca12f04a176a29ce31ccbbbf4f5454b8af8e7fc14ddef6c09a7906156dbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/az/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/az/firefox-140.0b6.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "f54d622ba71e419a329768ac346d4469cffcac4b8077d686902ab254b7d5ac1d";
+      sha256 = "78934de24158bcb311683170a5131da2b746322e761d5fbddeb321982764fde7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/be/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/be/firefox-140.0b6.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "827a6e56ff56d907d4bfe825322564c31b690058a18b835f73612384f388645d";
+      sha256 = "e01175f882c4771dc533a3129178c8382c42757e4873c092da36ae8ebde4110a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/bg/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/bg/firefox-140.0b6.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "f4a9493a0ff3e35a9a0e73de70d7e5a681de1ef14e031320015cd0cd15d52145";
+      sha256 = "39b6654edc934d89c18e9d1e9b5a9af0ce0b320d872400c2e9acda873a9c103d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/bn/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/bn/firefox-140.0b6.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "0ec9de4c5276ef24b3d0531f4964cc01bb3d1c4d44530de59ead8a4ff804f42f";
+      sha256 = "f6afacf863c3d7ae32c15bf7fdb82fa6cab55a372628758d57dc603282ce0c35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/br/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/br/firefox-140.0b6.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "d6a1163df76100d1995929bcbce45aad6db99f600d29e93a7610662185ffdcb1";
+      sha256 = "aae4aa8ff7fd6680e5d2571379f439577950126a09eea6fe674f1bb500d4a6fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/bs/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/bs/firefox-140.0b6.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "00eec200da5859ff0c4ea01c582c12dc3610b4216876bda9e08bbe41f3d7719a";
+      sha256 = "4adf72960e23017bb0bc17c009fec323ecccd343a2fce5978c1b27207051f8aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ca-valencia/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ca-valencia/firefox-140.0b6.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "a73eeae5de570615e3de64949de40a6a149dbf0450170686342ef48fc330da48";
+      sha256 = "1f4f93108d0786912a5c18b65de23e206d1ed6456a2bcb98a4e481b21e397e09";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ca/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ca/firefox-140.0b6.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "532184e6c74f6de599e29360f5b2fcb7c68032fc48101296e13a4bed5e8500ac";
+      sha256 = "f0be5b5097befc19b90c81f042211c6d00f934d13a9cc1b243072f02075a7738";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/cak/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/cak/firefox-140.0b6.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "1fb82efc4e4f0b5e626c133bb17fa57ee54ff00916d306e66a96943d594b0da6";
+      sha256 = "5bf076d97c7b82cbf17bdee89a1d7c3cc79d91cfbde3a2b62238a0801778e107";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/cs/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/cs/firefox-140.0b6.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "d12c2f7e5c102a83995aec62fe69db2c1f9895b9680cdb2df6bdbfc03d622631";
+      sha256 = "9d57075e5c848034041250eb54d074daf69e77b6bcd5d9ce6f69796af0739b3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/cy/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/cy/firefox-140.0b6.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "479ccceda72ad7f2e2d0056545878f43ecd72ff834b09b7ef7e342955eaf83c4";
+      sha256 = "86f5f9313a932943b0baa0ef256fe569732008e89a9a4a5c66adb8d310663d33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/da/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/da/firefox-140.0b6.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "0ad71e504abe067cb52d68d88916be3393913c2f1978eb98dd48f94ab6daf4f9";
+      sha256 = "3775d07785b01441a592676a7546d689fb5ee0b378ba0204e7ac26e13eae5955";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/de/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/de/firefox-140.0b6.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "40ab7b73e1d433eeeae0c8b5fa5c032d14182bc526cbde7b4efc2e32c275a3b7";
+      sha256 = "8a33d39219373b134b8b489d096b09d5d60362ae67d302ac4c19297221a23720";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/dsb/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/dsb/firefox-140.0b6.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "cd782ee1d65b7fd5952e30c6c2c285215f7043f37b9ae3bb0aa51d6056b6a824";
+      sha256 = "9ef44a1dbb19631b3efbd09980bb7763a7d3d6c709c0dc1396f0d21a6dcfba59";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/el/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/el/firefox-140.0b6.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "19736769c65ceff853bfe9c4fd6541c2e30e13166dffd707a1a96077da5bee1c";
+      sha256 = "1364dbebf6329bf9e74395835f3a50377a744945a952bf0019943f3af81963c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/en-CA/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/en-CA/firefox-140.0b6.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "8880c95c0d00a51cd65829ddf5eca2ae9bd0f6a7e995d1d532224c223beb4a70";
+      sha256 = "a9105aa0ef0560c406b7e99248ee72ec32fc1341a7853dfcbeaa19db6d33088e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/en-GB/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/en-GB/firefox-140.0b6.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "56c46be9058e82aaa046788499c0c6e96c48cbeb0a05a47b907772b2c73122a4";
+      sha256 = "b3f6af8344a975f7f6d421a55ba8d5093209b5b99bf2081192a15efd4d6977e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/en-US/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/en-US/firefox-140.0b6.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "40820674c78e05b1413458c2844e874c8521670780fdb4489e62379a42fba704";
+      sha256 = "ae3fc88078ea41f85a24ab6c4f865b476ceebef4c3a2117e02607c7afdc191a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/eo/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/eo/firefox-140.0b6.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "3d444671937f8438ad98b3bf2ee935233a8025c0bd7de8a916be3d1806168222";
+      sha256 = "8cc56cc9d1b5f00356e7c060e74902c3887dd05681192d49602eb637495706d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/es-AR/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/es-AR/firefox-140.0b6.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "640d6480bc2680609dde51a76e512c8e9d1d8bcc93b75af239f254b824a0b330";
+      sha256 = "1f46f27b8ecf033c263d8a01cd3a5670796ce36c81ffe59c9654edf70c2efea1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/es-CL/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/es-CL/firefox-140.0b6.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "7a430e844e216eba749d2e65cdd5f698ea5e450e018e1a217b993c97c375ebbf";
+      sha256 = "6476b0ba91fb25eb196cd49afd41801bfe8ec4985200b66d09cc1d430ed7b26a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/es-ES/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/es-ES/firefox-140.0b6.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "1905f4a96c7de86f9b024d41ba07758e478f55c43d16bbb817c9b8e36b544e97";
+      sha256 = "884cfa9e904ae82ad83f671f0a659e9b32471d25df13dbe666a68d526172c4ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/es-MX/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/es-MX/firefox-140.0b6.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "d7eb82b97a007de775afc9055e33b7b8dbf51947567fe3b1a6e37e2b8765c4a2";
+      sha256 = "586e2f31126ab58c7c9ff9935e95a4f009274119f08d196c59de21907c0f0b79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/et/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/et/firefox-140.0b6.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "aa3921d10df3e89d33375ae23b32a668e78c22c30fff3e546957d75c815d1ba1";
+      sha256 = "044a218da86f3aa042834b6b4dd72f0ebfbbdafb54bc822b1f265280bbb7ae9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/eu/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/eu/firefox-140.0b6.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "b678e517a072e9aa3a585acb027a59b3f18d0e4e132ce03cba26c8d5598ca04d";
+      sha256 = "7dcaf2b10df00a0d594279b1e05e346a1f7a1551b5b479f6691d95de93403158";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fa/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/fa/firefox-140.0b6.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "e23cedbe5d62203347749feaf3ad189b19593be7d328519296d727c142b07774";
+      sha256 = "6098121dd11f772b24d157cb0aa1eff7acc914bfe05586672350454598c09622";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ff/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ff/firefox-140.0b6.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "a2867f278763c04b7d1bc50bdd4dd5ea49be62bba9986740b680cddf6f2b458b";
+      sha256 = "81d1eea86c5299adbb8c5d6076a5f7f910ef10b0620ec8aabb9551e8ff100a93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fi/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/fi/firefox-140.0b6.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "a9758c8d99ea549fb056bfba4f74d70824105bb5f999343347d661f4ccd53283";
+      sha256 = "017ed1a20f955537b8641828cc168c75a1ca912a44155d035c8adc17c0723581";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/fr/firefox-140.0b6.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "12616ac5602bfcce857eccdd7ac50a98bac7bc9d5c6510ac49ab4627d6c762ac";
+      sha256 = "816b97fb48194cf5f738a05d204434c43a3619ece174825cc1d0b012d53845cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fur/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/fur/firefox-140.0b6.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "a6b9aaa2fa7f8c25efcf338bef0bb98d57535c9ba7d0c99775b2b6cd0c44f15d";
+      sha256 = "c3b8c021459f70b7a56d47d4b6d159bce7c2e5e02d6eb01025a08f7c377310b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fy-NL/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/fy-NL/firefox-140.0b6.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "13a13fa59708aae286e6f99cbb301334ed082f94995454ff8f333c88c214f67d";
+      sha256 = "ed00ebe292e5fcce02dc3e7a296dc8fe56b06e285f5884a89be8d3aefb0a931f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ga-IE/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ga-IE/firefox-140.0b6.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "abf292f9c8a74e8f342c1e573441c5f2ed93a646e308131c098634f0e8403fdf";
+      sha256 = "e0e13635b24ef4a84668d192fea83f69f066592f2baa010d2634c55b699ac257";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/gd/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/gd/firefox-140.0b6.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "7ae719127ba74d411a09704cc68801ba147aa46a599f75da4e1a1d99c0bbb4de";
+      sha256 = "c1dabaf4658a4a73e0de9a4e8f804f181bf304fc7c7d3542073fe8c28be39750";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/gl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/gl/firefox-140.0b6.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "16391a560e0766f246ec605d5761f5445a9186118d4b9b154c5aa76d2694dde7";
+      sha256 = "a4ea22f0a82a2f920e5e3398995926f93e1bb0a1cefc704cef1412bd7d7bf5fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/gn/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/gn/firefox-140.0b6.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "88acc62bd18a767e3ace84d758359fd2e3483cced4b47376bb4b62abf0607fcc";
+      sha256 = "0998b1331fe1e87a3ca03c64d720be715d35e6bb90ff0fb8cf1ac4077ec20265";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/gu-IN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/gu-IN/firefox-140.0b6.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "00e7bbaa43437143c28ee9c0c661ed7c30a4ad887a5de6a99b53d036f8ba28db";
+      sha256 = "16f62c0e2bf9e9ad8fd807da12ffb34b1a49f1a22c93d025dc5d287c0aa186f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/he/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/he/firefox-140.0b6.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "88442ae052ba3e93b65d7d878c5628e852f25f192b987a0dec40bb7775fff789";
+      sha256 = "5017fb8bae1791da686b7f8d09081334fc26c91b50790f642e4567e367b054e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hi-IN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/hi-IN/firefox-140.0b6.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "c64522ad816a1b8f298b141bc545895f17aa495b3c227d377ae4bc89cd01ace8";
+      sha256 = "41e966607bd8974e25768e49e8c2ea389c19d183a5c48155be2abe489b7daea9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/hr/firefox-140.0b6.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "dda7aebbb74867704f5b4cbd2fba4a5f5d2974543c48faa4e634f746c08fd653";
+      sha256 = "2cd3ae2af8f30aaedd60ca8ad4fd30d37d613c80687ee0febe8dccb0aaa954c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hsb/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/hsb/firefox-140.0b6.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "3ccf8a34bbad1bb4efc5fcf12aa203d7098c22654910e068e8af92c9a21056b8";
+      sha256 = "a921b7fd7fb36227594f60a7891cd052807d4f78f7facfc888490c10bbb5019b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hu/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/hu/firefox-140.0b6.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4b4d9c7965fc90649ea66f91d04f885c180c6127ea9ab8685b2229f148497a20";
+      sha256 = "d7443861c49462e780638801de1e43217677110eb9c5198fcfc333b144d91ca2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hy-AM/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/hy-AM/firefox-140.0b6.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "e68ad63527eab5b51274d5b23a4e1487b01e46da6f58f933f1afcd3347eb32e8";
+      sha256 = "459af37c50eda7ce2394a0f410a0daeafdb8114df77b4933bc6fbd9057b3dc30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ia/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ia/firefox-140.0b6.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "5546814c18755b68c3eff2903599e1a8c9612ec8d13b1989ebe8db66c2331adc";
+      sha256 = "91f680cdae1bf75398b86e6f16c20f05917efcddc5482ecef0b60aad18a215ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/id/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/id/firefox-140.0b6.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "98eb4c8c3a34600d34fbbf41abe853390193396044e02f8faa2b841576730eb1";
+      sha256 = "20e45c279a9c94d3870248c511b0d3f9e002ff93f7cb4f61ee3606a76012bc81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/is/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/is/firefox-140.0b6.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "4ce9326633f6965b19cb116bb084af2376b79723e3aa2125f6108127ce797c8e";
+      sha256 = "fa73b2738537764133d71d2beb15e0a0b5f1b34df335b84dcc76e23f5903c47f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/it/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/it/firefox-140.0b6.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "1633f576551a196695492299d9cc6c654b7a6fc436ece013c0052d0d59b18fd9";
+      sha256 = "c67b03b3a21c21cc196e87a4fe44e96bc1fa7bcc138b8e9f5dd109f30a2ea27e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ja/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ja/firefox-140.0b6.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "4fa482c73b534fdf8da15d9f242c319742373aba34cd2033d890c2e10ff1a952";
+      sha256 = "f748f10054ca044435d03337fb16b922a4513929186dbd6fa3954e397b4f7b9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ka/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ka/firefox-140.0b6.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "8d35d90b1a228b3a93dae95913a3a246824f9fef9ddddf226d1d45dbb5f52cf3";
+      sha256 = "b764067cc3dd81cd029ee418dcb2876afcd04c5d1288e1f8e8f0fb0bc11652c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/kab/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/kab/firefox-140.0b6.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "39e2c59bcc692622d37813b2c6dbdb53322217759bb36adb3c40e564fb633816";
+      sha256 = "545392d704bf3efb780b634366abc503dbbb773baa0cb4b720d8ea26c7d8d5f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/kk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/kk/firefox-140.0b6.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "5bfbfe860b5594b35583dc219524119d449ce843058c2416966923db02a37b4e";
+      sha256 = "cbf09845b5ea0c2d3964bd391f699cf6c0138a65f650b538330e101aa0493a88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/km/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/km/firefox-140.0b6.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "dc60d8f33da1bf2131700143f92c45c407db0c72198a9eeb30be6c50ed219fd0";
+      sha256 = "03c4299ea106f19383d8e3ee96657c4953ba7ba137c369c6f37382223fc675ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/kn/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/kn/firefox-140.0b6.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "f9de9ea646106410dac113ed8a43f7fe5d8b2ab78f8cbad800c7e06f39dea83f";
+      sha256 = "b4f0d0cd7e89322200db11b1ad1205847b14ce53357788e4a8150b99838e3ad3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ko/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ko/firefox-140.0b6.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "046fe9882ebbe7a16b9c4e3a46881d3d58e524903e69025b41d4cf5ddfc39cb7";
+      sha256 = "2d01bf0017f16fb0c1c0e582e8a5b67b8e2ef20ef51e953f5690b7f12ca2ebf9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/lij/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/lij/firefox-140.0b6.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "c3f54a55d3bca2b3d16bb808161b31759a045624fe3828fa4dc00d4395b6e934";
+      sha256 = "636259f735696e95ce397ba0d5b7f7764702491406229dfd7425ead6e7340623";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/lt/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/lt/firefox-140.0b6.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "cc6c6f218dd93c702840afbf6b4947fe25f9a3ce6f1f0c3d6c53612f5ffdea6f";
+      sha256 = "42e902162cdd874b5586f2ce2c8a9a9302dbb231928e7425259bfad3ce964db4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/lv/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/lv/firefox-140.0b6.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "6413e4d6878ed2cf612f8562f4d7a87b572b44a861b98def88932f5261d4532a";
+      sha256 = "0604cfc1f31b65d17f019eb42296e69730674cb04862c14929cfc0f9e6508071";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/mk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/mk/firefox-140.0b6.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "f193552cc2c671273e2ceff6d63b721d994905232b1ebeb2272406d11f7c2631";
+      sha256 = "38d564c93c332d7c2da567b8bececf38daad80282427ad8c5056d34223d500a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/mr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/mr/firefox-140.0b6.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "de2083da32a191962280df959e5f2bdf5a9cd1bfd5e619236052225b2c4432b9";
+      sha256 = "cb6bcb2c9d8f8f4fd8ea9b9084811d4eef589ce11c0fbe08a65306dabc8f0c04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ms/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ms/firefox-140.0b6.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "060c67fc339f7ca5685524c6164b1b23783c5959bc1ee88947ed5d646a4469bd";
+      sha256 = "e4d9a5131aa92cedde0b2708c57dc5c07ea39fc1caf5885869bb7959c51a0bdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/my/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/my/firefox-140.0b6.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "cd1b449874fcef63e5e7366c26c88096121212ea92cc1a20b8d0cefe3d1ab6f3";
+      sha256 = "fe0317e8a76f98962e28f4e958b6af2cd159ade85c30ff742ebd6d2bf08cbb2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/nb-NO/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/nb-NO/firefox-140.0b6.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "afe1046c6fe6d1ba75b57520d2162e23e190d7eaebd41bf4f8b3b9cb435e34ad";
+      sha256 = "86bd123290299872a5f2c7a5b595cf40b268b942be1d885307d0844d7bf6be4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ne-NP/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ne-NP/firefox-140.0b6.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "5b5b6cd0004f7ace163588b162dd2ff7ddb08064e5bf2e4ee6c73a5d855c3944";
+      sha256 = "7518b27513141150a3594f11e380ca53c94f16aebdab70b47fb3e9b7bcdd5980";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/nl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/nl/firefox-140.0b6.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "60a452998b7797a259080a39ce7900aa45a3ec92e09933d3eebd654cd2d9cdf5";
+      sha256 = "e90009b1e48d1569a7f58caa280301c7ec08ec96d948a35b1c9d779914bbe528";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/nn-NO/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/nn-NO/firefox-140.0b6.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "b1cc96a175d3377eaf6ad67f3737d08b5fdf45e54312d0147448167753e0b413";
+      sha256 = "fea69d9a206a4551d868ee8785bb393c881248b8c3921ee72d9300af4bbb976c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/oc/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/oc/firefox-140.0b6.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "44839b3805ab01d637a5adc270e9e86086f96b7b947162039f6ce356c7e98d99";
+      sha256 = "1fce99f304498dc4f0b57e5b72c45f7794200ce602ea1ef164c30141242cb1d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/pa-IN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/pa-IN/firefox-140.0b6.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "3ee9443ed3a85a3b4c2a22db5ee258bfc21ae8785675ed5b11ee8d5563cd16f7";
+      sha256 = "d297d30be098565a3465e9e754ef4574a86f02745582a829842809c31e7ad96f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/pl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/pl/firefox-140.0b6.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "30270dbb80419f92173ab90c2b99269dcdc5052a94efd1bed12b223d68ec0fc8";
+      sha256 = "a56a7810bbcda13feb96dc387a517fe2b17f753e90e51e25649dc1eafe395b8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/pt-BR/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/pt-BR/firefox-140.0b6.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "e22b7b27b89cecfd7866648ba16db249f8b53856bc9e49e7d722ab006c61a052";
+      sha256 = "6c690de44032785f5b0744507cec3f8de18864b4e4b87a95d904d1eb91c2eebe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/pt-PT/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/pt-PT/firefox-140.0b6.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "9592fbe56057246e6519641e4ce97d727e894cd70fab2aa91aa63196e13535da";
+      sha256 = "225790fcb18195777044676919338af8382d3d3e941035abfc7339d201cf8c9b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/rm/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/rm/firefox-140.0b6.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "15e0f382c19db6af473d49dbdfb48c2b8891255cf7b85694f1c0ef12620c4bef";
+      sha256 = "6a7ef06460dfd17cb3404ac37f26efad541ddbe8561a0bfbde46309595e9eff5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ro/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ro/firefox-140.0b6.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "480b8d1c13c8a647feb799366c91c9223a3b3afc32e6e758d7edb57d016fb4cc";
+      sha256 = "e117d4d651309ef6f8140156c266ac8da40fa4aa8d94eb43b9239d2f959cf063";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ru/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ru/firefox-140.0b6.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "983807e6ee0951ff1cb56518a5d4c764a204616a6826381e43dba49f8c398836";
+      sha256 = "8db80259e879eef2dff706952ca9d7ca5d19430ebcf096c554e8c6476e706364";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sat/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/sat/firefox-140.0b6.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "3be3f00cece3378b9afb0364339527d6f2cad06c73cbf095a4c6fe34a0f7171f";
+      sha256 = "c188276663efa50e65b425b2782fda9a48abefc927c14a5028330a1f303ecd53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sc/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/sc/firefox-140.0b6.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "780c0e439a16d97b5a0a4e8dbf21695b18316083496655d89ca7c15762d30ca1";
+      sha256 = "86f11d795e454349c52e1e11ba27d4450057bf4ed34470ba5e247d98dbc81d48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sco/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/sco/firefox-140.0b6.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "394998ba5da43c7ffdb36ba640f3657e286faeb09b4895171c689a70aa0357ed";
+      sha256 = "18bc467710002822c7ea3d64dacde32ac5e63f3eff6e783a5940340094112721";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/si/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/si/firefox-140.0b6.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "c6f7172c8ae66768a8c1c8ec1237d50c1409952abd90f5c7baa6b0c2db35c94b";
+      sha256 = "0183d3f674a52f77eabe70bd7e4cf6ddefafbe63e4c4a7c531fe278df44b4879";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/sk/firefox-140.0b6.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "51e4555381d62f4eabcdb45817fd91cd025eca458a175c8c9a9927f3c8eea624";
+      sha256 = "87b651fc158b90391e26c5f203ef83de9f0e2e7583da32b055517f54c33fff37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/skr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/skr/firefox-140.0b6.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "9ef1756da491f25f7357deb640604f470a3a159211f0ea1ac4c31a657a26b1e3";
+      sha256 = "d8add697f79c5b3885db3ad11e997145bf4961e6e7a3050fff60893c9d8ed7d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/sl/firefox-140.0b6.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "62d5913ad935a30f8b6536231a747b54b69f81681f81468a5ddbd5daabe10431";
+      sha256 = "a86132fb0b515b6305a028c1a5db05c19aea27ffe32bcf45e86ad787ba414091";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/son/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/son/firefox-140.0b6.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "df3ac2759b995a974762a94018ae6c7c142209e7fd12be96186eaf56b5447d50";
+      sha256 = "44c8eb2cebf499787b53a6fb6b5935dc07edb298fac94c91d111ceaa15cee342";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sq/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/sq/firefox-140.0b6.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "a107def094ebf1d6bd77b05c153747fc058f3fcced730aa5513a8a33a2f34ed0";
+      sha256 = "1b22f775d19a412d6ba6aed33637076c1d232fcfe1ae72a7bc4f69e943aacd47";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/sr/firefox-140.0b6.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "1ec6bb2204b6e25e1cef465abb74ea115914d1ec179006f4ff9ab8d5cfa95b05";
+      sha256 = "8369302b248ab2cf0b13f98ca0280b9604f16f524ace8b9e5bf897a273589ae6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sv-SE/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/sv-SE/firefox-140.0b6.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "47ef089aae34922e892e5e24fc31f0a9ed0dadad427834d46e96dbd189236a1e";
+      sha256 = "b768fc130f0098ab7139e2256451f696291c6511a92568b9b8f0e0fac8e4f55c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/szl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/szl/firefox-140.0b6.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "c3ea0cb6a2f1430d1f96ae5a3bee2083b265936ec9a5625ffcd31c91c542ad01";
+      sha256 = "e65a61516d5d50bb042c802800f5ccb78e89f9407a2c20abedb4af6fd7bf44f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ta/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ta/firefox-140.0b6.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "0a8274d9d638706a05dbb5573191fb5c604da633a39a3065dc46e75b50bfe595";
+      sha256 = "49c920bf3981ae5b006810b09262436b0b727f54b47f92768c9beaba4ce02dec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/te/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/te/firefox-140.0b6.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "9de2c77e2cfc1cb33de926f2f0af656369071ce896086c39b0f6e823802c5651";
+      sha256 = "c35da2873dcdf14a1c82eabdf5993492bc0fd1b6b16215dcfcb27259b6b2bacd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/tg/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/tg/firefox-140.0b6.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "ccdf9edaa6d7642a066800f5edee083c92303473ea9eeafd04e17505367ce082";
+      sha256 = "34cf2a7bac30ec63f04619d1af7f834e0a985336017d39f951f2f8e3b9b70350";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/th/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/th/firefox-140.0b6.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "ca2deb4e79e3ed447e0b62c678dfba1bc3d47749d983e478f98eef8f075eeea8";
+      sha256 = "0381cb55121754b1ee6d8e1b2b9d02d3f36249f3c1682b9f43edee72ad8204ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/tl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/tl/firefox-140.0b6.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "24b5c9689dc2958f4607932614f9d3ac97286248d932bbe43574c71425126eee";
+      sha256 = "0919075e4bee9347c39c798c75a99c2ce649c13616cc24b7c049a087a8a1c34d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/tr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/tr/firefox-140.0b6.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "278381e636f98ec68c9ed75c721cff588f2e291a1611386db6b4f0038cfa7403";
+      sha256 = "418fea6d08064abbb3083b18cb984dcb3262b905b046628d0326307e345400c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/trs/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/trs/firefox-140.0b6.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "5d4d4db5dcd4428e7ab6d351d4a1e6fdb7f6f327d031ec045f1e0572f39569be";
+      sha256 = "05314fe33cd5385b9ef91fefd2a762152ac23e37e02d7e2b472e895d57e1168e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/uk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/uk/firefox-140.0b6.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "1f7ed2ac92af2d802e743433d6d8bb501057a019770178afc4f83d9382f082ca";
+      sha256 = "e00f4d1f6bca26f76a153338d198ae66faba06890d3f4eeb5b44ddfd30eb0671";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ur/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/ur/firefox-140.0b6.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "941d716e18c08961041052a3e3ce47b8b927e3c2ff4e2d02aa377e18c3ee9899";
+      sha256 = "082a79e6e6b5581f7875bce9ce639bce31aa8b91c5d21cb06ad5e5a14f9374f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/uz/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/uz/firefox-140.0b6.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "542417ee58e5997d60c3eaba77f3e1d7be9f5bef5f4d96e3ca9252988a1dd4ff";
+      sha256 = "838688993ec796618ac9591a1a625f1e36b47e2e6e095dc23afe635b391901b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/vi/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/vi/firefox-140.0b6.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "d501faabcda4703590242da47168bd90c1ba5b8ccf53573ea92d4ee150c60347";
+      sha256 = "238703e05962465bf1f5a6a92ce1087ff2e9580bf2f53f68ff1e3c6b29c0855e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/xh/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/xh/firefox-140.0b6.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "c0aade40862694b4eefc2e1b138e28802bf72e7ca99a9aa77dff668140c0f8f9";
+      sha256 = "e0d99e21a6f51a6e855d6d08fe7f2e9e843ae50e5ec5669625fdf6cda16e654d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/zh-CN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/zh-CN/firefox-140.0b6.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "d6acae4e60b6b50f05a17630e45da73dbe2ff691ec216c0368493efd44c4b978";
+      sha256 = "db71a35fe0ca3c3c6e4d876fd63799d62a99782c758374329f1fc5ccf89493a8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/zh-TW/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-x86_64/zh-TW/firefox-140.0b6.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "7493a417c1d4cca1bcbfcd782d8b5d0d4ba3817b18bc7598544e7ca1b9f5c06f";
+      sha256 = "a870eb913257d6cc7c20de330b21bf5b6d32fae4912c3cbc35272d6b0c26229a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ach/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ach/firefox-140.0b6.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "3be76f9194d24421ce986d088a4e54f38a9e934a272f62c6aa6e9bef9a09a666";
+      sha256 = "d2f0b4c8fe575b71fef12e929319af3bf93a27a2cbf3527d93c75a07038eddf8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/af/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/af/firefox-140.0b6.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "a8eb60898c425fd996b02c304d495668b283dcf763c034c30c19841b71fe5be3";
+      sha256 = "15e3d504b0a371a21fda09566740c9d103f1b170d734c3578f31ca9bb8f66cad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/an/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/an/firefox-140.0b6.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "6722650b3809255e939976cda6f6a15b6c1b88e0a3fb2143ce14f05bc1748001";
+      sha256 = "811be339e2c8e66b7afc32d2c70adc4515a9b9569dbee6f342756b5429c2df4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ar/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ar/firefox-140.0b6.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "96246f81a7d0678bb32714ba376bbb2834f989eb7418d4edd1827d4511e344a4";
+      sha256 = "7d73d8431416034c6b6c0112e2991d1f4fb248a7f8e209b922cad2a926d2c51c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ast/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ast/firefox-140.0b6.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "ccedf416b838286c42ffa27534d9328916a5d51d7897a8f9f9f0914b317ecf9e";
+      sha256 = "44e68de0c7d4280bc08cabd991eb37cc0792b680055600471ec763e43cd5b890";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/az/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/az/firefox-140.0b6.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "0efad9674c64ee1f67f930b46266124d3c0e1b4220522700a89ce8e2abdd133b";
+      sha256 = "31c4d3a48e3672a7c8fc81ebb29337e57be65999781c9d56c91456f704f81240";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/be/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/be/firefox-140.0b6.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "fe4d45528436e5a6eb6d6cbe692974a8e07f3d7721bf2bf9f3aba2bd4c40a685";
+      sha256 = "ede450caa7f05865b3694f3821bc092e0de6616b640b4748b45673b41a33c099";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/bg/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/bg/firefox-140.0b6.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "793c784ffd98c017155376f029e5270a5d2c5195e017ebaabee330031b5281ce";
+      sha256 = "a605ad91d87ea41ce7a93f564cd7fd647ba6fce99d403754414a9dd0b3f967d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/bn/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/bn/firefox-140.0b6.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "52e39351fb98bbdebd22764b77c420a2778adcb6ee6fa9c82845c4cddb4a48cf";
+      sha256 = "a08d45ac7f0a780562206e552ae7ab5462a83ac14bfead0c2103ac675e5f556b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/br/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/br/firefox-140.0b6.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "fa0707853f1b21e708b627a58127efa6848935bdfb071bd9dfa34cc712c544a4";
+      sha256 = "4f51e2f63ea3e4e5c3eb7025c125cc4b828cd8880b6736c43abfca5b879e3f8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/bs/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/bs/firefox-140.0b6.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "038c08de66a19e28293dc5ad8ab5ff099a653fe11e66a50f117b09201b0487cc";
+      sha256 = "7e88222a53d40e8a07d8cc273b07451947cb97d0f3d496372d970903f2ad0fd4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ca-valencia/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ca-valencia/firefox-140.0b6.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "893d8ccd8276108f74802b6ade3aeaa182d35f24a7d4f59f73f7d9f0083e5374";
+      sha256 = "1f8687252bfdefe43c8906cdb4bf8d80fc8640228627ddc9160acfd39e628d4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ca/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ca/firefox-140.0b6.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "89cf5bb8d68c2e396fc3459d708ecf561d2ab58dee924f81034ecff6a9a58f89";
+      sha256 = "24d65222d3f9219ec0be30c5ec56a6f84240bbbf21fbbe9030fd719cc2898a6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/cak/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/cak/firefox-140.0b6.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "6dc7a40dc583ad71310ca5844563298d68b2f4dfe6160d77323bee582ed70054";
+      sha256 = "5059334800af7ec61d95bccba166cf2535d2bdf9741b7e3ce4ade7bd5cdd5e47";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/cs/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/cs/firefox-140.0b6.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "0bb58b90686bafd341991a97b4006417970684d0c82b542718e539c12ec11768";
+      sha256 = "ade2f416e75e8897310d856bfb5973361800585e6b66678623bea921a3434ee7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/cy/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/cy/firefox-140.0b6.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "d704d90a4b3063f983651d777064c9d705d9deedb1e0f69428687d8d383762ed";
+      sha256 = "4351eab5adf589d168b2c198445df2071798e5a9aeaed154942594edc9a8083a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/da/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/da/firefox-140.0b6.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "5675f10f6fda9082aacb42895dfcf0f78e6e53c649b2a620fadffd92db731b4d";
+      sha256 = "8942e7b9e12ca93113af82d6d962616d1c31756112e61d0dd3663cd0504a59d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/de/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/de/firefox-140.0b6.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "a3b2053b85e7ec3046c2f4f2e437c685fc5d4ead7dcfdce1ba40e1560251317e";
+      sha256 = "59067654101e138c156bc0cca05ecf34ec16aab9a4e5de9a6ce2e3bc26c3261b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/dsb/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/dsb/firefox-140.0b6.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "c3a198d51af7a9f1301b85d586ac61c0afd8b1243656e36de880d14c2bf51ce7";
+      sha256 = "526ce1d68ea90d5a3588b179ac64a303d9d23ef2b46b4fe91b7942ab60ccc2d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/el/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/el/firefox-140.0b6.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "7921f62be7826f76229007503e8e27915b7d682346baf5bcf6149dedd4a921c6";
+      sha256 = "7d48fc74739da6112497526c0937a3e5865b5df23e3487e3f946d828a2570fbd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/en-CA/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/en-CA/firefox-140.0b6.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "ba39324c5662162aa1674d7cab7d4edf6fb02fd05bb99b2b0fb3f0d1fe7ecf71";
+      sha256 = "45da4da2bcb75edc054a52ee20aff8dafa5bdd0bcc90670c1fd25b43ad52dfd5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/en-GB/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/en-GB/firefox-140.0b6.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "02c2bc0cfa15192edb33b22834b678c9a8d99372cbd028d48a190113b8f93d7b";
+      sha256 = "f38ce30e7897332d617cb0b1b6524f34f76e49d4e7a17d8497d4c8e5bf48fb87";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/en-US/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/en-US/firefox-140.0b6.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "45a4c9e6e1f2119bbccf4e2bb5a285ee5fb2c9003adbf15931f4c6f781d67c2c";
+      sha256 = "744bb60dfe646854831b6b2370190ad5dfc304dd6554deff999516c56e6d81da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/eo/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/eo/firefox-140.0b6.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "5caa0619cf07394e3ac1c68a8348ff7f47aaee9587fcd0a50c4346215617b5cc";
+      sha256 = "afced063370710bf3d41bad286f7bcab50913a84ba1b91d50afc8426ce51a2bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/es-AR/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/es-AR/firefox-140.0b6.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "d224e1606ccb29e5f73626cdfca835d01ede2f4b746de8b139308665bae59f71";
+      sha256 = "eb29815d5e8eb1eb042fa81dba0d36537b2454511da08848842d544bf8cfb18b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/es-CL/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/es-CL/firefox-140.0b6.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "343b33976f5db469de0eb6b025be4d5373191c9b7173d16d89a1dbb2cee118e2";
+      sha256 = "61d15090c8d7d2b0e2a11cab506da51cb2c373b120e678570cd9b676d8f66966";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/es-ES/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/es-ES/firefox-140.0b6.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "0462fcae5b37d56c6b5a0a537aae8dd5f8909eb9014824450179c9440fcf9451";
+      sha256 = "a1faac6928171076c66f71be8f29c17547bb92989b163bc4ad074577394a0173";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/es-MX/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/es-MX/firefox-140.0b6.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "51cc0b92eb8c5948cd8f1ad2c2b0cbc6484f1de3da813761d48717f1a8b198c1";
+      sha256 = "f513b34704478c1887552ce2d25d1967d103320fbbaf7a603c956fb2453befc3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/et/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/et/firefox-140.0b6.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "02def4898b2b63c80c5acf9e4265b84875645f309d6954518fae3767f419ea18";
+      sha256 = "f907f4648ea7af3ae32a5961c166610a3c7758d94e0f952ca52cb33b78a5cfb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/eu/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/eu/firefox-140.0b6.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "39fa560b9fadfbf7f29d1e0352f60109ea9edd25f341542a0965bf9d6912baff";
+      sha256 = "290d946ce84974b3c632f9c3e061d90a9a99edccde8ded6a42986385e0eeff89";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fa/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/fa/firefox-140.0b6.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "e9685986383fc1a660d1548d0e86e1f6d6b24997dab0bb6cbcffdae57aec743d";
+      sha256 = "370aa3e5cd53d25654f317239ad54399d9e0dd66e3ea087216c6e6d0d2733af6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ff/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ff/firefox-140.0b6.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "43805aadb07a9df678c40e29b4581a1a21adae6540a979a180acbd005ad66505";
+      sha256 = "541b9ddef7f2ab5890e1f5a2f406b1fb9a2ecd9deab6ac133b99c95fb2cae12a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fi/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/fi/firefox-140.0b6.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "42ff002d3533302a4005e45d21c1fb4d2bb33dd34da84f376e0215afeae40ee9";
+      sha256 = "b98d0801eef3570adbd582c7c0c986ff04458e9d1dd2ebc51c5bb1fbde2dcb73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/fr/firefox-140.0b6.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "daf13073c63bbb8f1c83e64f7ae8238105f0b24490492bb171381b8359835ba4";
+      sha256 = "1fca999a4f229c6cb0873ca8aa8394037cb6c714830fbbcd37ee28ffe9c718f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fur/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/fur/firefox-140.0b6.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "b77e8cd7d890e59391cb0901c428b3af4285d46a8b7b97395256b7211688d445";
+      sha256 = "83ae16e567c02107d7ba91939e5646ef6cba12599f7e38ca78a55b535482bf16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fy-NL/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/fy-NL/firefox-140.0b6.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "b29253db8b87cab953abf1381155f8cfa055103720c4252ff4383b0d0bc9b24a";
+      sha256 = "d2c2f3e5b5af91decea6b7ebf5dab2f3d1af8bcbf646b7fa3c43f520a22566f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ga-IE/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ga-IE/firefox-140.0b6.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "3a73a2bd7d32be4e6ec2bb41bb3b910ed41ecaa678f26cb6283c7c4bf9c1115a";
+      sha256 = "297539876431286bf553f117fab3a7b685531d72598f304d3458ff4a517587b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/gd/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/gd/firefox-140.0b6.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "c7d7266fc4f89031ed171dbca0ec522631d4052f21fee6189edf5b25b3253b23";
+      sha256 = "475bcb51afdaa55ac37bc726ba3fee59fc10b94b9b599a93ac6abd4733d09cb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/gl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/gl/firefox-140.0b6.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "0705bf96b77ec990537b154dfe739bae3f86db9526ff66eaa9c65e4a21b1e927";
+      sha256 = "207410a4654026bb5c7ce013292f56cd01c29b2258fdb0a9814e0d5d77b149b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/gn/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/gn/firefox-140.0b6.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "052a95f7cbe122fa15f11b6b6aff20a681dc9f8f17ccf58b3627a6f4eab36122";
+      sha256 = "99eb7d29efbbf6e554900813317319e0fa3ad63f7eee9ca25de095cbcc493fd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/gu-IN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/gu-IN/firefox-140.0b6.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "a37cb18d401f9dea9e1f3d6200297133653982d2e29f68babde5178b13092820";
+      sha256 = "bd709c5ec938d75c7d671c5daa148504d6c9ca92aeb99d3d18c8c3925f6a18cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/he/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/he/firefox-140.0b6.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "de6d96dd60e87f374535095d01d00cebf5d76002c151318a524711482f05d4e3";
+      sha256 = "5ff6c30851da3fbc1264a756a5033a727bd034389a907f977c01f19e98a1adde";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hi-IN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/hi-IN/firefox-140.0b6.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "1dbdb7f28f064e171bb25121f84b3d677e2a0e9825547577dea168e45101408b";
+      sha256 = "027a328ca0740683923a1c3ff25a819948145c242ceab503e5104818b272afa6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/hr/firefox-140.0b6.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "f8851d7d962ef0cc5b45129b30eec0cb4906ae790b2e4a04171b6aafb1a423ec";
+      sha256 = "e80303a7d26effef99db9a6c4f1503f4741398448b3bbec31ed9b01d06b7fd40";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hsb/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/hsb/firefox-140.0b6.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "a8075b7c3682a5c21f0723466e2bc1ff1a87f1648af55b979284564a86591827";
+      sha256 = "f977ea04c392b706c821eb7768128868d542dfacd6c3473196e938f47bfcfad6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hu/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/hu/firefox-140.0b6.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "8562d9f2effeb5c63c99de48586412b1952054f1d35341a960d3c1b68da98a1c";
+      sha256 = "46c7ca5364ad35e8e228d6b3d85dfbc1021250b9c476f49cd6a893fc6a901b04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hy-AM/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/hy-AM/firefox-140.0b6.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "13e5bae04b5f2a30fe58e46263618f093efd3e457d1cddc6096148dfe602a2a6";
+      sha256 = "c1e295ec58562a570995049960f82ea50f1af7019fea5347a1a5dee96e07fc3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ia/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ia/firefox-140.0b6.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "91d6a400ac1c0ee6845677c526ff1c179b369f107ff36535765293b44f1ac43d";
+      sha256 = "04d95ce50b8043066bb7504299f474f8aa7dac6492ff02358a88c8d3d8fb3e99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/id/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/id/firefox-140.0b6.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "eb086df64f9f18ed83e29b57a897d3652fce933b92e9db72472ef2c7cb36497a";
+      sha256 = "2d2427f8cc377920f4fc30335aa4592eda7b5d2886080153b3da3b4f4d2a73f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/is/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/is/firefox-140.0b6.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "3cbfe061954939a9f3d90f790612b921eb644bf792b2ca0cbaaa77b1054b8ca4";
+      sha256 = "f9b3a865e6bb380aacb2f4b334b93add7034547be50052027b02fcd834b75ecd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/it/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/it/firefox-140.0b6.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "ea608343fba2138887a168ad3251493dea1f537e08745f3108f6962364d47f34";
+      sha256 = "5370c6da3f46aef9026846bc5bc0566fb90a32aa0754db8fae8b607a4d2a43fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ja/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ja/firefox-140.0b6.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "5977a78da473ce233e8d48034f6a04ac519888189cd4f4b3bf314ead6a7b74e9";
+      sha256 = "9d08742f62ae6ca7b165f2f96bf6271d2cf0046d7193c8b9f2cdb34d03b96859";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ka/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ka/firefox-140.0b6.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "d4874532ae1e9afe9b4c77ba064cec618cb48c8d90d6e5941fecde77c37c29d7";
+      sha256 = "1f02ea4d7ef27f1a3d91619c36bd7792ae98f372ead28eb113855b8fd04ab910";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/kab/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/kab/firefox-140.0b6.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "0a453f53f7e88968f09c8697193aaadf2a0e7036d8a8ed01c7b54b38e61fd8a9";
+      sha256 = "6fa89a1a815c47a995ff59d07146d61cd7d89c2bcb9ccea47487b50c532924a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/kk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/kk/firefox-140.0b6.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "62279adb30aa4c792beef58eff120112fa9151abd1f74bf40d6f2cd097d453b8";
+      sha256 = "6753dc18bb24785def22e0dca28396b78d68844bd6938e3dcaeaba1065e2d3ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/km/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/km/firefox-140.0b6.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "8bfb8f1af400e143c3f795aeecbec5652d9cde304a6551e5bfcbf7cb2a8cc676";
+      sha256 = "9a1a7159d5c46f610aed98e90cacbbd212d20ff728aa4c631e162fbaf6d8406c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/kn/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/kn/firefox-140.0b6.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "5b1ed6ee0e97d89cc83bf4f8408b409f5e0aeda5b68dbf7fbe2d9867cfc8f4d9";
+      sha256 = "cb088595f1d75e551abd1d73d6a538b4cbb8bad5b6ec01e56fefcc10fd9e0706";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ko/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ko/firefox-140.0b6.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "04747f583bf7cf9035a52e584ca76c84798830ccc74c8f6faa46a5af4df74011";
+      sha256 = "4e4804dd60447ca1e679f8d47dc6135e1f3206b7b43af6dd005e022802f6b48c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/lij/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/lij/firefox-140.0b6.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "432359d0dfcafeabdb98e7baead22a23c1e9a2e30ad6cdba88fd7f2fbfc9ba8e";
+      sha256 = "9c5d5b72d87a7c264bd7f3c7dba35396ce1ccdd8c65849b00be6eee217f4d3f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/lt/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/lt/firefox-140.0b6.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "3aaf5547d7a0e5cb1fe120de403650a682579540cd4411d113bed81c9e0ee781";
+      sha256 = "c5d223f1330fb422e93cfcb3260e1c01304b0d6fb679eebdfeff03981b83c359";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/lv/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/lv/firefox-140.0b6.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "2af656a600c244eb615b21e204336bd28549648dc1af363e08ffb8802565f9b4";
+      sha256 = "114b816891f56fdcea51d1f884bb8296f6ec2d4f681606369d5dfc9ec9e2fdb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/mk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/mk/firefox-140.0b6.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "c0c62629f81a5bb1e1ec256269b2285bbaef67caec7d1c4b8ad8102a72abf180";
+      sha256 = "6b5b923590b1fe5f44dd9c66786a975a1daaa960d347ebafb4f4e68944d3cc44";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/mr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/mr/firefox-140.0b6.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "dab2b1103c27706124fe8f4f8ff059baf21151cf0e50f8fce2ce40788545a5cd";
+      sha256 = "74ea9528539de6d1eb5ca192771086f8b0de3605fe1832ec2e36f34b5bac6888";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ms/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ms/firefox-140.0b6.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "4c4872d23b305cc66b7efcd0d36065ad3aefedf0e0fc53f05881c3708be5782a";
+      sha256 = "a91bf31e8d1d10e8e9130fd17b51746ef82d97c0bfe13315234d84307e1545e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/my/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/my/firefox-140.0b6.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "900e5e7cdb64fc9e1dd966d1fbdcbe2c8086c1ab2be54d2d9f1c2fddb0673cef";
+      sha256 = "00d39a9f695533772299e360e37a9802e3a3c4b6f1abc9c497c463005ea1574a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/nb-NO/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/nb-NO/firefox-140.0b6.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "1299f2becf8ab50225fb68d18d1345754d43334d30aa5f3500d674278208b777";
+      sha256 = "974b886f74d31d85d895235de365d3f0b600ff6e7a3f30c79d5ce7752e379f7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ne-NP/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ne-NP/firefox-140.0b6.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "cf41fc923f63a7f1a4bf720cb3a8fa1595ef92d121d729d7e902cffefaa852fe";
+      sha256 = "e1eee217e3b7b553b4ca8d558efba40b2edde4ed638953d1e6a0915c175b49fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/nl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/nl/firefox-140.0b6.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "84b2cbff63025fab413175ad49c47ea734f0823b8eeee7676789f9c27bb9de23";
+      sha256 = "c54d599a561e854b9ceff273d33b80ecb309a5020e49d8048b2ea66c1cdde8b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/nn-NO/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/nn-NO/firefox-140.0b6.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "818e77d80fd86e8e27460b8f629f05215c985a80a275f30f3864821d6619db30";
+      sha256 = "e75f486146d99c1cc914676ac94fb1525f560a1de0c75c34d07271d6186e019a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/oc/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/oc/firefox-140.0b6.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "5636ac4f5757edde5867ad0d186e6d779dde239fc302962b7f257a5428a5a87c";
+      sha256 = "6bf3e0d03d5322ad4b1201ece3f5e0a5cae2af55fa05b60ab49cb6baa5dc4867";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/pa-IN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/pa-IN/firefox-140.0b6.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "b033beca5afb4fb0c8715d29f2d9e6b0bdb2115d63ff8d5552adc1ebb86f18e4";
+      sha256 = "3a992433e2e830936b1058ad2d367fb350f6c15664244557248b405d2c954b08";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/pl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/pl/firefox-140.0b6.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "afeb6ddc491281c001dc98c177bb19120d46fe3d738f777daa2f9c0582faa828";
+      sha256 = "da7da39491ac13769a6673b4e6f126c156dd2913ab6d620ca1055a72aaac5254";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/pt-BR/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/pt-BR/firefox-140.0b6.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "b0d75cf5e760cd505c397dff4fcaafd8f0bed1b416c40beeaa297912b1110f44";
+      sha256 = "eea15f6e8b4b044dcea2031611fe076aab859bbf402908cfb2910e892ce0ee18";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/pt-PT/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/pt-PT/firefox-140.0b6.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "e1c7cbe5bc38bbeed8cd3abd05ef956366e2f398b70e42b3007342a4e61760bd";
+      sha256 = "5fdb682b34ca8d49c684752b9e02c87220b90324e1ca80a364aabf91e41666b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/rm/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/rm/firefox-140.0b6.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "ab26f4fb5846a8eca415748e69dc37f33a6d3ab91ff0db384d627553a69fe9a4";
+      sha256 = "49e7c74c44294802392928abc00d2602c3f2154ec04e6f48b6a612cfb24cc43b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ro/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ro/firefox-140.0b6.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "483e633f4e2922e521c0492d47d420fcb5a1ff7209d7f42c58952c5e7705fb44";
+      sha256 = "ba5e9d888d7416c25882776486cbf8f2098c676dd4f2d56ab65b506477949451";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ru/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ru/firefox-140.0b6.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "dcd3441f6f5a9390407f2794f8d747511215246f5c9a85ac4d6b704bd4bbff9e";
+      sha256 = "219cf4ad9f20736b7d0f6d018daeb39f2410f5bd70abd8b3329d6e5a461ed495";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sat/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/sat/firefox-140.0b6.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "1fa56ccd4d66542467487d17ee7e95f847f0920774692a03da8cc14f1cf2ac70";
+      sha256 = "64ab98b82919db52ea2434fff7d65f82b4283370c694e42315023477d84344ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sc/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/sc/firefox-140.0b6.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "d626a423d3d02011a9a5090633595add37d6c99fc741ec96a1a66761312bc1ea";
+      sha256 = "7b167dd8f162d5235bee196db9c4855caf819bc8731d1ec7156a37b55acb52f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sco/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/sco/firefox-140.0b6.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "3d8c5bc791c943e82b678918f3459471a3ababef8e44e9ee4257f036b552b813";
+      sha256 = "2d8b1adc2b3d34d621ef2bca5020e41e89f9e8534ab6d91e56a4ad3ed04e7b97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/si/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/si/firefox-140.0b6.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "980d3542c6c25d306e1b24404731554d4a21157eb1bf5fc17ab31949d2e5e563";
+      sha256 = "e12f2ec9b3ca80de69c96fd7d4f208ca8d7555e436c7848202b65c043af64e3c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/sk/firefox-140.0b6.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "055076bedecfbf77818bc70c0d69b6deacc4ac9f015bc419738b1dfbb499e6ea";
+      sha256 = "cb16aa9355ef7e8eb43b18d19f9dbdc0bbea9fc36a1ab13317678de0e2af6a24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/skr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/skr/firefox-140.0b6.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "72856c1bfacaf66461ea1cef6cbe5481787751674e6a79b89997aaa23880ab52";
+      sha256 = "e56e34598b0ec80d599dce78cd2d4c9859468eb2cb2877da53ce529baa38da31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/sl/firefox-140.0b6.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "366b072e83d350147ef916e8386db402e0dd2ac0d086d7b1242f8dfd91c00cc2";
+      sha256 = "21de66e4aeb3f66fea37be933f4b8a376c0048297768d88c0f1a65f4d5f09f8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/son/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/son/firefox-140.0b6.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "3d4a4fea98df1c0013371f96db1e95d3b8266a5a773cb2ecc4f58ab7d4522c27";
+      sha256 = "541a51db2ee1d8854fe949901ebb15c0f6969f87bdffa1815bc4a6ef93321570";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sq/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/sq/firefox-140.0b6.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "195ebd91159fc04d11a34801d7b0871b5b998f401e8c4e3cc516113bf067b7c8";
+      sha256 = "0584176b701fcd82ecb53723ebbb793846680873adaca5b1b32abe8e149ed1e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/sr/firefox-140.0b6.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "95431dd518de2fe5a679e8635f6e3cdfa3ae99d7b42eb93ef8591b6bb5ee0d1d";
+      sha256 = "23936d0de1043c74b1e971d7ca721324016d98158781b517ce024beef092412c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sv-SE/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/sv-SE/firefox-140.0b6.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "5cc49bda64618b9e07ad9d1b6af8625bc3a7ca158467ec880836bd20a2a08dbb";
+      sha256 = "bae54d47460f3c11773d252f3e1029e754bc4d6e3ce273ca584146054a7b2acc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/szl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/szl/firefox-140.0b6.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "f6d2d95427f8eb184d600b101e0bd3ab78580f837765eee297c022cd2e603433";
+      sha256 = "d2419e9f0a9f72d4ebce03887489af6d7b5a997e7d7334ff893ef18e44c84763";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ta/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ta/firefox-140.0b6.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "f5ef3477f4fdd8708908b2cf41486c0083ee9724d6f313cb28f24abf3f26a156";
+      sha256 = "8c3cadbded3754fc10a0b261cabe28a0b68d1185403f0d37849d455778aeae78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/te/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/te/firefox-140.0b6.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "f41f2fdd0d2cdfb76eb440e8ea7756368ddc4285736bfe604c65b03df42061ec";
+      sha256 = "6bbd734e9ddb18d4ea281da0beed20a601196b9a720438d6697efdb30508ad75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/tg/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/tg/firefox-140.0b6.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "815ea87b2552b0c6093bf6dbaec6dfc660d3625f44f2bf042b5869e42c23e25e";
+      sha256 = "adb666a98cf8648a4633206020e27517ad39cb950c248541b9434f21446288ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/th/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/th/firefox-140.0b6.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "a58b8c1730cd066c5dfc26e8d2d4d3b6557a72a0c680e4163c43279c671c5ec4";
+      sha256 = "0179b0d20e57e6cb67da17f28d2391a3318a550227e752e1906d0c579aab6a3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/tl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/tl/firefox-140.0b6.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "817db84221e7361a7c932d0880c6e82aa7a64552931e015c4c4694c1ab9ea253";
+      sha256 = "6124e86e5d986a503a6fd0c185057162ea3540503d80999eafe3a34680e0bad6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/tr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/tr/firefox-140.0b6.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "909252098ca36f93de56732fd0762fdd041657559d42a7200c821115b38980aa";
+      sha256 = "149b8bb8c8dd85ab43deb6dbc400f3d4959b557d10a67cf92b6f79d47e738695";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/trs/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/trs/firefox-140.0b6.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "e1c4ad015d1e3565c4435e769bc59d5bff953f719123a330f8e37c43833881a2";
+      sha256 = "4f0cf978ecf62cd4a923a18fb5044796bbb2efc6338e1cf27bff9c349183bacf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/uk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/uk/firefox-140.0b6.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "0e31db03a117def0867bcf5d3e1acc7ebaff9daf4325cf3be548e72bb09057e0";
+      sha256 = "51c0ebe8f9b5281babb44870bff97ad02398a55404776c1661174ef988a1c0f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ur/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/ur/firefox-140.0b6.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "63ef448ad869a987cb0e7756f25e81e7d1c6bc083048e7eb49dbf5100626879c";
+      sha256 = "bc98672543b6462ae5178df9fe930326cb8b9e4def69a6a3d8ce282fdb090261";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/uz/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/uz/firefox-140.0b6.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "77d9943bb83a8b1b42f448b0e3e0c3cee11a1ea0bb1dae18ba52c52ed5a7d7df";
+      sha256 = "f22197a95cec99fa2cc84f6295d9eeb6c6f3f5faf3aaf7508c1506569bbb4fc0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/vi/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/vi/firefox-140.0b6.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "c47d720da1f5aeae9d8429ed71f1044275888751a0c217a6a534e61e9f4dfdec";
+      sha256 = "24d60c5620a29e75af5a43593d7c2229bcb4aa708d01ab40cae92269b59df25c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/xh/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/xh/firefox-140.0b6.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "8f4530d50019aeedf2d059135acc6ed42147f86d98ee7defaee5ae2d826c4821";
+      sha256 = "95190a46cd3041b6624160a75c37319eade659b3b154419b3b95ed670cbf2e90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/zh-CN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/zh-CN/firefox-140.0b6.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "59f60c919eb0d331166eeb9d76449c0a57593e82061a9d3319d680253ecaa503";
+      sha256 = "d3da8d8f8eaab4d6447199f9e5108f292883c79ba5c7cd48ae4dd1f2d9bcd2d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/zh-TW/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-i686/zh-TW/firefox-140.0b6.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "c6c71d581e46b18e48fa76699835ae7bdbb11033366674f9e1d2be0cfcab80bd";
+      sha256 = "b0afc944c042e4dc8a98f3cf1701693a98c2f8d230be21d35b7bc474d2496065";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ach/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ach/firefox-140.0b6.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "241018608d47cb0d022e323e968922b082acd7064b3ca8e7bafe665ff23c9b3e";
+      sha256 = "5b15edca7ba886bfcb34bee6c08cda64f757a848a20ea91450ceb75555351f8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/af/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/af/firefox-140.0b6.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "f8ae5994e39898cf2611db052640f7eff4425c5c7d94107491173f900245df32";
+      sha256 = "e778e95f524f7f5cc69171caac0475712ae05b278d6737fff9b0a2d00ae78ff1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/an/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/an/firefox-140.0b6.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "4a18c94a3ec5544664a89c9cedd5e25c5b15ff41cce68890a7f2036a720c9b1a";
+      sha256 = "9b902942c9f8c9d74a37b91d6c2f950a56bd56e1db6f626552e1a4b5eead83cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ar/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ar/firefox-140.0b6.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "3478f78815017cb30bff0946399ddddd15f90a739213c4e54f8e09602c76df83";
+      sha256 = "97157acefcec8cd9a5564a12f1c08c084891f22c70dea4eaca301c3a9e711876";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ast/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ast/firefox-140.0b6.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "fec697046bdc9c5edfda4ab3f6df1df84819a3ea7b46250f20722b05ea356dc1";
+      sha256 = "4cc18776eb262ffb699f58d96312eace21cefc7d88673568e585a07ca37173bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/az/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/az/firefox-140.0b6.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "78a68fba1f9dfec4510bb2cd493d82fcac31801bb7bb5718f8afeb57940870c1";
+      sha256 = "2ff4833d379ae47a2365fd72570b3e230ee3acec037bdeb432b3caaf6b013a3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/be/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/be/firefox-140.0b6.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "8e27d99cdad038331140386da3749f2c85afd5cffdf8afdf9b35a735027a690d";
+      sha256 = "e7553858a06e1a1f35bf9f3da91b2b367e5c203221ad8fc064359b5b6c60cf07";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/bg/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/bg/firefox-140.0b6.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "fa1e2d472ace070d1dc8beabf7cddf85b571957c453ccf8cd08ea14ee213761a";
+      sha256 = "0c09e5d84a4a63293d46ffaabaf65aaeed0a70799768b4f7b5ea0d485b7202eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/bn/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/bn/firefox-140.0b6.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "bf8b652eef9f6fe89adf3cab9639b59cd2ce5009c31f690923a09ae399b68570";
+      sha256 = "6c0bc3a7c3ad9ec76923dc886a8a0c676ebda43969b8dfc31a5d39320db80024";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/br/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/br/firefox-140.0b6.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "fa245862a996f8023b25035e2176e54047af8d333912a89be7faca81908a4604";
+      sha256 = "ee2553bb9d8dee02646c6c3bf17e17af86fd6e8607ad8432c3d742652f15bcc9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/bs/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/bs/firefox-140.0b6.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "34976543a5bc5d9558d8e725391b22805dcf8b8797cf6a54701cee7328106550";
+      sha256 = "abf76060303df5d1773e6828987fbfbdb00af03588fcdf6a3965b320502e6b63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ca-valencia/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ca-valencia/firefox-140.0b6.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "8a9a04837e328286f8128f9b744d274d98f7db5762c244f9294e0f9fe7766731";
+      sha256 = "19a3c72cf20d28353d59a1cf0ee3dce6490e10a90ce9f44b2f1944c4c43245bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ca/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ca/firefox-140.0b6.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "384a1314de0b0c566fdfe39c2a74905f972a624fa434359dd6914e7224d95641";
+      sha256 = "0412d10ef86ed5a8ddab3e1ba25cd4d7ebfc4f9c2013e0b234c1d92d6bd77b73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/cak/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/cak/firefox-140.0b6.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "ffd23426e799190a55d6e2db09f3ab1ad9512a8fdf11a065ced8eda4715198c3";
+      sha256 = "a33cbfb911b5096eaa412cbd04906f024cd732b01b456c4963aebd2adf317253";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/cs/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/cs/firefox-140.0b6.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "779085fadd246044b587c08ff4ed2397215a97b0d0ca4a5a3df70142bf75e43a";
+      sha256 = "bf20cc69af960c04edd471c4fd72d3597ec7fb4924b3449789f1a5b44d5a0133";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/cy/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/cy/firefox-140.0b6.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "be7161a550b8698b20cc2a5005a0c6656a10ae2685c5ad52d5133da4d7812f76";
+      sha256 = "f0925388ec9f9316399c82f03b4b6350bea6d3b515e0587c9e6fc5b897b77324";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/da/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/da/firefox-140.0b6.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "2f524f76f90fca51a39a3d8c574c50aaf7cef68e276431966ca616c40212a964";
+      sha256 = "15f52ae2b4065cb38b36f9e395bc7b6d6f5bf2bfafda2410f661738ebff2a5c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/de/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/de/firefox-140.0b6.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "8ebe0cdd840bc6ef9e3f2a5801a6308d35d265ca32eeb54db6ae863216a10b5c";
+      sha256 = "dfe792ee7af319e1b84451b4cfeaedbc49292b4eafdffd07149adbb493ef7127";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/dsb/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/dsb/firefox-140.0b6.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "72b2c42048b933c29410db5ab1cf3b83f1b9d89a5b1130777598bc8572437bac";
+      sha256 = "a7a4fbfcfb260fb3acde102faaedc31a1b8a06c6fb2e9c15876786d831437e3b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/el/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/el/firefox-140.0b6.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "138e9495ccf965c528ad0c2482b11557c6ff0ab4723332bbdd37bd2ce1afbe72";
+      sha256 = "96de1969c025ed81f08258aa2acb5c3bcc8de287634d8593d71a7eee82661572";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/en-CA/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/en-CA/firefox-140.0b6.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "fe569caab44348927473fcca363e859f3ac3ba1eff752abd9978e9e0cccc397d";
+      sha256 = "66ead601728050a0d3a11e745dadf8cc5ebbce10081a2b3ccaf5b74b094fa0f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/en-GB/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/en-GB/firefox-140.0b6.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "c069247ef7744b71547ba952b2d332563bb0bed5ee4c33a5bab20c8f0b71156e";
+      sha256 = "89248abcaaaa0ad95c1122e329765895d1ecda7bb09c249436e5754d24b66d4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/en-US/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/en-US/firefox-140.0b6.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "e91834ae34ef10d436a22795b4d5716df01a31c83fdefd8cf22a62deb4dc26c6";
+      sha256 = "74b718e0d55d4b5604ec0329c031d1c4df6d1e8f563a1cdf0856359b5a1e0733";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/eo/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/eo/firefox-140.0b6.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "b2626c8d82f90f958e39c6fc8fdd11e0e477e54c0fa770b8642ea4eacc5c145e";
+      sha256 = "8f838213f60897bf7efa4ac2bae5d2158bdc0badca1199007daaa28300c3798b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/es-AR/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/es-AR/firefox-140.0b6.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "20bbd71dda6392b8e296d36f27be410e2bb831bccad9a6eb520b3ef3a8eadf2b";
+      sha256 = "71347bf238c17fade8c0b976162f79c15fc7ddb2757739e6726fa9c5178483b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/es-CL/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/es-CL/firefox-140.0b6.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "47492d04205be6c535209513f64b9c0896a3a786c5af3e87add57425e95d2a04";
+      sha256 = "a03fd736264f9350ce8afbb7bf748ef1334cd0c56d3a46b7cc4a7cbec9102ae6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/es-ES/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/es-ES/firefox-140.0b6.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "f1504517f6e874ae5c73cc73fda5763b692d403be5b2d6a3c5fdebca847dd044";
+      sha256 = "359b40f625f56dc6d0d0b9d485ac63191150c3a44a74e9075a41e911ceeb4a86";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/es-MX/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/es-MX/firefox-140.0b6.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "9e8fae58eebc5fd0fc212ed66ed63add5408730de3b360020ea39ee3c67e70a2";
+      sha256 = "c57bb72b0bef5d9cb51c8090105a5f67e1588ca4e7c7df39c4f62065af0615db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/et/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/et/firefox-140.0b6.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "c9256db0e31b1d836cb4ad7d45c9289d45dc05853a0883071103b581743645b9";
+      sha256 = "c2fa39b2e8e8a30b9cb5bf5659a060740dfb38674788bdd3c49ccb097113a1a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/eu/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/eu/firefox-140.0b6.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "a85b68a93d51c3c42343a7038ac72d4ee3b0847aee312a3f720899abc3b30961";
+      sha256 = "904d296570aba820bbd085669c99c14c821af6115fc06141afa1769fb5216f48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fa/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/fa/firefox-140.0b6.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "44ee01aa1e8c1ef973cdb2b28916635fef9bb81a7dbb7e735e055aac02f65007";
+      sha256 = "748a9367cd5c0eb882d6d215b75398eae46125ea1468a58a5afbf062c949a294";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ff/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ff/firefox-140.0b6.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "0dc1f2c9223adfbff26376aa55fa858ea89e04fcb4f3326b115bc6f9cd0f1791";
+      sha256 = "30afedea01cf5bcb552b75c07dc5681f16fa24f64fbf25f3b366ba0a2142409d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fi/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/fi/firefox-140.0b6.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "43c5253851fc94038a7b8c922660651f43484d70cc54d22dc0f521fb978e76b4";
+      sha256 = "d60fa03385f079befeea5fd302a655c6e93612b9ce191ad1e04023c6ddc83130";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/fr/firefox-140.0b6.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "eaed4f0100d898555c1f2bfab43592648342b9be1a712602c43929a77f61f67c";
+      sha256 = "571d520820c9bc24310ec5191040ca999ca41d1f95b99f16d4147f0a867dc253";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fur/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/fur/firefox-140.0b6.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "e74ce591b238c6a6754180aaf8eec4701206c84204b2792e505d3b065235be10";
+      sha256 = "2f7a970b94fa2a0fd54768558517fe8bfe8e0f27a946b0495603b824982a2623";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fy-NL/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/fy-NL/firefox-140.0b6.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "15309be99c0df4c8bf23ac5387e8ba6c15b2051e54a331a943c4cc54959e645f";
+      sha256 = "43e6c3489dfdebe246ab67d6d625706b8b445748a3ee182568572f3c3038a94a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ga-IE/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ga-IE/firefox-140.0b6.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "0b7d2969509f650aa4e725d38022ec61633e89d5b325075be3eb97649abf58f2";
+      sha256 = "c14c09e50413596f1e50aed7a64744103e2d6765b7e41b34a0551e5562313203";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/gd/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/gd/firefox-140.0b6.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "9f28a60ecd9e6eee111df4b57b437739a77a55276d9fb66d2191c4fb0a0b9886";
+      sha256 = "11dde7a7e5b04f37df9932a3b43f7f2a8b1983311888742366ac1bcc9634a1af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/gl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/gl/firefox-140.0b6.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "d561f29fa446a9541f43651f439cde9a4c7c5dd7a4fe7d8dbb41e7dcc1aa351f";
+      sha256 = "68328e15c35b069a9ca2ebccdaef368d66f7dce7f14adf7bebeeaa7c0a41892b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/gn/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/gn/firefox-140.0b6.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "84415639e92579f37ecd8598d2757a3a49aa8c81287c3d8c5b653e489e5e41a6";
+      sha256 = "7180f6d3d3b3718547663e4d6545066ab258cfdf5910124625035cc35f1c26e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/gu-IN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/gu-IN/firefox-140.0b6.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "d05bd65e0115b4dd204833e980928e8f409e79fbad11cf003c22863775e41b14";
+      sha256 = "d459f0bcfbc1ca990121513e0bed6b3315ea114e297ccbe7e80a9e310bb94cb9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/he/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/he/firefox-140.0b6.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "3dc2d50792fe1ecf2248f243da773da783df54c039ef6f47e316caec33353f51";
+      sha256 = "b83d10b890852cd347b36923838ac0fc38d1b1d6657fa27852c9a0d7f0d8de30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hi-IN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/hi-IN/firefox-140.0b6.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "e8004158a6a24786c3ce373e43c9d9cab82142bb7d2eae9fd187f8be3e315606";
+      sha256 = "3b3d208f0ee43f5fb49b11e64c5d2f4cdd4939d004d9429e24849ffbba6311f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/hr/firefox-140.0b6.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "c0c047431c8ae0786a77b3934f47b9b5723028e028ce487a895f997fc7ca40ff";
+      sha256 = "c02589f2dd9f4b736e6a00f151e1ad5e763279b1a9d4b5e037b14f71b8d005f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hsb/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/hsb/firefox-140.0b6.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "12d757bb7689211acc5a9bf7380eb4b8f659dc5e797a16481ff43d19252670a0";
+      sha256 = "622f74e99562c74d055ae1bfde21dca5d24362498cd72a71f6dcb0a424599541";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hu/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/hu/firefox-140.0b6.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "21e08a716cd14ae2ddd8797cecd3a387d6a69f1725283da9dab778cee0ac5a96";
+      sha256 = "3c2af96b89aa2a91bee2c684876912b2fe94e29ec04e64f516c27dadee496a3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hy-AM/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/hy-AM/firefox-140.0b6.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "cf0ec104784fa1f8b0965ccb54476021b0aa553fa61f76258ccc0838af3fdc58";
+      sha256 = "13b89a8966517155f3dc21f24c200b303f9f109f7aacd2714119102582f74f14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ia/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ia/firefox-140.0b6.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "d398f24f832df11e54319485990d6b0763b88018e4942734f97eb6aa1027ab14";
+      sha256 = "2e3d19abddff21e05666f3de3fc92d1b82e324273d0ac743e5e7c1591f5bb405";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/id/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/id/firefox-140.0b6.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "66300532e61904c2ec3b38654fa5c04fc77132264560651eb47d08505f92aa93";
+      sha256 = "0a4a3ed1eb5ea28e8c0076cafa34c5a9b1008fb6cc118b73e8addb0c1a944452";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/is/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/is/firefox-140.0b6.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "905759bb5644dba6962cac36370c8092c8b4d940dd0fd811d89f2633d8278375";
+      sha256 = "599184c990b9960c021822eaebe88a57fa4900843fabe2d1e2a40c0806e29cdb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/it/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/it/firefox-140.0b6.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "090d658b0d9883ae4cb030efbae33dcad50cec614cc4df645d9d578f8f3d9f78";
+      sha256 = "9ede42df893c8034c5773b149e1a9d83671999ca6931829b6042177531649dc3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ja/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ja/firefox-140.0b6.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "498c93faff28cdf519c68228a929538a6d86722aa23cf77c65b9a6bc9eec6cde";
+      sha256 = "ac162386b75ed1f4e0019fb3adca8ed1b23dfae029aae7cbadc7cc9ae49c3cec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ka/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ka/firefox-140.0b6.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "6a7219133dc2cd5828fca8c47c8918960078a1edb04e5d0f130572802228d8f2";
+      sha256 = "f6c5896f77ac909c9af4fddb4c5a4d920dc3fc2d8b564c22264d719a7c763163";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/kab/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/kab/firefox-140.0b6.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "61bf24a6f254d3a290207fd3c2578d3fe0968ac6af729c5468952c7508e60f32";
+      sha256 = "cbf718b24c98f40c9b76415f307da3e0d53aa920e6a4db70ed9829f359c20431";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/kk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/kk/firefox-140.0b6.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "c390e1a6bea9f444984fc78ac8b321c1f7a629540716f311677ce31ae853f52e";
+      sha256 = "9bdc580d9b0de74523b8e0dcaa171ea116d482342bb7121267245ccbfd509b34";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/km/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/km/firefox-140.0b6.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "f37ca60447383abbef2720253a82d551a906b0e358c404480e94b8e69dbcd92a";
+      sha256 = "bb77e241893deff4db5e9f128c9cc28caba530c7e85ba458b1664768c97dea4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/kn/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/kn/firefox-140.0b6.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "a5069cf01bfb68e73a524638cbb8fc435e54cf874369c0ae8199e724dcbd96eb";
+      sha256 = "89c2e1abcf24f2d0831c110d5633151edcb90a4203a0bd19b83e384f8773b3aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ko/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ko/firefox-140.0b6.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "af9ba9b7c6e825b6fbd57cd1b2d015f6ca9ddde361d643d1fe520b7869e21221";
+      sha256 = "157613edeaafeb7d68bdc577fdb31ee6c75df0711f0d79f08a8f3a5595775891";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/lij/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/lij/firefox-140.0b6.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "271945a88d4fc02733fa3de327e613d822445f18c70601f43bf503dc4bb76076";
+      sha256 = "38b59f648d4627b9a71752f56feaff5587982317f7e37d0a64fc72df4dc755e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/lt/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/lt/firefox-140.0b6.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "6e822b90f21a571e72b01c353b0d2371ce0e0e788382c5cb9fbd558869f0abee";
+      sha256 = "0273f44ecb90e322660b7a9421964c1280bc82e18ace52fb504b8c9febb23b15";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/lv/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/lv/firefox-140.0b6.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "840962acfde031c9bf7ac3be1e491444ea5dec8f4fde6eb018376dc39e2beb73";
+      sha256 = "8fe48d4fcc4ac652babc461a5df06825597d18c74109e89ced2fb0d733541313";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/mk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/mk/firefox-140.0b6.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "f1d13371556a0fb39f65e2e327eb87a0abed3d550988faa5a06785145693326e";
+      sha256 = "b961d6b55540d9d9fa567b3013d4fe1f812d9937c3412345e1baa92564444a04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/mr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/mr/firefox-140.0b6.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "ece70d221688bc7e21b28d849a75fc827f892195ad2ce0eba0851edf5a458ae4";
+      sha256 = "e6dd1df55d196d150a46385c46d8657a744ca26caa810d14e04aaf2910e3b452";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ms/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ms/firefox-140.0b6.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "2ebac815285a5fee53d0038f7504acf772775b76e9c142825d9d38d406abbf1a";
+      sha256 = "f366c7de84e193bd073f6319dbce4777e16fdf9d1cbf53147f3d75265c8031e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/my/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/my/firefox-140.0b6.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "f17264509af2285d77811bb37e04a78ba50795cc7ca9d7315ecf0b657063b02f";
+      sha256 = "33f8c912359b751b729514df0d4d557643cb79274f51a7bb74b467cff33745a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/nb-NO/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/nb-NO/firefox-140.0b6.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "be7310e5f244efd65bd649ec6a87831d74f275d9d47f9fa3af413562e1f520bd";
+      sha256 = "a43a870dd37f15fbeb101da1960ecdb639ecfd2985410e13c1f1da183605ec67";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ne-NP/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ne-NP/firefox-140.0b6.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "f2490420afc5dfcf52ebe57bcce39f3a4884dea697f244a6bb1c5ad59f4318f2";
+      sha256 = "b13943075cab22dba51f25ba6c5124316c3be4b0cb2ff77fde4a9247fa8c02fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/nl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/nl/firefox-140.0b6.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "a6cd59a175f6406118408261f6294124a7441e17847a5ec818747a79b5cfc044";
+      sha256 = "64b77da1ffd4eacdaf27daf254e1962a46a4ce8f18f60e1673c27200355d5366";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/nn-NO/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/nn-NO/firefox-140.0b6.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "a55c303f21439df3d7a93fb093b70b13bbd0c310d381132f1d3a0e3eb55b7edc";
+      sha256 = "a705d090315ec18416ef1cb457f497ba683d477458949af30bffd0ab2c853f61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/oc/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/oc/firefox-140.0b6.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "24e06d73859e511ec57f291bd2516492e5a30e28455a16e24eda79e186d4e484";
+      sha256 = "3e174eb2d5857949af246dea468b4c193acbd25bcd4fc906c000f387ac8269a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/pa-IN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/pa-IN/firefox-140.0b6.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "01658567d989c0427da0ed91c633d770ed281855f1dcf9eacfc8a9d4e1c4a61d";
+      sha256 = "5fe8a03510b6aac0e79d18ccf41f2fcb4d269fc1c37a4f491954d05f8f48616b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/pl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/pl/firefox-140.0b6.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "66661a57a4177366c8e50a5a9ed1c75e56d36aec6f1a11c9db167084ea23bae8";
+      sha256 = "426d5cdf137a6ab9de2f3777bc334a028d2dc8daddb2b6df27c0dde224567168";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/pt-BR/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/pt-BR/firefox-140.0b6.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "a563cf71764b735541cc1c7ea937819c7edaeaadc14cbfff3739c1ac3e16d6bf";
+      sha256 = "3e138e048eeaae877d4fed415408f460283e6e6082189ed0835af6c55ea40b85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/pt-PT/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/pt-PT/firefox-140.0b6.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "7abe6b559e61fa1fe77b9cb91c647378db6b5a45957ee03259cf9ff7f783800a";
+      sha256 = "6d867d7cfcc8f9885474d28b3c46323075883bba1e75ca47c3ac3cbe048315c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/rm/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/rm/firefox-140.0b6.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "9e6b92cb0b7f3ff8fd449b4a96d8b13f7eebe3f3113c98fa94eddb0a4121ebae";
+      sha256 = "c8330384c35ebaf86549f8fa2c1d73fb9ee236e33f8a54b353403624d348da57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ro/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ro/firefox-140.0b6.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "38e9fa5a6953c89263feeca394a71efc409c4c9f785f34550decbba2cbc18c63";
+      sha256 = "dfb2ffdc9ffc70f7eb2f04fc2b5e0445f039706b15f669490b830e53844f0377";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ru/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ru/firefox-140.0b6.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "f9fcbe379df93978d282f531609abfbc710054bc4c1461ac9fbd80a9c9b15ede";
+      sha256 = "c13c2d800a4a2b3fe556274d16ad2be4ee26e642f56dabfb176da516e07e92f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sat/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/sat/firefox-140.0b6.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "5f609b6774298690551bb08643d3e13733e2081fe108834908ea4f744f865fab";
+      sha256 = "87da408c95335989987a8fc08adeb48558b65222530fbcc56f15a8989e44ac73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sc/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/sc/firefox-140.0b6.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "4ac4a80995702ccb10076113ef853d614ebd5d8321f336d670f2d7443b4301d2";
+      sha256 = "d5654ae0594dff8078bec584fc3884bb399c218181f6415bec8d2eae610c99ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sco/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/sco/firefox-140.0b6.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "2ac20c11a5333d3d6c61acbcc4f651e5fdda00faf85126dbe224d961506d063c";
+      sha256 = "0cf196fa3fb5d8a4ef068eae26cab0cb9e38bddb1aa2261b2ae4e04bebdfe2c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/si/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/si/firefox-140.0b6.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "c41d50301986acd685f22891df7003e6758ffd8b6e88b999e96e2600262cc03d";
+      sha256 = "0ffa2511f59d9b5702d55d827c27847cdbddb3285794a21bb86546fe7c949449";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/sk/firefox-140.0b6.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "cd8fb4a85e71d82519a3d0bcf5f8502c84bded00029ee9f1a1ffcd40cdf0f0f7";
+      sha256 = "03bd3e41fdd25dcff6a55555237bd025153df0529a2075d33dcfc1054116ce7a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/skr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/skr/firefox-140.0b6.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "5d86ae9529ea78a30b437eb85a3fc230162a62ac287ee16d4a2118d380b04f6e";
+      sha256 = "9cf365d13319694513adb0e47a7805d843d44c976019a1f50c4b1ddde76ff62a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/sl/firefox-140.0b6.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "f9b3bc5c542d63952ac4fc287d6d19239fd5b14d2bfb550eb868fe2bf84ad9d7";
+      sha256 = "fdd2f3c6f0124bf5ca160d10cec486ead78fa2e889bea2c5e134390dbc1b1cc8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/son/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/son/firefox-140.0b6.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "146bcb03804707694ff45463fa78e3b33b0ef1e4c29e8c879171cd8495f2b506";
+      sha256 = "4a2031a9b2a4d51e919903920fe77b7084abc15cc30c9f551df0948a3c816d5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sq/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/sq/firefox-140.0b6.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "2a888fb0dc58d32d0682333b55b3fe84f79a2a3af9538fb26504745adfa04411";
+      sha256 = "16155600c16b2982190500613130a34b098d5891b9eca894e555f0281b22f20d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/sr/firefox-140.0b6.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "59a955e11e42f8a72274274c341a7b191ed1dc7bb3f6755ed127ecc13207735a";
+      sha256 = "096dd836daf90b18f701253df7c66fe4cab845dffe5e60f6f35e2c661d8f3cc8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sv-SE/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/sv-SE/firefox-140.0b6.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "fcc9eaa8966ef2fab3befa7bb962513f15e43b8f35035db6b31cdcf517fd4a73";
+      sha256 = "788cbe4cc058a0c23a0f0057dcdaa309ab12b35e4b1fc340aecd92ca0cf4cc5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/szl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/szl/firefox-140.0b6.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "7e5e7210213bcc5686701b258ef1b8feb95257dd23761d72a32bd22fe454d7bf";
+      sha256 = "521bf2cc23622f3f2604280bcfa1f4659051b88a7ffedcaa6dacbc0f98c43a66";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ta/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ta/firefox-140.0b6.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "ff668385625e513b54d37fbcbd1acdf9981c408b9b94f4029fcd09a1c2176b5c";
+      sha256 = "42a0073e0ae87cd35ced857704b2dbb9f82ef8bd2a176cda6b5591eb2ad6333d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/te/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/te/firefox-140.0b6.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "e02f9fdd62addb35ac5b762050be969602555389507046d9faf5fa7329ab4823";
+      sha256 = "6ae3d560934edbfb3bae0d4b2a1b314da00bc963eb3cfc3ed7a903570d0f5022";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/tg/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/tg/firefox-140.0b6.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "30e5a40d34e1d99a3b8837ba126c781f71073015129d851fe1fb56eec39377bf";
+      sha256 = "4dd4a7b1cc077a3373a5e7b8ca0e7843c183647d5db20028eabf7f365f73711e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/th/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/th/firefox-140.0b6.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "a7a947887fad3a4d8ef01dab58cdbc067981dcc9d7459df5d60bc656d5e2497f";
+      sha256 = "dcd8f27f9d2aeb8238ab26682998798885c1efcbce3f1d57658b7a3a4fa23127";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/tl/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/tl/firefox-140.0b6.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "a7be643c4803c4cc96b84618c35b1c922bef223585a75f18b8349752cb975296";
+      sha256 = "5784552f364919bcb9bf9d0465ea76123cf7ba88bb143afa88e5e367c5155ca2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/tr/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/tr/firefox-140.0b6.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "19e5d98f276f5635841c87e6c8023e72acd60bd756ed8cfddaa0f2781fe1818f";
+      sha256 = "c78ed3a6888b25870cf88adb9f634a264ad3ee9e8ca9d265da4d490118ee1241";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/trs/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/trs/firefox-140.0b6.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "564791342249ef49da8ae779e84a013c834f0881c4acf7ed9d948b8f50d89c8a";
+      sha256 = "6aafade8a1be4d728699217df5af58d35201dc0d7ae06b48b811f04291e28b53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/uk/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/uk/firefox-140.0b6.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "215715aeb75eac4285b506b3a576f358c9c49b487c124c6da4f62c6c75c171cf";
+      sha256 = "a9b244db3309a36817d592de909023fecc3ead9bb1a4cf18af9be2635770c9b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ur/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/ur/firefox-140.0b6.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "9a0aba63bf9b643d94b85f21e05b817aacacd46e74531c1de2771962b47e234c";
+      sha256 = "890c8fd5caa23fad6573f96c6ccdf494c8f98a4e5396efc336635293ab6a8e6f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/uz/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/uz/firefox-140.0b6.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "395c7875c568318821381aea1a879e63e477ee281eb3f071bd26ee43a5f803e6";
+      sha256 = "b8046e671f98405f294fcf7e9c4e267fd2ed4febd2f808de001455051409bb5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/vi/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/vi/firefox-140.0b6.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "be24eaa206c9e1685a068f44547603770de6f623a3701edec12fe8289fc425b5";
+      sha256 = "e27c08f33fc10a4cd4c0b70d75d6566a6cc7b4cc6b0aaad4a4b92c108060349f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/xh/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/xh/firefox-140.0b6.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "3b0d01efdd7cac99912ee95dd058a0a115e7f0dacccfa948b0a56e4a9fbf88f5";
+      sha256 = "4fc6beb921e2361125efc2c450655714e675dc9d50a2ec82391f49eaed1172c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/zh-CN/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/zh-CN/firefox-140.0b6.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "08de3ee0eb0cfaacd24a525ebc645e3a3ebe8b7b4ec2bb25a1f9afab20c65ba9";
+      sha256 = "34b989b326905d4bf6edf463b6203b712de51900ce743233d00f1b3b6df1e822";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/zh-TW/firefox-140.0b4.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/linux-aarch64/zh-TW/firefox-140.0b6.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "be9a2ec30189f97b100dc683e61c6484aad2830b1ba1263a043ed5e6e9a3afed";
+      sha256 = "5334fddef31da56b1cc03b9bccbb0658c47a24a4fb77fa8391a60af102fde10d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ach/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ach/Firefox%20140.0b6.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "7011b99f89c7c60f226f115896cad9e68d5cbaeca7a819684f85d8b071595c76";
+      sha256 = "b55c9da845a9ad7dfb14d787a0cb0df34fa9e6fa3c05b165be9ce64267d008b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/af/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/af/Firefox%20140.0b6.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "2c3e99a5d7c10303a21aae63646ee282ab113392ed786697bfab38a5ad486773";
+      sha256 = "b8cb63d503a141499caa5fb68ecfb7f2ca5f49fef960d6119024b8b89dca5b03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/an/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/an/Firefox%20140.0b6.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "2c656ae52400af6838b92d40968452d7d61d520746363e5a53a54048e382c4de";
+      sha256 = "ebda4c5460c13c8602ceee736f9ac844996beb7752e51934e5b019e0d60214a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ar/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ar/Firefox%20140.0b6.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "5bc54dd06348de5a8ffda4f2fdd1223c78532a31041a7a6e28a3dccac2f57e06";
+      sha256 = "2467bfc7aa85172172dfe260e247c04359b7be21367da86470175222dae629eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ast/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ast/Firefox%20140.0b6.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "054584aa35018c91369ba1e53675333debe62c8c10fb34b27fd9233869330cfa";
+      sha256 = "cdb7b50b3f3364e0b0b27e2f4c8aaede449ab1244523e812cd0822ab281fda57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/az/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/az/Firefox%20140.0b6.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "665f07436f9d3da77906c250a390d07fadc472d9014bf708c4b76e4787aee258";
+      sha256 = "9218696ae94c2d932669d94f29885906759a39bf5bce2580d8b188085571ecc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/be/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/be/Firefox%20140.0b6.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "c9934c38c43f95da6d3a5ed936b39f0a33399dc805dc26a357423a6d76082527";
+      sha256 = "10569a7297baa577cabef6c73bfc6d89168864e36ddc67a815c9a6551cd4fae2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/bg/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/bg/Firefox%20140.0b6.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "ce43e7486523ea791a3410b23d6445ac4742bdfc17f4dff7fef166c9dfb74fc7";
+      sha256 = "03acebd1cb5b0614b51511c780462c62f31214eb86751753bf7dff3ec503a0f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/bn/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/bn/Firefox%20140.0b6.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "82f8fd00def7073356e6091e759cb14bce43d1e808118deeedd35c3c9e52442b";
+      sha256 = "b6f512cfd426c73a95a9a0f649b032079a66ffee662d22e1b67e9faf83ea724f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/br/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/br/Firefox%20140.0b6.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "b4dacee5016f58f013682c8979db040c62c0430517f796934928e3d3758f93fe";
+      sha256 = "657be978a9c98b8ab0e8d98c94efbfdebc903071283ea805bf126e29e72684f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/bs/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/bs/Firefox%20140.0b6.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "94061d43536184681a280e8439b05f0a5d035aac89cebc28021750818ac2e912";
+      sha256 = "46c70921eb40ff3ef655e96fb971cd20400723e94cc0a5a1ff30c7f65edd58a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ca-valencia/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ca-valencia/Firefox%20140.0b6.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "eef766eb8aa3a35ec8b56cbe5bcdb3a1a6b452bc2d7b6922de7dab7735267bdf";
+      sha256 = "19c2bfac3bf614054b224dba62b3afbb72d3eb66d033adf2fdaae38554554cf1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ca/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ca/Firefox%20140.0b6.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "d4e684531c5ac1410eeb5454448e61fdc037a768df6355084a9383a560400dab";
+      sha256 = "ea93aaba1785ef017831f83ced895332adadf219504e70c54d0c57ff9496f9ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/cak/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/cak/Firefox%20140.0b6.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "64ed36ea6ac02037d431b10790ec589a54bc0855b41f40729cc2f0dd1b5735da";
+      sha256 = "e3f364f81cf5ac7cec821f05f7cc07177fa7d0af8722c91b4f0fbc347cb97d23";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/cs/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/cs/Firefox%20140.0b6.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "df4e1c59384368749ade8227c196346925c49673d9460b25b0b2f63f7b5d77c5";
+      sha256 = "a86648acdcbed9d7421c72424d42052157ea1f825c14603c0266508238e189e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/cy/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/cy/Firefox%20140.0b6.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "7be81560ab2efa8961f8283bf9ae41b78e9bfecb4fc062bb5a370b691b6e69c6";
+      sha256 = "c1725f092c3e43f9b7ed234cf5283c69e61095ae80594d99ddb65cbfd234996c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/da/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/da/Firefox%20140.0b6.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "84658e5fea8ba57840788c7d4bdf7ea2600fbea63a7b4c4a2339e70c81f0570d";
+      sha256 = "a752f31d76882f756a4f7e8488eafd0f746ece071894b5a79e5f119892e071b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/de/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/de/Firefox%20140.0b6.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "7b18cf594122f970a0e54bd404c92a509134003a48dc238669b93e22207b2301";
+      sha256 = "70ee084818040191e975e1a8a8ad80acb6a62f4e46f22df1e5683b22a844c4c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/dsb/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/dsb/Firefox%20140.0b6.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "5eaf65eff742646d55df43fe7cf2c2a64b920203a566c8e781eebac4162348aa";
+      sha256 = "908627cb2807b27c09825bcbdd7998ba015d95488309fe74c90d309df342e901";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/el/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/el/Firefox%20140.0b6.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "d45c6ff3e7303e12f87b5d6b049653c9ae1a5516784703514f91959fdab73d70";
+      sha256 = "b29bf2354ce959e36b82b22db10220656dceaa8d7429b5abd142fa1faa381e7c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/en-CA/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/en-CA/Firefox%20140.0b6.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "6375d180427113749371732054557dcc40e7d90e7a0207bcdb9306468a211021";
+      sha256 = "0756edd349c74d680ee93bdb5e2ac5d290f203a3293c03b160b9b359d2f58464";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/en-GB/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/en-GB/Firefox%20140.0b6.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "185dc01cd6183516cab7f175982bc0de5ece04605077c2775a1f670e5360172e";
+      sha256 = "460eec43ccc80b8a260ac3d4a5623ad694c504e1c01d912a48c13ef9f539c7b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/en-US/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/en-US/Firefox%20140.0b6.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "dce036c33d4749910cc2d87ce4c6786f7538a83dfe22f1ae1f9bfd17d4a23523";
+      sha256 = "cd0326af92ca17e5121c916edfe10e913ec39d8ccd16c079207effa7d4aaab75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/eo/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/eo/Firefox%20140.0b6.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "287ecfcbed7e32717ee2fc2940f40ec38612a14965f6c24ee6c48aaf9e2d3dac";
+      sha256 = "92e1280e109c947c297a6047b975972af21ac979a39f75b6e9f0a7b05896560d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/es-AR/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/es-AR/Firefox%20140.0b6.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "f0ab0790375fb20a4b99ee6fd99af0191442ef8d251711bed2796f4dd6fd8caf";
+      sha256 = "7cceac00533262e4736748a4ce273aca2676e99e4c52ecf667e421994e9f8b25";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/es-CL/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/es-CL/Firefox%20140.0b6.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "26154d26c371d0de08f5e5bef5661972b6b13c4e94e285d51cf776fc77c4300e";
+      sha256 = "a06a0de4c99dd388ea23b37c845a2861a5fe5e0f0e9d303ee86eb01aef4e392a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/es-ES/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/es-ES/Firefox%20140.0b6.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "921969d77ee23e539e68a079742bfca9bd0a749af53befc3b42849ee9abf0b34";
+      sha256 = "05761e789f9c61f4bc8749bbc584bc64fcb07d0c2c8b18a27b8b4459b5a80621";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/es-MX/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/es-MX/Firefox%20140.0b6.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "9dbe72025242d5510d023c190c38c5966ca986f0b06200e3797e06da48c67a93";
+      sha256 = "c688be8725af8d5b8ab9a81f9dbb4ca5255a8578fe759d46f602b4ba13e445d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/et/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/et/Firefox%20140.0b6.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "4e4895663ae7c07d9bcb8c56478cb7a07e8573acee7cc1f451ed777b1fd2776b";
+      sha256 = "6dd742ab79ea9d0653f4096a63d6fcea9f142707fbaf5eef8dc0c8cb8070baf3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/eu/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/eu/Firefox%20140.0b6.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "1e0ce31608914502e0101246e059da95f83f05303f5a6b2646e7595e0b008bd9";
+      sha256 = "64c3c50a965bf153482e1ab9a78384be231f58051b66cdb9bb790f4cccc6b171";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fa/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/fa/Firefox%20140.0b6.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "529cc279815596836eeee0240db66fc3b4132d5d462c58a8caf0d3cfc6777f1e";
+      sha256 = "c5b677703e9eb533987b7371d4f4de7654df9d415958f1216ca0287d5bc24f8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ff/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ff/Firefox%20140.0b6.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "1aff9b2159f017763c1c3add776bee0b13d30e56c5d89b1364b9ad362a5c8b73";
+      sha256 = "e4f6751e5eca0f69c303da861cbd150e7af6fddeeaeab1caf3934dd73adb6a91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fi/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/fi/Firefox%20140.0b6.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "a70fdfb3abb400bf51d186d8c4a609f25ee0da2d29d9c26f93a1cdfc7b755c47";
+      sha256 = "3892f17ad12fa9347a2650c152aa19e5b6b5ec79f21bcd28a641261925bc8976";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fr/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/fr/Firefox%20140.0b6.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "f7f6396a4a0a892db2e566f35c41d2b327956d4a7afa137c559c06a237f2e040";
+      sha256 = "3462880c9f1f48ab6976d507727b7e3d7d0e86c0eddef198e426a7ce3f9e4659";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fur/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/fur/Firefox%20140.0b6.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "c863d7680e463d3948316b98bcdfc17b9dc2e72012fb7d8d242789271b94b581";
+      sha256 = "7b00ba6b6eb8fe2f04a2411c9e1e764afa49e2d6d8b183eee0bbdc97e017922a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fy-NL/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/fy-NL/Firefox%20140.0b6.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "6dac9e3b8abbc4667041767b43229188ec1a47244189ff0c742220bfc14ed298";
+      sha256 = "e115dce3ec12cad902029ccb060cd56a258524cfb797bb3aff5645221c192c3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ga-IE/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ga-IE/Firefox%20140.0b6.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "2974969a324c77ec27ac89e769891b56bc4a89ddeaf3bc049fad077d38b3de76";
+      sha256 = "25c3a1ff61afd4d0ca9ccb2d5d5d1a7a8f224c2cbc7f9aa00b48248c32ea64fc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/gd/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/gd/Firefox%20140.0b6.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "c9177b756cc02ff1c708bc7f13516c8794ec871589a0838df5681dd14611b717";
+      sha256 = "481725f402a7b0970ca3d5d535a75d3198da2eeac41c2cfae24f99ee0c3ed5bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/gl/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/gl/Firefox%20140.0b6.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "3625754df8b228d7f8b51bbafdddc6648c4b7b78d16d287fd6c648bde449e899";
+      sha256 = "4294ffc7380aec2e1c2e65475fcdff5159b8ee53fd4e806d60112ccfdd1d0df2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/gn/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/gn/Firefox%20140.0b6.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "b2e5bdb585f18fbc0933a4b782edcd08513d606afb1d2686705ee7fabf66987d";
+      sha256 = "5ecd0e96fb453c2ba66deea4550f21d5f8fd350f4d688a3b5962a0198a84a3a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/gu-IN/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/gu-IN/Firefox%20140.0b6.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "7e0a44037cbf60148bec07d2c8f0bf78079b80692da2230ae2158a090d48b785";
+      sha256 = "f47ad848401f16be4d0b8dd8081ce53d9173cd856b68de2c98c4c611a8dbb4de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/he/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/he/Firefox%20140.0b6.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "920ade68106d20857e5af7b064c3d97d8661818be36bada7a21d6f89682db91a";
+      sha256 = "d2a83af6f008ac9753ab19cc6169c0bccc5a3d7999c396bb96bfd81db6959790";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hi-IN/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/hi-IN/Firefox%20140.0b6.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "cbdfb08d1cde45a370bde21191eb901c1b7a9e08bcf29c94fbe728182a8c2992";
+      sha256 = "210b0d9c78cec2cb72eaa070bfe814cfeadddadef4fdf11840396e94c4c4174a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hr/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/hr/Firefox%20140.0b6.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "7b3c21df86b3cc960cfcb948284f042b68e367f8b3a28ffcadb7258a8538d6ee";
+      sha256 = "16b7bcff84e6f5dafef18f3cb1e392b60220c23318b74755de13970f05c62edb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hsb/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/hsb/Firefox%20140.0b6.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "0dddbcdd417f10b2d2e576346c313dd325b170cebb478827ee3f19154aa2e3f4";
+      sha256 = "874ad72bcef64fc6a89026a67895e13510b1230ed4df3445e1dada090724315a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hu/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/hu/Firefox%20140.0b6.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "6aa34847a12eab43aa04ca1ee27c5edd5562a5e916fe47a64a5a469b46201e3e";
+      sha256 = "a82849f2244b6d0662566f3ee25bc4c277d91a703635bbe41a7bc63c60e8f239";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hy-AM/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/hy-AM/Firefox%20140.0b6.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "4f723e805556cca933b97981871c1e1408cfbd766b15037981af9deddd041fb1";
+      sha256 = "abb9561be5a12506d7a077936753f83bc234b3f160e26225757e1c0bbfecda73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ia/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ia/Firefox%20140.0b6.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "9ad43eff14c069d7ef7f27e2b47fd4713af832410c579868293ee7f78cc8c07b";
+      sha256 = "52835ece73d0f34ec410d2f6c6240fc7d0860d6b055a4a0a19be71e39c68e759";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/id/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/id/Firefox%20140.0b6.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "3176ea295423ecd71a466a79e9657fea751e6d8c71db66a0709168556f8eae45";
+      sha256 = "5c6a886706bb6b27c717af90a20fc1d694748ad8cfe568eaf374dffb872a6c0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/is/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/is/Firefox%20140.0b6.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "9cf0acbdb7c99914542941333fd1fbe108fed41f46af9fbefaf0a480adc0564b";
+      sha256 = "9707fec98234f35621fec0a43b4410eed814064126d701d76b520188b5f47dfb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/it/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/it/Firefox%20140.0b6.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "5e345715eba89bc244e16c73dacc522a3b83e9ec3f99ae072945b18cfa904f5a";
+      sha256 = "dc7b193ad74003a206ea2bc681837c175de45322be21d395b75062fb227cef2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ja-JP-mac/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ja-JP-mac/Firefox%20140.0b6.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "308d2c19609ed3874fe8cd3619602d606356ed55c4ca0f1fca1dede932c19e79";
+      sha256 = "aa4c38ccbe19b139465acfb54984ff5076ee596b562b51f2cbe522fff14c4527";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ka/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ka/Firefox%20140.0b6.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "d0ebffe428b05422977dac4bf3380c3e57a0ed42d7a4110699ec4b92fe168bce";
+      sha256 = "e1402e34d8a455d9f2473a81ba853e5fb369581ecc329d296115ddb33967875d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/kab/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/kab/Firefox%20140.0b6.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "e0002e9e16c91d5b8a9ea7d3de83799bbd77e6c23aee05759052e8d6303e01bd";
+      sha256 = "1575a80d66865bdea6e972aada77795c07e74dbebd92b30f3fa32a229f0a487c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/kk/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/kk/Firefox%20140.0b6.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "efff905c517fbdb1b3a1171b3114790cda03acb4002c9653070092149b92bc8d";
+      sha256 = "fa2d1f2d2deeaf1d095b3ae32b90394763a326c724455e8bb644c21d7cb31b61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/km/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/km/Firefox%20140.0b6.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "473c31374b6d982e61d75cb3974e20bcbd13c4613bcfddfea50aa43418903f54";
+      sha256 = "849d0e8f1a42faf78440f331cc3b77e85e4e3a75e4a8d3e31609a14904644ce3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/kn/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/kn/Firefox%20140.0b6.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "9436efdd09ef9eaaf104d90426cb091e1bc217468bd66cffcb7d91f8d2758f07";
+      sha256 = "2aeb6d55236f0b89756f4dd496a53f972ec8c24c8c52db4aefbdbbad7747fd52";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ko/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ko/Firefox%20140.0b6.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "9973a287baaa00930831a865beb370faee052f7ea486c728f2ed13060ff3280c";
+      sha256 = "c007683b92b34d34b305aa998f59d0d9affc4e07ecc3848576fa065922e6a97b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/lij/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/lij/Firefox%20140.0b6.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "f4c9678e933e440751b97f35b6e04941d9ce76b5869d45748b91df8336155274";
+      sha256 = "6792e8affd2b4b240663b34f983c3467942e7f6a4135ae27da9fd3632d39ae92";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/lt/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/lt/Firefox%20140.0b6.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "ddb021dca21e65e30012aab734d160118b26c3542fc3afff2db857dbda216221";
+      sha256 = "514e98aa37a819951b35c8e3c0cb57045deaf2d1a24d0f0bccbecf89d3e0b6a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/lv/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/lv/Firefox%20140.0b6.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "f63120daedf1ea0648de93f9178db541fed0144508ad5fddb3e512f32369c3b0";
+      sha256 = "2a254dafd7c4bbe05c0855347f620e95188a49e4336363c90fa17959e1b610a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/mk/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/mk/Firefox%20140.0b6.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "9501890bd79ddda990d8023a787efda67acb7d42e5283bd354ecd89d7a5e5546";
+      sha256 = "2af405b2012bc0641c2e4eece36f7c5282b38315b052998138a5ed36dd11f5f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/mr/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/mr/Firefox%20140.0b6.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "ba43292eb30482a03f83a4fde41e63accf37ea30b89fc8b4350a2ddf94572af0";
+      sha256 = "304b360bb71fa4071a05fc0bb3142a231e9f500da09a8e442c0848fcac99fd4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ms/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ms/Firefox%20140.0b6.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "84ce117ea9b6703b743d70c85dcb679bfdf3652d5f2e5d765f4437873a979223";
+      sha256 = "5e4c5e3a6e5fd45c2653b54d3b6174e99511aa9e20b976dc21af048036066bd4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/my/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/my/Firefox%20140.0b6.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "ed8c07f47e46998bf072d6d0db2a677326bb56e55d56197ded040b34cbc4a63d";
+      sha256 = "ecb541b9ca27ea7d879941fef632bd8ba4d576503291d74abb507dd9041f44d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/nb-NO/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/nb-NO/Firefox%20140.0b6.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "676be48e68f893f271c5db650d11cd17bf323157907e2176a76d97053d9a35c4";
+      sha256 = "4909f39237eb6480cd188bd87012a95cb33435fd5a98c0baf82567ea9020a8d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ne-NP/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ne-NP/Firefox%20140.0b6.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "fdc56c722f0509cc1f99bf4d7759faedfdb8d5f74ebbc41fd604cbc85f5de4ab";
+      sha256 = "464e6346b517c62c00bca230af7d6f9ae996677f450776530c51046e4d21f750";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/nl/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/nl/Firefox%20140.0b6.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "f908f97357b129f8ddd56da82b17da273dabab6fec022823bea2976645331860";
+      sha256 = "4bfcd05169003a8bfd3276860b8c6162dfe91c515b4e014bdb14783aa110390f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/nn-NO/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/nn-NO/Firefox%20140.0b6.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "3d38846a8f6ee404b6f5e55121f3c6a40b278cb4a224859c95e191f614741cfe";
+      sha256 = "7cc8e377ae8db78e84cc3e7de5a8477902d8dd331df1c63380b607f7e660a3bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/oc/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/oc/Firefox%20140.0b6.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "c2db065e02821b6abe15a8448bf45f07ab842ccb3d14504f52ff15cdcf786879";
+      sha256 = "428788ef0bdf30d681924a9a581581ba63fdd2bd8152b3b33e020b9db2f298d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/pa-IN/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/pa-IN/Firefox%20140.0b6.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "f6774c2c7f78362beef99450be1865f5ab9a0681fd41a18403e916c31c9538b4";
+      sha256 = "2cc98f9a1b36ba958be93784731a629b535b5c310b4ed7dd3c979cc543076288";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/pl/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/pl/Firefox%20140.0b6.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "cc14ee424433ab322b17058ea8719ba9368ff5e7a91d2f691a92dc1d13964f11";
+      sha256 = "43ab0fdd7d995d4c60d962c3db5f1907a4f8ae8f5bbf9401a96b424d458cee48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/pt-BR/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/pt-BR/Firefox%20140.0b6.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "20db9ade31f00b3aae5fcb9fe71d63c31d31520f31a0e87644b34cc0a8c928bb";
+      sha256 = "b469cbd87a88d09fae83f8b2ba395ebc468935b6beb7db8b83bcb1f47396ff4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/pt-PT/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/pt-PT/Firefox%20140.0b6.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "15d5a45a13311a67f86fb9814e1ac49f5090933f1110ca0ccc1f5bf51d4312e9";
+      sha256 = "31e3ad58f6790f04383bd0e32c530cea7559d8234a1faa234a40405181ada782";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/rm/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/rm/Firefox%20140.0b6.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "07452f83b2a572e0c536e0a08aec5146aca7fef1a162d0d14ce49aa4b2032fae";
+      sha256 = "c5f25f30d5f12576711457bc884ba679ac790108c3db1ee70b307205b6875cf4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ro/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ro/Firefox%20140.0b6.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "98500565dda18961b9e35a4ed0a16a0c7cec95a72bfcfc43c86b4f31a32e1074";
+      sha256 = "a3a266d6889610681ac0b4f5226190aa7ef64df557bf69df17a0e8ab9cc336f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ru/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ru/Firefox%20140.0b6.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "f85319ac38fb8be330bb80e6b1e5fc781d8aad2f8a6a300e1c85916f0baf7c62";
+      sha256 = "017954fc938efc470dffb50141944b041958a50c79fd24f6172a180db46e2078";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sat/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/sat/Firefox%20140.0b6.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "5cc725cf1112960bccdee3d5f8ffb1a8fa7d62cdb50aeeea5becff34bd971320";
+      sha256 = "75d42a50eb3526478cd966e0327733426b74e5159733527f34afee1cc1de2596";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sc/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/sc/Firefox%20140.0b6.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "7770966f953067fd4170aeb4bc0d3be8deb405f74e2129abca7253e792f69b3c";
+      sha256 = "53946a3f22d87ea274b3ea737150a6f80095a6be9b158ebe2f287739a7835732";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sco/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/sco/Firefox%20140.0b6.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "e10ae6867387b2306b2ceb74e136d28ca332a9573d2d16d10ea8d4ccde9cf85d";
+      sha256 = "9dda7a42af7a7a04b0301f2fc528cf908da7612d5cab43dc8dbb094e4d5faee2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/si/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/si/Firefox%20140.0b6.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "d3e02db688b3093c05b7efdaadcef600f956a614572504489e4d69cc975c8a08";
+      sha256 = "d7bb27ea910c83d42522f57dd1da9212a3294aa3850aebaac2695d38e46f4ef6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sk/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/sk/Firefox%20140.0b6.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "28b1b6fa00da50a5717bdf35bd98af2ed217fcb6d6f782865d7d9bd0acbeb7c1";
+      sha256 = "dde7bb699ca39a97b8a9d6438df6bc352c51dad20b5981dfe38251cc269dc7f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/skr/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/skr/Firefox%20140.0b6.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "fd1ad12da34e3bbbb9fdfcd64c2369a3b26ea9f6ec034673fcf0235d8627765d";
+      sha256 = "eebc4cdbdd6676ccdcf8b180ce7c2682b9f8e7350e79a24564e34cfa1607b4cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sl/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/sl/Firefox%20140.0b6.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "1b418886de3282ff93ee5ccce0e359b5c5d94de3a3cf6fc85f5342d9f18e80ad";
+      sha256 = "7c2ea1dca6b8d9cf2bfa1dd6293a6b348e6ab18a100b406f5d3a30c71f1b2e7d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/son/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/son/Firefox%20140.0b6.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "ab8f032f880c20a83bd6e4a64740122567a48084ab973ec4f708539009d8afdf";
+      sha256 = "8b0c01e1cbb12df69fe954c63035881f9f3333b330134903eafcc215d831534d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sq/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/sq/Firefox%20140.0b6.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "f1ed88be1dc9ef4a5dd873f615c7008e87122f690a0ca8f2c4435c8c07266423";
+      sha256 = "2a586a51f2422727b47b1adc60409da330a6a49bdd216116a2b45cea0d903437";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sr/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/sr/Firefox%20140.0b6.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "8c76f294b168a7089308b5370b46eb507853964c43e33058d3ff5b0a9cb94a74";
+      sha256 = "df767db631863e930224f4f5b434af5dda0b0a41696ec5c158173b52f0f8604a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sv-SE/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/sv-SE/Firefox%20140.0b6.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "33067551aad68665fbafab6357ace0debe78032fa1a9a63b2c7f5c35aee6cd6e";
+      sha256 = "029264295eac7a66f050c8aa6951e036b8bceb77e4371af076e57d86d9b3df24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/szl/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/szl/Firefox%20140.0b6.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "cabd50959911a80e1a663327564d546753b6f053a3147d5e5238713f54c930fd";
+      sha256 = "2c3849b9b9c87b5b9f6e979f8a6fafa4b01c9bc14124843315039e691a38edd4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ta/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ta/Firefox%20140.0b6.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "55c572220f5e0d0c16b5314e8429a221b668d6b05bd21d1410deb850a20587c5";
+      sha256 = "d2943aa24ff22e41068bcc90bc6303e659f484d5bcacd7af97788cbd10b50100";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/te/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/te/Firefox%20140.0b6.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "dd24dff0bf95f49d5415e541596e2b832481cf9fda89d4a978ce8e3c40690647";
+      sha256 = "1e50c08c4463e659ff845a49cc199653ae686ef858755cba389cf73da128d88d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/tg/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/tg/Firefox%20140.0b6.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "4b628008a8536fd67cf6e403fd9f771f765994e172c228bdf214ec73d7b483b0";
+      sha256 = "37f238ad85c4cf54b0ee15e85925fd20089f43419ae5ee715548c572a2cfd437";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/th/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/th/Firefox%20140.0b6.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "edda1adddebf16eb8ccd31d08fdf77f7f4d349c57dccbd29c98998831f3405a5";
+      sha256 = "e1a656061c4a75e9d615e5a5fc606a9d9f0d5eee1b6d7673011e86913efd203c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/tl/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/tl/Firefox%20140.0b6.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "5c9cf0f10257b5788edab5298069a66157be9b740a618c22b6e6f7b6495aee05";
+      sha256 = "8e0a4dce49b2d37c7ca42109693d2b8cc308b2fd5e61bc2671322e31a7f38fe8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/tr/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/tr/Firefox%20140.0b6.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "23d6fe36c78458a9c20baca7f9f559c2044e02a7d0298994ae3fce29846a6cbc";
+      sha256 = "8956253cbaab457d68da6c59d6babfc7efd69a514ccb0b97926cf1574a12c104";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/trs/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/trs/Firefox%20140.0b6.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "da3998812d320ea6242a345a239ead76b5e08a479a758fd0769918461c6a89e8";
+      sha256 = "c4935598b8ddb10a3c7078acb982d303d4b10d018104e4af80e4cc9e68bd3faf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/uk/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/uk/Firefox%20140.0b6.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "02faddd1b0b5b79211c36438a2ce47238231c11dcf675d65974b8478f7f16818";
+      sha256 = "3fbaf24aaeec14b7a5448a6b1c040652dde18f20c77eaf84a464649132dc52db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ur/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/ur/Firefox%20140.0b6.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "bf9846f9ef42b29670ac7a578afe0d0daff713cbe2dcea8fc80e937f753dd284";
+      sha256 = "a1669faa39064f6d931c8dbf8f87744ddba9fc084a6d7dca8260e1a07d73557e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/uz/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/uz/Firefox%20140.0b6.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "dca6f4b4b872c20d9ba2c1b42a2a02e6ae5a70df363fe0f12a3509e6fbc05ee9";
+      sha256 = "fd3a3c761959a2397731d1238c5cecb2a5be1ae7c94d31d6443816cc0401d856";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/vi/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/vi/Firefox%20140.0b6.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "bdbf2095fcd35554cd83ed9a115d6037e24487861ed8746d3b3285735d5518ec";
+      sha256 = "0afa6ce2c479289cc88973ff877bc5c3d25ecf60a6fd8c8c65d08bb60dea16f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/xh/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/xh/Firefox%20140.0b6.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "86496e2fa6591ff5218eb4a7187b5cd303c86e6dc6d6bf9cc32e20aa6b199d77";
+      sha256 = "96ccfcd62e221d67e1f58e279396af1c0ae4b39eb96873df419b78ef5e002fd4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/zh-CN/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/zh-CN/Firefox%20140.0b6.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "8ab9a64b3733fd391678c47a2307d44205a9ae67aad5895aa11ceb73eeccf6ff";
+      sha256 = "1c682d40183b7256d5e0759399cb486639ce56cce460811f962e754ee9196ac2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/zh-TW/Firefox%20140.0b4.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b6/mac/zh-TW/Firefox%20140.0b6.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "a1e2692eb4a0a728b051a9f6c3998b7f87b0e118133fb94b069f582c0eb463e9";
+      sha256 = "bba2984115271c7a9c21d80b98b373a5b44c032e7b966b45602fec6904df7e0e";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,1859 +1,2477 @@
 {
-  version = "140.0b3";
+  version = "140.0b4";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ach/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ach/firefox-140.0b4.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "87c1f8aa057b132bdf97b81aa911cde1b76df420f4319052dac1fb36f73aeaa7";
+      sha256 = "79c4bae3ab2ecc83eaaaab31104e117ba66ad82abc4dfae2f5ec76dde47f51ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/af/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/af/firefox-140.0b4.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "995fb3776e849a87271df8f7967fff46febbb57ac4e513e520fe2790947e8e04";
+      sha256 = "699a969d7ab130bc9bda98abf1e5ff47b77dd6de0cbdb0c1201f465ba8cee7e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/an/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/an/firefox-140.0b4.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "a3daa36f2d0477ff3bf8af4df84b1bbd6d001093b1b7453489486efabfc1c0c9";
+      sha256 = "68f2fd1f33a6fd473c53cf0e3574e780cfa9a28c298d2733813676d71650e6ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ar/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ar/firefox-140.0b4.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "36bb911e75abad10dd74d9d1aa541ee8b34f7918f5867acbfeb2682386d1b875";
+      sha256 = "16d9b35f06fb47a74a778d64cf7abe219a3624ca4732287970ce9f109cfa688c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ast/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ast/firefox-140.0b4.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "3df5f717c4ba64c88fcf873e01a667dc72ec006be98e4ccdf776381fb5c2999f";
+      sha256 = "8063552de94d50d73b2adfe01eed122e50c399aeacf4944769e27ac51af5ca5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/az/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/az/firefox-140.0b4.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "0fbc914fed6b0344f6701dda29c92a613650987a9c5c3b6cc6f5f99f1d77df47";
+      sha256 = "f54d622ba71e419a329768ac346d4469cffcac4b8077d686902ab254b7d5ac1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/be/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/be/firefox-140.0b4.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "0e07670b6e2f0912d3c7c599b7db147212b0cad36737681d8012f2dca7d8c22e";
+      sha256 = "827a6e56ff56d907d4bfe825322564c31b690058a18b835f73612384f388645d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/bg/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/bg/firefox-140.0b4.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "7d96d3e05a94d268accf129fe008688fe492472ae1edbb8eb50fc29f7c899be9";
+      sha256 = "f4a9493a0ff3e35a9a0e73de70d7e5a681de1ef14e031320015cd0cd15d52145";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/bn/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/bn/firefox-140.0b4.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "0788fda0e35abb70344cc4030bb54af725ec4dc3725f8ebc12df70ceeb860fdb";
+      sha256 = "0ec9de4c5276ef24b3d0531f4964cc01bb3d1c4d44530de59ead8a4ff804f42f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/br/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/br/firefox-140.0b4.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "5a45b3c49e0ccd7314881494d825badb16372fda7bb94fd704b8eb49fe9492c3";
+      sha256 = "d6a1163df76100d1995929bcbce45aad6db99f600d29e93a7610662185ffdcb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/bs/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/bs/firefox-140.0b4.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "e4dd687373bf633cfde18764d9b424ac245349925a7fdb5a45fd1698b8ed1164";
+      sha256 = "00eec200da5859ff0c4ea01c582c12dc3610b4216876bda9e08bbe41f3d7719a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ca-valencia/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ca-valencia/firefox-140.0b4.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "f4dd916b333e0abc0551d7651156e94cdf31049d7fe7e51b2f46f877066fc144";
+      sha256 = "a73eeae5de570615e3de64949de40a6a149dbf0450170686342ef48fc330da48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ca/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ca/firefox-140.0b4.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "020a985e9841238d683fa817e26f1791ea60946701c91e8eab3def9c2db23278";
+      sha256 = "532184e6c74f6de599e29360f5b2fcb7c68032fc48101296e13a4bed5e8500ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/cak/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/cak/firefox-140.0b4.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "542b5987fb29f278c2d1c0451053a37874f8a9ee1c80a3e2d818821b740a465c";
+      sha256 = "1fb82efc4e4f0b5e626c133bb17fa57ee54ff00916d306e66a96943d594b0da6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/cs/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/cs/firefox-140.0b4.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "390df2e96d9b0f2c6a5c5ef01b9f4790e0d65a5bd559bcd7b5645e632fe05b6c";
+      sha256 = "d12c2f7e5c102a83995aec62fe69db2c1f9895b9680cdb2df6bdbfc03d622631";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/cy/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/cy/firefox-140.0b4.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "a0cd0379ffe29c33eb1f34dce54f56e9c6801cf25378633e4c3cf9a0badfae22";
+      sha256 = "479ccceda72ad7f2e2d0056545878f43ecd72ff834b09b7ef7e342955eaf83c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/da/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/da/firefox-140.0b4.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "582033616abeaa16914802635720708294de44afb42c118098b5d30a3df96968";
+      sha256 = "0ad71e504abe067cb52d68d88916be3393913c2f1978eb98dd48f94ab6daf4f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/de/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/de/firefox-140.0b4.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "e05ae143147e96e5b5c686813f8284640b193b12fa1ecc878a033d7a6b62572a";
+      sha256 = "40ab7b73e1d433eeeae0c8b5fa5c032d14182bc526cbde7b4efc2e32c275a3b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/dsb/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/dsb/firefox-140.0b4.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "bf11f20d86bd8c8fec4a4d9fa14adfba00e9bce9b40f9a899a0fe8cafdfaa89e";
+      sha256 = "cd782ee1d65b7fd5952e30c6c2c285215f7043f37b9ae3bb0aa51d6056b6a824";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/el/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/el/firefox-140.0b4.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "f4758465dedcc1a1abbef1dfbfa1c1a0e630714eddfa98038826033f7baaddca";
+      sha256 = "19736769c65ceff853bfe9c4fd6541c2e30e13166dffd707a1a96077da5bee1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/en-CA/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/en-CA/firefox-140.0b4.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "75949735b5d56b36a143410517d109d55139bd670d505d0b467288094ccd34bb";
+      sha256 = "8880c95c0d00a51cd65829ddf5eca2ae9bd0f6a7e995d1d532224c223beb4a70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/en-GB/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/en-GB/firefox-140.0b4.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "e81b992506abce52d839623334376229a35659699c8770516b3c7e34d810ead7";
+      sha256 = "56c46be9058e82aaa046788499c0c6e96c48cbeb0a05a47b907772b2c73122a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/en-US/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/en-US/firefox-140.0b4.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "c1428da2dfc7a16deb7b9570fcccba94c13158373a359804233a4b5f330746a0";
+      sha256 = "40820674c78e05b1413458c2844e874c8521670780fdb4489e62379a42fba704";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/eo/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/eo/firefox-140.0b4.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "54790c6e1050b34d380e6daf96f387379aa825249af5889c71752eb728ecb10d";
+      sha256 = "3d444671937f8438ad98b3bf2ee935233a8025c0bd7de8a916be3d1806168222";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/es-AR/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/es-AR/firefox-140.0b4.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "d4dc96fba97c8f0c96ec5d596aaf6e30fe5f467399b59307ba1e91b5471979d5";
+      sha256 = "640d6480bc2680609dde51a76e512c8e9d1d8bcc93b75af239f254b824a0b330";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/es-CL/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/es-CL/firefox-140.0b4.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "c9888370387548a0c7b26facd131e8effc9b43bf27d4d2ad31cec12c3e39eecd";
+      sha256 = "7a430e844e216eba749d2e65cdd5f698ea5e450e018e1a217b993c97c375ebbf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/es-ES/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/es-ES/firefox-140.0b4.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "6fd830a501cebe0dd6a005cc00eb326cc82c30f38836da4ba46a79be13401377";
+      sha256 = "1905f4a96c7de86f9b024d41ba07758e478f55c43d16bbb817c9b8e36b544e97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/es-MX/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/es-MX/firefox-140.0b4.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "0f65338c18d4cd2bc4fc5b4eecaf62d759e532059588a920ce19de13d941ec7a";
+      sha256 = "d7eb82b97a007de775afc9055e33b7b8dbf51947567fe3b1a6e37e2b8765c4a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/et/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/et/firefox-140.0b4.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "904917e0115be1015954139ddf50395ec69e297082bd37f14a280415471116cb";
+      sha256 = "aa3921d10df3e89d33375ae23b32a668e78c22c30fff3e546957d75c815d1ba1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/eu/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/eu/firefox-140.0b4.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "9e03aeda162aa17a17eb3336e430dffbc415685cd211aadfc43a5f616c8e8758";
+      sha256 = "b678e517a072e9aa3a585acb027a59b3f18d0e4e132ce03cba26c8d5598ca04d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fa/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fa/firefox-140.0b4.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "6054bf75fad6b65c29b2f7c4e223df75f02b5ccabceb86b9c5e5e42b741f7bfd";
+      sha256 = "e23cedbe5d62203347749feaf3ad189b19593be7d328519296d727c142b07774";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ff/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ff/firefox-140.0b4.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "ebea919c503fc4523e1c594216ce8079316c9d377ba9bae6a6729ee3182c9df3";
+      sha256 = "a2867f278763c04b7d1bc50bdd4dd5ea49be62bba9986740b680cddf6f2b458b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fi/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fi/firefox-140.0b4.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "3126d98ccd0c5f16b77a71ad4c11423482cd5c7d8f7d10f7828e9e6d11e0f461";
+      sha256 = "a9758c8d99ea549fb056bfba4f74d70824105bb5f999343347d661f4ccd53283";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fr/firefox-140.0b4.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "9ddfee47dd74850d20f7aa87cbf92b46ff237d0a934d871025b92a364b2cb4c6";
+      sha256 = "12616ac5602bfcce857eccdd7ac50a98bac7bc9d5c6510ac49ab4627d6c762ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fur/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fur/firefox-140.0b4.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "05025972440fdc4087266a88d02e6968b52a43ff6d77f0190a659eac6ae816c4";
+      sha256 = "a6b9aaa2fa7f8c25efcf338bef0bb98d57535c9ba7d0c99775b2b6cd0c44f15d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/fy-NL/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/fy-NL/firefox-140.0b4.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "4243921762a60f5ce51e7737b6d3fe9bcc4dfea67c9198a1b917290efba9d0f2";
+      sha256 = "13a13fa59708aae286e6f99cbb301334ed082f94995454ff8f333c88c214f67d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ga-IE/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ga-IE/firefox-140.0b4.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "71a26a2fbaaf721ea307a8c3a8b083ef70077765f3a7278d25385b531ac315dc";
+      sha256 = "abf292f9c8a74e8f342c1e573441c5f2ed93a646e308131c098634f0e8403fdf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/gd/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/gd/firefox-140.0b4.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "c44b110b0fc96d3826103b0799bbd3df88cee0c8972f7e60f556590e053d9636";
+      sha256 = "7ae719127ba74d411a09704cc68801ba147aa46a599f75da4e1a1d99c0bbb4de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/gl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/gl/firefox-140.0b4.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "a6707479746e71d8c3d5af40500433c2290fce9d2ff98bd3ecd89bdbb9cd182c";
+      sha256 = "16391a560e0766f246ec605d5761f5445a9186118d4b9b154c5aa76d2694dde7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/gn/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/gn/firefox-140.0b4.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "d2dcd4701b0563af8825c3eb3aa22ffd2702d9a8458cd0ed4896a9bf57c0d291";
+      sha256 = "88acc62bd18a767e3ace84d758359fd2e3483cced4b47376bb4b62abf0607fcc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/gu-IN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/gu-IN/firefox-140.0b4.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "eec813b14a376b6f0e7c251ada0e972fbaae06db077e1e5ad63f5a069c81ad97";
+      sha256 = "00e7bbaa43437143c28ee9c0c661ed7c30a4ad887a5de6a99b53d036f8ba28db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/he/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/he/firefox-140.0b4.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "e3952c61718e26ea8f9aeb73a3b8146bd0163aa87388db2f518e997aed1163a1";
+      sha256 = "88442ae052ba3e93b65d7d878c5628e852f25f192b987a0dec40bb7775fff789";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hi-IN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hi-IN/firefox-140.0b4.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "b00059920c29e3e11dbb2fe3051acee804dda39838706a65c3716bdccabf7e9b";
+      sha256 = "c64522ad816a1b8f298b141bc545895f17aa495b3c227d377ae4bc89cd01ace8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hr/firefox-140.0b4.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "d77d3d50678d17098e9996edb0642bd8e6a1ccb983ea68e376d59e2ae0529779";
+      sha256 = "dda7aebbb74867704f5b4cbd2fba4a5f5d2974543c48faa4e634f746c08fd653";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hsb/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hsb/firefox-140.0b4.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "45e839005799d5bdbcbed3869680da6ca0ad42c3f9932b61e0f8e3fbc0316fee";
+      sha256 = "3ccf8a34bbad1bb4efc5fcf12aa203d7098c22654910e068e8af92c9a21056b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hu/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hu/firefox-140.0b4.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "2c655b6b1e91265befe5f7c1745a9ea8f4a97f6995ed2f4c4b3eede9fd07c8a5";
+      sha256 = "4b4d9c7965fc90649ea66f91d04f885c180c6127ea9ab8685b2229f148497a20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/hy-AM/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/hy-AM/firefox-140.0b4.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "bcc23fec185ab50660111850185ad9caeafabc056a77e6b8d99e12962da030ec";
+      sha256 = "e68ad63527eab5b51274d5b23a4e1487b01e46da6f58f933f1afcd3347eb32e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ia/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ia/firefox-140.0b4.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "c70ac08f5d1ac3c2175b5c1f0fed88564a8fc921771e0cb6082bfe9502f08407";
+      sha256 = "5546814c18755b68c3eff2903599e1a8c9612ec8d13b1989ebe8db66c2331adc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/id/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/id/firefox-140.0b4.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "b77533733de76fde27cdcb220f2f4c985784aeeb65456a8aa4f22689d1a78633";
+      sha256 = "98eb4c8c3a34600d34fbbf41abe853390193396044e02f8faa2b841576730eb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/is/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/is/firefox-140.0b4.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "e8d28dfed20bc64fdb431c6149c8f46a1601dcdb7c198e6aaac3bc26849ed564";
+      sha256 = "4ce9326633f6965b19cb116bb084af2376b79723e3aa2125f6108127ce797c8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/it/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/it/firefox-140.0b4.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "aa7017e3cc75ee281523f109c5a804a2686cb2d120af07f639cbe6e0b529f95b";
+      sha256 = "1633f576551a196695492299d9cc6c654b7a6fc436ece013c0052d0d59b18fd9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ja/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ja/firefox-140.0b4.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "aac539dc6adaed5e46f5dc180e6d5df7e58e7d06c9b3eb8840f67bb3005a3d1b";
+      sha256 = "4fa482c73b534fdf8da15d9f242c319742373aba34cd2033d890c2e10ff1a952";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ka/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ka/firefox-140.0b4.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "dca7592228e259a535805f0b40473448dbf5406f8bec1a313ae39621ba3a22e4";
+      sha256 = "8d35d90b1a228b3a93dae95913a3a246824f9fef9ddddf226d1d45dbb5f52cf3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/kab/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/kab/firefox-140.0b4.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "02cea8e48adce2143ffa78f564da31a26355572df7bf1a379e743a7ec4949a90";
+      sha256 = "39e2c59bcc692622d37813b2c6dbdb53322217759bb36adb3c40e564fb633816";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/kk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/kk/firefox-140.0b4.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "12e9811a0fb02ff7c52790d2fdfd116e2232fc6788cfd84e9d52009ab480d846";
+      sha256 = "5bfbfe860b5594b35583dc219524119d449ce843058c2416966923db02a37b4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/km/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/km/firefox-140.0b4.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "fbde93d1aad4c0cd059b14ae9ae0bd1ccf95374009aaafe68e830007b4cf496a";
+      sha256 = "dc60d8f33da1bf2131700143f92c45c407db0c72198a9eeb30be6c50ed219fd0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/kn/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/kn/firefox-140.0b4.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "975aaf5d7a139ea4ecb3d92b2cff56373a63069e7735478eafa596e1dca2a7d6";
+      sha256 = "f9de9ea646106410dac113ed8a43f7fe5d8b2ab78f8cbad800c7e06f39dea83f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ko/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ko/firefox-140.0b4.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "6c43fd5ae7e8d8af3e87940dfb49a6183c540fc18e98fcfe00ffce137b5682af";
+      sha256 = "046fe9882ebbe7a16b9c4e3a46881d3d58e524903e69025b41d4cf5ddfc39cb7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/lij/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/lij/firefox-140.0b4.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "da9bf66ee9231718bcbcbf16662b631984b75bb73bef82e58d1442560a2c0232";
+      sha256 = "c3f54a55d3bca2b3d16bb808161b31759a045624fe3828fa4dc00d4395b6e934";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/lt/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/lt/firefox-140.0b4.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "c8f018f9494291e01e4dedd3dc0e496c1c4fc4d346896f5225972d182f231c57";
+      sha256 = "cc6c6f218dd93c702840afbf6b4947fe25f9a3ce6f1f0c3d6c53612f5ffdea6f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/lv/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/lv/firefox-140.0b4.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "6a46324a4abedeea12aaeeb6f88af8b0277af5863a4977f06c33a0df7d3a9f3f";
+      sha256 = "6413e4d6878ed2cf612f8562f4d7a87b572b44a861b98def88932f5261d4532a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/mk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/mk/firefox-140.0b4.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "b1f2fc79baff629f24d0ae75fb8b29559a607b8b1434d745e8b9b5ab0c40ef14";
+      sha256 = "f193552cc2c671273e2ceff6d63b721d994905232b1ebeb2272406d11f7c2631";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/mr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/mr/firefox-140.0b4.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "04eceab79c3d3156fb27968108abbe0d7b0f01608f788eed474512bb82412fd8";
+      sha256 = "de2083da32a191962280df959e5f2bdf5a9cd1bfd5e619236052225b2c4432b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ms/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ms/firefox-140.0b4.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "17e8527080d60c18a363ced9e36548ed5bf575e8ad62bf5c397cf26fe06cb078";
+      sha256 = "060c67fc339f7ca5685524c6164b1b23783c5959bc1ee88947ed5d646a4469bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/my/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/my/firefox-140.0b4.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "19e137672d04c8eefff895b9c434a5b940c881aca4669b5f31947081c202c476";
+      sha256 = "cd1b449874fcef63e5e7366c26c88096121212ea92cc1a20b8d0cefe3d1ab6f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/nb-NO/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/nb-NO/firefox-140.0b4.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "97deb521ad609263c0dbe13458c4500021422a4f3bc84bbdd2a1aa290d288abf";
+      sha256 = "afe1046c6fe6d1ba75b57520d2162e23e190d7eaebd41bf4f8b3b9cb435e34ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ne-NP/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ne-NP/firefox-140.0b4.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "717d6e19cd002fc19208cf2506f2d4508561316f759154ff212928a20a44a195";
+      sha256 = "5b5b6cd0004f7ace163588b162dd2ff7ddb08064e5bf2e4ee6c73a5d855c3944";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/nl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/nl/firefox-140.0b4.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "765d8adf054295479e63d40fead98656d3d672bb7f4a42a8dc9c0cd5e8c29815";
+      sha256 = "60a452998b7797a259080a39ce7900aa45a3ec92e09933d3eebd654cd2d9cdf5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/nn-NO/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/nn-NO/firefox-140.0b4.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "74d183d64ed423bc1dea8972a4f32378aded5c733b6f58a1e6d178f49024f7c4";
+      sha256 = "b1cc96a175d3377eaf6ad67f3737d08b5fdf45e54312d0147448167753e0b413";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/oc/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/oc/firefox-140.0b4.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "883fe66e83b2af674d9596a52910f28703548bd7c0615e15587a980a93d38c16";
+      sha256 = "44839b3805ab01d637a5adc270e9e86086f96b7b947162039f6ce356c7e98d99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/pa-IN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/pa-IN/firefox-140.0b4.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "ee586be768d0035a681acf83b5c68cc1c5cab04054afe8deb141a4c9f21d2890";
+      sha256 = "3ee9443ed3a85a3b4c2a22db5ee258bfc21ae8785675ed5b11ee8d5563cd16f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/pl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/pl/firefox-140.0b4.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "c65c7e68fb0ccf5b01bf17aee844c4e4ecf5192a630a2b4e2bb30de5752a9f9d";
+      sha256 = "30270dbb80419f92173ab90c2b99269dcdc5052a94efd1bed12b223d68ec0fc8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/pt-BR/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/pt-BR/firefox-140.0b4.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "a097d98e98410dff2c051bd1d9a2667d54da22df0a1578c0d558e028835dd372";
+      sha256 = "e22b7b27b89cecfd7866648ba16db249f8b53856bc9e49e7d722ab006c61a052";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/pt-PT/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/pt-PT/firefox-140.0b4.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "788048f852dd4f215dcca69d6e658e75bf52fa9a2bdc7118b27d47025343d55a";
+      sha256 = "9592fbe56057246e6519641e4ce97d727e894cd70fab2aa91aa63196e13535da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/rm/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/rm/firefox-140.0b4.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "b691ae86cfc7a1d4d22a25c04d84e89e3b616970012559bc182225539af0a92b";
+      sha256 = "15e0f382c19db6af473d49dbdfb48c2b8891255cf7b85694f1c0ef12620c4bef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ro/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ro/firefox-140.0b4.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "b9f502952d67e13bec4a5d4c7a780ed5f06c628463cb6c4a3c5b70febb2724f4";
+      sha256 = "480b8d1c13c8a647feb799366c91c9223a3b3afc32e6e758d7edb57d016fb4cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ru/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ru/firefox-140.0b4.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "daa5e9adffeff031b2bd764802482730cb37335a6a4b5ba011e708ebe39f771c";
+      sha256 = "983807e6ee0951ff1cb56518a5d4c764a204616a6826381e43dba49f8c398836";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sat/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sat/firefox-140.0b4.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "3a2ebe89dc72f8b6988fb6742340623423df9d166030ed691c884d013de0fa83";
+      sha256 = "3be3f00cece3378b9afb0364339527d6f2cad06c73cbf095a4c6fe34a0f7171f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sc/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sc/firefox-140.0b4.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "db27ece945871d6f988ae710daf52874e4d6cbe03eb950c4a4faeff6d67bd9b1";
+      sha256 = "780c0e439a16d97b5a0a4e8dbf21695b18316083496655d89ca7c15762d30ca1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sco/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sco/firefox-140.0b4.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "976b40edd9700fbc012b55584824c77b4839be8cc2269dc8a178c6b2b3e57041";
+      sha256 = "394998ba5da43c7ffdb36ba640f3657e286faeb09b4895171c689a70aa0357ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/si/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/si/firefox-140.0b4.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "e7d94105a1bbfbb30d220e7b10b6c59118a7556541bb2a25ba4aa3b454827841";
+      sha256 = "c6f7172c8ae66768a8c1c8ec1237d50c1409952abd90f5c7baa6b0c2db35c94b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sk/firefox-140.0b4.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "cc38654e9236e9dfc8b58e3795c9d347447f3832c8d5b6d50afbfc1298c1c996";
+      sha256 = "51e4555381d62f4eabcdb45817fd91cd025eca458a175c8c9a9927f3c8eea624";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/skr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/skr/firefox-140.0b4.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "12e95e82e29358039287da28a81a7f90d9d6dc7262f0f2aa541253856931eab6";
+      sha256 = "9ef1756da491f25f7357deb640604f470a3a159211f0ea1ac4c31a657a26b1e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sl/firefox-140.0b4.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "bc6c1f3f4a8540baaa764aa34d571bb5743e2364cebd49d3326ddb01ba6b20cc";
+      sha256 = "62d5913ad935a30f8b6536231a747b54b69f81681f81468a5ddbd5daabe10431";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/son/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/son/firefox-140.0b4.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "d949c0da8ab52490c03fb8577dcd10a96cdf68378b4a70d5fd9ac28f6cb660e9";
+      sha256 = "df3ac2759b995a974762a94018ae6c7c142209e7fd12be96186eaf56b5447d50";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sq/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sq/firefox-140.0b4.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "fb531412139967abb42c99a5a68fad323892b6101953e8e6207d45b9f62a6f94";
+      sha256 = "a107def094ebf1d6bd77b05c153747fc058f3fcced730aa5513a8a33a2f34ed0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sr/firefox-140.0b4.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "a04d2d0347fb2761ad58b85304e0f8f9ffd343366608fd17cf687c2d53e61009";
+      sha256 = "1ec6bb2204b6e25e1cef465abb74ea115914d1ec179006f4ff9ab8d5cfa95b05";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/sv-SE/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/sv-SE/firefox-140.0b4.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "ae8abbd42e9dd09213511f359d0a069e8f58b8fb8b1139600fe678cc437e7fa1";
+      sha256 = "47ef089aae34922e892e5e24fc31f0a9ed0dadad427834d46e96dbd189236a1e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/szl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/szl/firefox-140.0b4.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "9939bccff2b5b00e0da9764d0d859eb17dc68477553c61c3bf8a3dd632779638";
+      sha256 = "c3ea0cb6a2f1430d1f96ae5a3bee2083b265936ec9a5625ffcd31c91c542ad01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ta/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ta/firefox-140.0b4.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "844ea991305f8b946b0c5ac059788ed661abb033016e8c2e096d872784ecf20e";
+      sha256 = "0a8274d9d638706a05dbb5573191fb5c604da633a39a3065dc46e75b50bfe595";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/te/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/te/firefox-140.0b4.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "bb21e776ffa953c82444f34ae9f81d06fa8d725c5a86e5b85b25d4171ce6079f";
+      sha256 = "9de2c77e2cfc1cb33de926f2f0af656369071ce896086c39b0f6e823802c5651";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/tg/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/tg/firefox-140.0b4.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "2f3d94b992a2a89169cb3628eb807967c0f4b02fb25c14ee7f9ea925c4d78e85";
+      sha256 = "ccdf9edaa6d7642a066800f5edee083c92303473ea9eeafd04e17505367ce082";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/th/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/th/firefox-140.0b4.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "cf58b75d8a9f1a4b8dd702a5dc4f3b8fb676e0f1c0d8949b445cef0aede13586";
+      sha256 = "ca2deb4e79e3ed447e0b62c678dfba1bc3d47749d983e478f98eef8f075eeea8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/tl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/tl/firefox-140.0b4.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "8cb619b4d8caa1a6e492b8b2815b4c41a25fe3b6f53852d99ca55da56fab8815";
+      sha256 = "24b5c9689dc2958f4607932614f9d3ac97286248d932bbe43574c71425126eee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/tr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/tr/firefox-140.0b4.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "e5b39883c5e0a906873f4af0e8d6a630337d05467759741276077b70deeaa23a";
+      sha256 = "278381e636f98ec68c9ed75c721cff588f2e291a1611386db6b4f0038cfa7403";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/trs/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/trs/firefox-140.0b4.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "a19d8f0262019768cbc61edbe3ce7b5eb69571b5ca1c5cc9736025f10e6250ec";
+      sha256 = "5d4d4db5dcd4428e7ab6d351d4a1e6fdb7f6f327d031ec045f1e0572f39569be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/uk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/uk/firefox-140.0b4.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "4525800927692a4230034a5ac44351b87857e5292e5bec60aa478d52f55c0606";
+      sha256 = "1f7ed2ac92af2d802e743433d6d8bb501057a019770178afc4f83d9382f082ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/ur/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/ur/firefox-140.0b4.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "fad4ca04ddb978bfb405ef496cecfc54e0f59ad5cfe0adefe9f79bd55da6dc9a";
+      sha256 = "941d716e18c08961041052a3e3ce47b8b927e3c2ff4e2d02aa377e18c3ee9899";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/uz/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/uz/firefox-140.0b4.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "9098b78744b8b8af558fd4edbab5be3a573048405b05376d0a08a9d2282784c9";
+      sha256 = "542417ee58e5997d60c3eaba77f3e1d7be9f5bef5f4d96e3ca9252988a1dd4ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/vi/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/vi/firefox-140.0b4.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "cc10fc7919e04a0401f910ed84092e8eeb8f926c2410c4ab2a9feb34b0a1fd80";
+      sha256 = "d501faabcda4703590242da47168bd90c1ba5b8ccf53573ea92d4ee150c60347";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/xh/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/xh/firefox-140.0b4.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "a9c75ada1290493a0f1265d47ed584dd5fe4c6ff3d763baee03d5c6741775394";
+      sha256 = "c0aade40862694b4eefc2e1b138e28802bf72e7ca99a9aa77dff668140c0f8f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/zh-CN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/zh-CN/firefox-140.0b4.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "0423bc10bc9f1affe9c4a54387c9c06d003fa5d600c42e351cccd1b94c096a13";
+      sha256 = "d6acae4e60b6b50f05a17630e45da73dbe2ff691ec216c0368493efd44c4b978";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-x86_64/zh-TW/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-x86_64/zh-TW/firefox-140.0b4.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "e07202200f0f41d691d8d4a4225b332b51fd00c14af0e5c2c61c1317938a69bd";
+      sha256 = "7493a417c1d4cca1bcbfcd782d8b5d0d4ba3817b18bc7598544e7ca1b9f5c06f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ach/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ach/firefox-140.0b4.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "3c3f09f172315420d76a89352cf556095d3120cc8fce3384b825680978682886";
+      sha256 = "3be76f9194d24421ce986d088a4e54f38a9e934a272f62c6aa6e9bef9a09a666";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/af/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/af/firefox-140.0b4.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "eaedf8f14d1a89141cfdd02d1331982d57c283810229f1bc4a2add6acf47a7dc";
+      sha256 = "a8eb60898c425fd996b02c304d495668b283dcf763c034c30c19841b71fe5be3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/an/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/an/firefox-140.0b4.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "52d635cf3d2cb3fe60f2f5a120714c011b6c5ddf46715450102d457fc9962318";
+      sha256 = "6722650b3809255e939976cda6f6a15b6c1b88e0a3fb2143ce14f05bc1748001";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ar/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ar/firefox-140.0b4.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "893cad4f3e9ff8f6eb46861c17873d29ce07cecab1a52c666f3af91ac94b0f4a";
+      sha256 = "96246f81a7d0678bb32714ba376bbb2834f989eb7418d4edd1827d4511e344a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ast/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ast/firefox-140.0b4.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "c7981fccfb22d3afb4e36e34ca11629bbb064b2256d297e0717dd7a7c76ef502";
+      sha256 = "ccedf416b838286c42ffa27534d9328916a5d51d7897a8f9f9f0914b317ecf9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/az/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/az/firefox-140.0b4.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "a1192052f0a9dfc637fe6dfea16b4bcc4a1e7a6881d025efcbe65f4dd4a49027";
+      sha256 = "0efad9674c64ee1f67f930b46266124d3c0e1b4220522700a89ce8e2abdd133b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/be/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/be/firefox-140.0b4.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "575d234e0d09dc61dd7eb2574b0db946b866472e31f45e80c6af90c99dd83cf6";
+      sha256 = "fe4d45528436e5a6eb6d6cbe692974a8e07f3d7721bf2bf9f3aba2bd4c40a685";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/bg/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/bg/firefox-140.0b4.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "39c2fc75618ea33423a5ae0c606d416484c0c6bceb82f6ca79e12e26efb23220";
+      sha256 = "793c784ffd98c017155376f029e5270a5d2c5195e017ebaabee330031b5281ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/bn/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/bn/firefox-140.0b4.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "c92ac4831df0e4e4f8af68ddcb82d3bae98505845f04bfd39bb3e573639d648d";
+      sha256 = "52e39351fb98bbdebd22764b77c420a2778adcb6ee6fa9c82845c4cddb4a48cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/br/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/br/firefox-140.0b4.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "39c3b934fe6bb0eb593d52fc17983994a680261e74f5764c9cf2dd5e0ecc0527";
+      sha256 = "fa0707853f1b21e708b627a58127efa6848935bdfb071bd9dfa34cc712c544a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/bs/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/bs/firefox-140.0b4.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "dd4b8a6c02cbe11536ef7de6d1ea64bb17eb16806aa6dcf838847f7b2649ba22";
+      sha256 = "038c08de66a19e28293dc5ad8ab5ff099a653fe11e66a50f117b09201b0487cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ca-valencia/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ca-valencia/firefox-140.0b4.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "3a43a9986e3bafbcb8c59904f8de749cd9a8e11a5a6424780c1db1f75e57a152";
+      sha256 = "893d8ccd8276108f74802b6ade3aeaa182d35f24a7d4f59f73f7d9f0083e5374";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ca/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ca/firefox-140.0b4.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "0e11daa82aa4663c1d07f96fa68cdd7e06d404ac372887e510173db91456203b";
+      sha256 = "89cf5bb8d68c2e396fc3459d708ecf561d2ab58dee924f81034ecff6a9a58f89";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/cak/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/cak/firefox-140.0b4.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "d3558555d2e55d4089a224c6f49cc9d4ae60cc5b55b95ea29b131f53e9516693";
+      sha256 = "6dc7a40dc583ad71310ca5844563298d68b2f4dfe6160d77323bee582ed70054";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/cs/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/cs/firefox-140.0b4.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "a6c2c7db6633d6fe5fd24ee17efb6cff59e00959fa0226234bc90805247fe0bb";
+      sha256 = "0bb58b90686bafd341991a97b4006417970684d0c82b542718e539c12ec11768";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/cy/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/cy/firefox-140.0b4.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "59c697c88dcf4658cd4ea85d5c110239b786df15d84e21006c3ae9254d932122";
+      sha256 = "d704d90a4b3063f983651d777064c9d705d9deedb1e0f69428687d8d383762ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/da/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/da/firefox-140.0b4.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "42c2bd817b7f337146f52c00b3671ddbc48f4a1b39bbece4e9fbcd3a97545e33";
+      sha256 = "5675f10f6fda9082aacb42895dfcf0f78e6e53c649b2a620fadffd92db731b4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/de/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/de/firefox-140.0b4.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "c8a4c21ce54d08d9539d2dedbc14a108842c401354e59b2a2e3f79f0322305e1";
+      sha256 = "a3b2053b85e7ec3046c2f4f2e437c685fc5d4ead7dcfdce1ba40e1560251317e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/dsb/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/dsb/firefox-140.0b4.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "7eab0cdf71a1571227b505450ed7af7d5605c306116a1fdb92697e2a5653afa7";
+      sha256 = "c3a198d51af7a9f1301b85d586ac61c0afd8b1243656e36de880d14c2bf51ce7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/el/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/el/firefox-140.0b4.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "f903fe1eb373a4ef6160aa6137f7081f52c2134301b807417c4a9fbd66cc3ad2";
+      sha256 = "7921f62be7826f76229007503e8e27915b7d682346baf5bcf6149dedd4a921c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/en-CA/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/en-CA/firefox-140.0b4.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "b9718d0a1333f27862797531fc96a410d28f483537f9eb23d8c42ce5abe755b9";
+      sha256 = "ba39324c5662162aa1674d7cab7d4edf6fb02fd05bb99b2b0fb3f0d1fe7ecf71";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/en-GB/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/en-GB/firefox-140.0b4.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "cf2534426f9b5fce7e8aa5fc301c3e59b4e1718fb87a9b2737f9d04de1011a8a";
+      sha256 = "02c2bc0cfa15192edb33b22834b678c9a8d99372cbd028d48a190113b8f93d7b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/en-US/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/en-US/firefox-140.0b4.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "71ae3e6d03e16c80d8f7f41e79954a4dfb9aaac6df0bc04264672cf4027b0488";
+      sha256 = "45a4c9e6e1f2119bbccf4e2bb5a285ee5fb2c9003adbf15931f4c6f781d67c2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/eo/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/eo/firefox-140.0b4.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "651ea1186149d9cd455c0b9dbc7c2c7dc70a46963d5690a576acc59cba6e56c7";
+      sha256 = "5caa0619cf07394e3ac1c68a8348ff7f47aaee9587fcd0a50c4346215617b5cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/es-AR/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/es-AR/firefox-140.0b4.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "d11382ca1dc4b707c5330b06cc9e951bdcaeea3846516195f52027e2c557bbbd";
+      sha256 = "d224e1606ccb29e5f73626cdfca835d01ede2f4b746de8b139308665bae59f71";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/es-CL/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/es-CL/firefox-140.0b4.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "9e26cf06cc5e01059711dd2d79dc25cf8635b28d17eba1f0d08c25eb61305a01";
+      sha256 = "343b33976f5db469de0eb6b025be4d5373191c9b7173d16d89a1dbb2cee118e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/es-ES/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/es-ES/firefox-140.0b4.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "164c2f0347d9244651104c835d75d9f4093218a0f67ea7709cb1f4162ee294d5";
+      sha256 = "0462fcae5b37d56c6b5a0a537aae8dd5f8909eb9014824450179c9440fcf9451";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/es-MX/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/es-MX/firefox-140.0b4.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "bd092ea5d5dd484a092605d72fce5358e86537e89a9a7a8974dd6576b02c8bf4";
+      sha256 = "51cc0b92eb8c5948cd8f1ad2c2b0cbc6484f1de3da813761d48717f1a8b198c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/et/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/et/firefox-140.0b4.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "3d19ddfefeabd49b3703fcfb0708bb6a46b19ad8bda204f91d4901e059b4d5ad";
+      sha256 = "02def4898b2b63c80c5acf9e4265b84875645f309d6954518fae3767f419ea18";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/eu/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/eu/firefox-140.0b4.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "b02d55efc88c1b8348dd719a599b568363db17923d5fcfb26952d551940557a3";
+      sha256 = "39fa560b9fadfbf7f29d1e0352f60109ea9edd25f341542a0965bf9d6912baff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fa/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fa/firefox-140.0b4.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "043510f251a179077cb270d628d9cca62785f746668c5bf8291ad8907b624b2b";
+      sha256 = "e9685986383fc1a660d1548d0e86e1f6d6b24997dab0bb6cbcffdae57aec743d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ff/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ff/firefox-140.0b4.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "8f52a213ab4f324f5fd94ba105c2c1e9970d69af93b2f9b30311a8bd7da615d8";
+      sha256 = "43805aadb07a9df678c40e29b4581a1a21adae6540a979a180acbd005ad66505";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fi/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fi/firefox-140.0b4.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "efae201318b19f549e69cb5aa4f59dc1bc87d682b40362203e25a5c1371b6d2f";
+      sha256 = "42ff002d3533302a4005e45d21c1fb4d2bb33dd34da84f376e0215afeae40ee9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fr/firefox-140.0b4.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "e43116b71ad9f1b9158187c3a4299c36e5719da985d00be7a871bdeada36b192";
+      sha256 = "daf13073c63bbb8f1c83e64f7ae8238105f0b24490492bb171381b8359835ba4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fur/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fur/firefox-140.0b4.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "23740807dd3b010a48486200bfa8ed888beb9b4e0aafa83b241409954f93365f";
+      sha256 = "b77e8cd7d890e59391cb0901c428b3af4285d46a8b7b97395256b7211688d445";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/fy-NL/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/fy-NL/firefox-140.0b4.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "49063a53eb3ad9f9c62c859211bd19a9ac55f2b60a277e27bc1d82297e919f19";
+      sha256 = "b29253db8b87cab953abf1381155f8cfa055103720c4252ff4383b0d0bc9b24a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ga-IE/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ga-IE/firefox-140.0b4.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "0deb27c1880f256fef7916633f78423128b1a8ff76a977bfcc265dfa77173a0a";
+      sha256 = "3a73a2bd7d32be4e6ec2bb41bb3b910ed41ecaa678f26cb6283c7c4bf9c1115a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/gd/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/gd/firefox-140.0b4.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "c3ce807880680a92dfef22fdb9cb8e638dc686a59049c6cf01efab4ac3732ce2";
+      sha256 = "c7d7266fc4f89031ed171dbca0ec522631d4052f21fee6189edf5b25b3253b23";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/gl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/gl/firefox-140.0b4.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "a978a9abb6a675968285efaa76ed1ea89e8741c071ff976ded923e83e242f75d";
+      sha256 = "0705bf96b77ec990537b154dfe739bae3f86db9526ff66eaa9c65e4a21b1e927";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/gn/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/gn/firefox-140.0b4.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "40d423c64850455905b955f9c84c0aceff20e79a469a654bb04722d1bf04c928";
+      sha256 = "052a95f7cbe122fa15f11b6b6aff20a681dc9f8f17ccf58b3627a6f4eab36122";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/gu-IN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/gu-IN/firefox-140.0b4.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "bf94bab9f91d5ea82131e43ed3d432b0261e3b2090c2d2db95fb035e4e961346";
+      sha256 = "a37cb18d401f9dea9e1f3d6200297133653982d2e29f68babde5178b13092820";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/he/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/he/firefox-140.0b4.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "db191d3e2a3fff647a1bf9a955075919de5cb5a376a4a1474a8adac44c3df841";
+      sha256 = "de6d96dd60e87f374535095d01d00cebf5d76002c151318a524711482f05d4e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hi-IN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hi-IN/firefox-140.0b4.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "c6a51b472c569cda3b50d7dc9e9d0a36cf820a8a788a8b5b4cdb582f175e7ce5";
+      sha256 = "1dbdb7f28f064e171bb25121f84b3d677e2a0e9825547577dea168e45101408b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hr/firefox-140.0b4.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "54aca88fb64a6b5141746ad4da23b081a482d94e04a7517b9c731340fa5440df";
+      sha256 = "f8851d7d962ef0cc5b45129b30eec0cb4906ae790b2e4a04171b6aafb1a423ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hsb/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hsb/firefox-140.0b4.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "6c586090e9fe87bc44892ac85637ad540ab5d5e158c17c5f14c68f9f63ee3a74";
+      sha256 = "a8075b7c3682a5c21f0723466e2bc1ff1a87f1648af55b979284564a86591827";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hu/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hu/firefox-140.0b4.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "dea07e07f30d00b08c14b7dbabf5a38cd7911923808cf9224293d32921c2a65a";
+      sha256 = "8562d9f2effeb5c63c99de48586412b1952054f1d35341a960d3c1b68da98a1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/hy-AM/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/hy-AM/firefox-140.0b4.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "5d5fe665856bd0790e63edd43651ff9754608ef8fbaab38a8cae31a1252d1751";
+      sha256 = "13e5bae04b5f2a30fe58e46263618f093efd3e457d1cddc6096148dfe602a2a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ia/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ia/firefox-140.0b4.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "e90c989cc7c7b8eada6272566265c263eebba4cbab6e258e0d5a2d431b1dd7da";
+      sha256 = "91d6a400ac1c0ee6845677c526ff1c179b369f107ff36535765293b44f1ac43d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/id/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/id/firefox-140.0b4.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "5482412883d928072d3a0e334213199e947cc03fd3db6fc598f7a915976dbbf6";
+      sha256 = "eb086df64f9f18ed83e29b57a897d3652fce933b92e9db72472ef2c7cb36497a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/is/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/is/firefox-140.0b4.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "5684323f967b0edcb1de2199f1ac3d15730bf87b19a0091776b5dabae99c3c1c";
+      sha256 = "3cbfe061954939a9f3d90f790612b921eb644bf792b2ca0cbaaa77b1054b8ca4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/it/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/it/firefox-140.0b4.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "12df3e97e46b5b6291f6317c827381635cc1916c042aa18a3da928646c3298b2";
+      sha256 = "ea608343fba2138887a168ad3251493dea1f537e08745f3108f6962364d47f34";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ja/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ja/firefox-140.0b4.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "208ab74c7967a65a4b73edf57d9d8189341007554e6aa75906df6255505b984f";
+      sha256 = "5977a78da473ce233e8d48034f6a04ac519888189cd4f4b3bf314ead6a7b74e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ka/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ka/firefox-140.0b4.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "5f193f7cb6008dfa55e7f2fcfa914c13d44a5d27dd18c291932d913a049d3c54";
+      sha256 = "d4874532ae1e9afe9b4c77ba064cec618cb48c8d90d6e5941fecde77c37c29d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/kab/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/kab/firefox-140.0b4.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "616a5fae71e292e4cfadf83c670879a5436337d859bcdb693498f2318a33e9e0";
+      sha256 = "0a453f53f7e88968f09c8697193aaadf2a0e7036d8a8ed01c7b54b38e61fd8a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/kk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/kk/firefox-140.0b4.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "7e90e3cf6ef7db5c534474a4b7eb458582c914814f5ab3e9faede1aeaedf288f";
+      sha256 = "62279adb30aa4c792beef58eff120112fa9151abd1f74bf40d6f2cd097d453b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/km/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/km/firefox-140.0b4.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "638c185fe326bdbc6e122fa900ed54600abede47bbc702b4c2aeace7fe81ea59";
+      sha256 = "8bfb8f1af400e143c3f795aeecbec5652d9cde304a6551e5bfcbf7cb2a8cc676";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/kn/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/kn/firefox-140.0b4.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "4f1bce2457170735ca89a1fdd49355b3ce66862eb25c4650018f29786a3e628c";
+      sha256 = "5b1ed6ee0e97d89cc83bf4f8408b409f5e0aeda5b68dbf7fbe2d9867cfc8f4d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ko/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ko/firefox-140.0b4.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "912d16eb2952971879b9a4a12d5bc0596bd26a3a446a0836d644d95322c0d88f";
+      sha256 = "04747f583bf7cf9035a52e584ca76c84798830ccc74c8f6faa46a5af4df74011";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/lij/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/lij/firefox-140.0b4.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "c9d88715308eb1dc9a7408e70d791619b96bfeb513a497264bbe4b35a2a6c21a";
+      sha256 = "432359d0dfcafeabdb98e7baead22a23c1e9a2e30ad6cdba88fd7f2fbfc9ba8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/lt/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/lt/firefox-140.0b4.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "2a04604e7455fe01534470c36a35fdec6b833c6fbf37a415ad65a2a33ac685eb";
+      sha256 = "3aaf5547d7a0e5cb1fe120de403650a682579540cd4411d113bed81c9e0ee781";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/lv/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/lv/firefox-140.0b4.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "a820fa038bd93794e06cf1e42a69759bbf6cde44196d1103fe7f877602510f8b";
+      sha256 = "2af656a600c244eb615b21e204336bd28549648dc1af363e08ffb8802565f9b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/mk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/mk/firefox-140.0b4.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "b6417ebc9f7f9f811346bcd013c65ae873bd3b2671d6a0c25f02c9d1fdf15f8e";
+      sha256 = "c0c62629f81a5bb1e1ec256269b2285bbaef67caec7d1c4b8ad8102a72abf180";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/mr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/mr/firefox-140.0b4.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "d9600fee7682011fa3eae2b090b50d67bab743c0393c5deff03c5667fa11f78f";
+      sha256 = "dab2b1103c27706124fe8f4f8ff059baf21151cf0e50f8fce2ce40788545a5cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ms/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ms/firefox-140.0b4.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "faffaf6851c21ebd1181c93772f912709bf81ab59b795cf4eb7201a162aedda4";
+      sha256 = "4c4872d23b305cc66b7efcd0d36065ad3aefedf0e0fc53f05881c3708be5782a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/my/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/my/firefox-140.0b4.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "97f5cea2c18b3e07388496fc45126dca7bf58a837eccb14385b2b29701d11108";
+      sha256 = "900e5e7cdb64fc9e1dd966d1fbdcbe2c8086c1ab2be54d2d9f1c2fddb0673cef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/nb-NO/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/nb-NO/firefox-140.0b4.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "9205b0871af11b98e802ca77f3c8504894cac12cbf1cbfa502767eb975eec6c0";
+      sha256 = "1299f2becf8ab50225fb68d18d1345754d43334d30aa5f3500d674278208b777";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ne-NP/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ne-NP/firefox-140.0b4.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "449ad603575859ce4627e743d808e5ffbfd2d595c1d492fa764a8cf059816b7f";
+      sha256 = "cf41fc923f63a7f1a4bf720cb3a8fa1595ef92d121d729d7e902cffefaa852fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/nl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/nl/firefox-140.0b4.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "ad5fa26a8566c22f9efd33ca0268736d4a38ffa3309fdf21f98c0a29f60462ad";
+      sha256 = "84b2cbff63025fab413175ad49c47ea734f0823b8eeee7676789f9c27bb9de23";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/nn-NO/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/nn-NO/firefox-140.0b4.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "1bd652bbb01825a9ad3efc7991fe315dff9fdc3596d197c413658c055f97efbf";
+      sha256 = "818e77d80fd86e8e27460b8f629f05215c985a80a275f30f3864821d6619db30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/oc/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/oc/firefox-140.0b4.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "79732be6d97e6f7fb812da0a718998bde7808f571d5a57fd8042d5b33584b79b";
+      sha256 = "5636ac4f5757edde5867ad0d186e6d779dde239fc302962b7f257a5428a5a87c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/pa-IN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/pa-IN/firefox-140.0b4.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "85076e967a48f3ba02fd785adbba0af0f6525c133efbda4a3884b5110c4d2a7c";
+      sha256 = "b033beca5afb4fb0c8715d29f2d9e6b0bdb2115d63ff8d5552adc1ebb86f18e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/pl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/pl/firefox-140.0b4.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "eef5081b1c72402758b244d7bfe7d1aeec301ccb2b3f1436fe8fac2ed5c8fa22";
+      sha256 = "afeb6ddc491281c001dc98c177bb19120d46fe3d738f777daa2f9c0582faa828";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/pt-BR/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/pt-BR/firefox-140.0b4.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "eaf150b7ea5496a4cd7648da0ecf507091ba7b4412a037db6ea48dc5614fd6f7";
+      sha256 = "b0d75cf5e760cd505c397dff4fcaafd8f0bed1b416c40beeaa297912b1110f44";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/pt-PT/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/pt-PT/firefox-140.0b4.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "81f6ab621772995f3bb3492695e32eaac1d667142e7bd4f6de0bb8825ed5b48c";
+      sha256 = "e1c7cbe5bc38bbeed8cd3abd05ef956366e2f398b70e42b3007342a4e61760bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/rm/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/rm/firefox-140.0b4.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "f26cd0a09eecdafbac993a9e305f3ec9969906cd06fdff5f5101dce71b7b48f4";
+      sha256 = "ab26f4fb5846a8eca415748e69dc37f33a6d3ab91ff0db384d627553a69fe9a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ro/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ro/firefox-140.0b4.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "6513741a8ac710a7016a33b3e3c00969954db50e3c2ddfa4a2debb5992e4c8ac";
+      sha256 = "483e633f4e2922e521c0492d47d420fcb5a1ff7209d7f42c58952c5e7705fb44";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ru/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ru/firefox-140.0b4.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "325d70559d8be33846c519a9aeda98d2a42651daaf9c12602d1d29059029a6b5";
+      sha256 = "dcd3441f6f5a9390407f2794f8d747511215246f5c9a85ac4d6b704bd4bbff9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sat/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sat/firefox-140.0b4.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "6ab0592eb32fdd72b6e5ac121199d2c7c46320b2e3215fa043112c8c60b72396";
+      sha256 = "1fa56ccd4d66542467487d17ee7e95f847f0920774692a03da8cc14f1cf2ac70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sc/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sc/firefox-140.0b4.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "7202e3e121225c034724e67f2bd1d0f5dc1359c5c316e76fb45e1522d975a2e2";
+      sha256 = "d626a423d3d02011a9a5090633595add37d6c99fc741ec96a1a66761312bc1ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sco/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sco/firefox-140.0b4.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "a3cfd6eabb41224e3a7ff23b19c2bfe3bee8b662c259eac3ff504d9dd371e4d5";
+      sha256 = "3d8c5bc791c943e82b678918f3459471a3ababef8e44e9ee4257f036b552b813";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/si/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/si/firefox-140.0b4.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "10b49deeca01bf571c8de9a49f18f51bd761d1eef4a00b15eb8740c734a69962";
+      sha256 = "980d3542c6c25d306e1b24404731554d4a21157eb1bf5fc17ab31949d2e5e563";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sk/firefox-140.0b4.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "ea6a2c21f49066ff5bd7e45d7e5cbb6fa1eb737ed111e2fadc325da659cb3e50";
+      sha256 = "055076bedecfbf77818bc70c0d69b6deacc4ac9f015bc419738b1dfbb499e6ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/skr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/skr/firefox-140.0b4.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "0f2421d1617932b5a17c158ca04b01e820c2adb6c7eda9d6f54e7b22e99ded02";
+      sha256 = "72856c1bfacaf66461ea1cef6cbe5481787751674e6a79b89997aaa23880ab52";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sl/firefox-140.0b4.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "654864b81f5abf3518f67787d5d9e404e3d5462953916649f3ada78f5ec8e3ab";
+      sha256 = "366b072e83d350147ef916e8386db402e0dd2ac0d086d7b1242f8dfd91c00cc2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/son/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/son/firefox-140.0b4.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "e7b42884848ddf9b32783020eb41c6e616c46a7b4b46bd1e2d32c99c78842bac";
+      sha256 = "3d4a4fea98df1c0013371f96db1e95d3b8266a5a773cb2ecc4f58ab7d4522c27";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sq/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sq/firefox-140.0b4.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "d82fb6ce158e37cbd74971d6a9cfe6c57004614c3f406f817f342c1f523b6c2a";
+      sha256 = "195ebd91159fc04d11a34801d7b0871b5b998f401e8c4e3cc516113bf067b7c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sr/firefox-140.0b4.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "028c133c6823549f499b1a079d07052c50f890c5f431412e856e6e9b52fa6797";
+      sha256 = "95431dd518de2fe5a679e8635f6e3cdfa3ae99d7b42eb93ef8591b6bb5ee0d1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/sv-SE/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/sv-SE/firefox-140.0b4.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "8e7eea05f48a536dab3b6924dada5d4f0fa11ccf6a691d993f84ffbb0dd8e8ad";
+      sha256 = "5cc49bda64618b9e07ad9d1b6af8625bc3a7ca158467ec880836bd20a2a08dbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/szl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/szl/firefox-140.0b4.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "e5c40fb83fc68718a38411bf8dd17172546c89328e8a352b6aa4ad81d8946963";
+      sha256 = "f6d2d95427f8eb184d600b101e0bd3ab78580f837765eee297c022cd2e603433";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ta/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ta/firefox-140.0b4.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "b2ca1cc8d20926557240946aa9ca432c1b24162d8c26be088f95c98a0e2a2697";
+      sha256 = "f5ef3477f4fdd8708908b2cf41486c0083ee9724d6f313cb28f24abf3f26a156";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/te/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/te/firefox-140.0b4.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "8a3d7b4669dae9648ac2f06a03781578f6803a241fbc5183499fa18a29f46fac";
+      sha256 = "f41f2fdd0d2cdfb76eb440e8ea7756368ddc4285736bfe604c65b03df42061ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/tg/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/tg/firefox-140.0b4.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "a65218675b9e62e2a2e72c8bd7a3a78a56cab0ce91426f623b6e6afdea1a04df";
+      sha256 = "815ea87b2552b0c6093bf6dbaec6dfc660d3625f44f2bf042b5869e42c23e25e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/th/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/th/firefox-140.0b4.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "9ddb3cae1f4d999d1a7840e019867f1554995cc8bef0a1aa8ac90ba547972722";
+      sha256 = "a58b8c1730cd066c5dfc26e8d2d4d3b6557a72a0c680e4163c43279c671c5ec4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/tl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/tl/firefox-140.0b4.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "a1455aec73754985d65d7b28ffe2897ee9bbde55506fd6d9772277b5346f4092";
+      sha256 = "817db84221e7361a7c932d0880c6e82aa7a64552931e015c4c4694c1ab9ea253";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/tr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/tr/firefox-140.0b4.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "9fbfd677f9a807daba18eb008a183fdf63cad7d42f42cf10311593ccf1e4af93";
+      sha256 = "909252098ca36f93de56732fd0762fdd041657559d42a7200c821115b38980aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/trs/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/trs/firefox-140.0b4.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "57a19f4b076bf14db8a83e96559c937e7e848d95621aebc04f8009d614312bfb";
+      sha256 = "e1c4ad015d1e3565c4435e769bc59d5bff953f719123a330f8e37c43833881a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/uk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/uk/firefox-140.0b4.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "ce745304c9068082289893584e10855f022e0b55b974088cd4d2f2d177e949a7";
+      sha256 = "0e31db03a117def0867bcf5d3e1acc7ebaff9daf4325cf3be548e72bb09057e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/ur/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/ur/firefox-140.0b4.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "b5fa6ae252d2a39f002d9f61bfca5f4c44322f134f82f6d75736197207ac93ba";
+      sha256 = "63ef448ad869a987cb0e7756f25e81e7d1c6bc083048e7eb49dbf5100626879c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/uz/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/uz/firefox-140.0b4.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "d17c250ae08b958bf0c9a3be3953133af69e88855c38dabd5a1f9281ae675b93";
+      sha256 = "77d9943bb83a8b1b42f448b0e3e0c3cee11a1ea0bb1dae18ba52c52ed5a7d7df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/vi/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/vi/firefox-140.0b4.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "45ba1505cc8b64e55ad518c1138e115c7f01c9572a13c2dd07970a479005cd39";
+      sha256 = "c47d720da1f5aeae9d8429ed71f1044275888751a0c217a6a534e61e9f4dfdec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/xh/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/xh/firefox-140.0b4.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "bc0aea632a700251fbd0359f8fef1b152a86fcad15707b4fb4bcb055c7755c50";
+      sha256 = "8f4530d50019aeedf2d059135acc6ed42147f86d98ee7defaee5ae2d826c4821";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/zh-CN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/zh-CN/firefox-140.0b4.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "4f31a97f9a0eb5677de689c839e61989d40856244d5239707378e5e01fcf0ea6";
+      sha256 = "59f60c919eb0d331166eeb9d76449c0a57593e82061a9d3319d680253ecaa503";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-i686/zh-TW/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-i686/zh-TW/firefox-140.0b4.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "cd397ce84153a60c04457fef2edd31b648eb71476598aca12ff59ddd4f09fe7b";
+      sha256 = "c6c71d581e46b18e48fa76699835ae7bdbb11033366674f9e1d2be0cfcab80bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ach/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ach/firefox-140.0b4.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "ca1d393c3f6d8f0b483256bb4dcbbfd87c3e73320acd272125db6a252d225690";
+      sha256 = "241018608d47cb0d022e323e968922b082acd7064b3ca8e7bafe665ff23c9b3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/af/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/af/firefox-140.0b4.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "904ce80c145a1d3230081bd7883d2c5e57ed02660b2404bfce3943df0561104f";
+      sha256 = "f8ae5994e39898cf2611db052640f7eff4425c5c7d94107491173f900245df32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/an/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/an/firefox-140.0b4.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "a994667975cc8c14d5b768d238a151506e9c9a2bdf6dafa73feba9e43aeab57c";
+      sha256 = "4a18c94a3ec5544664a89c9cedd5e25c5b15ff41cce68890a7f2036a720c9b1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ar/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ar/firefox-140.0b4.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "2a9798d1ef0a04664ab9c2683f7fd509c4da5d8129d769c781077c6d45dcc37e";
+      sha256 = "3478f78815017cb30bff0946399ddddd15f90a739213c4e54f8e09602c76df83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ast/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ast/firefox-140.0b4.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "e862943c675f5853709fdf1ca14d2ac28cf732d90d782bd9bada809556f1b654";
+      sha256 = "fec697046bdc9c5edfda4ab3f6df1df84819a3ea7b46250f20722b05ea356dc1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/az/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/az/firefox-140.0b4.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "c3e0a2cc6ae0646a5c7497e96b7b47947354f984ba733672fa38a7c14eed8856";
+      sha256 = "78a68fba1f9dfec4510bb2cd493d82fcac31801bb7bb5718f8afeb57940870c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/be/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/be/firefox-140.0b4.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "bd197bc761ba7d16d74ec1eb11f6eb0ea6122919ffba3a775690e3db029e471e";
+      sha256 = "8e27d99cdad038331140386da3749f2c85afd5cffdf8afdf9b35a735027a690d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/bg/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/bg/firefox-140.0b4.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "6dacd9985823ce3ae329eac3fc97530fa405737cac7115a3b56ec6a0db04cfb7";
+      sha256 = "fa1e2d472ace070d1dc8beabf7cddf85b571957c453ccf8cd08ea14ee213761a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/bn/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/bn/firefox-140.0b4.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "22e0bf169370241de826f2f882c987f01e5cee823dc303d0122e04a210d2b781";
+      sha256 = "bf8b652eef9f6fe89adf3cab9639b59cd2ce5009c31f690923a09ae399b68570";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/br/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/br/firefox-140.0b4.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "d3e532791588565ca5aa5dd892cb72298c34efd9a9d07e3b2e89c5df23d41fe6";
+      sha256 = "fa245862a996f8023b25035e2176e54047af8d333912a89be7faca81908a4604";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/bs/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/bs/firefox-140.0b4.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "9358ea0b92e59d528873a99bc452bd30c88a2943d23edcd71d47c3dd5521313e";
+      sha256 = "34976543a5bc5d9558d8e725391b22805dcf8b8797cf6a54701cee7328106550";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ca-valencia/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ca-valencia/firefox-140.0b4.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "133b4c9ec4c86a88203c251a5c54e312024d5def03e60e75c80ddbf7868fffaa";
+      sha256 = "8a9a04837e328286f8128f9b744d274d98f7db5762c244f9294e0f9fe7766731";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ca/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ca/firefox-140.0b4.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "b4a6e4975dd731eff8f7a70f1b9fbfc33dcc53f76efa3061232df7b0270f803a";
+      sha256 = "384a1314de0b0c566fdfe39c2a74905f972a624fa434359dd6914e7224d95641";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/cak/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/cak/firefox-140.0b4.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "9c647560a9a1f5012002cdf619f50e10c8f16b8e03e37d34a2aa312f714f9ae2";
+      sha256 = "ffd23426e799190a55d6e2db09f3ab1ad9512a8fdf11a065ced8eda4715198c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/cs/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/cs/firefox-140.0b4.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "5b81394b51d29a85677439bf4f91794b1daf5b878e920d1c0e6913fdb8c3fd73";
+      sha256 = "779085fadd246044b587c08ff4ed2397215a97b0d0ca4a5a3df70142bf75e43a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/cy/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/cy/firefox-140.0b4.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "f0e9b6ab15dfeba4e41ac3e540c02917d8b30213fe2a5fa234a43a9bf9580d33";
+      sha256 = "be7161a550b8698b20cc2a5005a0c6656a10ae2685c5ad52d5133da4d7812f76";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/da/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/da/firefox-140.0b4.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "fcad12e84319527cfc25f53192cdfadf51703ae1ab721f05c5f70817586f0626";
+      sha256 = "2f524f76f90fca51a39a3d8c574c50aaf7cef68e276431966ca616c40212a964";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/de/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/de/firefox-140.0b4.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "805b6c414e6a56ff4fcb3d2fff4cb2ff62105e1f3c5476ea61981916111652bd";
+      sha256 = "8ebe0cdd840bc6ef9e3f2a5801a6308d35d265ca32eeb54db6ae863216a10b5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/dsb/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/dsb/firefox-140.0b4.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "d9a0dc6db5f1a21ef94101b6ddf1e1c644d88f639b9cf1f4baf3d82759914b61";
+      sha256 = "72b2c42048b933c29410db5ab1cf3b83f1b9d89a5b1130777598bc8572437bac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/el/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/el/firefox-140.0b4.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "109873f011ac29c4bdc78f27e8a13541aa1b11175b29401197ed3d3512dec72f";
+      sha256 = "138e9495ccf965c528ad0c2482b11557c6ff0ab4723332bbdd37bd2ce1afbe72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/en-CA/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/en-CA/firefox-140.0b4.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "ab9ed750e684fd405ac3a797e4fb60ead2c64c39aa53d6742e0259930d371adb";
+      sha256 = "fe569caab44348927473fcca363e859f3ac3ba1eff752abd9978e9e0cccc397d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/en-GB/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/en-GB/firefox-140.0b4.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "c7c9bc00cb6cfe8dc9c4875b049a13d0655c00a3ff171c5647f5bedef107e7ea";
+      sha256 = "c069247ef7744b71547ba952b2d332563bb0bed5ee4c33a5bab20c8f0b71156e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/en-US/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/en-US/firefox-140.0b4.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "39261cfe396d7359aebaf6b5f3becd3bdb5c43b292869f544a88e801443c9efb";
+      sha256 = "e91834ae34ef10d436a22795b4d5716df01a31c83fdefd8cf22a62deb4dc26c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/eo/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/eo/firefox-140.0b4.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "75179c336ad589676d93d8dd6daa084c82573a621e69e3e8cbd09679c5f00755";
+      sha256 = "b2626c8d82f90f958e39c6fc8fdd11e0e477e54c0fa770b8642ea4eacc5c145e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/es-AR/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/es-AR/firefox-140.0b4.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "88ca0c23ae377fbea842073192f89fcbe2319ff4944ade3311c722370c166aa1";
+      sha256 = "20bbd71dda6392b8e296d36f27be410e2bb831bccad9a6eb520b3ef3a8eadf2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/es-CL/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/es-CL/firefox-140.0b4.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "32b6911754837cb979fec837168963f25590d19adc87ca84c3ee0634bc1797a8";
+      sha256 = "47492d04205be6c535209513f64b9c0896a3a786c5af3e87add57425e95d2a04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/es-ES/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/es-ES/firefox-140.0b4.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "ae81dada372a60bdfa0f6c48a988c42f23165e1d1c8cee3c7958c95b64c87d2a";
+      sha256 = "f1504517f6e874ae5c73cc73fda5763b692d403be5b2d6a3c5fdebca847dd044";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/es-MX/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/es-MX/firefox-140.0b4.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "c8171810252614f5cbc162b5f4dfe3afd897a8d9beec4978126909bad3f76bea";
+      sha256 = "9e8fae58eebc5fd0fc212ed66ed63add5408730de3b360020ea39ee3c67e70a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/et/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/et/firefox-140.0b4.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "76fd0607c61228898b9568987523b4a8e1f5a3b15a4b2859296c0e23c4e59585";
+      sha256 = "c9256db0e31b1d836cb4ad7d45c9289d45dc05853a0883071103b581743645b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/eu/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/eu/firefox-140.0b4.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "16205f39cffe37ce480d45e17d266c4bbc3ab1844ce2ea2e04485ddfcb647120";
+      sha256 = "a85b68a93d51c3c42343a7038ac72d4ee3b0847aee312a3f720899abc3b30961";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fa/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fa/firefox-140.0b4.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "36b1c98577255d88e2f7b01c88cdb1414b2016fa520aae459b66aa47b10f8996";
+      sha256 = "44ee01aa1e8c1ef973cdb2b28916635fef9bb81a7dbb7e735e055aac02f65007";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ff/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ff/firefox-140.0b4.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "2988f2897ef2c643cdfcd79dce0c126c24fccf6e9810aa58776d91a1baf1b453";
+      sha256 = "0dc1f2c9223adfbff26376aa55fa858ea89e04fcb4f3326b115bc6f9cd0f1791";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fi/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fi/firefox-140.0b4.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "c8dd76d403209b965f430d3251df3fe9800535074f3ed1c8d1ec3c49a0ef92ea";
+      sha256 = "43c5253851fc94038a7b8c922660651f43484d70cc54d22dc0f521fb978e76b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fr/firefox-140.0b4.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "7d43f4e963244761ce06e827776dc3037060457f15d806d248e406222b732d03";
+      sha256 = "eaed4f0100d898555c1f2bfab43592648342b9be1a712602c43929a77f61f67c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fur/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fur/firefox-140.0b4.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "75fa230906c272d17bccc003d3bd605a16ac21825812a964c78ca6e839365447";
+      sha256 = "e74ce591b238c6a6754180aaf8eec4701206c84204b2792e505d3b065235be10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/fy-NL/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/fy-NL/firefox-140.0b4.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "7b40e7c98e5bca1e7a503303d6d47160243bfc81991301c401da056f506469cc";
+      sha256 = "15309be99c0df4c8bf23ac5387e8ba6c15b2051e54a331a943c4cc54959e645f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ga-IE/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ga-IE/firefox-140.0b4.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "c2fea5545eb58658a6c3e8ef751b1c18372edb052bb66694b13f09fa0044fe1e";
+      sha256 = "0b7d2969509f650aa4e725d38022ec61633e89d5b325075be3eb97649abf58f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/gd/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/gd/firefox-140.0b4.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "d8894d4118e625b7ed8125621e58b561657f03915a7e4acc464c06e2c948f043";
+      sha256 = "9f28a60ecd9e6eee111df4b57b437739a77a55276d9fb66d2191c4fb0a0b9886";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/gl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/gl/firefox-140.0b4.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "59cee79cd1d2b593b3ab607d7e56314188f2f9d21aa2eafc4e3da19b27e7cd5a";
+      sha256 = "d561f29fa446a9541f43651f439cde9a4c7c5dd7a4fe7d8dbb41e7dcc1aa351f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/gn/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/gn/firefox-140.0b4.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "9570e9cd008c221d4587ee0ab740a98b74da2e74f2ade874eb96051c7319f60e";
+      sha256 = "84415639e92579f37ecd8598d2757a3a49aa8c81287c3d8c5b653e489e5e41a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/gu-IN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/gu-IN/firefox-140.0b4.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "b0ff6954af3e48e2fe996e38bfe72f060f17a7596640b5653893bdee6ee05f24";
+      sha256 = "d05bd65e0115b4dd204833e980928e8f409e79fbad11cf003c22863775e41b14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/he/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/he/firefox-140.0b4.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "61db85d5f194b2d6b797765180135949e683142e24a7c2f10872132a3acafeba";
+      sha256 = "3dc2d50792fe1ecf2248f243da773da783df54c039ef6f47e316caec33353f51";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hi-IN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hi-IN/firefox-140.0b4.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "e5c4e8fb08e6a36ee6c72dc0c4aadb5312e04f91cacf3679c89b7963c8d05541";
+      sha256 = "e8004158a6a24786c3ce373e43c9d9cab82142bb7d2eae9fd187f8be3e315606";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hr/firefox-140.0b4.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "85fb4cf83ac75fd1a0e7f44b73f64e4bfa61899df78f0318370f6d232fafa063";
+      sha256 = "c0c047431c8ae0786a77b3934f47b9b5723028e028ce487a895f997fc7ca40ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hsb/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hsb/firefox-140.0b4.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "05be655775adb1b4e113e047cc9188e7eefc78a4558f87a8176193697138c687";
+      sha256 = "12d757bb7689211acc5a9bf7380eb4b8f659dc5e797a16481ff43d19252670a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hu/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hu/firefox-140.0b4.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "566fb0b2e78f693ffdfb6b5990bebf7e84fcca396026b11678b8c613673364b7";
+      sha256 = "21e08a716cd14ae2ddd8797cecd3a387d6a69f1725283da9dab778cee0ac5a96";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/hy-AM/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/hy-AM/firefox-140.0b4.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "6e51cf2be81bd264143fe6d05f5dd0806456a111cb989b130fde546d2e561fcb";
+      sha256 = "cf0ec104784fa1f8b0965ccb54476021b0aa553fa61f76258ccc0838af3fdc58";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ia/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ia/firefox-140.0b4.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "74af672f73f85d2e7bffbfa346153358fc8418d0eb5a732d86aaf1be0b3627f9";
+      sha256 = "d398f24f832df11e54319485990d6b0763b88018e4942734f97eb6aa1027ab14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/id/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/id/firefox-140.0b4.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "1b37065b20cdcc2e7d7793f77fa71fd846779c4ebcd68f489461489b165ba1b8";
+      sha256 = "66300532e61904c2ec3b38654fa5c04fc77132264560651eb47d08505f92aa93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/is/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/is/firefox-140.0b4.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "782622a22fb4cac4e967c3d7c934c1fa0fc7e9734e8d4fe6738abeedad7b4188";
+      sha256 = "905759bb5644dba6962cac36370c8092c8b4d940dd0fd811d89f2633d8278375";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/it/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/it/firefox-140.0b4.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "a1c05f3d29b77c3274b65f20bfe0a0a7662133382a2080394cfdba0366cdef01";
+      sha256 = "090d658b0d9883ae4cb030efbae33dcad50cec614cc4df645d9d578f8f3d9f78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ja/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ja/firefox-140.0b4.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "a010cfc3fba7877b33666db790d020c13014b98bc6567d9f3c5274d9705681b8";
+      sha256 = "498c93faff28cdf519c68228a929538a6d86722aa23cf77c65b9a6bc9eec6cde";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ka/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ka/firefox-140.0b4.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "1c1beaa5d438a6214dc75ccf5100982ae415d814d5589f6d19c75f3edc8a2fd3";
+      sha256 = "6a7219133dc2cd5828fca8c47c8918960078a1edb04e5d0f130572802228d8f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/kab/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/kab/firefox-140.0b4.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "5db404895a198a93cadabd73b3e8b7b9707c9b631169a69268799aba8a2e50b5";
+      sha256 = "61bf24a6f254d3a290207fd3c2578d3fe0968ac6af729c5468952c7508e60f32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/kk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/kk/firefox-140.0b4.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "115ea1a7775f678f6c60342149993c98f107cab03e10b47ceee913a45f66f311";
+      sha256 = "c390e1a6bea9f444984fc78ac8b321c1f7a629540716f311677ce31ae853f52e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/km/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/km/firefox-140.0b4.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "de7a2faadd3072d434f8c5bd1fe62e23616c4097d5286801669ab6db27143332";
+      sha256 = "f37ca60447383abbef2720253a82d551a906b0e358c404480e94b8e69dbcd92a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/kn/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/kn/firefox-140.0b4.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "713a1bf13d20796677cf3b4712da2e8f45fe01ae8d2428a48aede0ddf0d57cf3";
+      sha256 = "a5069cf01bfb68e73a524638cbb8fc435e54cf874369c0ae8199e724dcbd96eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ko/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ko/firefox-140.0b4.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "e7642bae7805a364e3189c67143c9935188936925fbf5b9a0210141ed64a7587";
+      sha256 = "af9ba9b7c6e825b6fbd57cd1b2d015f6ca9ddde361d643d1fe520b7869e21221";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/lij/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/lij/firefox-140.0b4.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "9f65891d625c585c1515a005ce35b6de04c201428c1352efd9215fa033bdcf07";
+      sha256 = "271945a88d4fc02733fa3de327e613d822445f18c70601f43bf503dc4bb76076";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/lt/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/lt/firefox-140.0b4.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "3ca4a021fe1782414512fa7610d0eb5f3ace978373632c6a6f4d618c7afb7645";
+      sha256 = "6e822b90f21a571e72b01c353b0d2371ce0e0e788382c5cb9fbd558869f0abee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/lv/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/lv/firefox-140.0b4.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "e73d4256ae749209e41861c3bd20de05c5c50035f760c2c9355320d795e1e99d";
+      sha256 = "840962acfde031c9bf7ac3be1e491444ea5dec8f4fde6eb018376dc39e2beb73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/mk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/mk/firefox-140.0b4.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "508698c697ab258dfa923e5f63749569f87c070f2cdbc26ee0bc0a36b1996259";
+      sha256 = "f1d13371556a0fb39f65e2e327eb87a0abed3d550988faa5a06785145693326e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/mr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/mr/firefox-140.0b4.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "99e9e06270e56262f4fc4a95e6dbfb15ba918e57a964b4fadeec2ad7af4829be";
+      sha256 = "ece70d221688bc7e21b28d849a75fc827f892195ad2ce0eba0851edf5a458ae4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ms/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ms/firefox-140.0b4.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "c9c3935bb6814e5dbbbd980a4487d1dcffeba62f14e3e907f38e07dfaae4822a";
+      sha256 = "2ebac815285a5fee53d0038f7504acf772775b76e9c142825d9d38d406abbf1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/my/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/my/firefox-140.0b4.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "ca0ec2bdd803a7d0f61a135ea61d706394877508f32c645acb014f52bf4c4a33";
+      sha256 = "f17264509af2285d77811bb37e04a78ba50795cc7ca9d7315ecf0b657063b02f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/nb-NO/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/nb-NO/firefox-140.0b4.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "c74cfbcfcb0a8b50c18f0d0da54d4855d1326aa72718dfa73614ffc276fe07da";
+      sha256 = "be7310e5f244efd65bd649ec6a87831d74f275d9d47f9fa3af413562e1f520bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ne-NP/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ne-NP/firefox-140.0b4.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "f6e88a6e38af551c2ec786e2941c9a23451d236bfc9fc7411fd61d58ef02a93d";
+      sha256 = "f2490420afc5dfcf52ebe57bcce39f3a4884dea697f244a6bb1c5ad59f4318f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/nl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/nl/firefox-140.0b4.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "2a3dfe87d3b94479282f1bd8b700ff91df1d414ed4d9fc3733533f1db7ae2d5f";
+      sha256 = "a6cd59a175f6406118408261f6294124a7441e17847a5ec818747a79b5cfc044";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/nn-NO/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/nn-NO/firefox-140.0b4.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "fbe5608bfeea90d66f0d4f4c9dc8fe012cee2e0a664dc1eda948660e8e71a7fe";
+      sha256 = "a55c303f21439df3d7a93fb093b70b13bbd0c310d381132f1d3a0e3eb55b7edc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/oc/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/oc/firefox-140.0b4.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "36e7cfea755d82e8a210841c94c0a95bfee4a7a69cb9464726b08de103f86a01";
+      sha256 = "24e06d73859e511ec57f291bd2516492e5a30e28455a16e24eda79e186d4e484";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/pa-IN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/pa-IN/firefox-140.0b4.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "8c5885c4df9b41f70336217ebdc28d4e640dd99731def0546dd0e34879fd1f65";
+      sha256 = "01658567d989c0427da0ed91c633d770ed281855f1dcf9eacfc8a9d4e1c4a61d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/pl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/pl/firefox-140.0b4.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "24740a98cac566ddbaeac20d6e16d6fa715c63e703cb9b39be40b8cf9a9b18c9";
+      sha256 = "66661a57a4177366c8e50a5a9ed1c75e56d36aec6f1a11c9db167084ea23bae8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/pt-BR/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/pt-BR/firefox-140.0b4.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "cf51d2981a09199f6091cae1242c73560b1aceeaf04207175fc64e546ccc3396";
+      sha256 = "a563cf71764b735541cc1c7ea937819c7edaeaadc14cbfff3739c1ac3e16d6bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/pt-PT/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/pt-PT/firefox-140.0b4.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "2b3cb182d876a304b386f1c091c96be21416b93dcae669a9cc93f19d65741585";
+      sha256 = "7abe6b559e61fa1fe77b9cb91c647378db6b5a45957ee03259cf9ff7f783800a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/rm/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/rm/firefox-140.0b4.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "914f3b9c41e9cf814ba31a671809f4d2daec6c77ea80e70e808f0ad7beee88d3";
+      sha256 = "9e6b92cb0b7f3ff8fd449b4a96d8b13f7eebe3f3113c98fa94eddb0a4121ebae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ro/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ro/firefox-140.0b4.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "da7893ed953bf77fd859ffaa542a7cd4ad52357fa5797d0b3c2f31d0395b9720";
+      sha256 = "38e9fa5a6953c89263feeca394a71efc409c4c9f785f34550decbba2cbc18c63";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ru/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ru/firefox-140.0b4.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "bcfedd95d87f9e1bcbde13380f811a59ce5330f0b47668920f0d7319b3c8171f";
+      sha256 = "f9fcbe379df93978d282f531609abfbc710054bc4c1461ac9fbd80a9c9b15ede";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sat/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sat/firefox-140.0b4.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "d36f47b320f19627ae570e7e004d87226687c469d9de70508c721d0e8d0d132c";
+      sha256 = "5f609b6774298690551bb08643d3e13733e2081fe108834908ea4f744f865fab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sc/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sc/firefox-140.0b4.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "34440b5887d66dfba85fa9fe431d2b30b963125d211518e2dc001b1749711f1f";
+      sha256 = "4ac4a80995702ccb10076113ef853d614ebd5d8321f336d670f2d7443b4301d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sco/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sco/firefox-140.0b4.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "b3c82d814a526e801d2e4cab78b273e69238808bd1a11cb6edb12f730bc1d435";
+      sha256 = "2ac20c11a5333d3d6c61acbcc4f651e5fdda00faf85126dbe224d961506d063c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/si/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/si/firefox-140.0b4.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "32517ad2aa826fd61b2b8450f5da35ebc38b189465d3bf6bbc36797d39e2edb2";
+      sha256 = "c41d50301986acd685f22891df7003e6758ffd8b6e88b999e96e2600262cc03d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sk/firefox-140.0b4.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "c90574e5cd3d2fb46cc800d6ab278e5377c921501ed36cf24d509387a1f5cf67";
+      sha256 = "cd8fb4a85e71d82519a3d0bcf5f8502c84bded00029ee9f1a1ffcd40cdf0f0f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/skr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/skr/firefox-140.0b4.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "cab10bad18edfad2e656545add6001aff47cc80c551c99dd4b3d4da639854d27";
+      sha256 = "5d86ae9529ea78a30b437eb85a3fc230162a62ac287ee16d4a2118d380b04f6e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sl/firefox-140.0b4.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "a6cec788ebd392dbe0702b21fdb8ef0e35ca6ba2f0d8a9131e7f12fc10741154";
+      sha256 = "f9b3bc5c542d63952ac4fc287d6d19239fd5b14d2bfb550eb868fe2bf84ad9d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/son/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/son/firefox-140.0b4.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "e52956217c7c3ee45e7f4233beb469cd26fd379785d25c799f0c498664236862";
+      sha256 = "146bcb03804707694ff45463fa78e3b33b0ef1e4c29e8c879171cd8495f2b506";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sq/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sq/firefox-140.0b4.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "e06b5bfa27235106a82513ac24070c2a08841751b6a2121d6e24cba96a2079a7";
+      sha256 = "2a888fb0dc58d32d0682333b55b3fe84f79a2a3af9538fb26504745adfa04411";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sr/firefox-140.0b4.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "29202d10e74d780a567bf5a6c68d49824723e910c755a4c5687bdd5b03dce536";
+      sha256 = "59a955e11e42f8a72274274c341a7b191ed1dc7bb3f6755ed127ecc13207735a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/sv-SE/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/sv-SE/firefox-140.0b4.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "37e53d6d434776d3d99356a408d4fb4887c080476d1f6c30e1e8fb744a61d521";
+      sha256 = "fcc9eaa8966ef2fab3befa7bb962513f15e43b8f35035db6b31cdcf517fd4a73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/szl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/szl/firefox-140.0b4.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "66a989f4abed1ce9cbedb76a4d9d9e5d4f5f8a13311da63576531fb99678553a";
+      sha256 = "7e5e7210213bcc5686701b258ef1b8feb95257dd23761d72a32bd22fe454d7bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ta/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ta/firefox-140.0b4.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "945ed46a39471bc841582e54a7d1d0a9c9aa142071d7285973768f29fe089432";
+      sha256 = "ff668385625e513b54d37fbcbd1acdf9981c408b9b94f4029fcd09a1c2176b5c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/te/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/te/firefox-140.0b4.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "ccb22037cb8be01a0814daf27c3a53e49cafcd148f686dae99df59a93a0cf00a";
+      sha256 = "e02f9fdd62addb35ac5b762050be969602555389507046d9faf5fa7329ab4823";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/tg/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/tg/firefox-140.0b4.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "256cef45a12bb6635a74553c4e0666837ca801fbc0b2c3472cd3d322d4dd71d9";
+      sha256 = "30e5a40d34e1d99a3b8837ba126c781f71073015129d851fe1fb56eec39377bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/th/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/th/firefox-140.0b4.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "3c07a430511b639288beb38a5396c9bf47e0035af9d9809105d412c1a1348fe7";
+      sha256 = "a7a947887fad3a4d8ef01dab58cdbc067981dcc9d7459df5d60bc656d5e2497f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/tl/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/tl/firefox-140.0b4.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "8c13b2df39361cb03719249be3a1ee25ce2b76fb24e427a40577efa49165b492";
+      sha256 = "a7be643c4803c4cc96b84618c35b1c922bef223585a75f18b8349752cb975296";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/tr/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/tr/firefox-140.0b4.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "0481e7ab0f1a35659b669aa97a6c6fcd976b6d7654aa2e7c4ab19f1f12e45b71";
+      sha256 = "19e5d98f276f5635841c87e6c8023e72acd60bd756ed8cfddaa0f2781fe1818f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/trs/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/trs/firefox-140.0b4.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "2f42057e425350ab0c570638de750efa9a0d72cbe2f54270bcccf84832673596";
+      sha256 = "564791342249ef49da8ae779e84a013c834f0881c4acf7ed9d948b8f50d89c8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/uk/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/uk/firefox-140.0b4.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "b1905f0d4cf2005cfb2043fa93201ccb5a5cdb6735d0e0ad7abf3a33d5d1383f";
+      sha256 = "215715aeb75eac4285b506b3a576f358c9c49b487c124c6da4f62c6c75c171cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/ur/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/ur/firefox-140.0b4.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "d2a04cd00dcc36383febec0aa54e5dfb829b0957c46cb73a98b75fa9426c5825";
+      sha256 = "9a0aba63bf9b643d94b85f21e05b817aacacd46e74531c1de2771962b47e234c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/uz/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/uz/firefox-140.0b4.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "c8574ade0135845ff83bb0e4cda0889018e504182c75c255dbd58219d1b2a35a";
+      sha256 = "395c7875c568318821381aea1a879e63e477ee281eb3f071bd26ee43a5f803e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/vi/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/vi/firefox-140.0b4.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "707d5664f07614223f01de9d5bdf4b9e9da56094b8f7b86c0db95fb2b3165574";
+      sha256 = "be24eaa206c9e1685a068f44547603770de6f623a3701edec12fe8289fc425b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/xh/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/xh/firefox-140.0b4.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "2412b00ddda9df5fbfd19b61a1d38eb859287ae0fe7702bd78f508fcaa6788dd";
+      sha256 = "3b0d01efdd7cac99912ee95dd058a0a115e7f0dacccfa948b0a56e4a9fbf88f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/zh-CN/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/zh-CN/firefox-140.0b4.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "1404f86ca8c153daa32aaa64f2762e530f54da743dbd088a4ac269710b735bd7";
+      sha256 = "08de3ee0eb0cfaacd24a525ebc645e3a3ebe8b7b4ec2bb25a1f9afab20c65ba9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b3/linux-aarch64/zh-TW/firefox-140.0b3.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/linux-aarch64/zh-TW/firefox-140.0b4.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "43b9ffa8ba86eb6087dd7c4e7a876caf8817958691591adcf70e2d55c47ff927";
+      sha256 = "be9a2ec30189f97b100dc683e61c6484aad2830b1ba1263a043ed5e6e9a3afed";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ach/Firefox%20140.0b4.dmg";
+      locale = "ach";
+      arch = "mac";
+      sha256 = "7011b99f89c7c60f226f115896cad9e68d5cbaeca7a819684f85d8b071595c76";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/af/Firefox%20140.0b4.dmg";
+      locale = "af";
+      arch = "mac";
+      sha256 = "2c3e99a5d7c10303a21aae63646ee282ab113392ed786697bfab38a5ad486773";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/an/Firefox%20140.0b4.dmg";
+      locale = "an";
+      arch = "mac";
+      sha256 = "2c656ae52400af6838b92d40968452d7d61d520746363e5a53a54048e382c4de";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ar/Firefox%20140.0b4.dmg";
+      locale = "ar";
+      arch = "mac";
+      sha256 = "5bc54dd06348de5a8ffda4f2fdd1223c78532a31041a7a6e28a3dccac2f57e06";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ast/Firefox%20140.0b4.dmg";
+      locale = "ast";
+      arch = "mac";
+      sha256 = "054584aa35018c91369ba1e53675333debe62c8c10fb34b27fd9233869330cfa";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/az/Firefox%20140.0b4.dmg";
+      locale = "az";
+      arch = "mac";
+      sha256 = "665f07436f9d3da77906c250a390d07fadc472d9014bf708c4b76e4787aee258";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/be/Firefox%20140.0b4.dmg";
+      locale = "be";
+      arch = "mac";
+      sha256 = "c9934c38c43f95da6d3a5ed936b39f0a33399dc805dc26a357423a6d76082527";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/bg/Firefox%20140.0b4.dmg";
+      locale = "bg";
+      arch = "mac";
+      sha256 = "ce43e7486523ea791a3410b23d6445ac4742bdfc17f4dff7fef166c9dfb74fc7";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/bn/Firefox%20140.0b4.dmg";
+      locale = "bn";
+      arch = "mac";
+      sha256 = "82f8fd00def7073356e6091e759cb14bce43d1e808118deeedd35c3c9e52442b";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/br/Firefox%20140.0b4.dmg";
+      locale = "br";
+      arch = "mac";
+      sha256 = "b4dacee5016f58f013682c8979db040c62c0430517f796934928e3d3758f93fe";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/bs/Firefox%20140.0b4.dmg";
+      locale = "bs";
+      arch = "mac";
+      sha256 = "94061d43536184681a280e8439b05f0a5d035aac89cebc28021750818ac2e912";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ca-valencia/Firefox%20140.0b4.dmg";
+      locale = "ca-valencia";
+      arch = "mac";
+      sha256 = "eef766eb8aa3a35ec8b56cbe5bcdb3a1a6b452bc2d7b6922de7dab7735267bdf";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ca/Firefox%20140.0b4.dmg";
+      locale = "ca";
+      arch = "mac";
+      sha256 = "d4e684531c5ac1410eeb5454448e61fdc037a768df6355084a9383a560400dab";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/cak/Firefox%20140.0b4.dmg";
+      locale = "cak";
+      arch = "mac";
+      sha256 = "64ed36ea6ac02037d431b10790ec589a54bc0855b41f40729cc2f0dd1b5735da";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/cs/Firefox%20140.0b4.dmg";
+      locale = "cs";
+      arch = "mac";
+      sha256 = "df4e1c59384368749ade8227c196346925c49673d9460b25b0b2f63f7b5d77c5";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/cy/Firefox%20140.0b4.dmg";
+      locale = "cy";
+      arch = "mac";
+      sha256 = "7be81560ab2efa8961f8283bf9ae41b78e9bfecb4fc062bb5a370b691b6e69c6";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/da/Firefox%20140.0b4.dmg";
+      locale = "da";
+      arch = "mac";
+      sha256 = "84658e5fea8ba57840788c7d4bdf7ea2600fbea63a7b4c4a2339e70c81f0570d";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/de/Firefox%20140.0b4.dmg";
+      locale = "de";
+      arch = "mac";
+      sha256 = "7b18cf594122f970a0e54bd404c92a509134003a48dc238669b93e22207b2301";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/dsb/Firefox%20140.0b4.dmg";
+      locale = "dsb";
+      arch = "mac";
+      sha256 = "5eaf65eff742646d55df43fe7cf2c2a64b920203a566c8e781eebac4162348aa";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/el/Firefox%20140.0b4.dmg";
+      locale = "el";
+      arch = "mac";
+      sha256 = "d45c6ff3e7303e12f87b5d6b049653c9ae1a5516784703514f91959fdab73d70";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/en-CA/Firefox%20140.0b4.dmg";
+      locale = "en-CA";
+      arch = "mac";
+      sha256 = "6375d180427113749371732054557dcc40e7d90e7a0207bcdb9306468a211021";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/en-GB/Firefox%20140.0b4.dmg";
+      locale = "en-GB";
+      arch = "mac";
+      sha256 = "185dc01cd6183516cab7f175982bc0de5ece04605077c2775a1f670e5360172e";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/en-US/Firefox%20140.0b4.dmg";
+      locale = "en-US";
+      arch = "mac";
+      sha256 = "dce036c33d4749910cc2d87ce4c6786f7538a83dfe22f1ae1f9bfd17d4a23523";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/eo/Firefox%20140.0b4.dmg";
+      locale = "eo";
+      arch = "mac";
+      sha256 = "287ecfcbed7e32717ee2fc2940f40ec38612a14965f6c24ee6c48aaf9e2d3dac";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/es-AR/Firefox%20140.0b4.dmg";
+      locale = "es-AR";
+      arch = "mac";
+      sha256 = "f0ab0790375fb20a4b99ee6fd99af0191442ef8d251711bed2796f4dd6fd8caf";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/es-CL/Firefox%20140.0b4.dmg";
+      locale = "es-CL";
+      arch = "mac";
+      sha256 = "26154d26c371d0de08f5e5bef5661972b6b13c4e94e285d51cf776fc77c4300e";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/es-ES/Firefox%20140.0b4.dmg";
+      locale = "es-ES";
+      arch = "mac";
+      sha256 = "921969d77ee23e539e68a079742bfca9bd0a749af53befc3b42849ee9abf0b34";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/es-MX/Firefox%20140.0b4.dmg";
+      locale = "es-MX";
+      arch = "mac";
+      sha256 = "9dbe72025242d5510d023c190c38c5966ca986f0b06200e3797e06da48c67a93";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/et/Firefox%20140.0b4.dmg";
+      locale = "et";
+      arch = "mac";
+      sha256 = "4e4895663ae7c07d9bcb8c56478cb7a07e8573acee7cc1f451ed777b1fd2776b";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/eu/Firefox%20140.0b4.dmg";
+      locale = "eu";
+      arch = "mac";
+      sha256 = "1e0ce31608914502e0101246e059da95f83f05303f5a6b2646e7595e0b008bd9";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fa/Firefox%20140.0b4.dmg";
+      locale = "fa";
+      arch = "mac";
+      sha256 = "529cc279815596836eeee0240db66fc3b4132d5d462c58a8caf0d3cfc6777f1e";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ff/Firefox%20140.0b4.dmg";
+      locale = "ff";
+      arch = "mac";
+      sha256 = "1aff9b2159f017763c1c3add776bee0b13d30e56c5d89b1364b9ad362a5c8b73";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fi/Firefox%20140.0b4.dmg";
+      locale = "fi";
+      arch = "mac";
+      sha256 = "a70fdfb3abb400bf51d186d8c4a609f25ee0da2d29d9c26f93a1cdfc7b755c47";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fr/Firefox%20140.0b4.dmg";
+      locale = "fr";
+      arch = "mac";
+      sha256 = "f7f6396a4a0a892db2e566f35c41d2b327956d4a7afa137c559c06a237f2e040";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fur/Firefox%20140.0b4.dmg";
+      locale = "fur";
+      arch = "mac";
+      sha256 = "c863d7680e463d3948316b98bcdfc17b9dc2e72012fb7d8d242789271b94b581";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/fy-NL/Firefox%20140.0b4.dmg";
+      locale = "fy-NL";
+      arch = "mac";
+      sha256 = "6dac9e3b8abbc4667041767b43229188ec1a47244189ff0c742220bfc14ed298";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ga-IE/Firefox%20140.0b4.dmg";
+      locale = "ga-IE";
+      arch = "mac";
+      sha256 = "2974969a324c77ec27ac89e769891b56bc4a89ddeaf3bc049fad077d38b3de76";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/gd/Firefox%20140.0b4.dmg";
+      locale = "gd";
+      arch = "mac";
+      sha256 = "c9177b756cc02ff1c708bc7f13516c8794ec871589a0838df5681dd14611b717";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/gl/Firefox%20140.0b4.dmg";
+      locale = "gl";
+      arch = "mac";
+      sha256 = "3625754df8b228d7f8b51bbafdddc6648c4b7b78d16d287fd6c648bde449e899";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/gn/Firefox%20140.0b4.dmg";
+      locale = "gn";
+      arch = "mac";
+      sha256 = "b2e5bdb585f18fbc0933a4b782edcd08513d606afb1d2686705ee7fabf66987d";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/gu-IN/Firefox%20140.0b4.dmg";
+      locale = "gu-IN";
+      arch = "mac";
+      sha256 = "7e0a44037cbf60148bec07d2c8f0bf78079b80692da2230ae2158a090d48b785";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/he/Firefox%20140.0b4.dmg";
+      locale = "he";
+      arch = "mac";
+      sha256 = "920ade68106d20857e5af7b064c3d97d8661818be36bada7a21d6f89682db91a";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hi-IN/Firefox%20140.0b4.dmg";
+      locale = "hi-IN";
+      arch = "mac";
+      sha256 = "cbdfb08d1cde45a370bde21191eb901c1b7a9e08bcf29c94fbe728182a8c2992";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hr/Firefox%20140.0b4.dmg";
+      locale = "hr";
+      arch = "mac";
+      sha256 = "7b3c21df86b3cc960cfcb948284f042b68e367f8b3a28ffcadb7258a8538d6ee";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hsb/Firefox%20140.0b4.dmg";
+      locale = "hsb";
+      arch = "mac";
+      sha256 = "0dddbcdd417f10b2d2e576346c313dd325b170cebb478827ee3f19154aa2e3f4";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hu/Firefox%20140.0b4.dmg";
+      locale = "hu";
+      arch = "mac";
+      sha256 = "6aa34847a12eab43aa04ca1ee27c5edd5562a5e916fe47a64a5a469b46201e3e";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/hy-AM/Firefox%20140.0b4.dmg";
+      locale = "hy-AM";
+      arch = "mac";
+      sha256 = "4f723e805556cca933b97981871c1e1408cfbd766b15037981af9deddd041fb1";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ia/Firefox%20140.0b4.dmg";
+      locale = "ia";
+      arch = "mac";
+      sha256 = "9ad43eff14c069d7ef7f27e2b47fd4713af832410c579868293ee7f78cc8c07b";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/id/Firefox%20140.0b4.dmg";
+      locale = "id";
+      arch = "mac";
+      sha256 = "3176ea295423ecd71a466a79e9657fea751e6d8c71db66a0709168556f8eae45";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/is/Firefox%20140.0b4.dmg";
+      locale = "is";
+      arch = "mac";
+      sha256 = "9cf0acbdb7c99914542941333fd1fbe108fed41f46af9fbefaf0a480adc0564b";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/it/Firefox%20140.0b4.dmg";
+      locale = "it";
+      arch = "mac";
+      sha256 = "5e345715eba89bc244e16c73dacc522a3b83e9ec3f99ae072945b18cfa904f5a";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ja-JP-mac/Firefox%20140.0b4.dmg";
+      locale = "ja-JP-mac";
+      arch = "mac";
+      sha256 = "308d2c19609ed3874fe8cd3619602d606356ed55c4ca0f1fca1dede932c19e79";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ka/Firefox%20140.0b4.dmg";
+      locale = "ka";
+      arch = "mac";
+      sha256 = "d0ebffe428b05422977dac4bf3380c3e57a0ed42d7a4110699ec4b92fe168bce";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/kab/Firefox%20140.0b4.dmg";
+      locale = "kab";
+      arch = "mac";
+      sha256 = "e0002e9e16c91d5b8a9ea7d3de83799bbd77e6c23aee05759052e8d6303e01bd";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/kk/Firefox%20140.0b4.dmg";
+      locale = "kk";
+      arch = "mac";
+      sha256 = "efff905c517fbdb1b3a1171b3114790cda03acb4002c9653070092149b92bc8d";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/km/Firefox%20140.0b4.dmg";
+      locale = "km";
+      arch = "mac";
+      sha256 = "473c31374b6d982e61d75cb3974e20bcbd13c4613bcfddfea50aa43418903f54";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/kn/Firefox%20140.0b4.dmg";
+      locale = "kn";
+      arch = "mac";
+      sha256 = "9436efdd09ef9eaaf104d90426cb091e1bc217468bd66cffcb7d91f8d2758f07";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ko/Firefox%20140.0b4.dmg";
+      locale = "ko";
+      arch = "mac";
+      sha256 = "9973a287baaa00930831a865beb370faee052f7ea486c728f2ed13060ff3280c";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/lij/Firefox%20140.0b4.dmg";
+      locale = "lij";
+      arch = "mac";
+      sha256 = "f4c9678e933e440751b97f35b6e04941d9ce76b5869d45748b91df8336155274";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/lt/Firefox%20140.0b4.dmg";
+      locale = "lt";
+      arch = "mac";
+      sha256 = "ddb021dca21e65e30012aab734d160118b26c3542fc3afff2db857dbda216221";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/lv/Firefox%20140.0b4.dmg";
+      locale = "lv";
+      arch = "mac";
+      sha256 = "f63120daedf1ea0648de93f9178db541fed0144508ad5fddb3e512f32369c3b0";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/mk/Firefox%20140.0b4.dmg";
+      locale = "mk";
+      arch = "mac";
+      sha256 = "9501890bd79ddda990d8023a787efda67acb7d42e5283bd354ecd89d7a5e5546";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/mr/Firefox%20140.0b4.dmg";
+      locale = "mr";
+      arch = "mac";
+      sha256 = "ba43292eb30482a03f83a4fde41e63accf37ea30b89fc8b4350a2ddf94572af0";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ms/Firefox%20140.0b4.dmg";
+      locale = "ms";
+      arch = "mac";
+      sha256 = "84ce117ea9b6703b743d70c85dcb679bfdf3652d5f2e5d765f4437873a979223";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/my/Firefox%20140.0b4.dmg";
+      locale = "my";
+      arch = "mac";
+      sha256 = "ed8c07f47e46998bf072d6d0db2a677326bb56e55d56197ded040b34cbc4a63d";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/nb-NO/Firefox%20140.0b4.dmg";
+      locale = "nb-NO";
+      arch = "mac";
+      sha256 = "676be48e68f893f271c5db650d11cd17bf323157907e2176a76d97053d9a35c4";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ne-NP/Firefox%20140.0b4.dmg";
+      locale = "ne-NP";
+      arch = "mac";
+      sha256 = "fdc56c722f0509cc1f99bf4d7759faedfdb8d5f74ebbc41fd604cbc85f5de4ab";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/nl/Firefox%20140.0b4.dmg";
+      locale = "nl";
+      arch = "mac";
+      sha256 = "f908f97357b129f8ddd56da82b17da273dabab6fec022823bea2976645331860";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/nn-NO/Firefox%20140.0b4.dmg";
+      locale = "nn-NO";
+      arch = "mac";
+      sha256 = "3d38846a8f6ee404b6f5e55121f3c6a40b278cb4a224859c95e191f614741cfe";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/oc/Firefox%20140.0b4.dmg";
+      locale = "oc";
+      arch = "mac";
+      sha256 = "c2db065e02821b6abe15a8448bf45f07ab842ccb3d14504f52ff15cdcf786879";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/pa-IN/Firefox%20140.0b4.dmg";
+      locale = "pa-IN";
+      arch = "mac";
+      sha256 = "f6774c2c7f78362beef99450be1865f5ab9a0681fd41a18403e916c31c9538b4";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/pl/Firefox%20140.0b4.dmg";
+      locale = "pl";
+      arch = "mac";
+      sha256 = "cc14ee424433ab322b17058ea8719ba9368ff5e7a91d2f691a92dc1d13964f11";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/pt-BR/Firefox%20140.0b4.dmg";
+      locale = "pt-BR";
+      arch = "mac";
+      sha256 = "20db9ade31f00b3aae5fcb9fe71d63c31d31520f31a0e87644b34cc0a8c928bb";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/pt-PT/Firefox%20140.0b4.dmg";
+      locale = "pt-PT";
+      arch = "mac";
+      sha256 = "15d5a45a13311a67f86fb9814e1ac49f5090933f1110ca0ccc1f5bf51d4312e9";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/rm/Firefox%20140.0b4.dmg";
+      locale = "rm";
+      arch = "mac";
+      sha256 = "07452f83b2a572e0c536e0a08aec5146aca7fef1a162d0d14ce49aa4b2032fae";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ro/Firefox%20140.0b4.dmg";
+      locale = "ro";
+      arch = "mac";
+      sha256 = "98500565dda18961b9e35a4ed0a16a0c7cec95a72bfcfc43c86b4f31a32e1074";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ru/Firefox%20140.0b4.dmg";
+      locale = "ru";
+      arch = "mac";
+      sha256 = "f85319ac38fb8be330bb80e6b1e5fc781d8aad2f8a6a300e1c85916f0baf7c62";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sat/Firefox%20140.0b4.dmg";
+      locale = "sat";
+      arch = "mac";
+      sha256 = "5cc725cf1112960bccdee3d5f8ffb1a8fa7d62cdb50aeeea5becff34bd971320";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sc/Firefox%20140.0b4.dmg";
+      locale = "sc";
+      arch = "mac";
+      sha256 = "7770966f953067fd4170aeb4bc0d3be8deb405f74e2129abca7253e792f69b3c";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sco/Firefox%20140.0b4.dmg";
+      locale = "sco";
+      arch = "mac";
+      sha256 = "e10ae6867387b2306b2ceb74e136d28ca332a9573d2d16d10ea8d4ccde9cf85d";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/si/Firefox%20140.0b4.dmg";
+      locale = "si";
+      arch = "mac";
+      sha256 = "d3e02db688b3093c05b7efdaadcef600f956a614572504489e4d69cc975c8a08";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sk/Firefox%20140.0b4.dmg";
+      locale = "sk";
+      arch = "mac";
+      sha256 = "28b1b6fa00da50a5717bdf35bd98af2ed217fcb6d6f782865d7d9bd0acbeb7c1";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/skr/Firefox%20140.0b4.dmg";
+      locale = "skr";
+      arch = "mac";
+      sha256 = "fd1ad12da34e3bbbb9fdfcd64c2369a3b26ea9f6ec034673fcf0235d8627765d";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sl/Firefox%20140.0b4.dmg";
+      locale = "sl";
+      arch = "mac";
+      sha256 = "1b418886de3282ff93ee5ccce0e359b5c5d94de3a3cf6fc85f5342d9f18e80ad";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/son/Firefox%20140.0b4.dmg";
+      locale = "son";
+      arch = "mac";
+      sha256 = "ab8f032f880c20a83bd6e4a64740122567a48084ab973ec4f708539009d8afdf";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sq/Firefox%20140.0b4.dmg";
+      locale = "sq";
+      arch = "mac";
+      sha256 = "f1ed88be1dc9ef4a5dd873f615c7008e87122f690a0ca8f2c4435c8c07266423";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sr/Firefox%20140.0b4.dmg";
+      locale = "sr";
+      arch = "mac";
+      sha256 = "8c76f294b168a7089308b5370b46eb507853964c43e33058d3ff5b0a9cb94a74";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/sv-SE/Firefox%20140.0b4.dmg";
+      locale = "sv-SE";
+      arch = "mac";
+      sha256 = "33067551aad68665fbafab6357ace0debe78032fa1a9a63b2c7f5c35aee6cd6e";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/szl/Firefox%20140.0b4.dmg";
+      locale = "szl";
+      arch = "mac";
+      sha256 = "cabd50959911a80e1a663327564d546753b6f053a3147d5e5238713f54c930fd";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ta/Firefox%20140.0b4.dmg";
+      locale = "ta";
+      arch = "mac";
+      sha256 = "55c572220f5e0d0c16b5314e8429a221b668d6b05bd21d1410deb850a20587c5";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/te/Firefox%20140.0b4.dmg";
+      locale = "te";
+      arch = "mac";
+      sha256 = "dd24dff0bf95f49d5415e541596e2b832481cf9fda89d4a978ce8e3c40690647";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/tg/Firefox%20140.0b4.dmg";
+      locale = "tg";
+      arch = "mac";
+      sha256 = "4b628008a8536fd67cf6e403fd9f771f765994e172c228bdf214ec73d7b483b0";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/th/Firefox%20140.0b4.dmg";
+      locale = "th";
+      arch = "mac";
+      sha256 = "edda1adddebf16eb8ccd31d08fdf77f7f4d349c57dccbd29c98998831f3405a5";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/tl/Firefox%20140.0b4.dmg";
+      locale = "tl";
+      arch = "mac";
+      sha256 = "5c9cf0f10257b5788edab5298069a66157be9b740a618c22b6e6f7b6495aee05";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/tr/Firefox%20140.0b4.dmg";
+      locale = "tr";
+      arch = "mac";
+      sha256 = "23d6fe36c78458a9c20baca7f9f559c2044e02a7d0298994ae3fce29846a6cbc";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/trs/Firefox%20140.0b4.dmg";
+      locale = "trs";
+      arch = "mac";
+      sha256 = "da3998812d320ea6242a345a239ead76b5e08a479a758fd0769918461c6a89e8";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/uk/Firefox%20140.0b4.dmg";
+      locale = "uk";
+      arch = "mac";
+      sha256 = "02faddd1b0b5b79211c36438a2ce47238231c11dcf675d65974b8478f7f16818";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/ur/Firefox%20140.0b4.dmg";
+      locale = "ur";
+      arch = "mac";
+      sha256 = "bf9846f9ef42b29670ac7a578afe0d0daff713cbe2dcea8fc80e937f753dd284";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/uz/Firefox%20140.0b4.dmg";
+      locale = "uz";
+      arch = "mac";
+      sha256 = "dca6f4b4b872c20d9ba2c1b42a2a02e6ae5a70df363fe0f12a3509e6fbc05ee9";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/vi/Firefox%20140.0b4.dmg";
+      locale = "vi";
+      arch = "mac";
+      sha256 = "bdbf2095fcd35554cd83ed9a115d6037e24487861ed8746d3b3285735d5518ec";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/xh/Firefox%20140.0b4.dmg";
+      locale = "xh";
+      arch = "mac";
+      sha256 = "86496e2fa6591ff5218eb4a7187b5cd303c86e6dc6d6bf9cc32e20aa6b199d77";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/zh-CN/Firefox%20140.0b4.dmg";
+      locale = "zh-CN";
+      arch = "mac";
+      sha256 = "8ab9a64b3733fd391678c47a2307d44205a9ae67aad5895aa11ceb73eeccf6ff";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0b4/mac/zh-TW/Firefox%20140.0b4.dmg";
+      locale = "zh-TW";
+      arch = "mac";
+      sha256 = "a1e2692eb4a0a728b051a9f6c3998b7f87b0e118133fb94b069f582c0eb463e9";
     }
   ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport of https://github.com/NixOS/nixpkgs/pull/414855.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
