### PR TITLE
varnish: fix builds of `varnish`, `varnish77`, and `varnish60` on macOS

### DIFF
--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch2,
   pcre,
   pcre2,
   jemalloc,
@@ -55,6 +56,24 @@ let
         ++ lib.optional stdenv.hostPlatform.isLinux jemalloc;
 
       buildFlags = [ "localstatedir=/var/run" ];
+
+      patches =
+        lib.optionals (stdenv.isDarwin && lib.versionAtLeast version "7.7") [
+          # Fix VMOD section attribute on macOS
+          # Unreleased commit on master
+          (fetchpatch2 {
+            url = "https://github.com/varnishcache/varnish-cache/commit/a95399f5b9eda1bfdba6ee6406c30a1ed0720167.patch";
+            hash = "sha256-T7DIkmnq0O+Cr9DTJS4/rOtg3J6PloUo8jHMWoUZYYk=";
+          })
+          # Fix endian.h compatibility on macOS
+          # PR: https://github.com/varnishcache/varnish-cache/pull/4339
+          ./patches/0001-fix-endian-h-compatibility-on-macos.patch
+        ]
+        ++ lib.optionals (stdenv.isDarwin && lib.versionOlder version "7.6") [
+          # Fix duplicate OS_CODE definitions on macOS
+          # PR: https://github.com/varnishcache/varnish-cache/pull/4347
+          ./patches/0002-fix-duplicate-os-code-definitions-on-macos.patch
+        ];
 
       postPatch = ''
         substituteInPlace bin/varnishtest/vtc_main.c --replace /bin/rm "${coreutils}/bin/rm"

--- a/pkgs/servers/varnish/patches/0001-fix-endian-h-compatibility-on-macos.patch
+++ b/pkgs/servers/varnish/patches/0001-fix-endian-h-compatibility-on-macos.patch
@@ -1,0 +1,43 @@
+From 7a1c7020db85699e0693d637f6e31d49bf9ca3d0 Mon Sep 17 00:00:00 2001
+From: Rui Chen <rui@chenrui.dev>
+Date: Sun, 25 May 2025 23:54:29 -0400
+Subject: [PATCH] libvarnish: Fix endian.h compatibility for macOS builds
+
+Signed-off-by: Rui Chen <rui@chenrui.dev>
+---
+ lib/libvarnish/vsha256.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/lib/libvarnish/vsha256.c b/lib/libvarnish/vsha256.c
+index 29f97fe40..541b6e612 100644
+--- a/lib/libvarnish/vsha256.c
++++ b/lib/libvarnish/vsha256.c
+@@ -31,7 +31,14 @@
+ 
+ #include "config.h"
+ 
+-#ifndef __DARWIN_BYTE_ORDER
++#ifdef __APPLE__
++#  include <machine/endian.h>
++#  include <libkern/OSByteOrder.h>
++#  define htobe32(x) OSSwapHostToBigInt32(x)
++#  define htobe64(x) OSSwapHostToBigInt64(x)
++#  define VBYTE_ORDER __DARWIN_BYTE_ORDER
++#  define VBIG_ENDIAN __DARWIN_BIG_ENDIAN
++#else
+ #  include <endian.h>
+ #  ifdef _BYTE_ORDER
+ #    define VBYTE_ORDER	_BYTE_ORDER
+@@ -43,9 +50,6 @@
+ #  else
+ #    define VBIG_ENDIAN	__BIG_ENDIAN
+ #  endif
+-#else
+-#  define VBYTE_ORDER	__DARWIN_BYTE_ORDER
+-#  define VBIG_ENDIAN	__DARWIN_BIG_ENDIAN
+ #endif
+ 
+ #ifndef VBYTE_ORDER
+-- 
+2.49.0
+

--- a/pkgs/servers/varnish/patches/0002-fix-duplicate-os-code-definitions-on-macos.patch
+++ b/pkgs/servers/varnish/patches/0002-fix-duplicate-os-code-definitions-on-macos.patch
@@ -1,0 +1,43 @@
+From f56b314408d22252bf62d6cd2e098cf8139bd048 Mon Sep 17 00:00:00 2001
+From: Sander <hey@sandydoo.me>
+Date: Fri, 13 Jun 2025 01:12:59 +0200
+Subject: [PATCH] build: fix duplicate OS_CODE definitions on macOS
+
+`TARGET_OS_MAC` and `__APPLE__` are both true on macOS, which results in
+duplicate definitions for `OS_CODE`.
+
+Upstream removed the check for `TARGET_OS_MAC`, as well as the ancient
+compat code, in
+https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9.
+
+This was fixed in varnish >= 7.6 as part of https://github.com/varnishcache/varnish-cache/commit/86df12b6c1ad8208899ea353fdcbea227356fcf8.
+---
+ lib/libvgz/zutil.h | 11 +----------
+ 1 file changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/lib/libvgz/zutil.h b/lib/libvgz/zutil.h
+index 1c80e3842..294ea2b2d 100644
+--- a/lib/libvgz/zutil.h
++++ b/lib/libvgz/zutil.h
+@@ -137,17 +137,8 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
+ #endif
+ 
+ #ifdef __acorn
+-- 
+2.49.0
+


### PR DESCRIPTION
Applies several patches to get varnish to build on macOS.

For `varnish77`:

  - Fix `endian.h` compatibility for macOS
     https://github.com/varnishcache/varnish-cache/pull/4339

  - Fix VMOD section attribute on macOS
     https://github.com/varnishcache/varnish-cache/commit/a95399f5b9eda1bfdba6ee6406c30a1ed0720167.patch

For `varnish60`:

  - Fix duplicate OS_CODE definitions on macOS
     https://github.com/varnishcache/varnish-cache/pull/4347


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
