### PR TITLE
x{prop,refresh}: 1.2.7 -> 1.2.8 (only xprop) && refactor and migrate to pkgs/by-name from xorg namespace

### DIFF
--- a/pkgs/by-name/xp/xprop/package.nix
+++ b/pkgs/by-name/xp/xprop/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libx11,
+  xorgproto,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xprop";
+  version = "1.2.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xprop-${finalAttrs.version}.tar.xz";
+    hash = "sha256-1onirbfve0OfZGm1HNqKfa78gyQ4VMKjuPhNDwKdZ+4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libx11
+    xorgproto
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Command line tool to display and/or set window and font properties of an X server";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xprop";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpndSellVariant
+      mit
+    ];
+    mainProgram = "xprop";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xr/xrefresh/package.nix
+++ b/pkgs/by-name/xr/xrefresh/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libx11,
+  xorgproto,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xrefresh";
+  version = "1.1.0";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/xrefresh-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Ke1ZLV7ONaMCkATYxG8wAvkpcIcKlsEeOLr38RIri18=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libx11
+    xorgproto
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/app/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Utility to refresh all or part of an X screen";
+    homepage = "https://gitlab.freedesktop.org/xorg/app/xrefresh";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpnd
+    ];
+    mainProgram = "xrefresh";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -28,6 +28,7 @@
   xorgproto,
   xorg-sgml-doctools,
   xprop,
+  xrefresh,
   xtrans,
 }:
 
@@ -48,6 +49,7 @@ self: with self; {
     xbitmaps
     xorgproto
     xprop
+    xrefresh
     xtrans
     ;
   fontalias = font-alias;
@@ -7374,42 +7376,6 @@ self: with self; {
       buildInputs = [
         libX11
         libXmu
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xrefresh = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xrefresh";
-      version = "1.1.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xrefresh-1.1.0.tar.xz";
-        sha256 = "0pwb5c9g3xxs70gc35hahxq2ky8261pw9n04j01a6dffbqnmkv99";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
         xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -27,6 +27,7 @@
   xorg-docs,
   xorgproto,
   xorg-sgml-doctools,
+  xprop,
   xtrans,
 }:
 
@@ -46,6 +47,7 @@ self: with self; {
     sessreg
     xbitmaps
     xorgproto
+    xprop
     xtrans
     ;
   fontalias = font-alias;
@@ -7294,42 +7296,6 @@ self: with self; {
       buildInputs = [
         libX11
         libXmu
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xprop = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xprop";
-      version = "1.2.8";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/app/xprop-1.2.8.tar.xz";
-        sha256 = "1vk7kl10ykgqp2iw4m1q4j1zrbkxibd1rdb9cjgl6yzgnyny52fn";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
         xorgproto
       ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -313,6 +313,7 @@ print OUT <<EOF;
   xorgproto,
   xorg-sgml-doctools,
   xprop,
+  xrefresh,
   xtrans,
 }:
 
@@ -333,6 +334,7 @@ self: with self; {
     xbitmaps
     xorgproto
     xprop
+    xrefresh
     xtrans
     ;
   fontalias = font-alias;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -312,6 +312,7 @@ print OUT <<EOF;
   xorg-docs,
   xorgproto,
   xorg-sgml-doctools,
+  xprop,
   xtrans,
 }:
 
@@ -331,6 +332,7 @@ self: with self; {
     sessreg
     xbitmaps
     xorgproto
+    xprop
     xtrans
     ;
   fontalias = font-alias;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1231,7 +1231,6 @@ self: super:
     };
   });
 
-  xrefresh = addMainProgram super.xrefresh { };
   xset = addMainProgram super.xset { };
   xsetroot = addMainProgram super.xsetroot { };
   xsm = addMainProgram super.xsm { };

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1214,7 +1214,6 @@ self: super:
   xmore = addMainProgram super.xmore { };
 
   xpr = addMainProgram super.xpr { };
-  xprop = addMainProgram super.xprop { };
 
   xrdb = super.xrdb.overrideAttrs (attrs: {
     configureFlags = [ "--with-cpp=${mcpp}/bin/mcpp" ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -55,7 +55,6 @@ mirror://xorg/individual/app/xmessage-1.0.7.tar.xz
 mirror://xorg/individual/app/xmodmap-1.0.11.tar.xz
 mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
-mirror://xorg/individual/app/xprop-1.2.8.tar.xz
 mirror://xorg/individual/app/xrandr-1.5.3.tar.xz
 mirror://xorg/individual/app/xrdb-1.2.2.tar.xz
 mirror://xorg/individual/app/xrefresh-1.1.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -57,7 +57,6 @@ mirror://xorg/individual/app/xmore-1.0.4.tar.xz
 mirror://xorg/individual/app/xpr-1.2.0.tar.xz
 mirror://xorg/individual/app/xrandr-1.5.3.tar.xz
 mirror://xorg/individual/app/xrdb-1.2.2.tar.xz
-mirror://xorg/individual/app/xrefresh-1.1.0.tar.xz
 mirror://xorg/individual/app/xset-1.2.5.tar.xz
 mirror://xorg/individual/app/xsetroot-1.1.3.tar.xz
 mirror://xorg/individual/app/xsm-1.0.6.tar.xz


### PR DESCRIPTION
my plan is to migrate all packages from xorg to pkgs/by-name
in this iteration there are several PRs with one or more packages that should be able to get merged independently

this is the script i use to get the packages that don't depend on other xorg packages:
```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      # && !v.meta.unfree
      # && !v.meta.broken
      # && !v.meta.unsupported
      # && !lib.hasPrefix "font" n
      # && !lib.hasPrefix "xf86" n
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;
in
pkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (x: y: x.count < y.count || (x.count == y.count && x.name > y.name))
|> lib.reverseList
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:

```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
