### PR TITLE
ci/nixpkgs-vet: add badFiles and conflictingPaths checks

### DIFF
--- a/ci/nixpkgs-vet.nix
+++ b/ci/nixpkgs-vet.nix
@@ -29,5 +29,25 @@ runCommand "nixpkgs-vet"
 
     nixpkgs-vet --base ${filtered base} ${filtered head}
 
+    # TODO: Upstream into nixpkgs-vet, see:
+    # https://github.com/NixOS/nixpkgs-vet/issues/164
+    badFiles=$(find ${filtered head}/pkgs -type f -name '*.nix' -print | xargs grep -l '^[^#]*<nixpkgs/' || true)
+    if [[ -n $badFiles ]]; then
+      echo "Nixpkgs is not allowed to use <nixpkgs> to refer to itself."
+      echo "The offending files:"
+      echo "$badFiles"
+      exit 1
+    fi
+
+    # TODO: Upstream into nixpkgs-vet, see:
+    # https://github.com/NixOS/nixpkgs-vet/issues/166
+    conflictingPaths=$(find ${filtered head} | awk '{ print $1 " " tolower($1) }' | sort -k2 | uniq -D -f 1 | cut -d ' ' -f 1)
+    if [[ -n $conflictingPaths ]]; then
+      echo "Files in nixpkgs must not vary only by case."
+      echo "The offending paths:"
+      echo "$conflictingPaths"
+      exit 1
+    fi
+
     touch $out
   ''


### PR DESCRIPTION
Those checks are part of `top-level/nixpkgs-basic-release-checks.nix`, but can be run in CI already to prevent regressions. The idea is to upstream them into nixpkgs-vet eventually, but we can just as well run them as-is in the same derivation already.

This slices another small piece off of #406825 to reduce scope. @philiptaron [volunteered](https://github.com/NixOS/nixpkgs/pull/406825#issuecomment-2957157485) to upstream those into nixpkgs-vet later, thank you!

## Things done

- [x] Tested locally.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
