### PR TITLE
nixos/system-path: add overrides

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -9,7 +9,13 @@
 let
 
   requiredPackages =
-    map (pkg: lib.setPrio ((pkg.meta.priority or lib.meta.defaultPriority) + 3) pkg)
+    map
+      (
+        pkg:
+        lib.setPrio (
+          (pkg.meta.priority or lib.meta.defaultPriority) + config.environment.requiredPackagesPriorityOffset
+        ) pkg
+      )
       [
         pkgs.acl
         pkgs.attr
@@ -77,6 +83,20 @@ in
           configuration.  (The latter is the main difference with
           installing them in the default profile,
           {file}`/nix/var/nix/profiles/default`.
+        '';
+      };
+
+      requiredPackagesPriorityOffset = lib.mkOption {
+        type = lib.types.int;
+        default = 3;
+        example = lib.literalExpression "-5";
+        description = ''
+          Override the priority of base system packages that are
+          required in a NixOS System by setting an offset.
+
+          The priority is inverse to the value. Meaning, a lower
+          offset (-5) results in a higher priority for package. And
+          a higher offset (5) results in a lower priority for package.
         '';
       };
 

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -86,6 +86,20 @@ in
         '';
       };
 
+      ignoreCollisions = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          There can be collisions when installing outputs of two packages.
+          An example is a collision between the `''${pkg}/bin/cat` binary
+          provided by the `coreutils` and the `uutils-coreutils-noprefix`
+          packages. This option controls whether those collisions are
+          ignored (treated as warnings) or not (treated as errors, build
+          failure). This allows you to figure out which packages have
+          collisions and set a higher priority for package(s) you prefer.
+        '';
+      };
+
       requiredPackagesPriorityOffset = lib.mkOption {
         type = lib.types.int;
         default = 3;
@@ -196,7 +210,7 @@ in
       name = "system-path";
       paths = config.environment.systemPackages;
       inherit (config.environment) pathsToLink extraOutputsToInstall;
-      ignoreCollisions = true;
+      ignoreCollisions = config.environment.ignoreCollisions;
       # !!! Hacky, should modularise.
       # outputs TODO: note that the tools will often not be linked by default
       postBuild = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Given this module has no maintainers in the file, I'm pinging some people who were involved in a PR related to this file. @SuperSandro2000 @Aleksanaa @0x4A6F @davidak @Ericson2314

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
