### PR TITLE
libx{v,fixes,render,cursor,randr}: refactor, migrate to pkgs/by-name and rename from xorg namespace

### DIFF
--- a/pkgs/by-name/li/libxcursor/package.nix
+++ b/pkgs/by-name/li/libxcursor/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxfixes,
+  libxrender,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxcursor";
+  version = "1.2.3";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXcursor-${finalAttrs.version}.tar.xz";
+    hash = "sha256-/elALdTP552nHi2Wu5gK/F5v9Pin10wVnhlmr7KywsA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxfixes
+    libxrender
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXcursor \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X11 Cursor management library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcursor";
+    license = lib.licenses.hpndSellVariant;
+    maintainers = [ ];
+    pkgConfigModules = [ "xcursor" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxfixes/package.nix
+++ b/pkgs/by-name/li/libxfixes/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libX11,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxfixes";
+  version = "6.0.1";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXfixes-${finalAttrs.version}.tar.xz";
+    hash = "sha256-tpX5PNJJlCGrAtInREWOZQzMiMHUyBMNYCACE6vALVg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libX11
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXfixes \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Xlib-based library for the XFIXES Extension";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxfixes";
+    license = with lib.licenses; [
+      hpndSellVariant
+      mit
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xfixes" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxrandr/package.nix
+++ b/pkgs/by-name/li/libxrandr/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  libxext,
+  libxrender,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxrandr";
+  version = "1.5.4";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXrandr-${finalAttrs.version}.tar.xz";
+    hash = "sha256-GtWwZTdfSoWRWqYGEcxkB8BgSSohTX+dryFL51LDtNM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxext
+    libxrender
+  ];
+
+  propagatedBuildInputs = [ libxrender ];
+
+  configureFlags = lib.optional (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "--enable-malloc0returnsnull";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXrandr \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Xlib Resize, Rotate and Reflection (RandR) extension library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxrandr";
+    license = lib.licenses.hpndSellVariant;
+    maintainers = [ ];
+    pkgConfigModules = [ "xrandr" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxrender/package.nix
+++ b/pkgs/by-name/li/libxrender/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libx11,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxrender";
+  version = "0.9.12";
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXrender-${finalAttrs.version}.tar.xz";
+    hash = "sha256-uDISjaSLOcjWCCJEgXQ0A60Wkb9OVU5L6cF03xcdG5c=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+  ];
+
+  propagatedBuildInputs = [ xorgproto ];
+
+  configureFlags = lib.optional (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "--enable-malloc0returnsnull";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXrender \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Xlib library for the Render Extension to the X11 protocol";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxrender";
+    license = lib.licenses.hpndSellVariant;
+    maintainers = [ ];
+    pkgConfigModules = [ "xrender" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxv/package.nix
+++ b/pkgs/by-name/li/libxv/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  libX11,
+  libXext,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxv";
+  version = "1.0.13";
+
+  outputs = [
+    "out"
+    "dev"
+    "devdoc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXv-${finalAttrs.version}.tar.xz";
+    hash = "sha256-fTSRCVjhwfjRk9go/qG32hkilygKNUN68GkvADugN1U=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libX11
+    libXext
+  ];
+
+  configureFlags = lib.optional (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "--enable-malloc0returnsnull";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXv \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Xlib-based library for the X Video (Xv) extension to the X Window System";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxv";
+    license = with lib.licenses; [
+      hpnd
+      hpndSellVariant
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xv" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -14,6 +14,7 @@
   libxcvt,
   libxdmcp,
   libxext,
+  libxfixes,
   libxv,
   lndir,
   luit,
@@ -56,6 +57,7 @@ self: with self; {
   libXau = libxau;
   libXdmcp = libxdmcp;
   libXext = libxext;
+  libXfixes = libxfixes;
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
@@ -2157,42 +2159,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xdamage" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXfixes = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXfixes";
-      version = "6.0.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXfixes-6.0.1.tar.xz";
-        sha256 = "0n1dq2mi60i0c06i7j6lq64cq335ir2l89yj0amj3529s8ygk5dn";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xfixes" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -12,6 +12,7 @@
   libxau,
   libxcb,
   libxcvt,
+  libxcursor,
   libxdmcp,
   libxext,
   libxfixes,
@@ -56,6 +57,7 @@ self: with self; {
   libpthreadstubs = libpthread-stubs;
   libX11 = libx11;
   libXau = libxau;
+  libXcursor = libxcursor;
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
@@ -2083,46 +2085,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xcomposite" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXcursor = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXfixes,
-      libXrender,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXcursor";
-      version = "1.2.3";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXcursor-1.2.3.tar.xz";
-        sha256 = "1h62narayrhrkqalrmx7z3s6yppw1acbp5id3skrvrygshnl1sgx";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXfixes
-        libXrender
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xcursor" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -14,6 +14,7 @@
   libxcvt,
   libxdmcp,
   libxext,
+  libxv,
   lndir,
   luit,
   makedepend,
@@ -55,6 +56,7 @@ self: with self; {
   libXau = libxau;
   libXdmcp = libxdmcp;
   libXext = libxext;
+  libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;
@@ -2758,44 +2760,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtst" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXv = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXext,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXv";
-      version = "1.0.13";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXv-1.0.13.tar.xz";
-        sha256 = "0m9pl0xh0bv9y1x46d8a52bj46fsnyhzwa6qjg8zihg1b04r2d3x";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXext
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xv" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -15,6 +15,7 @@
   libxdmcp,
   libxext,
   libxfixes,
+  libxrender,
   libxv,
   lndir,
   luit,
@@ -58,6 +59,7 @@ self: with self; {
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
+  libXrender = libxrender;
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
@@ -2572,42 +2574,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xrandr" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXrender = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXrender";
-      version = "0.9.12";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXrender-0.9.12.tar.xz";
-        sha256 = "15qv3lbxyx61x55lwmafpy8idb836is82i1213bchfcblj6i4cmq";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xrender" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -16,6 +16,7 @@
   libxdmcp,
   libxext,
   libxfixes,
+  libxrandr,
   libxrender,
   libxv,
   lndir,
@@ -61,6 +62,7 @@ self: with self; {
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
+  libXrandr = libxrandr;
   libXrender = libxrender;
   libXv = libxv;
   utilmacros = util-macros;
@@ -2496,46 +2498,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xpresent" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXrandr = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libX11,
-      libXext,
-      libXrender,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXrandr";
-      version = "1.5.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXrandr-1.5.4.tar.xz";
-        sha256 = "1lxlqd9ffjr1myfpyk91594n1h07ck6121m6ba8qajjz6xjv1m8s";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libX11
-        libXext
-        libXrender
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xrandr" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -47,6 +47,7 @@ $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
 $pcMap{"xfixes"} = "libXfixes";
+$pcMap{"xrender"} = "libXrender";
 $pcMap{"xtrans"} = "xtrans";
 $pcMap{"xv"} = "libXv";
 $pcMap{"\$PIXMAN"} = "pixman";
@@ -302,6 +303,7 @@ print OUT <<EOF;
   libxdmcp,
   libxext,
   libxfixes,
+  libxrender,
   libxv,
   lndir,
   luit,
@@ -345,6 +347,7 @@ self: with self; {
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
+  libXrender = libxrender;
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -47,6 +47,7 @@ $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
 $pcMap{"xtrans"} = "xtrans";
+$pcMap{"xv"} = "libXv";
 $pcMap{"\$PIXMAN"} = "pixman";
 $pcMap{"\$RENDERPROTO"} = "xorgproto";
 $pcMap{"\$DRI3PROTO"} = "xorgproto";
@@ -299,6 +300,7 @@ print OUT <<EOF;
   libxcvt,
   libxdmcp,
   libxext,
+  libxv,
   lndir,
   luit,
   makedepend,
@@ -340,6 +342,7 @@ self: with self; {
   libXau = libxau;
   libXdmcp = libxdmcp;
   libXext = libxext;
+  libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -46,6 +46,7 @@ $pcMap{"xbitmaps"} = "xbitmaps";
 $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
+$pcMap{"xfixes"} = "libXfixes";
 $pcMap{"xtrans"} = "xtrans";
 $pcMap{"xv"} = "libXv";
 $pcMap{"\$PIXMAN"} = "pixman";
@@ -300,6 +301,7 @@ print OUT <<EOF;
   libxcvt,
   libxdmcp,
   libxext,
+  libxfixes,
   libxv,
   lndir,
   luit,
@@ -342,6 +344,7 @@ self: with self; {
   libXau = libxau;
   libXdmcp = libxdmcp;
   libXext = libxext;
+  libXfixes = libxfixes;
   libXv = libxv;
   utilmacros = util-macros;
   xcbproto = xcb-proto;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -48,6 +48,7 @@ $pcMap{"xcursor"} = "libXcursor";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
 $pcMap{"xfixes"} = "libXfixes";
+$pcMap{"xrandr"} = "libXrandr";
 $pcMap{"xrender"} = "libXrender";
 $pcMap{"xtrans"} = "xtrans";
 $pcMap{"xv"} = "libXv";
@@ -305,6 +306,7 @@ print OUT <<EOF;
   libxdmcp,
   libxext,
   libxfixes,
+  libxrandr,
   libxrender,
   libxv,
   lndir,
@@ -350,6 +352,7 @@ self: with self; {
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;
+  libXrandr = libxrandr;
   libXrender = libxrender;
   libXv = libxv;
   utilmacros = util-macros;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -44,6 +44,7 @@ $pcMap{"x11-xcb"} = "libX11";
 $pcMap{"xau"} = "libXau";
 $pcMap{"xbitmaps"} = "xbitmaps";
 $pcMap{"xcb-proto"} = "xcbproto";
+$pcMap{"xcursor"} = "libXcursor";
 $pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xext"} = "libXext";
 $pcMap{"xfixes"} = "libXfixes";
@@ -300,6 +301,7 @@ print OUT <<EOF;
   libxau,
   libxcb,
   libxcvt,
+  libxcursor,
   libxdmcp,
   libxext,
   libxfixes,
@@ -344,6 +346,7 @@ self: with self; {
   libpthreadstubs = libpthread-stubs;
   libX11 = libx11;
   libXau = libxau;
+  libXcursor = libxcursor;
   libXdmcp = libxdmcp;
   libXext = libxext;
   libXfixes = libxfixes;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -316,13 +316,6 @@ self: super:
     };
   });
 
-  libXfixes = super.libXfixes.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-  });
-
   libXi = super.libXi.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -281,13 +281,6 @@ self: super:
     propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.libXmu ];
   });
 
-  libXcursor = super.libXcursor.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-  });
-
   libXdamage = super.libXdamage.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -344,15 +344,6 @@ self: super:
     buildFlags = [ "BITMAP_DEFINES='-DBITMAPDIR=\"/no-such-path\"'" ];
   });
 
-  libXrandr = super.libXrandr.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-    configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.libXrender ];
-  });
-
   libSM = super.libSM.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -404,15 +404,6 @@ self: super:
     configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
   });
 
