### PR TITLE
treewide: checkInputs -> nativeCheckInputs

### DIFF
--- a/pkgs/applications/misc/electrum/grs.nix
+++ b/pkgs/applications/misc/electrum/grs.nix
@@ -80,7 +80,7 @@ python3.pkgs.buildPythonApplication {
       qdarkstyle
     ];
 
-  checkInputs =
+  nativeCheckInputs =
     with python3.pkgs;
     lib.optionals enableQt [
       pyqt6

--- a/pkgs/applications/networking/gns3/gui.nix
+++ b/pkgs/applications/networking/gns3/gui.nix
@@ -55,7 +55,7 @@ python3Packages.buildPythonApplication rec {
 
   doCheck = true;
 
-  checkInputs = with python3Packages; [ pytestCheckHook ];
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/applications/networking/gns3/server.nix
+++ b/pkgs/applications/networking/gns3/server.nix
@@ -72,7 +72,7 @@ python3Packages.buildPythonApplication {
     export HOME=$(mktemp -d)
   '';
 
-  checkInputs = with python3Packages; [
+  nativeCheckInputs = with python3Packages; [
     pytest-aiohttp
     pytest-rerunfailures
     pytestCheckHook

--- a/pkgs/applications/window-managers/i3/bumblebee-status/default.nix
+++ b/pkgs/applications/window-managers/i3/bumblebee-status/default.nix
@@ -42,7 +42,7 @@ python3.pkgs.buildPythonPackage {
   buildInputs = lib.concatMap (p: p.buildInputs or [ ]) selectedPlugins;
   propagatedBuildInputs = lib.concatMap (p: p.propagatedBuildInputs or [ ]) selectedPlugins;
 
-  checkInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3.pkgs; [
     freezegun
     netifaces
     psutil

--- a/pkgs/by-name/do/dooit/package.nix
+++ b/pkgs/by-name/do/dooit/package.nix
@@ -46,7 +46,7 @@ python3.pkgs.buildPythonApplication rec {
     export HOME=$(mktemp -d)
   '';
 
-  checkInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3.pkgs; [
     pytestCheckHook
     faker
   ];

--- a/pkgs/by-name/ed/eduvpn-client/package.nix
+++ b/pkgs/by-name/ed/eduvpn-client/package.nix
@@ -47,7 +47,7 @@ python3Packages.buildPythonApplication rec {
     ln -s $out/${python3Packages.python.sitePackages}/eduvpn/data/share/ $out/share
   '';
 
-  checkInputs = with python3Packages; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
   ];
 

--- a/pkgs/by-name/gt/gtimelog/package.nix
+++ b/pkgs/by-name/gt/gtimelog/package.nix
@@ -39,7 +39,7 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = with python3Packages; [
     pygobject3
   ];
-  checkInputs = with python3Packages; [
+  nativeCheckInputs = with python3Packages; [
     freezegun
   ];
 

--- a/pkgs/by-name/le/lesscpy/package.nix
+++ b/pkgs/by-name/le/lesscpy/package.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-EEXRepj2iGRsp1jf8lTm6cA3RWSOBRoIGwOVw7d8gkw=";
   };
 
-  checkInputs = with python3Packages; [ pytestCheckHook ];
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
   pythonImportsCheck = [ "lesscpy" ];
   propagatedBuildInputs = with python3Packages; [
     ply

--- a/pkgs/by-name/ni/nix-heuristic-gc/package.nix
+++ b/pkgs/by-name/ni/nix-heuristic-gc/package.nix
@@ -32,7 +32,7 @@ python3Packages.buildPythonPackage rec {
     python3Packages.humanfriendly
     python3Packages.rustworkx
   ];
-  checkInputs = [ python3Packages.pytestCheckHook ];
+  nativeCheckInputs = [ python3Packages.pytestCheckHook ];
 
   preCheck = "mv nix_heuristic_gc .nix_heuristic_gc";
 

--- a/pkgs/by-name/on/oncall/package.nix
+++ b/pkgs/by-name/on/oncall/package.nix
@@ -63,7 +63,7 @@ python3.pkgs.buildPythonApplication rec {
     cp -r configs db "$out/share/"
   '';
 
-  checkInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3.pkgs; [
     pytestCheckHook
     pytest-mock
   ];

--- a/pkgs/by-name/op/open-fprintd/package.nix
+++ b/pkgs/by-name/op/open-fprintd/package.nix
@@ -27,7 +27,7 @@ python3Packages.buildPythonPackage rec {
     pygobject3
   ];
 
-  checkInputs = with python3Packages; [ dbus-python ];
+  nativeCheckInputs = with python3Packages; [ dbus-python ];
 
   postInstall = ''
     install -D -m 644 debian/open-fprintd.service \

--- a/pkgs/by-name/ri/rivalcfg/package.nix
+++ b/pkgs/by-name/ri/rivalcfg/package.nix
@@ -20,7 +20,7 @@ python3Packages.buildPythonPackage rec {
     setuptools
   ];
 
-  checkInputs = [ python3Packages.pytest ];
+  nativeCheckInputs = [ python3Packages.pytest ];
   checkPhase = "pytest";
 
   # tests are broken

--- a/pkgs/by-name/te/tesh/package.nix
+++ b/pkgs/by-name/te/tesh/package.nix
@@ -16,7 +16,7 @@ python3Packages.buildPythonPackage rec {
     hash = "sha256-GIwg7Cv7tkLu81dmKT65c34eeVnRR5MIYfNwTE7j2Vs=";
   };
 
-  checkInputs = [ python3Packages.pytest ];
+  nativeCheckInputs = [ python3Packages.pytest ];
   nativeBuildInputs = [ python3Packages.poetry-core ];
   propagatedBuildInputs = with python3Packages; [
     click

--- a/pkgs/by-name/ye/yewtube/package.nix
+++ b/pkgs/by-name/ye/yewtube/package.nix
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication rec {
     pylast
   ];
 
-  checkInputs = with python3Packages; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
     dbus-python
     pygobject3

--- a/pkgs/development/python-modules/appnope/default.nix
+++ b/pkgs/development/python-modules/appnope/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     hash = "sha256-JYzNOPD1ofOrtZK5TTKxbF1ausmczsltR7F1Vwss8Sw=";
   };
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
     description = "Disable App Nap on macOS";

--- a/pkgs/development/python-modules/arpy/default.nix
+++ b/pkgs/development/python-modules/arpy/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     hash = "sha256-jD1XJJhcpJymn0CwZ65U06xLKm1JjHffmx/umEO7a5s=";
   };
 
-  checkInputs = [ unittestCheckHook ];
+  nativeCheckInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [ "arpy" ];
 

--- a/pkgs/development/python-modules/autograd-gamma/default.nix
+++ b/pkgs/development/python-modules/autograd-gamma/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "autograd_gamma" ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
     homepage = "https://github.com/CamDavidsonPilon/autograd-gamma";

--- a/pkgs/development/python-modules/bson/default.nix
+++ b/pkgs/development/python-modules/bson/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     six
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "bson" ];
 

--- a/pkgs/development/python-modules/calmjs-types/default.nix
+++ b/pkgs/development/python-modules/calmjs-types/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     extension = "zip";
   };
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "calmjs.types" ];
 

--- a/pkgs/development/python-modules/calmjs/default.nix
+++ b/pkgs/development/python-modules/calmjs/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     calmjs-types
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTests = [
     # spacing changes in argparse output

--- a/pkgs/development/python-modules/celery-singleton/default.nix
+++ b/pkgs/development/python-modules/celery-singleton/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     redis
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     pytest-celery
     pytest-cov-stub

--- a/pkgs/development/python-modules/django-app-helper/default.nix
+++ b/pkgs/development/python-modules/django-app-helper/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     six
   ];
 
-  checkInputs = [ django-filer ];
+  nativeCheckInputs = [ django-filer ];
 
   # Tests depend on django-filer, which depends on this package.
   # To avoid infinite recursion, we only enable tests when building passthru.tests.

--- a/pkgs/development/python-modules/django-cachalot/default.nix
+++ b/pkgs/development/python-modules/django-cachalot/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ django ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     beautifulsoup4
     django-debug-toolbar
     psycopg2

--- a/pkgs/development/python-modules/django-ckeditor/default.nix
+++ b/pkgs/development/python-modules/django-ckeditor/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   DJANGO_SETTINGS_MODULE = "ckeditor_demo.settings";
 
-  checkInputs = [
+  nativeCheckInputs = [
     django-extensions
     selenium
   ];

--- a/pkgs/development/python-modules/django-filer/default.nix
+++ b/pkgs/development/python-modules/django-filer/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     heif = [ pillow-heif ];
   };
 
-  checkInputs = [
+  nativeCheckInputs = [
     distutils
     django-app-helper
   ];

--- a/pkgs/development/python-modules/django-fsm/default.nix
+++ b/pkgs/development/python-modules/django-fsm/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   dependencies = [ django ];
 
-  checkInputs = [ django-guardian ];
+  nativeCheckInputs = [ django-guardian ];
 
   checkPhase = ''
     ${python.interpreter} tests/manage.py test

--- a/pkgs/development/python-modules/django-login-required-middleware/default.nix
+++ b/pkgs/development/python-modules/django-login-required-middleware/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ django ];
 
-  checkInputs = [ djangorestframework ];
+  nativeCheckInputs = [ djangorestframework ];
 
   pythonImportsCheck = [ "login_required" ];
 

--- a/pkgs/development/python-modules/django-sekizai/default.nix
+++ b/pkgs/development/python-modules/django-sekizai/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ django-classy-tags ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     pytest-django
   ];

--- a/pkgs/development/python-modules/django-tinymce/default.nix
+++ b/pkgs/development/python-modules/django-tinymce/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   DJANGO_SETTINGS_MODULE = "tests.settings";
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytest-django
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/djangocms-alias/default.nix
+++ b/pkgs/development/python-modules/djangocms-alias/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     django-parler
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     beautifulsoup4
     distutils
     django-app-helper

--- a/pkgs/development/python-modules/djangorestframework-csv/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-csv/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     djangorestframework
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     pytest-django
   ];

--- a/pkgs/development/python-modules/djangorestframework-jsonp/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-jsonp/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     djangorestframework
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     pytest-django
   ];

--- a/pkgs/development/python-modules/draftjs-exporter/default.nix
+++ b/pkgs/development/python-modules/draftjs-exporter/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     ];
   };
 
-  checkInputs = optional-dependencies.lxml ++ optional-dependencies.html5lib;
+  nativeCheckInputs = optional-dependencies.lxml ++ optional-dependencies.html5lib;
 
   checkPhase = ''
     # 2 tests in this file randomly fail because they depend on the order of

--- a/pkgs/development/python-modules/flask-babel/default.nix
+++ b/pkgs/development/python-modules/flask-babel/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "flask_babel" ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytest-mock
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/gassist-text/default.nix
+++ b/pkgs/development/python-modules/gassist-text/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     requests
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "gassist_text" ];
 

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     pygobject3
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     gst_all_1.gst-rtsp-server
   ];
 

