### PR TITLE
nushellPlugins.desktop-notifications: init at 1.2.11

### DIFF
--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -23,6 +23,7 @@ lib.makeScope newScope (
     skim = callPackage ./skim.nix { };
     semver = callPackage ./semver.nix { };
     hcl = callPackage ./hcl.nix { };
+    desktop-notifications = callPackage ./desktop-notifications.nix { };
   }
   // lib.optionalAttrs config.allowAliases {
     regex = throw "`nu_plugin_regex` is no longer compatible with the current Nushell release.";

--- a/pkgs/shells/nushell/plugins/desktop-notifications.nix
+++ b/pkgs/shells/nushell/plugins/desktop-notifications.nix
@@ -1,0 +1,40 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  pkg-config,
+  nix-update-script,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "nu_plugin_desktop_notifications";
+  version = "1.2.11-unstable-2025-05-05";
+
+  src = fetchFromGitHub {
+    repo = "nu_plugin_desktop_notifications";
+    owner = "FMotalleb";
+    rev = "de4464bf6ce6503977ee2bd41f11aeabc49214aa"; # No tag for nushell 0.104.0
+    hash = "sha256-ZQ1zOYcGTfHhRAnDxVxcZ740yF2nccIOWL+yuShhs0Y=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-DrHWdwljPsPkzbM9mok5x7gn6Op1ytwg67+HtcZg8G8=";
+
+  nativeBuildInputs =
+    [ pkg-config ]
+    ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ writableTmpDirAsHomeHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Nushell plugin for sending desktop notifications using notify-rust";
+    mainProgram = "nu_plugin_desktop_notifications";
+    homepage = "https://github.com/FMotalleb/nu_plugin_desktop_notifications";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aldenparker ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Adds [nu_desktop_notifications](https://github.com/FMotalleb/nu_plugin_desktop_notifications) as a nushell plugin.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
