### PR TITLE
xcpc: 20070122 -> 0.52.1

### DIFF
--- a/pkgs/by-name/xc/xcpc/package.nix
+++ b/pkgs/by-name/xc/xcpc/package.nix
@@ -1,39 +1,43 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  nix-update-script,
+  autoreconfHook,
+  autoconf-archive,
   pkg-config,
-  glib,
-  libXaw,
-  libX11,
-  libXext,
-  libDSKSupport ? true,
-  libdsk,
-  motifSupport ? false,
-  lesstif,
+  wrapGAppsHook3,
+  libepoxy,
 }:
 
 stdenv.mkDerivation rec {
-  version = "20070122";
+  version = "0.52.1";
   pname = "xcpc";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/xcpc/${pname}-${version}.tar.gz";
-    sha256 = "0hxsbhmyzyyrlidgg0q8izw55q0z40xrynw5a1c3frdnihj9jf7n";
+  src = fetchFromGitHub {
+    owner = "ponceto";
+    repo = "xcpc-emulator";
+    rev = "xcpc-${version}";
+    hash = "sha256-N4UfnCbebaAhx0490niMov/JqlrXt5goblWbW0ajkcc=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    wrapGAppsHook3
+    pkg-config
+  ];
 
-  buildInputs =
-    [
-      glib
-      libdsk
-      libXaw
-      libX11
-      libXext
-    ]
-    ++ lib.optional libDSKSupport libdsk
-    ++ lib.optional motifSupport lesstif;
+  buildInputs = [ libepoxy ];
+
+  passthru.updateScript = nix-update-script { };
+
+  postInstall = ''
+    substituteInPlace $out/share/applications/xcpc.desktop --replace-fail \
+      "$out/bin/" ""
+    substituteInPlace $out/share/applications/xcpc.desktop --replace-fail \
+      "$out/share/pixmaps/" ""
+  '';
 
   meta = with lib; {
     description = "Portable Amstrad CPC 464/664/6128 emulator written in C";


### PR DESCRIPTION
Changelog: https://github.com/ponceto/xcpc-emulator/blob/xcpc-0.52.1/ChangeLog

The versioning scheme changed too: this version was released 2024-09-08.

Per https://www.xcpc-emulator.net/download.html, it seems sourceforge is no longer used. So I chose the github mirror (arbitrarily).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
