### PR TITLE
telegram-desktop: 5.15.2 -> 5.15.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
@@ -8,6 +8,7 @@
   qtimageformats,
   qtsvg,
   qtwayland,
+  kimageformats,
   wrapGAppsHook3,
   wrapQtAppsHook,
   glib-networking,
@@ -33,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
       qtbase
       qtimageformats
       qtsvg
+      kimageformats
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       qtwayland

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
@@ -10,9 +10,7 @@
   python3,
   tdlib,
   tg_owt ? callPackage ./tg_owt.nix { inherit stdenv; },
-  kimageformats,
   qtbase,
-  qtimageformats,
   qtsvg,
   qtwayland,
   kcoreaddons,
@@ -83,7 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     [
       qtbase
-      qtimageformats
       qtsvg
       lz4
       xxHash
@@ -99,7 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
       boost
       ada
       (tdlib.override { tde2eOnly = true; })
-      kimageformats
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       protobuf

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
@@ -10,9 +10,6 @@
   python3,
   tdlib,
   tg_owt ? callPackage ./tg_owt.nix { inherit stdenv; },
-  libavif,
-  libheif,
-  libjxl,
   kimageformats,
   qtbase,
   qtimageformats,
@@ -51,14 +48,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "telegram-desktop-unwrapped";
-  version = "5.15.2";
+  version = "5.15.3";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "tdesktop";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-T+gzNY3jPfCWjV9yFEGlz8kNGeAioyDUD2qazM/j05I=";
+    hash = "sha256-ATGzh9zJezIOZ3uSm3rIV+KQ4XFWJvf5NaJ0ptjzYGc=";
   };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
@@ -102,17 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
       boost
       ada
       (tdlib.override { tde2eOnly = true; })
-      # even though the last 3 dependencies are already in `kimageformats`,
-      # because of a logic error in the cmake files, in td 5.15.{1,2} it
-      # doesn't link when you don't add them explicitly
-      #
-      # this has been fixed
-      # (https://github.com/desktop-app/cmake_helpers/pull/413), remove next
-      # release
       kimageformats
-      libavif
-      libheif
-      libjxl
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       protobuf


### PR DESCRIPTION
Sorry if this `telegram-desktop` PRs start to get spammy. They just release often...

`kimageformats` was moved to `default.nix`, as apparently it's only required at runtime, where Qt automatically looks for the plugins and enables the image support dynamically based on wether or not they are available. It is not strictly required to make it build and run as intended, so I don't think it should go in `unwrapped.nix`.

Changelog: https://github.com/telegramdesktop/tdesktop/releases/tag/v5.15.3

Diff: https://github.com/telegramdesktop/tdesktop/compare/v5.15.2...v5.15.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
