### PR TITLE
doc: fix build in CI

### DIFF
--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -57,10 +57,8 @@ stdenvNoCC.mkDerivation (
       substituteInPlace ./languages-frameworks/python.section.md \
         --subst-var-by python-interpreter-table "$(<"${pythonInterpreterTable}")"
 
-      cat \
-        ./functions/library.md.in \
-        ${lib-docs}/index.md \
-        > ./functions/library.md
+      cat ./functions/library.md.in ${lib-docs}/index.md > ./functions/library.md
+
       substitute ./manual.md.in ./manual.md \
         --replace-fail '@MANUAL_VERSION@' '${lib.version}'
 

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -1,7 +1,39 @@
 { lib, pkgs }:
 let
+  inherit (lib)
+    concatStringsSep
+    escape
+    flatten
+    id
+    isAttrs
+    isFloat
+    isInt
+    isList
+    isString
+    mapAttrs
+    mapAttrsToList
+    mkOption
+    optionalAttrs
+    optionalString
+    pipe
+    types
+    singleton
+    warn
+    ;
+
+  inherit (lib.generators)
+    mkValueStringDefault
+    toGitINI
+    toINI
+    toINIWithGlobalSection
+    toKeyValue
+    toLua
+    mkLuaInline
+    ;
+
   inherit (lib.types)
     attrsOf
+    atom
     bool
     coercedTo
     either
@@ -15,6 +47,7 @@ let
     oneOf
     path
     str
+    submodule
     ;
 
   # Attributes added accidentally in https://github.com/NixOS/nixpkgs/pull/335232 (2024-08-18)
@@ -40,7 +73,7 @@ let
           ;
       };
 in
