### PR TITLE
libapparmor: 4.1.0 -> 4.1.1

### DIFF
--- a/pkgs/by-name/ap/apparmor-parser/package.nix
+++ b/pkgs/by-name/ap/apparmor-parser/package.nix
@@ -59,9 +59,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkTarget = "tests";
 
+  checkFlags = lib.optionals stdenv.hostPlatform.isMusl [
+    # equality tests are broken on musl due to different priority values
+    # https://gitlab.com/apparmor/apparmor/-/issues/513
+    "-o equality"
+  ];
+
   postCheck = "popd";
 
-  doCheck = stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isMusl;
+  doCheck = stdenv.hostPlatform == stdenv.buildPlatform;
   checkInputs = [
     bashInteractive
     perl

--- a/pkgs/by-name/li/libapparmor/package.nix
+++ b/pkgs/by-name/li/libapparmor/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch2,
   autoreconfHook,
   autoconf-archive,
   pkg-config,
@@ -33,26 +32,15 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libapparmor";
-  version = "4.1.0";
+  version = "4.1.1";
 
   src = fetchFromGitLab {
     owner = "apparmor";
     repo = "apparmor";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oj6mGw/gvoRGpJqw72Lk6LJuurg8efjiV1pvZYbXz6A=";
+    hash = "sha256-f9FgowlV4lZKKuddGCirqbajhIGyTUQc7IFHSvqY6eQ=";
   };
   sourceRoot = "${finalAttrs.src.name}/libraries/libapparmor";
-
-  patches = [
-    # avoid creating non-reproducible pycache in check phase
-    # https://gitlab.com/apparmor/apparmor/-/merge_requests/1697
-    # remove on next release
-    (fetchpatch2 {
-      url = "https://gitlab.com/apparmor/apparmor/-/commit/b50ee983522f0efb5920676db545ae25b2e8998d.patch";
-      hash = "sha256-AXl0osJHX4uUGppiOuHjpvlSRChqGyRCqv+8TYoLYMk=";
-      stripLen = 2;
-    })
-  ];
 
   postPatch = ''
     substituteInPlace swig/perl/Makefile.am \


### PR DESCRIPTION
Release Notes: https://gitlab.com/apparmor/apparmor/-/wikis/Release_Notes_4.1.1
Diff: https://gitlab.com/apparmor/apparmor/-/commits/v4.1.1

Contains partial fixes for musl, some improvements to test coverage, and a couple minor fixes to oversights in the 4.1.0 release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-linux-musl
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
