### PR TITLE
lgpio: document pyProject options & use lib.optionalString

### DIFF
--- a/pkgs/by-name/lg/lgpio/package.nix
+++ b/pkgs/by-name/lg/lgpio/package.nix
@@ -6,7 +6,14 @@
   # If we build the python packages, these two are not null
   buildPythonPackage ? null,
   lgpioWithoutPython ? null,
-  # When building a python Packages, this specifies the python subproject
+  # When building a python Packages, this specifies the python subproject - a
+  # folder in the repository. The current options are:
+  #
+  # - <empty>
+  # - PY_LGPIO
+  # - PY_RGPIO
+  #
+  # Where an empty value means 'build the non python project'.
   pyProject ? "",
 }:
 
@@ -28,30 +35,18 @@ mkDerivation rec {
     swig
   ];
 
-  preConfigure =
-    if pyProject != "" then
-      ''
-        cd ${pyProject}
-      ''
-    else
-      "";
+  preConfigure = lib.optionalString (pyProject != "") ''
+    cd ${pyProject}
+  '';
   # Emulate ldconfig when building the C API
-  postConfigure =
-    if pyProject == "" then
-      ''
-        substituteInPlace Makefile \
-          --replace ldconfig 'echo ldconfig'
-      ''
-    else
-      "";
+  postConfigure = lib.optionalString (pyProject == "") ''
+    substituteInPlace Makefile \
+      --replace ldconfig 'echo ldconfig'
+  '';
 
-  preBuild =
-    if pyProject == "PY_LGPIO" then
-      ''
-        swig -python lgpio.i
-      ''
-    else
-      "";
+  preBuild = lib.optionalString (pyProject == "PY_LGPIO") ''
+    swig -python lgpio.i
+  '';
 
   buildInputs = [
     lgpioWithoutPython

--- a/pkgs/by-name/lg/lgpio/package.nix
+++ b/pkgs/by-name/lg/lgpio/package.nix
@@ -64,7 +64,7 @@ mkDerivation rec {
   meta = {
     description = "Linux C libraries and Python modules for manipulating GPIO";
     homepage = "https://github.com/joan2937/lg";
-    license = with lib.licenses; [ unlicense ];
+    license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [ doronbehar ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/pi/pigpio/package.nix
+++ b/pkgs/by-name/pi/pigpio/package.nix
@@ -28,7 +28,7 @@ mkDerivation rec {
   meta = {
     description = "C library for the Raspberry which allows control of the General Purpose Input Outputs (GPIO)";
     homepage = "https://github.com/joan2937/pigpio";
-    license = with lib.licenses; [ unlicense ];
+    license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [ doronbehar ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/pi/piscope/package.nix
+++ b/pkgs/by-name/pi/piscope/package.nix
@@ -23,9 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-VDrx/RLSpMhyD64PmdeWVacb9LleHakcy7D6zFxeyhw=";
   };
   # Fix FHS paths
-  postConfigure = ''
+  postPatch = ''
     substituteInPlace piscope.c \
-      --replace /usr/share/piscope $out/share/piscope
+      --replace-fail /usr/share/piscope $out/share/piscope
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
