### PR TITLE
scx.full: 1.0.12 -> 1.0.13

### DIFF
--- a/pkgs/os-specific/linux/scx/default.nix
+++ b/pkgs/os-specific/linux/scx/default.nix
@@ -22,7 +22,10 @@ let
       license = lib.licenses.gpl2Only;
       platforms = lib.platforms.linux;
       badPlatforms = [ "aarch64-linux" ];
-      maintainers = with lib.maintainers; [ johnrtitor ];
+      maintainers = with lib.maintainers; [
+        johnrtitor
+        Gliczy
+      ];
     };
   };
 

--- a/pkgs/os-specific/linux/scx/default.nix
+++ b/pkgs/os-specific/linux/scx/default.nix
@@ -12,7 +12,7 @@ let
     src = fetchFromGitHub {
       owner = "sched-ext";
       repo = "scx";
-      rev = "refs/tags/v${versionInfo.scx.version}";
+      tag = "v${versionInfo.scx.version}";
       inherit (versionInfo.scx) hash;
     };
 

--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -126,8 +126,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     "out"
   ];
 
-  # Enable this when default kernel in nixpkgs is 6.12+
-  doCheck = false;
+  doCheck = true;
 
   meta = scx-common.meta // {
     description = "Sched-ext C userspace schedulers";

--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -77,6 +77,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
       pkg-config
       zstd
       protobuf
+      llvmPackages.libllvm
     ]
     ++ bpftools.buildInputs
     ++ bpftools.nativeBuildInputs;

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -58,8 +58,14 @@ rustPlatform.buildRustPackage {
     "zerocallusedregs"
   ];
 
-  # Enable this when default kernel in nixpkgs is 6.12+
-  doCheck = false;
+  doCheck = true;
+  checkFlags = [
+    "--skip=compat::tests::test_ksym_exists"
+    "--skip=compat::tests::test_read_enum"
+    "--skip=compat::tests::test_struct_has_field"
+    "--skip=cpumask"
+    "--skip=topology"
+  ];
 
   meta = scx-common.meta // {
     description = "Sched-ext Rust userspace schedulers";

--- a/pkgs/os-specific/linux/scx/version.json
+++ b/pkgs/os-specific/linux/scx/version.json
@@ -1,8 +1,8 @@
 {
   "scx": {
-    "version": "1.0.12",
-    "hash": "sha256-ti4SPx66Ykwqsel7l8Rb0WEBypFbQKoDd0foMAtEmlE=",
-    "cargoHash": "sha256-nD+RalFCJLqQGMVtaJm/NLCrY8Iq5/eAsW+ydABvw2o="
+    "version": "1.0.13",
+    "hash": "sha256-uSYkAsDZEWJ7sB6jd7PZrwYepeLlTdiTi4kAgSDeVsU=",
+    "cargoHash": "sha256-+JDe7l4wX2balOUD11M9z60JSaRyMaIO7Pw1NrjnE30="
   },
   "bpftool": {
     "rev": "183e7010387d1fc9f08051426e9a9fbd5f8d409e",


### PR DESCRIPTION
https://github.com/sched-ext/scx/releases/tag/v1.0.13

- Added `llvmPackages.libllvm` to cscheds' `buildInputs` because `llvm-strip` is now required
- Enabled `doCheck` for `scx_cscheds`
- Added myself as maintainer

`scx_rustscheds`' tests fails if  `doCheck` is enabled, so I kept it disabled for now.
Here's the failing tests result:
```
scx_rustscheds> running 7 tests
scx_rustscheds> libbpf: kernel BTF is missing at '/sys/kernel/btf/vmlinux', was CONFIG_DEBUG_INFO_BTF enabled?
scx_rustscheds> libbpf: failed to find valid kernel BTF
scx_rustscheds> test build_id::tests::test_cargo_ver ... ok
scx_rustscheds> test build_id::tests::test_full_ver ... ok
scx_rustscheds> test compat::tests::test_ksym_exists ... FAILED
scx_rustscheds> test compat::tests::test_struct_has_field ... FAILED
scx_rustscheds> test compat::tests::test_read_enum ... FAILED
scx_rustscheds> test bpf_builder::tests::test_vmlinux_h_ver_sha1 ... ok
scx_rustscheds> test bpf_builder::tests::test_bpf_builder_new ... ok
scx_rustscheds> 
scx_rustscheds> failures:
scx_rustscheds> 
scx_rustscheds> ---- compat::tests::test_ksym_exists stdout ----
scx_rustscheds> 
scx_rustscheds> thread 'compat::tests::test_ksym_exists' panicked at rust/scx_utils/src/compat.rs:48:9:
scx_rustscheds> btf__load_vmlinux_btf() returned NULL, was CONFIG_DEBUG_INFO_BTF enabled?
scx_rustscheds> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
scx_rustscheds> 
scx_rustscheds> ---- compat::tests::test_struct_has_field stdout ----
scx_rustscheds> 
scx_rustscheds> thread 'compat::tests::test_struct_has_field' panicked at /build/scx_rustscheds-1.0.13-vendor/lazy_static-1.5.0/src/inline_lazy.rs:30:16:
scx_rustscheds> Once instance has previously been poisoned
scx_rustscheds> 
scx_rustscheds> ---- compat::tests::test_read_enum stdout ----
scx_rustscheds> 
scx_rustscheds> thread 'compat::tests::test_read_enum' panicked at /build/scx_rustscheds-1.0.13-vendor/lazy_static-1.5.0/src/inline_lazy.rs:30:16:
scx_rustscheds> Once instance has previously been poisoned
scx_rustscheds> 
scx_rustscheds> 
scx_rustscheds> failures:
scx_rustscheds>     compat::tests::test_ksym_exists
scx_rustscheds>     compat::tests::test_read_enum
scx_rustscheds>     compat::tests::test_struct_has_field
scx_rustscheds> 
scx_rustscheds> test result: FAILED. 4 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s

```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
