### PR TITLE
freedv: 1.9.9.2 -> 2.0

### DIFF
--- a/pkgs/by-name/fr/freedv/no-framework.patch
+++ b/pkgs/by-name/fr/freedv/no-framework.patch
@@ -1,0 +1,28 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 38b3b262..3be9bfee 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -146,21 +146,16 @@ if(APPLE)
+         TARGET FreeDV
+         POST_BUILD
+         COMMAND rm -rf dist_tmp FreeDV.dmg || true
+-        COMMAND DYLD_LIBRARY_PATH=${CODEC2_BUILD_DIR}/src:${portaudio_BINARY_DIR}:${samplerate_BINARY_DIR}/src:${Python3_ROOT_DIR}:${DYLD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/macdylibbundler/dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @loader_path/../libs/ -i /usr/lib -s ${CODEC2_BUILD_DIR}/src -s ${CMAKE_BINARY_DIR}/codec2_build/src ${PORTAUDIO_BUNDLE_ARG} -s ${samplerate_BINARY_DIR}/src -s ${rade_BINARY_DIR}/src -s ${Python3_ROOT_DIR}
++        COMMAND DYLD_LIBRARY_PATH=${CODEC2_BUILD_DIR}/src:${portaudio_BINARY_DIR}:${samplerate_BINARY_DIR}/src:${DYLD_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/macdylibbundler/dylibbundler ARGS -od -b -x FreeDV.app/Contents/MacOS/FreeDV -d FreeDV.app/Contents/libs -p @loader_path/../libs/ -i /usr/lib -s ${CODEC2_BUILD_DIR}/src -s ${CMAKE_BINARY_DIR}/codec2_build/src ${PORTAUDIO_BUNDLE_ARG} -s ${samplerate_BINARY_DIR}/src -s ${rade_BINARY_DIR}/src
+         COMMAND cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/freedv.icns FreeDV.app/Contents/Resources
+         COMMAND rm ARGS -rf FreeDV.app/Contents/Frameworks
+         COMMAND mkdir ARGS FreeDV.app/Contents/Frameworks
+-        COMMAND cp ARGS -a ${Python3_ROOT_DIR}/../../../Python.framework FreeDV.app/Contents/Frameworks
+-        COMMAND install_name_tool ARGS -add_rpath @loader_path/../Frameworks/Python.framework FreeDV.app/Contents/libs/librade*.dylib
+         COMMAND cp ARGS ../rade_src/radae_*e.py FreeDV.app/Contents/Resources
+         COMMAND cp ARGS -a ../rade_src/radae FreeDV.app/Contents/Resources
+         COMMAND cp ARGS -a ../rade_src/model19_check3 FreeDV.app/Contents/Resources
+         
+-        # Precompile Python code to improve startup time
+-        COMMAND cd FreeDV.app/Contents/Resources && ../Frameworks/Python.framework/Versions/Current/bin/python3 -c "import radae_txe\; import radae_rxe\;" && cd ../../..
+-        
+         # Codesign binary so that it can execute
+-        COMMAND codesign --force --options runtime --timestamp --entitlements ${CMAKE_CURRENT_SOURCE_DIR}/entitlements.plist --sign ${MACOS_CODESIGN_IDENTITY} ${CMAKE_CURRENT_BINARY_DIR}/FreeDV.app `find ${CMAKE_CURRENT_BINARY_DIR}/FreeDV.app -name '*.so' -o -name '*.dylib'` `find ${CMAKE_CURRENT_BINARY_DIR}/FreeDV.app/Contents/Frameworks/Python.framework/Versions/3.12/bin -name 'Python' -o -name 'python3.12*'` `find ${CMAKE_CURRENT_BINARY_DIR}/FreeDV.app/Contents/Frameworks/Python.framework/ -name 'Python'` ${CMAKE_CURRENT_BINARY_DIR}/FreeDV.app/Contents/MacOS/FreeDV ${CMAKE_CURRENT_BINARY_DIR}/FreeDV.app/Contents/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/torch/bin/* ${CMAKE_CURRENT_BINARY_DIR}/FreeDV.app/Contents/Frameworks/Python.framework/Versions/3.12/Python
++        COMMAND codesign --force --options runtime --timestamp --entitlements ${CMAKE_CURRENT_SOURCE_DIR}/entitlements.plist --sign ${MACOS_CODESIGN_IDENTITY} ${CMAKE_CURRENT_BINARY_DIR}/FreeDV.app `find ${CMAKE_CURRENT_BINARY_DIR}/FreeDV.app -name '*.so' -o -name '*.dylib'`
+     )
+ 
+     if (MACOS_CODESIGN_KEYCHAIN_PROFILE)

--- a/pkgs/by-name/fr/freedv/package.nix
+++ b/pkgs/by-name/fr/freedv/package.nix
@@ -1,9 +1,11 @@
 {
-  config,
   lib,
   stdenv,
   fetchFromGitHub,
   cmake,
+  pkg-config,
+  python3,
+  libopus,
   macdylibbundler,
   makeWrapper,
   darwin,
@@ -17,64 +19,115 @@
   hamlib_4,
   wxGTK32,
   sioclient,
-  pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
+  dbus,
+  apple-sdk_15,
   nix-update-script,
 }:
 
+let
+  radaeSrc = fetchFromGitHub {
+    owner = "drowe67";
+    repo = "radae";
+    rev = "2354cd2a4b3af60c7feb1c0d6b3d6dd7417c2ac9";
+    hash = "sha256-yEr/OCXV83qXi89QHXMrUtQ2UwNOsijQMN35Or2JP+Y=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "freedv";
-  version = "1.9.9.2";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "drowe67";
     repo = "freedv-gui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oFuAH81mduiSQGIDgDDy1IPskqqCBmfWbpqQstUIw9g=";
+    hash = "sha256-3vwFB+3LloumEAGlSJZc2+/I8uI6KLP/KuDGeDOj87k=";
   };
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "-Wl,-ld_classic" ""
-    substituteInPlace src/CMakeLists.txt \
-      --replace-fail "\''${CMAKE_SOURCE_DIR}/macdylibbundler/dylibbundler" "dylibbundler"
-    sed -i "/codesign/d;/hdiutil/d" src/CMakeLists.txt
-  '';
+  patches = [
+    ./no-framework.patch
+  ];
+
+  postPatch =
+    ''
+      cp -R ${radaeSrc} radae
+      chmod -R u+w radae
+      substituteInPlace radae/cmake/BuildOpus.cmake \
+        --replace-fail "https://gitlab.xiph.org/xiph/opus/-/archive/main/opus-main.tar.gz" "${libopus.src}" \
+        --replace-fail "./autogen.sh && " ""
+      substituteInPlace cmake/BuildRADE.cmake \
+        --replace-fail "GIT_REPOSITORY https://github.com/drowe67/radae.git" "URL $(realpath radae)" \
+        --replace-fail "GIT_TAG main" ""
+      patchShebangs test/test_*.sh
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "-Wl,-ld_classic" ""
+      substituteInPlace src/CMakeLists.txt \
+        --replace-fail "\''${CMAKE_SOURCE_DIR}/macdylibbundler/dylibbundler" "dylibbundler"
+      sed -i "/codesign/d;/hdiutil/d" src/CMakeLists.txt
+    '';
 
   nativeBuildInputs =
     [
       cmake
+      pkg-config
+      python3
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       macdylibbundler
       makeWrapper
       darwin.autoSignDarwinBinariesHook
+      darwin.sigtool
     ];
 
-  buildInputs = [
-    codec2
-    libsamplerate
-    libsndfile
-    lpcnet
-    speexdsp
-    hamlib_4
-    wxGTK32
-    sioclient
-  ] ++ (if pulseSupport then [ libpulseaudio ] else [ portaudio ]);
+  buildInputs =
+    [
+      codec2
+      libsamplerate
+      libsndfile
+      lpcnet
+      speexdsp
+      hamlib_4
+      wxGTK32
+      sioclient
+      python3.pkgs.numpy
+    ]
+    ++ (
+      if stdenv.hostPlatform.isLinux then
+        [
+          libpulseaudio
+          dbus
+        ]
+      else if stdenv.hostPlatform.isDarwin then
+        [
+          apple-sdk_15
+        ]
+      else
+        [
+          portaudio
+        ]
+    );
 
   cmakeFlags = [
     (lib.cmakeBool "USE_INTERNAL_CODEC2" false)
     (lib.cmakeBool "USE_STATIC_DEPS" false)
     (lib.cmakeBool "UNITTEST" true)
-    (lib.cmakeBool "USE_PULSEAUDIO" pulseSupport)
+    (lib.cmakeBool "USE_NATIVE_AUDIO" (with stdenv.hostPlatform; isLinux || isDarwin))
   ];
 
-  doCheck = true;
+  env.NIX_CFLAGS_COMPILE = "-I${codec2.src}/src";
 
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir -p $out/Applications
-    mv $out/bin/FreeDV.app $out/Applications
-    makeWrapper $out/Applications/FreeDV.app/Contents/MacOS/FreeDV $out/bin/freedv
-  '';
+  doCheck = false;
+
+  postInstall =
+    ''
+      install -Dm755 rade_build/src/librade.* -t $out/lib
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications
+      mv $out/bin/FreeDV.app $out/Applications
+      makeWrapper $out/Applications/FreeDV.app/Contents/MacOS/FreeDV $out/bin/freedv
+    '';
 
   passthru.updateScript = nix-update-script {
     extraArgs = [


### PR DESCRIPTION
Closes #414805.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
