### PR TITLE
unicon: 11.7 -> 13.2-unstable-2025-06-02

### DIFF
--- a/pkgs/by-name/un/unicon-lang/package.nix
+++ b/pkgs/by-name/un/unicon-lang/package.nix
@@ -1,66 +1,67 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  unzip,
   libX11,
-  libXt,
-  libnsl,
   libxcrypt,
+  fetchFromGitHub,
+  coreutils,
+  libpng,
+  xorg,
+  freetype,
+  zlib,
+  libjpeg,
+  openssl,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "unicon-lang";
-  version = "11.7";
-  src = fetchurl {
-    url = "http://unicon.org/dist/uni-2-4-2010.zip";
-    sha256 = "1g9l2dfp99dqih2ir2limqfjgagh3v9aqly6x0l3qavx3qkkwf61";
+  version = "13.2-unstable-2025-06-02";
+
+  src = fetchFromGitHub {
+    owner = "uniconproject";
+    repo = "unicon";
+    rev = "cf3b53b9578a004a52146a7adadc2a9409426624";
+    hash = "sha256-+4HSLnVTLdBVnKqWhOrx4XHTs3mRlM6n2ISQ+C1g3Ns=";
   };
-  nativeBuildInputs = [ unzip ];
+
+  postPatch = ''
+    substituteInPlace tests/Makefile --replace-fail "/bin/echo" "${coreutils}/bin/echo"
+    substituteInPlace tests/Makedefs --replace-fail "/bin/echo" "${coreutils}/bin/echo"
+  '';
+
   buildInputs = [
-    libnsl
-    libX11
-    libXt
     libxcrypt
+    # compression
+    zlib
+    # graphics
+    libX11
+    libjpeg
+    libpng
+    xorg.libXft
+    freetype
+    # ssl
+    openssl
   ];
 
   hardeningDisable = [ "fortify" ];
 
-  sourceRoot = ".";
+  enableParallelBuilding = true;
 
-  # Workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: ../common/ipp.o:(.bss+0x0): multiple definition of `lpath'; tglobals.o:(.bss+0x30): first defined here
-  # TODO: remove the workaround once upstream releases version past:
-  #   https://sourceforge.net/p/unicon/unicon/ci/b1a65230233f3825d055aee913b4fdcf178a0eaf/
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  doCheck = true;
+  checkTarget = "Test";
 
-  configurePhase = ''
-    case "$(uname -a | sed 's/ /_/g')" in
-    Darwin*Version_9*i386) sys=intel_macos;;
-    Linux*x86_64*) sys=amd64_linux;;
-    Linux*i686*) sys=intel_linux;;
-    *) sys=unknown;;
-    esac
-    echo "all: ; echo" >  uni/3d/makefile
-    make X-Configure name=$sys
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/unicon -version
+    runHook postInstallCheck
   '';
 
-  buildPhase = ''
-    make Unicon
-  '';
-
-  installPhase = ''
-    mkdir -p $out/
-    cp -r bin $out/
-  '';
-
-  meta = with lib; {
-    broken = (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
+  meta = {
     description = "Very high level, goal-directed, object-oriented, general purpose applications language";
     maintainers = [ ];
-    platforms = platforms.linux;
-    license = licenses.gpl2;
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2;
     homepage = "http://unicon.org";
   };
-}
+})

--- a/pkgs/by-name/un/unicon-lang/package.nix
+++ b/pkgs/by-name/un/unicon-lang/package.nix
@@ -62,6 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2;
-    homepage = "http://unicon.org";
+    homepage = "http://www.unicon.org";
   };
 })

--- a/pkgs/by-name/un/unicon-lang/package.nix
+++ b/pkgs/by-name/un/unicon-lang/package.nix
@@ -45,7 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   hardeningDisable = [ "fortify" ];
 
-  enableParallelBuilding = true;
+  # Issues when building plugins and running tests on aarch
+  enableParallelBuilding = false;
 
   doCheck = true;
   checkTarget = "Test";


### PR DESCRIPTION
Unicon development moved to [GitHub](https://github.com/uniconproject/unicon) and is quite active (though they do not seem to make new release often. All compilation failures are currently fixed when building from the latest master commit.

- #388196

Tested only basic functionality. Most of the test suite passes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