--- a/pkgs/development/python-modules/hist/default.nix
+++ b/pkgs/development/python-modules/hist/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     pytest-mpl
   ];

--- a/pkgs/development/python-modules/histoprint/default.nix
+++ b/pkgs/development/python-modules/histoprint/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     uhi
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Pretty print histograms to the console";

--- a/pkgs/development/python-modules/interface-meta/default.nix
+++ b/pkgs/development/python-modules/interface-meta/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "interface_meta" ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
     homepage = "https://github.com/matthewwardrop/interface_meta";

--- a/pkgs/development/python-modules/ipyxact/default.nix
+++ b/pkgs/development/python-modules/ipyxact/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   propagatedBuildInputs = [ pyyaml ];
-  checkInputs = [
+  nativeCheckInputs = [
     six
     lxml
   ];

--- a/pkgs/development/python-modules/irisclient/default.nix
+++ b/pkgs/development/python-modules/irisclient/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   dependencies = [ requests ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     httmock
     pytestCheckHook
     pytest-mock

--- a/pkgs/development/python-modules/iwlib/default.nix
+++ b/pkgs/development/python-modules/iwlib/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ pytest ];
   pythonImportsCheck = [ "iwlib" ];
 
-  checkInputs = [ pytest ];
+  nativeCheckInputs = [ pytest ];
   checkPhase = "python iwlib/_iwlib_build.py; pytest -v";
 
   meta = with lib; {

--- a/pkgs/development/python-modules/json-stream-rs-tokenizer/default.nix
+++ b/pkgs/development/python-modules/json-stream-rs-tokenizer/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   # To avoid infinite recursion, we only enable tests when building passthru.tests.
   doCheck = false;
 
-  checkInputs = [ json-stream ];
+  nativeCheckInputs = [ json-stream ];
 
   pythonImportsCheck = [ "json_stream_rs_tokenizer" ];
 

--- a/pkgs/development/python-modules/jupyter-server-fileid/default.nix
+++ b/pkgs/development/python-modules/jupyter-server-fileid/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "jupyter_server_fileid" ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytest-jupyter
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/kneed/default.nix
+++ b/pkgs/development/python-modules/kneed/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     scipy
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     pytest-cov-stub
     matplotlib

--- a/pkgs/development/python-modules/leidenalg/default.nix
+++ b/pkgs/development/python-modules/leidenalg/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ igraph ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     ddt
     unittestCheckHook
   ];

--- a/pkgs/development/python-modules/linode-metadata/default.nix
+++ b/pkgs/development/python-modules/linode-metadata/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytest
     pytest-asyncio
   ];