-  libXv = super.libXv.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "devdoc"
-    ];
-    configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
-  });
-
   libXvMC = super.libXvMC.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -372,16 +372,6 @@ self: super:
     ];
   });
 
-  libXrender = super.libXrender.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "doc"
-    ];
-    configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.xorgproto ];
-  });
-
   libXres = super.libXres.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -184,7 +184,6 @@ mirror://xorg/individual/lib/libxshmfence-1.3.3.tar.xz
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libXt-1.3.1.tar.xz
 mirror://xorg/individual/lib/libXtst-1.2.5.tar.xz
-mirror://xorg/individual/lib/libXv-1.0.13.tar.xz
 mirror://xorg/individual/lib/libXvMC-1.0.14.tar.xz
 mirror://xorg/individual/lib/libXxf86dga-1.1.6.tar.xz
 mirror://xorg/individual/lib/libXxf86misc-1.0.4.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -176,7 +176,6 @@ mirror://xorg/individual/lib/libXp-1.0.4.tar.xz
 mirror://xorg/individual/lib/libXpm-3.5.17.tar.xz
 mirror://xorg/individual/lib/libXpresent-1.0.1.tar.xz
 mirror://xorg/individual/lib/libXrandr-1.5.4.tar.xz
-mirror://xorg/individual/lib/libXrender-0.9.12.tar.xz
 mirror://xorg/individual/lib/libXres-1.2.2.tar.xz
 mirror://xorg/individual/lib/libXScrnSaver-1.2.4.tar.xz
 mirror://xorg/individual/lib/libxshmfence-1.3.3.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -165,7 +165,6 @@ mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz
 mirror://xorg/individual/lib/libXcursor-1.2.3.tar.xz
 mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz
