### PR TITLE
[Backport release-25.05]: cromite: 135.0.7049.100 -> 137.0.7151.72 

### DIFF
--- a/pkgs/by-name/cr/cromite/package.nix
+++ b/pkgs/by-name/cr/cromite/package.nix
@@ -169,12 +169,12 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "cromite";
-  version = "137.0.7151.44";
-  commit = "1abdac0aff0916b1e4a4bd52f1896eec00834262";
+  version = "137.0.7151.56";
+  commit = "b4f8d96284c854cbe6448d2e30ee5a30ce3f0b82";
 
   src = fetchurl {
     url = "https://github.com/uazo/cromite/releases/download/v${finalAttrs.version}-${finalAttrs.commit}/chrome-lin64.tar.gz";
-    hash = "sha256-33GS4uD3RJHy9M0S5TRB6kRb1SZR+ABLyOR1oeVLQto=";
+    hash = "sha256-f53Xh6xvk5Z8tkg/SUZS+plO3a7Qvn6ff2Soj7Dvvqw=";
   };
 
   # With strictDeps on, some shebangs were not being patched correctly

--- a/pkgs/by-name/cr/cromite/package.nix
+++ b/pkgs/by-name/cr/cromite/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  makeBinaryWrapper,
+  makeWrapper,
   patchelf,
   copyDesktopItems,
   makeDesktopItem,
@@ -166,15 +166,15 @@ let
       qt6.qtbase
       qt6.qtwayland
     ];
-  commit = "0ffdb845a6a3308cbd9826bb78269d1d05cfb8aa";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "cromite";
-  version = "135.0.7049.100";
+  version = "137.0.7151.44";
+  commit = "1abdac0aff0916b1e4a4bd52f1896eec00834262";
 
   src = fetchurl {
-    url = "https://github.com/uazo/cromite/releases/download/v${finalAttrs.version}-${commit}/chrome-lin64.tar.gz";
-    hash = "sha256-bB6CPqgwT1p7aXIKauOrRhG4dhCQ9tyO+HHRrkbrsPQ=";
+    url = "https://github.com/uazo/cromite/releases/download/v${finalAttrs.version}-${finalAttrs.commit}/chrome-lin64.tar.gz";
+    hash = "sha256-33GS4uD3RJHy9M0S5TRB6kRb1SZR+ABLyOR1oeVLQto=";
   };
 
   # With strictDeps on, some shebangs were not being patched correctly
@@ -182,7 +182,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = false;
 
   nativeBuildInputs = [
-    makeBinaryWrapper
+    makeWrapper
     patchelf
     copyDesktopItems
   ];
@@ -234,6 +234,7 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addDriverRunpath.driverLink}/share" \
       --set CHROME_WRAPPER  "cromite" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+      --add-flags "--simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT'" \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
     # Make sure that libGL and libvulkan are found by ANGLE libGLESv2.so
@@ -246,6 +247,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     changelog = "https://github.com/uazo/cromite/releases";

--- a/pkgs/by-name/cr/cromite/package.nix
+++ b/pkgs/by-name/cr/cromite/package.nix
@@ -169,12 +169,12 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "cromite";
-  version = "137.0.7151.56";
-  commit = "b4f8d96284c854cbe6448d2e30ee5a30ce3f0b82";
+  version = "137.0.7151.72";
+  commit = "4ea840397d139bcaf3298a54a80a93d135f7dac7";
 
   src = fetchurl {
     url = "https://github.com/uazo/cromite/releases/download/v${finalAttrs.version}-${finalAttrs.commit}/chrome-lin64.tar.gz";
-    hash = "sha256-f53Xh6xvk5Z8tkg/SUZS+plO3a7Qvn6ff2Soj7Dvvqw=";
+    hash = "sha256-WqOQaoboRqgYXW2tzyW3LMo5WRA8l5UWjUnfBIq6r9k=";
   };
 
   # With strictDeps on, some shebangs were not being patched correctly

--- a/pkgs/by-name/cr/cromite/update.sh
+++ b/pkgs/by-name/cr/cromite/update.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl gnused jq nix bash coreutils nix-update common-updater-scripts
+
+set -eou pipefail
+
+latestTag=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL https://api.github.com/repos/uazo/cromite/releases/latest | jq --raw-output .tag_name | sed 's/^v//')
+latestVersion="${latestTag%-*}"
+commit="${latestTag#*-}"
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; cromite.version or (lib.getVersion cromite)" | tr -d '"')
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "package is up-to-date: $currentVersion"
+    exit 0
+fi
+
+update-source-version cromite $commit --version-key=commit || true
+nix-update cromite --version $latestVersion


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/403794, https://github.com/NixOS/nixpkgs/pull/412893, https://github.com/NixOS/nixpkgs/pull/415840

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
