### PR TITLE
nixos/authelia: add options for SMTP secrets

### DIFF
--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -74,6 +74,14 @@ let
                 '';
               };
 
+              notifierSmtpPasswordFile = mkOption {
+                type = types.nullOr types.path;
+                default = null;
+                description = ''
+                  Path to your SMTP password file used to authenticate with the SMTP server.
+                '';
+              };
+
               oidcIssuerPrivateKeyFile = mkOption {
                 type = types.nullOr types.path;
                 default = null;
@@ -372,6 +380,7 @@ in
               AUTHELIA_STORAGE_ENCRYPTION_KEY_FILE = instance.secrets.storageEncryptionKeyFile;
               AUTHELIA_SESSION_SECRET_FILE = instance.secrets.sessionSecretFile;
               AUTHELIA_IDENTITY_PROVIDERS_OIDC_HMAC_SECRET_FILE = instance.secrets.oidcHmacSecretFile;
+              AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE = instance.secrets.notifierSmtpPasswordFile;
             })
             // instance.environmentVariables;
 

--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -82,6 +82,14 @@ let
                 '';
               };
 
+              notifierSmtpTlsCertificateChainFile = mkOption {
+                type = types.nullOr types.path;
+                default = null;
+                description = ''
+                  Path to your certificate chain file used for TLS connection verification with the SMTP server.
+                '';
+              };
+
               oidcIssuerPrivateKeyFile = mkOption {
                 type = types.nullOr types.path;
                 default = null;
@@ -381,6 +389,8 @@ in
               AUTHELIA_SESSION_SECRET_FILE = instance.secrets.sessionSecretFile;
               AUTHELIA_IDENTITY_PROVIDERS_OIDC_HMAC_SECRET_FILE = instance.secrets.oidcHmacSecretFile;
               AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE = instance.secrets.notifierSmtpPasswordFile;
+              AUTHELIA_NOTIFIER_SMTP_TLS_CERTIFICATE_CHAIN_FILE =
+                instance.secrets.notifierSmtpTlsCertificateChainFile;
             })
             // instance.environmentVariables;
 

--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -90,6 +90,14 @@ let
                 '';
               };
 
+              notifierSmtpTlsPrivateKeyFile = mkOption {
+                type = types.nullOr types.path;
+                default = null;
+                description = ''
+                  Path to your private key file used for TLS connection verification with the SMTP server.
+                '';
+              };
+
               oidcIssuerPrivateKeyFile = mkOption {
                 type = types.nullOr types.path;
                 default = null;
@@ -391,6 +399,7 @@ in
               AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE = instance.secrets.notifierSmtpPasswordFile;
               AUTHELIA_NOTIFIER_SMTP_TLS_CERTIFICATE_CHAIN_FILE =
                 instance.secrets.notifierSmtpTlsCertificateChainFile;
+              AUTHELIA_NOTIFIER_SMTP_TLS_PRIVATE_KEY_FILE = instance.secrets.notifierSmtpTlsPrivateKeyFile;
             })
             // instance.environmentVariables;
 


### PR DESCRIPTION
Adds the following options for configuring Authelia to notify via SMTP:

- `services.authelia.instances.<name>.secrets.notifierSmtpPasswordFile`
- `services.authelia.instances.<name>.secrets.notifierSmtpTlsCertificateChainFile `
- `services.authelia.instances.<name>.secrets.notifierSmtpTlsPrivateKeyFile`

These correspond to environment variables documented here: https://www.authelia.com/configuration/methods/secrets/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
