### PR TITLE
python3Packages.rosbags: init at 0.10.11

### DIFF
--- a/pkgs/development/python-modules/declinate/default.nix
+++ b/pkgs/development/python-modules/declinate/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "ternaris";
     repo = "declinate";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-JEO/GtbG/yQuj8vJJaWex9mGy6qpWOPHGlKrdG9vt28=";
   };
 
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   meta = {
     description = "Command line interface generator";
     homepage = "https://gitlab.com/ternaris/declinate";
-    changelog = "https://gitlab.com/ternaris/declinate/-/blob/${src.rev}/CHANGES.rst";
+    changelog = "https://gitlab.com/ternaris/declinate/-/blob/${src.tag}/CHANGES.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nim65s ];
   };

--- a/pkgs/development/python-modules/declinate/default.nix
+++ b/pkgs/development/python-modules/declinate/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  typing-extensions,
+
+  # nativeCheckInputs
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "declinate";
+  version = "0.0.6";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "ternaris";
+    repo = "declinate";
+    rev = "v${version}";
+    hash = "sha256-JEO/GtbG/yQuj8vJJaWex9mGy6qpWOPHGlKrdG9vt28=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "declinate"
+  ];
+
+  meta = {
+    description = "Command line interface generator";
+    homepage = "https://gitlab.com/ternaris/declinate";
+    changelog = "https://gitlab.com/ternaris/declinate/-/blob/${src.rev}/CHANGES.rst";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/rosbags/default.nix
+++ b/pkgs/development/python-modules/rosbags/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchFromGitLab {
     owner = "ternaris";
     repo = "rosbags";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-EOuvvC6VTnhZA9M6ZKn0TNjbCm+lXH4/TboDS0hcw1A=";
   };
 
@@ -59,7 +59,7 @@ buildPythonPackage rec {
   meta = {
     description = "Pure Python library to read, modify, convert, and write rosbag files";
     homepage = "https://gitlab.com/ternaris/rosbags";
-    changelog = "https://gitlab.com/ternaris/rosbags/-/blob/${src.rev}/CHANGES.rst";
+    changelog = "https://gitlab.com/ternaris/rosbags/-/blob/${src.tag}/CHANGES.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nim65s ];
   };

--- a/pkgs/development/python-modules/rosbags/default.nix
+++ b/pkgs/development/python-modules/rosbags/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "rosbags";
-  version = "0.10.10";
+  version = "0.10.11";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "ternaris";
     repo = "rosbags";
     tag = "v${version}";
-    hash = "sha256-EOuvvC6VTnhZA9M6ZKn0TNjbCm+lXH4/TboDS0hcw1A=";
+    hash = "sha256-uHRmeHwNswZt5q+RSlzjqZiXhH6qYAkf8AufrRNbBtY=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/rosbags/default.nix
+++ b/pkgs/development/python-modules/rosbags/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  lz4,
+  numpy,
+  ruamel-yaml,
+  typing-extensions,
+  zstandard,
+
+  # nativeCheckInputs
+  pytestCheckHook,
+
+  # checkInputs
+  declinate,
+}:
+
+buildPythonPackage rec {
+  pname = "rosbags";
+  version = "0.10.10";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "ternaris";
+    repo = "rosbags";
+    rev = "v${version}";
+    hash = "sha256-EOuvvC6VTnhZA9M6ZKn0TNjbCm+lXH4/TboDS0hcw1A=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    lz4
+    numpy
+    ruamel-yaml
+    typing-extensions
+    zstandard
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  checkInputs = [
+    declinate
+  ];
+
+  pythonImportsCheck = [
+    "rosbags"
+  ];
+
+  meta = {
+    description = "Pure Python library to read, modify, convert, and write rosbag files";
+    homepage = "https://gitlab.com/ternaris/rosbags";
+    changelog = "https://gitlab.com/ternaris/rosbags/-/blob/${src.rev}/CHANGES.rst";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15510,6 +15510,8 @@ self: super: with self; {
 
   ropper = callPackage ../development/python-modules/ropper { };
 
+  rosbags = callPackage ../development/python-modules/rosbags { };
+
   rotary-embedding-torch = callPackage ../development/python-modules/rotary-embedding-torch { };
 
   rouge-score = callPackage ../development/python-modules/rouge-score { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3373,6 +3373,8 @@ self: super: with self; {
 
   decli = callPackage ../development/python-modules/decli { };
 
+  declinate = callPackage ../development/python-modules/declinate { };
+
   decopatch = callPackage ../development/python-modules/decopatch { };
 
   decora-wifi = callPackage ../development/python-modules/decora-wifi { };


### PR DESCRIPTION
Add a standalone python tool to deal with rosbags, the file format to store data widely used in the ROS ecosystem.
While here, we need declinate for its tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
