### PR TITLE
xenia-canary: init at 0-unstable-2025-06-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25572,6 +25572,12 @@
     name = "Denny Schäfer";
     keys = [ { fingerprint = "C752 0E49 4D92 1740 D263  C467 B057 455D 1E56 7270"; } ];
   };
+  tuxy = {
+    email = "lastpass7565@gmail.com";
+    github = "tuxy";
+    githubId = 57819359;
+    name = "Binh Nguyen";
+  };
   tv = {
     email = "tv@krebsco.de";
     github = "4z3";

--- a/pkgs/by-name/xe/xenia-canary/package.nix
+++ b/pkgs/by-name/xe/xenia-canary/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  python3,
+  gtk3,
+  lz4,
+  SDL2,
+  pkg-config,
+  vulkan-loader,
+  ninja,
+  cmake,
+  libuuid,
+  wrapGAppsHook3,
+  makeDesktopItem,
+  copyDesktopItems,
+  llvmPackages_18,
+  autoPatchelfHook,
+  unstableGitUpdater,
+  fetchFromGitHub,
+}:
+llvmPackages_18.stdenv.mkDerivation {
+  pname = "xenia-canary";
+  version = "0-unstable-2025-06-07";
+
+  src = fetchFromGitHub {
+    owner = "xenia-canary";
+    repo = "xenia-canary";
+    fetchSubmodules = true;
+    rev = "422517c673bba086c2b857946ae5a37ee35b8e50";
+    hash = "sha256-88GHKXURfN8vaVNN7wKn562b6FvsIm/sTcUgtuhvVxM=";
+  };
+
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    python3
+    pkg-config
+    ninja
+    cmake
+    wrapGAppsHook3
+    copyDesktopItems
+    autoPatchelfHook
+    libuuid
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-Wno-error=unused-result"
+  ];
+
+  buildInputs = [
+    gtk3
+    lz4
+    SDL2
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    python3 xenia-build setup
+    python3 xenia-build build --config=release -j $NIX_BUILD_CORES
+    runHook postBuild
+  '';
+
+  runtimeDependencies = [
+    vulkan-loader
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "xenia_canary";
+      desktopName = "Xenia Canary";
+      genericName = "Xbox 360 Emulator";
+      exec = "xenia_canary";
+      comment = "Xbox 360 Emulator Research Project";
+      icon = "xenia-canary";
+      startupWMClass = "Xenia_canary";
+      categories = [
+        "Game"
+        "Emulator"
+      ];
+      keywords = [ "xbox" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    find ./build/bin -mindepth 3 -maxdepth 3 -type f -executable -exec install -Dm755 {} -t $out/bin \;
+    for width in 16 32 48 64 128 256; do
+      install -Dm644 assets/icon/$width.png $out/share/icons/hicolor/''${width}x''${width}/apps/xenia-canary.png
+    done
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Xbox 360 Emulator Research Project";
+    homepage = "https://github.com/xenia-canary/xenia-canary";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ tuxy ];
+    mainProgram = "xenia_canary";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Xbox 360 Emulator Research Project

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Currently no .desktop files or any desktop launchers. Just the xenia_canary command. Have tested with nix-build and nix-shell and works fine on nixos-unstable, but haven't tested with nixpkgs-review yet. Also added myself as maintainer for this project.

My first package, so please inform me of any issues on the package :)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
