### PR TITLE
btcpayserver: 2.1.1 -> 2.1.4

### DIFF
--- a/pkgs/by-name/bt/btcpayserver/deps.json
+++ b/pkgs/by-name/bt/btcpayserver/deps.json
@@ -51,8 +51,8 @@
   },
   {
     "pname": "BTCPayServer.Lightning.All",
-    "version": "1.6.9",
-    "hash": "sha256-pCCxZ1CW+Xc2KvG5yZ79vLYtcwr/PWsrz9A1x02ryb0="
+    "version": "1.6.10",
+    "hash": "sha256-v2D43E9aEFKN/oMP4W98BST+WBMRDLDBD6AKJZey7PA="
   },
   {
     "pname": "BTCPayServer.Lightning.Charge",
@@ -93,6 +93,11 @@
     "pname": "BTCPayServer.Lightning.LNDhub",
     "version": "1.5.3",
     "hash": "sha256-CbSjeix4JCVtgb8WCfsKgThpl/YbnhbJ3wcPoexpSew="
+  },
+  {
+    "pname": "BTCPayServer.Lightning.Phoenixd",
+    "version": "1.5.7",
+    "hash": "sha256-kDl8tDEzrwNwyFRp77NSFw0WkHwudeS5pefJNSvq/IM="
   },
   {
     "pname": "BTCPayServer.NETCore.Plugins",
@@ -701,28 +706,23 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "7.0.45",
-    "hash": "sha256-hWgtvAJvONk6jg1WiytE6M+ExkQJUCwO6cyVA6JE+8w="
-  },
-  {
-    "pname": "NBitcoin",
     "version": "7.0.50",
     "hash": "sha256-l3H70u5OAbd2hevX/yeVBdQyee/dUn5mp4iGvTnTcjk="
   },
   {
     "pname": "NBitcoin",
-    "version": "8.0.8",
-    "hash": "sha256-gpbxlfE7TN7mUOcWF9+r8htQTc19KqAuzsVaG5RYa3A="
-  },
-  {
-    "pname": "NBitcoin.Altcoins",
-    "version": "3.0.31",
-    "hash": "sha256-Mtaqj8Fl8jxeOBXz66fjZQKZ/yg6pARJKJTFW0V/wDA="
+    "version": "8.0.13",
+    "hash": "sha256-x7vMEgk5JXfGGNWfoclCwAbnx1mtlgbxl0HC0B/iV2E="
   },
   {
     "pname": "NBitcoin.Altcoins",
     "version": "3.0.33",
     "hash": "sha256-0RYmRKcluGwfTEcOEmoREC/9CgECEi7piQZetMXHOxI="
+  },
+  {
+    "pname": "NBitcoin.Altcoins",
+    "version": "4.0.8",
+    "hash": "sha256-n1e0BUhXl3D/fn1DbCdbelYfys2fc7+ZABazhUWxzo4="
   },
   {
     "pname": "NBitpayClient",

--- a/pkgs/by-name/bt/btcpayserver/package.nix
+++ b/pkgs/by-name/bt/btcpayserver/package.nix
@@ -8,13 +8,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "2.1.1";
+  version = "2.1.4";
 
   src = fetchFromGitHub {
     owner = "btcpayserver";
     repo = "btcpayserver";
     tag = "v${version}";
-    hash = "sha256-5zvxLEQbKTcslcpq1JRgY/L0XWnQ4UyFWww6SGcTtcs=";
+    hash = "sha256-GY6s/em5jlok1IFe474bD1L34Zlr6gYtG+Wn6eZxMIc=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";

--- a/pkgs/by-name/nb/nbxplorer/deps.json
+++ b/pkgs/by-name/nb/nbxplorer/deps.json
@@ -166,13 +166,13 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "8.0.12",
-    "hash": "sha256-OBJu6fQd0MBKSVHERI7EBtSQQvAL9T8Gr0e7Kx2q9/I="
+    "version": "8.0.18",
+    "hash": "sha256-5SKx6SluWXNHNz5FxxFPCkyJ3SSDACAVx3G1q9h38VU="
   },
   {
     "pname": "NBitcoin.Altcoins",
-    "version": "4.0.7",
-    "hash": "sha256-WN9uLRlIW+WGUSS4NE7ZE8kftQEaVDh7AnT1+P8g2gg="
+    "version": "4.0.8",
+    "hash": "sha256-n1e0BUhXl3D/fn1DbCdbelYfys2fc7+ZABazhUWxzo4="
   },
   {
     "pname": "NETStandard.Library",

--- a/pkgs/by-name/nb/nbxplorer/package.nix
+++ b/pkgs/by-name/nb/nbxplorer/package.nix
@@ -7,13 +7,13 @@
 
 buildDotnetModule rec {
   pname = "nbxplorer";
-  version = "2.5.26";
+  version = "2.5.27";
 
   src = fetchFromGitHub {
     owner = "dgarage";
     repo = "NBXplorer";
     tag = "v${version}";
-    hash = "sha256-gXLzUgFZxrDNbDjpPmVDIj2xi6I+IfkNwXBYvelRYPU=";
+    hash = "sha256-WCrxAomVU1hPRtI91ppmDKdLZEmNZYH9C0o069/dIMk=";
   };
 
   projectFile = "NBXplorer/NBXplorer.csproj";


### PR DESCRIPTION
- [x] The [nix-bitcoin VM test](https://gist.github.com/erikarvstedt/0450cddeaebaaf0bd7e975b72c9aab1d) succeeds on `x86_64-linux`.

Notes for reviewers:
You can verify GPG signatures with `refetch=1 pkgs/by-name/bt/btcpayserver/update.sh`.

cc @prusnak