### PR TITLE
treewide: remove primeos from maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20277,23 +20277,6 @@
     githubId = 1304102;
     name = "Pavan Rikhi";
   };
-  primeos = {
-    email = "dev.primeos@gmail.com";
-    matrix = "@primeos:matrix.org";
-    github = "primeos";
-    githubId = 7537109;
-    name = "Michael Weiss";
-    keys = [
-      {
-        # Git only
-        fingerprint = "86A7 4A55 07D0 58D1 322E  37FD 1308 26A6 C2A3 89FD";
-      }
-      {
-        # Email, etc.
-        fingerprint = "AF85 991C C950 49A2 4205  1933 BCA9 943D D1DF 4C04";
-      }
-    ];
-  };
   prince213 = {
     name = "Sizhe Zhao";
     email = "prc.zhao@outlook.com";

--- a/nixos/modules/programs/fuse.nix
+++ b/nixos/modules/programs/fuse.nix
@@ -4,7 +4,7 @@ let
   cfg = config.programs.fuse;
 in
 {
-  meta.maintainers = with lib.maintainers; [ primeos ];
+  meta.maintainers = with lib.maintainers; [ ];
 
   options.programs.fuse = {
     mountMax = lib.mkOption {

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -205,7 +205,5 @@ in
     ]
   );
 
-  meta.maintainers = with lib.maintainers; [
-    primeos
-  ];
+  meta.maintainers = with lib.maintainers; [ ];
 }

--- a/nixos/modules/programs/wshowkeys.nix
+++ b/nixos/modules/programs/wshowkeys.nix
@@ -27,5 +27,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ primeos ];
+  meta.maintainers = with lib.maintainers; [ ];
 }

--- a/nixos/tests/chromium.nix
+++ b/nixos/tests/chromium.nix
@@ -47,7 +47,6 @@ mapAttrs (
       {
         maintainers = with maintainers; [
           aszlig
-          primeos
         ];
       }
       // optionalAttrs (chromiumPkg.meta ? timeout) {

--- a/nixos/tests/hostname.nix
+++ b/nixos/tests/hostname.nix
@@ -23,7 +23,6 @@ let
       name = "hostname-${fqdn}";
       meta = with pkgs.lib.maintainers; {
         maintainers = [
-          primeos
           blitz
         ];
       };

--- a/nixos/tests/signal-desktop.nix
+++ b/nixos/tests/signal-desktop.nix
@@ -15,7 +15,6 @@ in
   meta = with pkgs.lib.maintainers; {
     maintainers = [
       flokli
-      primeos
     ];
   };
 

--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -3,7 +3,6 @@
   name = "sway";
   meta = {
     maintainers = with lib.maintainers; [
-      primeos
       synthetica
     ];
   };

--- a/nixos/tests/tinywl.nix
+++ b/nixos/tests/tinywl.nix
@@ -3,7 +3,7 @@
 {
   name = "tinywl";
   meta = {
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
   };
 
   nodes.machine =

--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -184,7 +184,7 @@ rec {
       longDescription = "Gammastep" + lib.removePrefix "Redshift" redshift.meta.longDescription;
       homepage = "https://gitlab.com/chinstrap/gammastep";
       mainProgram = "gammastep";
-      maintainers = (with lib.maintainers; [ primeos ]) ++ redshift.meta.maintainers;
+      maintainers = (with lib.maintainers; [ ]) ++ redshift.meta.maintainers;
     };
   };
 }

--- a/pkgs/applications/networking/newsreaders/quiterss/default.nix
+++ b/pkgs/applications/networking/newsreaders/quiterss/default.nix
@@ -44,6 +44,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/QuiteRSS/quiterss/blob/${version}/CHANGELOG";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -91,7 +91,6 @@ buildPythonApplication rec {
     changelog = "https://github.com/nicolargo/glances/blob/${src.tag}/NEWS.rst";
     license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [
-      primeos
       koral
     ];
   };

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -570,7 +570,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
-      primeos
       wmertens
       globin
       kashw2

--- a/pkgs/by-name/am/aml/package.nix
+++ b/pkgs/by-name/am/aml/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     license = licenses.isc;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
     broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/ca/cage/package.nix
+++ b/pkgs/by-name/ca/cage/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.hjdskes.nl/projects/cage/";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "cage";
   };
 })

