### PR TITLE
lomiri.lomiri: 0.4.1 -> 0.5.0

### DIFF
--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -7,6 +7,9 @@
 
 let
   cfg = config.services.desktopManager.lomiri;
+  nixos-gsettings-overrides = pkgs.lomiri.lomiri-gsettings-overrides.override {
+    inherit (cfg) extraGSettingsOverrides extraGSettingsOverridePackages;
+  };
 in
 {
   options.services.desktopManager.lomiri = {
@@ -21,6 +24,18 @@ in
       '';
       type = lib.types.bool;
       default = config.services.xserver.displayManager.lightdm.greeters.lomiri.enable || cfg.enable;
+    };
+
+    extraGSettingsOverrides = lib.mkOption {
+      description = "Additional GSettings overrides.";
+      type = lib.types.lines;
+      default = "";
+    };
+
+    extraGSettingsOverridePackages = lib.mkOption {
+      description = "List of packages for which GSettings are overridden.";
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
     };
   };
 
@@ -43,10 +58,17 @@ in
           "/share/wallpapers"
         ];
 
-        systemPackages = with pkgs.lomiri; [
-          lomiri-wallpapers # default + additional wallpaper
-          suru-icon-theme # basic indicator icons
-        ];
+        # Override GSettings defaults
+        sessionVariables.NIX_GSETTINGS_OVERRIDES_DIR = "${nixos-gsettings-overrides}/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas";
+
+        systemPackages =
+          [
+            nixos-gsettings-overrides # GSettings default overrides
+          ]
+          ++ (with pkgs.lomiri; [
+            lomiri-wallpapers # default + additional wallpaper
+            suru-icon-theme # basic indicator icons
+          ]);
       };
 
       fonts.packages = with pkgs; [

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -139,12 +139,8 @@ let
       Move the mouse to a screen location and hit left-click.
       """
 
-      # Need to reset to top-left, --absolute doesn't work?
-      machine.execute("ydotool mousemove -- -10000 -10000")
-      machine.sleep(2)
-
       # Move
-      machine.execute(f"ydotool mousemove -- {xpos} {ypos}")
+      machine.execute(f"ydotool mousemove --absolute -- {xpos} {ypos}")
       machine.sleep(2)
 
       # Click (C0 - left button: down & up)
@@ -157,7 +153,7 @@ let
       """
 
       # Using the keybind has a chance of instantly closing the menu again? Just click the button
-      mouse_click(20, 30)
+      mouse_click(15, 15)
 
   '';
 
@@ -653,7 +649,7 @@ in
               machine.screenshot("settings_lomiri-content-hub_peers")
 
               # Select Morph as content source
-              mouse_click(370, 100)
+              mouse_click(340, 80)
 
               # Expect Morph to be brought into the foreground, with its Downloads page open
               wait_for_text("No downloads")
@@ -853,8 +849,8 @@ in
       ocr = [ "Log Out" ];
       extraCheck = ''
         # We should be able to log out and return to the greeter
-        mouse_click(720, 280) # "Log Out"
-        mouse_click(400, 240) # confirm logout
+        mouse_click(600, 280) # "Log Out"
+        mouse_click(340, 220) # confirm logout
         machine.wait_until_fails("pgrep -u ${user} -f 'lomiri --mode=full-shell'")
       '';
     })

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -61,37 +61,54 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri";
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri";
     tag = finalAttrs.version;
