### PR TITLE
zenoh-c/zenoh-cpp: init at 1.4.0

### DIFF
--- a/pkgs/by-name/ze/zenoh-c/package.nix
+++ b/pkgs/by-name/ze/zenoh-c/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  cargo,
+  rustPlatform,
+  rustc,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zenoh-c";
+  version = "1.4.0"; # nixpkgs-update: no auto update
+
+  src = fetchFromGitHub {
+    owner = "eclipse-zenoh";
+    repo = "zenoh-c";
+    tag = version;
+    hash = "sha256-Mn3diwJgMkYXP9Dn5AqquN1UJ+P+b4QadiXqzzYZK+o=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src pname version;
+    hash = "sha256-Z9xKC7svGPSuQm4KCKOfGAFOdWgSjBK+/LFT3rAebTg=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/lib/pkgconfig/zenohc.pc \
+      --replace-fail "\''${prefix}/" ""
+  '';
+
+  meta = {
+    description = "C API for zenoh";
+    homepage = "https://github.com/eclipse-zenoh/zenoh-c";
+    license = with lib.licenses; [
+      asl20
+      epl20
+    ];
+    maintainers = with lib.maintainers; [ markuskowa ];
+  };
+}

--- a/pkgs/by-name/ze/zenoh-cpp/package.nix
+++ b/pkgs/by-name/ze/zenoh-cpp/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  zenoh-c,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zenoh-cpp";
+  version = "1.4.0"; # nixpkgs-update: no auto update
+
+  src = fetchFromGitHub {
+    owner = "eclipse-zenoh";
+    repo = "zenoh-cpp";
+    tag = version;
+    hash = "sha256-rznvif87UZbYzZB4yHG4R850qm6Z3beJ1NSG4wrf58M=";
+  };
+
+  cmakeFlags = [
+    "-DZENOHCXX_ZENOHC=ON"
+    "-DZENOHCXX_ZENOHPICO=OFF"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  propagatedBuildInputs = [
+    zenoh-c
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/lib/pkgconfig/zenohcxx.pc \
+      --replace-fail "\''${prefix}/" ""
+  '';
+
+  meta = {
+    description = "C++ API for zenoh";
+    homepage = "https://github.com/eclipse-zenoh/zenoh-cpp";
+    license = with lib.licenses; [
+      asl20
+      epl20
+    ];
+    maintainers = with lib.maintainers; [ markuskowa ];
+  };
+}


### PR DESCRIPTION
Add more language bindings to the [Zenoh](https://zenoh.io/) eco system.
Supersedes https://github.com/NixOS/nixpkgs/pull/356460/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
