### PR TITLE
roon-server: 2.51.1534 -> 2.52.1538

### DIFF
--- a/pkgs/by-name/ro/roon-server/package.nix
+++ b/pkgs/by-name/ro/roon-server/package.nix
@@ -16,7 +16,7 @@
   stdenv,
 }:
 let
-  version = "2.51.1534";
+  version = "2.52.1538";
   urlVersion = builtins.replaceStrings [ "." ] [ "0" ] version;
 in
 stdenv.mkDerivation {
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download.roonlabs.com/updates/production/RoonServer_linuxx64_${urlVersion}.tar.bz2";
-    hash = "sha256-x9zbWJ4lrqfC1CPquGsdgzhO3WBzd46dlZy6APqJbcg=";
+    hash = "sha256-pWg1Cp8aNdR/hoVZDF3kUznJtYsjJYX9J4g1xbmn/lg=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
https://community.roonlabs.com/t/roon-2-52-build-1538-and-arc-1-67-build-360-are-live/300916

## Things done

- Built on platform(s)
  - [ x] x86_64-linux
- [ x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ x] Tested basic functionality of all binary files (usually in `./result/bin/`)

Tested core functionality with clients on windows, android, iOS

Reviews requested from @lovesegfault @Ramblurr @SailorSnoW and perhaps @DirectXMan12