### PR TITLE
lima: 1.0.7 -> 1.1.1 with extracting lima-additional-guestagents

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -18,6 +18,8 @@
 - `base16-builder` node package has been removed due to lack of upstream maintenance.
 - `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by sil](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.
 
+- `lima` package no longer includes guest agents except for the host's architecture; these are now in `lima-additional-guestagents` package. If your guest VM's architecture differs from your Lima host's, you should also install `lima-additional-guestagents`. See also [upstream issue](https://github.com/lima-vm/lima/issues/3563).
+
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -18,7 +18,7 @@
 - `base16-builder` node package has been removed due to lack of upstream maintenance.
 - `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by sil](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.
 
-- `lima` package no longer includes guest agents except for the host's architecture; these are now in `lima-additional-guestagents` package. If your guest VM's architecture differs from your Lima host's, you should also install `lima-additional-guestagents`. See also [upstream issue](https://github.com/lima-vm/lima/issues/3563).
+- `lima` package now only includes the guest agent for the host's architecture by default. If your guest VM's architecture differs from your Lima host's, you'll need to enable the `lima-additional-guestagents` package by setting `withAdditionalGuestAgents = true` when overriding lima with this input.
 
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 

--- a/pkgs/by-name/li/lima-additional-guestagents/package.nix
+++ b/pkgs/by-name/li/lima-additional-guestagents/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  apple-sdk_15,
+  findutils,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "lima-additional-guestagents";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "lima-vm";
+    repo = "lima";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vmn5AQpFbugFOmeiPUNMkPkgV1cZSR3nli90tdFmF0A";
+  };
+
+  vendorHash = "sha256-1+jWEZ4VvVjJ7tSL4vlkCrWxCoSu8hiXefKSm3GExNs=";
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_15
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    make "VERSION=v${finalAttrs.version}" "CC=${stdenv.cc.targetPrefix}cc" additional-guestagents
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r _output/* $out
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    findutils
+  ];
+  doInstallCheck = true;
+
+  # Guest agents for the host's architecture are only in the "lima" package. So, we can't test this by running the binary.
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    [[ "$(find "$out/share" -type f -name 'lima-guestagent.Linux-*.gz' | wc -l)" -ge 5 ]]
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/lima-vm/lima";
+    description = "Lima Guest Agents for emulating non-native architectures";
+    changelog = "https://github.com/lima-vm/lima/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+  };
+})

--- a/pkgs/by-name/li/lima-additional-guestagents/package.nix
+++ b/pkgs/by-name/li/lima-additional-guestagents/package.nix
@@ -68,6 +68,10 @@ buildGoModule (finalAttrs: {
   meta = {
     homepage = "https://github.com/lima-vm/lima";
     description = "Lima Guest Agents for emulating non-native architectures";
+    longDescription = ''
+      Use this package only for a guest with a different architecture than the host.
+      This package requires "lima" to be available.
+    '';
     changelog = "https://github.com/lima-vm/lima/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/li/lima-additional-guestagents/package.nix
+++ b/pkgs/by-name/li/lima-additional-guestagents/package.nix
@@ -25,13 +25,20 @@ buildGoModule (finalAttrs: {
     apple-sdk_15
   ];
 
-  buildPhase = ''
-    runHook preBuild
+  buildPhase =
+    let
+      makeFlags = [
+        "VERSION=v${finalAttrs.version}"
+        "CC=${stdenv.cc.targetPrefix}cc"
+      ];
+    in
+    ''
+      runHook preBuild
 
-    make "VERSION=v${finalAttrs.version}" "CC=${stdenv.cc.targetPrefix}cc" additional-guestagents
+      make ${lib.escapeShellArgs makeFlags} additional-guestagents
 
-    runHook postBuild
-  '';
+      runHook postBuild
+    '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/li/lima-additional-guestagents/package.nix
+++ b/pkgs/by-name/li/lima-additional-guestagents/package.nix
@@ -63,14 +63,24 @@ buildGoModule (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     homepage = "https://github.com/lima-vm/lima";
     description = "Lima Guest Agents for emulating non-native architectures";
     longDescription = ''
-      Use this package only for a guest with a different architecture than the host.
-      This package requires "lima" to be available.
+      This package should only be used when your guest's architecture differs from the host's.
+
+      To enable its functionality in `limactl`, set `withAdditionalGuestAgents = true` in the `lima` package:
+      ```nix
+      pkgs.lima.override {
+        withAdditionalGuestAgents = true;
+      }
+      ```
+
+      Typically, you won't need to directly add this package to your *.nix files.
     '';
     changelog = "https://github.com/lima-vm/lima/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -89,6 +89,9 @@ buildGoModule (finalAttrs: {
     description = "Linux virtual machines with automatic file sharing and port forwarding";
     changelog = "https://github.com/lima-vm/lima/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ anhduy ];
+    maintainers = with lib.maintainers; [
+      anhduy
+      kachick
+    ];
   };
 })

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -14,16 +14,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "lima";
-  version = "1.0.7";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "lima-vm";
     repo = "lima";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pwSLQlYPJNzvXuW6KLmQoaafQyf3o6fjVAfKe9RJ3UE";
+    hash = "sha256-vmn5AQpFbugFOmeiPUNMkPkgV1cZSR3nli90tdFmF0A";
   };
 
-  vendorHash = "sha256-JxrUX22yNb5/tZIBWDiBaMLOpEnOk+2lZdpzCjjqO4E=";
+  vendorHash = "sha256-1+jWEZ4VvVjJ7tSL4vlkCrWxCoSu8hiXefKSm3GExNs=";
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -49,11 +49,20 @@ buildGoModule (finalAttrs: {
   # voiding the entitlements and making it non-operational.
   dontStrip = stdenv.hostPlatform.isDarwin;
 
-  buildPhase = ''
-    runHook preBuild
-    make "VERSION=v${finalAttrs.version}" "CC=${stdenv.cc.targetPrefix}cc" native
-    runHook postBuild
-  '';
+  buildPhase =
+    let
+      makeFlags = [
+        "VERSION=v${finalAttrs.version}"
+        "CC=${stdenv.cc.targetPrefix}cc"
+      ];
+    in
+    ''
+      runHook preBuild
+
+      make ${lib.escapeShellArgs makeFlags} native
+
+      runHook postBuild
+    '';
 
   installPhase =
     ''

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -116,6 +116,9 @@ buildGoModule (finalAttrs: {
   meta = {
     homepage = "https://github.com/lima-vm/lima";
     description = "Linux virtual machines with automatic file sharing and port forwarding";
+    longDescription = ''
+      Guest agents for non-native architectures are in the "lima-additional-guestagents" package.
+    '';
     changelog = "https://github.com/lima-vm/lima/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -44,9 +44,7 @@ buildGoModule (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace-fail 'codesign -f -v --entitlements vz.entitlements -s -' 'codesign -f --entitlements vz.entitlements -s -'
-
-    substituteInPlace Makefile \
+      --replace-fail 'codesign -f -v --entitlements vz.entitlements -s -' 'codesign -f --entitlements vz.entitlements -s -' \
       --replace-fail 'rm -rf _output vendor' 'rm -rf _output'
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16186,10 +16186,6 @@ with pkgs;
 
   utsushi-networkscan = callPackage ../misc/drivers/utsushi/networkscan.nix { };
 
-  lima = callPackage ../applications/virtualization/lima {
-    inherit (darwin) sigtool;
-  };
-
   image_optim = callPackage ../applications/graphics/image_optim { inherit (nodePackages) svgo; };
 
   # using the new configuration style proposal which is unstable


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Background: https://github.com/NixOS/nixpkgs/pull/409399#discussion_r2100715385
- Closes: #409399 
- upstream tracker issue: https://github.com/lima-vm/lima/issues/3563
- Diff: https://github.com/lima-vm/lima/compare/v1.0.7...v1.1.1

Lima recommends extracting guest agents from its main package starting with version 1.1.0.

~I initially thought adding `withAdditionalGuestAgent` inputs or a `limaMinimal` package would help maintain backward compatibility in nixpkgs. However, I agree with the upstream decision to reduce the main package size. For example, the build time for the lima package on my machine decreased from 5.5 minutes to 1.5 minutes. Also, continuing to depend on deprecated make tasks makes future maintenance difficult.~

Simply extracting `lima-additional-guestagents` doesn't enable its functions in `limactl`. To address this, I've added a `withAdditionalGuestAgents` input, which creates symlinks for the new package.

Most Lima users are on macOS, but I primarily use Lima on NixOS and don't personally need these additional agents. Therefore, I'd greatly appreciate testing and feedback from macOS users and those running guest VMs with different architectures than their host.

`tree` result diff of `lima` package on x86_64-linux

```diff
--- /lima-1.0.7-binaries-task  2025-06-09 12:06:11.599635028 +0900
+++ /lima-1.1.1-native-task  2025-06-09 12:06:11.599635028 +0900
@@ -11,27 +11,45 @@
     ├── bash-completion
     │   ├── completions
     │       ├── limactl.bash
-    ├── doc
-    │   ├── lima
-    │       ├── LICENSE
-    │       ├── MAINTAINERS.md
-    │       ├── README.md
-    │       ├── ROADMAP.md
-    │       ├── SECURITY.md
-    │       ├── VERSION
-    │       ├── templates -> ../../lima/templates
     ├── fish
     │   ├── vendor_completions.d
     │       ├── limactl.fish
     ├── lima
-    │   ├── lima-guestagent.Linux-aarch64
-    │   ├── lima-guestagent.Linux-armv7l
-    │   ├── lima-guestagent.Linux-riscv64
-    │   ├── lima-guestagent.Linux-x86_64
+    │   ├── lima-guestagent.Linux-x86_64.gz
     │   ├── templates
     │       ├── README.md
+    │       ├── _default
+    │       │   ├── mounts.yaml
+    │       ├── _images
+    │       │   ├── almalinux-8.yaml
+    │       │   ├── almalinux-9.yaml
+    │       │   ├── almalinux-kitten-10.yaml
+    │       │   ├── alpine-iso.yaml
+    │       │   ├── alpine.yaml
+    │       │   ├── archlinux.yaml
+    │       │   ├── centos-stream-10.yaml
+    │       │   ├── centos-stream-9.yaml
+    │       │   ├── debian-11.yaml
+    │       │   ├── debian-12.yaml
+    │       │   ├── fedora-41.yaml
+    │       │   ├── fedora-42.yaml
+    │       │   ├── fedora.yaml
+    │       │   ├── opensuse-leap.yaml
+    │       │   ├── oraclelinux-8.yaml
+    │       │   ├── oraclelinux-9.yaml
+    │       │   ├── rocky-8.yaml
+    │       │   ├── rocky-9.yaml
+    │       │   ├── ubuntu-20.04.yaml
+    │       │   ├── ubuntu-22.04.yaml
+    │       │   ├── ubuntu-24.04.yaml
+    │       │   ├── ubuntu-24.10.yaml
+    │       │   ├── ubuntu-25.04.yaml
+    │       │   ├── ubuntu-lts.yaml
+    │       │   ├── ubuntu.yaml
     │       ├── almalinux-8.yaml
     │       ├── almalinux-9.yaml
+    │       ├── almalinux-kitten-10.yaml
+    │       ├── almalinux-kitten.yaml
     │       ├── almalinux.yaml
     │       ├── alpine-iso.yaml
     │       ├── alpine.yaml
@@ -50,6 +68,7 @@
     │       ├── docker.yaml
     │       ├── experimental
     │       │   ├── alsa.yaml
+    │       │   ├── debian-sid.yaml
     │       │   ├── gentoo.yaml
     │       │   ├── opensuse-tumbleweed.yaml
     │       │   ├── rke2.yaml
@@ -57,9 +76,12 @@
     │       │   ├── vnc.yaml
     │       │   ├── wsl2.yaml
     │       ├── faasd.yaml
+    │       ├── fedora-41.yaml
+    │       ├── fedora-42.yaml
     │       ├── fedora.yaml
     │       ├── k3s.yaml
     │       ├── k8s.yaml
+    │       ├── linuxbrew.yaml
     │       ├── opensuse-leap.yaml
     │       ├── opensuse.yaml
     │       ├── oraclelinux-8.yaml
@@ -74,10 +96,11 @@
     │       ├── ubuntu-22.04.yaml
     │       ├── ubuntu-24.04.yaml
     │       ├── ubuntu-24.10.yaml
+    │       ├── ubuntu-25.04.yaml
     │       ├── ubuntu-lts.yaml
     │       ├── ubuntu.yaml
     ├── zsh
         ├── site-functions
             ├── _limactl
 
-15 directories, 66 files
+14 directories, 90 files
```

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
