### PR TITLE
typespec: 0.64.0 -> 1.1.0

### DIFF
--- a/pkgs/by-name/ty/typespec/package.nix
+++ b/pkgs/by-name/ty/typespec/package.nix
@@ -5,42 +5,47 @@
   makeWrapper,
   nix-update-script,
   nodejs,
-  pnpm_9,
+  pnpm,
   testers,
 }:
 
 let
-  workspace = "compiler...";
+  workspace = "@typespec/compiler...";
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "typespec";
-  version = "0.64.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "typespec";
-    tag = "typespec@${finalAttrs.version}";
-    hash = "sha256-zZTZdnmRTjhnoz/5JHnn4h/YlMpXF/I7o1mDeiRVPUA=";
+    tag = "typespec-stable@${finalAttrs.version}";
+    hash = "sha256-fUrBoDDv0UW5dqudD/bpzaT8SdIc5snI8Q/Fe5jWCvw=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     nodejs
-    pnpm_9.configHook
+    pnpm.configHook
   ];
 
   pnpmWorkspaces = [ workspace ];
-  pnpmDeps = pnpm_9.fetchDeps {
+  pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs)
       pname
       version
       src
       pnpmWorkspaces
+      postPatch
       ;
-    hash = "sha256-W8m6ibiy9Okga0qWpZWDYklXAwpHwk85Q6UTaFJhDrU=";
+    hash = "sha256-9RQZ2ycu78W3Ie6MLpo6x7Sa/iYsUdq5bYed56mOPxs=";
   };
 
   postPatch = ''
+    # The `packageManager` attribute matches the version _exactly_, which makes
+    # the build fail if it doesn't match exactly.
+    substituteInPlace package.json \
+      --replace-fail '"packageManager": "pnpm@10.11.0"' '"packageManager": "pnpm"'
     # `fetchFromGitHub` doesn't clone via git and thus installing would otherwise fail.
     substituteInPlace packages/compiler/scripts/generate-manifest.js \
       --replace-fail 'execSync("git rev-parse HEAD").toString().trim()' '"${finalAttrs.src.rev}"'
@@ -54,12 +59,19 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
+  preInstall = ''
+    # Remove unnecessary files.
+    find -name node_modules -type d -exec rm -rf {} \; || true
+    pnpm config set hoist=false
+    pnpm install --offline --ignore-scripts --frozen-lockfile --filter="@typespec/compiler" --prod --no-optional
+  '';
+
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/bin" "$out/lib/typespec/packages/compiler"
+    mkdir -p "$out/bin" "$out/lib/typespec"
     cp -r --parents \
-      node_modules \
+      node_modules/ \
       package.json \
       packages/compiler/cmd \
       packages/compiler/dist \
@@ -83,7 +95,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   passthru.updateScript = nix-update-script {
-    extraArgs = [ ''--version-regex=typespec@(\d+\.\d+\.\d+)'' ];
+    extraArgs = [ ''--version-regex=typespec-stable@(\d+\.\d+\.\d+)'' ];
   };
 
   meta = {
@@ -97,7 +109,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       All this while keeping your TypeSpec definition as a single source of truth.
     '';
     homepage = "https://typespec.io/";
-    changelog = "https://github.com/microsoft/typespec/releases/tag/typespec@${finalAttrs.version}";
+    changelog = "https://github.com/microsoft/typespec/releases/tag/typespec-stable@${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ paukaifler ];
     mainProgram = "tsp";


### PR DESCRIPTION
Also fixes #388160.

This update took a bit longer because I didn't manage to fix the noBrokenSymlinks issue the first time without including a massive number of unnecessary dependencies, but now I did.
I expect future updates to arrive much quicker.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