--- a/pkgs/development/python-modules/maison/default.nix
+++ b/pkgs/development/python-modules/maison/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     toml
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "maison" ];
 

--- a/pkgs/development/python-modules/merkletools/default.nix
+++ b/pkgs/development/python-modules/merkletools/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
       --replace "install_requires=install_requires" "install_requires=[],"
   '';
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "merkletools" ];
 

--- a/pkgs/development/python-modules/music-tag/default.nix
+++ b/pkgs/development/python-modules/music-tag/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ mutagen ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pytestFlagsArray = [ "test" ];
 

--- a/pkgs/development/python-modules/netbox-reorder-rack/default.nix
+++ b/pkgs/development/python-modules/netbox-reorder-rack/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  checkInputs = [ netbox ];
+  nativeCheckInputs = [ netbox ];
 
   preFixup = ''
     export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH

--- a/pkgs/development/python-modules/okta/default.nix
+++ b/pkgs/development/python-modules/okta/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     yarl
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pyfakefs
     pytest-asyncio
     pytest-mock

--- a/pkgs/development/python-modules/parameterized/default.nix
+++ b/pkgs/development/python-modules/parameterized/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     mock
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/pathspec/default.nix
+++ b/pkgs/development/python-modules/pathspec/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pathspec" ];
 
