### PR TITLE
apacheHttpdPackages_2_4.mod_timestamp: fix build with gcc 14

### DIFF
--- a/pkgs/servers/http/apache-modules/mod_timestamp/0001-DEFINE_STACK_OF-EVP_MD-seems-to-have-gone-recreate-i.patch
+++ b/pkgs/servers/http/apache-modules/mod_timestamp/0001-DEFINE_STACK_OF-EVP_MD-seems-to-have-gone-recreate-i.patch
@@ -1,0 +1,41 @@
+From 5f9d4458f05c5d9f4b416de867fd9327aba865d5 Mon Sep 17 00:00:00 2001
+From: Dirk-Willem van Gulik <dirkx@redwax.eu>
+Date: Fri, 21 Jan 2022 21:53:49 +0100
+Subject: [PATCH] DEFINE_STACK_OF(EVP_MD) seems to have gone; recreate it. And
+ quell a warning.
+
+---
+ mod_timestamp.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/mod_timestamp.c b/mod_timestamp.c
+index 289d50a..54af7c8 100644
+--- a/mod_timestamp.c
++++ b/mod_timestamp.c
+@@ -41,6 +41,14 @@
+ 
+ #include "mod_ca.h"
+ 
++#ifndef sk_EVP_MD_free
++/* Recent versions of OpenSSL seem to no longer define 
++ * a stack of EVP_MD's. 
++ */
++#include <openssl/safestack.h>
++DEFINE_STACK_OF(EVP_MD)
++#endif
++
+ #define DEFAULT_TIMESTAMP_SIZE 128*1024
+ 
+ module AP_MODULE_DECLARE_DATA timestamp_module;
+@@ -360,7 +368,7 @@ static const char *add_timestamp_digest(cmd_parms *cmd, void *dconf,
+         return apr_psprintf(cmd->pool,
+                 "'%s' could not be recognised as a valid digest.", arg);
+     }
+-    if (!sk_EVP_MD_push(conf->digests, digest)) {
++    if (!sk_EVP_MD_push(conf->digests, (EVP_MD *)digest)) {
+         return apr_psprintf(cmd->pool,
+                 "'%s' could not be added as a valid digest.", arg);
+     }
+-- 
+2.49.0
+

--- a/pkgs/servers/http/apache-modules/mod_timestamp/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_timestamp/default.nix
@@ -26,6 +26,9 @@ stdenv.mkDerivation rec {
     mod_ca
   ];
 
+  # FIXME: remove after next release after 0.2.3
+  patches = [ ./0001-DEFINE_STACK_OF-EVP_MD-seems-to-have-gone-recreate-i.patch ];
+
   env.NIX_CFLAGS_COMPILE = toString (
     lib.optionals stdenv.cc.isClang [
       "-Wno-error=int-conversion"


### PR DESCRIPTION
One note: even though the commit is merged upstream already, I had to download it and add it to the tree. This is because, although https://source.redwax.eu/projects/RS/repos/mod_timestamp/commits/5f9d4458f05c5d9f4b416de867fd9327aba865d5 works fine, https://source.redwax.eu/projects/RS/repos/mod_timestamp/commits/5f9d4458f05c5d9f4b416de867fd9327aba865d5/raw requires a login.

Tracking: #388196 #356812

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
