### PR TITLE
wdt: 1.27.1612021-unstable-2024-12-06 -> 1.27.1612021-unstable-2025-06-05

### DIFF
--- a/pkgs/by-name/wd/wdt/fix-glog-include.patch
+++ b/pkgs/by-name/wd/wdt/fix-glog-include.patch
@@ -1,0 +1,49 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index abbeead..93cac12 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -136,8 +136,7 @@ find_package(Threads) # this will set ${CMAKE_THREAD_LIBS_INIT} (ie pthreads)
+ find_path(DOUBLECONV_INCLUDE_DIR double-conversion/double-conversion.h)
+ find_library(DOUBLECONV_LIBRARY double-conversion)
+ # Glog
+-find_path(GLOG_INCLUDE_DIR glog/logging.h)
+-find_library(GLOG_LIBRARY glog)
++find_package(glog REQUIRED)
+ # Gflags
+ find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h)
+ find_library(GFLAGS_LIBRARY gflags)
+@@ -174,7 +173,7 @@ endif()
+ # You can also add jemalloc to the list if you have it/want it
+ target_link_libraries(wdt_min
+   ${FOLLY_LIBRARY}
+-  ${GLOG_LIBRARY}
++  glog::glog
+   ${GFLAGS_LIBRARY}
+   ${Boost_LIBRARIES}
+   ${DOUBLECONV_LIBRARY}
+@@ -226,7 +225,7 @@ if (NOT WDT_USE_SYSTEM_FOLLY)
+   endif()
+ 
+   add_library(folly4wdt ${FOLLY_CPP_SRC})
+-  target_link_libraries(folly4wdt ${GLOG_LIBRARY} ${DOUBLECONV_LIBRARY})
++  target_link_libraries(folly4wdt glog::glog ${DOUBLECONV_LIBRARY})
+ endif()
+ 
+ # Order is important - inside fb we want the above
+@@ -234,7 +233,6 @@ endif()
+ include_directories(${CMAKE_CURRENT_BINARY_DIR})
+ include_directories(${FOLLY_INCLUDE_DIR})
+ include_directories(${DOUBLECONV_INCLUDE_DIR})
+-include_directories(${GLOG_INCLUDE_DIR})
+ include_directories(${GFLAGS_INCLUDE_DIR})
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
+ 
+@@ -336,7 +334,7 @@ if (BUILD_TESTING)
+   )
+ 
+   target_link_libraries(wdtbenchlib
+-    ${GLOG_LIBRARY}
++    glog::glog
+     ${GFLAGS_LIBRARY}
+   )
+ 

--- a/pkgs/by-name/wd/wdt/package.nix
+++ b/pkgs/by-name/wd/wdt/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation {
   pname = "wdt";
-  version = "1.27.1612021-unstable-2024-12-06";
+  version = "1.27.1612021-unstable-2025-06-05";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "wdt";
-    rev = "7e56c871be706cc96df48be7c4017bff7c6fc7c8";
-    sha256 = "sha256-mvfJUiOI7Cre90hIaBJcmfTbTV5M+Hf+p6VKNYEc5WU=";
+    rev = "5cf3886d1b70f8aee60ec74b86823de1dce4233b";
+    sha256 = "sha256-g6wzYM++yv8tCUKom1bWB9MlImG/+OkhoTH+kTxURoA=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -36,6 +36,10 @@ stdenv.mkDerivation {
   postUnpack = ''
     ln -s $sourceRoot wdt
   '';
+
+  patches = [
+    ./fix-glog-include.patch
+  ];
 
   cmakeFlags = [
     "-DWDT_USE_SYSTEM_FOLLY=ON"


### PR DESCRIPTION
Fixes gcc 14 build. (Tracking: #388196 #356812)

Requires a new patch to fix the glog dependency, similar to those in https://github.com/NixOS/nixpkgs/pull/371610#discussion_r1905689334.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
