### PR TITLE
pan-bindings: update to version 1.1.1

### DIFF
--- a/pkgs/by-name/pa/pan-bindings/package.nix
+++ b/pkgs/by-name/pa/pan-bindings/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   buildGoModule,
   cmake,
   ncurses,
@@ -9,19 +10,23 @@
 }:
 
 let
-  version = "unstable-2024-03-03";
+  version = "1.1.1";
   src = fetchFromGitHub {
     owner = "lschulz";
     repo = "pan-bindings";
-    rev = "4361d30f1c5145a70651c259f2d56369725b0d15";
-    hash = "sha256-0WxrgXTCM+BwGcjjWBBKiZawje2yxB5RRac6Sk5t3qc=";
+    tag = "v${version}";
+    hash = "sha256-FpjbfmJwCx+aZxipE1QQTgOlXHtv2VkIKWSMQylr+WM=";
   };
   goDeps = (
     buildGoModule {
       name = "pan-bindings-goDeps";
       inherit src version;
+      prePatch = ''
+        # can be removed once https://github.com/NixOS/nixpkgs/pull/414434 is fully merged
+        substituteInPlace go/go.mod --replace-fail "toolchain go1.24.4" "toolchain go1.24.3"
+      '';
       modRoot = "go";
-      vendorHash = "sha256-7EitdEJTRtiM29qmVnZUM6w68vCBI8mxZhCA7SnAxLA=";
+      vendorHash = "sha256-3MybV76pHDnKgN2ENRgsyAvynXQctv0fJcRGzesmlww=";
     }
   );
 in
@@ -36,12 +41,21 @@ stdenv.mkDerivation {
     "-DBUILD_EXAMPLES=0"
   ];
 
-  patchPhase = ''
-    runHook prePatch
+  prePatch = ''
     export HOME=$TMP
     cp -r --reflink=auto ${goDeps.goModules} go/vendor
-    runHook postPatch
+    # can be removed once https://github.com/NixOS/nixpkgs/pull/414434 is fully merged
+    substituteInPlace go/go.mod --replace-fail "toolchain go1.24.4" "toolchain go1.24.3"
   '';
+
+  patches = [
+    # can be removed in the next release when the pull request is merged or the build issue otherwise resolved
+    (fetchpatch2 {
+      name = "fix-darwin-build";
+      url = "https://patch-diff.githubusercontent.com/raw/lschulz/pan-bindings/pull/4.patch";
+      hash = "sha256-0/lg3TxSosELtKycn+oJtK0JBDFQrQBbwUPu2ah9lgI=";
+    })
+  ];
 
   buildInputs = [
     ncurses


### PR DESCRIPTION
## Things done

This fixes the build on darwin by updating to the latest release. Still a draft, as I want to provide the build system patches I needed to to upstream as a pull request.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
