### PR TITLE
[Backport release-25.05] wdt: 1.27.1612021-unstable-2024-12-06 -> 1.27.1612021-unstable-2025-06-05

### DIFF
--- a/pkgs/by-name/wd/wdt/fix-glog-include.patch
+++ b/pkgs/by-name/wd/wdt/fix-glog-include.patch
@@ -1,0 +1,49 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index abbeead..93cac12 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -136,8 +136,7 @@ find_package(Threads) # this will set ${CMAKE_THREAD_LIBS_INIT} (ie pthreads)
+ find_path(DOUBLECONV_INCLUDE_DIR double-conversion/double-conversion.h)
+ find_library(DOUBLECONV_LIBRARY double-conversion)
+ # Glog
+-find_path(GLOG_INCLUDE_DIR glog/logging.h)
+-find_library(GLOG_LIBRARY glog)
++find_package(glog REQUIRED)
+ # Gflags
+ find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h)
+ find_library(GFLAGS_LIBRARY gflags)
+@@ -174,7 +173,7 @@ endif()
+ # You can also add jemalloc to the list if you have it/want it
+ target_link_libraries(wdt_min
+   ${FOLLY_LIBRARY}
+-  ${GLOG_LIBRARY}
++  glog::glog
+   ${GFLAGS_LIBRARY}
+   ${Boost_LIBRARIES}
+   ${DOUBLECONV_LIBRARY}
+@@ -226,7 +225,7 @@ if (NOT WDT_USE_SYSTEM_FOLLY)
+   endif()
+ 
+   add_library(folly4wdt ${FOLLY_CPP_SRC})
+-  target_link_libraries(folly4wdt ${GLOG_LIBRARY} ${DOUBLECONV_LIBRARY})
++  target_link_libraries(folly4wdt glog::glog ${DOUBLECONV_LIBRARY})
+ endif()
+ 
+ # Order is important - inside fb we want the above
+@@ -234,7 +233,6 @@ endif()
+ include_directories(${CMAKE_CURRENT_BINARY_DIR})
+ include_directories(${FOLLY_INCLUDE_DIR})
+ include_directories(${DOUBLECONV_INCLUDE_DIR})
+-include_directories(${GLOG_INCLUDE_DIR})
+ include_directories(${GFLAGS_INCLUDE_DIR})
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
+ 
+@@ -336,7 +334,7 @@ if (BUILD_TESTING)
+   )
+ 
+   target_link_libraries(wdtbenchlib
+-    ${GLOG_LIBRARY}
++    glog::glog
+     ${GFLAGS_LIBRARY}
+   )
+ 

--- a/pkgs/by-name/wd/wdt/package.nix
+++ b/pkgs/by-name/wd/wdt/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation {
   pname = "wdt";
-  version = "1.27.1612021-unstable-2024-12-06";
+  version = "1.27.1612021-unstable-2025-06-05";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "wdt";
-    rev = "7e56c871be706cc96df48be7c4017bff7c6fc7c8";
-    sha256 = "sha256-mvfJUiOI7Cre90hIaBJcmfTbTV5M+Hf+p6VKNYEc5WU=";
+    rev = "5cf3886d1b70f8aee60ec74b86823de1dce4233b";
+    sha256 = "sha256-g6wzYM++yv8tCUKom1bWB9MlImG/+OkhoTH+kTxURoA=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -36,6 +36,10 @@ stdenv.mkDerivation {
   postUnpack = ''
     ln -s $sourceRoot wdt
   '';
+
+  patches = [
+    ./fix-glog-include.patch
+  ];
 
   cmakeFlags = [
     "-DWDT_USE_SYSTEM_FOLLY=ON"


### PR DESCRIPTION
Backport of #416221 to `release-25.05`. Fixes Hydra build.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.