### PR TITLE
nixos/kutt: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6933,6 +6933,13 @@
     githubId = 757125;
     name = "Dzmitry Lahoda";
   };
+  e0 = {
+    email = "eliasoderso@riseup.net";
+    github = "e042";
+    githubId = 63226814;
+    name = "Elias";
+    keys = [ { fingerprint = "30E3 E009 E114 F95D F122 CD82 7AF8 8AB3 823A 5856"; } ];
+  };
   e1mo = {
     email = "nixpkgs@e1mo.de";
     matrix = "@e1mo:chaos.jetzt";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1587,6 +1587,7 @@
   ./services/web-apps/keycloak.nix
   ./services/web-apps/kimai.nix
   ./services/web-apps/komga.nix
+  ./services/web-apps/kutt.nix
   ./services/web-apps/lanraragi.nix
   ./services/web-apps/lasuite-docs.nix
   ./services/web-apps/lemmy.nix

--- a/nixos/modules/services/web-apps/kutt.nix
+++ b/nixos/modules/services/web-apps/kutt.nix
@@ -42,12 +42,6 @@ in
       enable = mkEnableOption "Kutt, a free modern URL shortener";
 
       package = mkPackageOption pkgs "kutt" { };
-      nodePackage = mkOption {
-        type = types.package;
-        default = pkgs.nodejs_22;
-        defaultText = literalExpression "pkgs.nodejs_24";
-        description = "Node.js package to use.";
-      };
 
       environmentFile = mkOption {
         type = types.path;
@@ -131,8 +125,8 @@ in
       wants = [ "postgresql.service" ];
       wantedBy = [ "multi-user.target" ];
 
-      preStart = "${cfg.package}/lib/node_modules/kutt/node_modules/.bin/knex migrate:latest";
-      script = "${cfg.nodePackage}/bin/node server/server.js --production";
+      preStart = "${cfg.package}/bin/kutt-knex migrate:latest";
+      script = "${cfg.package}/bin/kutt --production";
 
       environment = settings;
 
@@ -140,7 +134,6 @@ in
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
-        WorkingDirectory = "${cfg.package}/lib/node_modules/kutt";
         EnvironmentFile = cfg.environmentFile;
         Restart = "always";
 

--- a/nixos/modules/services/web-apps/kutt.nix
+++ b/nixos/modules/services/web-apps/kutt.nix
@@ -1,0 +1,203 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.kutt;
+  kutt = pkgs.buildNpmPackage (finalAttrs: {
+    pname = "kutt";
+    version = "3.2.3";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "thedevs-network";
+      repo = "kutt";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-mBfwgSTyE8qGdPLrR0w9yBgs/KL+rJ/EmepHJMpGF6Y=";
+    };
+
+    npmDepsHash = "sha256-6TCPP8CNcDfVYFt0/dkL/TZ/H2ATJJDCbx8LiGCEvsc=";
+
+    dontNpmBuild = true;
+    npmPackFlags = [ "--ignore-scripts" ];
+
+    meta = {
+      description = "Free Modern URL Shortener.";
+      homepage = "https://kutt.it";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ e0 ];
+    };
+  });
+
+  settings = lib.mkMerge ([
+    cfg.settings
+    (lib.optionalAttrs cfg.configureRedis {
+      REDIS_ENABLED = "true";
+    })
+    (lib.optionalAttrs cfg.configureNginx {
+      TRUST_PROXY = "true";
+    })
+    (lib.optionalAttrs cfg.configurePostgres {
+      DB_CLIENT = "pg";
+      DB_HOST = "/run/postgresql";
+      DB_NAME = cfg.user;
+      DB_USER = cfg.user;
+    })
+  ]);
+
+in
+{
+  options.services.kutt =
+    let
+      inherit (lib)
+        mkEnableOption
+        mkOption
+        types
+        literalExpression
+        ;
+    in
+    {
+      enable = mkEnableOption "Kutt, a free modern URL shortener";
+
+      nodePackage = mkOption {
+        type = types.package;
+        default = pkgs.nodejs_24;
+        defaultText = literalExpression "pkgs.nodejs_24";
+        description = "Node.js package to use.";
+      };
+
+      environmentFile = mkOption {
+        type = types.path;
+        default = null;
+        description = "Environment file for configuration of Kutt. Add your JWT_SECRET here.";
+      };
+
+      environment = mkOption {
+        type = with types; attrsOf types.str;
+        default = { };
+        description = "Environment variables for Kutt.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "kutt";
+        description = "User account under which the Kutt service runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "kutt";
+        description = "Group account under which the Kutt service runs.";
+      };
+
+      configureRedis = mkEnableOption "Whether to configure kutt to use the a local redis server";
+      configurePostgres = mkEnableOption "Whether to configure kutt to use the the local postgresql server";
+      configureNginx = mkEnableOption "Whether to configure kutt to use nginx as reverse proxy";
+
+      settings = mkOption {
+        type = with types; attrsOf str;
+        default = { };
+        example = {
+          PORT = "3000";
+          SITE_NAME = "Kutt";
+          DEFAULT_DOMAIN = "kutt.example.org";
+          LINK_LENGTH = "6";
+        };
+        description = "Configuration for Kutt, see <https://github.com/thedevs-network/kutt?tab=readme-ov-file#configuration>";
+      };
+    };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+    };
+
+    users.groups.${cfg.group} = { };
+
+    services.kutt.settings = with lib; {
+      PORT = mkDefault "3000";
+      SITE_NAME = mkDefault "Kutt";
+      DEFAULT_DOMAIN = mkDefault "kutt.example.org";
+      LINK_LENGTH = mkDefault "6";
+    };
+
+    systemd.services.kutt = {
+      description = "Kutt URL Shortener Service";
+      after = [
+        "network.target"
+        "postgresql.service"
+      ];
+      wants = [ "postgresql.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = "${kutt}/lib/node_modules/kutt/node_modules/.bin/knex migrate:latest";
+      script = "${cfg.nodePackage}/bin/node server/server.js --production";
+
+      environment = settings;
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = "${kutt}/lib/node_modules/kutt";
+        EnvironmentFile = cfg.environmentFile;
+        Restart = "always";
+
+        # Hardening
+        CapabilityBoundingSet = [ "" ];
+        DevicePolicy = "closed";
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+        MemoryDenyWriteExecute = "off";
+        NoNewPrivileges = true;
+        LockPersonality = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+      };
+    };
+
+    services.redis.servers.kutt = lib.mkIf cfg.configureRedis {
+      enable = true;
+      user = cfg.user;
+    };
+
+    services.postgresql = lib.mkIf cfg.configurePostgres {
+      enable = true;
+      ensureUsers = lib.singleton {
+        name = cfg.user;
+        ensureDBOwnership = true;
+      };
+      ensureDatabases = [ cfg.user ];
+    };
+
+    services.nginx.virtualHosts."${cfg.settings.DEFAULT_DOMAIN}" = lib.mkIf cfg.configureNginx {
+      locations."/" = {
+        proxyPass = "http://127.0.0.1:${toString cfg.settings.PORT}";
+        recommendedProxySettings = true;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/ku/kutt/package.nix
+++ b/pkgs/by-name/ku/kutt/package.nix
@@ -2,10 +2,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   lib,
-  pkg-config,
-  python3,
-  stdenv,
-  nodejs_22,
+  pkgs,
 }:
 buildNpmPackage (finalAttrs: {
   pname = "kutt";
@@ -23,10 +20,16 @@ buildNpmPackage (finalAttrs: {
   dontNpmBuild = true;
   npmPackFlags = [ "--ignore-scripts" ];
 
+  postInstall = ''
+    makeWrapper ${pkgs.nodejs_22}/bin/node $out/bin/kutt --chdir $out/lib/node_modules/kutt --add-flag server/server.js
+    makeWrapper $out/lib/node_modules/kutt/node_modules/.bin/knex $out/bin/kutt-knex --chdir $out/lib/node_modules/kutt
+  '';
+
   meta = {
     description = "Free modern URL shortener";
     homepage = "https://kutt.it";
     license = lib.licenses.mit;
+    mainProgram = "kutt";
     maintainers = with lib.maintainers; [ e0 ];
   };
 })

--- a/pkgs/by-name/ku/kutt/package.nix
+++ b/pkgs/by-name/ku/kutt/package.nix
@@ -1,0 +1,32 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  pkg-config,
+  python3,
+  stdenv,
+  nodejs_22,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "kutt";
+  version = "3.2.3";
+
+  src = fetchFromGitHub {
+    owner = "thedevs-network";
+    repo = "kutt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mBfwgSTyE8qGdPLrR0w9yBgs/KL+rJ/EmepHJMpGF6Y=";
+  };
+
+  npmDepsHash = "sha256-6TCPP8CNcDfVYFt0/dkL/TZ/H2ATJJDCbx8LiGCEvsc=";
+
+  dontNpmBuild = true;
+  npmPackFlags = [ "--ignore-scripts" ];
+
+  meta = {
+    description = "Free modern URL shortener";
+    homepage = "https://kutt.it";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ e0 ];
+  };
+})

--- a/pkgs/by-name/ku/kutt/package.nix
+++ b/pkgs/by-name/ku/kutt/package.nix
@@ -21,8 +21,12 @@ buildNpmPackage (finalAttrs: {
   npmPackFlags = [ "--ignore-scripts" ];
 
   postInstall = ''
-    makeWrapper ${pkgs.nodejs_22}/bin/node $out/bin/kutt --chdir $out/lib/node_modules/kutt --add-flag server/server.js
-    makeWrapper $out/lib/node_modules/kutt/node_modules/.bin/knex $out/bin/kutt-knex --chdir $out/lib/node_modules/kutt
+    makeWrapper ${lib.getExe pkgs.nodejs} $out/bin/kutt \
+      --chdir $out/lib/node_modules/kutt \
+      --add-flag server/server.js
+
+    makeWrapper $out/lib/node_modules/kutt/node_modules/.bin/knex $out/bin/kutt-knex \
+      --chdir $out/lib/node_modules/kutt
   '';
 
   meta = {


### PR DESCRIPTION
This PR adds a nixos module for [Kutt](https://github.com/thedevs-network/kutt), an open source, MIT licensed link shortener. It is actively maintained and has an active community.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
