### PR TITLE
packet: 0.4.0 → 0.5.1

### DIFF
--- a/pkgs/by-name/pa/packet/nautilus-extension-locale.patch
+++ b/pkgs/by-name/pa/packet/nautilus-extension-locale.patch
@@ -1,0 +1,26 @@
+diff --git a/data/resources/plugins/meson.build b/data/resources/plugins/meson.build
+index ac60edd..9e055b8 100644
+--- a/data/resources/plugins/meson.build
++++ b/data/resources/plugins/meson.build
+@@ -1,6 +1,7 @@
+ plugins_conf = configuration_data()
+ plugins_conf.set('APP_ID', application_id)
+ plugins_conf.set('LOCALE_DOMAIN', gettext_package)
++plugins_conf.set('LOCALE_DIR', localedir)
+ 
+ configure_file(
+   input: 'packet_nautilus.py.in',
+diff --git a/data/resources/plugins/packet_nautilus.py.in b/data/resources/plugins/packet_nautilus.py.in
+index 9c5e71e..7288ee9 100755
+--- a/data/resources/plugins/packet_nautilus.py.in
++++ b/data/resources/plugins/packet_nautilus.py.in
+@@ -23,7 +23,8 @@ def log(*vals: Any):
+ # TODO: Maybe have a separate gettext package for plugin scripts that gets
+ # copied over alongside the script. Seems more robust?
+ def init_i18n() -> gettext.NullTranslations | gettext.GNUTranslations:
+-    locale_dirs: List[Path | None] = [None]  # None for system default locale dir
++    # `None` is for system default locale dir
++    locale_dirs: List[Path | None] = [None, Path("@LOCALE_DIR@")]
+     (lang, enc) = locale.getlocale()
+ 
+     flatpak_info = None

--- a/pkgs/by-name/pa/packet/package.nix
+++ b/pkgs/by-name/pa/packet/package.nix
@@ -20,21 +20,27 @@
   blueprint-compiler,
   desktop-file-utils,
   appstream,
+  python3Packages,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "packet";
-  version = "0.4.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "nozwock";
     repo = "packet";
     tag = finalAttrs.version;
-    hash = "sha256-MnDXwgzSnz8bLEAZE4PORKKIP8Ao5ZiImRqRzlQzYU8=";
+    hash = "sha256-MZdZf4fLtUd30LncPLVkcNdjuzw+Wi33A1MJqQbEurk=";
   };
+
+  patches = [
+    # let nautilus find the locale directory
+    ./nautilus-extension-locale.patch
+  ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-LlqJoxAWHAQ47VlYB/sOtk/UkNa+E5CQS/3FQnAYFsI=";
+    hash = "sha256-ODrM8oGQpi+DpG4YQYibtVHbicuHOjZAlZ1wW2Gulec=";
   };
 
   nativeBuildInputs = [
@@ -59,7 +65,16 @@ stdenv.mkDerivation (finalAttrs: {
     gdk-pixbuf
     libadwaita
     pango
+    python3Packages.wrapPython
   ];
+
+  postFixup = ''
+    buildPythonPath ${python3Packages.dbus-python}
+    patchPythonScript $out/share/packet/plugins/packet_nautilus.py
+    # install the nautilus extension in the expected location
+    mkdir -p $out/share/nautilus-python
+    ln -s $out/share/packet/plugins $out/share/nautilus-python/extensions
+  '';
 
   meta = {
     description = "Quick Share client for Linux";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/nozwock/packet/releases/tag/0.5.0
https://github.com/nozwock/packet/releases/tag/0.5.0-1
https://github.com/nozwock/packet/releases/tag/0.5.1

NOTE: This update includes the Nautilus extension. Some additional configuration is required to make it work. See https://github.com/honnip/dotfiles/commit/4a4c01c552dd5ab9e448960df84c5e3f473cda87 or [nautilus-open-any-terminal module](https://github.com/NixOS/nixpkgs/blob/d41710e910db31af4e919de7c3275afb8fb05c73/nixos/modules/programs/nautilus-open-any-terminal.nix)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
