### PR TITLE
Revert "treewide: migrate nixos modules to networking.hosts"

### DIFF
--- a/nixos/lib/testing/network.nix
+++ b/nixos/lib/testing/network.nix
@@ -13,7 +13,6 @@ let
     nameValuePair
     optionalAttrs
     optionalString
-    optionals
     range
     toLower
     types
@@ -96,18 +95,16 @@ let
           name: config:
           let
             hostnames =
-              [
-                "${config.networking.hostName}"
-              ]
-              ++ optionals (config.networking.domain != null) [
-                "${config.networking.hostName}.${config.networking.domain}"
-              ];
+              optionalString (
+                config.networking.domain != null
+              ) "${config.networking.hostName}.${config.networking.domain} "
+              + "${config.networking.hostName}\n";
           in
           optionalAttrs (config.networking.primaryIPAddress != "") {
-            "${config.networking.primaryIPAddress}" = hostnames;
+            "${config.networking.primaryIPAddress}" = [ hostnames ];
           }
           // optionalAttrs (config.networking.primaryIPv6Address != "") {
-            "${config.networking.primaryIPv6Address}" = hostnames;
+            "${config.networking.primaryIPv6Address}" = [ hostnames ];
           }
         ) nodes;
 

--- a/nixos/lib/testing/network.nix
+++ b/nixos/lib/testing/network.nix
@@ -3,15 +3,15 @@
 let
   inherit (lib)
     attrNames
-    concatMapAttrs
+    concatMap
     concatMapStrings
+    flip
     forEach
     head
     listToAttrs
     mkDefault
     mkOption
     nameValuePair
-    optionalAttrs
     optionalString
     range
     toLower
@@ -91,22 +91,23 @@ let
         # interfaces, use the IP address corresponding to
         # the first interface (i.e. the first network in its
         # virtualisation.vlans option).
-        networking.hosts = concatMapAttrs (
-          name: config:
+        networking.extraHosts = flip concatMapStrings (attrNames nodes) (
+          m':
           let
+            config = nodes.${m'};
             hostnames =
               optionalString (
                 config.networking.domain != null
               ) "${config.networking.hostName}.${config.networking.domain} "
               + "${config.networking.hostName}\n";
           in
-          optionalAttrs (config.networking.primaryIPAddress != "") {
-            "${config.networking.primaryIPAddress}" = [ hostnames ];
-          }
-          // optionalAttrs (config.networking.primaryIPv6Address != "") {
-            "${config.networking.primaryIPv6Address}" = [ hostnames ];
-          }
-        ) nodes;
+          optionalString (
+            config.networking.primaryIPAddress != ""
+          ) "${config.networking.primaryIPAddress} ${hostnames}"
+          + optionalString (config.networking.primaryIPv6Address != "") (
+            "${config.networking.primaryIPv6Address} ${hostnames}"
+          )
+        );
 
         virtualisation.qemu.options = qemuOptions;
         boot.initrd.services.udev.rules = concatMapStrings (x: x + "\n") udevRules;

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -365,12 +365,9 @@ in
         keyFile = mkDefault key;
         trustedCaFile = mkDefault caCert;
       };
-      networking.hosts = mkIf (config.services.etcd.enable) {
-        "127.0.0.1" = [
-          "etcd.${top.addons.dns.clusterDomain}"
-          "etcd.local"
-        ];
-      };
+      networking.extraHosts = mkIf (config.services.etcd.enable) ''
+        127.0.0.1 etcd.${top.addons.dns.clusterDomain} etcd.local
+      '';
 
       services.flannel = with cfg.certs.flannelClient; {
         kubeconfig = top.lib.mkKubeConfig "flannel" {

--- a/nixos/modules/virtualisation/google-compute-config.nix
+++ b/nixos/modules/virtualisation/google-compute-config.nix
@@ -70,12 +70,10 @@ in
   # Rely on GCP's firewall instead
   networking.firewall.enable = mkDefault false;
 
-  networking.hosts = {
-    "169.254.169.254" = [
-      "metadata.google.internal"
-      "metadata"
-    ];
-  };
+  # Configure default metadata hostnames
+  networking.extraHosts = ''
+    169.254.169.254 metadata.google.internal metadata
+  '';
 
   networking.timeServers = [ "metadata.google.internal" ];
 

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -1084,10 +1084,14 @@ in
           ) config.containers;
 
         # Generate /etc/hosts entries for the containers.
-        networking.hosts = lib.mapAttrs' (name: cfg: {
-          name = head (splitString "/" cfg.localAddress);
-          value = lib.optionals (cfg.localAddress != null) [ "${name}.containers" ];
-        }) config.containers;
+        networking.extraHosts = concatStrings (
+          mapAttrsToList (
+            name: cfg:
+            optionalString (cfg.localAddress != null) ''
+              ${head (splitString "/" cfg.localAddress)} ${name}.containers
+            ''
+          ) config.containers
+        );
 
         networking.dhcpcd.denyInterfaces = [
           "ve-*"


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/414780#issuecomment-2954218096

https://github.com/NixOS/nixpkgs/pull/414953#issuecomment-2954196892