### PR TITLE
liblcf: 0.8 -> 0.8.1; easyrpg-player: 0.8 -> 0.8.1.1; libretro.easyrpg: 0.8-unstable-2023-04-29 -> 0.8.1.1

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/easyrpg.nix
+++ b/pkgs/applications/emulators/libretro/cores/easyrpg.nix
@@ -1,64 +1,73 @@
 {
   lib,
   fetchFromGitHub,
+  mkLibretroCore,
+  nix-update-script,
+  asciidoctor,
   cmake,
-  fetchpatch,
+  doxygen,
+  pkg-config,
+  flac,
+  fluidsynth,
   fmt,
   freetype,
+  glib,
   harfbuzz,
+  lhasa,
   liblcf,
   libpng,
   libsndfile,
+  libsysprof-capture,
   libvorbis,
   libxmp,
-  mkLibretroCore,
   mpg123,
+  nlohmann_json,
   opusfile,
-  pcre,
+  pcre2,
   pixman,
-  pkg-config,
   speexdsp,
+  wildmidi,
 }:
-mkLibretroCore {
+mkLibretroCore rec {
   core = "easyrpg";
-  version = "0.8-unstable-2023-04-29";
+  # liblcf needs to be updated before this.
+  version = "0.8.1.1";
 
   src = fetchFromGitHub {
     owner = "EasyRPG";
     repo = "Player";
-    rev = "f8e41f43b619413f95847536412b56f85307d378";
-    hash = "sha256-nvWM4czTv/GxY9raomBEn7dmKBeLtSA9nvjMJxc3Q8s=";
+    rev = version;
+    hash = "sha256-2a8IdYP6Suc8a+Np5G+xoNzuPxkk9gAgR+sjdKUf89M=";
     fetchSubmodules = true;
   };
 
   extraNativeBuildInputs = [
+    asciidoctor
     cmake
+    doxygen
     pkg-config
   ];
   extraBuildInputs = [
+    flac # needed by libsndfile
+    fluidsynth
     fmt
     freetype
+    glib
     harfbuzz
+    lhasa
     liblcf
     libpng
     libsndfile
+    libsysprof-capture # needed by glib
     libvorbis
     libxmp
     mpg123
+    nlohmann_json
     opusfile
-    pcre
+    pcre2 # needed by glib
     pixman
     speexdsp
-  ];
-  patches = [
-    # The following patch is shared with easyrpg-player.
-    # Update when new versions of liblcf and easyrpg-player are released.
-    # See easyrpg-player expression for details.
-    (fetchpatch {
-      name = "0001-Fix-building-with-fmtlib-10.patch";
-      url = "https://github.com/EasyRPG/Player/commit/ab6286f6d01bada649ea52d1f0881dde7db7e0cf.patch";
-      hash = "sha256-GdSdVFEG1OJCdf2ZIzTP+hSrz+ddhTMBvOPjvYQHy54=";
-    })
+    wildmidi
   ];
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
@@ -67,12 +76,13 @@ mkLibretroCore {
   ];
   makefile = "Makefile";
 
-  # Do not update automatically since we want to pin a specific version
-  passthru.updateScript = null;
+  # Since liblcf needs to be updated before this, we should not
+  # use the default unstableGitUpdater.
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "EasyRPG Player libretro port";
     homepage = "https://github.com/EasyRPG/Player";
-    license = lib.licenses.gpl3Only;
+    license = lib.licenses.gpl3Plus;
   };
 }

--- a/pkgs/by-name/li/liblcf/package.nix
+++ b/pkgs/by-name/li/liblcf/package.nix
@@ -2,24 +2,28 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nix-update-script,
   autoreconfHook,
   pkg-config,
   expat,
   icu74,
+  inih,
 }:
 
 stdenv.mkDerivation rec {
   pname = "liblcf";
-  version = "0.8";
+  # When updating this package, you should probably also update
+  # easyrpg-player and libretro.easyrpg
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "EasyRPG";
     repo = "liblcf";
     rev = version;
-    hash = "sha256-jJGIsNw7wplTL5FBWGL8osb9255o9ZaWgl77R+RLDMM=";
+    hash = "sha256-jIk55+n8wSk3Z3FPR18SE7U3OuWwmp2zJgvSZQBB2l0=";
   };
 
-  dtrictDeps = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     autoreconfHook
@@ -29,12 +33,15 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     expat
     icu74
+    inih
   ];
 
   enableParallelBuilding = true;
   enableParallelChecking = true;
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Library to handle RPG Maker 2000/2003 and EasyRPG projects";


### PR DESCRIPTION
Diff: https://github.com/EasyRPG/liblcf/compare/0.8...0.8.1
Short release notes: https://github.com/EasyRPG/liblcf/releases/tag/0.8.1
Full release notes: https://blog.easyrpg.org/2025/04/easyrpg-player-0-8-1-stun/

I also added passthru.updateScript.

Resolves: #384603
Tracking: #388196 #356812

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
