### PR TITLE
nixos/postfix-tlspol: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -26,6 +26,8 @@
 
 - [Draupnir](https://github.com/the-draupnir-project/draupnir), a Matrix moderation bot. Available as [services.draupnir](#opt-services.draupnir.enable).
 
+- [postfix-tlspol](https://github.com/Zuplu/postfix-tlspol), MTA-STS and DANE resolver and TLS policy server for Postfix. Available as [services.postfix-tlspol](#opt-services.postfix-tlspol.enable).
+
 - [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).
 
 [dwl](https://codeberg.org/dwl/dwl), a compact, hackable compositor for Wayland based on wlroots. Available as [programs.dwl](#opt-programs.dwl.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -739,6 +739,7 @@
   ./services/mail/opendkim.nix
   ./services/mail/opensmtpd.nix
   ./services/mail/pfix-srsd.nix
+  ./services/mail/postfix-tlspol.nix
   ./services/mail/postfix.nix
   ./services/mail/postfixadmin.nix
   ./services/mail/postgrey.nix

--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -1,0 +1,220 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    hasPrefix
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+
+  cfg = config.services.postfix-tlspol;
+
+  format = pkgs.formats.yaml_1_2 { };
+in
+
+{
+  options.services.postfix-tlspol = {
+    enable = mkEnableOption "postfix-tlspol";
+
+    package = mkPackageOption pkgs "postfix-tlspol" { };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = format.type;
+        options = {
+          server = {
+            address = mkOption {
+              type = types.str;
+              default = "unix:/run/postfix-tlspol/tlspol.sock";
+              example = "127.0.0.1:8642";
+              description = ''
+                Path or address/port where postfix-tlspol binds its socket to.
+              '';
+            };
+
+            socket-permissions = mkOption {
+              type = types.str;
+              default = "0660";
+              readOnly = true;
+              description = ''
+                Permissions to the UNIX socket, if configured.
+
+                ::: {.note}
+                Due to hardening on the systemd unit the socket can never be created world readable/writable.
+                :::
+              '';
+              apply = value: (builtins.fromTOML "v=0o${value}").v;
+            };
+
+            log-level = mkOption {
+              type = types.enum [
+                "debug"
+                "info"
+                "warn"
+                "error"
+              ];
+              default = "info";
+              example = "warn";
+              description = ''
+                Log level
+              '';
+            };
+
+            prefetch = mkOption {
+              type = types.bool;
+              default = true;
+              example = false;
+              description = ''
+                Whether to prefetch DNS records when the TTL of a cached record is about to expire.
+              '';
+            };
+
+            cache-file = mkOption {
+              type = types.path;
+              default = "/var/cache/postfix-tlspol/cache.db";
+              readOnly = true;
+              description = ''
+                Path to the cache file.
+              '';
+            };
+          };
+
+          dns = {
+            server = mkOption {
+              type = types.str;
+              default = "127.0.0.1:53";
+              description = ''
+                IP and port to your DNS resolver
+
+                ::: {.note}
+                The configured DNS resolver must validate DNSSEC signatures.
+                :::
+              '';
+            };
+          };
+        };
+      };
+
+      default = { };
+      description = ''
+        The postfix-tlspol configuration file as a Nix attribute set.
+
+        See the reference documentation for possible options.
+        <https://github.com/Zuplu/postfix-tlspol/blob/main/configs/config.default.yaml>
+      '';
+    };
+
+    configurePostfix = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to configure the required settings to use postfix-tlspol in the local Postfix instance.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."postfix-tlspol/config.yaml".source =
+      format.generate "postfix-tlspol.yaml" cfg.settings;
+
+    environment.systemPackages = [ cfg.package ];
+
+    # https://github.com/Zuplu/postfix-tlspol#postfix-configuration
+    services.postfix.config = mkIf (config.services.postfix.enable && cfg.configurePostfix) {
+      smtp_dns_support_level = "dnssec";
+      smtp_tls_security_level = "dane";
+      smtp_tls_policy_maps =
+        let
+          address =
+            if (hasPrefix "unix:" cfg.settings.server.address) then
+              cfg.settings.server.address
+            else
+              "inet:${cfg.settings.server.address}";
+        in
+        [ "socketmap:${address}:QUERYwithTLSRPT" ];
+    };
+
+    systemd.services.postfix-tlspol = {
+      after = [
+        "nss-lookup.target"
+        "network-online.target"
+      ];
+      wants = [
+        "nss-lookup.target"
+        "network-online.target"
+      ];
+      wantedBy = [ "multi-user.target" ];
+
+      description = "Postfix DANE/MTA-STS TLS policy socketmap service";
+      documentation = [ "https://github.com/Zuplu/postfix-tlspol" ];
+
+      # https://github.com/Zuplu/postfix-tlspol/blob/main/init/postfix-tlspol.service
+      serviceConfig = {
+        ExecStart = toString [
+          (lib.getExe cfg.package)
+          "-config"
+          "/etc/postfix-tlspol/config.yaml"
+        ];
+        ExecReload = "${lib.getExe' pkgs.util-linux "kill"} -HUP $MAINPID";
+        Restart = "always";
+        RestartSec = 5;
+
+        DynamicUser = true;
+
+        CacheDirectory = "postfix-tlspol";
+        CapabilityBoundingSet = [ "" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        ReadOnlyPaths = [ "/etc/postfix-tlspol/config.yaml" ];
+        RemoveIPC = true;
+        RestrictAddressFamilies =
+          [
+            "AF_INET"
+            "AF_INET6"
+          ]
+          ++ lib.optionals (lib.hasPrefix "unix:" cfg.settings.server.address) [
+            "AF_UNIX"
+          ];
+        RestrictNamespace = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged @resources"
+        ];
+        SystemCallErrorNumber = "EPERM";
+        SecureBits = [
+          "noroot"
+          "noroot-locked"
+        ];
+        RuntimeDirectory = "postfix-tlspol";
+        RuntimeDirectoryMode = "1750";
+        WorkingDirectory = "/var/cache/postfix-tlspol";
+        UMask = "0117";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1103,6 +1103,7 @@ in
   postfix-raise-smtpd-tls-security-level =
     handleTest ./postfix-raise-smtpd-tls-security-level.nix
       { };
+  postfix-tlspol = runTest ./postfix-tlspol.nix;
   postfixadmin = runTest ./postfixadmin.nix;
   postgres-websockets = runTest ./postgres-websockets.nix;
   postgresql = handleTest ./postgresql { };

--- a/nixos/tests/postfix-tlspol.nix
+++ b/nixos/tests/postfix-tlspol.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  ...
+}:
+{
+  name = "postfix-tlspol";
+
+  meta.maintainers = with lib.maintainers; [ hexa ];
+
+  nodes.machine = {
+    services.postfix-tlspol.enable = true;
+  };
+
+  enableOCR = true;
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("postfix-tlspol.service")
+
+    with subtest("Interact with the service"):
+      machine.succeed("postfix-tlspol -purge")
+
+      response = json.loads((machine.succeed("postfix-tlspol -query localhost")))
+      machine.log(json.dumps(response, indent=2))
+
+  '';
+
+}

--- a/pkgs/by-name/po/postfix-tlspol/package.nix
+++ b/pkgs/by-name/po/postfix-tlspol/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 buildGoModule rec {
@@ -21,6 +22,10 @@ buildGoModule rec {
   doCheck = false;
 
   ldflags = [ "-X main.Version=${version}" ];
+
+  passthru.tests = {
+    inherit (nixosTests) postfix-tlspol;
+  };
 
   meta = {
     description = "Lightweight MTA-STS + DANE/TLSA resolver and TLS policy server for Postfix, prioritizing DANE.";

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -192,7 +192,46 @@ optionalAttrs allowAliases aliases
               (listOf valueType)
             ])
             // {
-              description = "YAML value";
+              description = "YAML 1.1 value";
+            };
+        in
+        valueType;
+
+    };
+
+  yaml_1_2 =
+    { }:
+    {
+      generate =
+        name: value:
+        pkgs.callPackage (
+          { runCommand, remarshal }:
+          runCommand name
+            {
+              nativeBuildInputs = [ remarshal ];
+              value = builtins.toJSON value;
+              passAsFile = [ "value" ];
+              preferLocalBuild = true;
+            }
+            ''
+              json2yaml "$valuePath" "$out"
+            ''
+        ) { };
+
+      type =
+        let
+          valueType =
+            nullOr (oneOf [
+              bool
+              int
+              float
+              str
+              path
+              (attrsOf valueType)
+              (listOf valueType)
+            ])
+            // {
+              description = "YAML 1.2 value";
             };
         in
         valueType;

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -143,7 +143,7 @@ runBuildTests {
   };
 
   yaml_1_1Atoms = shouldPass {
-    format = formats.yaml { };
+    format = formats.yaml_1_1 { };
     input = {
       null = null;
       false = false;
@@ -172,6 +172,40 @@ runBuildTests {
       path: ${./testfile}
       str: foo
       time: '22:30:00'
+      'true': true
+    '';
+  };
+
+  yaml_1_2Atoms = shouldPass {
+    format = formats.yaml_1_2 { };
+    input = {
+      null = null;
+      false = false;
+      true = true;
+      float = 3.141;
+      str = "foo";
+      attrs.foo = null;
+      list = [
+        null
+        null
+      ];
+      path = ./testfile;
+      no = "no";
+      time = "22:30:00";
+    };
+    expected = ''
+      attrs:
+        foo: null
+      'false': false
+      float: 3.141
+      list:
+      - null
+      - null
+      no: no
+      'null': null
+      path: ${./testfile}
+      str: foo
+      time: 22:30:00
       'true': true
     '';
   };


### PR DESCRIPTION
Adds a module and test, and also the yaml1.2 format.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
