### PR TITLE
bazaar: init at 0.5.10

### DIFF
--- a/pkgs/by-name/ba/bazaar/package.nix
+++ b/pkgs/by-name/ba/bazaar/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  blueprint-compiler,
+  desktop-file-utils,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook4,
+  appstream,
+  bubblewrap,
+  flatpak,
+  glib-networking,
+  glycin-loaders,
+  gtk4,
+  json-glib,
+  libadwaita,
+  libdex,
+  libglycin,
+  libsoup_3,
+  libxmlb,
+  libyaml,
+  md4c,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bazaar";
+  version = "0.5.10";
+
+  src = fetchFromGitHub {
+    owner = "kolunmi";
+    repo = "bazaar";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-isswXfOJZ04MQbaQ6AcNSxasNllGSRS6vukskS0FvCk=";
+  };
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    appstream
+    flatpak
+    glib-networking
+    gtk4
+    json-glib
+    libadwaita
+    libdex
+    libglycin
+    libsoup_3
+    libxmlb
+    libyaml
+    md4c
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "$out/bin:${lib.makeBinPath [ bubblewrap ]}"
+      --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"
+    )
+  '';
+
+  passthru = {
+    inherit (libglycin) glycinPathsPatch;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "FlatHub-first app store for GNOME";
+    homepage = "https://github.com/kolunmi/bazaar";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      dtomvan
+      normalcea
+    ];
+    mainProgram = "bazaar";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/415342.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
