### PR TITLE
[24.11] wireshark: 4.2.9 -> 4.2.12

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -58,7 +58,7 @@ assert withQt -> qt6 != null;
 
 stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.2.9";
+  version = "4.2.11";
 
   outputs = [
     "out"
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     repo = "wireshark";
     owner = "wireshark";
     rev = "v${version}";
-    hash = "sha256-4GnDHGfd2FUOhel8/ZCzAH1iuUz1nTPdAAUCTcY0R5E=";
+    hash = "sha256-/P/JJKke2Y2iDs3w4x90YnHirG+jkldF71uJ3oTBvx4=";
   };
 
   patches = [


### PR DESCRIPTION
Fixes CVE-2025-5601 / https://www.wireshark.org/security/wnpa-sec-2025-02.html
Fixes CVE-2025-1492 / https://www.wireshark.org/security/wnpa-sec-2025-01.html

Changes:
https://www.wireshark.org/docs/relnotes/wireshark-4.2.10.html
https://www.wireshark.org/docs/relnotes/wireshark-4.2.11.html
https://www.wireshark.org/docs/relnotes/wireshark-4.2.12.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 415967`
Commit: `215863533918e3ffb66f8d6e5bcdf5562cae5e83`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 28 packages built:</summary>
  <ul>
    <li>compactor</li>
    <li>credslayer</li>
    <li>credslayer.dist</li>
    <li>dbmonster</li>
    <li>haka</li>
    <li>hfinger</li>
    <li>hfinger.dist</li>
    <li>ostinato</li>
    <li>python311Packages.dissect-cobaltstrike</li>
    <li>python311Packages.dissect-cobaltstrike.dist</li>
    <li>python311Packages.manuf</li>
    <li>python311Packages.manuf.dist</li>
    <li>python311Packages.pyshark</li>
    <li>python311Packages.pyshark.dist</li>
    <li>python312Packages.dissect-cobaltstrike</li>
    <li>python312Packages.dissect-cobaltstrike.dist</li>
    <li>python312Packages.manuf</li>
    <li>python312Packages.manuf.dist</li>
    <li>python312Packages.pyshark</li>
    <li>python312Packages.pyshark.dist</li>
    <li>qtwirediff</li>
    <li>termshark</li>
    <li>tshark (wireshark-cli)</li>
    <li>tshark.dev (wireshark-cli.dev)</li>
    <li>wifite2</li>
    <li>wifite2.dist</li>
    <li>wireshark (wireshark-qt)</li>
    <li>wireshark.dev (wireshark-qt.dev)</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
