### PR TITLE
s3ql: 5.2.3 -> 5.3.0

### DIFF
--- a/pkgs/by-name/s3/s3ql/0001-setup.py-remove-self-reference.patch
+++ b/pkgs/by-name/s3/s3ql/0001-setup.py-remove-self-reference.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Philip Taron <philip.taron@gmail.com>
+Date: Wed, 11 Jun 2025 10:41:42 -0700
+Subject: [PATCH] setup.py: remove self-reference and DEVELOPER_MODE
+
+Signed-off-by: Philip Taron <philip.taron@gmail.com>
+---
+ setup.py | 33 ++-------------------------------
+ 1 file changed, 2 insertions(+), 31 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 00f6e9b120525d63fbc17949b2804785f1286118..b5582bcc366148d9c0a442abade65a6127ef2d3c 100755
+--- a/setup.py
++++ b/setup.py
+@@ -26,15 +26,7 @@ from setuptools.command.test import test as TestCommand
+ 
+ faulthandler.enable()
+ 
+-basedir = os.path.abspath(os.path.dirname(sys.argv[0]))
+-DEVELOPER_MODE = os.path.exists(os.path.join(basedir, 'MANIFEST.in'))
+-if DEVELOPER_MODE:
+-    print('MANIFEST.in exists, running in developer mode')
+-
+-# Add S3QL sources
+-sys.path.insert(0, os.path.join(basedir, 'src'))
+-sys.path.insert(0, os.path.join(basedir, 'util'))
+-import s3ql
++basedir = "/build/source"
+ 
+ 
+ class pytest(TestCommand):
+@@ -52,27 +44,6 @@ def main():
+ 
+     compile_args = ['-Wall', '-Wextra', '-Wconversion', '-Wsign-compare']
+ 
+-    # Enable all fatal warnings only when compiling from Mercurial tip.
+-    # (otherwise we break forward compatibility because compilation with newer
+-    # compiler may fail if additional warnings are added)
+-    if DEVELOPER_MODE:
+-        if os.environ.get('CI') != 'true':
+-            compile_args.append('-Werror')
+-
+-        # Value-changing conversions should always be explicit.
+-        compile_args.append('-Werror=conversion')
+-
+-        # Note that (i > -1) is false if i is unsigned (-1 will be converted to
+-        # a large positive value). We certainly don't want to do this by
+-        # accident.
+-        compile_args.append('-Werror=sign-compare')
+-
+-        # These warnings have always been harmless, and have always been due to
+-        # issues in Cython code rather than S3QL. Cython itself warns if there
+-        # are unused variables in .pyx code.
+-        compile_args.append('-Wno-unused-parameter')
+-        compile_args.append('-Wno-unused-function')
+-
+     required_pkgs = [
+         'apsw >= 3.42.0',  # https://github.com/rogerbinns/apsw/issues/459
+         'cryptography',
+@@ -88,7 +59,7 @@ def main():
+     setuptools.setup(
+         name='s3ql',
+         zip_safe=False,
+-        version=s3ql.VERSION,
++        version="@version@",
+         description='a full-featured file system for online data storage',
+         long_description=long_desc,
+         author='Nikolaus Rath',


### PR DESCRIPTION
Changelog: https://github.com/s3ql/s3ql/releases/tag/s3ql-5.3.0

We patch out all the discovery logic in the build script now.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.