### PR TITLE
deno: 2.3.5 -> 2.3.6, fix tests

### DIFF
--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -3,6 +3,7 @@
   lib,
   callPackage,
   fetchFromGitHub,
+  fetchpatch,
   rustPlatform,
   cmake,
   yq,
@@ -21,6 +22,7 @@
   nodejs,
   git,
   python3,
+  esbuild,
 }:
 
 let
@@ -28,18 +30,26 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "deno";
-  version = "2.3.5";
+  version = "2.3.6";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = "deno";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true; # required for tests
-    hash = "sha256-lu3r1v3iB9NIruooRrV9NawUnKqufqlYJQe+Aumgn8E=";
+    hash = "sha256-l3cWnv2cEmoeecYj38eMIlgqlRjDbtQuc6Q3DmOJoqE=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-XJy7+cARYEX8tAPXLHJnEwXyZIwPaqhM7ZUzoem1Wo0=";
+  cargoHash = "sha256-alvn+d7XTYrw8KXw+k+++J3CsBwAUbQQlh24/EOEzwY=";
+  cargoPatches = [
+    (fetchpatch {
+      name = "fix-sigsegv-on-x86_64-unknown-linux-gnu-targets";
+      url = "https://github.com/denoland/deno/commit/400a9565c335b51d78c8909f4dbf1dbd4fb5e5d8.patch";
+      hash = "sha256-dTIw7P6sB6Esf+lSe/gc3cX54GkzLWF5X55yxP/QYoo=";
+      includes = [ "cli/Cargo.toml" ];
+    })
+  ];
 
   patches = [
     ./tests-replace-hardcoded-paths.patch
@@ -82,11 +92,42 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
   env.RUSTY_V8_ARCHIVE = librusty_v8;
 
-  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # Unset the env var defined by bintools-wrapper because it triggers Deno's sandbox protection in some tests.
-    # ref: https://github.com/denoland/deno/pull/25271
-    unset LD_DYLD_PATH
-  '';
+  # Many tests depend on prebuilt binaries being present at `./third_party/prebuilt`.
+  # We provide nixpkgs binaries for these for all platforms, but the test runner itself only handles
+  # these four arch+platform combinations.
+  doCheck =
+    stdenv.hostPlatform.isDarwin
+    || (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isx86_64));
+
+  preCheck =
+    # Provide esbuild binary at `./third_party/prebuilt/` just like upstream:
+    # https://github.com/denoland/deno_third_party/tree/master/prebuilt
+    # https://github.com/denoland/deno/blob/main/tests/util/server/src/servers/npm_registry.rs#L402
+    let
+      platform =
+        if stdenv.hostPlatform.isLinux then
+          "linux64"
+        else if stdenv.hostPlatform.isDarwin then
+          "mac"
+        else
+          throw "Unsupported platform";
+      arch =
+        if stdenv.hostPlatform.isAarch64 then
+          "aarch64"
+        else if stdenv.hostPlatform.isx86_64 then
+          "x64"
+        else
+          throw "Unsupported architecture";
+    in
+    ''
+      mkdir -p ./third_party/prebuilt/${platform}
+      cp ${lib.getExe esbuild} ./third_party/prebuilt/${platform}/esbuild-${arch}
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # Unset the env var defined by bintools-wrapper because it triggers Deno's sandbox protection in some tests.
+      # ref: https://github.com/denoland/deno/pull/25271
+      unset LD_DYLD_PATH
+    '';
 
   cargoTestFlags = [
     "--lib" # unit tests
@@ -119,6 +160,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
       # Flaky
       "--skip=init::init_subcommand_serve"
+      "--skip=serve::deno_serve_parallel"
+      "--skip=js_unit_tests::stat_test" # timing-sensitive
 
       # Test hangs, needs investigation
       "--skip=repl::pty_complete_imports_no_panic_empty_specifier"

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -56,10 +56,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ./tests-darwin-differences.patch
     ./tests-no-chown.patch
   ];
-  postPatch = ''
-    # Use patched nixpkgs libffi in order to fix https://github.com/libffi/libffi/pull/857
-    tomlq -ti '.workspace.dependencies.libffi = { "version": .workspace.dependencies.libffi, "features": ["system"] }' Cargo.toml
-  '';
+  postPatch =
+    ''
+      # Use patched nixpkgs libffi in order to fix https://github.com/libffi/libffi/pull/857
+      tomlq -ti '.workspace.dependencies.libffi = { "version": .workspace.dependencies.libffi, "features": ["system"] }' Cargo.toml
+    ''
+    +
+      lib.optionalString
+        (stdenv.hostPlatform.isLinux || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64))
+        ''
+          # LTO crashes with the latest Rust + LLVM combination.
+          # https://github.com/rust-lang/rust/issues/141737
+          # TODO: remove this once LLVM is upgraded to 20.1.7
+          tomlq -ti '.profile.release.lto = false' Cargo.toml
+        '';
 
   buildInputs = [
     libffi

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -162,9 +162,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "--skip=init::init_subcommand_serve"
       "--skip=serve::deno_serve_parallel"
       "--skip=js_unit_tests::stat_test" # timing-sensitive
+      "--skip=repl::pty_complete_imports"
+      "--skip=repl::pty_complete_expression"
 
       # Test hangs, needs investigation
       "--skip=repl::pty_complete_imports_no_panic_empty_specifier"
+
+      # Use of VSOCK, might not be available on all platforms
+      "--skip=js_unit_tests::serve_test"
+      "--skip=js_unit_tests::fetch_test"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # Expects specific shared libraries from macOS to be linked


### PR DESCRIPTION
https://github.com/denoland/deno/releases/tag/v2.3.6

Running the tests have become more complicated since https://github.com/denoland/deno/pull/29470 because a prebuilt `esbuild` binary is now required for around half the tests.

Also addresses the crashes reported at #417331. I hope it's okay not to split the changes into multiple commits, my thinking was that the version upgrade is not buildable on all platforms without the test-related fixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [X] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
