### PR TITLE
python312Packages.xgrammar: 0.1.16 -> 0.1.19

### DIFF
--- a/pkgs/development/python-modules/xgrammar/0001-fix-find-nanobind-from-python-module.patch
+++ b/pkgs/development/python-modules/xgrammar/0001-fix-find-nanobind-from-python-module.patch
@@ -1,0 +1,41 @@
+From c01e056ee845ae973ec36cc50125492ef8c02c12 Mon Sep 17 00:00:00 2001
+From: Conroy Cheers <conroy@corncheese.org>
+Date: Thu, 12 Jun 2025 17:45:27 +1000
+Subject: [PATCH] [Fix] find nanobind from Python module
+
+---
+ cpp/nanobind/CMakeLists.txt | 4 ++++
+ pyproject.toml              | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cpp/nanobind/CMakeLists.txt b/cpp/nanobind/CMakeLists.txt
+index 8ea5622..02500ac 100644
+--- a/cpp/nanobind/CMakeLists.txt
++++ b/cpp/nanobind/CMakeLists.txt
+@@ -3,6 +3,10 @@ find_package(
+   COMPONENTS Interpreter Development.Module
+   REQUIRED
+ )
++
++execute_process(
++  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
++  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_DIR)
+ find_package(nanobind CONFIG REQUIRED)
+ 
+ # Compile this source file seperately. Nanobind suggests to optimize bindings code for size, but
+diff --git a/pyproject.toml b/pyproject.toml
+index 11fae7d..d2078b1 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -44,7 +44,7 @@ provider = "scikit_build_core.metadata.regex"
+ input = "python/xgrammar/version.py"
+ 
+ [build-system]
+-requires = ["scikit-build-core>=0.10.0", "nanobind==2.5.0"]
++requires = ["scikit-build-core>=0.10.0", "nanobind>=2.5.0"]
+ build-backend = "scikit_build_core.build"
+ 
+ [tool.scikit-build]
+-- 
+2.49.0
+

--- a/pkgs/development/python-modules/xgrammar/default.nix
+++ b/pkgs/development/python-modules/xgrammar/default.nix
@@ -7,7 +7,7 @@
   # build-system
   cmake,
   ninja,
-  pybind11,
+  nanobind,
   scikit-build-core,
 
   # dependencies
@@ -25,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "xgrammar";
-  version = "0.1.14";
+  version = "0.1.19";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -33,13 +33,17 @@ buildPythonPackage rec {
     repo = "xgrammar";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-ohsoc3g5XUp9vSXxyOGj20wXzCXZC02ktHYVQjDqNeM=";
+    hash = "sha256-0b2tJx1D/2X/uosbthHfevUpTCBtuSKNlxOKyidTotA=";
   };
+
+  patches = [
+    ./0001-fix-find-nanobind-from-python-module.patch
+  ];
 
   build-system = [
     cmake
     ninja
-    pybind11
+    nanobind
     scikit-build-core
   ];
   dontUseCmakeConfigure = true;
@@ -59,6 +63,11 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     writableTmpDirAsHomeHook
+  ];
+
+  NIX_CFLAGS_COMPILE = toString [
+    # xgrammar hardcodes -flto=auto while using static linking, which can cause linker errors without this additional flag.
+    "-ffat-lto-objects"
   ];
 
   disabledTests = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Update `xgrammar` to [0.1.19](https://github.com/mlc-ai/xgrammar/releases/tag/v0.1.19)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
