### PR TITLE
doc/rl-2511: announce projected `x86_64-darwin` deprecation

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -17,6 +17,13 @@
   cc-wrapper will enforce that availability annotations are used or an appropriate deployment target is set.
   See the Darwin platform notes for details.
 
+- **We expect to drop support for `x86_64-darwin` by Nixpkgs 26.11,** in light of Apple’s announcement that macOS 26 will be the final version to support Intel Macs.
+  When support is fully removed, we will no longer build packages for the platform or guarantee that it can build at all.
+  This may happen in stages, depending on our available build and maintenance resources and decisions made by projects we rely on.
+
+  By the time of 26.11’s release, Homebrew will offer only limited [Tier 3](https://docs.brew.sh/Support-Tiers#tier-3) support for the platform, but MacPorts will likely continue to support it for a long time.
+  We also recommend users consider installing NixOS, which should continue to run on essentially all Intel Macs, especially after Apple stops security support for macOS 26 in 2028.
+
 - Darwin has switched to using the system libc++. This was done for improved compatibility and to avoid ODR violations.
   If a newer C++ library feature is not available on the default deployment target, you will need to increase the deployment target.
   See the Darwin platform documentation for more details.

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -12,14 +12,14 @@
 - The default GHC version has been updated from 9.8 to 9.10.
   `haskellPackages` correspondingly uses Stackage LTS 24 (instead of LTS 23) as a baseline.
 
-- Darwin has switched to using the system libc++. This was done for improved compatibility and to avoid ODR violations.
-  If a newer C++ library feature is not available on the default deployment target, you will need to increase the deployment target.
-  See the Darwin platform documentation for more details.
-
 - **This release of Nixpkgs requires macOS Sonoma 14.0 or newer, as announced in the 25.05 release notes.**
   The default SDK is now 14.4, but the minimum version is 14.0.
   cc-wrapper will enforce that availability annotations are used or an appropriate deployment target is set.
   See the Darwin platform notes for details.
+
+- Darwin has switched to using the system libc++. This was done for improved compatibility and to avoid ODR violations.
+  If a newer C++ library feature is not available on the default deployment target, you will need to increase the deployment target.
+  See the Darwin platform documentation for more details.
 
 - LLVM has been updated from 19 to 21.
 


### PR DESCRIPTION
macOS 27 is going to drop Intel support, so we’re pre‐announcing the inevitable so that people can prepare. We don’t yet know exactly which Nixpkgs release will drop support for `x86_64-darwin`, but the 26.11–27.11 range, between the release of the first OS version to not support the platform and the release of the first OS version to not be able to fully emulate it, seems like a safe bet.

We already announced that we’re aligning our OS support policy with Apple’s starting in 25.11, so it’s very unlikely that we could justify making an exception to devote resources to `x86_64-darwin` support in 28.11 and beyond, after Apple stop releasing security updates for the platform.

However, the end of support in Nixpkgs may come sooner than that. Apple have announced that [Rosetta 2 will be pared down] by macOS 28 to not support emulation of arbitrary applications. We use `aarch64-darwin` builder machines exclusively and rely on Rosetta 2 to build packages for `x86_64-darwin`. As we try to keep the builders on the latest OS versions, that would mean that we’d lose the ability to build for `x86_64-darwin` around the release of 27.11, unless we held back on updating the OS on the builders for a year.

[Rosetta 2 will be pared down]: https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment

Additionally, `x86_64-darwin` is the slowest system to build due to our limited Mac builder resources and the emulation overhead. Dropping support will more than double our effective `aarch64-darwin` build capacity and benefit the whole project by reducing the bottleneck on world rebuilds during `staging-next` cycles. It’s hard to find good data on the relative market share, but the May 2025 [Steam Hardware Survey] shows over 80% of their macOS users already being on Apple Silicon. Therefore, I’d personally expect us to drop support in 26.11 or 27.11, given the trade‐off between the resources it will take to continue supporting `x86_64-darwin` and the number of users it is likely to benefit. (And I’m typing this on a Intel Mac myself…)

[Steam Hardware Survey]: https://store.steampowered.com/hwsurvey/processormfg/

---

cc @NixOS/darwin-maintainers

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
