### PR TITLE
edk2: use finalAttrs

### DIFF
--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -31,187 +31,184 @@ let
       throw "Unsupported architecture";
 
   buildType = if stdenv.hostPlatform.isDarwin then "CLANGPDB" else "GCC5";
-
-  edk2 = stdenv.mkDerivation {
-    pname = "edk2";
-    version = "202505";
-
-    srcWithVendoring = fetchFromGitHub {
-      owner = "tianocore";
-      repo = "edk2";
-      tag = "edk2-stable${edk2.version}";
-      fetchSubmodules = true;
-      hash = "sha256-VuiEqVpG/k7pfy0cOC6XmY+8NBtU/OHdDB9Y52tyNe8=";
-    };
-
-    src = applyPatches {
-      name = "edk2-${edk2.version}-unvendored-src";
-      src = edk2.srcWithVendoring;
-
-      patches = [
-        # pass targetPrefix as an env var
-        (fetchpatch {
-          url = "https://src.fedoraproject.org/rpms/edk2/raw/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/0021-Tweak-the-tools_def-to-support-cross-compiling.patch";
-          hash = "sha256-E1/fiFNVx0aB1kOej2DJ2DlBIs9tAAcxoedym2Zhjxw=";
-        })
-        # https://github.com/tianocore/edk2/pull/5658
-        (fetchpatch {
-          name = "fix-cross-compilation-antlr-dlg.patch";
-          url = "https://github.com/tianocore/edk2/commit/a34ff4a8f69a7b8a52b9b299153a8fac702c7df1.patch";
-          hash = "sha256-u+niqwjuLV5tNPykW4xhb7PW2XvUmXhx5uvftG1UIbU=";
-        })
-      ];
-
-      postPatch = ''
-        # de-vendor OpenSSL
-        rm -r CryptoPkg/Library/OpensslLib/openssl
-        mkdir -p CryptoPkg/Library/OpensslLib/openssl
-        (
-        cd CryptoPkg/Library/OpensslLib/openssl
-        tar --strip-components=1 -xf ${buildPackages.openssl.src}
-
-        # Apply OpenSSL patches.
-        ${lib.pipe buildPackages.openssl.patches [
-          (builtins.filter (
-            patch:
-            !builtins.elem (baseNameOf patch) [
-              # Exclude patches not required in this context.
-              "nix-ssl-cert-file.patch"
-              "openssl-disable-kernel-detection.patch"
-              "use-etc-ssl-certs-darwin.patch"
-              "use-etc-ssl-certs.patch"
-            ]
-          ))
-          (map (patch: "patch -p1 < ${patch}\n"))
-          lib.concatStrings
-        ]}
-        )
-
-        # enable compilation using Clang
-        # https://bugzilla.tianocore.org/show_bug.cgi?id=4620
-        substituteInPlace BaseTools/Conf/tools_def.template --replace-fail \
-          'DEFINE CLANGPDB_WARNING_OVERRIDES    = ' \
-          'DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-unneeded-internal-declaration '
-      '';
-    };
-
-    nativeBuildInputs = [ pythonEnv ];
-    depsBuildBuild = [
-      buildPackages.stdenv.cc
-      buildPackages.bash
-    ];
-    depsHostHost = [ libuuid ];
-    strictDeps = true;
-
-    # trick taken from https://src.fedoraproject.org/rpms/edk2/blob/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/edk2.spec#_319
-    ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
-
-    makeFlags = [ "-C BaseTools" ];
-
-    env.NIX_CFLAGS_COMPILE =
-      "-Wno-return-type"
-      + lib.optionalString (stdenv.cc.isGNU) " -Wno-error=stringop-truncation"
-      + lib.optionalString (stdenv.hostPlatform.isDarwin) " -Wno-error=macro-redefined";
-
-    hardeningDisable = [
-      "format"
-      "fortify"
-    ];
-
-    installPhase = ''
-      mkdir -vp $out
-      mv -v BaseTools $out
-      mv -v edksetup.sh $out
-      # patchShebangs fails to see these when cross compiling
-      for i in $out/BaseTools/BinWrappers/PosixLike/*; do
-        chmod +x "$i"
-        patchShebangs --build "$i"
-      done
-    '';
-
-    enableParallelBuilding = true;
-
-    meta = {
-      description = "Intel EFI development kit";
-      homepage = "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II/";
-      changelog = "https://github.com/tianocore/edk2/releases/tag/edk2-stable${edk2.version}";
-      license = lib.licenses.bsd2;
-      platforms = with lib.platforms; aarch64 ++ arm ++ i686 ++ x86_64 ++ loongarch64 ++ riscv64;
-      maintainers = [ lib.maintainers.mjoerg ];
-    };
-
-    passthru = {
-      # exercise a channel blocker
-      tests = {
-        systemdBootExtraEntries = nixosTests.systemd-boot.extraEntries;
-        uefiUsb = nixosTests.boot.uefiCdrom;
-      };
-
-      updateScript = writeScript "update-edk2" ''
-        #!/usr/bin/env nix-shell
-        #!nix-shell -i bash -p common-updater-scripts coreutils gnused
-        set -eu -o pipefail
-        version="$(list-git-tags --url="${edk2.srcWithVendoring.url}" |
-                   sed -E --quiet 's/^edk2-stable([0-9]{6})$/\1/p' |
-                   sort --reverse --numeric-sort |
-                   head -n 1)"
-        if [[ "x$UPDATE_NIX_OLD_VERSION" != "x$version" ]]; then
-            update-source-version --source-key=srcWithVendoring \
-                "$UPDATE_NIX_ATTR_PATH" "$version"
-        fi
-      '';
-
-      mkDerivation =
-        projectDscPath: attrsOrFun:
-        stdenv.mkDerivation (
-          finalAttrs:
-          let
-            attrs = lib.toFunction attrsOrFun finalAttrs;
-          in
-          {
-            inherit (edk2) src;
-
-            depsBuildBuild = [ buildPackages.stdenv.cc ] ++ attrs.depsBuildBuild or [ ];
-            nativeBuildInputs = [
-              bc
-              pythonEnv
-            ] ++ attrs.nativeBuildInputs or [ ];
-            strictDeps = true;
-
-            ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
-
-            prePatch = ''
-              rm -rf BaseTools
-              ln -sv ${buildPackages.edk2}/BaseTools BaseTools
-            '';
-
-            configurePhase = ''
-              runHook preConfigure
-              export WORKSPACE="$PWD"
-              . ${buildPackages.edk2}/edksetup.sh BaseTools
-              runHook postConfigure
-            '';
-
-            buildPhase = ''
-              runHook preBuild
-              build -a ${targetArch} -b ${attrs.buildConfig or "RELEASE"} -t ${buildType} -p ${projectDscPath} -n $NIX_BUILD_CORES $buildFlags
-              runHook postBuild
-            '';
-
-            installPhase = ''
-              runHook preInstall
-              mv -v Build/*/* $out
-              runHook postInstall
-            '';
-          }
-          // removeAttrs attrs [
-            "nativeBuildInputs"
-            "depsBuildBuild"
-          ]
-        );
-    };
-  };
-
 in
 
