### PR TITLE
{ico,lib{applewm,dmx,fontenc,fs}}: refactor and move to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/ic/ico/package.nix
+++ b/pkgs/by-name/ic/ico/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libX11,
+  xorgproto,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ico";
+  version = "1.0.6";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/ico-${finalAttrs.version}.tar.xz";
+    hash = "sha256-OPNp1DHnUygP3nD6SJzJTOIE+fjqvS9J/H0yr6afRAU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libX11
+    xorgproto
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Simple animation program that may be used for testing various X11 operations and extensions";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/ico";
+    license = with lib.licenses; [
+      x11
+      hpnd
+      hpndSellVariant
+    ];
+    mainProgram = "ico";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libapplewm/package.nix
+++ b/pkgs/by-name/li/libapplewm/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  pkg-config,
+  autoreconfHook,
+  util-macros,
+  xorgproto,
+  libX11,
+  libXext,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libapplewm";
+  version = "1.4.1-unstable-2021-01-04";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "xorg/lib";
+    repo = "libapplewm";
+    rev = "be972ebc3a97292e7d2b2350eff55ae12df99a42";
+    hash = "sha256-NH9YeOEtnEupqpnsMLC21I+LmCOzT7KnfdzNNWqba/Y=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+    util-macros
+  ];
+
+  buildInputs = [
+    xorgproto
+    libX11
+    libXext
+  ];
+
+  passthru = {
+    # updateScript = # no updatescript since we don't use a tagged release (last one was 14 years ago)
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Xlib-based library for the Apple-WM extension";
+    longDescription = ''
+      AppleWM is a simple library designed to interface with the Apple-WM extension.
+      This extension allows X window managers to better interact with the Mac OS X Aqua user
+      interface when running X11 in a rootless mode.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libapplewm";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    pkgConfigModules = [ "applewm" ];
+    platforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/li/libdmx/package.nix
+++ b/pkgs/by-name/li/libdmx/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libdmx";
+  version = "1.1.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libdmx-${finalAttrs.version}.tar.xz";
+    hash = "sha256-NaTiaosLK0/jZEHcpGNkXD+lLSgqw1IFAaOOqULL908=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+  ];
+
+  configureFlags = lib.optional (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "--enable-malloc0returnsnull";
+
+  passthru = {
+    # updateScript = # libdmx it deprecated and thus needs no updatescript
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Xlib-based library for the DMX (Distributed Multihead X) extension";
+    longDescription = ''
+      This library allows X11 clients to use the Distributed Multihead X (DMX) Extension,
+      as previously implemented in the Xdmx server.
+      X.Org removed support for the Xdmx server from the xorg-server releases in the version 21
+      release in 2021. This library is thus now considered deprecated and the version 1.1.5 release
+      is the last release X.Org plans to make of libdmx.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libdmx";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    pkgConfigModules = [ "dmx" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libfontenc/package.nix
+++ b/pkgs/by-name/li/libfontenc/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  zlib,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libfontenc";
+  version = "1.1.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libfontenc-${finalAttrs.version}.tar.xz";
+    hash = "sha256-ewLD1AUjbg2GgGsd6daGj+YMMTYos4NQsDKRSqT9FMY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    zlib
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X font encoding library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libfontenc";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    pkgConfigModules = [ "fontenc" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libfs/package.nix
+++ b/pkgs/by-name/li/libfs/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  xtrans,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libfs";
+  version = "1.0.10";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libFS-${finalAttrs.version}.tar.xz";
+    hash = "sha256-m6u9PIYGnJhWPaBEBF/cDs5OwMk9zdLGiqdOs0tPO3c=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    xtrans
+  ];
+
+  configureFlags = lib.optional (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "--enable-malloc0returnsnull";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libFS \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X Font Service client library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libfs";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpndSellVariant
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "libfs" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -8,6 +8,7 @@
   ico,
   imake,
   libapplewm,
+  libdmx,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -39,6 +40,7 @@ self: with self; {
     gccmakedep
     ico
     imake
+    libdmx
     libpciaccess
     libxcb
     libxcvt
@@ -2883,44 +2885,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xxf86vm" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libdmx = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXext,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libdmx";
-      version = "1.1.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libdmx-1.1.5.tar.xz";
-        sha256 = "0kzprd1ak3m3042m5hra50nsagswciis9p21ckilyaqbidmf591m";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXext
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "dmx" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -10,6 +10,7 @@
   libapplewm,
   libdmx,
   libfontenc,
+  libfs,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -58,6 +59,7 @@ self: with self; {
   fontalias = font-alias;
   fontutil = font-util;
   libAppleWM = libapplewm;
+  libFS = libfs;
   libpthreadstubs = libpthread-stubs;
   libX11 = libx11;
   libXau = libxau;
@@ -1700,42 +1702,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libFS = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      xtrans,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libFS";
-      version = "1.0.10";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libFS-1.0.10.tar.xz";
-        sha256 = "0xrv9x5v6km7ib3d5k9xr704xkhfvigh8i507mb9i706hqybvawv";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        xtrans
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "libfs" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -9,6 +9,7 @@
   imake,
   libapplewm,
   libdmx,
+  libfontenc,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -41,6 +42,7 @@ self: with self; {
     ico
     imake
     libdmx
+    libfontenc
     libpciaccess
     libxcb
     libxcvt
@@ -2885,42 +2887,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xxf86vm" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libfontenc = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      zlib,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libfontenc";
-      version = "1.1.8";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libfontenc-1.1.8.tar.xz";
-        sha256 = "1ihlznj4m49jn1887cr86qqhrrlghvbfj7bbh230svi30pac60kv";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        zlib
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "fontenc" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -7,6 +7,7 @@
   gccmakedep,
   ico,
   imake,
+  libapplewm,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -52,6 +53,7 @@ self: with self; {
     ;
   fontalias = font-alias;
   fontutil = font-util;
+  libAppleWM = libapplewm;
   libpthreadstubs = libpthread-stubs;
   libX11 = libx11;
   libXau = libxau;
@@ -1694,44 +1696,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libAppleWM = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXext,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libAppleWM";
-      version = "be972ebc3a97292e7d2b2350eff55ae12df99a42";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "https://gitlab.freedesktop.org/xorg/lib/libAppleWM/-/archive/be972ebc3a97292e7d2b2350eff55ae12df99a42/libAppleWM-be972ebc3a97292e7d2b2350eff55ae12df99a42.tar.bz2";
-        sha256 = "1hrq03pahmrbb05r6a7j7m1nxl65wlfi6d2lwm1kvra63q91f9ph";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXext
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "applewm" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -5,6 +5,7 @@
   font-alias,
   font-util,
   gccmakedep,
+  ico,
   imake,
   libpciaccess,
   libpthread-stubs,
@@ -35,6 +36,7 @@ self: with self; {
   inherit
     bdftopcf
     gccmakedep
+    ico
     imake
     libpciaccess
     libxcb
@@ -1687,42 +1689,6 @@ self: with self; {
       nativeBuildInputs = [ pkg-config ];
       buildInputs = [
         libICE
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  ico = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "ico";
-      version = "1.0.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/ico-1.0.6.tar.xz";
-        sha256 = "01a4kykayckxzi4jzggaz3wh9qjcr6f4iykhvq7jhlz767a6kwrq";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
         xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -37,6 +37,7 @@ $pcMap{"GL"} = "libGL";
 $pcMap{"gbm"} = "libgbm";
 $pcMap{"hwdata"} = "hwdata";
 $pcMap{"dmx"} = "libdmx";
+$pcMap{"fontenc"} = "libfontenc";
 $pcMap{"fontutil"} = "fontutil";
 $pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"pthread-stubs"} = "libpthreadstubs";
@@ -295,6 +296,7 @@ print OUT <<EOF;
   imake,
   libapplewm,
   libdmx,
+  libfontenc,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -327,6 +329,7 @@ self: with self; {
     ico
     imake
     libdmx
+    libfontenc
     libpciaccess
     libxcb
     libxcvt

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -290,6 +290,7 @@ print OUT <<EOF;
   font-alias,
   font-util,
   gccmakedep,
+  ico,
   imake,
   libpciaccess,
   libpthread-stubs,
@@ -320,6 +321,7 @@ self: with self; {
   inherit
     bdftopcf
     gccmakedep
+    ico
     imake
     libpciaccess
     libxcb

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -36,6 +36,7 @@ $pcMap{"gl"} = "libGL";
 $pcMap{"GL"} = "libGL";
 $pcMap{"gbm"} = "libgbm";
 $pcMap{"hwdata"} = "hwdata";
+$pcMap{"dmx"} = "libdmx";
 $pcMap{"fontutil"} = "fontutil";
 $pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"pthread-stubs"} = "libpthreadstubs";
@@ -293,6 +294,7 @@ print OUT <<EOF;
   ico,
   imake,
   libapplewm,
+  libdmx,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -324,6 +326,7 @@ self: with self; {
     gccmakedep
     ico
     imake
+    libdmx
     libpciaccess
     libxcb
     libxcvt

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -292,6 +292,7 @@ print OUT <<EOF;
   gccmakedep,
   ico,
   imake,
+  libapplewm,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -337,6 +338,7 @@ self: with self; {
     ;
   fontalias = font-alias;
   fontutil = font-util;
+  libAppleWM = libapplewm;
   libpthreadstubs = libpthread-stubs;
   libX11 = libx11;
   libXau = libxau;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -39,6 +39,7 @@ $pcMap{"hwdata"} = "hwdata";
 $pcMap{"dmx"} = "libdmx";
 $pcMap{"fontenc"} = "libfontenc";
 $pcMap{"fontutil"} = "fontutil";
+$pcMap{"libfs"} = "libFS";
 $pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"pthread-stubs"} = "libpthreadstubs";
 $pcMap{"x11"} = "libX11";
@@ -297,6 +298,7 @@ print OUT <<EOF;
   libapplewm,
   libdmx,
   libfontenc,
+  libfs,
   libpciaccess,
   libpthread-stubs,
   libx11,
@@ -345,6 +347,7 @@ self: with self; {
   fontalias = font-alias;
   fontutil = font-util;
   libAppleWM = libapplewm;
+  libFS = libfs;
   libpthreadstubs = libpthread-stubs;
   libX11 = libx11;
   libXau = libxau;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -147,7 +147,6 @@ self: super:
   });
 
   iceauth = addMainProgram super.iceauth { };
-  ico = addMainProgram super.ico { };
 
   mkfontdir = xorg.mkfontscale;
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -150,16 +150,6 @@ self: super:
 
   mkfontdir = xorg.mkfontscale;
 
-  libAppleWM = super.libAppleWM.overrideAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [
-      autoreconfHook
-      xorg.utilmacros
-    ];
-    meta = attrs.meta // {
-      platforms = lib.platforms.darwin;
-    };
-  });
-
   libXtst = super.libXtst.overrideAttrs (attrs: {
     meta = attrs.meta // {
       pkgConfigModules = [ "xtst" ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -179,9 +179,6 @@ self: super:
   libXxf86misc = super.libXxf86misc.overrideAttrs (attrs: {
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
   });
-  libdmx = super.libdmx.overrideAttrs (attrs: {
-    configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
-  });
   libFS = super.libFS.overrideAttrs (attrs: {
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
   });

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -179,9 +179,6 @@ self: super:
   libXxf86misc = super.libXxf86misc.overrideAttrs (attrs: {
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
   });
-  libFS = super.libFS.overrideAttrs (attrs: {
-    configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
-  });
   libWindowsWM = super.libWindowsWM.overrideAttrs (attrs: {
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
   });

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -153,7 +153,6 @@ mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
-mirror://xorg/individual/lib/libFS-1.0.10.tar.xz
 mirror://xorg/individual/lib/libICE-1.1.2.tar.xz
 mirror://xorg/individual/lib/libSM-1.2.6.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -153,7 +153,6 @@ mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
-https://gitlab.freedesktop.org/xorg/lib/libAppleWM/-/archive/be972ebc3a97292e7d2b2350eff55ae12df99a42/libAppleWM-be972ebc3a97292e7d2b2350eff55ae12df99a42.tar.bz2
 mirror://xorg/individual/lib/libdmx-1.1.5.tar.xz
 mirror://xorg/individual/lib/libfontenc-1.1.8.tar.xz
 mirror://xorg/individual/lib/libFS-1.0.10.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -153,7 +153,6 @@ mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
-mirror://xorg/individual/lib/libfontenc-1.1.8.tar.xz
 mirror://xorg/individual/lib/libFS-1.0.10.tar.xz
 mirror://xorg/individual/lib/libICE-1.1.2.tar.xz
 mirror://xorg/individual/lib/libSM-1.2.6.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -153,7 +153,6 @@ mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
-mirror://xorg/individual/lib/libdmx-1.1.5.tar.xz
 mirror://xorg/individual/lib/libfontenc-1.1.8.tar.xz
 mirror://xorg/individual/lib/libFS-1.0.10.tar.xz
 mirror://xorg/individual/lib/libICE-1.1.2.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -9,7 +9,6 @@ mirror://xorg/individual/app/bitmap-1.1.1.tar.xz
 mirror://xorg/individual/app/editres-1.0.9.tar.xz
 mirror://xorg/individual/app/fonttosfnt-1.2.4.tar.xz
 mirror://xorg/individual/app/iceauth-1.0.10.tar.xz
-mirror://xorg/individual/app/ico-1.0.6.tar.xz
 mirror://xorg/individual/app/listres-1.0.6.tar.xz
 mirror://xorg/individual/app/mkfontscale-1.2.3.tar.xz
 mirror://xorg/individual/app/oclock-1.0.6.tar.xz


### PR DESCRIPTION
my plan is to migrate all packages from xorg to pkgs/by-name
in this iteration i will make several PRs that should be able to get merged separately without merge conflicts
it looks like chunks of 5 packages seem ok small chunks

this is the script i use to get the packages that don't depend on other xorg packages:
```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      # && !lib.hasPrefix "xf86" n
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;
in
pkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (
  x: y: x.count < y.count || (x.count == y.count && (lib.toLower x.name) > (lib.toLower y.name))
)
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:
```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
