### PR TITLE
z3: build with cmake, 4.15.0 -> 4.15.1

### DIFF
--- a/pkgs/by-name/fs/fstar/z3/default.nix
+++ b/pkgs/by-name/fs/fstar/z3/default.nix
@@ -8,15 +8,17 @@
 }:
 
 let
+  z3' = z3.override { useCmakeBuild = false; };
+
   # fstar has a pretty hard dependency on certain z3 patch versions.
   # https://github.com/FStarLang/FStar/issues/3689#issuecomment-2625073641
   # We need to package all the Z3 versions it prefers here.
   fstarNewZ3Version = "4.13.3";
   fstarNewZ3 =
-    if z3.version == fstarNewZ3Version then
-      z3
+    if z3'.version == fstarNewZ3Version then
+      z3'
     else
-      z3.overrideAttrs (final: rec {
+      z3'.overrideAttrs (final: rec {
         version = fstarNewZ3Version;
         src = fetchFromGitHub {
           owner = "Z3Prover";
@@ -28,10 +30,10 @@ let
 
   fstarOldZ3Version = "4.8.5";
   fstarOldZ3 =
-    if z3.version == fstarOldZ3Version then
-      z3
+    if z3'.version == fstarOldZ3Version then
+      z3'
     else
-      z3.overrideAttrs (prev: rec {
+      z3'.overrideAttrs (prev: rec {
         version = fstarOldZ3Version;
         src = fetchFromGitHub {
           owner = "Z3Prover";

--- a/pkgs/by-name/si/simbaplusplus/package.nix
+++ b/pkgs/by-name/si/simbaplusplus/package.nix
@@ -5,6 +5,7 @@
   cmake,
   llvmPackages,
   z3,
+  python3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,6 +32,10 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     llvmPackages.libllvm
     z3
+  ];
+
+  checkInputs = [
+    python3
   ];
 
   doCheck = true;

--- a/pkgs/by-name/z3/z3/fix-pkg-config-paths.patch
+++ b/pkgs/by-name/z3/z3/fix-pkg-config-paths.patch
@@ -1,0 +1,21 @@
+diff --git a/z3.pc.cmake.in b/z3.pc.cmake.in
+index 436dd6208..dd1e179c7 100644
+--- a/z3.pc.cmake.in
++++ b/z3.pc.cmake.in
+@@ -1,13 +1,10 @@
+-prefix=@CMAKE_INSTALL_PREFIX@
+-exec_prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-sharedlibdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
++includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ 
+ Name: z3
+ Description: The Z3 Theorem Prover
+ Version: @Z3_VERSION@
+ 
+ Requires:
+-Libs: -L${libdir} -L${sharedlibdir} -lz3
++Libs: -L${libdir} -lz3
+ Cflags: -I${includedir}

--- a/pkgs/by-name/z3/z3/package.nix
+++ b/pkgs/by-name/z3/z3/package.nix
@@ -2,23 +2,30 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python3,
+  python3Packages,
   fixDarwinDylibNames,
   nix-update-script,
   versionCheckHook,
 
   javaBindings ? false,
   ocamlBindings ? false,
-  pythonBindings ? true,
+  pythonBindings ? (!stdenv.hostPlatform.isStatic),
   jdk ? null,
   ocaml ? null,
   findlib ? null,
   zarith ? null,
+  cmake,
+  ninja,
+  testers,
+  useCmakeBuild ? (!ocamlBindings), # TODO: remove gnu make build once cmake supports ocaml
   ...
 }:
 
-assert javaBindings -> jdk != null;
-assert ocamlBindings -> ocaml != null && findlib != null && zarith != null;
+assert pythonBindings -> !stdenv.hostPlatform.isStatic;
+assert javaBindings -> jdk != null && (!stdenv.hostPlatform.isStatic);
+assert
+  ocamlBindings
+  -> ocaml != null && findlib != null && zarith != null && (!stdenv.hostPlatform.isStatic);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "z3";
@@ -31,17 +38,27 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-fk3NyV6vIDXivhiNOW2Y0i5c+kzc7oBqaeBWj/JjpTM=";
   };
 
+  patches = lib.optionals useCmakeBuild [
+    ./fix-pkg-config-paths.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs =
-    [ python3 ]
+    [ python3Packages.python ]
+    ++ lib.optionals pythonBindings [ python3Packages.setuptools ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixDarwinDylibNames ]
     ++ lib.optionals javaBindings [ jdk ]
     ++ lib.optionals ocamlBindings [
       ocaml
       findlib
+    ]
+    ++ lib.optionals useCmakeBuild [
+      cmake
+      ninja
     ];
-  propagatedBuildInputs = [ python3.pkgs.setuptools ] ++ lib.optionals ocamlBindings [ zarith ];
+
+  propagatedBuildInputs = lib.optionals ocamlBindings [ zarith ];
   enableParallelBuilding = true;
 
   postPatch = lib.optionalString ocamlBindings ''
@@ -49,58 +66,94 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $OCAMLFIND_DESTDIR/stublibs
   '';
 
-  configurePhase = ''
+  configurePhase = lib.optionalString (!useCmakeBuild) ''
     runHook preConfigure
 
-    ${python3.pythonOnBuildForHost.interpreter} \
+    ${python3Packages.python.pythonOnBuildForHost.interpreter} \
       scripts/mk_make.py \
       --prefix=$out \
       ${lib.optionalString javaBindings "--java"} \
       ${lib.optionalString ocamlBindings "--ml"} \
-      ${lib.optionalString pythonBindings "--python --pypkgdir=$out/${python3.sitePackages}"}
+      ${lib.optionalString pythonBindings "--python --pypkgdir=$out/${python3Packages.python.sitePackages}"}
 
     cd build
 
     runHook postConfigure
   '';
 
+  cmakeFlags =
+    [
+      (lib.cmakeBool "Z3_BUILD_PYTHON_BINDINGS" pythonBindings)
+      (lib.cmakeBool "Z3_INSTALL_PYTHON_BINDINGS" pythonBindings)
+      (lib.cmakeBool "Z3_BUILD_JAVA_BINDINGS" javaBindings)
+      (lib.cmakeBool "Z3_INSTALL_JAVA_BINDINGS" javaBindings)
+      (lib.cmakeBool "Z3_BUILD_OCAML_BINDINGS" ocamlBindings) # FIXME: ocaml does not properly install build output on cmake
+      (lib.cmakeBool "Z3_SINGLE_THREADED" (!finalAttrs.enableParallelBuilding))
+      (lib.cmakeBool "Z3_BUILD_LIBZ3_SHARED" (!stdenv.hostPlatform.isStatic))
+      (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" (placeholder "out"))
+      (lib.cmakeBool "Z3_BUILD_TEST_EXECUTABLES" finalAttrs.doCheck)
+      (lib.cmakeBool "Z3_ENABLE_EXAMPLE_TARGETS" false)
+    ]
+    ++ lib.optionals pythonBindings [
+      (lib.cmakeFeature "CMAKE_INSTALL_PYTHON_PKG_DIR" "${placeholder "python"}/${python3Packages.python.sitePackages}")
+      (lib.cmakeFeature "Python3_EXECUTABLE" "${lib.getExe python3Packages.python}")
+    ]
+    ++ lib.optionals javaBindings [
+      (lib.cmakeFeature "Z3_JAVA_JNI_LIB_INSTALLDIR" "${placeholder "java"}/lib")
+      (lib.cmakeFeature "Z3_JAVA_JAR_INSTALLDIR" "${placeholder "java"}/share/java")
+    ];
+
   doCheck = true;
   checkPhase = ''
     runHook preCheck
 
-    make -j $NIX_BUILD_CORES test
+    ${if useCmakeBuild then "ninja test-z3" else "make test"} -j $NIX_BUILD_CORES
     ./test-z3 -a
 
     runHook postCheck
   '';
 
   postInstall =
-    ''
-      mkdir -p $dev $lib
-      mv $out/lib $lib/lib
-      mv $out/include $dev/include
-    ''
+    lib.optionalString (!useCmakeBuild) (
+      ''
+        mkdir -p $dev $lib
+        mv $out/lib $lib/lib
+        mv $out/include $dev/include
+      ''
+      + lib.optionalString pythonBindings ''
+        mkdir -p $python/lib
+        mv $lib/lib/python* $python/lib/
+
+        # need to delete the lib folder to properly link the actual lib output
+        rm -rf $python/${python3Packages.python.sitePackages}/z3/lib
+      ''
+      + lib.optionalString javaBindings ''
+        mkdir -p $java/share/java $java/lib
+        mv $lib/lib/com.microsoft.z3.jar $java/share/java
+        mv $lib/lib/libz3java* $java/lib
+      ''
+    )
     + lib.optionalString pythonBindings ''
-      mkdir -p $python/lib
-      mv $lib/lib/python* $python/lib/
-      ln -sf $lib/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary} $python/${python3.sitePackages}/z3/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary}
-    ''
-    + lib.optionalString javaBindings ''
-      mkdir -p $java/share/java
-      mv com.microsoft.z3.jar $java/share/java
-      moveToOutput "lib/libz3java.${stdenv.hostPlatform.extensions.sharedLibrary}" "$java"
+      ln -sf $lib/lib $python/${python3Packages.python.sitePackages}/z3/lib
     '';
 
   doInstallCheck = true;
-  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ] ++ lib.optionals pythonBindings [ python3Packages.pythonImportsCheckHook ];
+
+  pythonImportsCheck = [
+    "z3"
+  ];
 
   outputs =
     [
       "out"
       "lib"
       "dev"
-      "python"
     ]
+    ++ lib.optionals pythonBindings [ "python" ]
     ++ lib.optionals javaBindings [ "java" ]
     ++ lib.optionals ocamlBindings [ "ocaml" ];
 
@@ -110,6 +163,9 @@ stdenv.mkDerivation (finalAttrs: {
         "--version-regex"
         "^z3-([0-9]+\\.[0-9]+\\.[0-9]+)$"
       ];
+    };
+    tests = lib.optionalAttrs useCmakeBuild {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     };
   };
 
@@ -125,5 +181,7 @@ stdenv.mkDerivation (finalAttrs: {
       ttuegel
       numinit
     ];
+    pkgConfigModules = lib.optionals useCmakeBuild [ "z3" ];
+    broken = useCmakeBuild && ocamlBindings;
   };
 })