-    hash = "sha256-5fwSLUTntVyV5FIVnPishrU/55tyTyx0Fzh6oitaWwo=";
+    hash = "sha256-blXEfDauwtDH+0OdUx0vAR+8lnAGrREssqjsBNmvomk=";
   };
 
   patches = [
-    # Fix greeter & related settings
-    # These patches are seemingly not submitted upstream yet
+    # Fix broken multimedia suspend due to missing media-hub
     (fetchpatch {
-      name = "1000-lomiri-QT_IM_MODULE-maliit.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/2003_maliit-not-maliitphablet-as-im-module-namespace.patch";
-      hash = "sha256-5HEMl0x1S9Hb7spxPRgu8OBebmpaLa6zko2uVEYtBmY=";
+      name = "2012-lomiri-dont-suspend-apps.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/1d6e83446f69299d1206927c2adbf78470ba27ec/debian/patches/2012_no-app-suspension-on-Debian+Ubuntu-proper.patch";
+      hash = "sha256-9mvkILrkig18fAw5KyA2+5vXup6Le7X0blgY0PJ2Trc=";
+    })
+
+    # Fix convergence on some tablets
+    (fetchpatch {
+      name = "1013-lomiri-fix-convergence-on-high-resolution-tablets.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/4d4904b728a3e66706c756f911ddc79b01f863a2/debian/patches/1013_fix-convergence-on-high-resolution-tablets.patch";
+      hash = "sha256-pQYIa8U0gEFdwZBuWMp8nL5j2HPSivMrsuKUC9scKg0=";
+    })
+
+    # Make greeter behave nicer & more Wayland-native
+    (fetchpatch {
+      name = "2014-lomiri-greeter-wrapper-on-wayland.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/e655e14c7d420021193e37debd3e7da620b45429/debian/patches/2014_lomiri-greeter-wrapper-on-wayland.patch";
+      hash = "sha256-aEId3UDqH1iUi9gV5IpW/5S5rke93UyZVr0jWlNYnOU=";
     })
     (fetchpatch {
-      name = "1001-lomiri-QT_QPA_PLATFORM-wayland.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/2004_qt-qpa-platform-is-wayland.patch";
-      hash = "sha256-4C6X2TW+yjZhqYPIcQ3GJeTKbz785i7p/DpT+vX1DSQ=";
+      name = "2015-lomiri-greeter-use-wayland.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/2f5acfa085c901359bf6f6cccbce36d7e2981555/debian/patches/2015_lomiri-greeter-use-wayland.patch";
+      hash = "sha256-fnTEVQnOBQVd95ucs+iDMcQFOevfQ8dckQg0PrtL/A0=";
     })
+
+    # Reduce desyncing of cursor
     (fetchpatch {
-      name = "1002-lomiri-Fix-Lomiri-greeter.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/5f9d28fe6f0ba9ab7eed149b4da7f6b3f4eae55a/debian/patches/1008_lomiri-greeter-wayland.patch";
-      hash = "sha256-vuNTKWA50krtx/+XB2pMI271q57N+kqWlfq54gtf/HI=";
+      name = "1005-lomiri-cursor-always-follow-cursor-position-from-mir.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/f3ba943006f5469a8a7aa24f232d6383afb3bc74/debian/patches/1005_cursor-always-follow-cursor-position-from-mir.patch";
+      hash = "sha256-FYWRHt3//gm3jT9dr35tH4PlZssMMA/zBhjkszgqTYo=";
     })
+
+    # Undo start-here integration & uglier colours for launcher
     (fetchpatch {
-      name = "1004-lomiri-Dont-reset-OSK-setting.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/2005_dont-reset-alwaysShowOsk-to-system-defaults-on-login.patch";
-      hash = "sha256-guq/Ykcq4WcuXxNKO1eA4sJFyGSpZo0gtyFTdeK/GeE=";
+      name = "0001-lomiri-LauncherPanel-Use-Lomiri-upstream-home-logo-and-home-background-color.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/defaabfaf4818ee6b618c97b34acf5e0ed2ebb2e.patch";
+      hash = "sha256-9YRWMV+1UT+EQd9Uq1+6enNzz+HDlSt3LTPM1BKJxiE=";
     })
 
     ./9901-lomiri-Disable-Wizard.patch
@@ -119,15 +136,11 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace tests/mocks/CMakeLists.txt \
         --replace-fail 'add_subdirectory(QtMir/Application)' ""
 
-      # This needs to launch the *lomiri* indicators, now that datetime is split into lomiri and non-lomiri variants
+      # Seems like the Debian patch that added this didn't read the lightdm greeter entry properly, so everything gets passed twice
+      substituteInPlace data/lomiri-greeter.desktop.in.in \
+        --replace-fail 'lomiri-greeter-wrapper @CMAKE_INSTALL_FULL_BINDIR@/lomiri --mode=greeter' 'lomiri-greeter-wrapper'
       substituteInPlace data/lomiri-greeter-wrapper \
-        --replace-fail 'ayatana-indicators.target' 'lomiri-indicators.target'
-
-      # NixOS-ify
-
-      # Use Nix flake instead of Canonical's Ubuntu logo
-      rm qml/Launcher/graphics/home.svg
-      ln -s ${nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake-white.svg qml/Launcher/graphics/home.svg
+        --replace-fail 'LOMIRI_BINARY:-lomiri' "LOMIRI_BINARY:-$out/bin/lomiri"
 
       # Look up default wallpaper in current system
       substituteInPlace plugins/Utils/constants.cpp \

--- a/pkgs/desktops/lomiri/data/lomiri-gsettings-overrides/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-gsettings-overrides/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  runCommand,
+  glib,
+  lomiri-schemas,
+  lomiri-wallpapers,
+  nixos-icons,
+  writeText,
+  extraGSettingsOverrides ? "",
+  extraGSettingsOverridePackages ? [ ],
+  nixos-artwork,
+}:
+
+let
+  # Overriding the background picture should be possible, but breaks within the VM tests.
+  # It results in either a grey background (prolly indicating an error somewhere)
+  # or hangs the session (also happens when using LSS, which sets it via AccountsService).
+  #
+  # So we can only override the launcher button details.
+  # Button colour: https://github.com/NixOS/nixos-artwork/blob/51a27e4a011e95cb559e37d32c44cf89b50f5154/logo/README.md#colours
+  gsettingsOverrides = writeText "lomiri-gschema-overrides" ''
+    [com.lomiri.Shell.Launcher]
+    logo-picture-uri='file://${nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake-white.svg'
+    home-button-background-color='#5277C3'
+
+    ${extraGSettingsOverrides}
+  '';
+
+  gsettingsOverridePackages = [
+    lomiri-schemas
+  ] ++ extraGSettingsOverridePackages;
+in
+runCommand "lomiri-gsettings-overrides" { preferLocalBuild = true; } ''
+  dataDir="$out/share/gsettings-schemas/nixos-gsettings-overrides"
+  schemaDir="$dataDir/glib-2.0/schemas"
+  mkdir -p "$schemaDir"
+
+  ${lib.strings.concatMapStringsSep "\n" (
+    pkg:
+    "cp -rf \"${glib.getSchemaPath pkg}\"/*.xml \"${glib.getSchemaPath pkg}\"/*.gschema.override \"$schemaDir\""
+  ) gsettingsOverridePackages}
+
+  chmod -R a+w "$dataDir"
+  cp --no-preserve=mode "${gsettingsOverrides}" "$schemaDir/zz-nixos-defaults.gschema.override"
+
+  ${lib.getExe' glib.dev "glib-compile-schemas"} --strict "$schemaDir" | tee gcs.log
+
+  if grep 'No schema files found' gcs.log >/dev/null; then
+    exit 1
+  fi
+''

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -31,6 +31,7 @@ let
       teleports = callPackage ./applications/teleports { };
 
       #### Data
+      lomiri-gsettings-overrides = callPackage ./data/lomiri-gsettings-overrides { };
       lomiri-schemas = callPackage ./data/lomiri-schemas { };
       lomiri-session = callPackage ./data/lomiri-session { };
       lomiri-sounds = callPackage ./data/lomiri-sounds { };


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri/-/blob/0.5.0/ChangeLog

All tests pass on my end, and we now have a nice way of customising the launcher icon & colour.

:)
![lomiri_launched](https://github.com/user-attachments/assets/2dd9cd4b-f83a-4261-a767-35825825b2b0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
