### PR TITLE
ci/treefmt: add yamlfmt

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -101,7 +101,7 @@ body:
       label: "Notify maintainers"
       description: |
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
-      value: |
+      value: |2
 
 
         ---

--- a/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
@@ -115,7 +115,7 @@ body:
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
 
         If this issue is related to the Darwin packaging architecture as a whole, or is related to the core Darwin frameworks, consider mentioning the `@NixOS/darwin-core` team.
-      value: |
+      value: |2
 
 
         ---

--- a/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
+++ b/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
@@ -105,7 +105,7 @@ body:
         Please note that the maintainer attribute name does not always match the maintainer's GitHub username. If that occurs, try looking in [`maintainers/maintainer-list.nix`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix) for the maintainer attribute name, and checking if the maintainer has a listed GitHub username.
 
         If in doubt, check `git blame` for whoever last touched the module, or check the associated package's maintainers. Please add the mentions above the `---` characters.
-      value: |
+      value: |2
 
 
         ---

--- a/.github/ISSUE_TEMPLATE/04_build_failure.yml
+++ b/.github/ISSUE_TEMPLATE/04_build_failure.yml
@@ -111,7 +111,7 @@ body:
       label: "Notify maintainers"
       description: |
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
-      value: |
+      value: |2
 
 
         ---

--- a/.github/ISSUE_TEMPLATE/05_update_request.yml
+++ b/.github/ISSUE_TEMPLATE/05_update_request.yml
@@ -86,7 +86,7 @@ body:
       label: "Notify maintainers"
       description: |
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
-      value: |
+      value: |2
 
 
         ---

--- a/.github/ISSUE_TEMPLATE/06_module_request.yml
+++ b/.github/ISSUE_TEMPLATE/06_module_request.yml
@@ -61,7 +61,7 @@ body:
       label: "Notify maintainers"
       description: |
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
-      value: |
+      value: |2
 
 
         ---

--- a/.github/ISSUE_TEMPLATE/07_backport_request.yml
+++ b/.github/ISSUE_TEMPLATE/07_backport_request.yml
@@ -66,7 +66,7 @@ body:
       label: "Notify maintainers"
       description: |
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
-      value: |
+      value: |2
 
 
         ---

--- a/.github/ISSUE_TEMPLATE/08_documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/08_documentation_request.yml
@@ -48,7 +48,7 @@ body:
       label: "Notify maintainers"
       description: |
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
-      value: |
+      value: |2
 
 
         ---

--- a/.github/ISSUE_TEMPLATE/09_unreproducible_package.yml
+++ b/.github/ISSUE_TEMPLATE/09_unreproducible_package.yml
@@ -120,7 +120,7 @@ body:
       label: "Notify maintainers"
       description: |
         Please mention the people who are in the **Maintainers** list of the offending package. This is done by by searching for the package on the [NixOS Package Search](https://search.nixos.org/packages) and mentioning the people listed under **Maintainers** by prefixing their GitHub usernames with an '@' character. Please add the mentions above the `---` characters in the template below.
-      value: |
+      value: |2
 
 
         ---

--- a/.github/actions/get-merge-commit/action.yml
+++ b/.github/actions/get-merge-commit/action.yml
@@ -72,10 +72,10 @@ runs:
           }
           throw new Error("Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com.")
 
+    - if: inputs.merged-as-untrusted && steps.commits.outputs.mergedSha
       # Would be great to do the checkouts in git worktrees of the existing spare checkout instead,
       # but Nix is broken with them:
       # https://github.com/NixOS/nix/issues/6073
-    - if: inputs.merged-as-untrusted && steps.commits.outputs.mergedSha
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ steps.commits.outputs.mergedSha }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    labels: [ ]
+    labels: []

--- a/.github/labeler-development-branches.yml
+++ b/.github/labeler-development-branches.yml
@@ -3,21 +3,21 @@
 
 "4.workflow: package set update":
   - any:
-    - head-branch:
-      - '-updates$'
+      - head-branch:
+          - '-updates$'
 
 "4.workflow: staging":
   - any:
-    - head-branch:
-      - '^staging-next$'
-      - '^staging-next-'
+      - head-branch:
+          - '^staging-next$'
+          - '^staging-next-'
 
 "6.topic: haskell":
   - any:
-    - head-branch:
-      - '^haskell-updates$'
+      - head-branch:
+          - '^haskell-updates$'
 
 "6.topic: python":
   - any:
-    - head-branch:
-      - '^python-updates$'
+      - head-branch:
+          - '^python-updates$'

--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -5,35 +5,35 @@
 
 "6.topic: policy discussion":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - .github/**/*
