### PR TITLE
nixos-rebuild-ng: enable by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -4,6 +4,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `nixos-rebuild-ng`, a full rewrite of `nixos-rebuild` in Python, is enabled by default from this release. You can disable it by setting [](#opt-system.rebuild.enableNg) to `false` in your configuration if you need, but please report any issues. It is expected that the next major version of NixOS (26.05) will remove the {option}`system.rebuild.enableNg` option.
+
 - Secure boot support can now be enabled for the Limine bootloader through {option}`boot.loader.limine.secureBoot.enable`. Bootloader install script signs the bootloader, then kernels are hashed during system rebuild and written to a config. This allows Limine to boot only the kernels installed through NixOS system.
 
 ## New Modules {#sec-release-25.11-new-modules}

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -280,6 +280,7 @@ in
   };
 
   options.system.rebuild.enableNg = lib.mkEnableOption "" // {
+    default = true;
     description = ''
       Whether to use ‘nixos-rebuild-ng’ in place of ‘nixos-rebuild’, the
       Python-based re-implementation of the original in Bash.
@@ -329,6 +330,12 @@ in
 
   config = {
     documentation.man.man-db.skipPackages = [ nixos-version ];
+
+    warnings = lib.optional (!config.system.disableInstallerTools && !config.system.rebuild.enableNg) ''
+      The Bash implementation of nixos-rebuild will be deprecated and removed in the 26.05 release of NixOS.
+      Please migrate to the newer implementation by removing 'system.rebuild.enableNg = false' from your configuration.
+      If you are unable to migrate due to any issues with the new implementation, please create an issue and tag the maintainers of 'nixos-rebuild-ng'.
+    '';
 
     # These may be used in auxiliary scripts (ie not part of toplevel), so they are defined unconditionally.
     system.build = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -942,7 +942,7 @@ in
   nixos-generate-config = runTest ./nixos-generate-config.nix;
   nixos-rebuild-install-bootloader = handleTestOn [
     "x86_64-linux"
-  ] ./nixos-rebuild-install-bootloader.nix { };
+  ] ./nixos-rebuild-install-bootloader.nix { withNg = false; };
   nixos-rebuild-install-bootloader-ng = handleTestOn [
     "x86_64-linux"
   ] ./nixos-rebuild-install-bootloader.nix { withNg = true; };

--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -35,40 +35,6 @@ an attempt of the rewrite.
   currently depends on `jq` for JSON parsing, while Python has `json` in
   standard library
 
-## Do's and Don'ts
-
-- Do: be as much of a drop-in replacement as possible
-- Do: fix obvious bugs
-- Do: improvements that are non-breaking
-- Don't: change logic in breaking ways even if this would be an improvement
-
-## How to use
-
-If you want to use `nixos-rebuild-ng` without replacing `nixos-rebuild`, add the
-following to your NixOS configuration:
-
-```nix
-{ pkgs, ... }:
-{
-  environment.systemPackages = [ pkgs.nixos-rebuild-ng ];
-}
-```
-
-And use `nixos-rebuild-ng` instead of `nixos-rebuild`.
-
-If you want to completely replace `nixos-rebuild` with `nixos-rebuild-ng`, add
-the following to your NixOS configuration:
-
-```nix
-{ ... }:
-{
-  system.rebuild.enableNg = true;
-}
-```
-
-This will set `config.system.build.nixos-rebuild` to `nixos-rebuild-ng`, so
-all tools that expect it in that location should work.
-
 ## Development
 
 Run:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR enables `nixos-rebuild-ng` by default.

Want to get this PR merged earlier in the 25.11 lifecycle so we can fix any blocking issues as earlier as possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
