### PR TITLE
python3Packages.bx-py-utils: 108 -> 109

### DIFF
--- a/pkgs/development/python-modules/bx-py-utils/default.nix
+++ b/pkgs/development/python-modules/bx-py-utils/default.nix
@@ -4,10 +4,10 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
-  setuptools-scm,
   beautifulsoup4,
   boto3,
   freezegun,
+  hatchling,
   lxml,
   openpyxl,
   parameterized,
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "bx-py-utils";
-  version = "108";
+  version = "109";
 
   disabled = pythonOlder "3.10";
 
@@ -29,14 +29,14 @@ buildPythonPackage rec {
     owner = "boxine";
     repo = "bx_py_utils";
     tag = "v${version}";
-    hash = "sha256-VMGP5yl+7kiZ3Ww4ESJPHABDCMZG1VsVDgVoLnGU5r4=";
+    hash = "sha256-y1R48nGeTCpcBAzU3kqNQumRToKvQx9qst1kXPWDIlk=";
   };
 
   postPatch = ''
     rm bx_py_utils_tests/publish.py
   '';
 
-  build-system = [ setuptools-scm ];
+  build-system = [ hatchling ];
 
   pythonImportsCheck = [
     "bx_py_utils.anonymize"
@@ -76,15 +76,17 @@ buildPythonPackage rec {
     # too closely affected by bs4 updates
     "test_pretty_format_html"
     "test_assert_html_snapshot_by_css_selector"
+    # test accesses the internet
+    "test_happy_path"
+    # test assumes a virtual environment
+    "test_code_style"
   ];
 
-  disabledTestPaths =
-    [ "bx_py_utils_tests/tests/test_project_setup.py" ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # processify() doesn't work under darwin
-      # https://github.com/boxine/bx_py_utils/issues/80
-      "bx_py_utils_tests/tests/test_processify.py"
-    ];
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # processify() doesn't work under darwin
+    # https://github.com/boxine/bx_py_utils/issues/80
+    "bx_py_utils_tests/tests/test_processify.py"
+  ];
 
   meta = {
     description = "Various Python utility functions";


### PR DESCRIPTION
Diff: https://github.com/boxine/bx_py_utils/compare/refs/tags/v108...refs/tags/v109

Changelog: https://github.com/boxine/bx_py_utils/releases/tag/v109


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
