### PR TITLE
mimalloc: portability improvements

### DIFF
--- a/pkgs/by-name/mi/mimalloc/package.nix
+++ b/pkgs/by-name/mi/mimalloc/package.nix
@@ -34,12 +34,12 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
   ];
-  cmakeFlags = [
-    "-DMI_INSTALL_TOPLEVEL=ON"
-  ]
-  ++ lib.optionals secureBuild [ "-DMI_SECURE=ON" ]
-  ++ lib.optionals stdenv.hostPlatform.isStatic [ "-DMI_BUILD_SHARED=OFF" ]
-  ++ lib.optionals (!finalAttrs.doCheck) [ "-DMI_BUILD_TESTS=OFF" ];
+  cmakeFlags = lib.mapAttrsToList lib.cmakeBool {
+    MI_INSTALL_TOPLEVEL = true;
+    MI_SECURE = secureBuild;
+    MI_BUILD_SHARED = !stdenv.hostPlatform.isStatic;
+    MI_BUILD_TESTS = finalAttrs.doCheck;
+  };
 
   postInstall =
     let

--- a/pkgs/by-name/mi/mimalloc/package.nix
+++ b/pkgs/by-name/mi/mimalloc/package.nix
@@ -40,6 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
     MI_BUILD_SHARED = stdenv.hostPlatform.hasSharedLibraries;
     MI_LIBC_MUSL = stdenv.hostPlatform.libc == "musl";
     MI_BUILD_TESTS = finalAttrs.doCheck;
+
+    # MI_OPT_ARCH is inaccurate (e.g. it assumes aarch64 == armv8.1-a).
+    # Nixpkgs's native platform configuration does a better job.
+    MI_NO_OPT_ARCH = true;
   };
 
   postPatch = ''

--- a/pkgs/by-name/mi/mimalloc/package.nix
+++ b/pkgs/by-name/mi/mimalloc/package.nix
@@ -10,14 +10,14 @@
 let
   soext = stdenv.hostPlatform.extensions.sharedLibrary;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mimalloc";
   version = "3.1.5";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "mimalloc";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-fk6nfyBFS1G0sJwUJVgTC1+aKd0We/JjsIYTO+IOfyg=";
   };
 
@@ -39,11 +39,11 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals secureBuild [ "-DMI_SECURE=ON" ]
   ++ lib.optionals stdenv.hostPlatform.isStatic [ "-DMI_BUILD_SHARED=OFF" ]
-  ++ lib.optionals (!doCheck) [ "-DMI_BUILD_TESTS=OFF" ];
+  ++ lib.optionals (!finalAttrs.doCheck) [ "-DMI_BUILD_TESTS=OFF" ];
 
   postInstall =
     let
-      rel = lib.versions.majorMinor version;
+      rel = lib.versions.majorMinor finalAttrs.version;
       suffix = if stdenv.hostPlatform.isLinux then "${soext}.${rel}" else ".${rel}${soext}";
     in
     ''
@@ -76,4 +76,4 @@ stdenv.mkDerivation rec {
       thoughtpolice
     ];
   };
-}
+})


### PR DESCRIPTION
Rebase of #380289, with https://github.com/NixOS/nixpkgs/pull/380289#discussion_r1957126213 & https://github.com/NixOS/nixpkgs/pull/380289#discussion_r1957127347 applied. (Also changed `MI_OPT_ARCH = false` to `MI_NO_OPT_ARCH = true`, because otherwise it seems to get ignored.)

Supersedes #415567. 

Closes #380289 (I think).
Closes #415567.

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
