### PR TITLE
crosswords: 0.3.12 → 0.3.15

### DIFF
--- a/pkgs/by-name/cr/crosswords/package.nix
+++ b/pkgs/by-name/cr/crosswords/package.nix
@@ -1,44 +1,49 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
-  meson,
-  ninja,
-  pkg-config,
-  wrapGAppsHook4,
   desktop-file-utils,
-  libadwaita,
+  fetchFromGitLab,
   isocodes,
   json-glib,
+  libadwaita,
   libipuz,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  shared-mime-info,
+  wrapGAppsHook4,
 }:
 
 stdenv.mkDerivation rec {
   pname = "crosswords";
-  version = "0.3.12";
+  version = "0.3.15";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "jrb";
     repo = "crosswords";
     rev = version;
-    hash = "sha256-3RL2LJdIHmDAjXaxqsE0n5UQMsuBJWEMoyAEoSBemR0=";
+    hash = "sha256-KcHcTjPoQNA5TBXnKgudjBTV/0JbeVMJ09XVAL7SizI=";
   };
 
   nativeBuildInputs = [
+    desktop-file-utils
     meson
     ninja
     pkg-config
+    shared-mime-info
     wrapGAppsHook4
-    desktop-file-utils
   ];
 
   buildInputs = [
-    libadwaita
     isocodes
     json-glib
+    libadwaita
     libipuz
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Crossword player and editor for GNOME";
@@ -46,7 +51,10 @@ stdenv.mkDerivation rec {
     changelog = "https://gitlab.gnome.org/jrb/crosswords/-/blob/${version}/NEWS.md?ref_type=tags";
     license = lib.licenses.gpl3Plus;
     mainProgram = "crosswords";
-    maintainers = with lib.maintainers; [ aleksana ];
+    maintainers = with lib.maintainers; [
+      aleksana
+      l0b0
+    ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/li/libipuz/package.nix
+++ b/pkgs/by-name/li/libipuz/package.nix
@@ -1,31 +1,50 @@
 {
   lib,
   stdenv,
+  cargo,
   fetchFromGitLab,
+  gi-docgen,
+  glib,
+  gobject-introspection,
+  json-glib,
   meson,
   ninja,
+  nix-update-script,
   pkg-config,
-  glib,
-  json-glib,
+  rustPlatform,
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libipuz";
-  version = "0.4.5";
+  version = "0.5.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "jrb";
     repo = "libipuz";
-    rev = version;
-    hash = "sha256-psC2cFqSTlToCtCxwosXyJbmX/96AEI0xqzXtlc/HQE=";
+    rev = finalAttrs.version;
+    hash = "sha256-8bFMtqRD90SF9uT39Wkjf0eUef+0HgyrqY+DFA/xutI=";
+  };
+
+  cargoRoot = "libipuz/rust";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      src
+      version
+      cargoRoot
+      ;
+    hash = "sha256-Aw/caE5Z5JxoKLEr2Dr2wq6cyFleNNwtKM1yXM8ZWmU=";
   };
 
   nativeBuildInputs = [
+    cargo
+    gi-docgen
+    glib
+    gobject-introspection
     meson
     ninja
     pkg-config
-    glib
+    rustPlatform.cargoSetupHook
   ];
 
   buildInputs = [
@@ -33,12 +52,20 @@ stdenv.mkDerivation rec {
     json-glib
   ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Library for parsing .ipuz puzzle files";
     homepage = "https://gitlab.gnome.org/jrb/libipuz";
-    changelog = "https://gitlab.gnome.org/jrb/libipuz/-/blob/${version}/NEWS.md?ref_type=tags";
-    license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ aleksana ];
+    changelog = "https://gitlab.gnome.org/jrb/libipuz/-/blob/${finalAttrs.version}/NEWS.md?ref_type=tags";
+    license = with lib.licenses; [
+      lgpl21Plus
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      aleksana
+      l0b0
+    ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Required upgrading libipuz 0.4.5 → 0.5.2.

Also:

- fix libipuz license
- enable auto-update
- add myself as maintainer

[Change log](https://gitlab.gnome.org/jrb/crosswords/-/blob/master/NEWS.md)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
