### PR TITLE
python3Packages.pennylane: init at 0.43.2

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -846,6 +846,14 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
+  quantum = {
+    members = [
+      anderscs
+    ];
+    scope = "Maintain quantum computing software like pennylane and related packages.";
+    shortName = "Quantum";
+  };
+
   r = {
     members = [
       b-rodrigues

--- a/pkgs/development/python-modules/autoray/default.nix
+++ b/pkgs/development/python-modules/autoray/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  hatchling,
+  hatch-vcs,
+  # test
+  pytestCheckHook,
+  numpy,
+  scipy,
+}:
+
+buildPythonPackage rec {
+  pname = "autoray";
+  version = "0.8.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.13";
+
+  src = fetchFromGitHub {
+    owner = "jcmgray";
+    repo = "autoray";
+    tag = "v${version}";
+    hash = "sha256-qpkbrmAhtubj+kmG2LotT5nV39JCoa0k8dPck3xNOrM=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "autoray" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+    scipy
+  ];
+
+  meta = {
+    homepage = "https://github.com/jcmgray/autoray";
+    description = "Abstract your array operations";
+    maintainers = with lib.maintainers; [ anderscs ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/diastatic-malt/default.nix
+++ b/pkgs/development/python-modules/diastatic-malt/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  # dependencies
+  astunparse,
+  gast,
+  termcolor,
+  # test
+  # pytestCheckHook,
+  numpy,
+  tensorflow,
+  importlib-resources,
+  importlib-metadata,
+}:
+
+buildPythonPackage rec {
+  pname = "diastatic-malt";
+  version = "2.15.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "PennyLaneAI";
+    repo = "diastatic-malt";
+    tag = "v${version}";
+    hash = "sha256-2lQZZWE4DtdeVPOTMLJgEZweYpr95ztswPNf2AH9VDA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    astunparse
+    gast
+    termcolor
+  ];
+
+  pythonImportsCheck = [ "malt" ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    # pytest tests depends on deprecated imp library and are therefore broken
+    # pytestCheckHook
+    numpy
+    tensorflow
+    importlib-resources
+    importlib-metadata
+  ];
+
+  meta = {
+    homepage = "https://github.com/PennyLaneAI/diastatic-malt";
+    description = "Source-to-source transformations and operator overloading";
+    teams = [ lib.teams.quantum ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/pennylane/default.nix
+++ b/pkgs/development/python-modules/pennylane/default.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  # Python dependencies
+  scipy,
+  networkx,
+  rustworkx,
+  autograd,
+  appdirs,
+  autoray,
+  cachetools,
+  requests,
+  tomlkit,
+  typing-extensions,
+  packaging,
+  diastatic-malt,
+  numpy,
+  # test
+  jax, # only full support for 0.6.0
+  jaxlib,
+  optax,
+  pytestCheckHook,
+  sybil,
+  flaky,
+  matplotlib,
+}:
+
+buildPythonPackage rec {
+  pname = "pennylane";
+  version = "0.43.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "PennyLaneAI";
+    repo = "pennylane";
+    tag = "v${version}";
+    hash = "sha256-in57w19nWUUqVhK63ObQ3HSnphKmcmw8feqh/Aypm7c=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRelaxDeps = true;
+
+  dependencies = [
+    scipy
+    networkx
+    rustworkx
+    autograd
+    appdirs
+    autoray
+    cachetools
+    requests
+    tomlkit
+    typing-extensions
+    packaging
+    diastatic-malt
+    numpy
+  ];
+
+  pythonRemoveDeps = [
+    "pennylane-lightning" # Circular runtime only dependency
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    matplotlib
+    sybil
+    flaky
+    jax
+    jaxlib
+    optax
+  ];
+
+  # Tests are very time consuming and many will fail since it only supports jax and jaxlib 0.6.0
+  doCheck = false;
+
+  pythonImportsCheck = [ "pennylane" ];
+
+  meta = {
+    homepage = "https://pennylane.ai";
+    changelog = "https://github.com/PennyLaneAI/pennylane/releases/tag/${src.tag}";
+    description = "Python framework for quantum programming";
+    teams = [ lib.teams.quantum ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/scipy-openblas32/default.nix
+++ b/pkgs/development/python-modules/scipy-openblas32/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchurl,
+  stdenv,
+}:
+
+buildPythonPackage rec {
+  pname = "scipy-openblas32";
+  version = "0.3.30.359.2";
+  format = "wheel";
+
+  # Since this is intended to be a binary distribution of openblas for python
+  # it makes sense to use the prebuilt binaries. Building from source did not work "out-of-the-box".
+  src =
+    fetchurl
+      {
+        x86_64-linux = {
+          url = "https://files.pythonhosted.org/packages/aa/66/3d5349b60dd0178030c23788d841e91b64b7f3263869040599682474feaa/scipy_openblas32-0.3.30.359.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl";
+          hash = "sha256-WQ6tOHlB+dng+Z3hJSGNFs3gCad5/nj0yqK167D/Ddo=";
+        };
+        x86_64-darwin = {
+          url = "https://files.pythonhosted.org/packages/39/c6/36b8b41e165258fe2b038ba204be58596385b92309fc2b2f9166d80d04ac/scipy_openblas32-0.3.30.359.2-py3-none-macosx_10_9_x86_64.whl";
+          hash = "sha256-qDsFi336n1DO7q5pTXi8FI1Szk6nVjmexBdAyZ5VA94=";
+        };
+        aarch64-linux = {
+          url = "https://files.pythonhosted.org/packages/4c/33/ae05f376af203677b9b4efe289f41c4489e4cfe4c7b49700e004459eb603/scipy_openblas32-0.3.30.359.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl";
+          hash = "sha256-SVHWXNUVUZkS7050iGvlAFilzjDQjOBwUGRMLoNlQOc=";
+        };
+        aarch64-darwin = {
+          url = "https://files.pythonhosted.org/packages/94/a8/e61228a776a91db01e4846d8d7a02349261a714b8569742b859c06c55572/scipy_openblas32-0.3.30.359.2-py3-none-macosx_11_0_arm64.whl";
+          hash = "sha256-AkxHWzPzmIIsSP3YxO0t5OQRtzbgtIZG7O0g02ulOis=";
+        };
+      }
+      ."${stdenv.hostPlatform.system}"
+        or (throw "Unsupported system for ${pname}: ${stdenv.hostPlatform.system}");
+
+  meta = {
+    changelog = "https://github.com/MacPython/openblas-libs/releases/tag/${version}";
+    description = "Provides OpenBLAS for python packaging";
+    homepage = "https://github.com/MacPython/openblas-libs";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      anderscs
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3807,6 +3807,8 @@ self: super: with self; {
 
   diagrams = callPackage ../development/python-modules/diagrams { };
 
+  diastatic-malt = callPackage ../development/python-modules/diastatic-malt { };
+
   diceware = callPackage ../development/python-modules/diceware { };
 
   dicom-numpy = callPackage ../development/python-modules/dicom-numpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16923,6 +16923,8 @@ self: super: with self; {
 
   scipy = callPackage ../development/python-modules/scipy { };
 
+  scipy-openblas32 = callPackage ../development/python-modules/scipy-openblas32 { };
+
   scipy-stubs = callPackage ../development/python-modules/scipy-stubs { };
 
   scmrepo = callPackage ../development/python-modules/scmrepo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1236,6 +1236,8 @@ self: super: with self; {
 
   autopxd2 = callPackage ../development/python-modules/autopxd2 { };
 
+  autoray = callPackage ../development/python-modules/autoray { };
+
   autoslot = callPackage ../development/python-modules/autoslot { };
 
   av = callPackage ../development/python-modules/av { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11986,6 +11986,8 @@ self: super: with self; {
 
   pendulum = callPackage ../development/python-modules/pendulum { };
 
+  pennylane = callPackage ../development/python-modules/pennylane { };
+
   pentapy = callPackage ../development/python-modules/pentapy { };
 
   pep440 = callPackage ../development/python-modules/pep440 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add PennyLane Quantum computing python library.
https://pennylane.ai/
Code: https://github.com/PennyLaneAI/pennylane

Solves #415267

Add additional python library dependencies:
* autoray 0.8.4
* diastatic-malt 2.15.2
* scipy-openblas32 0.3.30.0.8
* ~~pennylane-lightning 0.43.0~~
* ~~pennylane-catalyst 0.13.0~~

Additional runtime dependencies will be added later.


The full test suite of pennylane is very time consuming and therefore disabled.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
