### PR TITLE
pulsemeeter: init at 1.2.14

### DIFF
--- a/pkgs/by-name/pu/pulsemeeter/package.nix
+++ b/pkgs/by-name/pu/pulsemeeter/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  libpulseaudio,
+  libappindicator,
+  gobject-introspection,
+  wrapGAppsHook3,
+  callPackage,
+  bash,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "pulsemeeter";
+  version = "1.2.14";
+
+  src = fetchFromGitHub {
+    owner = "theRealCarneiro";
+    repo = "pulsemeeter";
+    tag = "v${version}";
+    hash = "sha256-QTXVE5WvunsjLS8I1rgX34BW1mT1UY+cRxURwXiQp5A=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    pulsectl
+    pygobject3
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    libappindicator
+    libpulseaudio
+    bash
+  ];
+
+  makeWrapperArgs = [
+    "\${gappsWrapperArgs[@]}"
+  ];
+
+  dontWrapGApps = true;
+
+  passthru.tests.version = callPackage ./version-test.nix { inherit version; };
+
+  meta = {
+    description = "Frontend of pulseaudio's routing capabilities, mimicking voicemeeter's workflow";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/theRealCarneiro/pulsemeeter";
+    maintainers = with lib.maintainers; [
+      therobot2105
+    ];
+    mainProgram = "pulsemeeter";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/pu/pulsemeeter/version-test.nix
+++ b/pkgs/by-name/pu/pulsemeeter/version-test.nix
@@ -1,0 +1,33 @@
+{
+  pkgs,
+  version,
+}:
+pkgs.testers.runNixOSTest {
+  name = "pulsemeeter-version";
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      services.pulseaudio.enable = true;
+      services.pulseaudio.systemWide = true;
+      users.users.alice = {
+        isNormalUser = true;
+        password = "foo";
+        extraGroups = [
+          "wheel"
+          "pulse-access"
+        ];
+        packages = with pkgs; [
+          pulsemeeter
+        ];
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.succeed("su -- root -c 'systemctl start pulseaudio'")
+    machine.succeed("su -- alice -c 'mkdir -p /home/alice/.config/pulsemeeter'")
+    version = machine.execute("su -- alice -c 'pulsemeeter -s | head -n 4 | tail -n 1'")
+    assert version == (0, 'Pulsemeeter version: \x1b[1m${version}\x1b[0m\n')
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
https://github.com/theRealCarneiro/pulsemeeter
A frontend to ease the use of pulseaudio's routing capabilities, mimicking voicemeeter's workflow
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