--- a/pkgs/by-name/da/dav1d/package.nix
+++ b/pkgs/by-name/da/dav1d/package.nix
@@ -87,6 +87,6 @@ stdenv.mkDerivation rec {
     # More technical: https://code.videolan.org/videolan/dav1d/blob/${version}/NEWS
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix ++ lib.platforms.windows;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/dy/dynamips/package.nix
+++ b/pkgs/by-name/dy/dynamips/package.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     mainProgram = "dynamips";
     maintainers = with lib.maintainers; [
-      primeos
       anthonyroussel
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/by-name/fi/fim/package.nix
+++ b/pkgs/by-name/fi/fim/package.nix
@@ -98,6 +98,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.nongnu.org/fbi-improved/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/fs/fscrypt-experimental/package.nix
+++ b/pkgs/by-name/fs/fscrypt-experimental/package.nix
@@ -57,6 +57,6 @@ buildGoModule rec {
     changelog = "https://github.com/google/fscrypt/releases/tag/v${version}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/fs/fscryptctl/package.nix
+++ b/pkgs/by-name/fs/fscryptctl/package.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/google/fscryptctl/blob/master/NEWS.md";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
   };
 })

--- a/pkgs/by-name/fw/fwknop/package.nix
+++ b/pkgs/by-name/fw/fwknop/package.nix
@@ -75,6 +75,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.cipherdyne.org/fwknop/";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/gn/gn/generic.nix
+++ b/pkgs/by-name/gn/gn/generic.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [
       stesie
       matthewbauer
-      primeos
     ];
   };
 }

--- a/pkgs/by-name/go/goobook/package.nix
+++ b/pkgs/by-name/go/goobook/package.nix
@@ -62,6 +62,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://gitlab.com/goobook/goobook";
     changelog = "https://gitlab.com/goobook/goobook/-/blob/${src.tag}/CHANGES.rst";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/in/iniparser/package.nix
+++ b/pkgs/by-name/in/iniparser/package.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     platforms = platforms.unix;
     pkgConfigModules = [ "iniparser" ];
-    maintainers = [ maintainers.primeos ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ip/iproute2/package.nix
+++ b/pkgs/by-name/ip/iproute2/package.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl2Only;
     maintainers = with maintainers; [
-      primeos
       fpletz
       globin
     ];

--- a/pkgs/by-name/is/isync/package.nix
+++ b/pkgs/by-name/is/isync/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "mbsync";
   };
 })

--- a/pkgs/by-name/li/libaom/package.nix
+++ b/pkgs/by-name/li/libaom/package.nix
@@ -128,7 +128,6 @@ stdenv.mkDerivation rec {
     homepage = "https://aomedia.org/av1-features/get-started/";
     changelog = "https://aomedia.googlesource.com/aom/+/refs/tags/v${version}/CHANGELOG";
     maintainers = with lib.maintainers; [
-      primeos
       kiloreux
       dandellion
     ];

--- a/pkgs/by-name/li/libdrm/package.nix
+++ b/pkgs/by-name/li/libdrm/package.nix
@@ -83,6 +83,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     platforms = lib.subtractLists platforms.darwin platforms.unix;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/li/libglvnd/package.nix
+++ b/pkgs/by-name/li/libglvnd/package.nix
@@ -112,6 +112,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     # https://gitlab.freedesktop.org/glvnd/libglvnd/-/issues/212
     badPlatforms = [ lib.systems.inspect.platformPatterns.isStatic ];
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/li/libmd/package.nix
+++ b/pkgs/by-name/li/libmd/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
       beerware
       publicDomain
     ];
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/li/libplacebo/package.nix
+++ b/pkgs/by-name/li/libplacebo/package.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
     homepage = "https://code.videolan.org/videolan/libplacebo";
     changelog = "https://code.videolan.org/videolan/libplacebo/-/tags/v${version}";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/li/libplacebo_5/package.nix
+++ b/pkgs/by-name/li/libplacebo_5/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     homepage = "https://code.videolan.org/videolan/libplacebo";
     changelog = "https://code.videolan.org/videolan/libplacebo/-/tags/v${version}";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/li/libxkbcommon_8/package.nix
+++ b/pkgs/by-name/li/libxkbcommon_8/package.nix
@@ -96,7 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/xkbcommon/libxkbcommon/blob/xkbcommon-${finalAttrs.version}/NEWS.md";
     license = licenses.mit;
     maintainers = with maintainers; [
-      primeos
       ttuegel
     ];
     mainProgram = "xkbcli";

