### PR TITLE
xfce.libxfce4windowing: 4.20.2 -> 4.20.3

### DIFF
--- a/pkgs/desktops/xfce/core/libxfce4windowing/default.nix
+++ b/pkgs/desktops/xfce/core/libxfce4windowing/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   mkXfceDerivation,
+  python3,
   wayland-scanner,
   glib,
   gtk3,
@@ -22,12 +23,13 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "libxfce4windowing";
-  version = "4.20.2";
+  version = "4.20.3";
 
-  sha256 = "sha256-Xw1hs854K5dZCAYoBMoqJzdSxPRFUYqEpWxg4DLSK5Q=";
+  sha256 = "sha256-l58cTz28UPSVfoIpjBCoSwcqdUJfG9e4UlhVYPyEeAs=";
 
   nativeBuildInputs =
     [
+      python3
       wayland-scanner
     ]
     ++ lib.optionals withIntrospection [
@@ -45,6 +47,10 @@ mkXfceDerivation {
     wayland-protocols
     wlr-protocols
   ];
+
+  postPatch = ''
+    patchShebangs xdt-gen-visibility
+  '';
 
   meta = {
     description = "Windowing concept abstraction library for X11 and Wayland";


### PR DESCRIPTION
https://gitlab.xfce.org/xfce/libxfce4windowing/-/compare/libxfce4windowing-4.20.2...libxfce4windowing-4.20.3


I was confused by [the budgie-desktop PR](https://github.com/BuddiesOfBudgie/budgie-desktop/pulls?q=deps%3A+Update+libxfce4windowing+VAPI) but in the end I found 4.20.3 has nothing to do with that PR...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

