### PR TITLE
Revert "[Backport staging-25.05] libtpms: 0.10.0 -> 0.10.1"

### DIFF
--- a/pkgs/by-name/li/libtpms/package.nix
+++ b/pkgs/by-name/li/libtpms/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libtpms";
-  version = "0.10.1";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "stefanberger";
     repo = "libtpms";
     rev = "v${version}";
-    sha256 = "sha256-uj06cAhepTOFxSeiBY/UVP/rtBQHLvrODe4ljU6ALOE=";
+    sha256 = "sha256-YKs/XYJ8UItOtSinl28/G9XFVzobFd4ZDKtClQDLXFk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#415755

As noted in https://github.com/NixOS/nixpkgs/pull/415663#issuecomment-2963500954 the upgrade had unexpected breaking changes.