--- a/pkgs/by-name/ls/lsb-release/package.nix
+++ b/pkgs/by-name/ls/lsb-release/package.nix
@@ -22,7 +22,7 @@ replaceVarsWith {
     description = "Prints certain LSB (Linux Standard Base) and Distribution information";
     mainProgram = "lsb_release";
     license = [ licenses.mit ];
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/mo/monkeysphere/package.nix
+++ b/pkgs/by-name/mo/monkeysphere/package.nix
@@ -137,6 +137,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/pg/pgpdump/package.nix
+++ b/pkgs/by-name/pg/pgpdump/package.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.mew.org/~kazu/proj/pgpdump/en/";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/sc/scdoc/package.nix
+++ b/pkgs/by-name/sc/scdoc/package.nix
@@ -43,9 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://git.sr.ht/~sircmpwn/scdoc/refs/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     mainProgram = "scdoc";
-    maintainers = with lib.maintainers; [
-      primeos
-    ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/si/signing-party/package.nix
+++ b/pkgs/by-name/si/signing-party/package.nix
@@ -307,7 +307,7 @@ stdenv.mkDerivation rec {
       gpl2Plus
       gpl3Plus
     ];
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/ss/sshfs-fuse/common.nix
+++ b/pkgs/by-name/ss/sshfs-fuse/common.nix
@@ -87,6 +87,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/libfuse/sshfs";
     license = licenses.gpl2Plus;
     mainProgram = "sshfs";
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/sw/sway-unwrapped/package.nix
+++ b/pkgs/by-name/sw/sway-unwrapped/package.nix
@@ -138,7 +138,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      primeos
       synthetica
     ];
     mainProgram = "sway";

--- a/pkgs/by-name/sw/swaybg/package.nix
+++ b/pkgs/by-name/sw/swaybg/package.nix
@@ -61,7 +61,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     mainProgram = "swaybg";
     maintainers = with maintainers; [
-      primeos
       ryan4yin
     ];
     platforms = platforms.linux;

--- a/pkgs/by-name/sw/swayidle/package.nix
+++ b/pkgs/by-name/sw/swayidle/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     mainProgram = "swayidle";
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/sw/swaylock/package.nix
+++ b/pkgs/by-name/sw/swaylock/package.nix
@@ -66,6 +66,6 @@ stdenv.mkDerivation rec {
     mainProgram = "swaylock";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/ub/ubridge/package.nix
+++ b/pkgs/by-name/ub/ubridge/package.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     mainProgram = "ubridge";
     maintainers = with lib.maintainers; [
-      primeos
       anthonyroussel
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/by-name/wa/wayland-utils/package.nix
+++ b/pkgs/by-name/wa/wayland-utils/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.freedesktop.org/wayland/wayland-utils";
     license = licenses.mit; # Expat version
     platforms = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
     mainProgram = "wayland-info";
   };
 }

--- a/pkgs/by-name/we/weston/package.nix
+++ b/pkgs/by-name/we/weston/package.nix
@@ -148,7 +148,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "weston";
     maintainers = with maintainers; [
-      primeos
       qyliss
     ];
   };

--- a/pkgs/by-name/we/wev/package.nix
+++ b/pkgs/by-name/we/wev/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
       X11 tool xev.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     mainProgram = "wev";
   };

--- a/pkgs/by-name/wl/wlsunset/package.nix
+++ b/pkgs/by-name/wl/wlsunset/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     changelog = "https://git.sr.ht/~kennylevinsen/wlsunset/refs/${version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "wlsunset";
   };
 }

--- a/pkgs/by-name/wo/wob/package.nix
+++ b/pkgs/by-name/wo/wob/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     '';
     changelog = "https://github.com/francma/wob/releases/tag/${version}";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
     mainProgram = "wob";
   };

--- a/pkgs/by-name/ws/wshowkeys/package.nix
+++ b/pkgs/by-name/ws/wshowkeys/package.nix
@@ -59,7 +59,6 @@ stdenv.mkDerivation {
     # TODO: gpl3Only or gpl3Plus (ask upstream)?
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      primeos
       berbiche
     ];
     mainProgram = "wshowkeys";

--- a/pkgs/development/libraries/libliftoff/generic.nix
+++ b/pkgs/development/libraries/libliftoff/generic.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      primeos
       Scrumplex
     ];
   };

--- a/pkgs/development/libraries/mesa/common.nix
+++ b/pkgs/development/libraries/mesa/common.nix
@@ -32,7 +32,6 @@ rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       k900
-      primeos
       vcunat
     ]; # Help is welcome :)
   };

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -117,7 +117,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit; # Expat version
     platforms = platforms.unix;
     maintainers = with maintainers; [
-      primeos
       codyopel
       qyliss
     ];

