### PR TITLE
speedify: init at 15.6.4-12495

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -54,6 +54,8 @@
 
 - [qBittorrent](https://www.qbittorrent.org/), is a bittorrent client programmed in C++ / Qt that uses libtorrent by Arvid Norberg. Available as [services.qbittorrent](#opt-services.qbittorrent.enable).
 
+- [Speedify](https://speedify.com/), a proprietary VPN which allows combining multiple internet connections (Wi-Fi, 4G, 5G, Ethernet, Starlink, Satellite, and more) to improve the stability, speed, and security of online experiences. Available as [services.speedify](#opt-services.speedify.enable).
+
 - [Szurubooru](https://github.com/rr-/szurubooru), an image board engine inspired by services such as Danbooru, dedicated for small and medium communities. Available as [services.szurubooru](#opt-services.szurubooru.enable).
 
 - The [Neat IP Address Planner](https://spritelink.github.io/NIPAP/) (NIPAP) can now be enabled through [services.nipap.enable](#opt-services.nipap.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1335,6 +1335,7 @@
   ./services/networking/soju.nix
   ./services/networking/solanum.nix
   ./services/networking/spacecookie.nix
+  ./services/networking/speedify.nix
   ./services/networking/spiped.nix
   ./services/networking/squid.nix
   ./services/networking/ssh/sshd.nix

--- a/nixos/modules/services/networking/speedify.nix
+++ b/nixos/modules/services/networking/speedify.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.speedify;
+in
+{
+  options.services.speedify = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        This option enables Speedify daemon.
+        This sets {option}`networking.firewall.checkReversePath` to "loose", which might be undesirable for security.
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "speedify" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelModules = [ "tun" ];
+
+    networking.firewall.checkReversePath = "loose";
+
+    systemd.services.speedify = {
+      description = "Speedify Service";
+      wantedBy = [ "multi-user.target" ];
+      wants = [
+        "network.target"
+        "network-online.target"
+      ];
+      after = [
+        "network-online.target"
+      ]
+      ++ lib.optional config.networking.networkmanager.enable "NetworkManager.service";
+      path = [
+        pkgs.procps
+        pkgs.nettools
+      ];
+      serviceConfig = {
+        ExecStart = "${cfg.package}/share/speedify/SpeedifyStartup.sh";
+        ExecStop = "${cfg.package}/share/speedify/SpeedifyShutdown.sh";
+        Restart = "on-failure";
+        RestartSec = 5;
+        TimeoutStartSec = 30;
+        TimeoutStopSec = 30;
+        Type = "forking";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    zahrun
+  ];
+}

--- a/pkgs/by-name/sp/speedify/package.nix
+++ b/pkgs/by-name/sp/speedify/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  dpkg,
+  fetchurl,
+  procps,
+  net-tools,
+  autoPatchelfHook,
+}:
+stdenv.mkDerivation rec {
+  pname = "speedify";
+  version = "15.6.4-12495";
+
+  src = fetchurl {
+    url = "https://apt.connectify.me/pool/main/s/speedify/speedify_${version}_amd64.deb";
+    hash = "sha256-b8J7JqVxuRREC16DeKD7hOBX4IZMbJPLArLmPtnDUB4=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    procps
+    net-tools
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    substituteInPlace "usr/share/speedify/SpeedifyStartup.sh" "usr/share/speedify/SpeedifyShutdown.sh" "usr/share/speedify/GenerateLogs.sh" \
+      --replace-fail '/usr/share/' "$out/share/"
+    substituteInPlace "usr/share/speedify/SpeedifyStartup.sh" \
+      --replace-fail 'logs' "/var/log/speedify"
+
+    mkdir -p $out/share/
+    mv usr/share $out/
+    mkdir -p $out/etc/
+    mv lib/systemd $out/etc/
+
+    mkdir -p $out/bin
+    ln -s $out/share/speedify/speedify_cli $out/bin/speedify_cli
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://speedify.com/";
+    description = "Use multiple internet connections in parallel";
+    longDescription = ''
+      Combine multiple internet connections (Wi-Fi, 4G, 5G, Ethernet, Starlink, Satellite, and more)
+      to improve the stability, speed, and security of your online experiences.
+      Check corresponding option {option}`services.speedify.enable`
+    '';
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ zahrun ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Speedify is a proprietary VPN which allows combining multiple internet connections (Wi-Fi, 4G, 5G, Ethernet, Starlink, Satellite, and more) to improve the stability, speed, and security of online experiences
Closes https://github.com/NixOS/nixpkgs/issues/229933.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
