### PR TITLE
x{cmsdb,driinfo,lsatoms,lsclientx,lsfonts,modmap}: refactor and migrate to pkgs/by-name from xorg namespace; xdriinfo: 1.0.7 -> 1.0.8

### DIFF
--- a/pkgs/by-name/xc/xcmsdb/package.nix
+++ b/pkgs/by-name/xc/xcmsdb/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libx11,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xcmsdb";
+  version = "1.0.7";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xcmsdb-${finalAttrs.version}.tar.xz";
+    hash = "sha256-XsQGjkiBh7BeqS7hNiyWt4qQ8ZzMehhExZIdcGJrvDg=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libx11 ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Device Color Characterization utility for X Color Management System";
+    longDescription = ''
+      xcmsdb is used to load, query, or remove Device Color Characterization data stored in
+      properties on the root window of the screen as specified in section 7, Device Color
+      Characterization, of the X11 Inter-Client Communication Conventions Manual (ICCCM).
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xcmsdb";
+    license = with lib.licenses; [
+      hpnd
+      mitOpenGroup
+    ];
+    mainProgram = "xcmsdb";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xd/xdriinfo/package.nix
+++ b/pkgs/by-name/xd/xdriinfo/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libGL,
+  xorgproto,
+  libx11,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xdriinfo";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xdriinfo-${finalAttrs.version}.tar.xz";
+    hash = "sha256-AEYwVkNbgiYcInrQ3hhz/UU2EBYH+8V1QOKOSgqbcfc=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libGL
+    xorgproto
+    libx11
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to query configuration information of X11 DRI drivers";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xdriinfo";
+    license = lib.licenses.mit;
+    mainProgram = "xdriinfo";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xl/xlsatoms/package.nix
+++ b/pkgs/by-name/xl/xlsatoms/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxcb,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xlsatoms";
+  version = "1.1.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xlsatoms-${finalAttrs.version}.tar.xz";
+    hash = "sha256-9L+hX1bAZtMmpdWykmRnCPJbkkdQaEC5BHzSaH3Mcbc=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libxcb ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to list interned atoms defined on X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xlsatoms";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "xlsatoms";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xl/xlsclients/package.nix
+++ b/pkgs/by-name/xl/xlsclients/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libxcb,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xlsclients";
+  version = "1.1.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xlsclients-${finalAttrs.version}.tar.xz";
+    hash = "sha256-aLruV+cCUKxKd1n7eCIYMfl9iLyOUdzC5k6z+MpWuuM=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libxcb ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to list client applications running on a X11 display";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xlsclients";
+    license = with lib.licenses; [
+      mitOpenGroup
+      mit
+    ];
+    mainProgram = "xlsclients";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xl/xlsfonts/package.nix
+++ b/pkgs/by-name/xl/xlsfonts/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libx11,
+  xorgproto,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xlsfonts";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xlsfonts-${finalAttrs.version}.tar.xz";
+    hash = "sha256-gH+QnqzmhLhm/GOz6WJynBIIIqbJbgUf9RzzULP/ts0=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libx11
+    xorgproto
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to list core protocol fonts on an X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xlsfonts";
+    license = lib.licenses.mitOpenGroup;
+    mainProgram = "xlsfonts";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xm/xmodmap/package.nix
+++ b/pkgs/by-name/xm/xmodmap/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libx11,
+  xorgproto,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xmodmap";
+  version = "1.0.11";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xmodmap-${finalAttrs.version}.tar.xz";
+    hash = "sha256-mi+BaPewvDgoKIR0A5Astr8XXhdlizYYnqyH7dqHfoE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libx11
+    xorgproto
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility for modifying keymaps and pointer button mappings in X";
+    longDescription = ''
+      The xmodmap program is used to edit and display the keyboard modifier map and keymap table
+      that are used by client applications to convert event keycodes into keysyms. It is usually run
+      from the user's session startup script to configure the keyboard according to personal tastes.
+    '';
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xmodmap";
+    license = with lib.licenses; [
+      mit
+      mitOpenGroup
+    ];
+    mainProgram = "xmodmap";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -23,6 +23,7 @@
   xbitmaps,
   xcb-proto,
   xcmsdb,