--- a/pkgs/by-name/z3/z3/package.nix
+++ b/pkgs/by-name/z3/z3/package.nix
@@ -29,13 +29,13 @@ assert
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "z3";
-  version = "4.15.0";
+  version = "4.15.1";
 
   src = fetchFromGitHub {
     owner = "Z3Prover";
     repo = "z3";
     rev = "z3-${finalAttrs.version}";
-    hash = "sha256-fk3NyV6vIDXivhiNOW2Y0i5c+kzc7oBqaeBWj/JjpTM=";
+    hash = "sha256-mzU21AlKjC5406lQXfBSz/AIwo/1FThqap5JgldkAgQ=";
   };
 
   patches = lib.optionals useCmakeBuild [

--- a/pkgs/tools/security/ghidra/extensions/kaiju/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/kaiju/default.nix
@@ -43,9 +43,9 @@ let
     # https://github.com/CERTCC/kaiju/blob/c9dbb55484b3d2a6abd9dfca2197cd00fb7ee3c1/build.gradle#L189
     preBuild = ''
       mkdir -p build/cmake/z3/java-bindings
-      ln -s ${lib.getOutput "lib" z3_lib}/lib/com.microsoft.z3.jar build/cmake/z3/java-bindings
+      ln -s ${lib.getOutput "java" z3_lib}/share/java/com.microsoft.z3.jar build/cmake/z3/java-bindings
       mkdir -p os/${ghidraPlatformName}
-      cp ${lib.getOutput "lib" z3_lib}/lib/* os/${ghidraPlatformName}
+      cp ${lib.getOutput "java" z3_lib}/lib/* os/${ghidraPlatformName}
     '';
 
     gradleFlags = [ "-PKAIJU_SKIP_Z3_BUILD=true" ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19598,7 +19598,7 @@ self: super: with self; {
 
   yubico-client = callPackage ../development/python-modules/yubico-client { };
 
-  z3-solver = (toPythonModule (pkgs.z3.override { python3 = python; })).python;
+  z3-solver = (toPythonModule (pkgs.z3.override { python3Packages = self; })).python;
 
   z3c-checkversions = callPackage ../development/python-modules/z3c-checkversions { };
 


### PR DESCRIPTION
Changelog: https://github.com/Z3Prover/z3/releases/tag/z3-4.15.1

Currently ocaml bindings do *build* with cmake, but they don't get installed properly. Until that is fixed, we need to keep the `py`+`make` based build.

The `cmake` build is needed to generate the cmake and pkg-config output, needed for e.g. prusa-slicer 2.9.2.

python import check and pkg-config passthru tester have been added for better coverage.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
