### PR TITLE
geminicommit: 0.4.0 -> 0.4.1, fix mainProgram

### DIFF
--- a/pkgs/by-name/ge/geminicommit/package.nix
+++ b/pkgs/by-name/ge/geminicommit/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "geminicommit";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "tfkhdyt";
     repo = "geminicommit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hJevJkniyICUUr1UyS0A5SKuuYRU0dGHMWzF99Yr2Eo=";
+    hash = "sha256-QUI5JI1udOo3IOXegoes3pwwgSfxXIjxXIPsA5SuAJo=";
   };
 
-  vendorHash = "sha256-IfqlPg+HPcOfjlwwuLi2/R21UD83xQzWyUmzM7JSDEs=";
+  vendorHash = "sha256-AFm+1RQ6sMSe+kY/cw1Ly/8WEj2/yk0nJQiEJzV6jKg=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/ge/geminicommit/package.nix
+++ b/pkgs/by-name/ge/geminicommit/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   installShellFiles,
   stdenv,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -26,9 +27,18 @@ buildGoModule (finalAttrs: {
   postInstall =
     let
       cmd = finalAttrs.meta.mainProgram;
+      goDefaultCmd = finalAttrs.pname;
     in
-    lib.optionalString (with stdenv; buildPlatform.canExecute hostPlatform) ''
-      # `geminicommit` requires write permissions to $HOME for its `config.toml`
+    # The official github released binary is renamed since v0.4.1,
+    # see: https://github.com/tfkhdyt/geminicommit/releases/tag/v0.4.1
+    # Here we link the old name (which is also the `go build` default name)
+    # for backward compatibility:
+    ''
+      mv $out/bin/${goDefaultCmd} $out/bin/${cmd}
+      ln -s $out/bin/${cmd} $out/bin/${goDefaultCmd}
+    ''
+    + lib.optionalString (with stdenv; buildPlatform.canExecute hostPlatform) ''
+      # `gmc` requires write permissions to $HOME for its `config.toml`
       # ... which is automatically initiated on startup
       export HOME=$(mktemp -d)
 
@@ -39,11 +49,17 @@ buildGoModule (finalAttrs: {
       done
     '';
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
   meta = {
     description = "CLI that generates git commit messages with Google Gemini AI";
     homepage = "https://github.com/tfkhdyt/geminicommit";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ bryango ];
-    mainProgram = "geminicommit";
+    mainProgram = "gmc";
   };
 })


### PR DESCRIPTION
Supersedes #414988.

Upstream has changed the name of the binary `geminicommit -> gmc`, but the change is only implemented in the github CI builder, which passes a `-o gmc` flag to the `go build` command. See:
- https://github.com/tfkhdyt/geminicommit/commit/2fc8feb2e69611bc0cfb5469cc940a459f282bc0
- https://github.com/tfkhdyt/geminicommit/releases/tag/v0.4.1

In Nixpkgs with `buildGoModule` the default binary name would still be the package name, i.e. `geminicommit`. It seems (to me) that there is no way to pass the `-o` flag to `buildGoModule`. So, to implement the upstream change of binary name, we simply rename the binary by hand in `postInstall`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
