### PR TITLE
python3Packages.pycrdt-websocket: 0.15.5 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/jupyter-server-ydoc/default.nix
+++ b/pkgs/development/python-modules/jupyter-server-ydoc/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchFromGitHub,
   buildPythonPackage,
   fetchPypi,
   hatchling,
@@ -13,6 +14,18 @@
   jupyter-collaboration,
 }:
 
+let
+  # pycrdt-websocket got breaking changes in 0.16.0 which break this package.
+  pycrdt-websocket' = pycrdt-websocket.overridePythonAttrs (rec {
+    version = "0.15.5";
+    src = fetchFromGitHub {
+      owner = "y-crdt";
+      repo = "pycrdt-websocket";
+      tag = "v${version}";
+      hash = "sha256-piNd85X5YsTAOC9frYQRDyb/DPfzZicIPJ+bEVzgOsU=";
+    };
+  });
+in
 buildPythonPackage rec {
   pname = "jupyter-server-ydoc";
   version = "2.1.0";
@@ -33,7 +46,7 @@ buildPythonPackage rec {
     jupyter-server-fileid
     jupyter-ydoc
     pycrdt
-    pycrdt-websocket
+    pycrdt-websocket'
   ];
 
   pythonImportsCheck = [ "jupyter_server_ydoc" ];

--- a/pkgs/development/python-modules/pycrdt-store/default.nix
+++ b/pkgs/development/python-modules/pycrdt-store/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  anyio,
+  pycrdt,
+  sqlite-anyio,
+
+  # tests
+  pytestCheckHook,
+
+  # postInstall
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "pycrdt-store";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "y-crdt";
+    repo = "pycrdt-store";
+    tag = version;
+    hash = "sha256-BaU6UKgS9hyqPKt0tTZW46XJtZi+a2ACg5bi0VDiT40=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    anyio
+    pycrdt
+    sqlite-anyio
+  ];
+
+  # pycrdt-store installs to $out/${python.sitePackages}/pycrdt/store, but `pycrdt`' files are not present.
+  # Hence, neither pythonImportsCheck nor pytestCheckPhase work in this derivation.
+  doCheck = false;
+
+  meta = {
+    description = "Persistent storage for pycrdt";
+    homepage = "https://github.com/y-crdt/pycrdt-store";
+    changelog = "https://github.com/y-crdt/pycrdt-store/blob/${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/pycrdt-websocket/default.nix
+++ b/pkgs/development/python-modules/pycrdt-websocket/default.nix
@@ -9,19 +9,10 @@
   # dependencies
   anyio,
   pycrdt,
-  sqlite-anyio,
+  pycrdt-store,
 
   # optional-dependencies
   channels,
-
-  # tests
-  httpx-ws,
-  hypercorn,
-  pytest-asyncio,
-  pytestCheckHook,
-  trio,
-  uvicorn,
-  websockets,
 }:
 
 buildPythonPackage rec {
@@ -30,7 +21,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "jupyter-server";
+    owner = "y-crdt";
     repo = "pycrdt-websocket";
     tag = version;
     hash = "sha256-Qux8IxJR1nGbdpGz7RZBKJjYN0qfwfEpd2UDlduOna0=";
@@ -41,43 +32,21 @@ buildPythonPackage rec {
   dependencies = [
     anyio
     pycrdt
-    sqlite-anyio
+    pycrdt-store
   ];
 
   optional-dependencies = {
     django = [ channels ];
   };
 
-  pythonImportsCheck = [ "pycrdt_websocket" ];
-
-  nativeCheckInputs = [
-    httpx-ws
-    hypercorn
-    pytest-asyncio
-    pytestCheckHook
-    trio
-    uvicorn
-    websockets
-  ];
-
-  disabledTests = [
-    # Looking for a certfile
-    # FileNotFoundError: [Errno 2] No such file or directory
-    "test_asgi"
-    "test_yroom_restart"
-  ];
-
-  disabledTestPaths = [
-    # requires nodejs and installed js modules
-    "tests/test_pycrdt_yjs.py"
-  ];
-
-  __darwinAllowLocalNetworking = true;
+  # pycrdt-websocket installs to $out/${python.sitePackages}/pycrdt/websocket, but `pycrdt`' files are not present.
+  # Hence, neither pythonImportsCheck nor pytestCheckPhase work in this derivation.
+  doCheck = false;
 
   meta = {
     description = "WebSocket Connector for pycrdt";
-    homepage = "https://github.com/jupyter-server/pycrdt-websocket";
-    changelog = "https://github.com/jupyter-server/pycrdt-websocket/blob/${src.tag}/CHANGELOG.md";
+    homepage = "https://github.com/y-crdt/pycrdt-websocket";
+    changelog = "https://github.com/y-crdt/pycrdt-websocket/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     teams = [ lib.teams.jupyter ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12788,6 +12788,8 @@ self: super: with self; {
 
   pycrdt = callPackage ../development/python-modules/pycrdt { };
 
+  pycrdt-store = callPackage ../development/python-modules/pycrdt-store { };
+
   pycrdt-websocket = callPackage ../development/python-modules/pycrdt-websocket { };
 
   pycritty = callPackage ../development/python-modules/pycritty { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/jupyter-server/pycrdt-websocket/compare/refs/tags/v0.15.5...refs/tags/0.16.0
Changelog: https://github.com/jupyter-server/pycrdt-websocket/blob/0.16.0/CHANGELOG.md
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Fixes #447939

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
