### PR TITLE
[24.11] gitlab: 17.11.3 -> 17.11.4

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,15 +1,15 @@
 {
-  "version": "17.11.3",
-  "repo_hash": "05mkhj0jpy2pmsvv3h2dphffrc01hpazxi95f44gic39z6gykap7",
+  "version": "17.11.4",
+  "repo_hash": "0whfpfds6al7g631i216s097r1hiia2qmf9qws6ip2c7mvqp0hfl",
   "yarn_hash": "0z06jaxqbg2wnq7yhpkba0cpxp4w4iy2cxla8nhc6kgx49xk179v",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v17.11.3-ee",
+  "rev": "v17.11.4-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "17.11.3",
-    "GITLAB_PAGES_VERSION": "17.11.3",
+    "GITALY_SERVER_VERSION": "17.11.4",
+    "GITLAB_PAGES_VERSION": "17.11.4",
     "GITLAB_SHELL_VERSION": "14.42.0",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "5.5.0",
-    "GITLAB_WORKHORSE_VERSION": "17.11.3"
+    "GITLAB_WORKHORSE_VERSION": "17.11.4"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -10,7 +10,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "17.11.3";
+  version = "17.11.4";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {

--- a/pkgs/by-name/gi/gitaly/package.nix
+++ b/pkgs/by-name/gi/gitaly/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "17.11.3";
+  version = "17.11.4";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -21,7 +21,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-A5y8FYc3WrzKKMexsmWz73DwEdr0bjRTyOh3TOD7jTE=";
+      hash = "sha256-87uTSq9hOnqScEWIliBuD3l2yGB2sMw8kbJyLE/y3pY=";
     };
 
     vendorHash = "sha256-ExqgxukFKXq/Z//hGSoDevfpJiNbVHhind63os1/3Fk=";

--- a/pkgs/by-name/gi/gitlab-container-registry/package.nix
+++ b/pkgs/by-name/gi/gitlab-container-registry/package.nix
@@ -7,7 +7,7 @@
 
 buildGoModule rec {
   pname = "gitlab-container-registry";
-  version = "4.22.0";
+  version = "4.23.1";
   rev = "v${version}-gitlab";
 
   # nixpkgs-update: no auto update
@@ -15,10 +15,10 @@ buildGoModule rec {
     owner = "gitlab-org";
     repo = "container-registry";
     inherit rev;
-    hash = "sha256-r7IVX4xH/K+tfoEKfO9HITHUZT6yfBP2Zr6EPZQUxfw=";
+    hash = "sha256-eCuSuQXtzd2jLJf9G8DO1KGXdT8bYGe9tcKw6BZNiiI=";
   };
 
-  vendorHash = "sha256-e7EIScdd0k5iFTDutFotNkKj1rKtBqfEexdkpjSHAoE=";
+  vendorHash = "sha256-OrdlQp+USRf+Yc7UDjIncDpbuRu5ui6TUoYY2MMc8Ro=";
 
   checkFlags =
     let

--- a/pkgs/by-name/gi/gitlab-pages/package.nix
+++ b/pkgs/by-name/gi/gitlab-pages/package.nix
@@ -6,14 +6,14 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "17.11.3";
+  version = "17.11.4";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    hash = "sha256-Au/s8MlFfEsOiQTvZ86574xxE2f7/TUFU3MVIScjb1Y=";
+    hash = "sha256-weC0LguQi76p1Ci3CNJHa50dTq88o6rwBbvfmoI4lUc=";
   };
 
   vendorHash = "sha256-jCuLRXr7WHGxbXVg2JB1vp9WiNaLgsIJ6GJSS4QrlwY=";


### PR DESCRIPTION
https://about.gitlab.com/releases/2025/06/11/patch-release-gitlab-18-0-2-released/

24.11 "backport" of #416069 (25.05 and unstable use gitlab 18, 24.11 gitlab 17)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
