### PR TITLE
python312Packages.vllm: 0.9.0.1 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/py-libnuma/default.nix
+++ b/pkgs/development/python-modules/py-libnuma/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  setuptools,
+  numactl,
+}:
+
+buildPythonPackage rec {
+  pname = "py-libnuma";
+  version = "1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "eedalong";
+    repo = "pynuma";
+    rev = "66cab0e008b850a04cfec5c4fb3f50bf28e3d488";
+    hash = "sha256-ALYCcdN5eXrVWsTRwkHCwo4xsLMs/du3mUl1xSlo5iU=";
+  };
+
+  postPatch = ''
+    substituteInPlace numa/__init__.py \
+      --replace-fail \
+        'LIBNUMA = CDLL(find_library("numa"))' \
+        'LIBNUMA = CDLL("${numactl}/lib/libnuma${stdenv.hostPlatform.extensions.sharedLibrary}")'
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numactl
+  ];
+
+  # Tests write NUMA configuration, which may be persistent until reboot.
+  doCheck = false;
+
+  pythonImportsCheck = [ "numa" ];
+
+  meta = {
+    description = "Python3 Interface to numa Linux library";
+    homepage = "https://github.com/eedalong/pynuma";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/vllm/0005-drop-intel-reqs.patch
+++ b/pkgs/development/python-modules/vllm/0005-drop-intel-reqs.patch
@@ -1,12 +1,25 @@
+From 7511784ceb9252091a9d63ac6b54dcc67dd2b262 Mon Sep 17 00:00:00 2001
+From: Conroy Cheers <conroy@corncheese.org>
+Date: Fri, 13 Jun 2025 17:42:10 +1000
+Subject: [PATCH] drop intel reqs
+
+---
+ requirements/cpu.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
 diff --git a/requirements/cpu.txt b/requirements/cpu.txt
-index 121330158..d41918883 100644
+index d7b0fc6d8..be2df751b 100644
 --- a/requirements/cpu.txt
 +++ b/requirements/cpu.txt
-@@ -20,7 +20,3 @@ datasets # for benchmark scripts
- 
+@@ -24,8 +24,5 @@ datasets # for benchmark scripts
  # cpu cannot use triton 3.3.0
  triton==3.2.0; platform_machine == "x86_64"
--
+ 
 -# Intel Extension for PyTorch, only for x86_64 CPUs
 -intel-openmp==2024.2.1; platform_machine == "x86_64"
 -intel_extension_for_pytorch==2.7.0; platform_machine == "x86_64"
+ py-libnuma; platform_system != "Darwin"
+ psutil; platform_system != "Darwin"
+-- 
+2.49.0
+

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   python,
   buildPythonPackage,
+  pythonAtLeast,
   fetchFromGitHub,
   fetchpatch,
   symlinkJoin,
@@ -67,6 +68,7 @@
   opentelemetry-exporter-otlp,
   bitsandbytes,
   flashinfer,
+  py-libnuma,
 
   # internal dependency - for overriding in overlays
   vllm-flash-attn ? null,
@@ -246,8 +248,11 @@ in
 
 buildPythonPackage rec {
   pname = "vllm";
-  version = "0.9.0.1";
+  version = "0.9.1";
   pyproject = true;
+
+  # https://github.com/vllm-project/vllm/issues/12083
+  disabled = pythonAtLeast "3.13";
 
   stdenv = torch.stdenv;
 
@@ -255,7 +260,7 @@ buildPythonPackage rec {
     owner = "vllm-project";
     repo = "vllm";
     tag = "v${version}";
-    hash = "sha256-gNe/kdsDQno8Fd6mo29feWmbyC0c2+kljlVxY4v7R9U=";
+    hash = "sha256-sp7rDpewTPXTVRBJHJMj+8pJDS6wAu0/OTJZwbPPqKc=";
   };
 
   patches = [
@@ -264,34 +269,33 @@ buildPythonPackage rec {
       url = "https://github.com/vllm-project/vllm/commit/6a5d7e45f52c3a13de43b8b4fa9033e3b342ebd2.patch";
       hash = "sha256-KYthqu+6XwsYYd80PtfrMMjuRV9+ionccr7EbjE4jJE=";
     })
+    (fetchpatch {
+      name = "fall-back-to-gloo-when-nccl-unavailable.patch";
+      url = "https://github.com/vllm-project/vllm/commit/aa131a94410683b0a02e74fed2ce95e6c2b6b030.patch";
+      hash = "sha256-jNlQZQ8xiW85JWyBjsPZ6FoRQsiG1J8bwzmQjnaWFBg=";
+    })
     ./0002-setup.py-nix-support-respect-cmakeFlags.patch
     ./0003-propagate-pythonpath.patch
     ./0004-drop-lsmod.patch
     ./0005-drop-intel-reqs.patch
   ];
 
-  postPatch =
-    ''
-      # pythonRelaxDeps does not cover build-system
-      substituteInPlace pyproject.toml \
-        --replace-fail "torch ==" "torch >="
+  postPatch = ''
+    # pythonRelaxDeps does not cover build-system
+    substituteInPlace pyproject.toml \
+      --replace-fail "torch ==" "torch >="
 
-      # Ignore the python version check because it hard-codes minor versions and
-      # lags behind `ray`'s python interpreter support
-      substituteInPlace CMakeLists.txt \
-        --replace-fail \
-          'set(PYTHON_SUPPORTED_VERSIONS' \
-          'set(PYTHON_SUPPORTED_VERSIONS "${lib.versions.majorMinor python.version}"'
+    # Ignore the python version check because it hard-codes minor versions and
+    # lags behind `ray`'s python interpreter support
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'set(PYTHON_SUPPORTED_VERSIONS' \
+        'set(PYTHON_SUPPORTED_VERSIONS "${lib.versions.majorMinor python.version}"'
 
-      # Pass build environment PYTHONPATH to vLLM's Python configuration scripts
-      substituteInPlace CMakeLists.txt \
-        --replace-fail '$PYTHONPATH' '$ENV{PYTHONPATH}'
-    ''
-    + lib.optionalString (nccl == null) ''
-      # On platforms where NCCL is not supported (e.g. Jetson), substitute Gloo (provided by Torch)
-      substituteInPlace vllm/distributed/parallel_state.py \
-        --replace-fail '"nccl"' '"gloo"'
-    '';
+    # Pass build environment PYTHONPATH to vLLM's Python configuration scripts
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '$PYTHONPATH' '$ENV{PYTHONPATH}'
+  '';
 
   nativeBuildInputs =
     [
@@ -362,7 +366,6 @@ buildPythonPackage rec {
       outlines
       pandas
       prometheus-fastapi-instrumentator
-      psutil
       py-cpuinfo
       pyarrow
       pydantic
@@ -392,9 +395,15 @@ buildPythonPackage rec {
       opentelemetry-api
       opentelemetry-exporter-otlp
       bitsandbytes
+      # vLLM needs Torch's compiler to be present in order to use torch.compile
+      torch.stdenv.cc
     ]
     ++ uvicorn.optional-dependencies.standard
     ++ aioprometheus.optional-dependencies.starlette
+    ++ lib.optionals stdenv.targetPlatform.isLinux [
+      py-libnuma
+      psutil
+    ]
     ++ lib.optionals cudaSupport [
       cupy
       pynvml
@@ -404,11 +413,11 @@ buildPythonPackage rec {
   dontUseCmakeConfigure = true;
   cmakeFlags =
     [
+    ]
+    ++ lib.optionals cudaSupport [
       (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_CUTLASS" "${lib.getDev cutlass}")
       (lib.cmakeFeature "FLASH_MLA_SRC_DIR" "${lib.getDev flashmla}")
       (lib.cmakeFeature "VLLM_FLASH_ATTN_SRC_DIR" "${lib.getDev vllm-flash-attn'}")
-    ]
-    ++ lib.optionals cudaSupport [
       (lib.cmakeFeature "TORCH_CUDA_ARCH_LIST" "${gpuTargetString}")
       (lib.cmakeFeature "CUTLASS_NVCC_ARCHS_ENABLED" "${cudaPackages.flags.cmakeCudaArchitecturesString}")
       (lib.cmakeFeature "CUDA_TOOLKIT_ROOT_DIR" "${symlinkJoin {

--- a/pkgs/development/python-modules/xgrammar/0001-fix-find-nanobind-from-python-module.patch
+++ b/pkgs/development/python-modules/xgrammar/0001-fix-find-nanobind-from-python-module.patch
@@ -1,0 +1,41 @@
+From c01e056ee845ae973ec36cc50125492ef8c02c12 Mon Sep 17 00:00:00 2001
+From: Conroy Cheers <conroy@corncheese.org>
+Date: Thu, 12 Jun 2025 17:45:27 +1000
+Subject: [PATCH] [Fix] find nanobind from Python module
+
+---
+ cpp/nanobind/CMakeLists.txt | 4 ++++
+ pyproject.toml              | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cpp/nanobind/CMakeLists.txt b/cpp/nanobind/CMakeLists.txt
+index 8ea5622..02500ac 100644
+--- a/cpp/nanobind/CMakeLists.txt
++++ b/cpp/nanobind/CMakeLists.txt
+@@ -3,6 +3,10 @@ find_package(
+   COMPONENTS Interpreter Development.Module
+   REQUIRED
+ )
++
++execute_process(
++  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
++  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_DIR)
+ find_package(nanobind CONFIG REQUIRED)
+ 
+ # Compile this source file seperately. Nanobind suggests to optimize bindings code for size, but
+diff --git a/pyproject.toml b/pyproject.toml
+index 11fae7d..d2078b1 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -44,7 +44,7 @@ provider = "scikit_build_core.metadata.regex"
+ input = "python/xgrammar/version.py"
+ 
+ [build-system]
+-requires = ["scikit-build-core>=0.10.0", "nanobind==2.5.0"]
++requires = ["scikit-build-core>=0.10.0", "nanobind>=2.5.0"]
+ build-backend = "scikit_build_core.build"
+ 
+ [tool.scikit-build]
+-- 
+2.49.0
+

--- a/pkgs/development/python-modules/xgrammar/default.nix
+++ b/pkgs/development/python-modules/xgrammar/default.nix
@@ -7,7 +7,7 @@
   # build-system
   cmake,
   ninja,
-  pybind11,
+  nanobind,
   scikit-build-core,
 
   # dependencies
@@ -25,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "xgrammar";
-  version = "0.1.14";
+  version = "0.1.19";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -33,13 +33,17 @@ buildPythonPackage rec {
     repo = "xgrammar";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-ohsoc3g5XUp9vSXxyOGj20wXzCXZC02ktHYVQjDqNeM=";
+    hash = "sha256-0b2tJx1D/2X/uosbthHfevUpTCBtuSKNlxOKyidTotA=";
   };
+
+  patches = [
+    ./0001-fix-find-nanobind-from-python-module.patch
+  ];
 
   build-system = [
     cmake
     ninja
-    pybind11
+    nanobind
     scikit-build-core
   ];
   dontUseCmakeConfigure = true;
@@ -59,6 +63,11 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     writableTmpDirAsHomeHook
+  ];
+
+  NIX_CFLAGS_COMPILE = toString [
+    # xgrammar hardcodes -flto=auto while using static linking, which can cause linker errors without this additional flag.
+    "-ffat-lto-objects"
   ];
 
   disabledTests = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11978,6 +11978,8 @@ self: super: with self; {
 
   py-improv-ble-client = callPackage ../development/python-modules/py-improv-ble-client { };
 
+  py-libnuma = callPackage ../development/python-modules/py-libnuma { };
+
   py-libzfs = callPackage ../development/python-modules/py-libzfs { };
 
   py-lru-cache = callPackage ../development/python-modules/py-lru-cache { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Update python312Packages.vllm to [v0.9.1](https://github.com/vllm-project/vllm/releases/tag/v0.9.1)
python312Packages.xgrammar: 0.1.14 -> 0.1.19
python312Packages.py-libnuma: init at 1.2

The substituteInPlace call previously used to disable `nccl` on unsupported platforms broke, and has been replaced with a patch.

Added `torch.stdenv.cc` to vllm `dependencies`, as it expects CC to be available for dynamo recompilation at runtime.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
