### PR TITLE
libretro.mkLibretroCore: switch to lib.extendMkDerivation

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/mupen64plus.nix
+++ b/pkgs/applications/emulators/libretro/cores/mupen64plus.nix
@@ -41,11 +41,13 @@ mkLibretroCore {
     })
   ];
 
+  extraNativeBuildInputs = [
+    nasm
+  ];
   extraBuildInputs = [
     libGLU
     libGL
     libpng
-    nasm
     xorg.libX11
   ];
   makefile = "Makefile";

--- a/pkgs/applications/emulators/libretro/cores/same_cdi.nix
+++ b/pkgs/applications/emulators/libretro/cores/same_cdi.nix
@@ -2,7 +2,7 @@
   lib,
   alsa-lib,
   fetchFromGitHub,
-  gcc12Stdenv,
+  fetchpatch2,
   libGL,
   libGLU,
   mkLibretroCore,
@@ -21,6 +21,15 @@ mkLibretroCore {
     hash = "sha256-EGE3NuO0gpZ8MKPypH8rFwJiv4QsdKuIyLKVuKTcvws=";
   };
 
+  patches = [
+    (fetchpatch2 {
+      # https://github.com/libretro/same_cdi/pull/19
+      name = "Fixes_compilation_errors_as_per_issue_9.patch";
+      url = "https://github.com/libretro/same_cdi/commit/bf3212315546cdd514118a4f3ea764fd9c401091.patch?full_index=1";
+      hash = "sha256-1vrMxnRtEWUt+6I/4PSfCPDIUAGKkXFd2UVr9473ngo=";
+    })
+  ];
+
   extraNativeBuildInputs = [ python3 ];
   extraBuildInputs = [
     alsa-lib
@@ -29,9 +38,6 @@ mkLibretroCore {
     portaudio
     xorg.libX11
   ];
-  # FIXME = build fail with GCC13:
-  # error = 'uint8_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
-  stdenv = gcc12Stdenv;
 
   meta = {
     description = "SAME_CDI is a libretro core to play CD-i games";

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -4,7 +4,7 @@
 }:
 
 lib.makeScope newScope (self: {
-  mkLibretroCore = self.callPackage ./mkLibretroCore.nix;
+  mkLibretroCore = self.callPackage ./mkLibretroCore.nix { };
 
   atari800 = self.callPackage ./cores/atari800.nix { };
 

--- a/pkgs/applications/emulators/libretro/mkLibretroCore.nix
+++ b/pkgs/applications/emulators/libretro/mkLibretroCore.nix
@@ -6,96 +6,93 @@
   retroarch-bare,
   unstableGitUpdater,
   zlib,
-  # Params
-  core,
-  makefile ? "Makefile.libretro",
-  extraBuildInputs ? [ ],
-  extraNativeBuildInputs ? [ ],
-  ## Location of resulting RetroArch core on $out
-  libretroCore ? "/lib/retroarch/cores",
-  ## The core filename is derived from the core name
-  ## Setting `normalizeCore` to `true` will convert `-` to `_` on the core filename
-  normalizeCore ? true,
-  ...
-}@args:
+}:
 
-let
-  d2u = if normalizeCore then (lib.replaceStrings [ "-" ] [ "_" ]) else (x: x);
-  coreDir = placeholder "out" + libretroCore;
-  coreFilename = "${d2u core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary}";
-  mainProgram = "retroarch-${core}";
-  extraArgs = builtins.removeAttrs args [
-    "lib"
-    "stdenv"
-    "makeWrapper"
-    "retroarch-bare"
-    "unstableGitUpdater"
-    "zlib"
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
 
+  excludeDrvArgNames = [
     "core"
     "extraBuildInputs"
     "extraNativeBuildInputs"
     "libretroCore"
-    "makefile"
     "normalizeCore"
-    "passthru"
-    "meta"
   ];
-in
-stdenv.mkDerivation (
-  {
-    pname = "libretro-${core}";
 
-    buildInputs = [ zlib ] ++ extraBuildInputs;
-    nativeBuildInputs = [ makeWrapper ] ++ extraNativeBuildInputs;
+  extendDrvArgs =
+    finalAttrs:
+    {
+      core,
+      enableParallelBuilding ? true,
+      extraBuildInputs ? [ ],
+      extraNativeBuildInputs ? [ ],
+      makeFlags ? [ ],
+      makefile ? "Makefile.libretro",
+      meta ? { },
+      passthru ? { },
+      strictDeps ? true,
+      ## Location of resulting RetroArch core on $out
+      libretroCore ? "/lib/retroarch/cores",
+      ## The core filename is derived from the core name
+      ## Setting `normalizeCore` to `true` will convert `-` to `_` on the core filename
+      normalizeCore ? true,
+      ...
+    }:
+    let
+      d2u = if normalizeCore then (lib.replaceStrings [ "-" ] [ "_" ]) else (x: x);
+      coreDir = placeholder "out" + libretroCore;
+      coreFilename = "${d2u core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary}";
+      mainProgram = "retroarch-${core}";
+    in
+    {
+      pname = "libretro-${core}";
 
-    inherit makefile;
+      buildInputs = [ zlib ] ++ extraBuildInputs;
+      nativeBuildInputs = [ makeWrapper ] ++ extraNativeBuildInputs;
 
-    makeFlags = [
-      "platform=${
-        {
-          linux = "unix";
-          darwin = "osx";
-          windows = "win";
-        }
-        .${stdenv.hostPlatform.parsed.kernel.name} or stdenv.hostPlatform.parsed.kernel.name
-      }"
-      "ARCH=${
-        {
-          armv7l = "arm";
-          armv6l = "arm";
-          aarch64 = "arm64";
-          i686 = "x86";
-        }
-        .${stdenv.hostPlatform.parsed.cpu.name} or stdenv.hostPlatform.parsed.cpu.name
-      }"
-    ] ++ (args.makeFlags or [ ]);
+      inherit enableParallelBuilding makefile strictDeps;
 
-    installPhase = ''
-      runHook preInstall
+      makeFlags = [
+        "platform=${
+          {
+            linux = "unix";
+            darwin = "osx";
+            windows = "win";
+          }
+          .${stdenv.hostPlatform.parsed.kernel.name} or stdenv.hostPlatform.parsed.kernel.name
+        }"
+        "ARCH=${
+          {
+            armv7l = "arm";
+            armv6l = "arm";
+            aarch64 = "arm64";
+            i686 = "x86";
+          }
+          .${stdenv.hostPlatform.parsed.cpu.name} or stdenv.hostPlatform.parsed.cpu.name
+        }"
+      ] ++ makeFlags;
 
-      install -Dt ${coreDir} ${coreFilename}
-      makeWrapper ${retroarch-bare}/bin/retroarch $out/bin/${mainProgram} \
-        --add-flags "-L ${coreDir}/${coreFilename}"
+      installPhase = ''
+        runHook preInstall
 
-      runHook postInstall
-    '';
+        install -Dt ${coreDir} ${coreFilename}
+        makeWrapper ${retroarch-bare}/bin/retroarch $out/bin/${mainProgram} \
+          --add-flags "-L ${coreDir}/${coreFilename}"
 
-    enableParallelBuilding = true;
+        runHook postInstall
+      '';
 
-    passthru = {
-      inherit core libretroCore;
-      # libretro repos sometimes has a fake tag like "Current", ignore
-      # it by setting hardcodeZeroVersion
-      updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
-    } // (args.passthru or { });
+      passthru = {
+        inherit core libretroCore;
+        # libretro repos sometimes has a fake tag like "Current", ignore
+        # it by setting hardcodeZeroVersion
+        updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+      } // passthru;
 
-    meta = {
-      inherit mainProgram;
-      inherit (retroarch-bare.meta) platforms;
-      homepage = "https://www.libretro.com/";
-      teams = [ lib.teams.libretro ];
-    } // (args.meta or { });
-  }
-  // extraArgs
-)
+      meta = {
+        inherit mainProgram;
+        inherit (retroarch-bare.meta) platforms;
+        teams = [ lib.teams.libretro ];
+      } // meta;
+    };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Switch `mkLibretroCore` to use https://github.com/NixOS/nixpkgs/pull/234651.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
