### PR TITLE
mlton 20210117 -> 20241230

### DIFF
--- a/pkgs/development/compilers/mlton/20241230-binary.nix
+++ b/pkgs/development/compilers/mlton/20241230-binary.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  patchelf,
+  bash,
+  gmp,
+}:
+let
+  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
+  pname = "mlton";
+  version = "20241230";
+  link =
+    { arch, os }:
+    "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.${arch}-${os}.tgz";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+  src =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      (fetchurl {
+        url = link {
+          arch = "amd64";
+          os = "linux.ubuntu-24.04_glibc2.39";
+        };
+        hash = "sha256-ldXnjHcWGu77LP9WL6vTC6FngzhxPFAUflAA+bpIFZM=";
+      })
+    else if stdenv.hostPlatform.system == "aarch64-linux" then
+      (fetchurl {
+        url = link {
+          arch = "arm64";
+          os = "linux.ubuntu-24.04-arm_glibc2.39";
+        };
+        hash = "sha256-rn65t253SfUShAM3kXiLQJHT7JS7EO3fAPB23LWIwfc=";
+      })
+    else if stdenv.hostPlatform.system == "x86_64-darwin" then
+      (fetchurl {
+        url = link {
+          arch = "amd64";
+          os = "darwin.macos-13_gmp-static";
+        };
+        sha256 = "sha256-fW0hqjrWUcy+PIN8WHb1r4EYgfuwF9Zz3q7f2ZtxOi0=";
+      })
+    else if stdenv.hostPlatform.system == "aarch64-darwin" then
+      (fetchurl {
+        url = link {
+          arch = "arm64";
+          os = "darwin.macos-15_gmp-static";
+        };
+        hash = "sha256-xhFP2plFjP/mbLz1CNtlZzkm0Kx6twfD/Dmn79Vj908=";
+      })
+    else
+      throw "Architecture not supported";
+
+  buildInputs = [
+    bash
+    gmp
+  ];
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux patchelf;
+  strictDeps = true;
+
+  buildPhase = ''
+    make update \
+      CC="$(type -p cc)" \
+      WITH_GMP_INC_DIR="${gmp.dev}/include" \
+      WITH_GMP_LIB_DIR="${gmp}/lib"
+  '';
+
+  installPhase = ''
+    make install PREFIX=$out
+  '';
+
+  postFixup =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf --set-interpreter ${dynamic-linker} $out/lib/mlton/mlton-compile
+      patchelf --set-rpath ${gmp}/lib $out/lib/mlton/mlton-compile
+
+      for e in mllex mlnlffigen mlprof mlyacc; do
+        patchelf --set-interpreter ${dynamic-linker} $out/bin/$e
+        patchelf --set-rpath ${gmp}/lib $out/bin/$e
+      done
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install_name_tool -change \
+        /opt/local/lib/libgmp.10.dylib \
+        ${gmp}/lib/libgmp.10.dylib \
+        $out/lib/mlton/mlton-compile
+
+      for e in mllex mlnlffigen mlprof mlyacc; do
+        install_name_tool -change \
+          /opt/local/lib/libgmp.10.dylib \
+          ${gmp}/lib/libgmp.10.dylib \
+          $out/bin/$e
+      done
+    '';
+
+  meta = import ./meta.nix;
+}

--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -4,6 +4,8 @@ rec {
   mlton20130715 = callPackage ./20130715.nix { };
 
   mlton20180207Binary = callPackage ./20180207-binary.nix { };
+  mlton20210117Binary = callPackage ./20210117-binary.nix { };
+  mlton20241230Binary = callPackage ./20241230-binary.nix { };
 
   mlton20180207 = callPackage ./from-git-source.nix {
     mltonBootstrap = mlton20180207Binary;
@@ -12,13 +14,18 @@ rec {
     sha256 = "00rdd2di5x1dzac64il9z05m3fdzicjd3226wwjyynv631jj3q2a";
   };
 
-  mlton20210117Binary = callPackage ./20210117-binary.nix { };
-
   mlton20210117 = callPackage ./from-git-source.nix {
     mltonBootstrap = mlton20210117Binary;
     version = "20210117";
     rev = "on-20210117-release";
     sha256 = "sha256-rqL8lnzVVR+5Hc7sWXK8dCXN92dU76qSoii3/4StODM=";
+  };
+
+  mlton20241230 = callPackage ./from-git-source.nix {
+    mltonBootstrap = mlton20241230Binary;
+    version = "20241230";
+    rev = "on-20241230-release";
+    sha256 = "sha256-gJUzav2xH8C4Vy5FuqN73Z6lPMSPQgJApF8LgsJXRWo=";
   };
 
   mltonHEAD = callPackage ./from-git-source.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5903,10 +5903,11 @@ with pkgs;
     mlton20180207Binary
     mlton20180207
     mlton20210117
+    mlton20241230
     mltonHEAD
     ;
 
-  mlton = mlton20210117;
+  mlton = mlton20241230;
 
   mono = mono6;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add latest MLton release (20241230). Point `mlton` to point to this new release instead of the 20210117 release.
The [patch notes](https://github.com/MLton/mlton/releases/tag/on-20241230-release) states no breaking changes, only bug fixes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
As far as I know, there are no nixos or package tests available for `mlton`, which is a bit of a problem in itself, but outside the scope of this PR.
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
