### PR TITLE
catalyst: init at 2.0.0

### DIFF
--- a/pkgs/by-name/ca/catalyst/package.nix
+++ b/pkgs/by-name/ca/catalyst/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  gfortran,
+  mpi,
+  python3Packages,
+  ctestCheckHook,
+  mpiCheckPhaseHook,
+  mpiSupport ? true,
+  pythonSupport ? false,
+  fortranSupport ? false,
+
+  # passthru.tests
+  testers,
+  catalyst,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "catalyst";
+  version = "2.0.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.kitware.com";
+    owner = "paraview";
+    repo = "catalyst";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uPb7vgJpKquZVmSMxeWDVMiNkUdYv3oVVKu7t4+zkbs=";
+  };
+
+  nativeBuildInputs =
+    [
+      cmake
+    ]
+    ++ lib.optionals pythonSupport [
+      python3Packages.python
+      python3Packages.pythonImportsCheckHook
+    ]
+    ++ lib.optionals fortranSupport [
+      gfortran
+    ];
+
+  propagatedBuildInputs =
+    # create meta package providing dist-info for python3Pacakges.catalyst that common cmake build does not do
+    lib.optional pythonSupport (
+      python3Packages.mkPythonMetaPackage {
+        inherit (finalAttrs) pname version meta;
+        dependencies =
+          with python3Packages;
+          [
+            numpy
+          ]
+          ++ lib.optional mpiSupport (mpi4py.override { inherit mpi; });
+      }
+    )
+    ++ lib.optional mpiSupport mpi;
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
+    (lib.cmakeBool "CATALYST_USE_MPI" mpiSupport)
+    (lib.cmakeBool "CATALYST_WRAP_PYTHON" pythonSupport)
+    (lib.cmakeBool "CATALYST_WRAP_FORTRAN" fortranSupport)
+    (lib.cmakeBool "CATALYST_BUILD_TESTING" finalAttrs.finalPackage.doCheck)
+  ];
+
+  postInstall = lib.optionalString pythonSupport ''
+    python -m compileall -s $out $out/${python3Packages.python.sitePackages}
+  '';
+
+  doCheck = true;
+
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export DYLD_LIBRARY_PATH=$PWD/lib:$DYLD_LIBRARY_PATH
+  '';
+
+  __darwinAllowLocalNetworking = mpiSupport;
+
+  nativeCheckInputs = [ ctestCheckHook ] ++ lib.optional mpiSupport mpiCheckPhaseHook;
+
+  disabledTests = lib.optionals fortranSupport [
+    # unexpected fortran binding symbol *__iso_c_binding_C_ptr
+    "catalyst-abi-nm"
+  ];
+
+  pythonImportsCheck = [ "catalyst" ];
+
+  passthru.tests = {
+    cmake-config = testers.hasCmakeConfigModules {
+      moduleNames = [ "catalyst" ];
+      package = finalAttrs.finalPackage;
+    };
+    serial = catalyst.override { mpiSupport = false; };
+    fortran = catalyst.override { fortranSupport = true; };
+  };
+
+  meta = {
+    description = "In situ visualization and analysis library";
+    homepage = "https://kitware.github.io/paraview-catalyst";
+    downloadPage = "https://gitlab.kitware.com/paraview/catalyst";
+    license = with lib.licenses; [
+      bsd3
+      # vendored conduit
+      bsd3Lbnl
+    ];
+    maintainers = with lib.maintainers; [ qbisi ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2291,6 +2291,13 @@ self: super: with self; {
 
   catalogue = callPackage ../development/python-modules/catalogue { };
 
+  catalyst = toPythonModule (
+    pkgs.catalyst.override {
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
+
   catboost = callPackage ../development/python-modules/catboost {
     catboost = pkgs.catboost.override {
       pythonSupport = true;


### PR DESCRIPTION
catalyst: a in situ visualization and analysis library.

homepage: https://kitware.github.io/paraview-catalyst/
downloadPage: https://gitlab.kitware.com/paraview/catalyst

external dependency of adios2/vtk/paraview

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