-        - CONTRIBUTING.md
-        - pkgs/README.md
-        - nixos/README.md
-        - maintainers/README.md
-        - lib/README.md
-        - doc/README.md
+      - changed-files:
+          - any-glob-to-any-file:
+              - .github/**/*
+              - CONTRIBUTING.md
+              - pkgs/README.md
+              - nixos/README.md
+              - maintainers/README.md
+              - lib/README.md
+              - doc/README.md
 
 "8.has: documentation":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/**/*
-        - nixos/doc/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/**/*
+              - nixos/doc/**/*
 
 "backport release-24.11":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - .github/workflows/*
-        - ci/**/*.*
+      - changed-files:
+          - any-glob-to-any-file:
+              - .github/workflows/*
+              - ci/**/*.*
 
 "backport release-25.05":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - .github/workflows/*
-        - ci/**/*.*
+      - changed-files:
+          - any-glob-to-any-file:
+              - .github/workflows/*
+              - ci/**/*.*
 
 # keep-sorted end

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,599 +5,599 @@
 
 "4.workflow: backport":
   - any:
-    - base-branch:
-      - '^release-'
-      - '^staging-\d'
-      - '^staging-next-\d'
+      - base-branch:
+          - '^release-'
+          - '^staging-\d'
+          - '^staging-next-\d'
 
 # NOTE: bsd, darwin and cross-compilation labels are handled by ofborg
 "6.topic: agda":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/agda.section.md
-        - nixos/tests/agda.nix
-        - pkgs/build-support/agda/**/*
-        - pkgs/development/libraries/agda/**/*
-        - pkgs/top-level/agda-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/agda.section.md
+              - nixos/tests/agda.nix
+              - pkgs/build-support/agda/**/*
+              - pkgs/development/libraries/agda/**/*
+              - pkgs/top-level/agda-packages.nix
 
 "6.topic: cinnamon":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/x11/desktop-managers/cinnamon.nix
-        - nixos/tests/cinnamon.nix
-        - nixos/tests/cinnamon-wayland.nix
-        - pkgs/by-name/ci/cinnamon-*/**/*
-        - pkgs/by-name/cj/cjs/**/*
-        - pkgs/by-name/mu/muffin/**/*
-        - pkgs/by-name/ne/nemo/**/*
-        - pkgs/by-name/ne/nemo-*/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/x11/desktop-managers/cinnamon.nix
+              - nixos/tests/cinnamon.nix
+              - nixos/tests/cinnamon-wayland.nix
+              - pkgs/by-name/ci/cinnamon-*/**/*
+              - pkgs/by-name/cj/cjs/**/*
+              - pkgs/by-name/mu/muffin/**/*
+              - pkgs/by-name/ne/nemo/**/*
+              - pkgs/by-name/ne/nemo-*/**/*
 
 "6.topic: continuous integration":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - .github/**/*
-        - ci/**/*.*
+      - changed-files:
+          - any-glob-to-any-file:
+              - .github/**/*
+              - ci/**/*.*
 
 "6.topic: coq":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/applications/science/logic/coq/**/*
-        - pkgs/development/coq-modules/**/*
-        - pkgs/top-level/coq-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/applications/science/logic/coq/**/*
+              - pkgs/development/coq-modules/**/*
+              - pkgs/top-level/coq-packages.nix
 
 "6.topic: COSMIC":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/desktop-managers/cosmic.nix
-        - nixos/modules/services/display-managers/cosmic-greeter.nix
-        - nixos/tests/cosmic.nix
-        - pkgs/by-name/co/cosmic-*/**/*
-        - pkgs/by-name/xd/xdg-desktop-portal-cosmic/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/desktop-managers/cosmic.nix
+              - nixos/modules/services/display-managers/cosmic-greeter.nix
+              - nixos/tests/cosmic.nix
+              - pkgs/by-name/co/cosmic-*/**/*
+              - pkgs/by-name/xd/xdg-desktop-portal-cosmic/*
 
 "6.topic: crystal":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/development/compilers/crystal/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/development/compilers/crystal/**/*
 
 "6.topic: cuda":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/development/cuda-modules/**/*
-        - pkgs/top-level/cuda-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/development/cuda-modules/**/*
+              - pkgs/top-level/cuda-packages.nix
 
 "6.topic: deepin":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/desktops/deepin/**/*
-        - pkgs/desktops/deepin/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/desktops/deepin/**/*
+              - pkgs/desktops/deepin/**/*
 
 "6.topic: docker tools":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/applications/virtualization/docker/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/applications/virtualization/docker/**/*
 
 "6.topic: dotnet":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/dotnet.section.md
