### PR TITLE
proxyman: init at 3.1.0

### DIFF
--- a/pkgs/by-name/pr/proxyman/package.nix
+++ b/pkgs/by-name/pr/proxyman/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  asar,
+}:
+let
+  pname = "proxyman";
+  version = "3.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/ProxymanApp/proxyman-windows-linux/releases/download/${version}/Proxyman-${version}.AppImage";
+    hash = "sha256-R/PrJCIK6dWwdivzeTpAhyD1Ir34hdBaHDtE+TRHOxo=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+    postExtract = ''
+      ${asar}/bin/asar extract $out/resources/app.asar app
+
+      # This will fix the issue with Proxyman not detecting NixOS as a valid Linux environment
+      substituteInPlace app/dist/main/main.js --replace-fail "/etc/ca-certificates/trust-source/anchors/" "/etc/ssl/certs/"
+
+      # This will permanently mark the certificate as installed, as this should be done through Nix config rather than
+      # placing / editing a file in /etc like Proxyman would expect.
+      # Configure the certificate located in "~/.config/Proxyman/certificate/certs/ca.pem" using security.pki.certificates in your nix config
+      substituteInPlace app/dist/main/main.js --replace-fail "return this.isFile(this.getNewCertPath(e))" "return true"
+
+      ${asar}/bin/asar pack app $out/resources/app.asar
+    '';
+  };
+
+in
+appimageTools.wrapAppImage {
+  inherit pname version;
+  src = appimageContents;
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/proxyman.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/proxyman.png -t $out/share/pixmaps
+    substituteInPlace $out/share/applications/proxyman.desktop \
+      --replace-fail "Exec=AppRun" "Exec=proxyman --"
+  '';
+
+  meta = {
+    description = "Capture, inspect, and manipulate HTTP(s) requests/responses with ease";
+    homepage = "https://proxyman.com";
+    changelog = "https://proxyman.com/changelog-windows";
+    license = lib.licenses.unfree;
+    mainProgram = "proxyman";
+    maintainers = with lib.maintainers; [ nilathedragon ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
This PR adds a package for the non-free application [Proxyman](https://proxyman.com). Proxyman is a popular software for working with HTTP(S) traffic.

The package wraps the official AppImage, which unfortunately does not run out of the box on NixOS systems. This is why two patches were included in the package:

1. Ensure Proxyman correctly identifies the trust store backend as "Linux"
2. Completely disable Proxyman's SSL certificate installation procedure, as it will not work on NixOS

Proxyman by default wants to install its root certificate in the system trust store. With NixOS, this of course won't work as we will do this through the system configuration instead. Proxyman will refuse service until the SSL certificate setup is completed, therefore a small patch is applied to trick it into thinking the certificate is installed. The installation procedure for NixOS is written as a comment inside the package.nix file.

Last but not least I did get permission from the Proxyman team to re-package their AppImage on their Discord.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
