### PR TITLE
ocamlPackages.amqp-client: init at 2.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/amqp-client/async.nix
+++ b/pkgs/development/ocaml-modules/amqp-client/async.nix
@@ -1,0 +1,29 @@
+{
+  buildDunePackage,
+  async,
+  uri,
+  amqp-client,
+  ezxmlm,
+}:
+
+buildDunePackage {
+  pname = "amqp-client-async";
+
+  inherit (amqp-client) version src;
+
+  doCheck = true;
+
+  buildInputs = [
+    ezxmlm
+  ];
+
+  propagatedBuildInputs = [
+    amqp-client
+    async
+    uri
+  ];
+
+  meta = amqp-client.meta // {
+    description = "Amqp client library, async version";
+  };
+}

--- a/pkgs/development/ocaml-modules/amqp-client/default.nix
+++ b/pkgs/development/ocaml-modules/amqp-client/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  version ? "2.3.0",
+}:
+
+buildDunePackage {
+  pname = "amqp-client";
+
+  inherit version;
+  minimalOCamlVersion = "4.14.0";
+
+  src = fetchFromGitHub {
+    owner = "andersfugmann";
+    repo = "amqp-client";
+    tag = version;
+    hash = "sha256-zWhkjVoKyNCIBXD5746FywCg3DKn1mXb1tn1VlF9Tyg=";
+  };
+
+  doCheck = true;
+
+  meta = {
+    description = "Amqp client base library";
+    homepage = "https://github.com/andersfugmann/amqp-client";
+    license = lib.licenses.bsd3;
+    changelog = "https://raw.githubusercontent.com/andersfugmann/amqp-client/refs/tags/${version}/Changelog";
+    maintainers = with lib.maintainers; [ momeemt ];
+    longDescription = ''
+      This library provides high level client bindings for amqp. The library
+      is tested with rabbitmq, but should work with other amqp
+      servers. The library is written in pure OCaml.
+
+      This is the base library required by lwt/async versions.
+      You should install either amqp-client-async or amqp-client-lwt
+      for actual client functionality.
+    '';
+  };
+}

--- a/pkgs/development/ocaml-modules/amqp-client/lwt.nix
+++ b/pkgs/development/ocaml-modules/amqp-client/lwt.nix
@@ -1,0 +1,28 @@
+{
+  buildDunePackage,
+  lwt,
+  lwt_log,
+  amqp-client,
+  uri,
+  ezxmlm,
+}:
+buildDunePackage {
+  pname = "amqp-client-lwt";
+
+  inherit (amqp-client) version src;
+
+  buildInputs = [ ezxmlm ];
+
+  propagatedBuildInputs = [
+    lwt
+    lwt_log
+    amqp-client
+    uri
+  ];
+
+  doCheck = true;
+
+  meta = amqp-client.meta // {
+    description = "Amqp client library, lwt version";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -32,6 +32,12 @@ let
 
         ancient = callPackage ../development/ocaml-modules/ancient { };
 
+        amqp-client = callPackage ../development/ocaml-modules/amqp-client { };
+
+        amqp-client-async = callPackage ../development/ocaml-modules/amqp-client/async.nix { };
+
+        amqp-client-lwt = callPackage ../development/ocaml-modules/amqp-client/lwt.nix { };
+
         angstrom = callPackage ../development/ocaml-modules/angstrom { };
 
         angstrom-async = callPackage ../development/ocaml-modules/angstrom-async { };


### PR DESCRIPTION
OCaml Amqp client library for Async and Lwt.

https://github.com/andersfugmann/amqp-client

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
