### PR TITLE
[Backport release-25.05] firebird_2_5: drop

### DIFF
--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -55,34 +55,6 @@ let
   };
 in
 rec {
-
-  firebird_2_5 = stdenv.mkDerivation (
-    base
-    // rec {
-      version = "2.5.9";
-
-      src = fetchFromGitHub {
-        owner = "FirebirdSQL";
-        repo = "firebird";
-        rev = "R${builtins.replaceStrings [ "." ] [ "_" ] version}";
-        sha256 = "sha256-YyvlMeBux80OpVhsCv+6IVxKXFRsgdr+1siupMR13JM=";
-      };
-
-      configureFlags = base.configureFlags ++ [ "--with-system-icu" ];
-
-      installPhase = ''
-        runHook preInstall
-        mkdir -p $out
-        cp -r gen/firebird/* $out
-        runHook postInstall
-      '';
-
-      meta = base.meta // {
-        platforms = [ "x86_64-linux" ];
-      };
-    }
-  );
-
   firebird_3 = stdenv.mkDerivation (
     base
     // rec {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -646,6 +646,7 @@ mapAliases {
   finger_bsd = bsd-finger;
   fingerd_bsd = bsd-fingerd;
   fira-code-nerdfont = lib.warnOnInstantiate "fira-code-nerdfont is redundant. Use nerd-fonts.fira-code instead." nerd-fonts.fira-code; # Added 2024-11-10
+  firebird_2_5 = throw "'firebird_2_5' has been removed as it has reached end-of-life and does not build."; # Added 2025-06-10
   firefox-esr-115 = throw "The Firefox 115 ESR series has reached its end of life. Upgrade to `firefox-esr` or `firefox-esr-128` instead.";
   firefox-esr-115-unwrapped = throw "The Firefox 115 ESR series has reached its end of life. Upgrade to `firefox-esr-unwrapped` or `firefox-esr-128-unwrapped` instead.";
   firefox-wayland = firefox; # Added 2022-11-15

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10390,7 +10390,6 @@ with pkgs;
   inherit (callPackages ../servers/firebird { })
     firebird_4
     firebird_3
-    firebird_2_5
     firebird
     ;
 


### PR DESCRIPTION
Backport of #415603 to `release-25.05`. Fixes Hydra build.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
  