### PR TITLE
nixos/bcachefs: init module for autoScrub

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -28,6 +28,8 @@
 - [LACT](https://github.com/ilya-zlobintsev/LACT), a GPU monitoring and configuration tool, can now be enabled through [services.lact.enable](#opt-services.lact.enable).
   Note that for LACT to work properly on AMD GPU systems, you need to enable [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable).
 
+- Auto-scrub support for Bcachefs filesystems can now be enabled through [services.bcachefs.autoScrub.enable](#opt-services.bcachefs.autoScrub.enable) to periodically check for data corruption. If there's a correct copy available, it will automatically repair corrupted blocks.
+
 - [tlsrpt-reporter], an application suite to generate and deliver TLSRPT reports. Available as [services.tlsrpt](#opt-services.tlsrpt.enable).
 
 - [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -7,6 +7,7 @@
 }:
 
 let
+  cfgScrub = config.services.bcachefs.autoScrub;
 
   bootFs = lib.filterAttrs (
     n: fs: (fs.fsType == "bcachefs") && (utils.fsNeededForBoot fs)
@@ -159,6 +160,32 @@ let
 in
 
 {
+  options.services.bcachefs.autoScrub = {
+    enable = lib.mkEnableOption "regular bcachefs scrub";
+
+    fileSystems = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      example = [ "/" ];
+      description = ''
+        List of paths to bcachefs filesystems to regularly call {command}`bcachefs scrub` on.
+        Defaults to all mount points with bcachefs filesystems.
+      '';
+    };
+
+    interval = lib.mkOption {
+      default = "monthly";
+      type = lib.types.str;
+      example = "weekly";
+      description = ''
+        Systemd calendar expression for when to scrub bcachefs filesystems.
+        The recommended period is a month but could be less.
+        See
+        {manpage}`systemd.time(7)`
+        for more information on the syntax.
+      '';
+    };
+  };
+
   config = lib.mkIf (config.boot.supportedFilesystems.bcachefs or false) (
     lib.mkMerge [
       {
@@ -204,6 +231,95 @@ in
         );
 
         boot.initrd.systemd.services = lib.mapAttrs' (mkUnits "/sysroot") bootFs;
+      })
+
+      (lib.mkIf (cfgScrub.enable) {
+        assertions = [
+          {
+            assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.14";
+            message = "Bcachefs scrubbing is supported from kernel version 6.14 or later.";
+          }
+          {
+            assertion = cfgScrub.enable -> (cfgScrub.fileSystems != [ ]);
+            message = ''
+              If 'services.bcachefs.autoScrub' is enabled, you need to have at least one
+              bcachefs file system mounted via 'fileSystems' or specify a list manually
+              in 'services.bcachefs.autoScrub.fileSystems'.
+            '';
+          }
+        ];
+
+        # This will remove duplicated units from either having a filesystem mounted multiple
+        # time, or additionally mounted subvolumes, as well as having a filesystem span
+        # multiple devices (provided the same device is used to mount said filesystem).
+        services.bcachefs.autoScrub.fileSystems =
+          let
+            isDeviceInList = list: device: builtins.filter (e: e.device == device) list != [ ];
+
+            uniqueDeviceList = lib.foldl' (
+              acc: e: if isDeviceInList acc e.device then acc else acc ++ [ e ]
+            ) [ ];
+          in
+          lib.mkDefault (
+            map (e: e.mountPoint) (
+              uniqueDeviceList (
+                lib.mapAttrsToList (name: fs: {
+                  mountPoint = fs.mountPoint;
+                  device = fs.device;
+                }) (lib.filterAttrs (name: fs: fs.fsType == "bcachefs") config.fileSystems)
+              )
+            )
+          );
+
+        systemd.timers =
+          let
+            scrubTimer =
+              fs:
+              let
+                fs' = utils.escapeSystemdPath fs;
+              in
+              lib.nameValuePair "bcachefs-scrub-${fs'}" {
+                description = "regular bcachefs scrub timer on ${fs}";
+
+                wantedBy = [ "timers.target" ];
+                timerConfig = {
+                  OnCalendar = cfgScrub.interval;
+                  AccuracySec = "1d";
+                  Persistent = true;
+                };
+              };
+          in
+          lib.listToAttrs (map scrubTimer cfgScrub.fileSystems);
+
+        systemd.services =
+          let
+            scrubService =
+              fs:
+              let
+                fs' = utils.escapeSystemdPath fs;
+              in
+              lib.nameValuePair "bcachefs-scrub-${fs'}" {
+                description = "bcachefs scrub on ${fs}";
+                # scrub prevents suspend2ram or proper shutdown
+                conflicts = [
+                  "shutdown.target"
+                  "sleep.target"
+                ];
+                before = [
+                  "shutdown.target"
+                  "sleep.target"
+                ];
+
+                script = "${lib.getExe pkgs.bcachefs-tools} data scrub ${fs}";
+
+                serviceConfig = {
+                  Type = "oneshot";
+                  Nice = 19;
+                  IOSchedulingClass = "idle";
+                };
+              };
+          in
+          lib.listToAttrs (map scrubService cfgScrub.fileSystems);
       })
     ]
   );

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -323,4 +323,8 @@ in
       })
     ]
   );
+
+  meta = {
+    inherit (pkgs.bcachefs-tools.meta) maintainers;
+  };
 }

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -132,6 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
       davidak
+      johnrtitor
       Madouura
     ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Mostly inspired by btrfs scrub module.

Note that scrub is available from kernel 6.14.

Tagging few people who use bcachefs as far as I know for review.

CC @reedriley @tmuehlbacher

## Things done

- [x] Tested with my configuration
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
