### PR TITLE
Add Lute and Python module dependencies

### DIFF
--- a/pkgs/by-name/lu/lute3/package.nix
+++ b/pkgs/by-name/lu/lute3/package.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  fetchPypi,
+  japaneseSupport ? true,
+  mecab,
+}:
+let
+  version = "3.10.1";
+  python = python3.override {
+    packageOverrides = after: before: {
+      platformdirs = before.platformdirs.overridePythonAttrs (
+        oldAttrs:
+        let
+          version = "3.11.0";
+        in
+        {
+          inherit version;
+          src = fetchFromGitHub {
+            owner = "platformdirs";
+            repo = "platformdirs";
+            tag = version;
+            hash = "sha256-E3qwAczUzJOYO4IDul9uO6K6wowOtYpQ7Q76TA+lIho=";
+          };
+        }
+      );
+
+      waitress = before.waitress.overridePythonAttrs (
+        oldAttrs:
+        let
+          version = "2.1.2";
+        in
+        {
+          inherit version;
+          src = fetchPypi {
+            inherit version;
+            pname = "waitress";
+            hash = "sha256-eApAgsX7wP3movz+Xibm78Ho9CVzCGPAQIV2l4H1Hro=";
+          };
+        }
+      );
+    };
+  };
+  python3Packages = python.pkgs;
+  src = fetchFromGitHub {
+    owner = "LuteOrg";
+    repo = "lute-v3";
+    tag = version;
+    hash = "sha256-ZeMXFky/MBW/nce+aUDYerh/9LHBDjl/Eh4f/4obXs8=";
+    fetchSubmodules = true;
+    # Rewrite the submodule's SSH URL so the fetcher can resolve it in the sandbox.
+    preFetch = ''
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+  };
+in
+python3Packages.buildPythonApplication {
+  inherit src version;
+  pname = "lute3";
+  pyproject = true;
+
+  build-system = [ python3Packages.flit-core ];
+
+  dependencies = [
+    python3Packages.flask-sqlalchemy
+    python3Packages.flask-wtf
+    python3Packages.natto-py
+    python3Packages.jaconv
+    python3Packages.platformdirs
+    python3Packages.beautifulsoup4
+    python3Packages.toml
+    python3Packages.waitress
+    python3Packages.openepub
+    python3Packages.pyparsing
+    python3Packages.pypdf
+    python3Packages.subtitle-parser
+    python3Packages.ahocorapy
+    python3Packages.requests
+    python3Packages.pyyaml
+  ];
+
+  makeWrapperArgs =
+    let
+      packagesToBinPath = lib.optionals japaneseSupport [ mecab ];
+    in
+    [
+      "--prefix"
+      "PATH"
+      ":"
+      (lib.makeBinPath packagesToBinPath)
+    ];
+
+  propagatedBuildInputs = lib.optionals japaneseSupport [ mecab ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    mecab
+  ];
+
+  preCheck = ''
+    echo "ENV: prod
+    DBNAME: test_lute.db
+    DATAPATH: $(mktemp -d)" > lute/config/config.yml;
+    export MECAB_PATH="${mecab}/lib/libmecab.so";
+  '';
+
+  disabledTestPaths = [
+    "tests/features/test_rendering.py"
+    "tests/features/test_term_import.py"
+  ];
+
+  meta = {
+    homepage = "https://github.com/LuteOrg/lute-v3";
+    description = "LUTE = Learning Using Texts: learn languages through reading.";
+    longDescription = ''
+      LUTE (Learning Using Texts) is a standalone web application that you install on your computer and read texts with.
+
+      Lute contains the core features you need for learning through reading:
+
+      * defining languages and dictionaries
+      * creating and editing texts
+      * creating terms and multi-word terms
+    '';
+    changelog = "https://raw.githubusercontent.com/LuteOrg/lute-v3/refs/tags/${version}/docs/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "lute";
+  };
+}

