### PR TITLE
[Backport 25.05]: yaziPlugins

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/bypass/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/bypass/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "bypass.yazi";
-  version = "25.3.2-unstable-2025-05-30";
+  version = "25.3.2-unstable-2025-06-01";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";
     repo = "bypass.yazi";
-    rev = "381fb89a21a58605c555c109f190309b2d116d30";
-    hash = "sha256-04cyOlG843Ot+jRT8GNFjJOzV4YdPBpI9XqbaK6KXu0=";
+    rev = "c1e5fcf6eeed0bfceb57b9738da6db9d0fb8af56";
+    hash = "sha256-ZndDtTMkEwuIMXG4SGe4B95Nw4fChfFhxJHj+IY30Kc=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/bypass/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/bypass/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "bypass.yazi";
-  version = "25.3.2-unstable-2025-05-11";
+  version = "25.3.2-unstable-2025-05-30";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";
     repo = "bypass.yazi";
-    rev = "85b5e9624a9eaa14c70b17b873209a2054f4062a";
-    hash = "sha256-2fblXb2uE6tq9goZKzMFgiEUVsx+uaRLyIq9BzTM8KA=";
+    rev = "381fb89a21a58605c555c109f190309b2d116d30";
+    hash = "sha256-04cyOlG843Ot+jRT8GNFjJOzV4YdPBpI9XqbaK6KXu0=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/chmod/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/chmod/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "chmod.yazi";
-  version = "25.2.26-unstable-2025-03-02";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "b44c245500b34e713732a9130bf436b13b4777e9";
-    hash = "sha256-nZ8yfnKvNLM5aA+mmQ3PkfM5lwSKwWnkQewcg9GwseI=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/duckdb/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/duckdb/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "duckdb.yazi";
-  version = "25.4.8-unstable-2025-04-28";
+  version = "25.4.8-unstable-2025-05-29";
 
   src = fetchFromGitHub {
     owner = "wylie102";
     repo = "duckdb.yazi";
-    rev = "02f902dfaf22f20c121da49bfcf5500f4fb11d7d";
-    hash = "sha256-fESxJDU7befG2aDxm79M9Eq71RH1UwA4hi0OgK9vPbM=";
+    rev = "3f8c8633d4b02d3099cddf9e892ca5469694ba22";
+    hash = "sha256-XQM459V3HbPgXKgd9LnAIKRQOAaJPdZA/Tp91TSGHqY=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/full-border/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/full-border/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "full-border.yazi";
-  version = "25.2.26-unstable-2025-03-11";
+  version = "25.2.26-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "92f78dc6d0a42569fd0e9df8f70670648b8afb78";
-    hash = "sha256-mqo71VLZsHmgTybxgqKNo9F2QeMuCSvZ89uen1VbWb4=";
+    rev = "f9b3f8876eaa74d8b76e5b8356aca7e6a81c0fb7";
+    hash = "sha256-EoIrbyC7WgRzrEtvso2Sr6HnNW91c5E+RZGqnjEi6Zo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/git/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/git/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "git.yazi";
-  version = "25.4.4-unstable-2025-04-04";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "9a095057d698aaaedc4dd23d638285bd3fd647e9";
-    hash = "sha256-Lx+TliqMuaXpjaUtjdUac7ODg2yc3yrd1mSWJo9Mz2Q=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/jump-to-char/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/jump-to-char/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "jump-to-char.yazi";
-  version = "25.2.26-unstable-2025-03-02";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "b44c245500b34e713732a9130bf436b13b4777e9";
-    hash = "sha256-nZ8yfnKvNLM5aA+mmQ3PkfM5lwSKwWnkQewcg9GwseI=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/lsar/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/lsar/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "lsar.yazi";
-  version = "25.2.26-unstable-2025-03-02";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "b44c245500b34e713732a9130bf436b13b4777e9";
-    hash = "sha256-nZ8yfnKvNLM5aA+mmQ3PkfM5lwSKwWnkQewcg9GwseI=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mactag.yazi";
-  version = "25.4.4-unstable-2025-04-04";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "9a095057d698aaaedc4dd23d638285bd3fd647e9";
-    hash = "sha256-Lx+TliqMuaXpjaUtjdUac7ODg2yc3yrd1mSWJo9Mz2Q=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.4.8-unstable-2025-05-19";
+  version = "25.5.28-unstable-2025-05-30";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "70ed2287159b17bf2b9c1598252c5c33ba52b8a3";
-    hash = "sha256-MMsKb9+zeOtWrpE3SalWhGIqeOwHrLdwf8xWYvWXjbo=";
+    rev = "c6d0de764f6e667c1a7a49f8acc9030c02a1a45c";
+    hash = "sha256-CVHY66AcOC0STi+uDwbKe+HI3WN7MPgszlFHB479V/E=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.5.28-unstable-2025-05-30";
+  version = "25.5.31-unstable-2025-06-05";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "c6d0de764f6e667c1a7a49f8acc9030c02a1a45c";
-    hash = "sha256-CVHY66AcOC0STi+uDwbKe+HI3WN7MPgszlFHB479V/E=";
+    rev = "a7d1aa69a1a107e64540c17f19ac94be1366769f";
+    hash = "sha256-HUD8Sv1C4gzZRvSEIYqcmm+A0mBYDuwZHCNH26kipS0=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.2.7-unstable-2025-04-17";
+  version = "25.4.8-unstable-2025-05-19";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "9629b1e85c3757c834ec83fb7d931982c55f4c3f";
-    hash = "sha256-EDEIiZJy/RfXVaLNsKDeklH4qY2h+js2m0y6VSAjPkk=";
+    rev = "70ed2287159b17bf2b9c1598252c5c33ba52b8a3";
+    hash = "sha256-MMsKb9+zeOtWrpE3SalWhGIqeOwHrLdwf8xWYvWXjbo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/miller/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/miller/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "miller.yazi";
-  version = "0-unstable-2024-08-28";
+  version = "0-unstable-2025-04-17";
 
   src = fetchFromGitHub {
     owner = "Reledia";
     repo = "miller.yazi";
-    rev = "40e02654725a9902b689114537626207cbf23436";
-    hash = "sha256-GXZZ/vI52rSw573hoMmspnuzFoBXDLcA0fqjF76CdnY=";
+    rev = "0a3d1316e38132ae9a6b91fbd69bab295cbbf2fe";
+    hash = "sha256-pZpx7V5ud5JhEkgkfVBSuM0CFIIUXZZ+pOX0xVlHf+0=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mime-ext.yazi";
-  version = "25.4.4-unstable-2025-04-04";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "9a095057d698aaaedc4dd23d638285bd3fd647e9";
-    hash = "sha256-Lx+TliqMuaXpjaUtjdUac7ODg2yc3yrd1mSWJo9Mz2Q=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mount/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mount/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mount.yazi";
-  version = "25.2.26-unstable-2025-03-02";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "b44c245500b34e713732a9130bf436b13b4777e9";
-    hash = "sha256-nZ8yfnKvNLM5aA+mmQ3PkfM5lwSKwWnkQewcg9GwseI=";
+    rev = "f9b3f8876eaa74d8b76e5b8356aca7e6a81c0fb7";
+    hash = "sha256-EoIrbyC7WgRzrEtvso2Sr6HnNW91c5E+RZGqnjEi6Zo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mount/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mount/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mount.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.28-unstable-2025-06-11";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "f9b3f8876eaa74d8b76e5b8356aca7e6a81c0fb7";
-    hash = "sha256-EoIrbyC7WgRzrEtvso2Sr6HnNW91c5E+RZGqnjEi6Zo=";
+    rev = "c1d638374c76655896c06e9bc91cdb39857b7f15";
+    hash = "sha256-cj2RjeW4/9ZRCd/H4PxrIQWW9kSOxtdi72f+8o13aPI=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/nord/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/nord/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "nord.yazi";
-  version = "0-unstable-2025-05-14";
+  version = "0-unstable-2025-05-20";
 
   src = fetchFromGitHub {
     owner = "stepbrobd";
     repo = "nord.yazi";
-    rev = "0f8eff4367021be1b741391d98853fbd1a34baf9";
-    hash = "sha256-bcYIbKFU1bvGRS6lgEBMe2jT13bECYgQATuh3QKmhQE=";
+    rev = "c9a58b4361ac82d5ddc91e6e27b620bb096d0bee";
+    hash = "sha256-yjxdoZlOPFliNbp+SwNFd+PPWlD7j8edXC8urQo7WZA=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "ouch.yazi";
-  version = "0-unstable-2025-06-01";
+  version = "0-unstable-2025-06-10";
 
   src = fetchFromGitHub {
     owner = "ndtoan96";
     repo = "ouch.yazi";
-    rev = "10b462765f37502065555e83c68a72bb26870fe2";
-    hash = "sha256-mtXl76a54Deg4cyrD0wr++sD/5b/kCsnJ+ngM6OokTc=";
+    rev = "1ee69a56da3c4b90ec8716dd9dd6b82e7a944614";
+    hash = "sha256-4KZeDkMXlhUV0Zh+VGBtz9kFPGOWCexYVuKUSCN463o=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "ouch.yazi";
-  version = "0-unstable-2025-04-12";
+  version = "0-unstable-2025-06-01";
 
   src = fetchFromGitHub {
     owner = "ndtoan96";
     repo = "ouch.yazi";
-    rev = "2496cd9ac2d1fb52597b22ae84f3af06c826a86d";
-    hash = "sha256-OsNfR7rtnq+ceBTiFjbz+NFMSV/6cQ1THxEFzI4oPJk=";
+    rev = "10b462765f37502065555e83c68a72bb26870fe2";
+    hash = "sha256-mtXl76a54Deg4cyrD0wr++sD/5b/kCsnJ+ngM6OokTc=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/piper/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/piper/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "piper.yazi";
-  version = "25.4.8-unstable-2025-04-21";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "71f925e4b7d6d2fa3e1e7822422d755ea709eb69";
-    hash = "sha256-4XhVQ72JIfkT9A2hcE+3ch/xLEBe+HeFmjupy266OJo=";
+    rev = "f9b3f8876eaa74d8b76e5b8356aca7e6a81c0fb7";
+    hash = "sha256-EoIrbyC7WgRzrEtvso2Sr6HnNW91c5E+RZGqnjEi6Zo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/projects/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/projects/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "projects.yazi";
-  version = "0-unstable-2025-05-17";
+  version = "0-unstable-2025-05-29";
 
   src = fetchFromGitHub {
     owner = "MasouShizuka";
     repo = "projects.yazi";
-    rev = "df44165610faa66f623a3e2085e05085cba23d66";
-    hash = "sha256-XVN605TujmA4f1gCjJRnBBrCjmfoTdtNwhRBEqTBnLM=";
+    rev = "96af237d2255d5dab5493c020f55561f63c28777";
+    hash = "sha256-N8XH6adXPk/iU173fXEViv0NPwFZ0WYiyEJGBs4c6ec=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/projects/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/projects/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "projects.yazi";
-  version = "0-unstable-2025-05-29";
+  version = "0-unstable-2025-06-03";
 
   src = fetchFromGitHub {
     owner = "MasouShizuka";
     repo = "projects.yazi";
-    rev = "96af237d2255d5dab5493c020f55561f63c28777";
-    hash = "sha256-N8XH6adXPk/iU173fXEViv0NPwFZ0WYiyEJGBs4c6ec=";
+    rev = "7037dd5eee184ccb7725bdc9f7ea6faa188420d5";
+    hash = "sha256-Lc0MeiAuPgJTq4ojNw9hwxqPJ74S4ymn4uPTkxGeZGc=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/projects/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/projects/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "projects.yazi";
-  version = "0-unstable-2025-03-03";
+  version = "0-unstable-2025-05-17";
 
   src = fetchFromGitHub {
     owner = "MasouShizuka";
     repo = "projects.yazi";
-    rev = "4f11eccf835556600a37730b383ee12f00d4fc59";
-    hash = "sha256-XHGlQn0Nsxh/WScz4v2I+IWvzGJ9QTXbB7zgSCPQ+E0=";
+    rev = "df44165610faa66f623a3e2085e05085cba23d66";
+    hash = "sha256-XVN605TujmA4f1gCjJRnBBrCjmfoTdtNwhRBEqTBnLM=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/relative-motions/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/relative-motions/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "relative-motions.yazi";
-  version = "25.4.8-unstable-2025-04-16";
+  version = "25.5.28-unstable-2025-06-05";
 
   src = fetchFromGitHub {
     owner = "dedukun";
     repo = "relative-motions.yazi";
-    rev = "ce2e890227269cc15cdc71d23b35a58fae6d2c27";
-    hash = "sha256-Ijz1wYt+L+24Fb/rzHcDR8JBv84z2UxdCIPqTdzbD14=";
+    rev = "2e3b6172e6226e0db96aea12d09dea2d2e443fea";
+    hash = "sha256-v0e06ieBKNmt9DATdL7R4AyVFa9DlNBwpfME3LHozLA=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/restore/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/restore/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "restore.yazi";
-  version = "25.2.7-unstable-2025-04-24";
+  version = "25.5.28-unstable-2025-05-30";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "restore.yazi";
-    rev = "539aad5077dc8b342a580036e416f2b949b6590e";
-    hash = "sha256-ngwbweKF7pSEpzy1TNzbKz8cFIWaDison5vCiGxkHFk=";
+    rev = "86dff4319ace07da83c235ccab7a14bc0853a03a";
+    hash = "sha256-7hMFTeNghXIf3Db2AtguIzLkWbXYtJNwGkFdymDr35s=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/restore/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/restore/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "restore.yazi";
-  version = "25.5.28-unstable-2025-05-30";
+  version = "25.5.31-unstable-2025-06-05";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "restore.yazi";
-    rev = "86dff4319ace07da83c235ccab7a14bc0853a03a";
-    hash = "sha256-7hMFTeNghXIf3Db2AtguIzLkWbXYtJNwGkFdymDr35s=";
+    rev = "b7c33766e0bc4bbbb99e8e934be90e3beb881d29";
+    hash = "sha256-qtthY7eySqXoA3TARubZF0SsYkkLEgkjdtPUxR5ro0I=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "rich-preview.yazi";
-  version = "0-unstable-2025-04-22";
+  version = "0-unstable-2025-05-30";
 
   src = fetchFromGitHub {
     owner = "AnirudhG07";
     repo = "rich-preview.yazi";
-    rev = "fdcf37320e35f7c12e8087900eebffcdafaee8cb";
-    hash = "sha256-HO9hTCfgGTDERClZaLnUEWDvsV9GMK1kwFpWNM1wq8I=";
+    rev = "de28f504f21ee78b9e4799f116df2aa177384229";
+    hash = "sha256-pJ5aMAECK0M4v/8czGP5RZygfRAyS9IdQCeP3ZP1Gcs=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rich-preview/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "rich-preview.yazi";
-  version = "0-unstable-2025-05-30";
+  version = "0-unstable-2025-05-31";
 
   src = fetchFromGitHub {
     owner = "AnirudhG07";
     repo = "rich-preview.yazi";
-    rev = "de28f504f21ee78b9e4799f116df2aa177384229";
-    hash = "sha256-pJ5aMAECK0M4v/8czGP5RZygfRAyS9IdQCeP3ZP1Gcs=";
+    rev = "843c3faf0a99f5ce31d02372c868d8dae92ca29d";
+    hash = "sha256-celObHo9Y3pFCd1mTx1Lz77Tc22SJTleRblAkbH/RqY=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
@@ -5,12 +5,12 @@
 }:
 mkYaziPlugin {
   pname = "rsync.yazi";
-  version = "0-unstable-2025-06-07";
+  version = "0-unstable-2025-06-09";
   src = fetchFromGitHub {
     owner = "GianniBYoung";
     repo = "rsync.yazi";
-    rev = "782481e58316f4b422f5c259f07c63b940555246";
-    hash = "sha256-ZrvaJl3nf/CGavvk1QEyOMUbfKQ/JYSmZguvbXIIw9M=";
+    rev = "55631aaaa7654b86469a07bbedf62a5561caa2c9";
+    hash = "sha256-4U6tYAZboMV5YguQIBpcZtcLWwF3TYYFFUXLtVxYxwU=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
@@ -5,7 +5,7 @@
 }:
 mkYaziPlugin {
   pname = "rsync.yazi";
-  version = "0-unstable-2025-04-12";
+  version = "0-unstable-2025-04-24";
   src = fetchFromGitHub {
     owner = "GianniBYoung";
     repo = "rsync.yazi";

--- a/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
@@ -5,12 +5,12 @@
 }:
 mkYaziPlugin {
   pname = "rsync.yazi";
-  version = "0-unstable-2025-04-24";
+  version = "0-unstable-2025-06-07";
   src = fetchFromGitHub {
     owner = "GianniBYoung";
     repo = "rsync.yazi";
-    rev = "ed7b7f9de971ecd8376d7ccb7a6d0d6f979c1dcb";
-    hash = "sha256-xAhkDTNi0MjHqESKk8j60WABYvaF7NElO2W/rsL2w2Y=";
+    rev = "782481e58316f4b422f5c259f07c63b940555246";
+    hash = "sha256-ZrvaJl3nf/CGavvk1QEyOMUbfKQ/JYSmZguvbXIIw9M=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-enter/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-enter/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-enter.yazi";
-  version = "25.2.26-unstable-2025-03-02";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "b44c245500b34e713732a9130bf436b13b4777e9";
-    hash = "sha256-nZ8yfnKvNLM5aA+mmQ3PkfM5lwSKwWnkQewcg9GwseI=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-filter/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-filter/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-filter.yazi";
-  version = "25.2.26-unstable-2025-03-02";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "b44c245500b34e713732a9130bf436b13b4777e9";
-    hash = "sha256-nZ8yfnKvNLM5aA+mmQ3PkfM5lwSKwWnkQewcg9GwseI=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-paste/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-paste/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-paste.yazi";
-  version = "0-unstable-2025-04-27";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "864a0210d9ba1e8eb925160c2e2a25342031d8d3";
-    hash = "sha256-m3709h7/AHJAtoJ3ebDA40c77D+5dCycpecprjVqj/k=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/starship/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/starship/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "starship.yazi";
-  version = "25.4.8-unstable-2025-04-20";
+  version = "25.4.8-unstable-2025-05-30";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";
     repo = "starship.yazi";
-    rev = "6fde3b2d9dc9a12c14588eb85cf4964e619842e6";
-    hash = "sha256-+CSdghcIl50z0MXmFwbJ0koIkWIksm3XxYvTAwoRlDY=";
+    rev = "428d43ac0846cb1885493a1f01c049a883b70155";
+    hash = "sha256-YkDkMC2SJIfpKrt93W/v5R3wOrYcat7QTbPrWqIKXG8=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/starship/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/starship/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "starship.yazi";
-  version = "25.4.8-unstable-2025-05-30";
+  version = "25.4.8-unstable-2025-06-01";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";
     repo = "starship.yazi";
-    rev = "428d43ac0846cb1885493a1f01c049a883b70155";
-    hash = "sha256-YkDkMC2SJIfpKrt93W/v5R3wOrYcat7QTbPrWqIKXG8=";
+    rev = "6a0f3f788971b155cbc7cec47f6f11aebbc148c9";
+    hash = "sha256-q1G0Y4JAuAv8+zckImzbRvozVn489qiYVGFQbdCxC98=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/toggle-pane/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/toggle-pane/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "toggle-pane.yazi";
-  version = "25.2.26-unstable-2025-04-21";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "4b027c79371af963d4ae3a8b69e42177aa3fa6ee";
-    hash = "sha256-auGNSn6tX72go7kYaH16hxRng+iZWw99dKTTUN91Cow=";
+    rev = "a54b96a3f21495ab3659e45d5354bcc8413be15c";
+    hash = "sha256-TtVaWazkk2xnomhJFinElbUsXUKAbDDhLEVq5Ah3nAk=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "vcs-files.yazi";
-  version = "25.4.8-unstable-2025-04-08";
+  version = "25.5.28-unstable-2025-05-28";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "a1738e8088366ba73b33da5f45010796fb33221e";
-    hash = "sha256-eiLkIWviGzG9R0XP1Cik3Bg0s6lgk3nibN6bZvo8e9o=";
+    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
+    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/yatline-githead/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline-githead/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "yatline-githead.yazi";
+  version = "0-unstable-2025-05-31";
+
+  src = fetchFromGitHub {
+    owner = "imsi32";
+    repo = "yatline-githead.yazi";
+    rev = "f8f969e84c39ad4215334ea5012183a2a5a6160b";
+    hash = "sha256-Cs8zSYtUfdCmKwIkJwQGyQNeSOmmpPvObCMnGm+32zg=";
+  };
+
+  meta = {
+    description = "githead.yazi with yatline.yazi support";
+    homepage = "https://github.com/imsi32/yatline-githead.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ khaneliman ];
+  };
+}

--- a/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "yatline.yazi";
-  version = "0-unstable-2025-05-31";
+  version = "0-unstable-2025-06-11";
 
   src = fetchFromGitHub {
     owner = "imsi32";
     repo = "yatline.yazi";
-    rev = "4872af0da53023358154c8233ab698581de5b2b2";
-    hash = "sha256-7uk8QXAlck0/4bynPdh/m7Os2ayW1UXbELmusPqRmf4=";
+    rev = "73bce63ffb454ea108a96f316e2a8c2e16a35262";
+    hash = "sha256-pIaqnxEGKiWvtFZJm0e7GSbbIc2qaTCB+czHLcVuVzY=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "yatline.yazi";
-  version = "0-unstable-2025-04-22";
+  version = "0-unstable-2025-05-31";
 
   src = fetchFromGitHub {
     owner = "imsi32";
     repo = "yatline.yazi";
-    rev = "2ecf715d33866e5f8a63af25f6a242821746ddb7";
-    hash = "sha256-l4IrdALlgKd1USxE2+bD0Lkw3DgBoQDBxgxevrFhytU=";
+    rev = "4872af0da53023358154c8233ab698581de5b2b2";
+    hash = "sha256-7uk8QXAlck0/4bynPdh/m7Os2ayW1UXbELmusPqRmf4=";
   };
 
   meta = {


### PR DESCRIPTION
Following issue #416356 I opened this PR so that we have something to talk about.

Test build pending of course.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