-mirror://xorg/individual/lib/libXfixes-6.0.1.tar.xz
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
 mirror://xorg/individual/lib/libXfont2-2.0.7.tar.xz
 mirror://xorg/individual/lib/libXft-2.3.9.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -174,7 +174,6 @@ mirror://xorg/individual/lib/libXmu-1.2.1.tar.xz
 mirror://xorg/individual/lib/libXp-1.0.4.tar.xz
 mirror://xorg/individual/lib/libXpm-3.5.17.tar.xz
 mirror://xorg/individual/lib/libXpresent-1.0.1.tar.xz
-mirror://xorg/individual/lib/libXrandr-1.5.4.tar.xz
 mirror://xorg/individual/lib/libXres-1.2.2.tar.xz
 mirror://xorg/individual/lib/libXScrnSaver-1.2.4.tar.xz
 mirror://xorg/individual/lib/libxshmfence-1.3.3.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -163,7 +163,6 @@ mirror://xorg/individual/lib/libSM-1.2.6.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz
-mirror://xorg/individual/lib/libXcursor-1.2.3.tar.xz
 mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
 mirror://xorg/individual/lib/libXfont2-2.0.7.tar.xz


### PR DESCRIPTION
my plan is to migrate all packages from xorg to pkgs/by-name
in this iteration there are several PRs with one or more packages that should be able to get merged independently

this is the script i use to get the packages that don't depend on other xorg packages:
```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      # && !lib.hasPrefix "xf86" n
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;
in
pkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (x: y: x.count < y.count || (x.count == y.count && x.name > y.name))
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
