### PR TITLE
tests.cc-wrapper.supported: fix eval

### DIFF
--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -40,6 +40,8 @@ with pkgs;
               (filter (n: n != "gccCrossLibcStdenv"))
               (filter (n: n != "gcc49Stdenv"))
               (filter (n: n != "gcc6Stdenv"))
+              (filter (n: n != "gcc7Stdenv"))
+              (filter (n: n != "gcc8Stdenv"))
             ]
             ++
               lib.optionals


### PR DESCRIPTION
Currently throws:

```
error: gcc7Stdenv has been removed from Nixpkgs, as it is unmaintained
and obsolete
```


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
