### PR TITLE
pihole-ftl: fix settings.webserver.tls.cert

### DIFF
--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -255,7 +255,7 @@ in
           log.webserver = "${cfg.logDirectory}/webserver.log";
         };
 
-        webserver.tls = "${cfg.stateDirectory}/tls.pem";
+        webserver.tls.cert = "${cfg.stateDirectory}/tls.pem";
       }
 
       (lib.optionalAttrs cfg.useDnsmasqConfig {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently the certificates are installed in `/etc/pihole` instead of the `stateDirectory`
```
➜  /etc/pihole ll                                                          [root@raspberrypi]
drwxr-xr-x    - pihole pihole 10 Jun 01:24  hosts
drwxrwxr-x    - pihole pihole 10 Jun 11:16  listsCache
.rw-r-----   44 pihole pihole 10 Jun 11:16  cli_pw
.rw-r--r-- 5,7k pihole pihole 10 Jun 01:29  dnsmasq.conf
.r--------  777 pihole pihole 10 Jun 11:16  pihole.toml
.rw-------  713 pihole pihole 10 Jun 11:16  tls.crt
.rw------- 1,0k pihole pihole 10 Jun 11:16  tls.pem
.rw-------  733 pihole pihole 10 Jun 11:16  tls_ca.crt
```

The `pihole.toml` template says this:
```toml
  [webserver.tls]
    # Path to the TLS (SSL) certificate file. All directories along the path must be
    # readable and accessible by the user running FTL (typically 'pihole'). This option is
    # only required when at least one of webserver.port is TLS. The file must be in PEM
    # format, and it must have both, private key and certificate (the *.pem file created
    # must contain a 'CERTIFICATE' section as well as a 'RSA PRIVATE KEY' section).
    # The *.pem file can be created using
    #     cp server.crt server.pem
    #     cat server.key >> server.pem
    # if you have these files instead
    #
    # Possible values are:
    #     <valid TLS certificate file (*.pem)>
    cert = "/etc/pihole/tls.pem"
```

@averyvigolo 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