-        - maintainers/scripts/update-dotnet-lockfiles.nix
-        - pkgs/build-support/dotnet/**/*
-        - pkgs/development/compilers/dotnet/**/*
-        - pkgs/test/dotnet/**/*
-        - pkgs/top-level/dotnet-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/dotnet.section.md
+              - maintainers/scripts/update-dotnet-lockfiles.nix
+              - pkgs/build-support/dotnet/**/*
+              - pkgs/development/compilers/dotnet/**/*
+              - pkgs/test/dotnet/**/*
+              - pkgs/top-level/dotnet-packages.nix
 
 "6.topic: emacs":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/editors/emacs.nix
-        - nixos/modules/services/editors/emacs.xml
-        - nixos/tests/emacs-daemon.nix
-        - pkgs/applications/editors/emacs/build-support/**/*
-        - pkgs/applications/editors/emacs/elisp-packages/**/*
-        - pkgs/applications/editors/emacs/**/*
-        - pkgs/top-level/emacs-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/editors/emacs.nix
+              - nixos/modules/services/editors/emacs.xml
+              - nixos/tests/emacs-daemon.nix
+              - pkgs/applications/editors/emacs/build-support/**/*
+              - pkgs/applications/editors/emacs/elisp-packages/**/*
+              - pkgs/applications/editors/emacs/**/*
+              - pkgs/top-level/emacs-packages.nix
 
 "6.topic: Enlightenment DE":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/x11/desktop-managers/enlightenment.nix
-        - pkgs/desktops/enlightenment/**/*
-        - pkgs/development/python-modules/python-efl/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/x11/desktop-managers/enlightenment.nix
+              - pkgs/desktops/enlightenment/**/*
+              - pkgs/development/python-modules/python-efl/*
 
 "6.topic: erlang":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/beam.section.md
-        - pkgs/development/beam-modules/**/*
-        - pkgs/development/interpreters/elixir/**/*
-        - pkgs/development/interpreters/erlang/**/*
-        - pkgs/development/tools/build-managers/rebar/**/*
-        - pkgs/development/tools/build-managers/rebar3/**/*
-        - pkgs/development/tools/erlang/**/*
-        - pkgs/top-level/beam-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/beam.section.md
+              - pkgs/development/beam-modules/**/*
+              - pkgs/development/interpreters/elixir/**/*
+              - pkgs/development/interpreters/erlang/**/*
+              - pkgs/development/tools/build-managers/rebar/**/*
+              - pkgs/development/tools/build-managers/rebar3/**/*
+              - pkgs/development/tools/erlang/**/*
+              - pkgs/top-level/beam-packages.nix
 
 "6.topic: fetch":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/build-support/fetch*/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/build-support/fetch*/**/*
 
 "6.topic: flakes":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - '**/flake.nix'
-        - lib/systems/flake-systems.nix
-        - nixos/modules/config/nix-flakes.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - '**/flake.nix'
+              - lib/systems/flake-systems.nix
+              - nixos/modules/config/nix-flakes.nix
 
 "6.topic: flutter":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/build-support/flutter/*.nix
-        - pkgs/development/compilers/flutter/**/*.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/build-support/flutter/*.nix
+              - pkgs/development/compilers/flutter/**/*.nix
 
 "6.topic: games":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/games/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/games/**/*
 
 "6.topic: GNOME":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/gnome.section.md
-        - nixos/modules/services/desktops/gnome/**/*
-        - nixos/modules/services/desktop-managers/gnome.nix
-        - nixos/tests/gnome-xorg.nix
-        - nixos/tests/gnome.nix
-        - pkgs/desktops/gnome/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/gnome.section.md
+              - nixos/modules/services/desktops/gnome/**/*
+              - nixos/modules/services/desktop-managers/gnome.nix
+              - nixos/tests/gnome-xorg.nix
+              - nixos/tests/gnome.nix
+              - pkgs/desktops/gnome/**/*
 
 "6.topic: golang":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/go.section.md
-        - pkgs/build-support/go/**/*
-        - pkgs/development/compilers/go/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/go.section.md
+              - pkgs/build-support/go/**/*
+              - pkgs/development/compilers/go/**/*
 
 "6.topic: hardware":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/hardware/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/hardware/**/*
 
 "6.topic: haskell":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/haskell.section.md
-        - maintainers/scripts/haskell/**/*
-        - pkgs/development/compilers/ghc/**/*
-        - pkgs/development/haskell-modules/**/*
-        - pkgs/development/tools/haskell/**/*
-        - pkgs/test/haskell/**/*
-        - pkgs/top-level/haskell-packages.nix
-        - pkgs/top-level/release-haskell.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/haskell.section.md
+              - maintainers/scripts/haskell/**/*
+              - pkgs/development/compilers/ghc/**/*
+              - pkgs/development/haskell-modules/**/*
+              - pkgs/development/tools/haskell/**/*
+              - pkgs/test/haskell/**/*
+              - pkgs/top-level/haskell-packages.nix
+              - pkgs/top-level/release-haskell.nix
 
 "6.topic: java":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        # Distributions
