### PR TITLE
nushellPlugins.clipboard: init at 0.104.0

### DIFF
--- a/pkgs/shells/nushell/plugins/clipboard.nix
+++ b/pkgs/shells/nushell/plugins/clipboard.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  pkg-config,
+  nix-update-script,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "nushell_plugin_clipboard";
+  version = "0.104.0-unstable-2025-05-05";
+
+  src = fetchFromGitHub {
+    repo = "nu_plugin_clipboard";
+    owner = "FMotalleb";
+    rev = "0f91062388d5bc3346325f6029c5fa3691715a76"; # No tag for nushell 0.104.0
+    hash = "sha256-JUjZlWx2RtphrZhSX4Fgb8r9Y1kxs3HNt4CyuxpiDcA=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-d0jmzKme0yZl9j/pgcZXYSUjUHZ7SaWM22Im1zcph2s=";
+
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+  cargoBuildFlags = [ "--features use-wayland" ]; # Needed on wayland, will still be compatable with x11
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Nushell plugin for interacting with the clipboard";
+    longDescription = ''
+      NOTE: Turning off the daemon may be needed for copy to work.
+      More info can be found at the project's github.
+      Issue mentioning the problem: https://github.com/FMotalleb/nu_plugin_clipboard/issues/1
+      Project readme mentions the mitigation: https://github.com/FMotalleb/nu_plugin_clipboard
+    '';
+    mainProgram = "nu_plugin_clipboard";
+    homepage = "https://github.com/FMotalleb/nu_plugin_clipboard";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aldenparker ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -23,6 +23,7 @@ lib.makeScope newScope (
     skim = callPackage ./skim.nix { };
     semver = callPackage ./semver.nix { };
     hcl = callPackage ./hcl.nix { };
+    clipboard = callPackage ./clipboard.nix { };
   }
   // lib.optionalAttrs config.allowAliases {
     regex = throw "`nu_plugin_regex` is no longer compatible with the current Nushell release.";


### PR DESCRIPTION
Adds [nu_plugin_clipboard](https://github.com/FMotalleb/nu_plugin_clipboard) as a nushell plugin.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
