### PR TITLE
python3Packages.geojson-pydantic: init at 2.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5962,6 +5962,14 @@
     name = "Dee Engan";
     keys = [ { fingerprint = "9C24 79F5 F0CE 48F4 00EE  4A5B B8ED 46EB 468B F72D"; } ];
   };
+  deej-io = {
+    email = "me@deej.io";
+    github = "deej-io";
+    githubId = 7419862;
+    name = "Daniel Rollins";
+    matrix = "@deej-io:matrix.org";
+    keys = [ { fingerprint = "A0BE BED3 A3A0 7127 1411 6234 6830 B0AE 30DD 38DB"; } ];
+  };
   deejayem = {
     email = "nixpkgs.bu5hq@simplelogin.com";
     github = "deejayem";

--- a/pkgs/development/python-modules/geojson-pydantic/default.nix
+++ b/pkgs/development/python-modules/geojson-pydantic/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  pytestCheckHook,
+  pydantic,
+  shapely,
+}:
+
+buildPythonPackage rec {
+  pname = "geojson-pydantic";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "developmentseed";
+    repo = "geojson-pydantic";
+    tag = version;
+    hash = "sha256-SOo4Hs1WMUerMLMgjzUVuDkUXCuiStJ4P9iMSpUF8Uw=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [ pydantic ];
+
+  pythonImportsCheck = [ "geojson_pydantic" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    shapely
+  ];
+
+  meta = {
+    changelog = "https://github.com/developmentseed/geojson-pydantic/blob/${src.tag}/CHANGELOG.md";
+    description = "Suite of Pydantic models matching the GeoJSON specification RFC 7946";
+    homepage = "https://github.com/developmentseed/geojson-pydantic";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ deej-io ];
+  };
+}

--- a/pkgs/development/python-modules/geojson-pydantic/default.nix
+++ b/pkgs/development/python-modules/geojson-pydantic/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+  pydantic,
+  shapely,
+}:
+
+buildPythonPackage rec {
+  pname = "geojson-pydantic";
+  version = "2.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "developmentseed";
+    repo = "geojson-pydantic";
+    tag = version;
+    hash = "sha256-XIhlZhHcBSIPGd+fFCA3CDnEoqoYvbEVmb+VFG22m5Q=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ pydantic ];
+
+  pythonImportsCheck = [ "geojson_pydantic" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [ shapely ];
+
+  meta = {
+    changelog = "https://github.com/developmentseed/geojson-pydantic/blob/${src.tag}/CHANGELOG.md";
+    description = "Suite of Pydantic models matching the GeoJSON specification RFC 7946";
+    homepage = "https://github.com/developmentseed/geojson-pydantic";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ deej-io ];
+    teams = [ lib.teams.geospatial ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5592,6 +5592,8 @@ self: super: with self; {
 
   geojson-client = callPackage ../development/python-modules/geojson-client { };
 
+  geojson-pydantic = callPackage ../development/python-modules/geojson-pydantic { };
+
   geomet = callPackage ../development/python-modules/geomet { };
 
   geometric = callPackage ../development/python-modules/geometric { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6695,6 +6695,8 @@ self: super: with self; {
 
   geojson-client = callPackage ../development/python-modules/geojson-client { };
 
+  geojson-pydantic = callPackage ../development/python-modules/geojson-pydantic { };
+
   geomet = callPackage ../development/python-modules/geomet { };
 
   geometric = callPackage ../development/python-modules/geometric { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds myself as a maintainer and packages the geojson-pydantic python library.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
