### PR TITLE
grayjay: 7 -> 9

### DIFF
--- a/pkgs/by-name/gr/grayjay/deps.json
+++ b/pkgs/by-name/gr/grayjay/deps.json
@@ -86,11 +86,6 @@
   },
   {
     "pname": "Microsoft.ClearScript.V8.Native.win-x64",
-    "version": "7.4.3",
-    "hash": "sha256-8lRSVozrki7h64MIgP6v0VWEV1fR1op+hjHd8S4nJ88="
-  },
-  {
-    "pname": "Microsoft.ClearScript.V8.Native.win-x64",
     "version": "7.4.5",
     "hash": "sha256-WF4K7g1w510viiXHJJjKQrsD/mvb99tF76yBCljN1Qw="
   },

--- a/pkgs/by-name/gr/grayjay/package.nix
+++ b/pkgs/by-name/gr/grayjay/package.nix
@@ -35,13 +35,13 @@
   _experimental-update-script-combinators,
 }:
 let
-  version = "7";
+  version = "8";
   src = fetchFromGitLab {
     domain = "gitlab.futo.org";
     owner = "videostreaming";
     repo = "Grayjay.Desktop";
     tag = version;
-    hash = "sha256-EaAMkYbQwj0IXDraRZHqvdK19SlyKtXfqkIOGzkiY7Q=";
+    hash = "sha256-inJteBsGrLp09vhhfZnMKmKOot2ElAzDp6TfOlXwsy8=";
     fetchSubmodules = true;
     fetchLFS = true;
   };

--- a/pkgs/by-name/gr/grayjay/package.nix
+++ b/pkgs/by-name/gr/grayjay/package.nix
@@ -35,13 +35,13 @@
   _experimental-update-script-combinators,
 }:
 let
-  version = "8";
+  version = "9";
   src = fetchFromGitLab {
     domain = "gitlab.futo.org";
     owner = "videostreaming";
     repo = "Grayjay.Desktop";
     tag = version;
-    hash = "sha256-inJteBsGrLp09vhhfZnMKmKOot2ElAzDp6TfOlXwsy8=";
+    hash = "sha256-O211trFJ9tQRVdlztp5ER0Ej6SIrCDn45mRGns7NV90=";
     fetchSubmodules = true;
     fetchLFS = true;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Changelog 7->8](https://github.com/futo-org/Grayjay.Desktop/releases/tag/8): 
>  - Playlist imports now support embedded ids (new exports from mobile)
>  - Additional messaging if the sync listener failed to start
>  - Overlay menus now flip vertically if out of bound
>  - Overlay menus now close when you scroll (in most views)
> 
> Fixes:
>  - Fix licenses not being accepted
>  - Some Sync activity not being propogated.
>  - Fix issue where DEV plugins cannot be enabled
>  - Fix issue where offline videos cannot be loaded without a client enabled
>  - Fix failed comments not showing a proper error
>  - Fix sync error on enabling on initial install
>  - Fix downloads ui overflow

[Changelog 8->9](https://github.com/futo-org/Grayjay.Desktop/releases/tag/9): 
>  - Desktop livechat now uses local UI instead of (failing) iframes.
>  - Desktop now implements additional video loading animation and game (for longer waits) 
>  - Plugins can now use websockets
>  - Plugins can now use Async (Only using timeouts right now)
>  - Plugins can now use sleep (not recommended)
>  - Plugins can now use live chat events
>  - Plugins can now use ReloadRequired exceptions in specific locations
> 
> Improvements
>  - Dash generation is now done async when possible
>  - Database now uses pooling (may fix db locked error)
> 
> Fixes
>  - Fix crash when deleting history while playing a video
>  - Fix issue where certain view/dialog ui would get stuck on some operating systems (eg. Import dialog).
>  - Various scroll container fixes
>  - Fix issue with Chromecast not proxying properly, may fix playback.
>  - Fix ChromeCast timestamp not updating properly.
>  - Dash manifests are now cached in case of (same) re-requests.

Closes #415800 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