-  checkInputs = [ unittestCheckHook ];
+  nativeCheckInputs = [ unittestCheckHook ];
 
   passthru.tests = {
     inherit

--- a/pkgs/development/python-modules/paver/default.nix
+++ b/pkgs/development/python-modules/paver/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   dependencies = [ six ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     cogapp
     mock
     pytestCheckHook

--- a/pkgs/development/python-modules/permissionedforms/default.nix
+++ b/pkgs/development/python-modules/permissionedforms/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ django ];
 
-  checkInputs = [ django-modelcluster ];
+  nativeCheckInputs = [ django-modelcluster ];
 
   checkPhase = ''
     ${python.interpreter} runtests.py

--- a/pkgs/development/python-modules/pyTelegramBotAPI/default.nix
+++ b/pkgs/development/python-modules/pyTelegramBotAPI/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     watchdog = [ watchdog ];
   };
 
-  checkInputs =
+  nativeCheckInputs =
     [
       pytestCheckHook
       requests

--- a/pkgs/development/python-modules/pyperscan/default.nix
+++ b/pkgs/development/python-modules/pyperscan/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     maturinBuildHook
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   buildInputs = [ vectorscan ] ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
 

--- a/pkgs/development/python-modules/pyquery/default.nix
+++ b/pkgs/development/python-modules/pyquery/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pyquery" ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
     requests
     webob

--- a/pkgs/development/python-modules/qasync/default.nix
+++ b/pkgs/development/python-modules/qasync/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyqt5 ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "qasync" ];
 

