### PR TITLE
protoc-gen-grpc-java: init at 1.73.0

### DIFF
--- a/pkgs/by-name/pr/protoc-gen-grpc-java/hashes.nix
+++ b/pkgs/by-name/pr/protoc-gen-grpc-java/hashes.nix
@@ -1,0 +1,11 @@
+{
+  linux-aarch_64 = "sha256-sgdZoaSM7LgK4DbbKPJO3FdBA37YAX86meaKDLQiOmg=";
+  linux-ppcle_64 = "sha256-k4nQGJNwtd8W4nJLyWPRhqjikczy7p7ffDIrWxkcUTA=";
+  linux-s390_64 = "sha256-fcuNlJeUmduFzqt5WaefYk3lFVmdHeSFIEkbwT2I1O0=";
+  linux-x86_32 = "sha256-KNvqGkeERd2UxzhjO/Fp6Uv7DGBt15rPGviRmH7pmno=";
+  linux-x86_64 = "sha256-7LI115E3BOz3jnHavkQBbN0hsjKuSbnXNAjXFw/D14I=";
+  osx-aarch_64 = "sha256-gAo2bcsivjDVFX5cUvzngoHgqTAPt+3Hiuynd17/KTo=";
+  osx-x86_64 = "sha256-gAo2bcsivjDVFX5cUvzngoHgqTAPt+3Hiuynd17/KTo=";
+  windows-x86_32 = "sha256-ERbksXFy4AFhZSFG9G4AMOi68EzEScBvDJFF9+rnPnU=";
+  windows-x86_64 = "sha256-wZU6on7A84fPm8xwD8pBgSk8+fkB14LdvWZXEniz8LU=";
+}

--- a/pkgs/by-name/pr/protoc-gen-grpc-java/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-grpc-java/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  autoPatchelfHook,
+}:
+let
+  hostArch =
+    let
+      platform = stdenv.hostPlatform;
+      os =
+        if platform.isLinux then
+          "linux"
+        else if platform.isDarwin then
+          "osx"
+        else if platform.isWindows then
+          "windows"
+        else
+          throw "Unsupoprted OS \"${platform.parsed.kernel.name}\"";
+      arch =
+        if platform.isx86_32 then
+          "x86_32"
+        else if platform.isx86_64 then
+          "x86_64"
+        else if platform.isAarch64 then
+          "aarch_64"
+        else if platform.isPower64 && platform.isLittleEndian then
+          "ppcle_64"
+        else if platform.isS390x then
+          "s390_64"
+        else
+          throw "Unsupported CPU \"${platform.parsed.cpu.name}\"";
+    in
+    "${os}-${arch}";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "protoc-gen-grpc-java";
+  version = "1.73.0";
+  src = fetchurl {
+    url = "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${finalAttrs.version}/protoc-gen-grpc-java-${finalAttrs.version}-${hostArch}.exe";
+    hash = (import ./hashes.nix).${hostArch} or (throw "Unsuported host arch ${hostArch}");
+  };
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [ stdenv.cc.cc ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D $src $out/bin/protoc-gen-grpc-java
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "gRPC Java Codegen Plugin for Protobuf Compiler";
+    longDescription = ''
+      This generates the Java interfaces out of the service definition from a `.proto` file.
+      It works with the Protobuf Compiler (`protoc`).
+    '';
+    changelog = "https://github.com/grpc/grpc-java/releases/tag/v${finalAttrs.version}";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+    homepage = "https://grpc.io/docs/languages/java/generated-code/";
+    platforms = [
+      # Linux
+      "x86_64-linux"
+      "i686-linux"
+      "aarch64-linux"
+      "powerpc64le-linux"
+      "s390x-linux"
+      # Darwin
+      "x86_64-darwin"
+      "aarch64-darwin"
+      # Windows
+      "x86_64-windows"
+      "i686-windows"
+    ];
+  };
+})

--- a/pkgs/by-name/pr/protoc-gen-grpc-java/update.sh
+++ b/pkgs/by-name/pr/protoc-gen-grpc-java/update.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq gnused nix
+
+set -euo pipefail
+
+ARCHS=(
+  'linux-aarch_64'
+  'linux-ppcle_64'
+  'linux-s390_64'
+  'linux-x86_32'
+  'linux-x86_64'
+  'osx-aarch_64'
+  'osx-x86_64'
+  'windows-x86_32'
+  'windows-x86_64'
+)
+HASHES_FILE=pkgs/by-name/pr/protoc-gen-grpc-java/hashes.nix
+
+version="$(
+  curl --silent --location --fail \
+    ${GITHUB_TOKEN:+-u ":${GITHUB_TOKEN}"} \
+    https://api.github.com/repos/grpc/grpc-java/releases/latest |
+    jq -r '.tag_name' |
+    sed 's/^v//'
+)"
+
+echo '{' >"${HASHES_FILE}"
+for arch in "${ARCHS[@]}"; do
+  url="https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${version}/protoc-gen-grpc-java-${version}-${arch}.exe"
+  hash=$(nix hash convert --hash-algo sha256 --to sri "$(nix-prefetch-url "${url}")")
+  echo "  ${arch} = \"${hash}\";" >>"${HASHES_FILE}"
+done
+echo '}' >>"${HASHES_FILE}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added `protoc-gen-grpc-java` at its current version `1.73.0` ([GitHub](https://github.com/grpc/grpc-java/tree/master/compiler), [mvnrepository](https://mvnrepository.com/artifact/io.grpc/protoc-gen-grpc-java)); it wraps all binary artifact for all available architectures.

This is required for some Java packages since the original binaries link dynamically to `glibc++` making it painful to package such apps (hence `autoPatchelfHook`).

Currently it uses pre-built binaries since the original build process is a bit weird (it involves both Gradle and Bazel), but it may be improved in the future to actually have the binaries built from source.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