-        - pkgs/development/compilers/adoptopenjdk-icedtea-web/**/*
-        - pkgs/development/compilers/corretto/**/*
-        - pkgs/development/compilers/graalvm/**/*
-        - pkgs/development/compilers/openjdk/**/*
-        - pkgs/by-name/op/openjfx/**/*
-        - pkgs/development/compilers/semeru-bin/**/*
-        - pkgs/development/compilers/temurin-bin/**/*
-        - pkgs/development/compilers/zulu/**/*
-        # Documentation
-        - doc/languages-frameworks/java.section.md
-        # Gradle
-        - doc/languages-frameworks/gradle.section.md
-        - pkgs/development/tools/build-managers/gradle/**/*
-        - pkgs/by-name/gr/gradle-completion/**/*
-        # Maven
-        - pkgs/by-name/ma/maven/**/*
-        - doc/languages-frameworks/maven.section.md
-        # Ant
-        - pkgs/by-name/an/ant/**/*
-        # javaPackages attrset
-        - pkgs/development/java-modules/**/*
-        - pkgs/top-level/java-packages.nix
-        # Maintainer tooling
-        - pkgs/by-name/ni/nixpkgs-openjdk-updater/**/*
-        # Misc
-        - nixos/modules/programs/java.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              # Distributions
+              - pkgs/development/compilers/adoptopenjdk-icedtea-web/**/*
+              - pkgs/development/compilers/corretto/**/*
+              - pkgs/development/compilers/graalvm/**/*
+              - pkgs/development/compilers/openjdk/**/*
+              - pkgs/by-name/op/openjfx/**/*
+              - pkgs/development/compilers/semeru-bin/**/*
+              - pkgs/development/compilers/temurin-bin/**/*
+              - pkgs/development/compilers/zulu/**/*
+              # Documentation
+              - doc/languages-frameworks/java.section.md
+              # Gradle
+              - doc/languages-frameworks/gradle.section.md
+              - pkgs/development/tools/build-managers/gradle/**/*
+              - pkgs/by-name/gr/gradle-completion/**/*
+              # Maven
+              - pkgs/by-name/ma/maven/**/*
+              - doc/languages-frameworks/maven.section.md
+              # Ant
+              - pkgs/by-name/an/ant/**/*
+              # javaPackages attrset
+              - pkgs/development/java-modules/**/*
+              - pkgs/top-level/java-packages.nix
+              # Maintainer tooling
+              - pkgs/by-name/ni/nixpkgs-openjdk-updater/**/*
+              # Misc
+              - nixos/modules/programs/java.nix
 
 "6.topic: jitsi":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/networking/jitsi-videobridge.nix
-        - nixos/modules/services/web-apps/jitsi-meet.nix
-        - pkgs/servers/web-apps/jitsi-meet/**/*
-        - pkgs/servers/jitsi-videobridge/**/*
-        - pkgs/applications/networking/instant-messengers/jitsi/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/networking/jitsi-videobridge.nix
+              - nixos/modules/services/web-apps/jitsi-meet.nix
+              - pkgs/servers/web-apps/jitsi-meet/**/*
+              - pkgs/servers/jitsi-videobridge/**/*
+              - pkgs/applications/networking/instant-messengers/jitsi/**/*
 
 "6.topic: julia":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/julia.section.md
-        - pkgs/development/compilers/julia/**/*
-        - pkgs/development/julia-modules/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/julia.section.md
+              - pkgs/development/compilers/julia/**/*
+              - pkgs/development/julia-modules/**/*
 
 "6.topic: jupyter":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/development/python-modules/jupyter*/**/*
-        - pkgs/development/python-modules/mkdocs-jupyter/*
-        - nixos/modules/services/development/jupyter/**/*
-        - pkgs/applications/editors/jupyter-kernels/**/*
-        - pkgs/applications/editors/jupyter/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/development/python-modules/jupyter*/**/*
+              - pkgs/development/python-modules/mkdocs-jupyter/*
+              - nixos/modules/services/development/jupyter/**/*
+              - pkgs/applications/editors/jupyter-kernels/**/*
+              - pkgs/applications/editors/jupyter/**/*
 
 "6.topic: k3s":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/cluster/k3s/**/*
-        - nixos/tests/k3s/**/*
-        - pkgs/applications/networking/cluster/k3s/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/cluster/k3s/**/*
+              - nixos/tests/k3s/**/*
+              - pkgs/applications/networking/cluster/k3s/**/*
 
 "6.topic: kernel":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/build-support/kernel/**/*
