### PR TITLE
nixos/zrepl: Improve tests

### DIFF
--- a/nixos/tests/zrepl.nix
+++ b/nixos/tests/zrepl.nix
@@ -1,76 +1,178 @@
 {
   name = "zrepl";
 
-  nodes.host =
-    { pkgs, ... }:
-    {
-      config = {
-        # Prerequisites for ZFS and tests.
-        boot.supportedFilesystems = [ "zfs" ];
-        environment.systemPackages = [ pkgs.zrepl ];
-        networking.hostId = "deadbeef";
-        services.zrepl = {
-          enable = true;
-          settings = {
-            # Enable Prometheus output for status assertions.
-            global.monitoring = [
-              {
-                type = "prometheus";
-                listen = ":9811";
-              }
-            ];
-            # Create a periodic snapshot job for an ephemeral zpool.
-            jobs = [
-              {
-                name = "snap_test";
-                type = "snap";
+  nodes = {
+    source =
+      { nodes, pkgs, ... }:
+      {
+        config = {
+          # Prerequisites for ZFS and tests.
+          virtualisation.emptyDiskImages = [
+            2048
+          ];
 
-                filesystems."test" = true;
-                snapshotting = {
-                  type = "periodic";
-                  prefix = "zrepl_";
-                  interval = "1s";
-                };
+          boot.supportedFilesystems = [ "zfs" ];
+          environment.systemPackages = [
+            pkgs.parted
+            pkgs.zrepl
+          ];
+          networking.firewall.allowedTCPPorts = [ 8888 ];
+          networking.hostId = "deadbeef";
+          services.zrepl = {
+            enable = true;
+            settings = {
+              # Enable Prometheus output for status assertions.
+              global.monitoring = [
+                {
+                  type = "prometheus";
+                  listen = ":9811";
+                }
+              ];
+              # Create a periodic snapshot job for an ephemeral zpool.
+              jobs = [
+                {
+                  name = "snapshots";
+                  type = "snap";
 
-                pruning.keep = [
-                  {
-                    type = "last_n";
-                    count = 8;
-                  }
-                ];
-              }
-            ];
+                  filesystems."tank/data" = true;
+                  snapshotting = {
+                    type = "periodic";
+                    prefix = "zrepl_";
+                    interval = "10s";
+                  };
+
+                  pruning.keep = [
+                    {
+                      type = "last_n";
+                      count = 8;
+                    }
+                  ];
+                }
+                {
+                  name = "backup-target";
+                  type = "source";
+
+                  serve = {
+                    type = "tcp";
+                    listen = ":8888";
+
+                    clients = {
+                      "${nodes.target.networking.primaryIPAddress}" = "${nodes.target.networking.hostName}";
+                      "${nodes.target.networking.primaryIPv6Address}" = "${nodes.target.networking.hostName}";
+                    };
+                  };
+                  filesystems."tank/data" = true;
+                  # Snapshots are handled by the separate snap job
+                  snapshotting = {
+                    type = "manual";
+                  };
+                }
+              ];
+            };
           };
         };
       };
-    };
+
+    target =
+      { pkgs, ... }:
+      {
+        config = {
+          # Prerequisites for ZFS and tests.
+          virtualisation.emptyDiskImages = [
+            2048
+          ];
+
+          boot.supportedFilesystems = [ "zfs" ];
+          environment.systemPackages = [
+            pkgs.parted
+            pkgs.zrepl
+          ];
+          networking.hostId = "deadd0d0";
+          services.zrepl = {
+            enable = true;
+            settings = {
+              # Enable Prometheus output for status assertions.
+              global.monitoring = [
+                {
+                  type = "prometheus";
+                  listen = ":9811";
+                }
+              ];
+              jobs = [
+                {
+                  name = "source-pull";
+                  type = "pull";
+
+                  connect = {
+                    type = "tcp";
+                    address = "source:8888";
+                  };
+                  root_fs = "tank/zrepl/source";
+                  interval = "15s";
+                  recv = {
+                    placeholder = {
+                      encryption = "off";
+                    };
+                  };
+                  pruning = {
+                    keep_sender = [
+                      {
+                        type = "regex";
+                        regex = ".*";
+                      }
+                    ];
+                    keep_receiver = [
+                      {
+                        type = "grid";
+                        grid = "1x1h(keep=all) | 24x1h";
+                        regex = "^zrepl_";
+                      }
+                    ];
+                  };
+                }
+              ];
+            };
+          };
+        };
+      };
+  };
 
   testScript = ''
     start_all()
 
     with subtest("Wait for zrepl and network ready"):
-        host.systemctl("start network-online.target")
-        host.wait_for_unit("network-online.target")
-        host.wait_for_unit("zrepl.service")
+        for machine in source, target:
+          machine.systemctl("start network-online.target")
+          machine.wait_for_unit("network-online.target")
+          machine.wait_for_unit("zrepl.service")
 
-    with subtest("Create test zpool"):
-        # ZFS requires 64MiB minimum pool size.
-        host.succeed("fallocate -l 64MiB /root/zpool.img")
-        host.succeed("zpool create test /root/zpool.img")
+    with subtest("Create tank zpool"):
+        for machine in source, target:
+          machine.succeed(
+            "parted --script /dev/vdb mklabel gpt",
+            "zpool create tank /dev/vdb",
+          )
 
-    with subtest("Check for completed zrepl snapshot"):
+    # Create ZFS datasets
+    source.succeed("zfs create tank/data")
+    target.succeed("zfs create -p tank/zrepl/source")
+
+    with subtest("Check for completed zrepl snapshot on target"):
         # zrepl periodic snapshot job creates a snapshot with this prefix.
-        host.wait_until_succeeds("zfs list -t snapshot | grep -q zrepl_")
+        target.wait_until_succeeds("zfs list -t snapshot | grep -q tank/zrepl/source/tank/data@zrepl_")
+
+    with subtest("Check for completed zrepl bookmark on source"):
+        source.wait_until_succeeds("zfs list -t bookmark | grep -q tank/data#zrepl_")
 
     with subtest("Verify HTTP monitoring server is configured"):
-        out = host.succeed("curl -f localhost:9811/metrics")
+        out = source.succeed("curl -f localhost:9811/metrics")
 
         assert (
             "zrepl_start_time" in out
         ), "zrepl start time metric was not found in Prometheus output"
 
         assert (
-            "zrepl_zfs_snapshot_duration_count{filesystem=\"test\"}" in out
-        ), "zrepl snapshot counter for test was not found in Prometheus output"
+            "zrepl_zfs_snapshot_duration_count{filesystem=\"tank/data\"}" in out
+        ), "zrepl snapshot counter for tank/data was not found in Prometheus output"
   '';
 }


### PR DESCRIPTION
* Use a block device for zpool
* Have two virtual machines so that source->target replication works

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
