### PR TITLE
saunafs: 4.8.1 -> 4.11.0

### DIFF
--- a/pkgs/by-name/sa/saunafs/package.nix
+++ b/pkgs/by-name/sa/saunafs/package.nix
@@ -5,6 +5,9 @@
   fetchFromGitHub,
   cmake,
   asciidoc,
+  pkg-config,
+  db,
+  curl,
   jemalloc,
   boost186,
   fmt,
@@ -13,17 +16,19 @@
   yaml-cpp,
   isa-l,
   judy,
+  prometheus-cpp,
+  libz,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "saunafs";
-  version = "4.8.1";
+  version = "4.11.0";
 
   src = fetchFromGitHub {
     owner = "leil-io";
     repo = "saunafs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-CGnU32TuHkDZYbC3bbjfz4lFWjYe3yrhX08K+UIP51Q=";
+    hash = "sha256-ZQ0+jiVpHZhAOdYneKkPi3M45LU9xj2FBbqo6VcD0JY=";
   };
 
   patches = [
@@ -39,8 +44,11 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     asciidoc
+    pkg-config
   ];
   buildInputs = [
+    db
+    curl
     fmt
     spdlog
     yaml-cpp
@@ -49,6 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     jemalloc
     isa-l
     judy
+    prometheus-cpp
+    libz
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/sa/saunafs/sfstool.patch
+++ b/pkgs/by-name/sa/saunafs/sfstool.patch
@@ -1,12 +1,11 @@
 diff --git a/src/tools/sfstools.sh b/src/tools/sfstools.sh
-index ffd9ec22..a1cb83b6 100755
+index 2d47a275..30d1b20c 100755
 --- a/src/tools/sfstools.sh
 +++ b/src/tools/sfstools.sh
-@@ -1,4 +1,6 @@
- #!/usr/bin/env bash
+@@ -2,4 +2,5 @@
  
  tool="$(basename $0)"
+ >&2 echo "Warning: ${tool} is deprecated. Use saunafs ${tool#sfs} instead."
 -exec saunafs "${tool#sfs}" "$@"
 +dir="$(dirname $0)"
-+
 +exec "$dir/saunafs" "${tool#sfs}" "$@"


### PR DESCRIPTION
<!--
Release notes: https://github.com/leil-io/saunafs/releases
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