-        - pkgs/os-specific/linux/kernel/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/build-support/kernel/**/*
+              - pkgs/os-specific/linux/kernel/**/*
 
 "6.topic: lib":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - lib/**
+      - changed-files:
+          - any-glob-to-any-file:
+              - lib/**
 
 "6.topic: llvm/clang":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/development/compilers/llvm/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/development/compilers/llvm/**/*
 
 "6.topic: lua":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/development/tools/misc/luarocks/*
-        - pkgs/development/interpreters/lua-5/**/*
-        - pkgs/development/interpreters/luajit/**/*
-        - pkgs/development/lua-modules/**/*
-        - pkgs/top-level/lua-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/development/tools/misc/luarocks/*
+              - pkgs/development/interpreters/lua-5/**/*
+              - pkgs/development/interpreters/luajit/**/*
+              - pkgs/development/lua-modules/**/*
+              - pkgs/top-level/lua-packages.nix
 
 "6.topic: Lumina DE":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/x11/desktop-managers/lumina.nix
-        - pkgs/desktops/lumina/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/x11/desktop-managers/lumina.nix
+              - pkgs/desktops/lumina/**/*
 
 "6.topic: LXQt":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/x11/desktop-managers/lxqt.nix
-        - pkgs/desktops/lxqt/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/x11/desktop-managers/lxqt.nix
+              - pkgs/desktops/lxqt/**/*
 
 "6.topic: mate":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/x11/desktop-managers/mate.nix
-        - nixos/tests/mate.nix
-        - pkgs/desktops/mate/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/x11/desktop-managers/mate.nix
+              - nixos/tests/mate.nix
+              - pkgs/desktops/mate/**/*
 
 "6.topic: module system":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - lib/modules.nix
-        - lib/types.nix
-        - lib/options.nix
-        - lib/tests/modules.sh
-        - lib/tests/modules/**
+      - changed-files:
+          - any-glob-to-any-file:
+              - lib/modules.nix
+              - lib/types.nix
+              - lib/options.nix
+              - lib/tests/modules.sh
+              - lib/tests/modules/**
 
 "6.topic: musl":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/os-specific/linux/musl/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/os-specific/linux/musl/**/*
 
 "6.topic: nim":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/nim.section.md
-        - pkgs/build-support/build-nim-package.nix
-        - pkgs/build-support/build-nim-sbom.nix
-        - pkgs/by-name/ni/nim*
-        - pkgs/top-level/nim-overrides.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/nim.section.md
+              - pkgs/build-support/build-nim-package.nix
+              - pkgs/build-support/build-nim-sbom.nix
+              - pkgs/by-name/ni/nim*
+              - pkgs/top-level/nim-overrides.nix
 
 "6.topic: nixos":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/**/*
-        - pkgs/by-name/sw/switch-to-configuration-ng/**/*
-        - pkgs/by-name/ni/nixos-rebuild-ng/**/*
-        - pkgs/os-specific/linux/nixos-rebuild/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/**/*
+              - pkgs/by-name/sw/switch-to-configuration-ng/**/*
+              - pkgs/by-name/ni/nixos-rebuild-ng/**/*
+              - pkgs/os-specific/linux/nixos-rebuild/**/*
 
 "6.topic: nixos-container":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/virtualisation/nixos-containers.nix
-        - pkgs/tools/virtualization/nixos-container/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/virtualisation/nixos-containers.nix
+              - pkgs/tools/virtualization/nixos-container/**/*
 
 "6.topic: nodejs":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/javascript.section.md
-        - pkgs/build-support/node/**/*
-        - pkgs/development/node-packages/**/*
-        - pkgs/development/tools/yarn/*
-        - pkgs/development/tools/yarn2nix-moretea/**/*
-        - pkgs/development/tools/pnpm/**/*
-        - pkgs/development/web/nodejs/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/javascript.section.md
+              - pkgs/build-support/node/**/*
+              - pkgs/development/node-packages/**/*
+              - pkgs/development/tools/yarn/*
+              - pkgs/development/tools/yarn2nix-moretea/**/*
+              - pkgs/development/tools/pnpm/**/*
+              - pkgs/development/web/nodejs/*
 
 "6.topic: nvidia":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/hardware/video/nvidia.nix
-        - nixos/modules/services/hardware/nvidia-container-toolkit/**/*
-        - nixos/modules/services/hardware/nvidia-optimus.nix
-        - pkgs/os-specific/linux/nvidia-x11/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/hardware/video/nvidia.nix
+              - nixos/modules/services/hardware/nvidia-container-toolkit/**/*
+              - nixos/modules/services/hardware/nvidia-optimus.nix
+              - pkgs/os-specific/linux/nvidia-x11/**/*
 
 "6.topic: ocaml":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/ocaml.section.md
