### PR TITLE
lm_sensors: 3.6.0 -> 3.6.2

### DIFF
--- a/pkgs/by-name/lm/lm_sensors/package.nix
+++ b/pkgs/by-name/lm/lm_sensors/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   bash,
   bison,
   flex,
@@ -13,7 +12,7 @@
 }:
 
 let
-  version = "3.6.0";
+  version = "3.6.2";
   tag = "V" + lib.replaceStrings [ "." ] [ "-" ] version;
 
 in
@@ -22,20 +21,11 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchFromGitHub {
-    owner = "lm-sensors";
+    owner = "hramrach"; # openSUSE fork used by openSUSE and Gentoo
     repo = "lm-sensors";
     inherit tag;
-    hash = "sha256-9lfHCcODlS7sZMjQhK0yQcCBEoGyZOChx/oM0CU37sY=";
+    hash = "sha256-EmS9H3TQac6bHs2G8t1C2cQNAjN13zPoKDysny6aTFw=";
   };
-
-  patches = [
-    # Fix compile failure on GCC 14 with `sensord` enabled.
-    # From: https://github.com/lm-sensors/lm-sensors/pull/483
-    (fetchpatch {
-      url = "https://github.com/lm-sensors/lm-sensors/pull/483/commits/7a6170f07d05cc6601b4668f211e9389f2e75286.patch";
-      hash = "sha256-Q49quv3eXeMvY3jgZFs/F7Rljbq4YyehIDIlsgmloBQ=";
-    })
-  ];
 
   outputs = [
     "bin"
@@ -51,13 +41,6 @@ stdenv.mkDerivation {
     ''
       substituteInPlace lib/init.c \
         --replace-fail 'ETCDIR "/sensors.d"' '"/etc/sensors.d"'
-    ''
-    # Upstream build system have knob to enable and disable building of static
-    # library, shared library is built unconditionally.
-    + lib.optionalString stdenv.hostPlatform.isStatic ''
-      sed -i 'lib/Module.mk' -e '/LIBTARGETS :=/,+1d; /-m 755/ d'
-      substituteInPlace prog/sensors/Module.mk \
-        --replace-fail 'lib/$(LIBSHBASENAME)' ""
     '';
 
   nativeBuildInputs = [
@@ -80,6 +63,8 @@ stdenv.mkDerivation {
     "MANDIR=${placeholder "man"}/share/man"
     # This is a dependency of the library.
     "ETCDIR=${placeholder "out"}/etc"
+    "BUILD_SHARED_LIB=${if stdenv.hostPlatform.isStatic then "0" else "1"}"
+    "BUILD_STATIC_LIB=${if stdenv.hostPlatform.isStatic then "1" else "0"}"
 
     "CC=${stdenv.cc.targetPrefix}cc"
     "AR=${stdenv.cc.targetPrefix}ar"
@@ -87,21 +72,15 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  # Making regexp to patch-out installing of .so symlinks from Makefile is
-  # complicated, it is easier to remove them post-install.
-  postInstall =
-    ''
-      mkdir -p $doc/share/doc/lm_sensors
-      cp -r configs doc/* $doc/share/doc/lm_sensors
-    ''
-    + lib.optionalString stdenv.hostPlatform.isStatic ''
-      rm $out/lib/*.so*
-    '';
+  postInstall = ''
+    mkdir -p $doc/share/doc/lm_sensors
+    cp -r configs doc/* $doc/share/doc/lm_sensors
+  '';
 
   meta = {
     homepage = "https://hwmon.wiki.kernel.org/lm_sensors";
-    changelog = "https://raw.githubusercontent.com/lm-sensors/lm-sensors/${tag}/CHANGES";
-    description = "Tools for reading hardware sensors";
+    changelog = "https://raw.githubusercontent.com/hramrach/lm-sensors/${tag}/CHANGES";
+    description = "Tools for reading hardware sensors - maintained fork";
     license = with lib.licenses; [
       lgpl21Plus
       gpl2Plus


### PR DESCRIPTION
Current upstream is effectly dead (no activity since 2020), but openSUSE is actively maintaining a fork that gentoo also uses.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
