### PR TITLE
quickshell: init at 0.1.0

### DIFF
--- a/pkgs/by-name/qu/quickshell/package.nix
+++ b/pkgs/by-name/qu/quickshell/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+
+  pkg-config,
+  cmake,
+  ninja,
+  spirv-tools,
+  qt6,
+  breakpad,
+  jemalloc,
+  cli11,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  xorg,
+  libdrm,
+  libgbm,
+  pipewire,
+  pam,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "quickshell";
+  version = "0.1.0";
+
+  # github mirror: https://github.com/quickshell-mirror/quickshell
+  src = fetchFromGitea {
+    domain = "git.outfoxxed.me";
+    owner = "quickshell";
+    repo = "quickshell";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DdE50ZJN/mKsSF/vc9hrMboOeJ7BST5DD6GNEXgVbWg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    qt6.qtshadertools
+    spirv-tools
+    wayland-scanner
+    qt6.wrapQtAppsHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtwayland
+    qt6.qtsvg
+    cli11
+    wayland
+    wayland-protocols
+    libdrm
+    libgbm
+    breakpad
+    jemalloc
+    xorg.libxcb
+    pam
+    pipewire
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "DISTRIBUTOR" "Nixpkgs")
+    (lib.cmakeBool "DISTRIBUTOR_DEBUGINFO_AVAILABLE" true)
+    (lib.cmakeFeature "INSTALL_QML_PREFIX" qt6.qtbase.qtQmlPrefix)
+    (lib.cmakeFeature "GIT_REVISION" "tag-v${finalAttrs.version}")
+  ];
+
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+  dontStrip = false;
+
+  meta = {
+    homepage = "https://quickshell.outfoxxed.me";
+    description = "Flexbile QtQuick based desktop shell toolkit";
+    license = lib.licenses.lgpl3Only;
+    platforms = lib.platforms.linux;
+    mainProgram = "quickshell";
+    maintainers = with lib.maintainers; [ outfoxxed ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds Quickshell, a QtQuick based toolkit for building desktop shell components.

Website: https://quickshell.outfoxxed.me

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