-        - pkgs/development/compilers/ocaml/**/*
-        - pkgs/development/compilers/reason/**/*
-        - pkgs/development/ocaml-modules/**/*
-        - pkgs/development/tools/ocaml/**/*
-        - pkgs/top-level/ocaml-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/ocaml.section.md
+              - pkgs/development/compilers/ocaml/**/*
+              - pkgs/development/compilers/reason/**/*
+              - pkgs/development/ocaml-modules/**/*
+              - pkgs/development/tools/ocaml/**/*
+              - pkgs/top-level/ocaml-packages.nix
 
 "6.topic: pantheon":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/desktops/pantheon/**/*
-        - nixos/modules/services/x11/desktop-managers/pantheon.nix
-        - nixos/modules/services/x11/display-managers/lightdm-greeters/pantheon.nix
-        - nixos/tests/pantheon.nix
-        - pkgs/desktops/pantheon/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/desktops/pantheon/**/*
+              - nixos/modules/services/x11/desktop-managers/pantheon.nix
+              - nixos/modules/services/x11/display-managers/lightdm-greeters/pantheon.nix
+              - nixos/tests/pantheon.nix
+              - pkgs/desktops/pantheon/**/*
 
 "6.topic: php":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/php.section.md
-        - nixos/tests/php/**/*
-        - pkgs/build-support/php/**/*
-        - pkgs/development/interpreters/php/**/*
-        - pkgs/development/php-packages/**/*
-        - pkgs/test/php/default.nix
-        - pkgs/top-level/php-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/php.section.md
+              - nixos/tests/php/**/*
+              - pkgs/build-support/php/**/*
+              - pkgs/development/interpreters/php/**/*
+              - pkgs/development/php-packages/**/*
+              - pkgs/test/php/default.nix
+              - pkgs/top-level/php-packages.nix
 
 "6.topic: printing":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/services/printing/cupsd.nix
-        - pkgs/misc/cups/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/services/printing/cupsd.nix
+              - pkgs/misc/cups/**/*
 
 "6.topic: python":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/python.section.md
-        - pkgs/development/interpreters/python/**/*
-        - pkgs/development/python-modules/**/*
-        - pkgs/top-level/python-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/python.section.md
+              - pkgs/development/interpreters/python/**/*
+              - pkgs/development/python-modules/**/*
+              - pkgs/top-level/python-packages.nix
 
 "6.topic: qt/kde":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/qt.section.md
-        - nixos/modules/services/x11/desktop-managers/plasma5.nix
-        - nixos/tests/plasma5.nix
-        - pkgs/applications/kde/**/*
-        - pkgs/desktops/plasma-5/**/*
-        - pkgs/development/libraries/kde-frameworks/**/*
-        - pkgs/development/libraries/qt-5/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/qt.section.md
+              - nixos/modules/services/x11/desktop-managers/plasma5.nix
+              - nixos/tests/plasma5.nix
+              - pkgs/applications/kde/**/*
+              - pkgs/desktops/plasma-5/**/*
+              - pkgs/development/libraries/kde-frameworks/**/*
+              - pkgs/development/libraries/qt-5/**/*
 
 "6.topic: R":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/applications/science/math/R/**/*
-        - pkgs/development/r-modules/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/applications/science/math/R/**/*
+              - pkgs/development/r-modules/**/*
 
 "6.topic: rocm":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/development/rocm-modules/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/development/rocm-modules/**/*
 
 "6.topic: ruby":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/ruby.section.md
-        - pkgs/development/interpreters/ruby/**/*
-        - pkgs/development/ruby-modules/**/*
-        - pkgs/top-level/ruby-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/ruby.section.md
+              - pkgs/development/interpreters/ruby/**/*
+              - pkgs/development/ruby-modules/**/*
+              - pkgs/top-level/ruby-packages.nix
 
 "6.topic: rust":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/rust.section.md
-        - pkgs/build-support/rust/**/*
-        - pkgs/development/compilers/rust/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/rust.section.md
+              - pkgs/build-support/rust/**/*
+              - pkgs/development/compilers/rust/**/*
 
 "6.topic: stdenv":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/stdenv/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/stdenv/**/*
 
 "6.topic: steam":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/games/steam/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/games/steam/**/*
 
 "6.topic: systemd":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/os-specific/linux/systemd/**/*
-        - nixos/modules/system/boot/systemd*/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/os-specific/linux/systemd/**/*
+              - nixos/modules/system/boot/systemd*/**/*
 
 "6.topic: tcl":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/tcl.section.md