+  xdriinfo,
   xkeyboard-config,
   xorg-cf-files,
   xorg-docs,
@@ -47,6 +48,7 @@ self: with self; {
     sessreg
     xbitmaps
     xcmsdb
+    xdriinfo
     xorgproto
     xtrans
     ;
@@ -4235,44 +4237,6 @@ self: with self; {
         libXxf86dga
         libXxf86misc
         libXxf86vm
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xdriinfo = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libGL,
-      xorgproto,
-      libX11,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xdriinfo";
-      version = "1.0.7";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xdriinfo-1.0.7.tar.xz";
-        sha256 = "0d7p9fj3znq0av9pjgi2kphqaz5w7b9hxlz63zbxs69bknp8p0yx";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libGL
-        xorgproto
-        libX11
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -22,6 +22,7 @@
   util-macros,
   xbitmaps,
   xcb-proto,
+  xcmsdb,
   xkeyboard-config,
   xorg-cf-files,
   xorg-docs,
@@ -45,6 +46,7 @@ self: with self; {
     pixman
     sessreg
     xbitmaps
+    xcmsdb
     xorgproto
     xtrans
     ;
@@ -3954,38 +3956,6 @@ self: with self; {
         libXrender
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xcmsdb = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xcmsdb";
-      version = "1.0.7";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xcmsdb-1.0.7.tar.xz";
-        sha256 = "0f5wddi707cjqm21hynckkqr12mpjqn3dq9fm5gb11w19270di2y";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ libX11 ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -28,6 +28,7 @@
   xlsatoms,
   xlsclients,
   xlsfonts,
+  xmodmap,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -55,6 +56,7 @@ self: with self; {
     xlsatoms
     xlsclients
     xlsfonts
+    xmodmap
     xorgproto
     xtrans
     ;
@@ -6961,42 +6963,6 @@ self: with self; {
       buildInputs = [
         libXaw
         libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xmodmap = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xmodmap";
-      version = "1.0.11";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xmodmap-1.0.11.tar.xz";
-        sha256 = "10byhzdfv1xckqc3d2v52xg1ggxn5j806x4450l3ig5hyxl82bws";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -26,6 +26,7 @@
   xdriinfo,
   xkeyboard-config,
   xlsatoms,
+  xlsclients,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -51,6 +52,7 @@ self: with self; {
     xcmsdb
     xdriinfo
     xlsatoms
+    xlsclients
     xorgproto
     xtrans
     ;
@@ -6872,38 +6874,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xlsclients = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libxcb,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xlsclients";
-      version = "1.1.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xlsclients-1.1.5.tar.xz";
-        sha256 = "1qxsav5gicsfwv1dqlcfpj47vy9i30i7iysrfx5aql02wxbyxfk8";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ libxcb ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -27,6 +27,7 @@
   xkeyboard-config,
   xlsatoms,
   xlsclients,
+  xlsfonts,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -53,6 +54,7 @@ self: with self; {
     xdriinfo
     xlsatoms
     xlsclients
+    xlsfonts
     xorgproto
     xtrans
     ;
@@ -6873,42 +6875,6 @@ self: with self; {
         libXmu
         xorgproto
         libXt
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xlsfonts = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xlsfonts";
-      version = "1.0.8";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xlsfonts-1.0.8.tar.xz";
-        sha256 = "1kdnzyrm1wqwylghavn9lqi0h4lwf9ifkcv3zikbi176mjg90zw0";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -25,6 +25,7 @@
   xcmsdb,
   xdriinfo,
   xkeyboard-config,
+  xlsatoms,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -49,6 +50,7 @@ self: with self; {
     xbitmaps
     xcmsdb
     xdriinfo
+    xlsatoms
     xorgproto
     xtrans
     ;
@@ -6870,38 +6872,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xlsatoms = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libxcb,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xlsatoms";
-      version = "1.1.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xlsatoms-1.1.4.tar.xz";
-        sha256 = "1dviriynilkw0jwl0s2h8y95pwh8cxj95cnmllkd6rn0args3gzl";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ libxcb ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -311,6 +311,7 @@ print OUT <<EOF;
   xdriinfo,
   xkeyboard-config,
   xlsatoms,
+  xlsclients,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -336,6 +337,7 @@ self: with self; {
     xcmsdb
     xdriinfo
     xlsatoms
+    xlsclients
     xorgproto
     xtrans
     ;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -307,6 +307,7 @@ print OUT <<EOF;
   util-macros,
   xbitmaps,
   xcb-proto,
+  xcmsdb,
   xkeyboard-config,
   xorg-cf-files,
   xorg-docs,
@@ -330,6 +331,7 @@ self: with self; {
     pixman
     sessreg
     xbitmaps
+    xcmsdb
     xorgproto
     xtrans
     ;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -312,6 +312,7 @@ print OUT <<EOF;
   xkeyboard-config,
   xlsatoms,
   xlsclients,
+  xlsfonts,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -338,6 +339,7 @@ self: with self; {
     xdriinfo
     xlsatoms
     xlsclients
+    xlsfonts
     xorgproto
     xtrans
     ;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -308,6 +308,7 @@ print OUT <<EOF;
   xbitmaps,
   xcb-proto,
   xcmsdb,
+  xdriinfo,
   xkeyboard-config,
   xorg-cf-files,
   xorg-docs,
@@ -332,6 +333,7 @@ self: with self; {
     sessreg
     xbitmaps
     xcmsdb
+    xdriinfo
     xorgproto
     xtrans
     ;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -313,6 +313,7 @@ print OUT <<EOF;
   xlsatoms,
   xlsclients,
   xlsfonts,
+  xmodmap,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -340,6 +341,7 @@ self: with self; {
     xlsatoms
     xlsclients
     xlsfonts
+    xmodmap
     xorgproto
     xtrans
     ;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -310,6 +310,7 @@ print OUT <<EOF;
   xcmsdb,
   xdriinfo,
   xkeyboard-config,
+  xlsatoms,
   xorg-cf-files,
   xorg-docs,
   xorgproto,
@@ -334,6 +335,7 @@ self: with self; {
     xbitmaps
     xcmsdb
     xdriinfo
+    xlsatoms
     xorgproto
     xtrans
     ;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1100,7 +1100,6 @@ self: super:
 
   xbacklight = addMainProgram super.xbacklight { };
   xclock = addMainProgram super.xclock { };
-  xcmsdb = addMainProgram super.xcmsdb { };
   xcompmgr = addMainProgram super.xcompmgr { };
   xconsole = addMainProgram super.xconsole { };
   xcursorgen = addMainProgram super.xcursorgen { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -819,13 +819,6 @@ self: super:
       postPatch = lib.concatStrings (lib.mapAttrsToList patchIn layouts);
     });
 
-  xlsfonts = super.xlsfonts.overrideAttrs (attrs: {
-    meta = attrs.meta // {
-      license = lib.licenses.mit;
-      mainProgram = "xlsfonts";
-    };
-  });
-
   xorgserver = super.xorgserver.overrideAttrs (
     attrs_passed:
     let

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1198,7 +1198,6 @@ self: super:
   xkbprint = addMainProgram super.xkbprint { };
   xkill = addMainProgram super.xkill { };
   xload = addMainProgram super.xload { };
-  xlsatoms = addMainProgram super.xlsatoms { };
   xlsclients = addMainProgram super.xlsclients { };
   xmag = addMainProgram super.xmag { };
   xmessage = addMainProgram super.xmessage { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1198,7 +1198,6 @@ self: super:
   xkbprint = addMainProgram super.xkbprint { };
   xkill = addMainProgram super.xkill { };
   xload = addMainProgram super.xload { };
-  xlsclients = addMainProgram super.xlsclients { };
   xmag = addMainProgram super.xmag { };
   xmessage = addMainProgram super.xmessage { };
   xmodmap = addMainProgram super.xmodmap { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -745,13 +745,6 @@ self: super:
     };
   });
 
-  xdriinfo = super.xdriinfo.overrideAttrs (attrs: {
-    buildInputs = attrs.buildInputs ++ [ libGL ];
-    meta = attrs.meta // {
-      mainProgram = "xdriinfo";
-    };
-  });
-
   xev = addMainProgram super.xev { };
   xeyes = addMainProgram super.xeyes { };
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1193,7 +1193,6 @@ self: super:
   xload = addMainProgram super.xload { };
   xmag = addMainProgram super.xmag { };
   xmessage = addMainProgram super.xmessage { };
-  xmodmap = addMainProgram super.xmodmap { };
   xmore = addMainProgram super.xmore { };
 
   xpr = addMainProgram super.xpr { };

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -45,7 +45,6 @@ mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
 mirror://xorg/individual/app/xkbutils-1.0.6.tar.xz
 mirror://xorg/individual/app/xkill-1.0.6.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
-mirror://xorg/individual/app/xlsfonts-1.0.8.tar.xz
 mirror://xorg/individual/app/xmag-1.0.8.tar.xz
 mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
 mirror://xorg/individual/app/xmodmap-1.0.11.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -45,7 +45,6 @@ mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
 mirror://xorg/individual/app/xkbutils-1.0.6.tar.xz
 mirror://xorg/individual/app/xkill-1.0.6.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
-mirror://xorg/individual/app/xlsclients-1.1.5.tar.xz
 mirror://xorg/individual/app/xlsfonts-1.0.8.tar.xz
 mirror://xorg/individual/app/xmag-1.0.8.tar.xz
 mirror://xorg/individual/app/xmessage-1.0.7.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -45,7 +45,6 @@ mirror://xorg/individual/app/xkbprint-1.0.7.tar.xz
 mirror://xorg/individual/app/xkbutils-1.0.6.tar.xz
 mirror://xorg/individual/app/xkill-1.0.6.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
-mirror://xorg/individual/app/xlsatoms-1.1.4.tar.xz
 mirror://xorg/individual/app/xlsclients-1.1.5.tar.xz
 mirror://xorg/individual/app/xlsfonts-1.0.8.tar.xz
 mirror://xorg/individual/app/xmag-1.0.8.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -23,7 +23,6 @@ mirror://xorg/individual/app/xauth-1.1.4.tar.xz
 mirror://xorg/individual/app/xbacklight-1.2.4.tar.xz
 mirror://xorg/individual/app/xcalc-1.1.2.tar.xz
 mirror://xorg/individual/app/xclock-1.1.1.tar.xz
-mirror://xorg/individual/app/xcmsdb-1.0.7.tar.xz
 mirror://xorg/individual/app/xcompmgr-1.1.10.tar.xz
 mirror://xorg/individual/app/xconsole-1.1.0.tar.xz
 mirror://xorg/individual/app/xcursorgen-1.0.9.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -28,7 +28,6 @@ mirror://xorg/individual/app/xconsole-1.1.0.tar.xz
 mirror://xorg/individual/app/xcursorgen-1.0.9.tar.xz
 mirror://xorg/individual/app/xdm-1.1.17.tar.xz
 mirror://xorg/individual/app/xdpyinfo-1.3.4.tar.xz
-mirror://xorg/individual/app/xdriinfo-1.0.7.tar.xz
 mirror://xorg/individual/app/xev-1.2.6.tar.xz
 mirror://xorg/individual/app/xeyes-1.3.0.tar.xz
 mirror://xorg/individual/app/xfd-1.1.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -47,7 +47,6 @@ mirror://xorg/individual/app/xkill-1.0.6.tar.xz
 mirror://xorg/individual/app/xload-1.2.0.tar.xz
 mirror://xorg/individual/app/xmag-1.0.8.tar.xz
 mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
-mirror://xorg/individual/app/xmodmap-1.0.11.tar.xz
 mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
 mirror://xorg/individual/app/xprop-1.2.8.tar.xz

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12327,8 +12327,6 @@ with pkgs;
     freeoffice
     ;
 
-  inherit (xorg) xlsfonts;
-
   gimp3 = callPackage ../applications/graphics/gimp {
     lcms = lcms2;
   };


### PR DESCRIPTION
my plan is to migrate all packages from xorg to pkgs/by-name
in this iteration there are several PRs with one or more packages that should be able to get merged independently
this one has 6 packages, one more than usual but i can't split them without merge conflicts and leaving one would be :(

this is the script i use to get the packages that don't depend on other xorg packages:
```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      # && !lib.hasPrefix "xf86" n
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;
in
pkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (x: y: x.count < y.count || (x.count == y.count && x.name > y.name))
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
