### PR TITLE
treewide: pytestFlagsArray -> pytestFlags and join flag and option argument

### DIFF
--- a/pkgs/by-name/ab/ablog/package.nix
+++ b/pkgs/by-name/ab/ablog/package.nix
@@ -39,13 +39,10 @@ python3Packages.buildPythonApplication rec {
     defusedxml
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::sphinx.deprecation.RemovedInSphinx90Warning"
-    "--rootdir"
-    "src/ablog"
-    "-W"
-    "ignore::sphinx.deprecation.RemovedInSphinx90Warning" # Ignore ImportError
+  pytestFlags = [
+    "-Wignore::sphinx.deprecation.RemovedInSphinx90Warning"
+    "--rootdir=src/ablog"
+    "-Wignore::sphinx.deprecation.RemovedInSphinx90Warning" # Ignore ImportError
   ];
 
   # assert "post 1" not in html

--- a/pkgs/by-name/aw/aws-encryption-sdk-cli/package.nix
+++ b/pkgs/by-name/aw/aws-encryption-sdk-cli/package.nix
@@ -60,9 +60,8 @@ localPython.pkgs.buildPythonApplication rec {
   ];
 
   # Upstream did not adapt to pytest 8 yet.
-  pytestFlagsArray = [
-    "-W"
-    "ignore::pytest.PytestRemovedIn8Warning"
+  pytestFlags = [
+    "-Wignore::pytest.PytestRemovedIn8Warning"
   ];
 
   passthru = {

--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -144,7 +144,7 @@ py.pkgs.buildPythonApplication rec {
   # tests/unit/customizations/sso/test_utils.py uses sockets
   __darwinAllowLocalNetworking = true;
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "-Wignore::DeprecationWarning"
   ];
 

--- a/pkgs/by-name/bo/borgbackup/package.nix
+++ b/pkgs/by-name/bo/borgbackup/package.nix
@@ -101,7 +101,7 @@ python.pkgs.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--benchmark-skip"
     "--pyargs"
     "borg.testsuite"

--- a/pkgs/by-name/br/browsr/package.nix
+++ b/pkgs/by-name/br/browsr/package.nix
@@ -71,7 +71,7 @@ python3.pkgs.buildPythonApplication rec {
     "browsr"
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--snapshot-update"
   ];
 

--- a/pkgs/by-name/de/devpi-client/package.nix
+++ b/pkgs/by-name/de/devpi-client/package.nix
@@ -56,7 +56,7 @@ python3.pkgs.buildPythonApplication rec {
     export HOME=$(mktemp -d);
   '';
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # --fast skips tests which try to start a devpi-server improperly
     "--fast"
   ];

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -259,7 +259,7 @@ python.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = with python.pkgs; [ pytestCheckHook ] ++ pythonPath;
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # Always show more information when tests fail
     "-vv"
   ];

--- a/pkgs/by-name/gd/gdal/package.nix
+++ b/pkgs/by-name/gd/gdal/package.nix
@@ -268,7 +268,7 @@ stdenv.mkDerivation (finalAttrs: {
     filelock
     lxml
   ];
-  pytestFlagsArray = [
+  pytestFlags = [
     "--benchmark-disable"
   ];
   disabledTestPaths = [

--- a/pkgs/by-name/ma/maigret/package.nix
+++ b/pkgs/by-name/ma/maigret/package.nix
@@ -80,9 +80,9 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonRemoveDeps = [ "future-annotations" ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # DeprecationWarning: There is no current event loop
-    "-W ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests =

--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -32,7 +32,7 @@ python3Packages.buildPythonApplication {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "-v" ];
+  pytestFlags = [ "-v" ];
   pythonImportsCheck = [ "memtree" ];
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -77,7 +77,7 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "-vv" ];
+  pytestFlags = [ "-vv" ];
 
   makeWrapperArgs = lib.optionals (withTmpdir != null) [
     "--set TMPDIR ${withTmpdir}"

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -103,7 +103,7 @@ python3Packages.buildPythonApplication rec {
     patchShebangs pre_commit/resources/hook-tmpl
   '';
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--forked"
   ];
 

--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -245,9 +245,8 @@ python.pkgs.buildPythonApplication rec {
     ]
     ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [
-    "--reruns"
-    "3"
+  pytestFlags = [
+    "--reruns=3"
   ];
 
   disabledTests = [

--- a/pkgs/by-name/sn/snowflake-cli/package.nix
+++ b/pkgs/by-name/sn/snowflake-cli/package.nix
@@ -52,9 +52,7 @@ python3Packages.buildPythonApplication rec {
     pytest-httpserver
   ];
 
-  pytestFlagsArray = [
-    "-n"
-    "$NIX_BUILD_CORES"
+  pytestFlags = [
     "--snapshot-warn-unused"
   ];
 

--- a/pkgs/development/embedded/fpga/apio/default.nix
+++ b/pkgs/development/embedded/fpga/apio/default.nix
@@ -76,7 +76,7 @@ buildPythonApplication rec {
     "test2"
   ];
 
-  pytestFlagsArray = [ "--offline" ];
+  pytestFlags = [ "--offline" ];
 
   strictDeps = true;
 

--- a/pkgs/development/python-modules/aioazuredevops/default.nix
+++ b/pkgs/development/python-modules/aioazuredevops/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     "test_get_build"
   ];
 
-  pytestFlagsArray = [ "--snapshot-update" ];
+  pytestFlags = [ "--snapshot-update" ];
 
   pythonImportsCheck = [ "aioazuredevops" ];
 

--- a/pkgs/development/python-modules/aioelectricitymaps/default.nix
+++ b/pkgs/development/python-modules/aioelectricitymaps/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "aioelectricitymaps" ];
 
   # https://github.com/jpbede/aioelectricitymaps/pull/415
-  pytestFlagsArray = [ "--snapshot-update" ];
+  pytestFlags = [ "--snapshot-update" ];
 
   meta = with lib; {
     description = "Module for interacting with Electricity maps";

--- a/pkgs/development/python-modules/aiogithubapi/default.nix
+++ b/pkgs/development/python-modules/aiogithubapi/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/aiohttp-jinja2/default.nix
+++ b/pkgs/development/python-modules/aiohttp-jinja2/default.nix
@@ -38,9 +38,8 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   pythonImportsCheck = [ "aiohttp_jinja2" ];

--- a/pkgs/development/python-modules/aiohttp-retry/default.nix
+++ b/pkgs/development/python-modules/aiohttp-retry/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "aiohttp_retry" ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   meta = with lib; {
     description = "Retry client for aiohttp";

--- a/pkgs/development/python-modules/aiosyncthing/default.nix
+++ b/pkgs/development/python-modules/aiosyncthing/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   pythonImportsCheck = [ "aiosyncthing" ];
 

--- a/pkgs/development/python-modules/aiounifi/default.nix
+++ b/pkgs/development/python-modules/aiounifi/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     trustme
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   pythonImportsCheck = [ "aiounifi" ];
 

--- a/pkgs/development/python-modules/aiowaqi/default.nix
+++ b/pkgs/development/python-modules/aiowaqi/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     "test_search"
   ];
 
-  pytestFlagsArray = [ "--snapshot-update" ];
+  pytestFlags = [ "--snapshot-update" ];
 
   meta = with lib; {
     description = "Module to interact with the WAQI API";

--- a/pkgs/development/python-modules/aiowithings/default.nix
+++ b/pkgs/development/python-modules/aiowithings/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "aiowithings" ];
 
-  pytestFlagsArray = [ "--snapshot-update" ];
+  pytestFlags = [ "--snapshot-update" ];
 
   disabledTests = [
     # Tests require network access

--- a/pkgs/development/python-modules/amqtt/default.nix
+++ b/pkgs/development/python-modules/amqtt/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   disabledTests = lib.optionals (pythonAtLeast "3.12") [
     # stuck in epoll

--- a/pkgs/development/python-modules/androguard/default.nix
+++ b/pkgs/development/python-modules/androguard/default.nix
@@ -84,7 +84,7 @@ buildPythonPackage rec {
   ];
 
   # If it won't be verbose, you'll see nothing going on for a long time.
-  pytestFlagsArray = [ "--verbose" ];
+  pytestFlags = [ "--verbose" ];
 
   preFixup = lib.optionalString withGui ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")

--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -86,9 +86,8 @@ buildPythonPackage rec {
     "tests/lib/test_bedrock.py"
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/ariadne/default.nix
+++ b/pkgs/development/python-modules/ariadne/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ariadne" ];
 
-  pytestFlagsArray = [ "--snapshot-update" ];
+  pytestFlags = [ "--snapshot-update" ];
 
   disabledTests = [
     # TypeError: TestClient.request() got an unexpected keyword argument 'content'

--- a/pkgs/development/python-modules/aspectlib/default.nix
+++ b/pkgs/development/python-modules/aspectlib/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     tornado
   ];
 
-  pytestFlagsArray = [ "-W ignore::DeprecationWarning" ];
+  pytestFlags = [ "-Wignore::DeprecationWarning" ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -142,7 +142,7 @@ buildPythonPackage rec {
     # https://github.com/NixOS/nixpkgs/issues/255262
     cd "$out"
   '';
-  pytestFlagsArray = [
+  pytestFlags = [
     "--hypothesis-profile=ci"
   ];
   postCheck = ''

--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -62,10 +62,9 @@ buildPythonPackage rec {
     pytest-rerunfailures
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   # Tests must be run in the build directory. The tests create files

--- a/pkgs/development/python-modules/asyncclick/default.nix
+++ b/pkgs/development/python-modules/asyncclick/default.nix
@@ -32,9 +32,8 @@ buildPythonPackage rec {
     trio
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::trio.TrioDeprecationWarning"
+  pytestFlags = [
+    "-Wignore::trio.TrioDeprecationWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/bindep/default.nix
+++ b/pkgs/development/python-modules/bindep/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     export PATH=$PATH:$out/bin
   '';
 
-  pytestFlagsArray = [ "-s" ];
+  pytestFlags = [ "-s" ];
 
   pythonImportsCheck = [ "bindep" ];
 

--- a/pkgs/development/python-modules/bitstring/default.nix
+++ b/pkgs/development/python-modules/bitstring/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--benchmark-disable"
   ];
 

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -73,9 +73,8 @@ buildPythonPackage rec {
     parameterized
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   preCheck =

--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -49,10 +49,9 @@ buildPythonPackage rec {
     pytest-xdist
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # DeprecationWarning: JAXopt is no longer maintained
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/bluetooth-data-tools/default.nix
+++ b/pkgs/development/python-modules/bluetooth-data-tools/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   pythonImportsCheck = [ "bluetooth_data_tools" ];
 

--- a/pkgs/development/python-modules/buienradar/default.nix
+++ b/pkgs/development/python-modules/buienradar/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     "test_readdata3"
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--snapshot-warn-unused"
   ];
 

--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -70,9 +70,8 @@ buildPythonPackage rec {
         wheel
       ];
 
-      pytestFlagsArray = [
-        "-W"
-        "ignore::DeprecationWarning"
+      pytestFlags = [
+        "-Wignore::DeprecationWarning"
       ];
 
       __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-cloudflare/default.nix
@@ -27,12 +27,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
-    "-p no:cacheprovider"
+  pytestFlags = [
+    "-pno:cacheprovider"
 
     # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = certbot.meta // {

--- a/pkgs/development/python-modules/certbot-dns-google/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-google/default.nix
@@ -26,8 +26,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
-    "-p no:cacheprovider"
+  pytestFlags = [
+    "-pno:cacheprovider"
   ];
 
   meta = certbot.meta // {

--- a/pkgs/development/python-modules/certbot-dns-ovh/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-ovh/default.nix
@@ -27,12 +27,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
-    "-p no:cacheprovider"
+  pytestFlags = [
+    "-pno:cacheprovider"
 
     # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = certbot.meta // {

--- a/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-rfc2136/default.nix
@@ -24,12 +24,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
-    "-p no:cacheprovider"
+  pytestFlags = [
+    "-pno:cacheprovider"
 
     # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = certbot.meta // {

--- a/pkgs/development/python-modules/certbot-dns-route53/default.nix
+++ b/pkgs/development/python-modules/certbot-dns-route53/default.nix
@@ -27,12 +27,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
-    "-p no:cacheprovider"
+  pytestFlags = [
+    "-pno:cacheprovider"
 
     # Monitor https://github.com/certbot/certbot/issues/9606 for a solution
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = certbot.meta // {

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -61,10 +61,9 @@ buildPythonPackage rec {
     pytest-xdist
   ];
 
-  pytestFlagsArray = [
-    "-p no:cacheprovider"
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-pno:cacheprovider"
+    "-Wignore::DeprecationWarning"
   ];
 
   makeWrapperArgs = [ "--prefix PATH : ${dialog}/bin" ];

--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -66,9 +66,8 @@ buildPythonPackage rec {
     export CI=true
   '';
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests =

--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -181,13 +181,11 @@ buildPythonPackage rec {
     SWAGGER_UI_DOWNLOAD_URL = "file://${swagger-ui}";
   };
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "-x" # these are slow tests, so stop on the first failure
     "-v"
-    "-W"
-    "ignore:DeprecationWarning"
-    "-W"
-    "ignore:PytestCollectionWarning"
+    "-Wignore:DeprecationWarning"
+    "-Wignore:PytestCollectionWarning"
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/colour/default.nix
+++ b/pkgs/development/python-modules/colour/default.nix
@@ -22,8 +22,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
-    "--doctest-glob=\"*.rst\""
+  pytestFlags = [
+    "--doctest-glob=*.rst"
     "--doctest-modules"
   ];
 

--- a/pkgs/development/python-modules/connect-box/default.nix
+++ b/pkgs/development/python-modules/connect-box/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "connect_box" ];
 
-  pytestFlagsArray = [ "--vcr-record=none" ];
+  pytestFlags = [ "--vcr-record=none" ];
 
   meta = with lib; {
     description = "Interact with a Compal CH7465LG cable modem/router";

--- a/pkgs/development/python-modules/cons/default.nix
+++ b/pkgs/development/python-modules/cons/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pytest-html
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--html=testing-report.html"
     "--self-contained-html"
   ];

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     pytest-xdist
   ] ++ optional-dependencies.ssh;
 
-  pytestFlagsArray = [ "--disable-pytest-warnings" ];
+  pytestFlags = [ "--disable-pytest-warnings" ];
 
   disabledTestPaths = [
     # save compute time by not running benchmarks

--- a/pkgs/development/python-modules/cypherpunkpay/default.nix
+++ b/pkgs/development/python-modules/cypherpunkpay/default.nix
@@ -77,9 +77,8 @@ buildPythonPackage rec {
     webtest
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/datafusion/default.nix
+++ b/pkgs/development/python-modules/datafusion/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "datafusion" ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--pyargs"
     pname
   ];

--- a/pkgs/development/python-modules/datalad/default.nix
+++ b/pkgs/development/python-modules/datalad/default.nix
@@ -230,10 +230,9 @@ buildPythonPackage rec {
     httpretty
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # Deprecated in 3.13. Use exc_type_str instead.
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   pythonImportsCheck = [ "datalad" ];

--- a/pkgs/development/python-modules/deploykit/default.nix
+++ b/pkgs/development/python-modules/deploykit/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [ "test_ssh" ];
 
   # don't swallow stdout/stderr
-  pytestFlagsArray = [ "-s" ];
+  pytestFlags = [ "-s" ];
 
   pythonImportsCheck = [ "deploykit" ];
 

--- a/pkgs/development/python-modules/discovery30303/default.nix
+++ b/pkgs/development/python-modules/discovery30303/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   pythonImportsCheck = [ "discovery30303" ];
 

--- a/pkgs/development/python-modules/django-redis/default.nix
+++ b/pkgs/development/python-modules/django-redis/default.nix
@@ -67,9 +67,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/dynalite-devices/default.nix
+++ b/pkgs/development/python-modules/dynalite-devices/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   pythonImportsCheck = [ "dynalite_devices_lib" ];
 

--- a/pkgs/development/python-modules/elastic-transport/default.nix
+++ b/pkgs/development/python-modules/elastic-transport/default.nix
@@ -58,9 +58,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "elastic_transport" ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/etuples/default.nix
+++ b/pkgs/development/python-modules/etuples/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     pytest-html
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--html=testing-report.html"
     "--self-contained-html"
   ];

--- a/pkgs/development/python-modules/execnet/default.nix
+++ b/pkgs/development/python-modules/execnet/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     "test_stdouterrin_setnull"
   ];
 
-  pytestFlagsArray = [ "-vvv" ];
+  pytestFlags = [ "-vvv" ];
 
   pythonImportsCheck = [ "execnet" ];
 

--- a/pkgs/development/python-modules/fairseq/default.nix
+++ b/pkgs/development/python-modules/fairseq/default.nix
@@ -89,7 +89,7 @@ buildPythonPackage rec {
     cd tests
   '';
 
-  pytestFlagsArray = [ "--import-mode append" ];
+  pytestFlags = [ "--import-mode=append" ];
 
   disabledTests = [
     # this test requires xformers

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -116,11 +116,11 @@ buildPythonPackage rec {
     ++ passlib.optional-dependencies.bcrypt
     ++ optional-dependencies.all;
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # ignoring deprecation warnings to avoid test failure from
     # tests/test_tutorial/test_testing/test_tutorial001.py
-    "-W ignore::DeprecationWarning"
-    "-W ignore::pytest.PytestUnraisableExceptionWarning"
+    "-Wignore::DeprecationWarning"
+    "-Wignore::pytest.PytestUnraisableExceptionWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/fastdiff/default.nix
+++ b/pkgs/development/python-modules/fastdiff/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pytest-benchmark
   ];
 
-  pytestFlagsArray = [ "--benchmark-skip" ];
+  pytestFlags = [ "--benchmark-skip" ];
 
   pythonImportsCheck = [ "fastdiff" ];
 

--- a/pkgs/development/python-modules/fastnumbers/default.nix
+++ b/pkgs/development/python-modules/fastnumbers/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--hypothesis-profile=standard" ];
+  pytestFlags = [ "--hypothesis-profile=standard" ];
 
   pythonImportsCheck = [ "fastnumbers" ];
 

--- a/pkgs/development/python-modules/flask-marshmallow/default.nix
+++ b/pkgs/development/python-modules/flask-marshmallow/default.nix
@@ -43,9 +43,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "flask_marshmallow" ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/flask-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/flask-sqlalchemy/default.nix
@@ -45,10 +45,9 @@ buildPythonPackage rec {
     "test_explicit_table"
   ];
 
-  pytestFlagsArray = lib.optionals (pythonAtLeast "3.12") [
+  pytestFlags = lib.optionals (pythonAtLeast "3.12") [
     # datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version.
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   pythonImportsCheck = [ "flask_sqlalchemy" ];

--- a/pkgs/development/python-modules/flufl/lock.nix
+++ b/pkgs/development/python-modules/flufl/lock.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   # disable code coverage checks for all OS. Upstream does not enforce these
   # checks on Darwin, and code coverage cannot be improved downstream nor is it
   # relevant to the user.
-  pytestFlagsArray = [ "--no-cov" ];
+  pytestFlags = [ "--no-cov" ];
 
   pythonImportsCheck = [ "flufl.lock" ];
 

--- a/pkgs/development/python-modules/fyta-cli/default.nix
+++ b/pkgs/development/python-modules/fyta-cli/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "fyta_cli" ];
 
-  pytestFlagsArray = [ "--snapshot-update" ];
+  pytestFlags = [ "--snapshot-update" ];
 
   meta = with lib; {
     description = "Module to access the FYTA API";

--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   disabledTestPaths = lib.optionals (pythonAtLeast "3.12") [ "test/test_init.py" ];
 
-  pytestFlagsArray = [ "--skip-tests-requiring-internet" ];
+  pytestFlags = [ "--skip-tests-requiring-internet" ];
 
   pythonImportsCheck = [ "geopy" ];
 

--- a/pkgs/development/python-modules/graphene/default.nix
+++ b/pkgs/development/python-modules/graphene/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   pythonImportsCheck = [ "graphene" ];
 

--- a/pkgs/development/python-modules/grpc-google-iam-v1/default.nix
+++ b/pkgs/development/python-modules/grpc-google-iam-v1/default.nix
@@ -36,9 +36,8 @@ buildPythonPackage rec {
     "google.iam.v1"
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/guessit/default.nix
+++ b/pkgs/development/python-modules/guessit/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   pythonImportsCheck = [ "guessit" ];
 

--- a/pkgs/development/python-modules/habiticalib/default.nix
+++ b/pkgs/development/python-modules/habiticalib/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     syrupy
   ];
 
-  pytestFlagsArray = [ "--snapshot-update" ];
+  pytestFlags = [ "--snapshot-update" ];
 
   pythonImportsCheck = [ "habiticalib" ];
 

--- a/pkgs/development/python-modules/hmmlearn/default.nix
+++ b/pkgs/development/python-modules/hmmlearn/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "hmmlearn" ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--pyargs"
     "hmmlearn"
   ];

--- a/pkgs/development/python-modules/homematicip/default.nix
+++ b/pkgs/development/python-modules/homematicip/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   disabledTests = [
     # Assert issues with datetime

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -85,11 +85,9 @@ buildPythonPackage rec {
     export PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-    "-W"
-    "ignore::trio.TrioDeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
+    "-Wignore::trio.TrioDeprecationWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/hydra-core/default.nix
+++ b/pkgs/development/python-modules/hydra-core/default.nix
@@ -72,9 +72,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::UserWarning"
+  pytestFlags = [
+    "-Wignore::UserWarning"
   ];
 
   # Test environment setup broken under Nix for a few tests:

--- a/pkgs/development/python-modules/icontract/default.nix
+++ b/pkgs/development/python-modules/icontract/default.nix
@@ -67,10 +67,9 @@ buildPythonPackage rec {
     "tests/test_typeguard.py"
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # RuntimeWarning: coroutine '*' was never awaited
-    "-W"
-    "ignore::RuntimeWarning"
+    "-Wignore::RuntimeWarning"
   ];
 
   pythonImportsCheck = [ "icontract" ];

--- a/pkgs/development/python-modules/ifcopenshell/default.nix
+++ b/pkgs/development/python-modules/ifcopenshell/default.nix
@@ -183,8 +183,8 @@ buildPythonPackage rec {
     popd
   '';
 
-  pytestFlagsArray = [
-    "-p no:pytest-blender"
+  pytestFlags = [
+    "-pno:pytest-blender"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/imread/default.nix
+++ b/pkgs/development/python-modules/imread/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # verbose build outputs needed to debug hard-to-reproduce hydra failures
     "-v"
     "--pyargs"

--- a/pkgs/development/python-modules/janus/default.nix
+++ b/pkgs/development/python-modules/janus/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   meta = with lib; {
     description = "Mixed sync-async queue";

--- a/pkgs/development/python-modules/jupyter-core/default.nix
+++ b/pkgs/development/python-modules/jupyter-core/default.nix
@@ -45,9 +45,9 @@ buildPythonPackage rec {
     export HOME=$TMPDIR
   '';
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # suppress pytest.PytestUnraisableExceptionWarning: Exception ignored in: <socket.socket fd=-1, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0>
-    "-W ignore::pytest.PytestUnraisableExceptionWarning"
+    "-Wignore::pytest.PytestUnraisableExceptionWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/jupyter-packaging/default.nix
+++ b/pkgs/development/python-modules/jupyter-packaging/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytest-timeout
   ];
 
-  pytestFlagsArray = [ "-Wignore::DeprecationWarning" ];
+  pytestFlags = [ "-Wignore::DeprecationWarning" ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -86,14 +86,12 @@ buildPythonPackage rec {
     flaky
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
     # 19 failures on python 3.13:
     # ResourceWarning: unclosed database in <sqlite3.Connection object at 0x7ffff2a0cc70>
     # TODO: Can probably be removed at the next update
-    "-W"
-    "ignore::pytest.PytestUnraisableExceptionWarning"
+    "-Wignore::pytest.PytestUnraisableExceptionWarning"
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/jupyterlab-server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-server/default.nix
@@ -67,9 +67,8 @@ buildPythonPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/langgraph-prebuilt/default.nix
+++ b/pkgs/development/python-modules/langgraph-prebuilt/default.nix
@@ -73,11 +73,9 @@ buildPythonPackage rec {
     export PYTHONPATH=${src}/libs/langgraph:$PYTHONPATH
   '';
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::pytest.PytestDeprecationWarning"
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::pytest.PytestDeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/logical-unification/default.nix
+++ b/pkgs/development/python-modules/logical-unification/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     "test_reify_recursion_limit"
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--benchmark-skip"
     "--html=testing-report.html"
     "--self-contained-html"

--- a/pkgs/development/python-modules/marshmallow-dataclass/default.nix
+++ b/pkgs/development/python-modules/marshmallow-dataclass/default.nix
@@ -38,10 +38,9 @@ buildPythonPackage rec {
     typeguard
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12.
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests = lib.optionals (pythonAtLeast "3.10") [

--- a/pkgs/development/python-modules/matrix-nio/default.nix
+++ b/pkgs/development/python-modules/matrix-nio/default.nix
@@ -97,7 +97,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   disabledTestPaths = lib.optionals (!withOlm) [
     "tests/encryption_test.py"

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -96,9 +96,8 @@ buildPythonPackage rec {
     requests
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::pydantic.warnings.PydanticDeprecatedSince211"
+  pytestFlags = [
+    "-Wignore::pydantic.warnings.PydanticDeprecatedSince211"
   ];
 
   disabledTests =

--- a/pkgs/development/python-modules/minikanren/default.nix
+++ b/pkgs/development/python-modules/minikanren/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage {
     pytest-html
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--html=testing-report.html"
     "--self-contained-html"
   ];

--- a/pkgs/development/python-modules/mlrose/default.nix
+++ b/pkgs/development/python-modules/mlrose/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "mlrose" ];
 
   # Fix random seed during tests
-  pytestFlagsArray = [ "--randomly-seed 0" ];
+  pytestFlags = [ "--randomly-seed=0" ];
 
   meta = with lib; {
     description = "Machine Learning, Randomized Optimization and SEarch";

--- a/pkgs/development/python-modules/mlxtend/default.nix
+++ b/pkgs/development/python-modules/mlxtend/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "-sv" ];
+  pytestFlags = [ "-sv" ];
 
   disabledTests = [
     # Type changed in numpy2 test should be updated

--- a/pkgs/development/python-modules/motmetrics/default.nix
+++ b/pkgs/development/python-modules/motmetrics/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage {
     pytest-benchmark
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   pythonImportsCheck = [ "motmetrics" ];
 

--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -72,7 +72,7 @@ buildPythonPackage rec {
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   # See https://github.com/NixOS/nixpkgs/issues/381908 and https://github.com/NixOS/nixpkgs/issues/385450.
-  pytestFlagsArray = [ "--timeout=600" ];
+  pytestFlags = [ "--timeout=600" ];
 
   pythonImportsCheck = [ "moviepy" ];
 

--- a/pkgs/development/python-modules/narwhals/default.nix
+++ b/pkgs/development/python-modules/narwhals/default.nix
@@ -69,9 +69,8 @@ buildPythonPackage rec {
     "test_unary_two_elements"
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -87,9 +87,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/neurokit2/default.nix
+++ b/pkgs/development/python-modules/neurokit2/default.nix
@@ -90,7 +90,7 @@ buildPythonPackage rec {
     "tests/tests_microstates.py"
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # Otherwise, test collection fails with:
     # AttributeError: module 'scipy.ndimage._delegators' has no attribute '@py_builtins_signature'. Did you mean: 'grey_dilation_signature'?
     # https://github.com/scipy/scipy/issues/22236

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -77,9 +77,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   env = {

--- a/pkgs/development/python-modules/numpyro/default.nix
+++ b/pkgs/development/python-modules/numpyro/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "numpyro" ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # Tests memory consumption grows significantly with the number of parallel processes (reaches ~200GB with 80 jobs)
     "--maxprocesses=8"
 
@@ -72,8 +72,7 @@ buildPythonPackage rec {
     # UserWarning: There are not enough devices to run parallel chains: expected 2 but got 1.
     # Chains will be drawn sequentially. If you are running MCMC in CPU, consider using `numpyro.set_host_device_count(2)` at the beginning of your program.
     # You can double-check how many devices are available in your system using `jax.local_device_count()`.
-    "-W"
-    "ignore::UserWarning"
+    "-Wignore::UserWarning"
   ];
 
   disabledTests =

--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -106,9 +106,8 @@ buildPythonPackage rec {
     respx
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
     # snapshot mismatches
     "--inline-snapshot=update"
   ];

--- a/pkgs/development/python-modules/openapi-schema-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-schema-validator/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     "test_array_prefixitems_invalid"
   ];
 
-  pytestFlagsArray = [ "-vvv" ];
+  pytestFlags = [ "-vvv" ];
 
   pythonImportsCheck = [ "openapi_schema_validator" ];
 

--- a/pkgs/development/python-modules/openpyxl/default.nix
+++ b/pkgs/development/python-modules/openpyxl/default.nix
@@ -38,9 +38,8 @@ buildPythonPackage rec {
     pytest7CheckHook
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests =

--- a/pkgs/development/python-modules/optimistix/default.nix
+++ b/pkgs/development/python-modules/optimistix/default.nix
@@ -53,11 +53,10 @@ buildPythonPackage rec {
     pytest-xdist
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # Since jax 0.5.3:
     # DeprecationWarning: shape requires ndarray or scalar arguments, got <class 'jax._src.api.ShapeDtypeStruct'> at position 0. In a future JAX release this will be an error.
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/param/default.nix
+++ b/pkgs/development/python-modules/param/default.nix
@@ -41,9 +41,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   pythonImportsCheck = [ "param" ];

--- a/pkgs/development/python-modules/parselmouth/default.nix
+++ b/pkgs/development/python-modules/parselmouth/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--run-praat-tests"
     "-v"
   ];

--- a/pkgs/development/python-modules/pecan/default.nix
+++ b/pkgs/development/python-modules/pecan/default.nix
@@ -45,7 +45,10 @@ buildPythonPackage rec {
     webtest
   ];
 
-  pytestFlags = [ "--pyargs" "pecan" ];
+  pytestFlags = [
+    "--pyargs"
+    "pecan"
+  ];
 
   pythonImportsCheck = [ "pecan" ];
 

--- a/pkgs/development/python-modules/pecan/default.nix
+++ b/pkgs/development/python-modules/pecan/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     webtest
   ];
 
-  pytestFlagsArray = [ "--pyargs pecan" ];
+  pytestFlags = [ "--pyargs" "pecan" ];
 
   pythonImportsCheck = [ "pecan" ];
 

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -98,9 +98,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # DeprecationWarning: 'jinja2.Markup' is deprecated and...
-    "-W ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/pims/default.nix
+++ b/pkgs/development/python-modules/pims/default.nix
@@ -37,9 +37,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pims" ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::Warning"
+  pytestFlags = [
+    "-Wignore::Warning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/pint/default.nix
+++ b/pkgs/development/python-modules/pint/default.nix
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     matplotlib
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/proto-plus/default.nix
+++ b/pkgs/development/python-modules/proto-plus/default.nix
@@ -31,10 +31,9 @@ buildPythonPackage rec {
     googleapis-common-protos
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   pythonImportsCheck = [ "proto" ];

--- a/pkgs/development/python-modules/psygnal/default.nix
+++ b/pkgs/development/python-modules/psygnal/default.nix
@@ -48,9 +48,8 @@ buildPythonPackage rec {
     attrs
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::pydantic.warnings.PydanticDeprecatedSince211"
+  pytestFlags = [
+    "-Wignore::pydantic.warnings.PydanticDeprecatedSince211"
   ];
 
   pythonImportsCheck = [ "psygnal" ];

--- a/pkgs/development/python-modules/pure-protobuf/default.nix
+++ b/pkgs/development/python-modules/pure-protobuf/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   pythonImportsCheck = [ "pure_protobuf" ];
 

--- a/pkgs/development/python-modules/pycrdt/default.nix
+++ b/pkgs/development/python-modules/pycrdt/default.nix
@@ -53,9 +53,8 @@ buildPythonPackage rec {
     y-py
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::pytest.PytestUnknownMarkWarning" # requires unpackaged pytest-mypy-testing
+  pytestFlags = [
+    "-Wignore::pytest.PytestUnknownMarkWarning" # requires unpackaged pytest-mypy-testing
   ];
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--generate-lockfile" ]; };

--- a/pkgs/development/python-modules/pydantic-compat/default.nix
+++ b/pkgs/development/python-modules/pydantic-compat/default.nix
@@ -41,12 +41,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
-    "-W"
+  pytestFlags = [
     # pydantic.warnings.PydanticDeprecatedSince211: Accessing this attribute on the instance is
     # deprecated, and will be removed in Pydantic V3. Instead, you should access this attribute from
     # the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
-    "ignore::pydantic.warnings.PydanticDeprecatedSince211"
+    "-Wignore::pydantic.warnings.PydanticDeprecatedSince211"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/pykakasi/default.nix
+++ b/pkgs/development/python-modules/pykakasi/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     "test_aozora"
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   pythonImportsCheck = [ "pykakasi" ];
 

--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -60,13 +60,12 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # DeprecationWarning: pyreverse will drop support for resolving and
     # displaying implemented interfaces in pylint 3.0. The
     # implementation relies on the '__implements__'  attribute proposed
     # in PEP 245, which was rejected in 2006.
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
     "-v"
   ];
 

--- a/pkgs/development/python-modules/pylutron-caseta/default.nix
+++ b/pkgs/development/python-modules/pylutron-caseta/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ] ++ lib.optionals (pythonOlder "3.11") [ async-timeout ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   pythonImportsCheck = [ "pylutron_caseta" ];
 

--- a/pkgs/development/python-modules/pynetdicom/default.nix
+++ b/pkgs/development/python-modules/pynetdicom/default.nix
@@ -75,10 +75,9 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pynetdicom" ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # https://github.com/pydicom/pynetdicom/issues/923
-    "-W"
-    "ignore::pytest.PytestRemovedIn9Warning"
+    "-Wignore::pytest.PytestRemovedIn9Warning"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pypck/default.nix
+++ b/pkgs/development/python-modules/pypck/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [ "test_connection_lost" ];
 

--- a/pkgs/development/python-modules/pyspcwebgw/default.nix
+++ b/pkgs/development/python-modules/pyspcwebgw/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   pythonImportsCheck = [ "pyspcwebgw" ];
 

--- a/pkgs/development/python-modules/pytest-mpi/default.nix
+++ b/pkgs/development/python-modules/pytest-mpi/default.nix
@@ -41,10 +41,9 @@ buildPythonPackage rec {
   # Tests cause the Python interpreter to crash from some reason, a hard issue
   # to debug. (TODO: discuss this with upstream)
   doCheck = false;
-  pytestFlagsArray = [
+  pytestFlags = [
     # https://github.com/aragilar/pytest-mpi/issues/4#issuecomment-634614337
-    "-p"
-    "pytester"
+    "-ppytester"
   ];
 
   pythonImportsCheck = [ "pytest_mpi" ];

--- a/pkgs/development/python-modules/pytest-postgresql/default.nix
+++ b/pkgs/development/python-modules/pytest-postgresql/default.nix
@@ -45,9 +45,8 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-cov-stub
   ];
-  pytestFlagsArray = [
-    "-p"
-    "no:postgresql"
+  pytestFlags = [
+    "-pno:postgresql"
   ];
   disabledTestPaths = [ "tests/docker/test_noproc_docker.py" ]; # requires Docker
   disabledTests = [

--- a/pkgs/development/python-modules/pytest-randomly/default.nix
+++ b/pkgs/development/python-modules/pytest-randomly/default.nix
@@ -39,9 +39,8 @@ buildPythonPackage rec {
   ];
 
   # needs special invocation, copied from tox.ini
-  pytestFlagsArray = [
-    "-p"
-    "no:randomly"
+  pytestFlags = [
+    "-pno:randomly"
   ];
 
   pythonImportsCheck = [ "pytest_randomly" ];

--- a/pkgs/development/python-modules/pytest-regressions/default.nix
+++ b/pkgs/development/python-modules/pytest-regressions/default.nix
@@ -58,9 +58,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pytest-subprocess/default.nix
+++ b/pkgs/development/python-modules/pytest-subprocess/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  pytestFlagsArray = [ "-W ignore::DeprecationWarning" ];
+  pytestFlags = [ "-Wignore::DeprecationWarning" ];
 
   meta = with lib; {
     description = "Plugin to fake subprocess for pytest";

--- a/pkgs/development/python-modules/python-arango/default.nix
+++ b/pkgs/development/python-modules/python-arango/default.nix
@@ -98,15 +98,11 @@ buildPythonPackage rec {
       --foxx.api=false &
   '';
 
-  pytestFlagsArray = [
-    "--host"
-    testDBOpts.host
-    "--port"
-    testDBOpts.port
-    "--passwd"
-    testDBOpts.password
-    "--secret"
-    testDBOpts.secret
+  pytestFlags = [
+    "--host=${testDBOpts.host}"
+    "--port=${testDBOpts.port}"
+    "--passwd=${testDBOpts.password}"
+    "--secret=${testDBOpts.secret}"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/python-docx/default.nix
+++ b/pkgs/development/python-modules/python-docx/default.nix
@@ -51,9 +51,8 @@ buildPythonPackage rec {
     "it_accepts_unicode_providing_there_is_no_encoding_declaration"
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/python-kasa/default.nix
+++ b/pkgs/development/python-modules/python-kasa/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     ];
   };
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   disabledTestPaths = [
     # Skip the examples tests

--- a/pkgs/development/python-modules/pythonnet/default.nix
+++ b/pkgs/development/python-modules/pythonnet/default.nix
@@ -53,9 +53,9 @@ buildPythonPackage {
     clr-loader
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # Run tests using .NET Core, Mono is unsupported for now due to find_library problem in clr-loader
-    "--runtime coreclr"
+    "--runtime=coreclr"
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pytraccar/default.nix
+++ b/pkgs/development/python-modules/pytraccar/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     pytest-asyncio
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   postPatch = ''
     # Upstream doesn't set version in the repo

--- a/pkgs/development/python-modules/pyunpack/default.nix
+++ b/pkgs/development/python-modules/pyunpack/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     cabextract
   ];
 
-  pytestFlagsArray = [ "-x" ];
+  pytestFlags = [ "-x" ];
 
   pythonImportsCheck = [ "pyunpack" ];
 

--- a/pkgs/development/python-modules/pyvirtualdisplay/default.nix
+++ b/pkgs/development/python-modules/pyvirtualdisplay/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     xorg.xvfb
   ];
 
-  pytestFlagsArray = [ "-v" ];
+  pytestFlags = [ "-v" ];
 
   meta = with lib; {
     description = "Python wrapper for Xvfb, Xephyr and Xvnc";

--- a/pkgs/development/python-modules/pywizlight/default.nix
+++ b/pkgs/development/python-modules/pywizlight/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   disabledTests = [
     # Tests requires network features (e. g., discovery testing)

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -127,7 +127,7 @@ buildPythonPackage rec {
     testtools
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--timeout=30"
     "--durations=10"
   ];

--- a/pkgs/development/python-modules/qiskit-finance/default.nix
+++ b/pkgs/development/python-modules/qiskit-finance/default.nix
@@ -75,7 +75,7 @@ buildPythonPackage rec {
     "test_yahoo"
     "test_wikipedia"
   ];
-  pytestFlagsArray = [ "--durations=10" ];
+  pytestFlags = [ "--durations=10" ];
 
   meta = with lib; {
     description = "Software for developing quantum computing programs";

--- a/pkgs/development/python-modules/qiskit-nature/default.nix
+++ b/pkgs/development/python-modules/qiskit-nature/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "qiskit_nature" ];
 
-  pytestFlagsArray = [ "--durations=10" ];
+  pytestFlags = [ "--durations=10" ];
 
   disabledTests = [
     "test_two_qubit_reduction" # failure cause unclear

--- a/pkgs/development/python-modules/qiskit-optimization/default.nix
+++ b/pkgs/development/python-modules/qiskit-optimization/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "qiskit_optimization" ];
-  pytestFlagsArray = [ "--durations=10" ];
+  pytestFlags = [ "--durations=10" ];
 
   meta = with lib; {
     description = "Software for developing quantum computing programs";

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -131,7 +131,7 @@ buildPythonPackage rec {
     # Too many floating point arithmetic errors
     "test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py"
   ];
-  pytestFlagsArray = [ "--durations=10" ];
+  pytestFlags = [ "--durations=10" ];
   disabledTests =
     [
       "TestUnitarySynthesisPlugin" # use unittest mocks for transpiler.run(), seems incompatible somehow w/ pytest infrastructure

--- a/pkgs/development/python-modules/rtoml/default.nix
+++ b/pkgs/development/python-modules/rtoml/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   disabledTests = [
     # TypeError: loads() got an unexpected keyword argument 'name'

--- a/pkgs/development/python-modules/ruyaml/default.nix
+++ b/pkgs/development/python-modules/ruyaml/default.nix
@@ -35,9 +35,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   pythonImportsCheck = [ "ruyaml" ];

--- a/pkgs/development/python-modules/schemdraw/default.nix
+++ b/pkgs/development/python-modules/schemdraw/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
 
   preCheck = "rm test/test_pictorial.ipynb"; # Tries to download files
 
-  pytestFlagsArray = [ "--nbval-lax" ];
+  pytestFlags = [ "--nbval-lax" ];
 
   pythonImportsCheck = [ "schemdraw" ];
 

--- a/pkgs/development/python-modules/scikit-learn-extra/default.nix
+++ b/pkgs/development/python-modules/scikit-learn-extra/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     rm -r sklearn_extra
   '';
 
-  pytestFlagsArray = [ "--pyargs sklearn_extra" ];
+  pytestFlags = [ "--pyargs" "sklearn_extra" ];
   disabledTestPaths = [
     "benchmarks"
     "examples"

--- a/pkgs/development/python-modules/scikit-learn-extra/default.nix
+++ b/pkgs/development/python-modules/scikit-learn-extra/default.nix
@@ -42,7 +42,10 @@ buildPythonPackage rec {
     rm -r sklearn_extra
   '';
 
-  pytestFlags = [ "--pyargs" "sklearn_extra" ];
+  pytestFlags = [
+    "--pyargs"
+    "sklearn_extra"
+  ];
   disabledTestPaths = [
     "benchmarks"
     "examples"

--- a/pkgs/development/python-modules/scikit-misc/default.nix
+++ b/pkgs/development/python-modules/scikit-misc/default.nix
@@ -59,7 +59,10 @@ buildPythonPackage rec {
     cd "$(mktemp -d)"
   '';
 
-  pytestFlags = [ "--pyargs" "skmisc" ];
+  pytestFlags = [
+    "--pyargs"
+    "skmisc"
+  ];
 
   pythonImportsCheck = [ "skmisc" ];
 

--- a/pkgs/development/python-modules/scikit-misc/default.nix
+++ b/pkgs/development/python-modules/scikit-misc/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     cd "$(mktemp -d)"
   '';
 
-  pytestFlagsArray = [ "--pyargs skmisc" ];
+  pytestFlags = [ "--pyargs" "skmisc" ];
 
   pythonImportsCheck = [ "skmisc" ];
 

--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -59,11 +59,10 @@ buildPythonPackage rec {
     cd build/lib
   '';
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # FutureWarning: Can't acquire a memory view of a Dask array. This will raise in the future
     # https://github.com/radio-astro-tools/spectral-cube/issues/943
-    "-W"
-    "ignore::FutureWarning"
+    "-Wignore::FutureWarning"
   ];
 
   disabledTests =

--- a/pkgs/development/python-modules/sqlalchemy-utils/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utils/default.nix
@@ -92,9 +92,8 @@ buildPythonPackage rec {
       "test_render_mock_ddl"
     ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   pythonImportsCheck = [ "sqlalchemy_utils" ];

--- a/pkgs/development/python-modules/sqlitedict/default.nix
+++ b/pkgs/development/python-modules/sqlitedict/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "sqlitedict" ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   meta = with lib; {
     description = "Persistent, thread-safe dict";

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -58,13 +58,10 @@ buildPythonPackage rec {
     typing-extensions
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
-    "-W"
-    "ignore::trio.TrioDeprecationWarning"
-    "-W"
-    "ignore::ResourceWarning" # FIXME remove once test suite is fully compatible with anyio 4.4.0
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
+    "-Wignore::trio.TrioDeprecationWarning"
+    "-Wignore::ResourceWarning" # FIXME remove once test suite is fully compatible with anyio 4.4.0
   ];
 
   pythonImportsCheck = [ "starlette" ];

--- a/pkgs/development/python-modules/sunpy/default.nix
+++ b/pkgs/development/python-modules/sunpy/default.nix
@@ -145,9 +145,8 @@ buildPythonPackage rec {
     "sunpy/io/setup_package.py"
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   # Wants a configuration file

--- a/pkgs/development/python-modules/systembridgeconnector/default.nix
+++ b/pkgs/development/python-modules/systembridgeconnector/default.nix
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     "test_wait_for_response_timeout"
   ];
 
-  pytestFlagsArray = [ "--snapshot-warn-unused" ];
+  pytestFlags = [ "--snapshot-warn-unused" ];
 
   meta = {
     changelog = "https://github.com/timmo001/system-bridge-connector/releases/tag/${version}";

--- a/pkgs/development/python-modules/systembridgemodels/default.nix
+++ b/pkgs/development/python-modules/systembridgemodels/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     "test_update"
   ];
 
-  pytestFlagsArray = [ "--snapshot-warn-unused" ];
+  pytestFlags = [ "--snapshot-warn-unused" ];
 
   meta = {
     changelog = "https://github.com/timmo001/system-bridge-models/releases/tag/${version}";

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -79,7 +79,7 @@ buildPythonPackage rec {
     "test_textual_env_var"
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # Some tests in groups require state from previous tests
     # See https://github.com/Textualize/textual/issues/4924#issuecomment-2304889067
     "--dist=loadgroup"

--- a/pkgs/development/python-modules/timeslot/default.nix
+++ b/pkgs/development/python-modules/timeslot/default.nix
@@ -27,11 +27,11 @@ buildPythonPackage {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # The pyproject.toml specifies the flag `--cov=timeslot`,
     # This causes an error when running without pytest-cov,
     # so use this flag to override that option, as we don't need coverage.
-    "--override-ini addopts=''"
+    "--override-ini=addopts="
   ];
 
   pythonImportsCheck = [ "timeslot" ];

--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -41,11 +41,9 @@ buildPythonPackage rec {
     pandas
   ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::FutureWarning"
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::FutureWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   # Remove performance testing.

--- a/pkgs/development/python-modules/trio-asyncio/default.nix
+++ b/pkgs/development/python-modules/trio-asyncio/default.nix
@@ -41,12 +41,10 @@ buildPythonPackage rec {
     sniffio
   ] ++ lib.optionals (pythonOlder "3.11") [ exceptiongroup ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # RuntimeWarning: Can't run the Python asyncio tests because they're not installed
-    "-W"
-    "ignore::RuntimeWarning"
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::RuntimeWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/trio/default.nix
+++ b/pkgs/development/python-modules/trio/default.nix
@@ -76,9 +76,8 @@ buildPythonPackage rec {
     PYTHONPATH=$PWD/src:$PYTHONPATH
   '';
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   # It appears that the build sandbox doesn't include /etc/services, and these tests try to use it.

--- a/pkgs/development/python-modules/uarray/default.nix
+++ b/pkgs/development/python-modules/uarray/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
     cd $TMP
   '';
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--pyargs"
     "uarray"
   ];

--- a/pkgs/development/python-modules/uiprotect/default.nix
+++ b/pkgs/development/python-modules/uiprotect/default.nix
@@ -91,7 +91,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   disabledTests = [
     # https://127.0.0.1 vs https://127.0.0.1:0

--- a/pkgs/development/python-modules/ulid-transform/default.nix
+++ b/pkgs/development/python-modules/ulid-transform/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlags = [ "--benchmark-disable" ];
 
   pythonImportsCheck = [ "ulid_transform" ];
 

--- a/pkgs/development/python-modules/unifi-discovery/default.nix
+++ b/pkgs/development/python-modules/unifi-discovery/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--asyncio-mode=auto" ];
+  pytestFlags = [ "--asyncio-mode=auto" ];
 
   pythonImportsCheck = [ "unifi_discovery" ];
 

--- a/pkgs/development/python-modules/vega-datasets/default.nix
+++ b/pkgs/development/python-modules/vega-datasets/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [ "--doctest-modules" ];
+  pytestFlags = [ "--doctest-modules" ];
 
   pythonImportsCheck = [ "vega_datasets" ];
 

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -275,7 +275,7 @@ buildPythonPackage rec {
   ];
 
   # test_matplotlib_image_with_multiple_axes may take >60s
-  pytestFlagsArray = [
+  pytestFlags = [
     "--timeout=1024"
   ];
 

--- a/pkgs/development/python-modules/wheel-inspect/default.nix
+++ b/pkgs/development/python-modules/wheel-inspect/default.nix
@@ -55,9 +55,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "wheel_inspect" ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/yamlfix/default.nix
+++ b/pkgs/development/python-modules/yamlfix/default.nix
@@ -61,9 +61,8 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "yamlfix" ];
 
-  pytestFlagsArray = [
-    "-W"
-    "ignore::DeprecationWarning"
+  pytestFlags = [
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/zconfig/default.nix
+++ b/pkgs/development/python-modules/zconfig/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ZConfig" ];
 
-  pytestFlagsArray = [ "-s" ];
+  pytestFlags = [ "-s" ];
 
   meta = {
     description = "Structured Configuration Library";

--- a/pkgs/development/python-modules/ziafont/default.nix
+++ b/pkgs/development/python-modules/ziafont/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     in
     lib.concatMapStrings copyFontCmd checkFonts;
 
-  pytestFlagsArray = [ "--nbval-lax" ];
+  pytestFlags = [ "--nbval-lax" ];
 
   pythonImportsCheck = [ "ziafont" ];
 

--- a/pkgs/development/python-modules/ziamath/default.nix
+++ b/pkgs/development/python-modules/ziamath/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     in
     lib.concatMapStrings copyFontCmd checkFonts;
 
-  pytestFlagsArray = [ "--nbval-lax" ];
+  pytestFlags = [ "--nbval-lax" ];
 
   pythonImportsCheck = [ "ziamath" ];
 

--- a/pkgs/development/python-modules/zigpy-znp/default.nix
+++ b/pkgs/development/python-modules/zigpy-znp/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [ "--reruns=3" ];
+  pytestFlags = [ "--reruns=3" ];
 
   disabledTests = [
     # failing since zigpy 0.60.0

--- a/pkgs/servers/home-assistant/custom-components/sleep_as_android/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/sleep_as_android/package.nix
@@ -36,7 +36,7 @@ buildHomeAssistantComponent {
     paho-mqtt
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # Fixes `AttributeError: 'async_generator' object has no attribute 'data'`
     #  See https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/158
     "--asyncio-mode=auto"

--- a/pkgs/tools/audio/beets/plugins/copyartifacts.nix
+++ b/pkgs/tools/audio/beets/plugins/copyartifacts.nix
@@ -44,7 +44,11 @@ python3Packages.buildPythonApplication rec {
     writableTmpDirAsHomeHook
   ];
 
-  pytestFlagsArray = [ "-r fEs" ];
+  pytestFlags = [
+    # This is the same as:
+    #   -r fEs
+    "-rfEs"
+  ];
 
   meta = {
     description = "Beets plugin to move non-music files during the import process";

--- a/pkgs/tools/filesystems/ceph/old-python-packages/cryptography.nix
+++ b/pkgs/tools/filesystems/ceph/old-python-packages/cryptography.nix
@@ -102,7 +102,7 @@ buildPythonPackage rec {
     pytz
   ];
 
-  pytestFlagsArray = [ "--disable-pytest-warnings" ];
+  pytestFlags = [ "--disable-pytest-warnings" ];
 
   disabledTestPaths =
     [


### PR DESCRIPTION


This treewide change targets Python packages that specifies pytest flags with pytestFlagsArray, and whose flags cannot be consructed by other pytestCheckHook-honoured arguments.

Use the __structuredAttrs-agnostic argument pytestFlags instead of the deprecated pytestFlagsArray.

For flags with option arguments, join each flag and their option argument into a single command-line argument following [POSIX Utility Argument Syntax](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html) for easier overriding (remove/replace).

Examples:
* `[ "-W" "ignore:message:WarningClass" ]` -> `[ "-Wignore:message:WarningClass" ]`
* `[ "--reruns" "3" ]` -> `[ "--reruns=3" ]`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