-        - pkgs/development/interpreters/tcl/*
-        - pkgs/development/tcl-modules/**/*
-        - pkgs/top-level/tcl-packages.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/tcl.section.md
+              - pkgs/development/interpreters/tcl/*
+              - pkgs/development/tcl-modules/**/*
+              - pkgs/top-level/tcl-packages.nix
 
 "6.topic: teams":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-          - maintainers/team-list.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - maintainers/team-list.nix
 
 "6.topic: testing":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        # NOTE: Let's keep the scope limited to test frameworks that are
-        #       *developed in this repo*;
-        #       - not individual tests
-        #       - not packages for test frameworks
-        - pkgs/build-support/testers/**
-        - nixos/lib/testing/**
-        - nixos/lib/test-driver/**
-        - nixos/tests/nixos-test-driver/**
-        - nixos/lib/testing-python.nix      # legacy
-        - nixos/tests/make-test-python.nix  # legacy
-        # lib/debug.nix has a test framework (runTests) but it's not the main focus
+      - changed-files:
+          - any-glob-to-any-file:
+              # NOTE: Let's keep the scope limited to test frameworks that are
+              #       *developed in this repo*;
+              #       - not individual tests
+              #       - not packages for test frameworks
+              - pkgs/build-support/testers/**
+              - nixos/lib/testing/**
+              - nixos/lib/test-driver/**
+              - nixos/tests/nixos-test-driver/**
+              - nixos/lib/testing-python.nix # legacy
+              - nixos/tests/make-test-python.nix # legacy
+              # lib/debug.nix has a test framework (runTests) but it's not the main focus
 
 "6.topic: TeX":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/texlive.section.md
-        - pkgs/test/texlive/**
-        - pkgs/tools/typesetting/tex/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/texlive.section.md
+              - pkgs/test/texlive/**
+              - pkgs/tools/typesetting/tex/**/*
 
 "6.topic: updaters":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/common-updater/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/common-updater/**/*
 
 "6.topic: vim":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/languages-frameworks/vim.section.md
-        - pkgs/applications/editors/vim/**/*
-        - pkgs/applications/editors/vim/plugins/**/*
-        - nixos/modules/programs/neovim.nix
-        - pkgs/applications/editors/neovim/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - doc/languages-frameworks/vim.section.md
+              - pkgs/applications/editors/vim/**/*
+              - pkgs/applications/editors/vim/plugins/**/*
+              - nixos/modules/programs/neovim.nix
+              - pkgs/applications/editors/neovim/**/*
 
 "6.topic: vscode":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/applications/editors/vscode/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/applications/editors/vscode/**/*
 
 "6.topic: windows":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/os-specific/windows/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/os-specific/windows/**/*
 
 "6.topic: xen-project":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/virtualisation/xen*
-        - pkgs/by-name/xe/xen/*
-        - pkgs/by-name/qe/qemu_xen/*
-        - pkgs/by-name/xe/xen-guest-agent/*
-        - pkgs/by-name/xt/xtf/*
-        - pkgs/build-support/xen/*
-        - pkgs/development/ocaml-modules/xen*/*
-        - pkgs/development/ocaml-modules/vchan/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/virtualisation/xen*
+              - pkgs/by-name/xe/xen/*
+              - pkgs/by-name/qe/qemu_xen/*
+              - pkgs/by-name/xe/xen-guest-agent/*
+              - pkgs/by-name/xt/xtf/*
+              - pkgs/build-support/xen/*
+              - pkgs/development/ocaml-modules/xen*/*
+              - pkgs/development/ocaml-modules/vchan/*
 
 "6.topic: xfce":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/doc/manual/configuration/xfce.xml
-        - nixos/modules/services/x11/desktop-managers/xfce.nix
-        - nixos/tests/xfce.nix
-        - pkgs/desktops/xfce/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/doc/manual/configuration/xfce.xml
+              - nixos/modules/services/x11/desktop-managers/xfce.nix
+              - nixos/tests/xfce.nix
+              - pkgs/desktops/xfce/**/*
 
 "6.topic: zig":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - pkgs/development/compilers/zig/**/*
-        - doc/hooks/zig.section.md
+      - changed-files:
+          - any-glob-to-any-file:
+              - pkgs/development/compilers/zig/**/*
+              - doc/hooks/zig.section.md
 
 "8.has: changelog":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/doc/manual/release-notes/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/doc/manual/release-notes/**/*
 
 "8.has: maintainer-list (update)":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - maintainers/maintainer-list.nix
+      - changed-files:
+          - any-glob-to-any-file:
+              - maintainers/maintainer-list.nix
 
 "8.has: module (update)":
   - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - nixos/modules/**/*
+      - changed-files:
+          - any-glob-to-any-file:
+              - nixos/modules/**/*
 
 # keep-sorted end

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -52,7 +52,7 @@ jobs:
   outpaths:
     name: Outpaths
     runs-on: ubuntu-24.04-arm
