### PR TITLE
replaceDependencies: Fix with ca-derivations

### DIFF
--- a/pkgs/build-support/replace-dependencies.nix
+++ b/pkgs/build-support/replace-dependencies.nix
@@ -43,7 +43,7 @@ let
   inherit (builtins) unsafeDiscardStringContext appendContext;
   inherit (lib)
     listToAttrs
-    isStorePath
+    isStringLike
     readFile
     attrValues
     mapAttrs
@@ -52,6 +52,16 @@ let
     mapAttrsToList
     ;
   inherit (lib.attrsets) mergeAttrsList;
+
+  isNonCaStorePath =
+    x:
+    if isStringLike x then
+      let
+        str = toString x;
+      in
+      builtins.substring 0 1 str == "/" && (dirOf str == builtins.storeDir)
+    else
+      false;
 
   toContextlessString = x: unsafeDiscardStringContext (toString x);
   warn = if verbose then lib.warn else (x: y: y);
@@ -90,7 +100,7 @@ let
 
   realisation =
     drv:
-    if isStorePath drv then
+    if isNonCaStorePath drv then
       # Input-addressed and fixed-output derivations have their realisation as outPath.
       toContextlessString drv
     else

--- a/pkgs/build-support/replace-direct-dependencies.nix
+++ b/pkgs/build-support/replace-direct-dependencies.nix
@@ -12,20 +12,30 @@
 }:
 let
   inherit (lib)
-    isStorePath
+    isStringLike
     substring
     stringLength
     optionalString
     escapeShellArgs
     concatMap
     ;
+
+  isNonCaStorePath =
+    x:
+    if isStringLike x then
+      let
+        str = toString x;
+      in
+      builtins.substring 0 1 str == "/" && (dirOf str == builtins.storeDir)
+    else
+      false;
 in
 if replacements == [ ] then
   drv
 else
   let
     drvName =
-      if isStorePath drv then
+      if isNonCaStorePath drv then
         # Reconstruct the name from the actual store path if available.
         substring 33 (stringLength (baseNameOf drv)) (baseNameOf drv)
       else if drv ? drvAttrs.name then


### PR DESCRIPTION
Broken in 7a07cc0da9787e936a6b4099c1109906088d3868 since that changed isStorePath to return true for content-addressed paths.


## Things done

Tested using this in my own NixOS config with ca-derivations enabled. The NixOS test was also previously failing, and is now passing.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
