### PR TITLE
libglycin: init at 1.2.1, glycin-loaders: refactor

### DIFF
--- a/pkgs/by-name/fr/fractal/package.nix
+++ b/pkgs/by-name/fr/fractal/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   # We should eventually use a cargo vendor patch hook instead
   preConfigure = ''
     pushd ../$(stripHash $cargoDeps)/glycin-2.*
-      patch -p3 < ${glycin-loaders.passthru.glycinPathsPatch}
+      patch -p2 < ${glycin-loaders.passthru.glycinPathsPatch}
     popd
   '';
 

--- a/pkgs/by-name/gl/glycin-loaders/fix-glycin-paths.patch
+++ b/pkgs/by-name/gl/glycin-loaders/fix-glycin-paths.patch
@@ -1,7 +1,7 @@
-diff --git a/vendor/glycin/src/sandbox.rs b/vendor/glycin/src/sandbox.rs
+diff --git a/glycin/src/sandbox.rs b/glycin/src/sandbox.rs
 index 08db832..4f44b21 100644
---- a/vendor/glycin/src/sandbox.rs
-+++ b/vendor/glycin/src/sandbox.rs
+--- a/glycin/src/sandbox.rs
++++ b/glycin/src/sandbox.rs
 @@ -202,7 +202,7 @@ impl Sandbox {
  
                  args.push(self.exec());

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -1,7 +1,8 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  rustPlatform,
+  fetchFromGitLab,
   replaceVars,
   bubblewrap,
   cairo,
@@ -26,9 +27,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "glycin-loaders";
   version = "1.2.1";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
-    hash = "sha256-zMV46aPoPQ3BU1c30f2gm6qVxxZ/Xl7LFfeGZUCU7tU=";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "glycin";
+    rev = "1.2.1";
+    hash = "sha256-M4DcWLE40OPB7zIkv4uLj6xTac3LTDcZ2uAO2S/cUz4=";
   };
 
   patches = [
@@ -39,6 +43,15 @@ stdenv.mkDerivation (finalAttrs: {
     finalAttrs.passthru.glycinPathsPatch
   ];
 
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    hash = "sha256-iNSpLvIi3oZKSRlkwkDJp5i8MdixRvmWIOCzbFHIdHw=";
+  };
+
   nativeBuildInputs = [
     cargo
     gettext # for msgfmt
@@ -47,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     rustc
+    rustPlatform.cargoSetupHook
   ];
 
   buildInputs = [

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -93,14 +93,14 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Glycin loaders for several formats";
     homepage = "https://gitlab.gnome.org/GNOME/glycin";
-    teams = [ teams.gnome ];
-    license = with licenses; [
+    teams = [ lib.teams.gnome ];
+    license = with lib.licenses; [
       mpl20 # or
       lgpl21Plus
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/li/libglycin/package.nix
+++ b/pkgs/by-name/li/libglycin/package.nix
@@ -1,0 +1,1 @@
+{ glycin-loaders }: glycin-loaders.override { libGlycinOnly = true; }

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Dirty approach to add patches after cargoSetupPostUnpackHook
     # We should eventually use a cargo vendor patch hook instead
     pushd ../$(stripHash $cargoDeps)/glycin-2.*
-      patch -p3 < ${glycin-loaders.passthru.glycinPathsPatch}
+      patch -p2 < ${glycin-loaders.passthru.glycinPathsPatch}
     popd
   '';
 

--- a/pkgs/by-name/sn/snapshot/package.nix
+++ b/pkgs/by-name/sn/snapshot/package.nix
@@ -31,10 +31,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OTF2hZogt9I138MDAxuiDGhkQRBpiNyRHdkbe21m4f0=";
   };
 
-  patches = [
+  preConfigure = ''
     # Fix paths in glycin library
-    glycin-loaders.passthru.glycinPathsPatch
-  ];
+    patch -d vendor -p1 ${glycin-loaders.passthru.glycinPathsPatch}
+  '';
 
   nativeBuildInputs = [
     cargo


### PR DESCRIPTION
This PR splits the `glycin-loaders` package into two:
- `libglycin`, (`-Dlibglycin=true`, `-Dglycin-loaders=false`)
- `glycin-loaders`, (`-Dlibglycin=false`, `-Dglycin-loaders=true`)

Don't know if I modified the patch accordingly.

The problem was that meson didn't like it that I modified in `vendor/glycin`, in the release tarball by GNOME. So I modified `glycin` in the source tree and used `fetchCargoVendor` to fetch the dependencies instead. Hopefully that's okay, as by doing this I've dropped the usage of `mirror://`.

Needed to package Bazaar (as per https://github.com/NixOS/nixpkgs/issues/415342) later down the line. I've put up a draft PR for that package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
