### PR TITLE
cc-wrapper: add `glibcxxassertions` hardening flag

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -574,6 +574,9 @@
   "strictflexarrays3": [
     "index.html#strictflexarrays3"
   ],
+  "glibcxxassertions": [
+    "index.html#glibcxxassertions"
+  ],
   "tester-shfmt": [
     "index.html#tester-shfmt"
   ],

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1688,6 +1688,12 @@ This should be turned off or fixed for build errors such as:
 sorry, unimplemented: __builtin_clear_padding not supported for variable length aggregates
 ```
 
+#### `glibcxxassertions` {#glibcxxassertions}
+
+Adds the `-D_GLIBCXX_ASSERTIONS` compiler flag. This flag only has an effect on libstdc++ targets, and when defined, enables extra error checking in the form of precondition assertions, such as bounds checking in c++ strings and null pointer checks when dereferencing c++ smart pointers.
+
+These checks may have an impact on performance in some cases.
+
 #### `pacret` {#pacret}
 
 This flag adds the `-mbranch-protection=pac-ret` compiler option on aarch64-linux targets. This uses ARM v8.3's Pointer Authentication feature to sign function return pointers before adding them to the stack. The pointer's authenticity is then validated before returning to its destination. This dramatically increases the difficulty of ROP exploitation techniques.

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -52,7 +52,7 @@ fi
 
 
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify fortify3 shadowstack stackprotector stackclashprotection nostrictaliasing pacret strictflexarrays1 strictflexarrays3 pie pic strictoverflow format trivialautovarinit zerocallusedregs)
+  declare -a allHardeningFlags=(fortify fortify3 shadowstack stackprotector stackclashprotection nostrictaliasing pacret strictflexarrays1 strictflexarrays3 pie pic strictoverflow glibcxxassertions format trivialautovarinit zerocallusedregs)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -110,6 +110,10 @@ for flag in "${!hardeningEnableMap[@]}"; do
     pacret)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling pacret >&2; fi
       hardeningCFlagsBefore+=('-mbranch-protection=pac-ret')
+      ;;
+    glibcxxassertions)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling glibcxxassertions >&2; fi
+      hardeningCFlagsBefore+=('-D_GLIBCXX_ASSERTIONS')
       ;;
     stackprotector)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling stackprotector >&2; fi

--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -178,6 +178,9 @@ stdenv.mkDerivation (finalAttrs: {
     ZSTD_ROOT = zstd.dev;
   };
 
+  # fails tests on glibc with this enabled
+  hardeningDisable = [ "glibcxxassertions" ];
+
   preConfigure = ''
     patchShebangs build-support/
     substituteInPlace "src/arrow/vendored/datetime/tz.cpp" \

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -150,6 +150,7 @@ let
     "pie"
     "relro"
     "stackprotector"
+    "glibcxxassertions"
     "stackclashprotection"
     "strictoverflow"
     "trivialautovarinit"

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -4,6 +4,7 @@
   runCommand,
   runCommandWith,
   runCommandCC,
+  writeText,
   bintools,
   hello,
   debian-devscripts,
@@ -39,6 +40,17 @@ let
   f3exampleWithStdEnv = writeCBinWithStdenv ./fortify3-example.c;
 
   flexArrF2ExampleWithStdEnv = writeCBinWithStdenv ./flex-arrays-fortify-example.c;
+
+  checkGlibcxxassertionsWithStdEnv =
+    expectDefined:
+    writeCBinWithStdenv (
+      writeText "main.cpp" ''
+        #if${if expectDefined then "n" else ""}def _GLIBCXX_ASSERTIONS
+        #error "Expected _GLIBCXX_ASSERTIONS to be ${if expectDefined then "" else "un"}defined"
+        #endif
+        int main() {}
+      ''
+    );
 
   # for when we need a slightly more complicated program
   helloWithStdEnv =
@@ -502,6 +514,10 @@ nameDrvAfterAttrName (
       hardeningEnable = [ "shadowstack" ];
     }) false;
 
+    glibcxxassertionsExplicitEnabled = checkGlibcxxassertionsWithStdEnv true stdenv {
+      hardeningEnable = [ "glibcxxassertions" ];
+    };
+
     bindNowExplicitDisabled =
       checkTestBin
         (f2exampleWithStdEnv stdenv {
@@ -696,6 +712,10 @@ nameDrvAfterAttrName (
     shadowStackExplicitDisabled = shadowStackTest (f1exampleWithStdEnv stdenv {
       hardeningDisable = [ "shadowstack" ];
     }) true;
+
+    glibcxxassertionsExplicitDisabled = checkGlibcxxassertionsWithStdEnv false stdenv {
+      hardeningDisable = [ "glibcxxassertions" ];
+    };
 
     # most flags can't be "unsupported" by compiler alone and
     # binutils doesn't have an accessible hardeningUnsupportedFlags
@@ -895,6 +915,12 @@ nameDrvAfterAttrName (
         {
           ignoreStackProtector = false;
           expectFailure = true;
+        };
+
+    glibcxxassertionsStdenvUnsupp =
+      checkGlibcxxassertionsWithStdEnv false (stdenvUnsupport [ "glibcxxassertions" ])
+        {
+          hardeningEnable = [ "glibcxxassertions" ];
         };
 
     fortify3EnabledEnvEnablesFortify1 =
@@ -1107,6 +1133,10 @@ nameDrvAfterAttrName (
       allExplicitDisabledShadowStack = shadowStackTest (f1exampleWithStdEnv stdenv {
         hardeningDisable = [ "all" ];
       }) true;
+
+      glibcxxassertionsExplicitDisabled = checkGlibcxxassertionsWithStdEnv false stdenv {
+        hardeningDisable = [ "all" ];
+      };
     }
   )
 )

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -164,6 +164,7 @@ self: super: {
               "shadowstack"
               "nostrictaliasing"
               "pacret"
+              "glibcxxassertions"
               "trivialautovarinit"
             ]
           ) super'.stdenv;


### PR DESCRIPTION
This adds another flag included in the 2025 openssf hardening guide: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#precondition-checks-for-c-standard-library-calls

As ever, as a new hardening flag I have disabled it by default except in `pkgsExtraHardening`. Because of the possibility of slowdowns, this is one of the flags I probably won't advocate moving to default-enabled any time soon.

This hardening flag is a little bit *odd* because it only has an effect when compiling against glibc's `libstdc++`, but note how I **haven't** included any mechanism to "unsupport" it on platforms that use `libc++`. This is because we don't currently have any nice mechanism to detect what c++ standard library a platform is using - and whether we're using clang or gcc is a poor approximation of this. Instead this PR will happily add the `-D_GLIBCXX_ASSERTIONS` definition on all platforms, whether using `libstdc++` or not, with the idea that other c++ standard libraries will just ignore it.

Clang's `libc++` *does have* a similar feature that I'm planning on introducing in a separate PR. Why not put both flags under a common generic hardening flag name? Firstly I'm not convinced that the assertions of each library will have similar enough package-breaking characteristics, and secondly `libc++`'s hardening feature has multiple levels that I think are worth exposing separately. Once we get into multiple levels of strictness, ensuring sensible parity *between* the exposed levels *between* the two implementations feels like it would be a fool's errand.

I built quite a lot of c++ packages on aarch64-linux with this default-enabled and only found `arrow-cpp`'s build to be affected by it.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
