### PR TITLE
socklog: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/by-name/so/socklog/package.nix
+++ b/pkgs/by-name/so/socklog/package.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "socklog";
-  version = "2.1.0";
+  version = "2.1.1";
 
   src = fetchurl {
     url = "https://smarden.org/socklog/socklog-${version}.tar.gz";
-    sha256 = "0mdlmhiq2j2fip7c4l669ams85yc3c1s1d89am7dl170grw9m1ma";
+    hash = "sha256-6xk3JB1seyoEArSf/evwIrsvzaPgDBsaF66Lzx5KObo=";
   };
 
   sourceRoot = "admin/socklog-${version}";
@@ -20,16 +20,6 @@ stdenv.mkDerivation rec {
     "man"
     "doc"
   ];
-
-  postPatch = ''
-    # Fails to run as user without supplementary groups
-    echo "int main() { return 0; }" >src/chkshsgr.c
-
-    # Fixup implicit function declarations
-    sed -i src/pathexec_run.c -e '1i#include <unistd.h>'
-    sed -i src/prot.c -e '1i#include <unistd.h>' -e '2i#include <grp.h>'
-    sed -i src/seek_set.c -e '1i#include <unistd.h>'
-  '';
 
   configurePhase = ''
     echo "$NIX_CC/bin/cc $NIX_CFLAGS_COMPILE"   >src/conf-cc


### PR DESCRIPTION
Changes (from package/CHANGES):
```
socklog 2.1.1
Fri, 11 Oct 2024 00:00:17 +0000
  * doc/install.html: add link to sha256sum.asc.
  * doc/install.html: change mail address.
  * doc/index.html: remove reference to socklog 2.0.x.
  * doc/*.html: remove <small>$Id$</small>.
  * debian/: remove; obsolete.
  * pathexec.h, pathexec_env.c, pathexec_run.c, seek_set.c, sgetopt.c,
    sgetopt.h, socklog-check.c, socklog-conf.c, socklog.c, subgetopt.c,
    subgetopt.h, trycpp.c, tryflock.c, trypoll.c, trysgact.c, trysgprm.c,
    tryto.c, tryulong64.c, trywaitp.c, uncat.c, x86cpuid.c: incorporate
    lib changes from runit-2.2.0 and adapt socklog programs to properly
    build with modern toolchains (thx Gentoo, Debian, Void Linux).
  * prot.c, prot.h, chkshsgr.c, tryshsgr.c, hasshsgr.h?, warn-shsgr:
    remove; obsolete.
  * Makefile, TARGETS: no longer check for "shortsetgroups" (thx Leah
    Neukirchen).
  * socklog.c: replace prot_gid() with setgroups() and prot_uid() with
    setuid().
```

Fixes GCC 14 build. (Tracking: #388196 #356812)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
