### PR TITLE
ci/nixpkgs-vet.sh: fix passing arguments

### DIFF
--- a/ci/nixpkgs-vet.sh
+++ b/ci/nixpkgs-vet.sh
@@ -63,4 +63,4 @@ git -C "$tmp/merged" merge -q --no-edit "$baseSha"
 trace -e "\e[34m$(git -C "$tmp/merged" rev-parse HEAD)\e[0m"
 
 trace "Running nixpkgs-vet.."
-nix-build ci -A nixpkgs-vet --argstr base "$tmp/base" --argstr head "$tmp/merged"
+nix-build ci -A nixpkgs-vet --arg base "$tmp/base" --arg head "$tmp/merged"


### PR DESCRIPTION
It currently fails with this:

```
error: lib.fileset.toSource: `root` (/tmp/nix-shell-19054-0/tmp.MB62qzBqsj/base) is a string-like value, but it should be a path instead.
   Paths in strings are not supported by `lib.fileset`, use `lib.sources` or derivations instead.
```

Resolves #416175


## Things done

- [x] Tested locally with `ci/nixpkgs-vet.sh master`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
