### PR TITLE
lomiri.lomiri-camera-app: 4.0.8 -> 4.1.0

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri-camera-app/1001-treewide-Fix-imports-in-tests-after-QML-files-were-moved.patch
+++ b/pkgs/desktops/lomiri/applications/lomiri-camera-app/1001-treewide-Fix-imports-in-tests-after-QML-files-were-moved.patch
@@ -1,0 +1,86 @@
+From 75a0baa32f434546c5d6cfaf8ae19d561aa8dddd Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Mon, 9 Jun 2025 20:00:40 +0200
+Subject: [PATCH] treewide: Fix imports in tests after QML files were moved out
+ of top-level dir
+
+---
+ CMakeLists.txt                               | 2 ++
+ tests/unittests/tst_BottomEdgeIndicators.qml | 3 +--
+ tests/unittests/tst_PhotogridView.qml        | 3 +--
+ tests/unittests/tst_StopWatch.qml            | 3 +--
+ tests/unittests/tst_ViewFinderGeometry.qml   | 3 +--
+ 5 files changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index faa998c..9d54fbe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -191,6 +191,8 @@ install(DIRECTORY ${QML_DIR}
+     DESTINATION ${CAMERA_APP_DIR}
+     )
+ 
++# For tests
++file(COPY ${QML_DIR} DESTINATION ${CMAKE_BINARY_DIR})
+ 
+ set(ASSETS_DIR assets)
+ 
+diff --git a/tests/unittests/tst_BottomEdgeIndicators.qml b/tests/unittests/tst_BottomEdgeIndicators.qml
+index 129b840..3dd4c0c 100644
+--- a/tests/unittests/tst_BottomEdgeIndicators.qml
++++ b/tests/unittests/tst_BottomEdgeIndicators.qml
+@@ -17,8 +17,7 @@
+ 
+ import QtQuick 2.12
+ import QtTest 1.0
+-import "../../"
+-import "../../.." //Needed for out of source build
++import "../../qml/components"
+ 
+ TestCase {
+     name: "BottomEdgeIndicators"
+diff --git a/tests/unittests/tst_PhotogridView.qml b/tests/unittests/tst_PhotogridView.qml
+index 4c7404a..3f14840 100644
+--- a/tests/unittests/tst_PhotogridView.qml
++++ b/tests/unittests/tst_PhotogridView.qml
+@@ -17,8 +17,7 @@
+ 
+ import QtQuick 2.12
+ import QtTest 1.0
+-import "../../"
+-import "../../.." //Needed for out of source build
++import "../../qml/components"
+ 
+ TestCase {
+     name: "PhotogridView"
+diff --git a/tests/unittests/tst_StopWatch.qml b/tests/unittests/tst_StopWatch.qml
+index aac9c36..5ad29f8 100644
+--- a/tests/unittests/tst_StopWatch.qml
++++ b/tests/unittests/tst_StopWatch.qml
+@@ -17,8 +17,7 @@
+ 
+ import QtQuick 2.12
+ import QtTest 1.0
+-import "../../"
+-import "../../.." //Needed for out of source build
++import "../../qml/components"
+ 
+ TestCase {
+     name: "StopWatch"
+diff --git a/tests/unittests/tst_ViewFinderGeometry.qml b/tests/unittests/tst_ViewFinderGeometry.qml
+index 154437f..42aaacc 100644
+--- a/tests/unittests/tst_ViewFinderGeometry.qml
++++ b/tests/unittests/tst_ViewFinderGeometry.qml
+@@ -17,8 +17,7 @@
+ 
+ import QtQuick 2.12
+ import QtTest 1.0
+-import "../../"
+-import "../../.." //Needed for out of source build
++import "../../qml/Viewfinder"
+ 
+ TestCase {
+     name: "ViewFinderGeometry"
+-- 
+2.49.0
+

--- a/pkgs/desktops/lomiri/applications/lomiri-camera-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-camera-app/default.nix
@@ -28,14 +28,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-camera-app";
-  version = "4.0.8";
+  version = "4.1.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/apps/lomiri-camera-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4Tkiv0f+1uZKkeyE60G/ThThMyNp+l8q6d4tiKipM3A=";
+    hash = "sha256-rGWIcaU3iFZIse69DUVjCebWH18yVrqWHcGoXItGX3k=";
   };
+
+  patches = [
+    # Remove when https://gitlab.com/ubports/development/apps/lomiri-camera-app/-/merge_requests/234 merged & in release
+    ./1001-treewide-Fix-imports-in-tests-after-QML-files-were-moved.patch
+  ];
 
   # We don't want absolute paths in desktop files
   postPatch = ''


### PR DESCRIPTION
https://gitlab.com/ubports/development/apps/lomiri-camera-app/-/blob/v4.1.0/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
