### PR TITLE
roon-server: 2.51.1534 -> 2.52.1538

### DIFF
--- a/pkgs/by-name/ro/roon-server/package.nix
+++ b/pkgs/by-name/ro/roon-server/package.nix
@@ -104,6 +104,7 @@ stdenv.mkDerivation {
       runHook postInstall
     '';
 
+  passthru.updateScript = ./update.py;
   meta = with lib; {
     description = "Music player for music lovers";
     changelog = "https://community.roonlabs.com/c/roon/software-release-notes/18";
@@ -113,6 +114,7 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [
       lovesegfault
       steell
+      ramblurr
     ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "RoonServer";

--- a/pkgs/by-name/ro/roon-server/package.nix
+++ b/pkgs/by-name/ro/roon-server/package.nix
@@ -16,7 +16,7 @@
   stdenv,
 }:
 let
-  version = "2.51.1534";
+  version = "2.52.1538";
   urlVersion = builtins.replaceStrings [ "." ] [ "0" ] version;
 in
 stdenv.mkDerivation {
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download.roonlabs.com/updates/production/RoonServer_linuxx64_${urlVersion}.tar.bz2";
-    hash = "sha256-x9zbWJ4lrqfC1CPquGsdgzhO3WBzd46dlZy6APqJbcg=";
+    hash = "sha256-pWg1Cp8aNdR/hoVZDF3kUznJtYsjJYX9J4g1xbmn/lg=";
   };
 
   dontConfigure = true;

--- a/pkgs/by-name/ro/roon-server/update.py
+++ b/pkgs/by-name/ro/roon-server/update.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i python3 -p python3 curl common-updater-scripts nix coreutils
+
+"""
+Updater script for the roon-server package.
+"""
+
+import subprocess
+import urllib.request
+import re
+import sys
+import os
+
+
+def get_current_version():
+    """Get the current version of roon-server from the package.nix file."""
+    result = subprocess.run(
+        [
+            "nix-instantiate",
+            "--eval",
+            "-E",
+            "with import ./. {}; roon-server.version or (lib.getVersion roon-server)",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    result.check_returncode()
+    return result.stdout.strip().strip('"')
+
+
+def get_latest_version_info():
+    """Get the latest version information from the Roon Labs API."""
+    url = "https://updates.roonlabs.net/update/?v=2&platform=linux&version=&product=RoonServer&branding=roon&branch=production&curbranch=production"
+    with urllib.request.urlopen(url) as response:
+        content = response.read().decode("utf-8")
+
+        # Parse the response
+        info = {}
+        for line in content.splitlines():
+            if "=" in line:
+                key, value = line.split("=", 1)
+                info[key] = value
+
+        return info
+
+
+def parse_version(display_version):
+    """Parse the display version string to get the version in the format used in the package.nix file."""
+    # Example: "2.47 (build 1510) production" -> "2.47.1510"
+    match = re.search(r"(\d+\.\d+)\s+\(build\s+(\d+)\)", display_version)
+    if match:
+        return f"{match.group(1)}.{match.group(2)}"
+    return None
+
+
+def get_hash(url):
+    """Calculate the hash of the package."""
+    result = subprocess.run(
+        ["nix-prefetch-url", "--type", "sha256", url], capture_output=True, text=True
+    )
+    result.check_returncode()
+    pkg_hash = result.stdout.strip()
+
+    result = subprocess.run(
+        ["nix", "hash", "to-sri", f"sha256:{pkg_hash}"], capture_output=True, text=True
+    )
+    result.check_returncode()
+    return result.stdout.strip()
+
+
+def update_package(new_version, hash_value):
+    """Update the package.nix file with the new version and hash."""
+    subprocess.run(
+        [
+            "update-source-version",
+            "roon-server",
+            new_version,
+            hash_value,
+            "--ignore-same-version",
+        ],
+        check=True,
+    )
+
+
+def main():
+    current_version = get_current_version()
+    print(f"Current roon-server version: {current_version}")
+
+    try:
+        latest_info = get_latest_version_info()
+
+        display_version = latest_info.get("displayversion", "")
+        download_url = latest_info.get("updateurl", "")
+
+        if not display_version or not download_url:
+            print("Error: Failed to get version information from Roon Labs API")
+            sys.exit(1)
+
+        print(f"Latest version from API: {display_version}")
+        print(f"Download URL: {download_url}")
+
+        new_version = parse_version(display_version)
+        if not new_version:
+            print(
+                f"Error: Failed to parse version from display version: {display_version}"
+            )
+            sys.exit(1)
+
+        print(f"Parsed version: {new_version}")
+
+        if new_version == current_version:
+            print("roon-server is already up to date!")
+            return
+
+        print(f"Calculating hash for new version {new_version}...")
+        hash_value = get_hash(download_url)
+
+        print(
+            f"Updating package.nix with new version {new_version} and hash {hash_value}"
+        )
+        update_package(new_version, hash_value)
+
+        print(f"Successfully updated roon-server to version {new_version}")
+
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [as promised](https://github.com/NixOS/nixpkgs/pull/379047#issuecomment-2642175058) added myself as maintainer and created an update script
- **roon-server: 2.51.1534 -> 2.52.1538**
    -  changelog https://community.roonlabs.com/t/roon-2-52-build-1538-and-arc-1-67-build-360-are-live/300916

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
