### PR TITLE
[25.05] nixos/kanidm: merge recursively with extraJsonFile, Fix bind paths

### DIFF
--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -180,7 +180,9 @@ let
 
   finalJson =
     if cfg.provision.extraJsonFile != null then
-      "<(${lib.getExe pkgs.jq} -s '.[0] * .[1]' ${provisionStateJson} ${cfg.provision.extraJsonFile})"
+      ''
+        <(${lib.getExe pkgs.yq-go} '. *+ load("${cfg.provision.extraJsonFile}") | (.. | select(type == "!!seq")) |= unique' ${provisionStateJson})
+      ''
     else
       provisionStateJson;
 
@@ -437,10 +439,8 @@ in
         description = ''
           A JSON file for provisioning persons, groups & systems.
           Options set in this file take precedence over values set using the other options.
-          In the case of duplicates, `jq` will remove all but the last one
-          when merging this file with the options.
+          The files get deeply merged, and deduplicated.
           The accepted JSON schema can be found at <https://github.com/oddlama/kanidm-provision#json-schema>.
-          Note: theoretically `jq` cannot merge nested types, but this does not pose an issue as kanidm-provision's JSON scheme does not use nested types.
         '';
         type = types.nullOr types.path;
         default = null;

--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -235,6 +235,29 @@ import ./make-test-python.nix (
             };
           };
 
+        specialisation.extraJsonFile.configuration =
+          { ... }:
+          {
+            services.kanidm.provision = lib.mkForce {
+              enable = true;
+              idmAdminPasswordFile = pkgs.writeText "idm-admin-pw" provisionIdmAdminPassword;
+
+              extraJsonFile = pkgs.writeText "extra-json.json" (
+                builtins.toJSON {
+                  persons.testuser2.displayName = "Test User 2";
+                  groups.testgroup1.members = [ "testuser2" ];
+                }
+              );
+
+              groups.testgroup1 = { };
+
+              persons.testuser1 = {
+                displayName = "Test User 1";
+                groups = [ "testgroup1" ];
+              };
+            };
+          };
+
         security.pki.certificateFiles = [ certs.ca.cert ];
 
         networking.hosts."::1" = [ serverDomain ];
@@ -515,6 +538,21 @@ import ./make-test-python.nix (
 
             out = provision.succeed("kanidm system oauth2 get service2")
             assert_lacks(out, "name: service2")
+
+            provision.succeed("kanidm logout -D idm_admin")
+
+        with subtest("Test Provisioning - extraJsonFile"):
+            provision.succeed('${specialisations}/extraJsonFile/bin/switch-to-configuration test')
+            provision_login("${provisionIdmAdminPassword}")
+            out = provision.succeed("kanidm group get testgroup1")
+            assert_contains(out, "name: testgroup1")
+            out = provision.succeed("kanidm person get testuser1")
+            assert_contains(out, "name: testuser1")
+            out = provision.succeed("kanidm person get testuser2")
+            assert_contains(out, "name: testuser2")
+            out = provision.succeed("kanidm group get testgroup1")
+            assert_contains(out, "member: testuser1")
+            assert_contains(out, "member: testuser2")
 
             provision.succeed("kanidm logout -D idm_admin")
       '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Manual backport of:
- https://github.com/NixOS/nixpkgs/pull/411439
- https://github.com/NixOS/nixpkgs/pull/409310

Cherry pick conflicts are because of https://github.com/NixOS/nixpkgs/commit/f34483be5ee2418a563545a56743b7b59c549935.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