-edk2
+stdenv.mkDerivation (finalAttrs: {
+  pname = "edk2";
+  version = "202505";
+
+  srcWithVendoring = fetchFromGitHub {
+    owner = "tianocore";
+    repo = "edk2";
+    tag = "edk2-stable${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-VuiEqVpG/k7pfy0cOC6XmY+8NBtU/OHdDB9Y52tyNe8=";
+  };
+
+  src = applyPatches {
+    name = "edk2-${finalAttrs.version}-unvendored-src";
+    src = finalAttrs.srcWithVendoring;
+
+    patches = [
+      # pass targetPrefix as an env var
+      (fetchpatch {
+        url = "https://src.fedoraproject.org/rpms/edk2/raw/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/0021-Tweak-the-tools_def-to-support-cross-compiling.patch";
+        hash = "sha256-E1/fiFNVx0aB1kOej2DJ2DlBIs9tAAcxoedym2Zhjxw=";
+      })
+      # https://github.com/tianocore/edk2/pull/5658
+      (fetchpatch {
+        name = "fix-cross-compilation-antlr-dlg.patch";
+        url = "https://github.com/tianocore/edk2/commit/a34ff4a8f69a7b8a52b9b299153a8fac702c7df1.patch";
+        hash = "sha256-u+niqwjuLV5tNPykW4xhb7PW2XvUmXhx5uvftG1UIbU=";
+      })
+    ];
+
+    postPatch = ''
+      # de-vendor OpenSSL
+      rm -r CryptoPkg/Library/OpensslLib/openssl
+      mkdir -p CryptoPkg/Library/OpensslLib/openssl
+      (
+      cd CryptoPkg/Library/OpensslLib/openssl
+      tar --strip-components=1 -xf ${buildPackages.openssl.src}
+
+      # Apply OpenSSL patches.
+      ${lib.pipe buildPackages.openssl.patches [
+        (builtins.filter (
+          patch:
+          !builtins.elem (baseNameOf patch) [
+            # Exclude patches not required in this context.
+            "nix-ssl-cert-file.patch"
+            "openssl-disable-kernel-detection.patch"
+            "use-etc-ssl-certs-darwin.patch"
+            "use-etc-ssl-certs.patch"
+          ]
+        ))
+        (map (patch: "patch -p1 < ${patch}\n"))
+        lib.concatStrings
+      ]}
+      )
+
+      # enable compilation using Clang
+      # https://bugzilla.tianocore.org/show_bug.cgi?id=4620
+      substituteInPlace BaseTools/Conf/tools_def.template --replace-fail \
+        'DEFINE CLANGPDB_WARNING_OVERRIDES    = ' \
+        'DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-unneeded-internal-declaration '
+    '';
+  };
+
+  nativeBuildInputs = [ pythonEnv ];
+  depsBuildBuild = [
+    buildPackages.stdenv.cc
+    buildPackages.bash
+  ];
+  depsHostHost = [ libuuid ];
+  strictDeps = true;
+
+  # trick taken from https://src.fedoraproject.org/rpms/edk2/blob/08f2354cd280b4ce5a7888aa85cf520e042955c3/f/edk2.spec#_319
+  ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
+
+  makeFlags = [ "-C BaseTools" ];
+
+  env.NIX_CFLAGS_COMPILE =
+    "-Wno-return-type"
+    + lib.optionalString (stdenv.cc.isGNU) " -Wno-error=stringop-truncation"
+    + lib.optionalString (stdenv.hostPlatform.isDarwin) " -Wno-error=macro-redefined";
+
+  hardeningDisable = [
+    "format"
+    "fortify"
+  ];
+
+  installPhase = ''
+    mkdir -vp $out
+    mv -v BaseTools $out
+    mv -v edksetup.sh $out
+    # patchShebangs fails to see these when cross compiling
+    for i in $out/BaseTools/BinWrappers/PosixLike/*; do
+      chmod +x "$i"
+      patchShebangs --build "$i"
+    done
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Intel EFI development kit";
+    homepage = "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II/";
+    changelog = "https://github.com/tianocore/edk2/releases/tag/edk2-stable${finalAttrs.version}";
+    license = lib.licenses.bsd2;
+    platforms = with lib.platforms; aarch64 ++ arm ++ i686 ++ x86_64 ++ loongarch64 ++ riscv64;
+    maintainers = [ lib.maintainers.mjoerg ];
+  };
+
+  passthru = {
+    # exercise a channel blocker
+    tests = {
+      systemdBootExtraEntries = nixosTests.systemd-boot.extraEntries;
+      uefiUsb = nixosTests.boot.uefiCdrom;
+    };
+
+    updateScript = writeScript "update-edk2" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts coreutils gnused
+      set -eu -o pipefail
+      version="$(list-git-tags --url="${finalAttrs.srcWithVendoring.url}" |
+                 sed -E --quiet 's/^edk2-stable([0-9]{6})$/\1/p' |
+                 sort --reverse --numeric-sort |
+                 head -n 1)"
+      if [[ "x$UPDATE_NIX_OLD_VERSION" != "x$version" ]]; then
+          update-source-version --source-key=srcWithVendoring \
+              "$UPDATE_NIX_ATTR_PATH" "$version"
+      fi
+    '';
+
+    mkDerivation =
+      projectDscPath: attrsOrFun:
+      stdenv.mkDerivation (
+        finalAttrsInner:
+        let
+          attrs = lib.toFunction attrsOrFun finalAttrsInner;
+        in
+        {
+          inherit (finalAttrs) src;
+
+          depsBuildBuild = [ buildPackages.stdenv.cc ] ++ attrs.depsBuildBuild or [ ];
+          nativeBuildInputs = [
+            bc
+            pythonEnv
+          ] ++ attrs.nativeBuildInputs or [ ];
+          strictDeps = true;
+
+          ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
+
+          prePatch = ''
+            rm -rf BaseTools
+            ln -sv ${buildPackages.edk2}/BaseTools BaseTools
+          '';
+
+          configurePhase = ''
+            runHook preConfigure
+            export WORKSPACE="$PWD"
+            . ${buildPackages.edk2}/edksetup.sh BaseTools
+            runHook postConfigure
+          '';
+
+          buildPhase = ''
+            runHook preBuild
+            build -a ${targetArch} -b ${attrs.buildConfig or "RELEASE"} -t ${buildType} -p ${projectDscPath} -n $NIX_BUILD_CORES $buildFlags
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            mv -v Build/*/* $out
+            runHook postInstall
+          '';
+        }
+        // removeAttrs attrs [
+          "nativeBuildInputs"
+          "depsBuildBuild"
+        ]
+      );
+  };
+})


### PR DESCRIPTION
First step to fix overriding for edk2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
