### PR TITLE
vobcopy: 1.2.0 -> 1.2.1; change upstream

### DIFF
--- a/pkgs/by-name/vo/vobcopy/fix-darwin.patch
+++ b/pkgs/by-name/vo/vobcopy/fix-darwin.patch
@@ -1,0 +1,28 @@
+diff --git a/vobcopy.h b/vobcopy.h
+index dcf4266..d34c2b4 100644
+--- a/vobcopy.h
++++ b/vobcopy.h
+@@ -115,6 +115,7 @@ typedef enum  { FALSE=0, TRUE=1 }  bool;
+ 
+ #ifdef HAVE_SYS_STATVFS_H
+ #include <sys/statvfs.h>
++#ifndef __APPLE__
+ #ifndef USE_STATFS
+ #define USE_STATVFS
+ #ifndef USE_STATFS_FOR_DEV
+@@ -122,6 +123,7 @@ typedef enum  { FALSE=0, TRUE=1 }  bool;
+ #endif
+ #endif
+ #endif
++#endif
+ 
+ #ifdef HAVE_MNTENT_H
+ #include <mntent.h>
+@@ -164,6 +166,6 @@ char *safestrncpy(char *dest, const char *src, size_t n);
+ int check_progress( void ); /* this can be removed because the one below supersedes it */
+ int progressUpdate( int starttime, int cur, int tot, int force );
+ 
+-#ifndef HAVE_FDATASYNC
++#if !defined(HAVE_FDATASYNC) || defined(__APPLE__)
+ #define fdatasync(fd) 0
+ #endif

--- a/pkgs/by-name/vo/vobcopy/package.nix
+++ b/pkgs/by-name/vo/vobcopy/package.nix
@@ -1,32 +1,41 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
+  gettext,
   libdvdread,
   libdvdcss,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "vobcopy";
-  version = "1.2.0";
+  version = "1.2.1-unstable-2023-08-29";
 
-  src = fetchurl {
-    url = "http://www.vobcopy.org/download/vobcopy-${version}.tar.bz2";
-    sha256 = "01l1yihbd73srzghzzx5dgfg3yfb5kml5dix52mq0snhjp8h89c9";
+  src = fetchFromGitHub {
+    owner = "barak";
+    repo = "vobcopy";
+    rev = "cb560b3a67358f51d51ecc0e511f49f09f304a13";
+    hash = "sha256-2EtSO39yOFoCZ5GMqtp+SvmzqSevlqYDo73p0lVHZ3o=";
   };
 
+  # Based on https://github.com/barak/vobcopy/issues/14, but also fixes
+  # "error: call to undeclared function 'fdatasync'". The latter patch
+  # is inspired by https://github.com/php/php-src/commit/e69729f2ba02ddc26c70b4bd88ef86c0a2277bdc
+  patches = [ ./fix-darwin.patch ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
   buildInputs = [
+    gettext # Fails on Darwin otherwise
     libdvdread
     libdvdcss
-  ];
-  makeFlags = [
-    "DESTDIR=$(out)"
-    "PREFIX=/"
   ];
 
   meta = {
     description = "Copies DVD .vob files to harddisk, decrypting them on the way";
-    homepage = "http://vobcopy.org/projects/c/c.shtml";
+    homepage = "https://github.com/barak/vobcopy";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     mainProgram = "vobcopy";


### PR DESCRIPTION
The previous upstream seems to be dead, but a Debian maintainer has a fork.

Fixes GCC 14 build. (Tracking: #388196 #356812)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
