### PR TITLE
{mkcal,lib2geom}: use ctestCheckHook, openmvs: remove redundant check phase

### DIFF
--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -68,11 +68,6 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = true;
-  checkPhase = ''
-    runHook preCheck
-    ctest
-    runHook postCheck
-  '';
 
   meta = {
     description = "Open Multi-View Stereo reconstruction library";

--- a/pkgs/by-name/li/lib2geom/package.nix
+++ b/pkgs/by-name/li/lib2geom/package.nix
@@ -10,6 +10,7 @@
   cairo,
   double-conversion,
   gtest,
+  ctestCheckHook,
   lib,
   inkscape,
   pkgsCross,
@@ -47,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     gtest
+    ctestCheckHook
   ];
 
   cmakeFlags = [
@@ -56,41 +58,32 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  dontUseNinjaCheck = true;
+  disabledTests =
+    lib.optionals stdenv.hostPlatform.isMusl [
+      # Fails due to rounding differences
+      # https://gitlab.com/inkscape/lib2geom/-/issues/70
+      "circle-test"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.system != "x86_64-linux") [
+      # Broken on all platforms, test just accidentally passes on some.
+      # https://gitlab.com/inkscape/lib2geom/-/issues/63
+      "elliptical-arc-test"
 
-  # TODO: Update cmake hook to make it simpler to selectively disable cmake tests: #113829
-  checkPhase =
-    let
-      disabledTests =
-        lib.optionals stdenv.hostPlatform.isMusl [
-          # Fails due to rounding differences
-          # https://gitlab.com/inkscape/lib2geom/-/issues/70
-          "circle-test"
-        ]
-        ++ lib.optionals (stdenv.hostPlatform.system != "x86_64-linux") [
-          # Broken on all platforms, test just accidentally passes on some.
-          # https://gitlab.com/inkscape/lib2geom/-/issues/63
-          "elliptical-arc-test"
+      # https://gitlab.com/inkscape/lib2geom/-/issues/69
+      "polynomial-test"
 
-          # https://gitlab.com/inkscape/lib2geom/-/issues/69
-          "polynomial-test"
+      # https://gitlab.com/inkscape/lib2geom/-/issues/75
+      "line-test"
 
-          # https://gitlab.com/inkscape/lib2geom/-/issues/75
-          "line-test"
+      # Failure observed on i686
+      "angle-test"
+      "self-intersections-test"
 
-          # Failure observed on i686
-          "angle-test"
-          "self-intersections-test"
-
-          # Failure observed on aarch64-darwin
-          "bezier-test"
-          "ellipse-test"
-        ];
-    in
-    ''
-      runHook preCheck
-      ctest --output-on-failure -E '^${lib.concatStringsSep "|" disabledTests}$'
-      runHook postCheck
-    '';
+      # Failure observed on aarch64-darwin
+      "bezier-test"
+      "ellipse-test"
+    ];
 
   passthru = {
     tests = {

--- a/pkgs/by-name/mk/mkcal/package.nix
+++ b/pkgs/by-name/mk/mkcal/package.nix
@@ -12,6 +12,7 @@
   perl,
   pkg-config,
   tzdata,
+  ctestCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -62,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     tzdata
+    ctestCheckHook
   ];
 
   cmakeFlags = [
@@ -69,25 +71,17 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "INSTALL_TESTS" false)
     (lib.cmakeBool "BUILD_DOCUMENTATION" true)
-    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (
-      lib.concatStringsSep ";" [
-        # Exclude tests
-        "-E"
-        (lib.strings.escapeShellArg "(${
-          lib.concatStringsSep "|" [
-            # Test expects to be passed a real, already existing database to test migrations. We don't have one
-            "tst_perf"
-
-            # 10/97 tests fail. Half seem related to time (zone) issues w/ local time / Helsinki timezone
-            # Other half are x-1/x on lists of alarms/events
-            "tst_storage"
-          ]
-        })")
-      ]
-    ))
   ];
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  disabledTests = [
+    # Test expects to be passed a real, already existing database to test migrations. We don't have one
+    "tst_perf"
+
+    # 10/97 tests fail. Half seem related to time (zone) issues w/ local time / Helsinki timezone
+    # Other half are x-1/x on lists of alarms/events
+    "tst_storage"
+  ];
 
   # Parallelism breaks tests
   enableParallelChecking = false;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow-up to #406011. Things done:

- Use ctestCheckHook for `mkcal` and `lib2geom` to simplify test skipping logic. `lib2geom` had this as a TODO.
- Drop redundant `checkPhase` for `openmvs` as the default stdenv builds `test` target anyway, which calls ctest under the hood.
- Built on x86_64-linux and x86_64-darwin and checked that the number of tests that are run did not change. This matters because `disabledTests` does not support regexes, whereas `-E` matches the test name against a regex. AFAICT here the refactoring is equivalent.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
