### PR TITLE
reaction: 1.4.1 -> 2.0.1

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -33,7 +33,8 @@
 
 ### Breaking changes {#sec-nixpkgs-release-25.11-lib-breaking}
 
-- Create the first release note entry in this section!
+- `reaction` has been updated to version 2, which includes some breaking changes.
+  For more information, [check the release article](https://blog.ppom.me/en-reaction-v2).
 
 
 ### Deprecations {#sec-nixpkgs-release-25.11-lib-deprecations}

--- a/pkgs/by-name/re/reaction/package.nix
+++ b/pkgs/by-name/re/reaction/package.nix
@@ -1,46 +1,46 @@
 {
   lib,
-  buildGoModule,
   fetchFromGitLab,
+  rustPlatform,
+  nix-update-script,
+  installShellFiles,
 }:
-let
-  version = "1.4.1";
-in
-buildGoModule {
-  inherit version;
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "reaction";
+  version = "2.0.1";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "ppom";
     repo = "reaction";
-    rev = "v${version}";
-    hash = "sha256-UL3ck+gejZAu/mZS3ZiZ78a2/I+OesaSRZUhHirgu9o=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HpnLh0JfGZsHcvDQSiKfW62QcCe/QDsVP/nGBo9x494=";
   };
 
-  vendorHash = "sha256-THUIoWFzkqaTofwH4clBgsmtUlLS9WIB2xjqW7vkhpg=";
+  cargoHash = "sha256-i8KZygESxgty8RR3C+JMuE1aAsBxoLuGsL4jqjdGr0E=";
 
-  ldflags = [
-    "-X main.version=${version}"
-    "-X main.commit=unknown"
+  nativeBuildInputs = [
+    installShellFiles
   ];
 
-  postBuild = ''
-    $CC helpers_c/ip46tables.c -o ip46tables
-    $CC helpers_c/nft46.c -o nft46
+  postInstall = ''
+    installBin $releaseDir/ip46tables $releaseDir/nft46
+    installManPage $releaseDir/reaction*.1
+    installShellCompletion --cmd reaction \
+      --bash $releaseDir/reaction.bash \
+      --fish $releaseDir/reaction.fish \
+      --zsh $releaseDir/_reaction
   '';
 
-  postInstall = ''
-    cp ip46tables nft46 $out/bin
-  '';
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Scan logs and take action: an alternative to fail2ban";
     homepage = "https://framagit.org/ppom/reaction";
-    changelog = "https://framagit.org/ppom/reaction/-/releases/v${version}";
+    changelog = "https://framagit.org/ppom/reaction/-/releases/v${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     mainProgram = "reaction";
     maintainers = with lib.maintainers; [ ppom ];
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Updated reaction to v2.0.1.

reaction has been rewritten in Rust.

See [the release article](https://blog.ppom.me/en-reaction-v2/).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
