### PR TITLE
opencv: fix cross compliation by patching protobuf

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   pkg-config,
   unzip,
@@ -300,6 +301,13 @@ effectiveStdenv.mkDerivation {
   patches =
     [
       ./cmake-don-t-use-OpenCVFindOpenEXR.patch
+      # NOTE: remove patch in opencv v4.12.0 (next release)
+      # https://github.com/opencv/opencv/pull/27428
+      # it is required to allow cross compilation by letting PROTOC_EXE be set by protobuf hook
+      (fetchpatch2 {
+        url = "https://github.com/opencv/opencv/commit/bbe2f50b5d50a282b2260100be9e559067e55fbf.patch?full_index=1";
+        hash = "sha256-T+zmrOeyEmNyu1hJPDGUub59EMXwe6ZqP6PV/tDJFCk=";
+      })
     ]
     ++ optionals enableCuda [
       ./cuda_opt_flow.patch

--- a/pkgs/development/libraries/protobuf/cmake-configure-protoc-exe-21.patch
+++ b/pkgs/development/libraries/protobuf/cmake-configure-protoc-exe-21.patch
@@ -1,0 +1,47 @@
+commit 649864521c0e09f3a3bd7939d91ba1ef488946dc
+Author: phanirithvij <phanirithvij2000@gmail.com>
+Date:   Tue Jun 10 10:58:49 2025 +0530
+
+    [CMake] Allow for protoc executable to be configured
+    
+    copied from commit 3163111b6fb1da08b9d6ad75518d91b89cd03bbf
+    
+    Signed-off-by: phanirithvij <phanirithvij2000@gmail.com>
+
+diff --git a/cmake/protobuf-config.cmake.in b/cmake/protobuf-config.cmake.in
+index 61669118c..55f32516f 100644
+--- a/cmake/protobuf-config.cmake.in
++++ b/cmake/protobuf-config.cmake.in
+@@ -11,7 +11,7 @@ function(protobuf_generate)
+   include(CMakeParseArguments)
+ 
+   set(_options APPEND_PATH)
+-  set(_singleargs LANGUAGE OUT_VAR EXPORT_MACRO PROTOC_OUT_DIR PLUGIN PLUGIN_OPTIONS)
++  set(_singleargs LANGUAGE OUT_VAR EXPORT_MACRO PROTOC_OUT_DIR PLUGIN PLUGIN_OPTIONS PROTOC_EXE)
+   if(COMMAND target_sources)
+     list(APPEND _singleargs TARGET)
+   endif()
+@@ -92,6 +92,11 @@ function(protobuf_generate)
+     endforeach()
+   endif()
+ 
++  if(NOT protobuf_generate_PROTOC_EXE)
++    # Default to using the CMake executable
++    set(protobuf_generate_PROTOC_EXE protobuf::protoc)
++  endif()
++
+   foreach(DIR ${protobuf_generate_IMPORT_DIRS})
+     get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
+     list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
+@@ -146,9 +151,9 @@ function(protobuf_generate)
+ 
+     add_custom_command(
+       OUTPUT ${_generated_srcs}
+-      COMMAND protobuf::protoc
++      COMMAND ${protobuf_generate_PROTOC_EXE}
+       ARGS ${protobuf_generate_PROTOC_OPTIONS} --${protobuf_generate_LANGUAGE}_out ${_plugin_options}:${protobuf_generate_PROTOC_OUT_DIR} ${_plugin} ${_protobuf_include_path} ${_abs_file}
+-      DEPENDS ${_abs_file} protobuf::protoc
++      DEPENDS ${_abs_file} ${protobuf_generate_PROTOC_EXE}
+       COMMENT ${_comment}
+       VERBATIM )
+   endforeach()


### PR DESCRIPTION
- patch protobuf_21-28 to allow using cmake specified protoc_exe
- patch opencv dnn cmakelists.txt to pass correct protoc_exe which allows cross compilation (upstreamed patch)

https://github.com/NixOS/nixpkgs/pull/370155 introduced protobuf_29 which doesn't require the custom [patch](https://github.com/protocolbuffers/protobuf/pull/17888) to protobuf. but it was reverted in https://github.com/NixOS/nixpkgs/pull/375774/commits/c312f6f8187eefb9c860bc54d1e508490f20c94a.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
