### PR TITLE
memtree: 0-unstable-2024-01-04 → 0-unstable-2025-06-10

### DIFF
--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication {
   pname = "memtree";
-  version = "0-unstable-2025-06-06";
+  version = "0-unstable-2025-06-10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nicoonoclaste";
     repo = "memtree";
-    rev = "279f1fa0a811de86c278ce74830bd8aa1b00db58";
-    hash = "sha256-gUULox3QSx68x8lb1ytanY36cw/I9L4HdpR8OPOsxuc=";
+    rev = "ad1a7d1e4fa5f195c2aa1012101d01ab580a05e8";
+    hash = "sha256-UmleB7wr1bh9t7vwt3o8Uwp3LUzAzB5jlPi3OvgECAg=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -14,7 +14,10 @@ python3Packages.buildPythonApplication {
     owner = "nicoonoclaste";
     repo = "memtree";
     rev = "ad1a7d1e4fa5f195c2aa1012101d01ab580a05e8";
-    hash = "sha256-UmleB7wr1bh9t7vwt3o8Uwp3LUzAzB5jlPi3OvgECAg=";
+    hash = "sha256-stIRBXhaLqYsN2WMQnu46z39ssantzM8M6T3kCOoZKc=";
+
+    # Remove irrelevant content, avoid src hash change on flake.lock updates etc.
+    postFetch = "rm -r $out/.* $out/flake.* $out/bors.toml";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "nbraud";
+    owner = "nicoonoclaste";
     repo = "memtree";
     rev = "279f1fa0a811de86c278ce74830bd8aa1b00db58";
     hash = "sha256-gUULox3QSx68x8lb1ytanY36cw/I9L4HdpR8OPOsxuc=";

--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -17,13 +17,11 @@ python3Packages.buildPythonApplication {
     hash = "sha256-gUULox3QSx68x8lb1ytanY36cw/I9L4HdpR8OPOsxuc=";
   };
 
-  pythonRelaxDeps = [ "rich" ];
-
-  nativeBuildInputs = with python3Packages; [
+  build-system = with python3Packages; [
     poetry-core
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     rich
   ];
 


### PR DESCRIPTION
- version constraint on `rich` relaxed upstream
- package brought up to current nixpkgs/Python standards

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
