### PR TITLE
python3Packages.islpy: 2025.1.5 -> 2025.2

### DIFF
--- a/pkgs/development/python-modules/islpy/default.nix
+++ b/pkgs/development/python-modules/islpy/default.nix
@@ -8,10 +8,11 @@
   nanobind,
   ninja,
   pcpp,
-  scikit-build,
-  setuptools,
+  scikit-build-core,
+  typing-extensions,
 
   # buildInputs
+  imath,
   isl,
 
   # tests
@@ -20,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "islpy";
-  version = "2025.1.5";
+  version = "2025.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "inducer";
     repo = "islpy";
     tag = "v${version}";
-    hash = "sha256-hzqxVLNKm63XliX5rDB54f6n1nJPVJJSAMmNTInbOEE=";
+    hash = "sha256-RMqqnhW8MibGhAhJZF/EjycFJ7E3j4aur0a6UaPyeIs=";
   };
 
   build-system = [
@@ -35,19 +36,24 @@ buildPythonPackage rec {
     nanobind
     ninja
     pcpp
-    scikit-build
-    setuptools
+    scikit-build-core
+    typing-extensions
   ];
 
-  buildInputs = [ isl ];
+  buildInputs = [
+    imath
+    isl
+  ];
 
   dontUseCmakeConfigure = true;
 
-  preConfigure = ''
-    python ./configure.py \
-        --no-use-shipped-isl \
-        --isl-inc-dir=${lib.getDev isl}/include \
-  '';
+  pypaBuildFlags = [
+    "--config-setting=cmake.define.USE_SHIPPED_ISL=OFF"
+    "--config-setting=cmake.define.USE_SHIPPED_IMATH=OFF"
+    "--config-setting=cmake.define.USE_BARVINOK=OFF"
+    "--config-setting=cmake.define.ISL_INC_DIRS:LIST='${lib.getDev isl}/include'"
+    "--config-setting=cmake.define.ISL_LIB_DIRS:LIST='${lib.getLib isl}/lib'"
+  ];
 
   # Force resolving the package from $out to make generated ext files usable by tests
   preCheck = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/inducer/islpy/compare/refs/tags/v2025.1.5...refs/tags/v2025.2
Changelog: https://github.com/inducer/islpy/releases/tag/v2025.2

cc @TomaSajt 

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
