### PR TITLE
haskell.lib.combineInputs: init

### DIFF
--- a/pkgs/development/haskell-modules/lib/compose.nix
+++ b/pkgs/development/haskell-modules/lib/compose.nix
@@ -730,4 +730,148 @@ rec {
       libraryPkgconfigDepends = propagatedPlainBuildInputs old.libraryPkgconfigDepends or [ ];
       testPkgconfigDepends = propagatedPlainBuildInputs old.testPkgconfigDepends or [ ];
     });
+
+  /*
+    Get the combined build inputs for a list of Haskell packages.
+
+    This combines all of the build input attributes of the packages
+    (`buildDepends`, `libraryHaskellDepends`, etc.) while being careful to
+    filter out packages from the arguments from the result.
+
+    This returns an attribute set where each key corresponds to a
+    `haskellPackages.mkDerivation` argument accepting a list of build inputs.
+
+    This logic is used by `haskellPackages.shellFor` to determine the packages
+    which are needed to build a particular set of packages.
+
+    ```
+    > combineInputs { packages = [haskellPackages.lens haskellPackages.aeson]; }
+    {
+      buildTools = [ ];
+      # ...
+      libraryHaskellDepends = [
+        «derivation /nix/store/pha8fwh6lc05nm2vvg1sivhyb5nmnkic-assoc-1.1.1.drv»
+        «derivation /nix/store/9j5w6q1hmf50r9jydj9n7vcplknw4fvv-base-orphans-0.9.3.drv»
+        # ...
+        «derivation /nix/store/r28dlymqid6q31dh5a46k36bag60ca52-witherable-0.5.drv»
+      ];
+      # ...
+      testHaskellDepends = [
+        «derivation /nix/store/rl0kfrl05z94in9f2fk8hl44r9pfyh44-HUnit-1.6.2.0.drv»
+        «derivation /nix/store/0dbqnww1fb3ml9f4s21phkw901yszd48-QuickCheck-2.14.3.drv»
+        # ...
+        «derivation /nix/store/0dml0xsw6s1v1d2qqhyk3qjyl4lw2fi4-vector-0.13.2.0.drv»
+      ];
+    }
+    ```
+  */
+  combineInputs =
+    {
+      # A list of packages to get the transitive inputs for.
+      #
+      # Note that while the `packages` parameter to `haskellPackages.shellFor`
+      # is a function from the Haskell package set to a list of packages, this
+      # function takes the list of packages directly.
+      packages,
+
+      # Extra dependencies, in the form of `haskellPackages.mkDerivation` build
+      # attributes.
+      #
+      # An example use case is when you have Haskell scripts that use
+      # libraries that don't occur in the dependencies of `packages`.
+      #
+      # Example:
+      #
+      #   extraDependencies = p: {
+      #     libraryHaskellDepends = [ p.releaser ];
+      #   };
+      extraDependencies ? { },
+
+      ...
+    }:
+    let
+      # This is a list of attribute sets, where each attribute set
+      # corresponds to the build inputs of one of the packages input to shellFor.
+      #
+      # Each attribute has keys like buildDepends, executableHaskellDepends,
+      # testPkgconfigDepends, etc.  The values for the keys of the attribute
+      # set are lists of dependencies.
+      #
+      # Example:
+      #   cabalDepsForSelected
+      #   => [
+      #        # This may be the attribute set corresponding to the `backend`
+      #        # package in the example above.
+      #        { buildDepends = [ gcc ... ];
+      #          libraryHaskellDepends = [ lens conduit ... ];
+      #          ...
+      #        }
+      #        # This may be the attribute set corresponding to the `common`
+      #        # package in the example above.
+      #        { testHaskellDepends = [ tasty hspec ... ];
+      #          libraryHaskellDepends = [ lens aeson ];
+      #          benchmarkHaskellDepends = [ criterion ... ];
+      #          ...
+      #        }
+      #        ...
+      #      ]
+      cabalDepsForSelected = builtins.map (p: p.getCabalDeps) (builtins.filter (p: p != null) packages);
+
+      # A predicate that takes a derivation as input, and tests whether it is
+      # the same as any of the `packages`.
+      #
+      # Returns true if the input derivation is not in the list of `packages`.
+      #
+      # isNotSelected :: Derivation -> Bool
+      #
+      # Example:
+      #
+      #   isNotSelected common [ frontend backend common ]
+      #   => false
+      #
+      #   isNotSelected lens [ frontend backend common ]
+      #   => true
+      isNotSelected = input: pkgs.lib.all (p: input.outPath or null != p.outPath) packages;
+
+      # A function that takes a list of list of derivations, filters out all
+      # the `packages` from each list, and concats the results.
+      #
+      #   zipperCombinedPkgs :: [[Derivation]] -> [Derivation]
+      #
+      # Example:
+      #   zipperCombinedPkgs [ [ lens conduit ] [ aeson frontend ] ]
+      #   => [ lens conduit aeson ]
+      #
+      # Note: The reason this isn't just the function `pkgs.lib.concat` is
+      # that we need to be careful to remove dependencies that are in the
+      # `packages` list.
+      #
+      # For instance, in the above example, if `common` is a dependency of
+      # `backend`, then zipperCombinedPkgs needs to be careful to filter out
+      # `common`, because cabal will end up ignoring that built version,
+      # assuming new-style commands.
+      zipperCombinedPkgs = vals: pkgs.lib.concatMap (drvList: pkgs.lib.filter isNotSelected drvList) vals;
+
+      # Zip `cabalDepsForSelected` into a single attribute list, combining
+      # the derivations in all the individual attributes.
+      #
+      # Example:
+      #   packageInputs
+      #   => # Assuming the value of cabalDepsForSelected is the same as
+      #      # the example in cabalDepsForSelected:
+      #      { buildDepends = [ gcc ... ];
+      #        libraryHaskellDepends = [ lens conduit aeson ... ];
+      #        testHaskellDepends = [ tasty hspec ... ];
+      #        benchmarkHaskellDepends = [ criterion ... ];
+      #        ...
+      #      }
+      #
+      # See the Note in `zipperCombinedPkgs` for what gets filtered out from
+      # each of these dependency lists.
+      packageInputs = pkgs.lib.zipAttrsWith (_name: zipperCombinedPkgs) (
+        cabalDepsForSelected ++ [ extraDependencies ]
+      );
+    in
+    packageInputs;
+
 }