-    needs: [ prepare ]
+    needs: [prepare]
     strategy:
       fail-fast: false
       matrix:
@@ -163,7 +163,7 @@ jobs:
   compare:
     name: Comparison
     runs-on: ubuntu-24.04-arm
-    needs: [ prepare, outpaths ]
+    needs: [prepare, outpaths]
     if: needs.prepare.outputs.targetSha
     permissions:
       issues: write # needed to create *new* labels
@@ -294,7 +294,7 @@ jobs:
     # No dependency on "compare", so that it can start at the same time.
     # We only wait for the "comparison" artifact to be available, which makes the start-to-finish time
     # for the eval workflow considerably faster.
-    needs: [ prepare, outpaths ]
+    needs: [prepare, outpaths]
     if: needs.prepare.outputs.targetSha
     uses: ./.github/workflows/reviewers.yml
     secrets: inherit

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -11,7 +11,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Merge every 24 hours
-    - cron:  '0 0 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -11,7 +11,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Merge every 6 hours
-    - cron:  '0 */6 * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -52,6 +52,21 @@ let
         # See https://github.com/NixOS/nixfmt
         programs.nixfmt.enable = true;
 
+        programs.yamlfmt = {
+          enable = true;
+          settings.formatter = {
+            retain_line_breaks = true;
+          };
+        };
+        settings.formatter.yamlfmt.excludes = [
+          # Breaks helm templating
+          "nixos/tests/k3s/k3s-test-chart/templates/*"
+          # Aligns comments with whitespace
+          "pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml"
+          # TODO: Fix formatting for auto-generated file
+          "pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml"
+        ];
+
         settings.formatter.editorconfig-checker = {
           command = "${pkgs.lib.getExe pkgs.editorconfig-checker}";
           options = [ "-disable-indent-size" ];

--- a/pkgs/by-name/an/antora/test/minimal_working_example/antora.yml
+++ b/pkgs/by-name/an/antora/test/minimal_working_example/antora.yml
@@ -1,4 +1,3 @@
----
 name: Antora
 
 nav:

--- a/pkgs/by-name/tf/tfk8s/tests/sample1/input.yaml
+++ b/pkgs/by-name/tf/tfk8s/tests/sample1/input.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/pkgs/development/julia-modules/tests/julia-top-n/package.yaml
+++ b/pkgs/development/julia-modules/tests/julia-top-n/package.yaml
@@ -1,38 +1,38 @@
-name:                julia-top-n
-version:             0.1.0.0
-license:             BSD-3-Clause
-author:              "Tom McLaughlin"
-maintainer:          "tom@codedown.io"
+name: julia-top-n
+version: 0.1.0.0
+license: BSD-3-Clause
+author: "Tom McLaughlin"
+maintainer: "tom@codedown.io"
 
 dependencies:
-- aeson
-- base >= 4.7 && < 5
-- bytestring
-- filepath
-- optparse-applicative
-- sandwich
-- string-interpolate
-- text
-- unliftio
-- vector
-- yaml
+  - aeson
+  - base >= 4.7 && < 5
+  - bytestring
+  - filepath
+  - optparse-applicative
+  - sandwich
+  - string-interpolate
+  - text
+  - unliftio
+  - vector
+  - yaml
 
 ghc-options:
-- -Wall
-- -Wcompat
-- -Widentities
-- -Wincomplete-record-updates
-- -Wincomplete-uni-patterns
-- -Wmissing-export-lists
-- -Wmissing-home-modules
-- -Wpartial-fields
-- -Wredundant-constraints
+  - -Wall
+  - -Wcompat
+  - -Widentities
+  - -Wincomplete-record-updates
+  - -Wincomplete-uni-patterns
+  - -Wmissing-export-lists
+  - -Wmissing-home-modules
+  - -Wpartial-fields
+  - -Wredundant-constraints
 
 executables:
   julia-top-n-exe:
-    main:                Main.hs
-    source-dirs:         app
+    main: Main.hs
+    source-dirs: app
     ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N

--- a/pkgs/development/julia-modules/tests/julia-top-n/stack.yaml
+++ b/pkgs/development/julia-modules/tests/julia-top-n/stack.yaml
@@ -3,9 +3,9 @@ resolver:
   url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/4.yaml
 
 packages:
-- .
+  - .
 
 nix:
   pure: false
   packages:
-  - zlib
+    - zlib


### PR DESCRIPTION
Most workflow files are already well formatted, but to make it easier to keep it that way, we can add yamlfmt.

I personally have a preference for non-indented arrays for YAML, but wanted to avoid bigger diffs here - the status-quo clearly are indented arrays.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
