### PR TITLE
formats: deprecate accidental `lib.types` aliases

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -1,5 +1,47 @@
 { lib, pkgs }:
-rec {
+let
+  inherit (lib.types)
+    attrsOf
+    bool
+    coercedTo
+    either
+    float
+    int
+    listOf
+    luaInline
+    mkOptionType
+    nonEmptyListOf
+    nullOr
+    oneOf
+    path
+    str
+    ;
+
+  # Attributes added accidentally in https://github.com/NixOS/nixpkgs/pull/335232 (2024-08-18)
+  # Deprecated in https://github.com/NixOS/nixpkgs/pull/415666 (2025-06)
+  aliases =
+    lib.mapAttrs (name: lib.warn "`formats.${name}` is deprecated; use `lib.types.${name}` instead.")
+      {
+        inherit
+          attrsOf
+          bool
+          coercedTo
+          either
+          float
+          int
+          listOf
+          luaInline
+          mkOptionType
+          nonEmptyListOf
+          nullOr
+          oneOf
+          path
+          str
+          ;
+      };
+in
+lib.optionalAttrs pkgs.config.allowAliases aliases
+// rec {
 
   /*
     Every following entry represents a format for program configuration files
@@ -42,25 +84,6 @@ rec {
   hocon = (import ./formats/hocon/default.nix { inherit lib pkgs; }).format;
 
   php = (import ./formats/php/default.nix { inherit lib pkgs; }).format;
-
-  inherit (lib) mkOptionType;
-  inherit (lib.types)
-    nullOr
-    oneOf
-    coercedTo
-    listOf
-    nonEmptyListOf
-    attrsOf
-    either
-    ;
-  inherit (lib.types)
-    bool
-    int
-    float
-    str
-    path
-    luaInline
-    ;
 
   json =
     { }:


### PR DESCRIPTION
Introduced in https://github.com/NixOS/nixpkgs/pull/335232 (commit 1f6ce17b6d6e41e3a68cffe54442aff985fd49c9), see discussion: https://github.com/NixOS/nixpkgs/pull/335232#discussion_r2138604344

cc @philiptaron


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested using the repl:

```
$ nix repl
Nix 2.28.3
Type :? for help.

nix-repl> pkgs = import ./. { }

nix-repl> pkgsNoAliases = import ./. { config.allowAliases = false; }

nix-repl> pkgs.formats.attrsOf
evaluation warning: `formats.attrsOf' is deprcated, use `lib.types.attrsOf' instead.
«lambda attrsOf @ /home/matt/nixpkgs/pr/lib/types.nix:752:17»

nix-repl> pkgsNoAliases.formats.attrsOf
error:
       … while evaluating the attribute 'formats.attrsOf'
         at /home/matt/nixpkgs/pr/pkgs/top-level/all-packages.nix:996:5:
          995|     })
          996|     formats
             |     ^
          997|     ;

       error: attribute 'attrsOf' missing
       at «string»:1:1:
            1| pkgsNoAliases.formats.attrsOf
             | ^
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
