### PR TITLE
nixos/restrict-suid-sgid: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -389,6 +389,7 @@
   ./security/pam_mount.nix
   ./security/please.nix
   ./security/polkit.nix
+  ./security/restrict-suid-sgid.nix
   ./security/rngd.nix
   ./security/rtkit.nix
   ./security/soteria.nix

--- a/nixos/modules/security/restrict-suid-sgid.nix
+++ b/nixos/modules/security/restrict-suid-sgid.nix
@@ -1,0 +1,59 @@
+{ lib, config, ... }:
+let
+  cfg = config.security.restrict-suid-sgid;
+in
+{
+  meta.maintainers = with lib.maintainers; [ grimmauld ];
+
+  options.security.restrict-suid-sgid = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        When enabled, it will be disallowed by default for
+        services to create SUID/SGID files. Some services
+        might need an explicit exception to work correctly.
+      '';
+    };
+
+    allowedServices = lib.mkOption {
+      type = lib.types.listOf lib.types.nonEmptyStr;
+      default = [
+        "suid-sgid-wrappers"
+        "systemd-tmpfiles-setup"
+        "systemd-tmpfiles-resetup"
+      ];
+      description = ''
+        List of services to be allowed to create SUID/SGID files.
+        On a normal nixos system, `suid-sgid-wrappers` is required
+        to create suid files for e.g. sudo and fuse to work correctly,
+        while `systemd-tmpfiles-setup` and `systemd-tmpfiles-resetup`
+        is being used by systemd internally to fix file permissions.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # needs to be a drop-in to take effect on *all* systemd units, not just those created by nix
+    # Better would be to set `RestrictSUIDSGID` in system.conf, but this is not yet supported.
+    # See also: https://github.com/systemd/systemd/issues/37602
+    systemd.units =
+      {
+        "service.d/10-restrict-suid-sgid.conf".text = ''
+          [Service]
+          RestrictSUIDSGID=yes
+        '';
+      }
+      // (lib.listToAttrs (
+        map (
+          n:
+          lib.nameValuePair "${n}.service.d/20-unrestrict-suid-sgid.conf" {
+            text = ''
+              [Service]
+              RestrictSUIDSGID=no
+            '';
+          }
+        ) cfg.allowedServices
+      ));
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1181,6 +1181,7 @@ in
   restartByActivationScript = runTest ./restart-by-activation-script.nix;
   restic-rest-server = runTest ./restic-rest-server.nix;
   restic = runTest ./restic.nix;
+  restrict-suid-sgid = runTest ./restrict-suid-sgid.nix;
   retroarch = runTest ./retroarch.nix;
   rke2 = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./rke2 { };
   rkvm = handleTest ./rkvm { };

--- a/nixos/tests/restrict-suid-sgid.nix
+++ b/nixos/tests/restrict-suid-sgid.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+{
+  name = "restrict-suid-sgid";
+  meta.maintainers = with lib.maintainers; [ grimmauld ];
+
+  nodes.machine = {
+    security.restrict-suid-sgid.enable = true;
+  };
+  testScript = ''
+    import json
+    allowed = ["suid-sgid-wrappers.service", "systemd-tmpfiles-resetup.service", "systemd-tmpfiles-setup.service"];
+    machine.wait_for_unit("default.target")
+
+    output = machine.succeed("systemctl list-units -o json -t service --no-pager --all")
+    for unit in json.loads(output):
+      if unit["load"] != "loaded":
+        continue
+      with subtest(unit["unit"]):
+        security_json = machine.succeed(f"systemd-analyze security {unit["unit"]} --json=short --no-pager")
+        for property in json.loads(security_json):
+          if property["name"] == "RestrictSUIDSGID":
+            assert (not property["set"]) if unit["unit"] in allowed else property["set"]
+  '';
+}


### PR DESCRIPTION
The `security.restrict-suid-sgid` module can be used to enforce `RestrictSUIDSGID` for all services on a system. Usually, a NixOS system only requires the wrapper setup service as well as the tmpfile setup services to set suid/sgid bit on files. Restricting this by default globally can not yet be done in `system.conf` [1], so a global drop-in and specialized drop-ins at higher priority is the best way to achieve this.

[1] https://github.com/systemd/systemd/issues/37602

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