--- a/pkgs/development/haskell-modules/lib/default.nix
+++ b/pkgs/development/haskell-modules/lib/default.nix
@@ -391,4 +391,6 @@ rec {
   # same package in the (recursive) dependencies of the package being
   # built. Will delay failures, if any, to compile time.
   allowInconsistentDependencies = compose.allowInconsistentDependencies;
+
+  combineInputs = compose.combineInputs;
 }

--- a/pkgs/test/haskell/default.nix
+++ b/pkgs/test/haskell/default.nix
@@ -5,6 +5,7 @@ lib.recurseIntoAttrs {
   documentationTarball = callPackage ./documentationTarball { };
   ghcWithPackages = callPackage ./ghcWithPackages { };
   incremental = callPackage ./incremental { };
+  lib = callPackage ./lib { };
   setBuildTarget = callPackage ./setBuildTarget { };
   shellFor = callPackage ./shellFor { };
   upstreamStackHpackVersion = callPackage ./upstreamStackHpackVersion { };

--- a/pkgs/test/haskell/lib/combineInputs/default.nix
+++ b/pkgs/test/haskell/lib/combineInputs/default.nix
@@ -1,0 +1,233 @@
+{
+  lib,
+  haskell,
+  haskellPackages,
+}:
+
+let
+
+  inherit (haskell.lib) combineInputs;
+
+  # An empty result set to save us a bunch of typing for empty lists.
+  #
+  # NOTE: This doesn't have any `benchmark*` attributes because we don't set
+  # `doBenchmark` for most of the test packages.
+  emptyResult = {
+    buildDepends = [ ];
+    buildTools = [ ];
+    executableFrameworkDepends = [ ];
+    executableHaskellDepends = [ ];
+    executablePkgconfigDepends = [ ];
+    executableSystemDepends = [ ];
+    executableToolDepends = [ ];
+    extraLibraries = [ ];
+    libraryFrameworkDepends = [ ];
+    libraryHaskellDepends = [ ];
+    libraryPkgconfigDepends = [ ];
+    librarySystemDepends = [ ];
+    libraryToolDepends = [ ];
+    pkg-configDepends = [ ];
+    setupHaskellDepends = [ ];
+    testDepends = [ ];
+    testFrameworkDepends = [ ];
+    testHaskellDepends = [ ];
+    testPkgconfigDepends = [ ];
+    testSystemDepends = [ ];
+    testToolDepends = [ ];
+  };
+
+  fakePkg =
+    args:
+    haskellPackages.mkDerivation (
+      {
+        version = "0";
+        license = lib.licenses.mit;
+        src = null;
+      }
+      // args
+    );
+
+  fakeHsPkgs = {
+    a = fakePkg {
+      pname = "a";
+      libraryHaskellDepends = [
+        fakeHsPkgs.b
+      ];
+    };
+
+    b = fakePkg {
+      pname = "b";
+      libraryHaskellDepends = [
+        fakeHsPkgs.d
+      ];
+    };
+
+    c = fakePkg {
+      pname = "c";
+      libraryHaskellDepends = [
+        fakeHsPkgs.d
+      ];
+    };
+
+    d = fakePkg {
+      pname = "d";
+    };
+
+    e = fakePkg {
+      pname = "e";
+      libraryHaskellDepends = [
+        fakeHsPkgs.a
+      ];
+    };
+
+    # A package with dependencies in all attributes.
+    allAttributes = fakePkg {
+      pname = "allAttributes";
+
+      doCheck = true;
+      doBenchmark = true;
+
+      buildDepends = [ fakeHsPkgs.a ];
+      buildTools = [ fakeHsPkgs.a ];
+      executableFrameworkDepends = [ fakeHsPkgs.a ];
+      executableHaskellDepends = [ fakeHsPkgs.a ];
+      executablePkgconfigDepends = [ fakeHsPkgs.a ];
+      executableSystemDepends = [ fakeHsPkgs.a ];
+      executableToolDepends = [ fakeHsPkgs.a ];
+      extraLibraries = [ fakeHsPkgs.a ];
+      libraryFrameworkDepends = [ fakeHsPkgs.a ];
+      libraryHaskellDepends = [ fakeHsPkgs.a ];
+      libraryPkgconfigDepends = [ fakeHsPkgs.a ];
+      librarySystemDepends = [ fakeHsPkgs.a ];
+      libraryToolDepends = [ fakeHsPkgs.a ];
+      pkg-configDepends = [ fakeHsPkgs.a ];
+      setupHaskellDepends = [ fakeHsPkgs.a ];
+      testDepends = [ fakeHsPkgs.a ];
+      testFrameworkDepends = [ fakeHsPkgs.a ];
+      testHaskellDepends = [ fakeHsPkgs.a ];
+      testPkgconfigDepends = [ fakeHsPkgs.a ];
+      testSystemDepends = [ fakeHsPkgs.a ];
+      testToolDepends = [ fakeHsPkgs.a ];
+      benchmarkDepends = [ fakeHsPkgs.a ];
+      benchmarkFrameworkDepends = [ fakeHsPkgs.a ];
+      benchmarkHaskellDepends = [ fakeHsPkgs.a ];
+      benchmarkPkgconfigDepends = [ fakeHsPkgs.a ];
+      benchmarkSystemDepends = [ fakeHsPkgs.a ];
+      benchmarkToolDepends = [ fakeHsPkgs.a ];
+    };
+  };
+
+  failures = lib.runTests {
+    testTrivial = {
+      expr = combineInputs {
+        packages = [ ];
+      };
+      # Interestingly, this doesn't include any attributes.
+      expected = { };
+    };
+
+    # We don't pull in transitive dependencies.
+    testTransitive = {
+      expr = combineInputs {
+        packages = [
+          fakeHsPkgs.a
+        ];
+      };
+      expected = emptyResult // {
+        libraryHaskellDepends = [
+          fakeHsPkgs.b
+        ];
+      };
+    };
+
+    # We can ask for multiple packages.
+    testMultiple = {
+      expr = combineInputs {
+        packages = [
+          fakeHsPkgs.a
+          fakeHsPkgs.c
+        ];
+      };
+      expected = emptyResult // {
+        libraryHaskellDepends = [
+          fakeHsPkgs.b
+          fakeHsPkgs.d
+        ];
+      };
+    };
+
+    # Dependencies which are in the `packages` input list are not returned.
+    testExcludeInputs = {
+      expr = combineInputs {
+        packages = [
+          fakeHsPkgs.a
+          fakeHsPkgs.e
+        ];
+      };
+      expected = emptyResult // {
+        libraryHaskellDepends = [
+          fakeHsPkgs.b
+        ];
+      };
+    };
+
+    testAllAttributes = {
+      expr = combineInputs {
+        packages = [
+          fakeHsPkgs.allAttributes
+        ];
+      };
+      expected = {
+        buildDepends = [ fakeHsPkgs.a ];
+        buildTools = [ fakeHsPkgs.a ];
+        executableFrameworkDepends = [ fakeHsPkgs.a ];
+        executableHaskellDepends = [ fakeHsPkgs.a ];
+        executablePkgconfigDepends = [ fakeHsPkgs.a ];
+        executableSystemDepends = [ fakeHsPkgs.a ];
+        executableToolDepends = [ fakeHsPkgs.a ];
+        extraLibraries = [ fakeHsPkgs.a ];
+        libraryFrameworkDepends = [ fakeHsPkgs.a ];
+        libraryHaskellDepends = [ fakeHsPkgs.a ];
+        libraryPkgconfigDepends = [ fakeHsPkgs.a ];
+        librarySystemDepends = [ fakeHsPkgs.a ];
+        libraryToolDepends = [ fakeHsPkgs.a ];
+        pkg-configDepends = [ fakeHsPkgs.a ];
+        setupHaskellDepends = [ fakeHsPkgs.a ];
+        testDepends = [ fakeHsPkgs.a ];
+        testFrameworkDepends = [ fakeHsPkgs.a ];
+        testHaskellDepends = [ fakeHsPkgs.a ];
+        testPkgconfigDepends = [ fakeHsPkgs.a ];
+        testSystemDepends = [ fakeHsPkgs.a ];
+        testToolDepends = [ fakeHsPkgs.a ];
+        benchmarkDepends = [ fakeHsPkgs.a ];
+        benchmarkFrameworkDepends = [ fakeHsPkgs.a ];
+        benchmarkHaskellDepends = [ fakeHsPkgs.a ];
+        benchmarkPkgconfigDepends = [ fakeHsPkgs.a ];
+        benchmarkSystemDepends = [ fakeHsPkgs.a ];
+        benchmarkToolDepends = [ fakeHsPkgs.a ];
+      };
+    };
+
+    # Packages in `extraDependencies` are returned, but _their_ dependencies are not.
+    testExtraDependencies = {
+      expr = combineInputs {
+        packages = [
+          fakeHsPkgs.a
+        ];
+        extraDependencies = {
+          libraryHaskellDepends = [
+            fakeHsPkgs.c
+          ];
+        };
+      };
+      expected = emptyResult // {
+        libraryHaskellDepends = [
+          fakeHsPkgs.b
+          fakeHsPkgs.c
+        ];
+      };
+    };
+  };
+
+in
+if failures == [ ] then null else builtins.throw (builtins.toJSON failures)

--- a/pkgs/test/haskell/lib/default.nix
+++ b/pkgs/test/haskell/lib/default.nix
@@ -1,0 +1,8 @@
+{
+  lib,
+  callPackage,
+}:
+
+lib.recurseIntoAttrs {
+  combineInputs = callPackage ./combineInputs { };
+}


### PR DESCRIPTION
This adds a new `haskell.lib.combineInputs` function which encapsulates the logic used by `haskellPackages.shellFor` to compute package dependencies.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
