### PR TITLE
python313Packages.streaming-form-data: 1.13.0 -> 1.19.1

### DIFF
--- a/pkgs/development/python-modules/streaming-form-data/default.nix
+++ b/pkgs/development/python-modules/streaming-form-data/default.nix
@@ -4,21 +4,23 @@
   buildPythonPackage,
   pythonOlder,
   cython,
+  setuptools,
   pytestCheckHook,
   requests-toolbelt,
 }:
 
 buildPythonPackage rec {
   pname = "streaming-form-data";
-  version = "1.13.0";
-  format = "setuptools";
+  version = "1.19.1";
+  pyproject = true;
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "siddhantgoel";
     repo = "streaming-form-data";
     rev = "v${version}";
-    hash = "sha256-Ntiad5GZtfRd+2uDPgbDzLBzErGFroffK6ZAmMcsfXA=";
+    hash = "sha256-3tK7dX5p1uH/azmFxzELM1bflGI/SHoLvsw+Ta+7rC4=";
   };
 
   # streaming-form-data has a small bit of code that uses smart_open, which has a massive closure.
@@ -26,13 +28,10 @@ buildPythonPackage rec {
   # So, just drop the dependency to not have to deal with it.
   patches = [ ./drop-smart-open.patch ];
 
-  # The repo has a vendored copy of the cython output, which doesn't build on 3.13,
-  # so regenerate it with our cython, which does.
-  preBuild = ''
-    cython streaming_form_data/_parser.pyx
-  '';
-
-  nativeBuildInputs = [ cython ];
+  nativeBuildInputs = [
+    cython
+    setuptools
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/streaming-form-data/default.nix
+++ b/pkgs/development/python-modules/streaming-form-data/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  pythonOlder,
   cython,
   setuptools,
   pytestCheckHook,
@@ -14,12 +13,10 @@ buildPythonPackage rec {
   version = "1.19.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.6";
-
   src = fetchFromGitHub {
     owner = "siddhantgoel";
     repo = "streaming-form-data";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-3tK7dX5p1uH/azmFxzELM1bflGI/SHoLvsw+Ta+7rC4=";
   };
 
@@ -28,7 +25,7 @@ buildPythonPackage rec {
   # So, just drop the dependency to not have to deal with it.
   patches = [ ./drop-smart-open.patch ];
 
-  nativeBuildInputs = [
+  build-system = [
     cython
     setuptools
   ];
@@ -42,14 +39,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "streaming_form_data" ];
 
-  preCheck = ''
-    # remove in-tree copy to make pytest find the installed one, with the native parts already built
-    rm -rf streaming_form_data
-  '';
-
   meta = {
     description = "Streaming parser for multipart/form-data";
     homepage = "https://github.com/siddhantgoel/streaming-form-data";
+    changelog = "https://github.com/siddhantgoel/streaming-form-data/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ zhaofengli ];
   };

--- a/pkgs/development/python-modules/streaming-form-data/drop-smart-open.patch
+++ b/pkgs/development/python-modules/streaming-form-data/drop-smart-open.patch
@@ -1,36 +1,49 @@
-diff --git a/streaming_form_data/targets.py b/streaming_form_data/targets.py
-index a399f3a..b816714 100644
---- a/streaming_form_data/targets.py
-+++ b/streaming_form_data/targets.py
-@@ -1,6 +1,5 @@
- import hashlib
+diff --git a/pyproject.toml b/pyproject.toml
+index 43b7231..51c5e9c 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -27,7 +27,6 @@ classifiers = [
+ ]
+ keywords = ["cython", "form-data", "forms", "http", "multipart", "streaming", "web"]
+ dependencies = [
+-    "smart-open>=7.0.5",
+ ]
+ 
+ [project.urls]
+diff --git a/src/streaming_form_data/targets.py b/src/streaming_form_data/targets.py
+index fc31f67..219c183 100644
+--- a/src/streaming_form_data/targets.py
++++ b/src/streaming_form_data/targets.py
+@@ -2,7 +2,6 @@ import hashlib
  from pathlib import Path
+ from typing import Callable, List, Optional, Union
+ 
 -import smart_open  # type: ignore
- from typing import Callable, List, Optional
  
  
-@@ -164,6 +163,7 @@ class S3Target(BaseTarget):
-     S3Target enables chunked uploads to S3 buckets (using smart_open)"""
- 
-     def __init__(self, file_path, mode, transport_params=None, **kwargs):
+ class BaseTarget:
+@@ -313,6 +312,7 @@ class SmartOpenTarget(BaseTarget):
+             mode:
+                 The mode in which the file should be opened
+         """
 +        raise Exception("Nixpkgs: disabled")
+ 
          super().__init__(**kwargs)
  
-         self._file_path = file_path
 diff --git a/tests/test_targets.py b/tests/test_targets.py
-index 0cc79ab..78ab40b 100644
+index 4aa6b57..d768e2f 100644
 --- a/tests/test_targets.py
 +++ b/tests/test_targets.py
 @@ -2,8 +2,6 @@ import os.path
  import tempfile
  
  import pytest
--from moto import mock_s3
+-from moto import mock_aws
 -import boto3
  
  from streaming_form_data.targets import (
      BaseTarget,
-@@ -271,6 +269,7 @@ def mock_client():
+@@ -305,6 +303,7 @@ def mock_client():
          yield client
  
  


### PR DESCRIPTION
https://github.com/siddhantgoel/streaming-form-data/blob/v1.19.1/CHANGELOG.md

~~This also fixes the build of `python313Packages.streaming-form-data` (#388196, #356812).~~

Python 3.13 build was fixed separately via https://github.com/NixOS/nixpkgs/commit/18590d1e372a8e4414120da1a0c497e1ed353454.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
