### PR TITLE
eukleides: unbreak, switch to mirror; texinfo4: drop

### DIFF
--- a/pkgs/by-name/eu/eukleides/package.nix
+++ b/pkgs/by-name/eu/eukleides/package.nix
@@ -1,23 +1,28 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   bison,
   flex,
   makeWrapper,
-  texinfo4,
   getopt,
   readline,
+  texinfo,
   texlive,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "eukleides";
   version = "1.5.4";
 
-  src = fetchurl {
-    url = "http://www.eukleides.org/files/eukleides-${finalAttrs.version}.tar.bz2";
-    sha256 = "0s8cyh75hdj89v6kpm3z24i48yzpkr8qf0cwxbs9ijxj1i38ki0q";
+  src = fetchFromGitLab {
+    # official upstream www.eukleides.org is down
+    domain = "salsa.debian.org";
+    owner = "georgesk";
+    repo = "eukleides";
+    rev = "upstream/${finalAttrs.version}";
+    hash = "sha256-keX7k14X/97zHh87A/7vUsfGc/S6fByd+rewW+LkJeM=";
   };
 
   patches = [
@@ -25,12 +30,14 @@ stdenv.mkDerivation (finalAttrs: {
     ./use-CC.patch
     # allow PostScript transparency in epstopdf call
     ./gs-allowpstransparency.patch
+    # fix curly brace escaping in eukleides.texi for newer texinfo compatiblity
+    ./texinfo-escape.patch
   ];
 
   nativeBuildInputs = [
     bison
     flex
-    texinfo4
+    texinfo
     makeWrapper
   ];
 
@@ -41,14 +48,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     substituteInPlace Makefile \
-      --replace mktexlsr true
+      --replace-fail mktexlsr true
 
     substituteInPlace doc/Makefile \
-      --replace ginstall-info install-info
+      --replace-fail ginstall-info install-info
 
     substituteInPlace Config \
-      --replace '/usr/local' "$out" \
-      --replace '$(SHARE_DIR)/texmf' "$tex"
+      --replace-fail '/usr/local' "$out" \
+      --replace-fail '$(SHARE_DIR)/texmf' "$tex"
   '';
 
   # Workaround build failure on -fno-common toolchains like upstream
@@ -56,6 +63,13 @@ stdenv.mkDerivation (finalAttrs: {
   #   ld: eukleides_build/triangle.o:(.bss+0x28): multiple definition of `A';
   #     eukleides_build/quadrilateral.o:(.bss+0x18): first defined here
   env.NIX_CFLAGS_COMPILE = "-fcommon";
+
+  preBuild = ''
+    mkdir build/eukleides_build
+    mkdir build/euktopst_build
+  '';
+
+  enableParallelBuilding = true;
 
   preInstall = ''
     mkdir -p $out/bin
@@ -83,6 +97,10 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     pkgs = [ finalAttrs.finalPackage.tex ];
   };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Geometry Drawing Language";

--- a/pkgs/by-name/eu/eukleides/texinfo-escape.patch
+++ b/pkgs/by-name/eu/eukleides/texinfo-escape.patch
@@ -1,0 +1,19 @@
+--- a/doc/eukleides.texi
++++ b/doc/eukleides.texi
+@@ -6,12 +6,12 @@
+ 
+ % ------------------------------------------------------------------------------
+ 
+-\def\LaTeX{L\kern-.34em\raise.49ex\hbox{\sevenrm A}\kern-.18em\TeX}
+-\def\mdeg{$^\circ$}
++\def\LaTeX@{L\kern-.34em\raise.49ex\hbox@{\sevenrm A@}\kern-.18em\TeX@}
++\def\mdeg@{$^\circ$@}
+ \font\degfont=cmtt8
+-\def\deg{\raise.7ex\hbox{\degfont o}}
+-\def\exm#1{\noindent{\textit Example:}\quad{\texttt #1}}
+-\def\exmp{\noindent{\textit Example:}}
++\def\deg@{\raise.7ex\hbox@{\degfont o@}@}
++\def\exm#1@{\noindent@{\textit Example:@}\quad@{\texttt #1@}@}
++\def\exmp@{\noindent@{\textit Example:@}@}
+ 
+ % ------------------------------------------------------------------------------

--- a/pkgs/development/tools/misc/texinfo/packages.nix
+++ b/pkgs/development/tools/misc/texinfo/packages.nix
@@ -69,25 +69,6 @@ let
   };
 in
 {
-  texinfo413 = stdenv.mkDerivation (finalAttrs: {
-    pname = "texinfo";
-    version = "4.13a";
-
-    src = fetchurl {
-      url = "mirror://gnu/texinfo/texinfo-${finalAttrs.version}.tar.lzma";
-      hash = "sha256-bSiwzq6GbjU2FC/FUuejvJ+EyDAxGcJXMbJHju9kyeU=";
-    };
-
-    buildInputs = [ ncurses ];
-    nativeBuildInputs = [ xz ];
-
-    # Disabled because we don't have zdiff in the stdenv bootstrap.
-    #doCheck = true;
-
-    meta = meta // {
-      branch = finalAttrs.version;
-    };
-  });
   texinfo6_5 = buildTexinfo {
     version = "6.5";
     hash = "sha256-d3dLP0oGwgcFzC7xyASGRCLjz5UjXpZbHwCkbffaX2I=";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1896,6 +1896,7 @@ mapAliases {
   tepl = libgedit-tepl; # Added 2024-04-29
   termplay = throw "'termplay' has been removed due to lack of maintenance upstream"; # Added 2025-01-25
   testVersion = testers.testVersion; # Added 2022-04-20
+  texinfo4 = throw "'texinfo4' has been removed in favor of the latest version"; # Added 2025-06-08
   tezos-rust-libs = ligo; # Added 2025-06-03
   tfplugindocs = terraform-plugin-docs; # Added 2023-11-01
   thiefmd = throw "'thiefmd' has been removed due to lack of maintenance upstream and incompatible with newer Pandoc. Please use 'apostrophe' or 'folio' instead"; # Added 2025-02-20

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7689,13 +7689,11 @@ with pkgs;
 
   texinfoPackages = callPackages ../development/tools/misc/texinfo/packages.nix { };
   inherit (texinfoPackages)
-    texinfo413
     texinfo6_5 # needed for allegro
     texinfo6_7 # needed for gpm, iksemel and fwknop
     texinfo6
     texinfo7
     ;
-  texinfo4 = texinfo413; # needed for eukleides and singular
   texinfo = texinfo7;
   texinfoInteractive = texinfo.override { interactive = true; };
 


### PR DESCRIPTION
Eukleides [upstream](http://www.eukleides.org/) is dead, Debian is maintaining a [mirror](https://salsa.debian.org/georgesk/eukleides).

By applying one of the [patches](https://salsa.debian.org/georgesk/eukleides/-/blob/master/debian/patches/old-patches.diff?ref_type=heads) found in Debian, `texinfo` compatibility can be fixed. Since this is the last package depending on `texinfo4` (build broken), it can be dropped.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
