### PR TITLE
lib.attrsToListRecursive: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -203,6 +203,8 @@ let
         mapAttrs'
         mapAttrsToList
         attrsToList
+        attrsToListRecursive
+        attrsToListRecursive'
         concatMapAttrs
         mapAttrsRecursive
         mapAttrsRecursiveCond


### PR DESCRIPTION
Added `lib.attrsets.attrsToListRecursive` and `lib.attrsets.attrsToListRecursive'` and their aliases in root. For further details please check corresponding docstrings.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
