### PR TITLE
graphite-editor: init at 0-unstable-2025-06-09

### DIFF
--- a/pkgs/by-name/gr/graphite-editor/package.nix
+++ b/pkgs/by-name/gr/graphite-editor/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  npmHooks,
+
+  binaryen,
+  cargo-about,
+  cargo-tauri,
+  nodejs,
+  pkg-config,
+  rustc,
+  wasm-bindgen-cli_0_2_100,
+  wasm-pack,
+  wrapGAppsHook4,
+
+  glib,
+  gtk3,
+  glib-networking,
+  libsoup_3,
+  openssl,
+  webkitgtk_4_1,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "graphite-editor";
+  version = "0-unstable-2025-06-09";
+
+  src = fetchFromGitHub {
+    owner = "GraphiteEditor";
+    repo = "Graphite";
+    rev = "5c8cd9a927c60c5348c32ac08fd7501c6aabbf05";
+    hash = "sha256-TRNifCuuAVSWohQLO8PjLlI4uwdHLtQu4Cc5BW1ZijI=";
+  };
+
+  env.npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    src = "${finalAttrs.src}/frontend";
+    hash = "sha256-XXD04aIPasjHtdOE/mcQ7TocRlSfzHGLiYNFWOPHVrM=";
+  };
+
+  buildAndTestSubdir = "frontend/src-tauri";
+
+  cargoHash = "sha256-ni2cHhGv5CVIP+mB56bZFWAA1qUjb8G7pd0+9FcujeA=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cargo-tauri.hook
+    rustc.llvmPackages.lld
+    wasm-bindgen-cli_0_2_100
+    wrapGAppsHook4
+
+    # frontend/ui
+    cargo-about
+    binaryen # wasm-opt
+    rustc # cargo metadata
+    nodejs
+    wasm-pack
+  ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib # gio-2.0
+    glib-networking # networking required to fetch fonts remotely
+    gtk3 # gdk-3.0
+    libsoup_3 # libsoup-3.0
+    openssl
+    webkitgtk_4_1 # javascriptcoregtk-4.1 webkit2gtk-4.1
+  ];
+
+  postPatch = ''
+    (
+      local postPatchHooks=() # written to by npmConfigHook
+      source ${npmHooks.npmConfigHook}/nix-support/setup-hook
+      npmRoot=frontend npmDeps=$npmDeps npmConfigHook
+    )
+  '';
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+    (
+      cd frontend
+      npm run build
+    )
+  '';
+
+  meta = {
+    description = "2D vector & raster editor that melds traditional layers & tools with a modern node-based, non-destructive, procedural workflow";
+    homepage = "https://github.com/GraphiteEditor/Graphite";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jk ];
+    mainProgram = "Graphite";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Resolves #346762

![image](https://github.com/user-attachments/assets/03aa938d-b9d1-465f-83c8-03b04f25fe3a)
Overall it loads up and looks in line with web or other screenshots of desktop. This is one of the demo artwork pieces with a quite large node graph.

We already have `graphite2` and `graphite-cli` for unrelated projects so I thought I'd go with the full name of `graphite-editor` from the org to be safe.

**Outstanding issues**:
* ~Currently text can be entered but disappears after confirming.~
  * Fonts are currently fetched remotely, fixed with glib-networking
* Opens with the inspect/dev toolbar open.
  * Dev tools are opened by default ATM - https://github.com/GraphiteEditor/Graphite/blob/master/frontend/src-tauri/src/main.rs#L65
* Give it a go outside of NixOS on other linux distros.
* Trial on MacOS or filter out.
* Test various features.
* Check build is accurate and matches common setups with tauri in nixpkgs. Some general cleanup.
* Double check with upstream project they're ready for a desktop build to be available at large. May need to hold back or keep it on a nur/flake for the time being since the project is Alpha & the desktop build itself is probably considered pre-alpha. The web option also works fine as a fallback.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
