### PR TITLE
workflows/reviewers: actually ping maintainers when undrafting

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,10 @@ permissions:
   issues: write
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   backport:
     name: Backport Pull Request

--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -17,6 +17,10 @@ concurrency:
 permissions:
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check:
     name: cherry-pick-check

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -12,6 +12,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   nixos:
     name: fmt-check

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -15,6 +15,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   shell-check:
     strategy:

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -35,6 +35,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 env:
   OWNERS_FILE: ci/OWNERS
   # Don't do anything on draft PRs

--- a/.github/workflows/edited.yml
+++ b/.github/workflows/edited.yml
@@ -22,6 +22,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   base:
     name: Trigger jobs

--- a/.github/workflows/eval-aliases.yml
+++ b/.github/workflows/eval-aliases.yml
@@ -12,6 +12,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   eval-aliases:
     name: Eval nixpkgs with aliases enabled

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -22,6 +22,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -17,6 +17,10 @@ permissions:
   issues: write # needed to create *new* labels
   pull-requests: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   labels:
     name: label-pr

--- a/.github/workflows/lib-tests.yml
+++ b/.github/workflows/lib-tests.yml
@@ -15,6 +15,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   nixpkgs-lib-tests:
     name: nixpkgs-lib-tests

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -24,6 +24,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   nixos:
     name: nixos-manual-build

--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -16,6 +16,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   nixpkgs:
     name: nixpkgs-manual-build

--- a/.github/workflows/nix-parse-v2.yml
+++ b/.github/workflows/nix-parse-v2.yml
@@ -12,6 +12,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   tests:
     name: nix-files-parseable-check

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -17,9 +17,6 @@ concurrency:
 
 permissions: {}
 
-# We don't use a concurrency group here, because the action is triggered quite often (due to the PR edit trigger), and contributors would get notified on any canceled run.
-# There is a feature request for suppressing notifications on concurrency-canceled runs: https://github.com/orgs/community/discussions/13015
-
 defaults:
   run:
     shell: bash

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -20,6 +20,10 @@ permissions: {}
 # We don't use a concurrency group here, because the action is triggered quite often (due to the PR edit trigger), and contributors would get notified on any canceled run.
 # There is a feature request for suppressing notifications on concurrency-canceled runs: https://github.com/orgs/community/discussions/13015
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check:
     name: nixpkgs-vet

--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   fail:
     if: |

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -16,6 +16,10 @@ on:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   periodic-merge:
     if: github.repository_owner == 'NixOS'

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -16,6 +16,10 @@ on:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   periodic-merge:
     if: github.repository_owner == 'NixOS'

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -12,6 +12,10 @@ on:
         required: true
         type: string
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   merge:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -22,6 +22,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   request:
     name: Request

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -62,6 +62,7 @@ jobs:
       # In the more special case, when a PR is undrafted an eval run will have started already.
       - name: Wait for comparison to be done
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: eval
         with:
           script: |
             const run_id = (await github.rest.actions.listWorkflowRuns({
@@ -71,6 +72,8 @@ jobs:
               event: context.eventName,
               head_sha: context.payload.pull_request.head.sha
             })).data.workflow_runs[0].id
+
+            core.setOutput('run-id', run_id)
 
             // Waiting 120 * 5 sec = 10 min. max.
             // The extreme case is an Eval run that just started when the PR is undrafted.
@@ -90,6 +93,8 @@ jobs:
       - name: Download the comparison results
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
+          run-id: ${{ steps.eval.outputs.run-id }}
+          github-token: ${{ github.token }}
           pattern: comparison
           path: comparison
           merge-multiple: true


### PR DESCRIPTION
#411160 introduced a regression when undrafting a PR: Maintainers will not be pinged right now. That's because the job is failing silently (still marked as success) with:

```
jq: error: Could not open file comparison/maintainers.json: No such file or directory
```

There's two things wrong here:
- Because we don't set the runtime shell for the workflow explicitly, `-o pipefail` is not enabled ([docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell)).
- We don't download the comparison artifact properly from the other workflow run. We look up the run-id, wait for the artifact to appear... but then don't use the run-id to actually target that workflow.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
