### PR TITLE
skawarePackages.buildManPages: remove passthru.updateScript

### DIFF
--- a/pkgs/development/skaware-packages/build-skaware-man-pages.nix
+++ b/pkgs/development/skaware-packages/build-skaware-man-pages.nix
@@ -22,6 +22,8 @@
   owner ? "~flexibeast",
   # : string
   rev ? "v${version}",
+  # : boolean
+  withUpdateScript ? true,
 }:
 
 let
@@ -33,25 +35,28 @@ let
   };
 in
 
-stdenv.mkDerivation {
-  inherit pname version src;
+stdenv.mkDerivation (
+  {
+    inherit pname version src;
 
-  makeFlags = [
-    "MAN_DIR=${manDir}"
-  ];
-
-  dontBuild = true;
-
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--override-filename"
-      "pkgs/development/skaware-packages/${lib.removeSuffix "-man-pages" pname}/default.nix"
+    makeFlags = [
+      "MAN_DIR=${manDir}"
     ];
-  };
 
-  meta = with lib; {
-    inherit description license maintainers;
-    inherit (src.meta) homepage;
-    platforms = platforms.all;
-  };
-}
+    dontBuild = true;
+
+    meta = with lib; {
+      inherit description license maintainers;
+      inherit (src.meta) homepage;
+      platforms = platforms.all;
+    };
+  }
+  // lib.optionalAttrs withUpdateScript {
+    passthru.updateScript = nix-update-script {
+      extraArgs = [
+        "--override-filename"
+        "pkgs/development/skaware-packages/${lib.removeSuffix "-man-pages" pname}/default.nix"
+      ];
+    };
+  }
+)

--- a/pkgs/development/skaware-packages/build-skaware-man-pages.nix
+++ b/pkgs/development/skaware-packages/build-skaware-man-pages.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromSourcehut,
-  nix-update-script,
 }:
 
 {
@@ -22,8 +21,6 @@
   owner ? "~flexibeast",
   # : string
   rev ? "v${version}",
-  # : boolean
-  withUpdateScript ? true,
 }:
 
 let
@@ -35,28 +32,18 @@ let
   };
 in
 
-stdenv.mkDerivation (
-  {
-    inherit pname version src;
+stdenv.mkDerivation {
+  inherit pname version src;
 
-    makeFlags = [
-      "MAN_DIR=${manDir}"
-    ];
+  makeFlags = [
+    "MAN_DIR=${manDir}"
+  ];
 
-    dontBuild = true;
+  dontBuild = true;
 
-    meta = with lib; {
-      inherit description license maintainers;
-      inherit (src.meta) homepage;
-      platforms = platforms.all;
-    };
-  }
-  // lib.optionalAttrs withUpdateScript {
-    passthru.updateScript = nix-update-script {
-      extraArgs = [
-        "--override-filename"
-        "pkgs/development/skaware-packages/${lib.removeSuffix "-man-pages" pname}/default.nix"
-      ];
-    };
-  }
-)
+  meta = with lib; {
+    inherit description license maintainers;
+    inherit (src.meta) homepage;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -19,6 +19,7 @@ skawarePackages.buildPackage {
     sha256 = "sha256-Ywke3FG/xhhUd934auDB+iFRDCvy8IJs6IkirP6O/As=";
     description = "mdoc(7) versions of the documentation for the s6-rc service manager";
     maintainers = [ lib.maintainers.qyliss ];
+    withUpdateScript = false;
   };
 
   description = "Service manager for s6-based systems";

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -19,7 +19,6 @@ skawarePackages.buildPackage {
     sha256 = "sha256-Ywke3FG/xhhUd934auDB+iFRDCvy8IJs6IkirP6O/As=";
     description = "mdoc(7) versions of the documentation for the s6-rc service manager";
     maintainers = [ lib.maintainers.qyliss ];
-    withUpdateScript = false;
   };
 
   description = "Service manager for s6-based systems";


### PR DESCRIPTION
Currently nix-update has a bug where it can downgrade versions when fetching from sourcehut[^1].

Simply disabling the updateScript on this package for now.

[^1]: https://github.com/Mic92/nix-update/issues/271


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
