### PR TITLE
postfix: add TLSRPT support

### DIFF
--- a/pkgs/by-name/li/libtlsrpt/package.nix
+++ b/pkgs/by-name/li/libtlsrpt/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libtlsrpt";
+  version = "0.5.0";
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "sys4";
+    repo = "libtlsrpt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-h7bWxxllKFj8+/FfC4yHSmz+Qij1BcgV4OCQZr1OkA8=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  separateDebugInfo = true;
+
+  meta = {
+    description = "Low-level C Library to implement TLSRPT into a MTA";
+    homepage = "https://github.com/sys4/libtlsrpt";
+    changelog = "https://github.com/sys4/libtlsrpt/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ hexa ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/po/postfix/package.nix
+++ b/pkgs/by-name/po/postfix/package.nix
@@ -26,6 +26,8 @@
   libmysqlclient,
   withSQLite ? false,
   sqlite,
+  withTLSRPT ? true,
+  libtlsrpt,
 }:
 
 let
@@ -48,6 +50,7 @@ let
       "-DHAS_LDAP"
       "-DUSE_LDAP_SASL"
     ]
+    ++ lib.optional withTLSRPT "-DUSE_TLSRPT"
   );
   auxlibs = lib.concatStringsSep " " (
     [
@@ -62,6 +65,7 @@ let
     ++ lib.optional withMySQL "-lmysqlclient"
     ++ lib.optional withSQLite "-lsqlite3"
     ++ lib.optional withLDAP "-lldap"
+    ++ lib.optional withTLSRPT "-ltlsrpt"
   );
 
 in
@@ -90,7 +94,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional withPgSQL libpq
     ++ lib.optional withMySQL libmysqlclient
     ++ lib.optional withSQLite sqlite
-    ++ lib.optional withLDAP openldap;
+    ++ lib.optional withLDAP openldap
+    ++ lib.optional withTLSRPT libtlsrpt;
 
   hardeningDisable = [ "format" ];
   hardeningEnable = [ "pie" ];


### PR DESCRIPTION
Packages libtlsrpt and makes it a default-enabled optional feature in the Postfix build.

https://www.postfix.org/TLSRPT_README.html
https://github.com/sys4/libtlsrpt

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (also via pkgsCross.aarch64-multiplatform)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
