### PR TITLE
explex,  explex-nf: init at 0.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20330,6 +20330,12 @@
     matrix = "@qyriad:katesiria.org";
     name = "Qyriad";
   };
+  r-aizawa = {
+    github = "Xantibody";
+    githubId = 109563705;
+    name = "Ryu Aizawa";
+    email = "zeku.bushinryu38@gmail.com";
+  };
   r-burns = {
     email = "rtburns@protonmail.com";
     github = "r-burns";

--- a/pkgs/by-name/ex/explex-nf/package.nix
+++ b/pkgs/by-name/ex/explex-nf/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "explex-nf";
+  version = "0.0.3";
+
+  src = fetchzip {
+    url = "https://github.com/yuru7/Explex/releases/download/v${finalAttrs.version}/Explex_NF_v${finalAttrs.version}.zip";
+    hash = "sha256-X4CnYT5B7IyG1Z5Ex6CXCfX7Hz3vNb5bP+vq1Vjx8XI=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 ExplexConsole_NF/*.ttf -t $out/share/fonts/truetype/explex-nf-console
+    install -Dm444 Explex35Console_NF/*.ttf -t $out/share/fonts/truetype/explex-nf-35console
+
+    runHook postInstall
+  '';
+  meta = {
+    description = "Composite font of 0xProto, IBM Plex Sans JP and nerd-fonts";
+    homepage = "https://github.com/yuru7/Explex";
+    changelog = "https://github.com/yuru7/Explex/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.r-aizawa ];
+  };
+})

--- a/pkgs/by-name/ex/explex/package.nix
+++ b/pkgs/by-name/ex/explex/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "explex";
+  version = "0.0.3";
+
+  src = fetchzip {
+    url = "https://github.com/yuru7/Explex/releases/download/v${finalAttrs.version}/Explex_v${finalAttrs.version}.zip";
+    hash = "sha256-OUmzF8GrwVgFAMSEiZLvh85nsOw1a0a7B70u2cRXXO8=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 Explex/*.ttf -t $out/share/fonts/truetype/explex
+    install -Dm444 Explex35/*.ttf -t $out/share/fonts/truetype/explex-35
+    install -Dm444 ExplexConsole/*.ttf -t $out/share/fonts/truetype/explex-console
+    install -Dm444 Explex35Console/*.ttf -t $out/share/fonts/truetype/explex-35console
+
+    runHook postInstall
+  '';
+  meta = {
+    description = "Composite font of 0xProto and IBM Plex Sans JP";
+    homepage = "https://github.com/yuru7/Explex";
+    changelog = "https://github.com/yuru7/Explex/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.r-aizawa ];
+  };
+})


### PR DESCRIPTION
## Description of changes
https://github.com/yuru7/Explex

A Japanese composite font, based on "[0xProto](https://github.com/0xType/0xProto)" and "[IBM Plex Sans JP](https://github.com/IBM/plex)".
Both 0xProto and IBM Plex Sans JP and Explex are licensed under the "OFL-1.1" license.

- https://github.com/IBM/plex/blob/bfd83ce9018a7e98cf7c76535ca9c8110a1a3170/LICENSE.txt#L9
- https://github.com/0xType/0xProto/blob/4262b41bde7d09a0def118fe7ded5de448f081f8/LICENSE#L8
- https://github.com/yuru7/Explex/blob/8442346923d3caf51820cde54570bb605a432ec4/LICENSE#L9

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
