### PR TITLE
ci/check-cherry-picks: fix indent of truncation marker

### DIFF
--- a/ci/check-cherry-picks.sh
+++ b/ci/check-cherry-picks.sh
@@ -121,7 +121,7 @@ while read -r new_commit_sha ; do
           # consider this too unlikely to happen, to deal with explicitly.
           max_length=10000
           if [ "${#diff}" -gt $max_length ]; then
-            printf -v diff "%s\n\n[...truncated...]" "$(echo "$diff" | head -c $max_length | head -n-1)"
+            printf -v diff "%s\n>\n> [...truncated...]" "$(echo "$diff" | head -c $max_length | head -n-1)"
           fi
           echo "$diff" >> $markdown_file
           echo '> ```' >> $markdown_file


### PR DESCRIPTION
This needs to be indented the same way as the remaining code-block, otherwise the `</details>` is not rendered correctly.

Effect can be seen in https://github.com/NixOS/nixpkgs/pull/414985#pullrequestreview-2908396271.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
