### PR TITLE
cyberchef: Add binary and desktop item

### DIFF
--- a/pkgs/by-name/cy/cyberchef/package.nix
+++ b/pkgs/by-name/cy/cyberchef/package.nix
@@ -1,30 +1,66 @@
 {
   lib,
   fetchzip,
+  fetchurl,
   stdenv,
+  makeDesktopItem,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "cyberchef";
+let
+  icon = fetchurl {
+    url = "https://raw.githubusercontent.com/gchq/CyberChef/c57556f49f723863b9be15668fd240672cd15b09/src/web/static/images/cyberchef-512x512.png";
+    hash = "sha256-Lg9JbVHhdILdrRtxYFWSv9HNJUx98JOaTbs+IbS1eO0=";
+  };
+  desktopItem = (
+    makeDesktopItem {
+      name = "cyberchef";
+      desktopName = "Cyberchef";
+      exec = "cyberchef";
+      icon = "cyberchef";
+      comment = "Cyber Swiss Army Knife for encryption, encoding, compression and data analysis";
+      categories = [ "Development" ];
+    }
+  );
   version = "10.19.4";
+in
+stdenv.mkDerivation {
+  pname = "cyberchef";
+  inherit version;
 
   src = fetchzip {
     url = "https://github.com/gchq/CyberChef/releases/download/v${version}/CyberChef_v${version}.zip";
-    sha256 = "sha256-eOMo7kdxC5HfmMrKUhGZU3vnBXibO2Fz1ftIS9RAbjY=";
+    hash = "sha256-eOMo7kdxC5HfmMrKUhGZU3vnBXibO2Fz1ftIS9RAbjY=";
     stripRoot = false;
   };
 
   installPhase = ''
     mkdir -p "$out/share/cyberchef"
+    mkdir -p "$out/bin"
+
     mv "CyberChef_v${version}.html" index.html
     mv * "$out/share/cyberchef"
+
+    cat <<INI > $out/bin/cyberchef
+    #!/bin/sh
+    xdg-open $out/share/cyberchef/index.html
+    INI
+
+    chmod +x $out/bin/cyberchef
+
+    install -m 444 -D ${icon} $out/share/icons/hicolor/512x512/apps/cyberchef.png
+
+    mkdir -p $out/share/applications/
+    cp ${desktopItem}/share/applications/*.desktop $out/share/applications/
   '';
 
   meta = {
     description = "Cyber Swiss Army Knife for encryption, encoding, compression and data analysis";
     homepage = "https://gchq.github.io/CyberChef";
     changelog = "https://github.com/gchq/CyberChef/blob/v${version}/CHANGELOG.md";
-    maintainers = with lib.maintainers; [ sebastianblunt ];
+    maintainers = with lib.maintainers; [
+      sebastianblunt
+      aldenparker
+    ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
Adds a shell script for starting cyberchef to the path as well as a desktop item for programs like wofi and fuzzel.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
