### PR TITLE
workflows/labels: manage approval labels

### DIFF
--- a/.github/workflows/dismissed-review.yml
+++ b/.github/workflows/dismissed-review.yml
@@ -1,0 +1,65 @@
+name: Dismissed review
+
+on:
+  workflow_run:
+    workflows:
+      - Review dismissed
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # The `check-cherry-picks` workflow creates review comments which reviewers
+  # are encouraged to manually dismiss if they're not relevant.
+  # When a CI-generated review is dismissed, this job automatically minimizes
+  # it, preventing it from cluttering the PR.
+  minimize:
+    name: Minimize as resolved
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            // PRs from forks don't have any PRs associated by default.
+            // Thus, we request the PR number with an API call *to* the fork's repo.
+            // Multiple pull requests can be open from the same head commit, either via
+            // different base branches or head branches.
+            const { head_repository, head_sha, repository } = context.payload.workflow_run
+            await Promise.all(
+              (await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+                owner: head_repository.owner.login,
+                repo: head_repository.name,
+                commit_sha: head_sha
+              }))
+              .filter(pull_request => pull_request.base.repo.id == repository.id)
+              .map(async (pull_request) =>
+                Promise.all(
+                  (await github.paginate(github.rest.pulls.listReviews, {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pull_request.number
+                  })).filter(review =>
+                    review.user.login == 'github-actions[bot]' &&
+                    review.state == 'DISMISSED'
+                  ).map(review => github.graphql(`
+                    mutation($node_id:ID!) {
+                      minimizeComment(input: {
+                        classifier: RESOLVED,
+                        subjectId: $node_id
+                      })
+                      { clientMutationId }
+                    }`,
+                    { node_id: review.node_id }
+                  ))
+                )
+              )
+            )

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -213,46 +213,6 @@ jobs:
           name: comparison
           path: comparison/*
 
-      - name: Labelling pull request
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const { readFile } = require('node:fs/promises')
-
-            const pr = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number
-            }
-
-            // Get all currently set labels that we manage
-            const before =
-              (await github.paginate(github.rest.issues.listLabelsOnIssue, pr))
-              .map(({ name }) => name)
-              .filter(name => name.startsWith('10.rebuild') || name == '11.by: package-maintainer')
-
-            // And the labels that should be there
-            const after = JSON.parse(await readFile('comparison/changed-paths.json', 'utf-8')).labels
-
-            // Remove the ones not needed anymore
-            await Promise.all(
-              before.filter(name => !after.includes(name))
-              .map(name => github.rest.issues.removeLabel({
-                ...pr,
-                name
-              }))
-            )
-
-            // And add the ones that aren't set already
-            const added = after.filter(name => !before.includes(name))
-            if (added.length > 0) {
-              await github.rest.issues.addLabels({
-                ...pr,
-                labels: added
-              })
-            }
-
       - name: Add eval summary to commit statuses
         if: ${{ github.event_name == 'pull_request_target' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -284,6 +244,16 @@ jobs:
               description,
               target_url
             })
+
+  labels:
+    name: Labels
+    needs: [ compare ]
+    uses: ./.github/workflows/labels.yml
+    permissions:
+      issues: write
+      pull-requests: write
+    with:
+      caller: ${{ github.workflow }}
 
   reviewers:
     name: Reviewers

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -6,14 +6,18 @@
 name: "Label PR"
 
 on:
-  pull_request_target:
+  workflow_call:
+    inputs:
+      caller:
+        description: Name of the calling workflow.
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ inputs.caller }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:
-  contents: read
   issues: write # needed to create *new* labels
   pull-requests: write
 
@@ -23,7 +27,55 @@ jobs:
     runs-on: ubuntu-24.04-arm
     if: "!contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
+      - name: Download the comparison results
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: comparison
+          path: comparison
+          merge-multiple: true
+
+      - name: Labels from eval
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { readFile } = require('node:fs/promises')
+
+            const pr = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            }
+
+            // Get all currently set labels that we manage
+            const before =
+              (await github.paginate(github.rest.issues.listLabelsOnIssue, pr))
+              .map(({ name }) => name)
+              .filter(name => name.startsWith('10.rebuild') || name == '11.by: package-maintainer')
+
+            // And the labels that should be there
+            const after = JSON.parse(await readFile('comparison/changed-paths.json', 'utf-8')).labels
+
+            // Remove the ones not needed anymore
+            await Promise.all(
+              before.filter(name => !after.includes(name))
+              .map(name => github.rest.issues.removeLabel({
+                ...pr,
+                name
+              }))
+            )
+
+            // And add the ones that aren't set already
+            const added = after.filter(name => !before.includes(name))
+            if (added.length > 0) {
+              await github.rest.issues.addLabels({
+                ...pr,
+                labels: added
+              })
+            }
+
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        name: Labels from touched files
         if: |
           github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
             github.head_ref == 'haskell-updates' ||
@@ -36,6 +88,7 @@ jobs:
           configuration-path: .github/labeler.yml # default
           sync-labels: true
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        name: Labels from touched files (no sync)
         if: |
           github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
             github.head_ref == 'haskell-updates' ||
@@ -48,6 +101,7 @@ jobs:
           configuration-path: .github/labeler-no-sync.yml
           sync-labels: false
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        name: Labels from touched files (development branches)
         # Development branches like staging-next, haskell-updates and python-updates get special labels.
         # This is to avoid the mass of labels there, which is mostly useless - and really annoying for
         # the backport labels.

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -12,6 +12,11 @@ on:
         description: Name of the calling workflow.
         required: true
         type: string
+  workflow_run:
+    workflows:
+      - Review dismissed
+      - Review submitted
+    types: [completed]
 
 concurrency:
   group: ${{ inputs.caller }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
@@ -27,56 +32,113 @@ jobs:
     runs-on: ubuntu-24.04-arm
     if: "!contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: eval
+        with:
+          script: |
+            const run_id = (await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'eval.yml',
+              event: 'pull_request_target',
+              head_sha: context.payload.pull_request?.head.sha ?? context.payload.workflow_run.head_sha
+            })).data.workflow_runs[0]?.id
+            core.setOutput('run-id', run_id)
+
       - name: Download the comparison results
+        if: steps.eval.outputs.run-id
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
+          run-id: ${{ steps.eval.outputs.run-id }}
+          github-token: ${{ github.token }}
           pattern: comparison
           path: comparison
           merge-multiple: true
 
       - name: Labels from eval
-        if: ${{ github.event_name != 'pull_request' }}
+        if: steps.eval.outputs.run-id && github.event_name != 'pull_request'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { readFile } = require('node:fs/promises')
 
-            const pr = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number
+            let pull_requests
+            if (context.payload.workflow_run) {
+              // PRs from forks don't have any PRs associated by default.
+              // Thus, we request the PR number with an API call *to* the fork's repo.
+              // Multiple pull requests can be open from the same head commit, either via
+              // different base branches or head branches.
+              const { head_repository, head_sha, repository } = context.payload.workflow_run
+              pull_requests = (await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+                owner: head_repository.owner.login,
+                repo: head_repository.name,
+                commit_sha: head_sha
+              })).filter(pull_request => pull_request.base.repo.id == repository.id)
+            } else {
+              pull_requests = [ context.payload.pull_request ]
             }
 
-            // Get all currently set labels that we manage
-            const before =
-              (await github.paginate(github.rest.issues.listLabelsOnIssue, pr))
-              .map(({ name }) => name)
-              .filter(name => name.startsWith('10.rebuild') || name == '11.by: package-maintainer')
-
-            // And the labels that should be there
-            const after = JSON.parse(await readFile('comparison/changed-paths.json', 'utf-8')).labels
-
-            // Remove the ones not needed anymore
             await Promise.all(
-              before.filter(name => !after.includes(name))
-              .map(name => github.rest.issues.removeLabel({
-                ...pr,
-                name
-              }))
-            )
+              pull_requests.map(async (pull_request) => {
+                const pr = {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pull_request.number
+                }
 
-            // And add the ones that aren't set already
-            const added = after.filter(name => !before.includes(name))
-            if (added.length > 0) {
-              await github.rest.issues.addLabels({
-                ...pr,
-                labels: added
+                // Get all currently set labels that we manage
+                const before =
+                  (await github.paginate(github.rest.issues.listLabelsOnIssue, pr))
+                  .map(({ name }) => name)
+                  .filter(name =>
+                    name.startsWith('10.rebuild') ||
+                    name == '11.by: package-maintainer' ||
+                    name.startsWith('12.approvals:') ||
+                    name == '12.approved-by: package-maintainer'
+                  )
+
+                const approvals =
+                  (await github.paginate(github.rest.pulls.listReviews, {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pull_request.number
+                  }))
+                  .filter(review => review.state == 'APPROVED')
+                  .map(review => review.user.id)
+
+                const maintainers = Object.keys(
+                  JSON.parse(await readFile('comparison/maintainers.json', 'utf-8'))
+                )
+
+                // And the labels that should be there
+                const after = JSON.parse(await readFile('comparison/changed-paths.json', 'utf-8')).labels
+                if (approvals.length > 0) after.push(`12.approvals: ${approvals.length > 2 ? '3+' : approvals.length}`)
+                if (maintainers.some(id => approvals.includes(id))) after.push('12.approved-by: package-maintainer')
+
+                // Remove the ones not needed anymore
+                await Promise.all(
+                  before.filter(name => !after.includes(name))
+                  .map(name => github.rest.issues.removeLabel({
+                    ...pr,
+                    name
+                  }))
+                )
+
+                // And add the ones that aren't set already
+                const added = after.filter(name => !before.includes(name))
+                if (added.length > 0) {
+                  await github.rest.issues.addLabels({
+                    ...pr,
+                    labels: added
+                  })
+                }
               })
-            }
+            )
 
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         name: Labels from touched files
         if: |
+          github.event_name != 'workflow_run' &&
           github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
             github.head_ref == 'haskell-updates' ||
             github.head_ref == 'python-updates' ||
@@ -87,9 +149,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml # default
           sync-labels: true
+
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         name: Labels from touched files (no sync)
         if: |
+          github.event_name != 'workflow_run' &&
           github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
             github.head_ref == 'haskell-updates' ||
             github.head_ref == 'python-updates' ||
@@ -100,12 +164,14 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler-no-sync.yml
           sync-labels: false
+
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         name: Labels from touched files (development branches)
         # Development branches like staging-next, haskell-updates and python-updates get special labels.
         # This is to avoid the mass of labels there, which is mostly useless - and really annoying for
         # the backport labels.
         if: |
+          github.event_name != 'workflow_run' &&
           github.event.pull_request.head.repo.owner.login == 'NixOS' && (
             github.head_ref == 'haskell-updates' ||
             github.head_ref == 'python-updates' ||

--- a/.github/workflows/review-dismissed.yml
+++ b/.github/workflows/review-dismissed.yml
@@ -1,0 +1,17 @@
+name: Review dismissed
+
+on:
+  pull_request_review:
+    types: [dismissed]
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  trigger:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - run: echo This is a no-op only used as a trigger for workflow_run.

--- a/.github/workflows/review-submitted.yml
+++ b/.github/workflows/review-submitted.yml
@@ -1,0 +1,17 @@
+name: Review submitted
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  trigger:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - run: echo This is a no-op only used as a trigger for workflow_run.


### PR DESCRIPTION
This enables the `labels` workflow to manage the `12.approvals: ?` and `12.approved-by: package-maintainer` labels. Two challenges had to be solved for that:
- The `pull_request_review` events run without permissions. We noticed this in #413256 already and I summarized it in https://github.com/NixOS/nixpkgs/issues/307917#issuecomment-2954097889 as well.
- We need eval results (package maintainers) to match them with the approved reviews.

The missing permissions are solved by running the labels workflow on `workflow_run` - which triggers on completion of a no-op `pull_request_review` workflow. This also allows us to bring back #413256, so did that in the first commit, verifying the approach.

To get the eval results, the label workflow is now run *after* Eval as a reusable workflow. This means labeling will happen with a delay, compared to the status-quo, but I don't see this as a problem. The labels workflow is triggered after Eval and after any approval or dismissal of reviews.

Currently, the approach to count approvals is based on pure number of approved reviews, *without* taking "push after review" as invalidation into account. I think the status-quo, automated (?) by @wegank, is different though. I assume we'll want that behavior and we should implement it as a **branch protection rule**, which reads:

> Dismiss stale pull request approvals when new commits are pushed
> New, reviewable commits pushed will dismiss previous pull request review approvals.

This will also give us better feedback in GitHub's UI than right now, where we remove the approvals label, but still see the approvals in the reviewers list. The branch protection rule should dismiss them entirely.

Also to consider: How is `12.approved-by: package-maintainer` to be defined? We defined `11.by: package-maintainer` as "the PR author must be maintainer of all touched packages". I don't think this definition makes sense for the approval label (and doesn't seem to be used like this in practice right now). So I went with "at least one reviewer needs to maintain at least one of the touched packages" to add this label.

Resolves #307917.

## Things done

It's hard to test it in my own fork, because I can't approve my own PRs. I did some basic testing with approvals created by CI, though - this should work. I did not test the different scenarios of "approving while eval is still running", "approval after eval ran", "dismissal" etc. - but they all just trigger the same workflow without any special conditions. So I'm fairly confident it should work.

- [x] Basic testing in my fork.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