-lib.optionalAttrs pkgs.config.allowAliases aliases
+optionalAttrs allowAliases aliases
 // rec {
 
   /*
@@ -188,7 +221,7 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
           }:
           let
             singleIniAtomOr =
-              if atomsCoercedToLists then coercedTo singleIniAtom lib.singleton else either singleIniAtom;
+              if atomsCoercedToLists then coercedTo singleIniAtom singleton else either singleIniAtom;
           in
           if listsAsDuplicateKeys then
             singleIniAtomOr (listOf singleIniAtom)
@@ -212,9 +245,9 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
         maybeToList =
           listToValue:
           if listToValue != null then
-            lib.mapAttrs (key: val: if lib.isList val then listToValue val else val)
+            mapAttrs (key: val: if isList val then listToValue val else val)
           else
-            lib.id;
+            id;
       in
       {
         ini =
@@ -239,14 +272,14 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
           in
           {
 
-            type = lib.types.attrsOf (iniSection atom);
+            type = attrsOf (iniSection atom);
             lib.types.atom = atom;
 
             generate =
               name: value:
-              lib.pipe value [
-                (lib.mapAttrs (_: maybeToList listToValue))
-                (lib.generators.toINI (
+              pipe value [
+                (mapAttrs (_: maybeToList listToValue))
+                (toINI (
                   removeAttrs args [
                     "listToValue"
                     "atomsCoercedToLists"
@@ -277,14 +310,14 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
             };
           in
           {
-            type = lib.types.submodule {
+            type = submodule {
               options = {
-                sections = lib.mkOption rec {
-                  type = lib.types.attrsOf (iniSection atom);
+                sections = mkOption rec {
+                  type = attrsOf (iniSection atom);
                   default = { };
                   description = type.description;
                 };
-                globalSection = lib.mkOption rec {
+                globalSection = mkOption rec {
                   type = iniSection atom;
                   default = { };
                   description = "global " + type.description;
@@ -300,14 +333,14 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
                 ...
               }:
               pkgs.writeText name (
-                lib.generators.toINIWithGlobalSection
+                toINIWithGlobalSection
                   (removeAttrs args [
                     "listToValue"
                     "atomsCoercedToLists"
                   ])
                   {
                     globalSection = maybeToList listToValue globalSection;
-                    sections = lib.mapAttrs (_: maybeToList listToValue) sections;
+                    sections = mapAttrs (_: maybeToList listToValue) sections;
                   }
               );
           };
@@ -327,7 +360,7 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
           {
             type = attrsOf (attrsOf (either atom (attrsOf atom)));
             lib.types.atom = atom;
-            generate = name: value: pkgs.writeText name (lib.generators.toGitINI value);
+            generate = name: value: pkgs.writeText name (toGitINI value);
           };
 
       }
@@ -343,7 +376,7 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
   # optional config options.
   systemd =
     let
-      mkValueString = lib.generators.mkValueStringDefault { };
+      mkValueString = mkValueStringDefault { };
       mkKeyValue = k: v: if v == null then "# ${k} is unset" else "${k} = ${mkValueString v}";
     in
     ini {
@@ -379,12 +412,12 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
 
           atom =
             if listsAsDuplicateKeys then
-              coercedTo singleAtom lib.singleton (listOf singleAtom)
+              coercedTo singleAtom singleton (listOf singleAtom)
               // {
                 description = singleAtom.description + " or a list of them for duplicate keys";
               }
             else if listToValue != null then
-              coercedTo singleAtom lib.singleton (nonEmptyListOf singleAtom)
+              coercedTo singleAtom singleton (nonEmptyListOf singleAtom)
               // {
                 description = singleAtom.description + " or a non-empty list of them";
               }
@@ -399,13 +432,11 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
         let
           transformedValue =
             if listToValue != null then
-              lib.mapAttrs (key: val: if lib.isList val then listToValue val else val) value
+              mapAttrs (key: val: if isList val then listToValue val else val) value
             else
               value;
         in
-        pkgs.writeText name (
-          lib.generators.toKeyValue (removeAttrs args [ "listToValue" ]) transformedValue
-        );
+        pkgs.writeText name (toKeyValue (removeAttrs args [ "listToValue" ]) transformedValue);
 
     };
 
@@ -543,18 +574,18 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
           "true"
         else if value == false then
           "false"
-        else if lib.isInt value || lib.isFloat value then
+        else if isInt value || isFloat value then
           toString value
-        else if lib.isString value then
+        else if isString value then
           string value
-        else if lib.isAttrs value then
+        else if isAttrs value then
           attrs value
-        else if lib.isList value then
+        else if isList value then
           list value
         else
           abort "formats.elixirConf: should never happen (value = ${value})";
 
-      escapeElixir = lib.escape [
+      escapeElixir = escape [
         "\\"
         "#"
         "\""
@@ -568,11 +599,11 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
         else
           let
             toKeyword = name: value: "${name}: ${toElixir value}";
-            keywordList = lib.concatStringsSep ", " (lib.mapAttrsToList toKeyword set);
+            keywordList = concatStringsSep ", " (mapAttrsToList toKeyword set);
           in
           "[" + keywordList + "]";
 
-      listContent = values: lib.concatStringsSep ", " (map toElixir values);
+      listContent = values: concatStringsSep ", " (map toElixir values);
 
       list = values: "[" + (listContent values) + "]";
 
@@ -593,7 +624,7 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
         set:
         let
           toEntry = name: value: "${toElixir name} => ${toElixir value}";
-          entries = lib.concatStringsSep ", " (lib.mapAttrsToList toEntry set);
+          entries = concatStringsSep ", " (mapAttrsToList toEntry set);
         in
         "%{${entries}}";
 
@@ -605,13 +636,13 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
           keyConfig =
             rootKey: key: value:
             "config ${rootKey}, ${key}, ${toElixir value}";
-          keyConfigs = rootKey: values: lib.mapAttrsToList (keyConfig rootKey) values;
-          rootConfigs = lib.flatten (lib.mapAttrsToList keyConfigs values);
+          keyConfigs = rootKey: values: mapAttrsToList (keyConfig rootKey) values;
+          rootConfigs = flatten (mapAttrsToList keyConfigs values);
         in
         ''
           import Config
 
-          ${lib.concatStringsSep "\n" rootConfigs}
+          ${concatStringsSep "\n" rootConfigs}
         '';
     in
     {
@@ -715,7 +746,7 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
               # Wrap standard types, since anything in the Elixir configuration
               # can be raw Elixir
             }
-            // lib.mapAttrs (_name: type: elixirOr type) lib.types;
+            // mapAttrs (_name: type: elixirOr type) types;
         };
 
       generate =
@@ -771,12 +802,12 @@ lib.optionalAttrs pkgs.config.allowAliases aliases
               inherit columnWidth;
               inherit indentWidth;
               indentType = if indentUsingTabs then "Tabs" else "Spaces";
-              value = lib.generators.toLua { inherit asBindings multiline; } value;
+              value = toLua { inherit asBindings multiline; } value;
               passAsFile = [ "value" ];
               preferLocalBuild = true;
             }
             ''
-              ${lib.optionalString (!asBindings) ''
+              ${optionalString (!asBindings) ''
                 echo -n 'return ' >> $out
               ''}
               cat $valuePath >> $out

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -52,26 +52,26 @@ let
 
   # Attributes added accidentally in https://github.com/NixOS/nixpkgs/pull/335232 (2024-08-18)
   # Deprecated in https://github.com/NixOS/nixpkgs/pull/415666 (2025-06)
-  aliases =
-    lib.mapAttrs (name: lib.warn "`formats.${name}` is deprecated; use `lib.types.${name}` instead.")
-      {
-        inherit
-          attrsOf
-          bool
-          coercedTo
-          either
-          float
-          int
-          listOf
-          luaInline
-          mkOptionType
-          nonEmptyListOf
-          nullOr
-          oneOf
-          path
-          str
-          ;
-      };
+  allowAliases = pkgs.config.allowAliases or false;
+  aliasWarning = name: warn "`formats.${name}` is deprecated; use `lib.types.${name}` instead.";
+  aliases = mapAttrs aliasWarning {
+    inherit
+      attrsOf
+      bool
+      coercedTo
+      either
+      float
+      int
+      listOf
+      luaInline
+      mkOptionType
+      nonEmptyListOf
+      nullOr
+      oneOf
+      path
+      str
+      ;
+  };
 in
 optionalAttrs allowAliases aliases
 // rec {


### PR DESCRIPTION
We saw some strange CI failures in https://github.com/NixOS/nixpkgs/pull/415662.

The tests continue to pass (without changing eval):

- [x] `nix-build -A tests.pkgs-lib`
- [x] `nix-build -A tests.pkgs-lib.formats`

https://github.com/NixOS/nixpkgs/pull/415719/commits/a822df313f4d687d897767f5612f860398dfd41e: fixes the build
https://github.com/NixOS/nixpkgs/pull/415719/commits/b3b4fccfea9e08d6d28ccda68c4f9c98cc42dec3: triggers a rebuild to show that works
https://github.com/NixOS/nixpkgs/pull/415719/commits/f13654fe8a4cb1dccf47064cf0742dd277d3892e: experimental extraction of `lib.` names into the let binding.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