--- a/pkgs/development/python-modules/natto-py/default.nix
+++ b/pkgs/development/python-modules/natto-py/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cffi,
+  unittestCheckHook,
+  includeMecab ? true,
+  mecab,
+  pyyaml,
+}:
+let
+  version = "1.0.1";
+in
+buildPythonPackage {
+  inherit version;
+  pname = "natto-py";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "buruzaemon";
+    repo = "natto-py";
+    tag = version;
+    hash = "sha256-G7IYv5MNVfsTcTKQIMRAP9apTrMUo9+JnM3OWcV35X8=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = lib.optionals includeMecab [ mecab ];
+
+  dependencies = [
+    cffi
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+    mecab
+    pyyaml
+  ];
+
+  preCheck = ''
+    export MECAB_PATH="${mecab}/lib/libmecab.so";
+    export MECAB_CHARSET="utf8";
+  '';
+
+  pythonImportsCheck = [ "natto" ];
+
+  meta = {
+    homepage = "https://github.com/buruzaemon/natto-py";
+    changelog = "https://raw.githubusercontent.com/buruzaemon/natto-py/refs/tags/${version}/CHANGELOG";
+    description = "natto-py combines the Python programming language with MeCab, the part-of-speech and morphological analyzer for the Japanese language.";
+    license = lib.licenses.bsd2;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/openepub/default.nix
+++ b/pkgs/development/python-modules/openepub/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  beautifulsoup4,
+  xmltodict,
+  pytestCheckHook,
+}:
+let
+  version = "0.0.9";
+in
+buildPythonPackage {
+  inherit version;
+  pname = "openepub";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sakolkar";
+    repo = "openepub";
+    tag = "v${version}";
+    hash = "sha256-rk9tM2cC78O9icFpVu5ZH5RI4sbZXWlYOGWOSvwqhDU=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  pythonRelaxDeps = [ "xmltodict" ];
+
+  dependencies = [
+    beautifulsoup4
+    xmltodict
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    "test_epub_get_text"
+    "test_epub_get_text_2"
+    "test_open_epub_from_stream"
+    "test_open_get_epub_obj_valid_path"
+  ];
+
+  pythonImportsCheck = [ "openepub" ];
+
+  meta = {
+    homepage = "https://github.com/sakolkar/openepub";
+    changelog = "https://github.com/sakolkar/openepub/releases/tag/v${version}";
+    description = "Python library to interact with EPUB files.";
+    license = lib.licenses.unlicense;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/subtitle-parser/default.nix
+++ b/pkgs/development/python-modules/subtitle-parser/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  chardet,
+  pytestCheckHook,
+}:
+let
+  version = "2.0.1";
+in
+buildPythonPackage {
+  inherit version;
+  pname = "subtitle-parser";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "remram44";
+    repo = "subtitle-parser";
+    tag = "v${version}";
+    hash = "sha256-uqMedb/WSUaXUHccNTiin3S7V5dDMEaAxla/evIKU1E=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    chardet
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "tests.py"
+  ];
+
+  pythonImportsCheck = [ "subtitle_parser" ];
+
+  meta = {
+    homepage = "https://github.com/remram44/subtitle-parser";
+    changelog = "https://raw.githubusercontent.com/remram44/subtitle-parser/refs/tags/v${version}/CHANGELOG.md";
+    description = "Parser for SRT and WebVTT subtitle files";
+    longDescription = "This is a simple Python library for parsing subtitle files in SRT or WebVTT format.";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11562,6 +11562,8 @@ self: super: with self; {
 
   opendal = callPackage ../development/python-modules/opendal { };
 
+  openepub = callPackage ../development/python-modules/openepub { };
+
   openerz-api = callPackage ../development/python-modules/openerz-api { };
 
   openevsewifi = callPackage ../development/python-modules/openevsewifi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18691,6 +18691,8 @@ self: super: with self; {
 
   subprocess-tee = callPackage ../development/python-modules/subprocess-tee { };
 
+  subtitle-parser = callPackage ../development/python-modules/subtitle-parser { };
+
   subunit = callPackage ../development/python-modules/subunit {
     inherit (pkgs) subunit cppunit check;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10831,6 +10831,8 @@ self: super: with self; {
 
   natsort = callPackage ../development/python-modules/natsort { };
 
+  natto-py = callPackage ../development/python-modules/natto-py { };
+
   natural = callPackage ../development/python-modules/natural { };
 
   naturalsort = callPackage ../development/python-modules/naturalsort { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[LUTE (Learning Using Texts)](https://github.com/LuteOrg/lute-v3) is a standalone web application that you install on your computer and read texts with.

Lute contains the core features you need for learning through reading:

* defining languages and dictionaries
* creating and editing texts
* creating terms and multi-word terms

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
