### PR TITLE
nixos/nix-daemon: go via the Nix daemon even as `root`

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -13,6 +13,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `NIX_REMOTE=daemon` is now set by default in any shell session, this means that all Nix invocations goes via the `nix-daemon` by default now. If you had a Nix invocation that was relying on `NIX_REMOTE` being unset and performing a direct store access, this usecase will be broken and to repair it, `NIX_REMOTE` needs to be unset before invoking `nix`. This now ensures that, even, as `root`, `nix` invocations goes through the Nix daemon.
+
 - The `offrss` package was removed due to lack of upstream maintenance since 2012. It's recommended for users to migrate to another RSS reader
 
 - `base16-builder` node package has been removed due to lack of upstream maintenance.

--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -270,7 +270,12 @@ in
     };
 
     # Set up the environment variables for running Nix.
-    environment.sessionVariables = cfg.envVars;
+    environment.sessionVariables =
+      # By default, including as the `root` user, Nix invocations should run via the daemon.
+      # If the user needs to override this, they can simply unset `NIX_REMOTE` if needed.
+      {
+        NIX_REMOTE = "daemon";
+      } // cfg.envVars;
 
     nix.nrBuildUsers = lib.mkDefault (
       if cfg.settings.auto-allocate-uids or false then


### PR DESCRIPTION
The NixOS module for the Nix daemon now defaults to using `NIX_REMOTE=daemon`
for all users by setting `environment.sessionVariables.NIX_REMOTE = "daemon";`.

This ensures that all user-initiated Nix operations go through the `nix-daemon`
even when run interactively as the root user.

Most users does not know about the single user mode anymore and it is *de*creasingly supported. With things like cgroups, running without mediation via the nix-daemon is increasingly harder and should be reserved to specialized tools that understands how to create the right environment to run the Nix tools that would perform direct store access.

Manual overrides are still possible by simply setting `nix.envVars.NIX_REMOTE = "";` or by unsetting it in your interactive environment.

Do note that doing `sudo nixos-rebuild` will exactly fall under this
scenario, i.e. the Nix invocations will perform direct store access
instead of using the Nix daemon. After this change, this will not be the
case anymore.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)): `nixosTests.misc`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
