### PR TITLE
_1password-gui: Add passthru.updateScript

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/darwin.nix
+++ b/pkgs/by-name/_1/_1password-gui/darwin.nix
@@ -30,4 +30,6 @@ stdenv.mkDerivation {
 
   # 1Password is notarized.
   dontFixup = true;
+
+  passthru.updateScript = ./update.sh;
 }

--- a/pkgs/by-name/_1/_1password-gui/linux.nix
+++ b/pkgs/by-name/_1/_1password-gui/linux.nix
@@ -153,4 +153,6 @@ stdenv.mkDerivation {
       # https://1password.community/discussion/comment/624011/#Comment_624011
       #--add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
   '';
+
+  passthru.updateScript = ./update.sh;
 }

--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,38 +1,58 @@
 {
   "stable": {
-    "x86_64-linux": {
-      "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.78.x64.tar.gz",
-      "hash": "sha256-COmXSjbCetPsbm40OrWGVtULPheEgnHEO0ZcIgWaG1w="
+    "linux": {
+      "version": "8.10.78",
+      "sources": {
+        "x86_64": {
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.78.x64.tar.gz",
+          "hash": "sha256-COmXSjbCetPsbm40OrWGVtULPheEgnHEO0ZcIgWaG1w="
+        },
+        "aarch64": {
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.78.arm64.tar.gz",
+          "hash": "sha256-diy7VhKRluSnVSR35Ogamf9RDHdqxSJifLOOYmMrJHE="
+        }
+      }
     },
-    "aarch64-linux": {
-      "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.78.arm64.tar.gz",
-      "hash": "sha256-diy7VhKRluSnVSR35Ogamf9RDHdqxSJifLOOYmMrJHE="
-    },
-    "x86_64-darwin": {
-      "url": "https://downloads.1password.com/mac/1Password-8.10.78-x86_64.zip",
-      "hash": "sha256-8fbjEc/Z0xCdXq/uHp4bQE5Js5hNLbVCRZxnepUdLUs="
-    },
-    "aarch64-darwin": {
-      "url": "https://downloads.1password.com/mac/1Password-8.10.78-aarch64.zip",
-      "hash": "sha256-x03dZ/eVrvFcbese1cBAvyJKwtWe6rOcgytn0OsEFDQ="
+    "darwin": {
+      "version": "8.10.78",
+      "sources": {
+        "x86_64": {
+          "url": "https://downloads.1password.com/mac/1Password-8.10.78-x86_64.zip",
+          "hash": "sha256-8fbjEc/Z0xCdXq/uHp4bQE5Js5hNLbVCRZxnepUdLUs="
+        },
+        "aarch64": {
+          "url": "https://downloads.1password.com/mac/1Password-8.10.78-aarch64.zip",
+          "hash": "sha256-x03dZ/eVrvFcbese1cBAvyJKwtWe6rOcgytn0OsEFDQ="
+        }
+      }
     }
   },
   "beta": {
-    "x86_64-linux": {
-      "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.10.80-18.BETA.x64.tar.gz",
-      "hash": "sha256-X2Wu/dQQ7fv+tTAU2/70S38wL6WdJuc/DXWoiHZvSP4="
+    "linux": {
+      "version": "8.10.80-18.BETA",
+      "sources": {
+        "x86_64": {
+          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.10.80-18.BETA.x64.tar.gz",
+          "hash": "sha256-X2Wu/dQQ7fv+tTAU2/70S38wL6WdJuc/DXWoiHZvSP4="
+        },
+        "aarch64": {
+          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.10.80-18.BETA.arm64.tar.gz",
+          "hash": "sha256-52aRg6QD/fKOzOHoG88q8VNJIizxnISFnpxek7bJ05w="
+        }
+      }
     },
-    "aarch64-linux": {
-      "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.10.80-18.BETA.arm64.tar.gz",
-      "hash": "sha256-52aRg6QD/fKOzOHoG88q8VNJIizxnISFnpxek7bJ05w="
-    },
-    "x86_64-darwin": {
-      "url": "https://downloads.1password.com/mac/1Password-8.10.80-18.BETA-x86_64.zip",
-      "hash": "sha256-kUU+nm19DmdY8ZG6d+EJFQXcCy/BOauXh83suQLSvz0="
-    },
-    "aarch64-darwin": {
-      "url": "https://downloads.1password.com/mac/1Password-8.10.80-18.BETA-aarch64.zip",
-      "hash": "sha256-eZG0QaB5NRwRCYcmlfZA/HTceLq7eUzR+AvzDeOrzAY="
+    "darwin": {
+      "version": "8.10.80-18.BETA",
+      "sources": {
+        "x86_64": {
+          "url": "https://downloads.1password.com/mac/1Password-8.10.80-18.BETA-x86_64.zip",
+          "hash": "sha256-kUU+nm19DmdY8ZG6d+EJFQXcCy/BOauXh83suQLSvz0="
+        },
+        "aarch64": {
+          "url": "https://downloads.1password.com/mac/1Password-8.10.80-18.BETA-aarch64.zip",
+          "hash": "sha256-eZG0QaB5NRwRCYcmlfZA/HTceLq7eUzR+AvzDeOrzAY="
+        }
+      }
     }
   }
 }

--- a/pkgs/by-name/_1/_1password-gui/update-sources.py
+++ b/pkgs/by-name/_1/_1password-gui/update-sources.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3 gnupg
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import OrderedDict
+
+DOWNLOADS_BASE_URL = "https://downloads.1password.com"
+OP_PGP_KEYID = "3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
+
+
+class Sources(OrderedDict):
+    def __init__(self):
+        self._jsonfp = open("sources.json", "r+")
+        self.update(json.load(self._jsonfp))
+        self._jsonfp.seek(0, os.SEEK_SET)
+
+    def persist(self):
+        json.dump(self, self._jsonfp, indent=2)
+        self._jsonfp.write("\n") # keep fmt.check happy
+
+
+class GPG:
+    def __new__(cls):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if hasattr(self, "gnupghome"):
+            return
+
+        self.gpg = shutil.which("gpg")
+        self.gpgv = shutil.which("gpgv")
+        self.gnupghome = tempfile.mkdtemp(prefix="1password-gui-gnupghome.")
+        self.env = {"GNUPGHOME": self.gnupghome}
+        self._run(
+            self.gpg,
+            "--no-default-keyring",
+            "--keyring",
+            "trustedkeys.kbx",
+            "--keyserver",
+            "keyserver.ubuntu.com",
+            "--receive-keys",
+            OP_PGP_KEYID,
+        )
+
+    def __del__(self):
+        shutil.rmtree(self.gnupghome)
+
+    def _run(self, *args):
+        try:
+            subprocess.run(args, env=self.env, check=True, capture_output=True)
+        except subprocess.CalledProcessError as cpe:
+            print(cpe.stderr, file=sys.stderr)
+            raise SystemExit(f"gpg error: {cpe.cmd}")
+
+    def verify(self, sigfile, datafile):
+        return self._run(self.gpgv, sigfile, datafile)
+
+
+def nix_store_prefetch(url):
+    nix = shutil.which("nix")
+    cp = subprocess.run(
+        [nix, "store", "prefetch-file", "--json", url], check=True, capture_output=True
+    )
+    out = json.loads(cp.stdout)
+
+    return out["storePath"], out["hash"]
+
+
+def mk_url(channel, os, version, arch):
+    if os == "linux":
+        arch_alias = {"x86_64": "x64", "aarch64": "arm64"}[arch]
+        path = f"linux/tar/{channel}/{arch}/1password-{version}.{arch_alias}.tar.gz"
+    elif os == "darwin":
+        path = f"mac/1Password-{version}-{arch}.zip"
+    else:
+        raise SystemExit(f"update-sources.py: unsupported OS {os}")
+
+    return f"{DOWNLOADS_BASE_URL}/{path}"
+
+
+def download(channel, os, version, arch):
+    url = mk_url(channel, os, version, arch)
+    store_path_tarball, hash = nix_store_prefetch(url)
+
+    # Linux release tarballs come with detached PGP signatures.
+    if os == "linux":
+        store_path_sig, _ = nix_store_prefetch(url + ".sig")
+        GPG().verify(store_path_sig, store_path_tarball)
+
+    return url, hash
+
+
+def main(args):
+    """Gets called with args in `channel/os/version` format.
+
+    e.g.:
+      update-sources.py stable/linux/8.10.80 beta/linux/8.10.82-12.BETA
+    """
+    sources = Sources()
+
+    for triplet in args[1:]:
+        channel, os, version = triplet.split("/")
+        release = sources[channel][os]
+        if release["version"] == version:
+            continue
+
+        release["version"] = version
+        for arch in release["sources"]:
+            url, hash = download(channel, os, version, arch)
+            release["sources"][arch].update({"url": url, "hash": hash})
+
+    sources.persist()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/pkgs/by-name/_1/_1password-gui/versions.json
+++ b/pkgs/by-name/_1/_1password-gui/versions.json
@@ -1,6 +1,0 @@
-{
-  "stable-linux": "8.10.78",
-  "stable-darwin": "8.10.78",
-  "beta-linux":"8.10.80-18.BETA",
-  "beta-darwin": "8.10.80-18.BETA"
-}


### PR DESCRIPTION
Replace most of my maintainer work with two scripts, so r-ryantm can detect the changes and send the PRs.

### How do we detect new releases?
- For Linux updates we use Repology API to observe 1Password's Arch User Repository.
- For Darwin updates, 1Password for Mac 8's autoupdate feed URL.


### Known Issues:
- 1P's app-updates feed for Darwin betas move to the stable version once it gets released. This isn't a bug in update.sh, but an artifact from upstream.

### Known Unknowns:
- `update-sources.py` uses `nix store prefetch-url` to download artifacts to the store and get their hashes. I'm not certain if `nix-command` experimental feature is enabled for r-ryantm runner.

### Manual Testing:
It seems to work.
```
~nixpkgs% nix-shell ~nixpkgs/maintainers/scripts/update.nix --argstr package _1password-gui --argstr commit true --argstr skip-prompt true
this derivation will be built:
  /nix/store/qidwnfdsxkfrg0jnvbmr9lxgmxicv3iv-packages.json.drv
these 4 paths will be fetched (7.66 MiB download, 37.78 MiB unpacked):
  /nix/store/3bx3x52ypbdiw4mmnmhm4pqg6jcb9r0s-libgit2-1.9.1-lib
  /nix/store/0g0h3gbbybal9l6nkyr9r8pz0hngkmda-nix-2.28.3
  /nix/store/j6s32bfmddnx28xp216af8fj5s2dsglp-nix-2.28.3-dev
  /nix/store/90s45p0f4wh1k3s4ka74czsnx7cb4030-nix-2.28.3-man
copying path '/nix/store/90s45p0f4wh1k3s4ka74czsnx7cb4030-nix-2.28.3-man' from 'https://cache.nixos.org'...
building '/nix/store/qidwnfdsxkfrg0jnvbmr9lxgmxicv3iv-packages.json.drv'...
copying path '/nix/store/3bx3x52ypbdiw4mmnmhm4pqg6jcb9r0s-libgit2-1.9.1-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/0g0h3gbbybal9l6nkyr9r8pz0hngkmda-nix-2.28.3' from 'https://cache.nixos.org'...
copying path '/nix/store/j6s32bfmddnx28xp216af8fj5s2dsglp-nix-2.28.3-dev' from 'https://cache.nixos.org'...

Going to be running update for following packages:
 - 1password-8.10.78


Running update for:
Preparing worktree (new branch 'update-tmpsvh9jxuo')
Updating files: 100% (48237/48237), done.
HEAD is now at 092c80392e14 _1password-gui: Add passthru.updateScript
Enqueuing group of 1 packages
 - 1password-8.10.78: UPDATING ...
[_1password-gui_updateScript 87c8f4e91224] _1password-gui: 8.10.78 -> 8.10.80
 Date: Thu Jun 12 08:12:05 2025 +0000
 1 file changed, 10 insertions(+), 10 deletions(-)
Deleted branch update-tmpsvh9jxuo (was 87c8f4e91224).

Packages updated!
~nixpkgs% git show
commit 87c8f4e91224e2f858663c23f16bed27736d4ac6 (HEAD -> _1password-gui_updateScript)
Author: Berk D. Demir <bdd@mindcast.org>
Date:   Thu Jun 12 08:12:05 2025 +0000

    _1password-gui: 8.10.78 -> 8.10.80

diff --git a/pkgs/by-name/_1/_1password-gui/sources.json b/pkgs/by-name/_1/_1password-gui/sources.json
index 89962dc25dbe..a6c5c66f07bf 100644
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.10.78",
+      "version": "8.10.80",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.78.x64.tar.gz",
-          "hash": "sha256-COmXSjbCetPsbm40OrWGVtULPheEgnHEO0ZcIgWaG1w="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.80.x64.tar.gz",
+          "hash": "sha256-fxhLeeJzzbIhRZcrLnkBvrwAA+jzGeOhnmiH3ErlDTE="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.78.arm64.tar.gz",
-          "hash": "sha256-diy7VhKRluSnVSR35Ogamf9RDHdqxSJifLOOYmMrJHE="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.80.arm64.tar.gz",
+          "hash": "sha256-Ffr7Xow6ZMGE4Spf3QfDoSydR3OXasMpM3ttiiPup+Q="
         }
       }
     },
     "darwin": {
-      "version": "8.10.78",
+      "version": "8.10.80",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.78-x86_64.zip",
-          "hash": "sha256-8fbjEc/Z0xCdXq/uHp4bQE5Js5hNLbVCRZxnepUdLUs="
+          "url": "https://downloads.1password.com/mac/1Password-8.10.80-x86_64.zip",
+          "hash": "sha256-4b7mocNt/H9xiai9E9pqT5LWNsRi6Skr+F1vctfmU3k="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.78-aarch64.zip",
-          "hash": "sha256-x03dZ/eVrvFcbese1cBAvyJKwtWe6rOcgytn0OsEFDQ="
+          "url": "https://downloads.1password.com/mac/1Password-8.10.80-aarch64.zip",
+          "hash": "sha256-8PJq6VVTAMQWLP9rLwOhtK02KZckn7ps4evDPL6EvYs="
         }
       }
     }
~nixpkgs% nix-shell ~nixpkgs/maintainers/scripts/update.nix --argstr package _1password-gui-beta --argstr commit true --argstr skip-prompt true
this derivation will be built:
  /nix/store/dv1qdx3c58r5wb3imk6b7g7q5bi0nx69-packages.json.drv
building '/nix/store/dv1qdx3c58r5wb3imk6b7g7q5bi0nx69-packages.json.drv'...

Going to be running update for following packages:
 - 1password-8.10.80-18.BETA


Running update for:
Preparing worktree (new branch 'update-tmpy_j6x9gr')
Updating files: 100% (48237/48237), done.
HEAD is now at 87c8f4e91224 _1password-gui: 8.10.78 -> 8.10.80
Enqueuing group of 1 packages
 - 1password-8.10.80-18.BETA: UPDATING ...
[_1password-gui_updateScript 3f177977d5af] _1password-gui-beta: 8.10.80-18.BETA -> 8.10.82-27.BETA
 Date: Thu Jun 12 08:12:55 2025 +0000
 1 file changed, 10 insertions(+), 10 deletions(-)
Deleted branch update-tmpy_j6x9gr (was 3f177977d5af).

Packages updated!
~nixpkgs% git show
commit 3f177977d5af9e8c43d1742a824e4cfc7b6615ce (HEAD -> _1password-gui_updateScript)
Author: Berk D. Demir <bdd@mindcast.org>
Date:   Thu Jun 12 08:12:55 2025 +0000

    _1password-gui-beta: 8.10.80-18.BETA -> 8.10.82-27.BETA

diff --git a/pkgs/by-name/_1/_1password-gui/sources.json b/pkgs/by-name/_1/_1password-gui/sources.json
index a6c5c66f07bf..2946ddd7a3ed 100644
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -29,28 +29,28 @@
   },
   "beta": {
     "linux": {
-      "version": "8.10.80-18.BETA",
+      "version": "8.10.82-27.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.10.80-18.BETA.x64.tar.gz",
-          "hash": "sha256-X2Wu/dQQ7fv+tTAU2/70S38wL6WdJuc/DXWoiHZvSP4="
+          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.10.82-27.BETA.x64.tar.gz",
+          "hash": "sha256-6ncTm+rgEPGRwMquOCWH8sXin9CrjiHsUDLKo3CrLIM="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.10.80-18.BETA.arm64.tar.gz",
-          "hash": "sha256-52aRg6QD/fKOzOHoG88q8VNJIizxnISFnpxek7bJ05w="
+          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.10.82-27.BETA.arm64.tar.gz",
+          "hash": "sha256-fRgTfZjQRrPbYUKIub+y9iYSBvsElN90ag0maPKTM2g="
         }
       }
     },
     "darwin": {
-      "version": "8.10.80-18.BETA",
+      "version": "8.10.82-27.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.80-18.BETA-x86_64.zip",
-          "hash": "sha256-kUU+nm19DmdY8ZG6d+EJFQXcCy/BOauXh83suQLSvz0="
+          "url": "https://downloads.1password.com/mac/1Password-8.10.82-27.BETA-x86_64.zip",
+          "hash": "sha256-jCxzPxRvb7gjhDeZVcTcuED4N436aJsivpfgae9dVc0="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.80-18.BETA-aarch64.zip",
-          "hash": "sha256-eZG0QaB5NRwRCYcmlfZA/HTceLq7eUzR+AvzDeOrzAY="
+          "url": "https://downloads.1password.com/mac/1Password-8.10.82-27.BETA-aarch64.zip",
+          "hash": "sha256-PibtIpKpyp0+jkzZ9odNow6Gew/fjWy9EvdIgeewpA4="
         }
       }
     }
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