--- a/pkgs/development/python-modules/range-typed-integers/default.nix
+++ b/pkgs/development/python-modules/range-typed-integers/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Package provides integer types that have a specific range of valid values";

--- a/pkgs/development/python-modules/screed/default.nix
+++ b/pkgs/development/python-modules/screed/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ setuptools-scm ];
 
   pythonImportsCheck = [ "screed" ];
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   # These tests use the screed CLI and make assumptions on how screed is
   # installed that break with nix. Can be enabled when upstream is fixed.

--- a/pkgs/development/python-modules/taskw-ng/default.nix
+++ b/pkgs/development/python-modules/taskw-ng/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     pytz
   ];
 
-  checkInputs = [ taskwarrior2 ];
+  nativeCheckInputs = [ taskwarrior2 ];
 
   # TODO: doesn't pass because `can_use` fails and `task --version` seems not to be answering.
   # pythonImportsCheck = [ "taskw_ng" ];

--- a/pkgs/development/python-modules/telepath/default.nix
+++ b/pkgs/development/python-modules/telepath/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     hash = "sha256-MS4Q41WVSrjFmFjv4fztyf0U2+5WkNU79aPEKv/CeUQ=";
   };
 
-  checkInputs = [ django ];
+  nativeCheckInputs = [ django ];
 
   checkPhase = ''
     ${python.interpreter} -m django test --settings=telepath.test_settings

--- a/pkgs/development/python-modules/throttler/default.nix
+++ b/pkgs/development/python-modules/throttler/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     hash = "sha256-fE35zPjBUn4e1VRkkIUMtYJ/+LbnUxnxyfnU+UEPwr4=";
   };
 
-  checkInputs = [
+  nativeCheckInputs = [
     aiohttp
     flake8
     pytest

--- a/pkgs/development/python-modules/tlv8/default.nix
+++ b/pkgs/development/python-modules/tlv8/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "sha256-G35xMFYasKD3LnGi9q8wBmmFvqgtg0HPdC+y82nxRWA=";
   };
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "tlv8" ];
 

--- a/pkgs/development/python-modules/uhi/default.nix
+++ b/pkgs/development/python-modules/uhi/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     numpy
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "Universal Histogram Interface";

--- a/pkgs/development/python-modules/volvooncall/default.nix
+++ b/pkgs/development/python-modules/volvooncall/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     ];
   };
 
-  checkInputs = [
+  nativeCheckInputs = [
     mock
     pytest-asyncio
     pytestCheckHook

--- a/pkgs/development/python-modules/yubico/default.nix
+++ b/pkgs/development/python-modules/yubico/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyusb ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "yubico" ];
 
   disabledTests = [

--- a/pkgs/servers/mail/mailman/package.nix
+++ b/pkgs/servers/mail/mailman/package.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     zope-configuration
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     sphinx
   ];
 

--- a/pkgs/tools/virtualization/mkosi/default.nix
+++ b/pkgs/tools/virtualization/mkosi/default.nix
@@ -118,7 +118,7 @@ buildPythonApplication rec {
     ./tools/make-man-page.sh
   '';
 
-  checkInputs = [
+  nativeCheckInputs = [
     pytestCheckHook
   ];
 


### PR DESCRIPTION
Candidates made with

    rg '(buildPythonPackage|buildPythonApplication)' -l | xargs grep nativeCheckInputs -L | xargs sd -F ' checkInputs =' ' nativeCheckInputs ='

Then I cherry-picked the migrations with `--patch` and checked evaluation. Pr is draft while i use a different host for nixpkgs-review


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
