### PR TITLE
gk-cli: 2.1.2 -> 3.0.9

### DIFF
--- a/pkgs/by-name/gk/gk-cli/package.nix
+++ b/pkgs/by-name/gk/gk-cli/package.nix
@@ -5,6 +5,7 @@
   coreutils,
   installShellFiles,
   makeWrapper,
+  gitMinimal,
   writeShellScript,
   curl,
   jq,
@@ -13,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gk-cli";
-  version = "2.1.2";
+  version = "3.0.9";
 
   src = (
     finalAttrs.passthru.sources.${stdenv.system}
@@ -28,18 +29,34 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -Dm555 gk -t $out/bin/
+    install -Dm555 gk*/gk -t $out/bin/
 
-    installShellCompletion --bash ./**/gk.bash
-    installShellCompletion --fish ./**/gk.fish
-    installShellCompletion --zsh ./**/_gk
+    wrapProgram $out/bin/gk \
+      --prefix PATH : "${lib.makeBinPath [ gitMinimal ]}"
 
     runHook postInstall
   '';
 
-  postFixup = ''
-    wrapProgram $out/bin/gk \
-      --prefix PATH : "${lib.makeBinPath [ coreutils ]}"
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    # Use timeout because gk hangs instead of closing in the sandbox
+    installShellCompletion --cmd gk \
+      --bash <(HOME="$(mktemp --directory)" timeout 3 $out/bin/gk completion bash) \
+      --fish <(HOME="$(mktemp --directory)" timeout 3 $out/bin/gk completion fish) \
+      --zsh <(HOME="$(mktemp --directory)" timeout 3 $out/bin/gk completion zsh)
+  '';
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  installCheckPhase = ''
+    OUTPUT="$(
+      HOME="$(mktemp --directory)" \
+      timeout 3 `# Use timeout because gk hangs instead of closing in the sandbox` \
+      $out/bin/gk setup \
+      2>/dev/null \
+      || true # Command fails because not logged in
+    )"
+
+    echo "$OUTPUT" | grep --quiet '^Git binary found: ✓$'
+    echo "$OUTPUT" | grep --quiet '^CLI version: ${finalAttrs.version}$'
   '';
 
   passthru = {
@@ -48,49 +65,44 @@ stdenv.mkDerivation (finalAttrs: {
         base_url = "https://github.com/gitkraken/gk-cli/releases/download/v${finalAttrs.version}/gk_${finalAttrs.version}_";
       in
       {
-        armv6l-linux = fetchzip {
-          url = "${base_url}Linux_arm6.zip";
-          hash = "sha256-pnEFTkx1JSmQlniVCXvIB6xGD8XyDh9OLDU0V9AZBTs=";
-          stripRoot = false;
-        };
-        armv7l-linux = fetchzip {
-          url = "${base_url}Linux_arm7.zip";
-          hash = "sha256-qj0++i698s4ELKHU9B2sGIqf9hUJip4+2Car+brkRkM=";
-          stripRoot = false;
-        };
         aarch64-linux = fetchzip {
-          url = "${base_url}Linux_arm64.zip";
-          hash = "sha256-vHGhlRHbk2/s3YmBdOPDbalEydpQVFkHiCkBVywa4N0=";
+          url = "${base_url}linux_arm64.zip";
+          hash = "sha256-aYgHLpG4nX3Op0+j733jYbK4ZwVKkctMkDPweNTJWso=";
           stripRoot = false;
         };
         x86_32-linux = fetchzip {
-          url = "${base_url}Linux_i386.zip";
-          hash = "sha256-t+P9SpS9u/17kga74kbYjD6nkjiFusyIwCRGDnkP3tU=";
+          url = "${base_url}linux_386.zip";
+          hash = "sha256-lVu25S7e6a/kHmiD5dxGAlHMQ5yN46+SdFpt8lghejM=";
           stripRoot = false;
         };
         x86_64-linux = fetchzip {
-          url = "${base_url}Linux_x86_64.zip";
-          hash = "sha256-O6T27edHi20ZFHiNaZKdk/5dtCn2Tpxm0PR934SRwFk=";
+          url = "${base_url}linux_amd64.zip";
+          hash = "sha256-/z2G//Zh8lTHkeJPahyld1EEXXhd/cgIvCojUmzFX8E=";
           stripRoot = false;
         };
         aarch64-darwin = fetchzip {
-          url = "${base_url}macOS_arm64.zip";
-          hash = "sha256-LW2K+aveJiyYqfga2jpF3DvvFeHJuozqbc/afgtq2Oc=";
+          url = "${base_url}darwin_arm64.zip";
+          hash = "sha256-nDVehD0TTNTvhuDU8RB4lZiVcEJpB+l6EGkzckC7JuU=";
           stripRoot = false;
         };
         x86_64-darwin = fetchzip {
-          url = "${base_url}macOS_x86_64.zip";
-          hash = "sha256-1w8B4YWouVViTGoUh987pPQIoqdzB0S+M2bBiRI6Kfg=";
+          url = "${base_url}darwin_amd64.zip";
+          hash = "sha256-Lhuqb5592T6VcTMVmAdIDfGMXaS4dSu0wbQeHheXXk4=";
+          stripRoot = false;
+        };
+        aarch64-windows = fetchzip {
+          url = "${base_url}windows_arm64.zip";
+          hash = "sha256-sXHeqR4AW/sRPp74PieXI1n4VGV94CnrcMF1ovAek8E=";
           stripRoot = false;
         };
         i686-windows = fetchzip {
-          url = "${base_url}Windows_i386.zip";
-          hash = "sha256-t81/wK1weZ/uEZ5TzivylARTUqks9rLIG7WzeoWXb1k=";
+          url = "${base_url}windows_386.zip";
+          hash = "sha256-u6DyHoYIaExS2CHu20odDVJxzI4k9PpdFQf6UDPAzz0=";
           stripRoot = false;
         };
         x86_64-windows = fetchzip {
-          url = "${base_url}Windows_x86_64.zip";
-          hash = "sha256-9yydDMI9Gz/OswRhJHF+2c3Ia0zDmXMbf7byj6PJe24=";
+          url = "${base_url}windows_amd64.zip";
+          hash = "sha256-nh+JPR95IWLm7CTrS8qK2dP3c4SH/zm1oIS5GNgxcyo=";
           stripRoot = false;
         };
       };


### PR DESCRIPTION
Diff: https://github.com/gitkraken/gk-cli/compare/v2.1.2...v3.0.9

Now:

* the archive contains a subfolder
* the archive doesn't contains the completions files
* build for Linux ARMv6 and ARMv7 are not published
* build for Windows ARM64 is published


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
