### PR TITLE
[25.05] kanidm-provision: 1.2.1 -> 1.3.0

### DIFF
--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -465,6 +465,17 @@ in
                 apply = unique;
                 default = [ ];
               };
+
+              overwriteMembers = mkOption {
+                description = ''
+                  Whether the member list should be overwritten each time (true) or appended
+                  (false). Append mode allows interactive group management in addition to the
+                  declared members. Also, future member removals cannot be reflected
+                  automatically in append mode.
+                '';
+                type = types.bool;
+                default = true;
+              };
             };
             config.members = concatLists (
               flip mapAttrsToList cfg.provision.persons (

--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -74,6 +74,10 @@ import ./make-test-python.nix (
               };
 
               groups.testgroup1 = { };
+              groups.imperative = {
+                overwriteMembers = false;
+                members = [ "testuser1" ];
+              };
 
               persons.testuser1 = {
                 displayName = "Test User";
@@ -134,6 +138,11 @@ import ./make-test-python.nix (
               };
 
               groups.testgroup1 = { };
+              groups.imperative = {
+                overwriteMembers = false;
+                # Will be retained:
+                # members = [ "testuser1" ];
+              };
 
               persons.testuser1 = {
                 displayName = "Test User (changed)";
@@ -329,6 +338,10 @@ import ./make-test-python.nix (
             out = provision.succeed("kanidm group get testgroup1")
             assert_contains(out, "name: testgroup1")
 
+            out = provision.succeed("kanidm group get imperative")
+            assert_contains(out, "name: imperative")
+            assert_contains(out, "member: testuser1")
+
             out = provision.succeed("kanidm group get supergroup1")
             assert_contains(out, "name: supergroup1")
             assert_contains(out, "member: testgroup1")
@@ -339,6 +352,7 @@ import ./make-test-python.nix (
             assert_contains(out, "legalname: Jane Doe")
             assert_contains(out, "mail: jane.doe@example.com")
             assert_contains(out, "memberof: testgroup1")
+            assert_contains(out, "memberof: imperative")
             assert_contains(out, "memberof: service1-access")
 
             out = provision.succeed("kanidm person get testuser2")
@@ -383,6 +397,10 @@ import ./make-test-python.nix (
             out = provision.succeed("kanidm group get testgroup1")
             assert_contains(out, "name: testgroup1")
 
+            out = provision.succeed("kanidm group get imperative")
+            assert_contains(out, "name: imperative")
+            assert_contains(out, "member: testuser1")
+
             out = provision.succeed("kanidm group get supergroup1")
             assert_contains(out, "name: supergroup1")
             assert_lacks(out, "member: testgroup1")
@@ -394,6 +412,7 @@ import ./make-test-python.nix (
             assert_contains(out, "mail: jane.doe@example.com")
             assert_contains(out, "mail: second.doe@example.com")
             assert_lacks(out, "memberof: testgroup1")
+            assert_contains(out, "memberof: imperative")
             assert_contains(out, "memberof: service1-access")
 
             out = provision.succeed("kanidm person get testuser2")

--- a/pkgs/by-name/ka/kanidm-provision/package.nix
+++ b/pkgs/by-name/ka/kanidm-provision/package.nix
@@ -2,7 +2,6 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  yq,
   versionCheckHook,
   nix-update-script,
   nixosTests,
@@ -10,25 +9,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kanidm-provision";
-  version = "1.2.1";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "oddlama";
     repo = "kanidm-provision";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kwxGrLz59Zk8PSsfQzPUeA/xWQZrV1NWlS5/yuqfIyI=";
+    hash = "sha256-m3bF4wFPVRc2E+E/pZc3js9T4rYbTejo/FFpysytWKw=";
   };
 
-  postPatch = ''
-    tomlq -ti '.package.version = "${finalAttrs.version}"' Cargo.toml
-  '';
-
   useFetchCargoVendor = true;
-  cargoHash = "sha256-uo/TGyfNChq/t6Dah0HhXhAwktyQk0V/wewezZuftNk=";
-
-  nativeBuildInputs = [
-    yq # for `tomlq`
-  ];
+  cargoHash = "sha256-dPTrIc/hTbMlFDXYMk/dTjqaNECazldfW43egDOwyLM=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";


### PR DESCRIPTION
Backport of #414697

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
