### PR TITLE
opensmalltalk-vm: 202206021410 -> 202312181441

### DIFF
--- a/pkgs/development/compilers/opensmalltalk-vm/default.nix
+++ b/pkgs/development/compilers/opensmalltalk-vm/default.nix
@@ -84,7 +84,7 @@ let
         "all"
       ];
 
-      enableParallelBuilding = true;
+      enableParallelBuilding = false;
 
       nativeBuildInputs = [
         file
@@ -115,7 +115,7 @@ let
       '';
 
       meta = {
-        description = "Cross-platform virtual machine for Squeak, Pharo, Cuis, and Newspeak";
+        description = "Cross-platform virtual machine for Squeak, Pharo, and Cuis";
         mainProgram = scriptName;
         homepage = "https://opensmalltalk.org/";
         license = with lib.licenses; [ mit ];
@@ -132,7 +132,7 @@ let
         scriptName = "squeak";
         configureFlagsArray = ''
           (
-            CFLAGS="-DNDEBUG -DDEBUGVM=0 -DMUSL -D_GNU_SOURCE -DUSEEVDEV -DCOGMTVM=0 -DDUAL_MAPPED_CODE_ZONE=1"
+            CFLAGS="-fpermissive -DNDEBUG -DDEBUGVM=0 -DMUSL -D_GNU_SOURCE -DUSEEVDEV -DCOGMTVM=0 -DDUAL_MAPPED_CODE_ZONE=1"
             LIBS="-lrt"
           )
         '';
@@ -141,6 +141,7 @@ let
           "--with-src=src/spur64.cog"
           "--without-npsqueak"
           "--enable-fast-bitblt"
+          "--disable-dynamicopenssl"
         ];
       };
 
@@ -150,7 +151,7 @@ let
         scriptName = "squeak";
         configureFlagsArray = ''
           (
-            CFLAGS="-DNDEBUG -DDEBUGVM=0 -DMUSL -D_GNU_SOURCE -DUSEEVDEV -D__ARM_ARCH_ISA_A64 -DARM64 -D__arm__ -D__arm64__ -D__aarch64__"
+            CFLAGS="-fpermissive -DNDEBUG -DDEBUGVM=0 -DMUSL -D_GNU_SOURCE -DUSEEVDEV -D__ARM_ARCH_ISA_A64 -DARM64 -D__arm__ -D__arm64__ -D__aarch64__"
           )
         '';
         configureFlags = [
@@ -158,41 +159,26 @@ let
           "--with-src=src/spur64.stack"
           "--disable-cogit"
           "--without-npsqueak"
+          "--disable-dynamicopenssl"
         ];
       };
     };
 
     "x86_64-linux" = {
-      "newspeak-cog-spur" = buildVM {
-        platformDir = "linux64x64";
-        vmName = "newspeak.cog.spur";
-        scriptName = "newspeak";
-        configureFlagsArray = ''
-          (
-            CFLAGS="-DNDEBUG -DDEBUGVM=0"
-          )
-        '';
-        configureFlags = [
-          "--with-vmversion=5.0"
-          "--with-src=src/spur64.cog.newspeak"
-          "--without-vm-display-fbdev"
-          "--without-npsqueak"
-        ];
-      };
-
       "squeak-cog-spur" = buildVM {
         platformDir = "linux64x64";
         vmName = "squeak.cog.spur";
         scriptName = "squeak";
         configureFlagsArray = ''
           (
-            CFLAGS="-DNDEBUG -DDEBUGVM=0 -DCOGMTVM=0"
+            CFLAGS="-fpermissive -DNDEBUG -DDEBUGVM=0 -DCOGMTVM=0"
           )
         '';
         configureFlags = [
           "--with-vmversion=5.0"
           "--with-src=src/spur64.cog"
           "--without-npsqueak"
+          "--disable-dynamicopenssl"
         ];
       };
     };

--- a/pkgs/development/compilers/opensmalltalk-vm/default.nix
+++ b/pkgs/development/compilers/opensmalltalk-vm/default.nix
@@ -16,6 +16,7 @@
   pango,
   pkg-config,
   xorg,
+  libGL,
 }:
 let
   buildVM =
@@ -31,8 +32,8 @@ let
       src = fetchFromGitHub {
         owner = "OpenSmalltalk";
         repo = "opensmalltalk-vm";
-        tag = "202206021410";
-        hash = "sha256-QqElPiJuqD5svFjWrLz1zL0Tf+pHxQ2fPvkVRn2lyBI=";
+        tag = "202312181441";
+        hash = "sha256-j8fVL8072ccdaRyW5sPDcYXxMcIZIvSFJ+4Q1+41ey0=";
       };
     in
     stdenv.mkDerivation {
@@ -44,6 +45,10 @@ let
       version = src.rev;
 
       inherit src;
+
+      # Fixes build errors triggered by the format-security compiler flag
+      # and caused by passing non-literals as the first argument to printf.
+      patches = [ ./printOptionStrings.patch ];
 
       postPatch = ''
         vmVersionFiles=$(sed -n 's/^versionfiles="\(.*\)"/\1/p' ./scripts/updateSCCSVersions)
@@ -74,7 +79,10 @@ let
 
       configureFlags = [ "--with-scriptname=${scriptName}" ] ++ configureFlags;
 
-      buildFlags = [ "all" ];
+      buildFlags = [
+        "getversion"
+        "all"
+      ];
 
       enableParallelBuilding = true;
 
@@ -86,6 +94,7 @@ let
       buildInputs = [
         alsa-lib
         freetype
+        libGL
         libpulseaudio
         libtool
         libuuid

--- a/pkgs/development/compilers/opensmalltalk-vm/printOptionStrings.patch
+++ b/pkgs/development/compilers/opensmalltalk-vm/printOptionStrings.patch
@@ -1,0 +1,26 @@
+diff --git a/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m b/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
+index d248e9fd0..0ae695061 100644
+--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
++++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
+@@ -559,7 +559,7 @@ printOptionStrings()
+ 			sizeof(char *),
+ 			(int (*)(const void*,const void*))sortStrings);
+ 	while (--count >= 0)
+-		printf(optionStrings[count]);
++		printf("%s", optionStrings[count]);
+ }
+ 
+ - (void) printUsage {
+diff --git a/platforms/unix/vm/sqUnixMain.c b/platforms/unix/vm/sqUnixMain.c
+index 4795563f5..419f527e3 100644
+--- a/platforms/unix/vm/sqUnixMain.c
++++ b/platforms/unix/vm/sqUnixMain.c
+@@ -1829,7 +1829,7 @@ printOptionStrings()
+ 			sizeof(char *),
+ 			(int (*)(const void*,const void*))sortStrings);
+ 	while (--count >= 0)
+-		printf(optionStrings[count]);
++		printf("%s", optionStrings[count]);
+ }
+ 
+ void


### PR DESCRIPTION
Continuation of #286421. I removed long deprecated newspeak-cog-spur, added `-fpermissive` and disabled parallel build, so it now compiles and runs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
