### PR TITLE
spral: 2025.01.08 -> 2025.05.20

### DIFF
--- a/pkgs/by-name/sp/spral/package.nix
+++ b/pkgs/by-name/sp/spral/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "spral";
-  version = "2025.01.08";
+  version = "2025.05.20";
 
   src = fetchFromGitHub {
     owner = "ralna";
     repo = "spral";
     rev = "v${version}";
-    hash = "sha256-tuhJClSjah/ud6PVr6biOq5KdKtspJ7hpWZ350yzz+U=";
+    hash = "sha256-9QEcAOFB3CtGNqr8LoDaj2vP3KMONlUVooeXECtGsxc=";
   };
 
   postPatch =

--- a/pkgs/by-name/sp/spral/package.nix
+++ b/pkgs/by-name/sp/spral/package.nix
@@ -35,6 +35,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-9QEcAOFB3CtGNqr8LoDaj2vP3KMONlUVooeXECtGsxc=";
   };
 
+  # Ignore a failing test on darwin
+  # ref. https://github.com/ralna/spral/issues/258
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace tests/ssids/meson.build --replace-fail \
+      "spral_tests += [['ssids', 'ssidst', files('ssids.f90')]]" ""
+  '';
+
   nativeBuildInputs =
     [
       gfortran

--- a/pkgs/by-name/sp/spral/package.nix
+++ b/pkgs/by-name/sp/spral/package.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
 
   fetchFromGitHub,
@@ -6,7 +7,10 @@
 
   nix-update-script,
 
+  enableCuda ? config.cudaSupport,
+
   # nativeBuildInputs
+  cudaPackages,
   gfortran,
   meson,
   ninja,
@@ -14,6 +18,7 @@
 
   # buildInputs
   blas,
+  hwloc,
   lapack,
   llvmPackages,
   metis,
@@ -30,15 +35,25 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-9QEcAOFB3CtGNqr8LoDaj2vP3KMONlUVooeXECtGsxc=";
   };
 
-  nativeBuildInputs = [
-    gfortran
-    meson
-    ninja
-    pkg-config
+  nativeBuildInputs =
+    [
+      gfortran
+      meson
+      ninja
+      pkg-config
+    ]
+    ++ lib.optionals enableCuda [
+      cudaPackages.cuda_nvcc
+    ];
+
+  propagatedBuildInputs = lib.optionals enableCuda [
+    cudaPackages.cuda_cudart
+    cudaPackages.libcublas
   ];
 
   buildInputs = [
     blas
+    (hwloc.override { inherit enableCuda; })
     lapack
     metis
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ];

--- a/pkgs/by-name/sp/spral/package.nix
+++ b/pkgs/by-name/sp/spral/package.nix
@@ -10,6 +10,7 @@
   gfortran,
   meson,
   ninja,
+  pkg-config,
 
   # buildInputs
   blas,
@@ -33,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     gfortran
     meson
     ninja
+    pkg-config
   ];
 
   buildInputs = [

--- a/pkgs/by-name/sp/spral/package.nix
+++ b/pkgs/by-name/sp/spral/package.nix
@@ -22,21 +22,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-9QEcAOFB3CtGNqr8LoDaj2vP3KMONlUVooeXECtGsxc=";
   };
 
-  postPatch =
-    ''
-      # Skipped test: ssidst
-      # hwloc/linux: failed to find sysfs cpu topology directory, aborting linux discovery.
-      substituteInPlace tests/meson.build --replace-fail \
-        "subdir('ssids')" \
-        ""
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # Skipped test: lsmrt, segfault
-      substituteInPlace tests/meson.build --replace-fail \
-        "['lsmrt', files('lsmr.f90')]," \
-        ""
-    '';
-
   nativeBuildInputs = [
     gfortran
     meson

--- a/pkgs/by-name/sp/spral/package.nix
+++ b/pkgs/by-name/sp/spral/package.nix
@@ -1,24 +1,31 @@
 {
-  blas,
-  fetchFromGitHub,
-  gfortran,
-  lapack,
   lib,
-  llvmPackages,
-  meson,
-  metis,
-  ninja,
+
+  fetchFromGitHub,
   stdenv,
+
+  nix-update-script,
+
+  # nativeBuildInputs
+  gfortran,
+  meson,
+  ninja,
+
+  # buildInputs
+  blas,
+  lapack,
+  llvmPackages,
+  metis,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "spral";
   version = "2025.05.20";
 
   src = fetchFromGitHub {
     owner = "ralna";
     repo = "spral";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-9QEcAOFB3CtGNqr8LoDaj2vP3KMONlUVooeXECtGsxc=";
   };
 
@@ -40,11 +47,13 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Sparse Parallel Robust Algorithms Library";
     homepage = "https://github.com/ralna/spral";
-    changelog = "https://github.com/ralna/spral/blob/${src.rev}/ChangeLog";
+    changelog = "https://github.com/ralna/spral/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ nim65s ];
   };
-}
+})


### PR DESCRIPTION
Follows #386858

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