--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.freedesktop.org/wayland/wayland-protocols";
     license = lib.licenses.mit; # Expat version
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
     pkgConfigModules = [ "wayland-protocols" ];
   };
 

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -130,7 +130,6 @@ let
         license = lib.licenses.mit;
         platforms = lib.platforms.linux;
         maintainers = with lib.maintainers; [
-          primeos
           synthetica
           rewine
         ];

--- a/pkgs/development/python-modules/aiohttp-cors/default.nix
+++ b/pkgs/development/python-modules/aiohttp-cors/default.nix
@@ -47,6 +47,6 @@ buildPythonPackage rec {
     description = "CORS support for aiohttp";
     homepage = "https://github.com/aio-libs/aiohttp-cors";
     license = licenses.asl20;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/keyutils/default.nix
+++ b/pkgs/development/python-modules/keyutils/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     description = "Set of python bindings for keyutils";
     homepage = "https://github.com/sassoftware/python-keyutils";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/raven/default.nix
+++ b/pkgs/development/python-modules/raven/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     mainProgram = "raven";
     homepage = "https://github.com/getsentry/raven-python";
     license = [ lib.licenses.bsd3 ];
-    maintainers = with lib.maintainers; [ primeos ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/scapy/default.nix
+++ b/pkgs/development/python-modules/scapy/default.nix
@@ -125,7 +125,6 @@ buildPythonPackage rec {
     license = licenses.gpl2Only;
     platforms = platforms.unix;
     maintainers = with maintainers; [
-      primeos
       bjornfor
     ];
   };

--- a/pkgs/development/tools/selenium/chromedriver/binary.nix
+++ b/pkgs/development/tools/selenium/chromedriver/binary.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
     '';
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.bsd3;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
     # Note from primeos: By updating Chromium I also update Google Chrome and
     # ChromeDriver.
     platforms = platforms.darwin;

--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -150,7 +150,6 @@ stdenv.mkDerivation rec {
       lgpl21Only
     ];
     maintainers = with lib.maintainers; [
-      primeos
       oxalica
     ];
     outputsToInstall = [ "bin" ];

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -96,6 +96,6 @@ stdenv.mkDerivation rec {
       bsd3
     ];
     platforms = platforms.linux;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/misc/android-tools/default.nix
+++ b/pkgs/tools/misc/android-tools/default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
       unicode-dfs-2015
     ];
     platforms = platforms.unix;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = with maintainers; [ ];
     teams = [ teams.android ];
   };
 }

--- a/pkgs/tools/security/bundler-audit/default.nix
+++ b/pkgs/tools/security/bundler-audit/default.nix
@@ -29,7 +29,6 @@ bundlerEnv rec {
     changelog = "https://github.com/rubysec/bundler-audit/blob/v${version}/ChangeLog.md";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
-      primeos
       nicknovitski
     ];
     platforms = platforms.unix;


### PR DESCRIPTION
This removes primeos from all nixos modules and packages maintainer entries. Having an inactive maintainer entry there is misleading and paints a false picture that the package/module is still being maintained. This leads to scenarios like https://github.com/NixOS/nixpkgs/issues/412462, https://github.com/NixOS/nixpkgs/issues/372789, https://github.com/NixOS/nixpkgs/issues/415345 that end up being unaddressed.
Package maintainers are expected to address bug reports and perform maintainence which hasn't been taken up by him for long.

In addition, I would also like @NixOS/commit-bit-delegation team to invoke [RFC 55](https://github.com/NixOS/rfcs/blob/master/rfcs/0055-retired-committers.md#detailed-design) (https://github.com/NixOS/nixpkgs/issues/88867) to remove @primeos's commit access as they haven't commited to Nixpkgs for more than a year, except https://github.com/NixOS/nixpkgs/commit/10cbea290552f490a610454a14754b55eadacbcb, which removed him from maintainers of few modules.

This, by no means, is belittling @primeos's contributions over the past few years (back when he was still active). He is free to request his commit bit back and restore maintainership once he becomes active again.

His entry in `maintainers-list.nix` hasn't been removed yet, that can be done if desired.

His commit history on nixpkgs for reference: https://github.com/NixOS/nixpkgs/commits?author=primeos

CC https://github.com/NixOS/nixpkgs-committers/issues/50
CC https://github.com/NixOS/nixpkgs/issues/88867