### PR TITLE
zipline: properly built sharp dependency against system libvips

### DIFF
--- a/nixos/tests/zipline.nix
+++ b/nixos/tests/zipline.nix
@@ -1,10 +1,13 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 {
   name = "zipline";
   meta.maintainers = with lib.maintainers; [ defelo ];
 
   nodes.machine = {
+    # On x86, testing with a CPU without SSE 4.2 support
+    # to ensure native libvips is used
+    virtualisation.qemu.options = lib.mkIf pkgs.stdenv.hostPlatform.isx86 [ "-cpu core2duo" ];
     services.zipline = {
       enable = true;
       settings = {
@@ -38,7 +41,7 @@
     import re
 
     machine.wait_for_unit("zipline.service")
-    machine.wait_for_open_port(8000)
+    machine.wait_for_open_port(8000, timeout=300)
 
     resp = machine.succeed("curl zipline.local:8000/api/setup -v -X POST -H 'Content-Type: application/json' -d '{\"username\": \"administrator\", \"password\": \"password\"}' 2>&1")
     data = json.loads(resp.splitlines()[-1])

--- a/pkgs/by-name/zi/zipline/package.nix
+++ b/pkgs/by-name/zi/zipline/package.nix
@@ -12,6 +12,9 @@
   versionCheckHook,
   nix-update-script,
   nixosTests,
+  node-gyp,
+  pkg-config,
+  python3,
 }:
 
 let
@@ -43,18 +46,30 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-O8RLaKff4Dj/JDeUOyf7GtcFcOu/aOuclyaZmVqVi5s=";
   };
 
-  buildInputs = [ vips ];
+  buildInputs = [
+    openssl
+    vips
+  ];
 
   nativeBuildInputs = [
     pnpm_10.configHook
     nodejs_24
     makeWrapper
+    # for sharp build:
+    node-gyp
+    pkg-config
+    python3
   ];
 
   env = environment;
 
   buildPhase = ''
     runHook preBuild
+
+    # Force build of sharp against native libvips (requires running install scripts).
+    # This is necessary for supporting old CPUs (ie. without SSE 4.2 instruction set).
+    pnpm config set nodedir ${nodejs_24}
+    pnpm install --force --offline --frozen-lockfile
 
     pnpm build
 
@@ -86,14 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkBin ziplinectl ctl
 
     runHook postInstall
-  '';
-
-  preFixup = ''
-    find $out -name libvips-cpp.so.42 -print0 | while read -d $'\0' libvips; do
-      echo replacing libvips at $libvips
-      rm $libvips
-      ln -s ${lib.getLib vips}/lib/libvips-cpp.so.42 $libvips
-    done
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
 instead of search/replace libvips-cpp.so which does not work anymore
 for old CPUs since sharp 0.34.0 due to
 https://github.com/lovell/sharp/commit/3fd818c4b59b055ce60ebc8938297ad69cc2e1e8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
