### PR TITLE
command-not-found: disable by default, simplify, document

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -18,6 +18,7 @@
 - `base16-builder` node package has been removed due to lack of upstream maintenance.
 - `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by sil](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.
 - `space-orbit` package has been removed due to lack of upstream maintenance. Debian upstream stopped tracking it in 2011.
+- `command-not-found` package is now disabled by default; it works only for nix-channels based systems, and requires setup for it to work.
 
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -33,7 +33,7 @@ in
 
     enable = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether interactive shells should show which Nix package (if
         any) provides a missing command.

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -37,6 +37,12 @@ in
       description = ''
         Whether interactive shells should show which Nix package (if
         any) provides a missing command.
+
+        Requires nix-channels to be set and downloaded (sudo nix-channels --update.)
+
+        See also nix-index and nix-index-database as an alternative for flakes-based systems.
+
+        Additionally, having the env var NIX_AUTO_RUN set will automatically run the matching package, and with NIX_AUTO_RUN_INTERACTIVE it will confirm the package before running.
       '';
     };
 

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -65,6 +65,13 @@ in
       }
     '';
 
+    # NOTE: Fish by itself checks for nixos command-not-found, let's instead makes it explicit.
+    programs.fish.interactiveShellInit = ''
+      function fish_command_not_found
+         "${commandNotFound}/bin/command-not-found" $argv
+      end
+    '';
+
     environment.systemPackages = [ commandNotFound ];
   };
 

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -54,44 +54,14 @@ in
 
   config = lib.mkIf cfg.enable {
     programs.bash.interactiveShellInit = ''
-      # This function is called whenever a command is not found.
       command_not_found_handle() {
-        local p='${commandNotFound}/bin/command-not-found'
-        if [ -x "$p" ] && [ -f '${cfg.dbPath}' ]; then
-          # Run the helper program.
-          "$p" "$@"
-          # Retry the command if we just installed it.
-          if [ $? = 126 ]; then
-            "$@"
-          else
-            return 127
-          fi
-        else
-          echo "$1: command not found" >&2
-          return 127
-        fi
+        '${commandNotFound}/bin/command-not-found' "$@"
       }
     '';
 
     programs.zsh.interactiveShellInit = ''
-      # This function is called whenever a command is not found.
       command_not_found_handler() {
-        local p='${commandNotFound}/bin/command-not-found'
-        if [ -x "$p" ] && [ -f '${cfg.dbPath}' ]; then
-          # Run the helper program.
-          "$p" "$@"
-
-          # Retry the command if we just installed it.
-          if [ $? = 126 ]; then
-            "$@"
-          else
-            return 127
-          fi
-        else
-          # Indicate than there was an error so ZSH falls back to its default handler
-          echo "$1: command not found" >&2
-          return 127
-        fi
+        '${commandNotFound}/bin/command-not-found' "$@"
       }
     '';
 

--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -10,6 +10,23 @@ my $program = $ARGV[0];
 
 my $dbPath = "@dbPath@";
 
+if (! -e $dbPath) {
+    print STDERR "$program: command not found\n";
+    print STDERR "\n";
+    print STDERR "command-not-found: Missing package database\n";
+    print STDERR "This likely means the database hasn't been generated yet.\n";
+    print STDERR "This tool requires nix-channels to generate the database.\n";
+    print STDERR "\n";
+    print STDERR "If you are using nix-channels you can run:\n";
+    print STDERR "    sudo nix-channels --update\n";
+    print STDERR "\n";
+    print STDERR "If you are using flakes, see nix-index and nix-index-database.\n";
+    print STDERR "\n";
+    print STDERR "If you would like to disable this message you can set:\n";
+    print STDERR "    programs.command-not-found.enable = false;\n";
+    exit 127;
+}
+
 my $dbh = DBI->connect("dbi:SQLite:dbname=$dbPath", "", "")
     or die "cannot open database `$dbPath'";
 $dbh->{RaiseError} = 0;

--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -14,8 +14,9 @@ if (! -e $dbPath) {
     print STDERR "$program: command not found\n";
     print STDERR "\n";
     print STDERR "command-not-found: Missing package database\n";
-    print STDERR "This likely means the database hasn't been generated yet.\n";
-    print STDERR "This tool requires nix-channels to generate the database.\n";
+    print STDERR "command-not-found is a tool for searching for missing packages.\n";
+    print STDERR "No database was found, this likely means the database hasn't been generated yet.\n";
+    print STDERR "This tool requires nix-channels to generate the database for the `nixos` channel.\n";
     print STDERR "\n";
     print STDERR "If you are using nix-channels you can run:\n";
     print STDERR "    sudo nix-channels --update\n";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
_(From my comment [here](https://github.com/NixOS/nixpkgs/pull/408910#issuecomment-2969867094).)_

Hi all, I'm new to nix, this is my first PR, please let me know if it is too controversial a change, or if I'm missing anything.

**This PR simplifies command-not-found, adds documentation and disables it by default as it is currently failing silently and depends on nix-channels that won't be in use for many users, and requires undocumented management and initialisation for other users.**

**Context**:
`command-not-found` is most important for new users (so they can find packages,) but for new users (using a flakes setup) it will be enabled and broken, at best failing silently and they won't know about its existence, at worst creating annoying and confusing error messages.

There are some rewrites and alternate approaches, the most recommended one is `programs.nix-index` which provides its own command-not-found (but is slow to generate the index, and requires running a command to explicitly generate that index.)

This is a 5-10 year old issue, is broken for new users using flakes, users using custom setups, and is broken for users using nix-channels without having run  `sudo nix-channels --update`. It will also produce very old results for users that have switched to a flakes-based system, and will suddenly break for other users who have changed their channels.

The ultimate issue is command-not-found does not provide or manage its package database.

**Problems:**
- Noisy errors in Fish [which will automatically use this script without a wrapper](https://github.com/fish-shell/fish-shell/blob/d584f36f5d68cc623d3b4fa685d0cb250fe68552/share/functions/fish_command_not_found.fish#L42-L46).
- Silent failure in bash and zsh.
- Won't work for a flakes setup, it depends entirely on nix-channels.
- Requires initial setup that isn't documented and is confusing - requires a nix-channel explicitly named `nixos`, won't check other channels.

See:
- https://discourse.nixos.org/t/command-not-found-not-working/24023
- https://discourse.nixos.org/t/command-not-found-unable-to-open-database/3807
- https://github.com/NixOS/nixpkgs/issues/12044
- https://discourse.nixos.org/t/flake-programs-sqlite-fixing-command-not-found-for-pure-flake-systems/27669
- https://discourse.nixos.org/t/how-to-specify-programs-sqlite-for-command-not-found-from-flakes/22722
- https://discourse.nixos.org/t/command-not-found-error/65161
- https://github.com/NixOS/nixpkgs/issues/39789
- https://discourse.nixos.org/t/why-isnt-there-an-official-built-in-way-to-find-what-package-provides-a-specific-executable/22937
- https://github.com/NixOS/nixos-channel-scripts/issues/4
- https://github.com/NixOS/nixos-channel-scripts/issues/9


**Changes:**
- **BREAKING: Disables `programs.command-not-found` by default.** There are a number of other alternatives including `nix-index`, for auto-run you can use `comma`.
- Removed the "rerun" mechanism from the wrapper, the script will not install the command but rather run it if NIX_AUTO_RUN is set, so this seems to left over from some legacy behaviour.
- Removes the script existence check from the wrapper script - in a nix system the script should definitely exist.
- Moves the database check from the wrapper script into the main script.
- The wrappers are now only simple passthroughs.
- Adds an error message that explains how to initialize the database.
- Docs: Requirement for nix-channels usage.
- Docs: NIX_AUTO_RUN feature.


**Related PRs:**
- https://github.com/NixOS/nixpkgs/pull/415070
- https://github.com/NixOS/nixpkgs/pull/408910
   Attempts to fix for Fish shells by adding a wrapper for fish, this PR supercedes that one by removing the need for the wrapper.

## Manual testing

### Missing database

```
# bash
[j@jrpi:~]$ asdf
asdf: command not found

command-not-found: Missing package database
This likely means the database hasn't been generated yet.
This tool requires nix-channels to generate the database.

If you are using nix-channels you can run:
    sudo nix-channels --update

If you are using flakes, see nix-index and nix-index-database.

If you would like to disable this message you can set:
    programs.command-not-found.enable = false;

# zsh
j@jrpi:~/ > asdf
asdf: command not found

command-not-found: Missing package database
This likely means the database hasn't been generated yet.
This tool requires nix-channels to generate the database.

If you are using nix-channels you can run:
    sudo nix-channels --update

If you are using flakes, see nix-index and nix-index-database.

If you would like to disable this message you can set:
    programs.command-not-found.enable = false;
# fish
j@jrpi ~ [127]> asdf
asdf: command not found

command-not-found: Missing package database
This likely means the database hasn't been generated yet.
This tool requires nix-channels to generate the database.

If you are using nix-channels you can run:
    sudo nix-channels --update

If you are using flakes, see nix-index and nix-index-database.

If you would like to disable this message you can set:
    programs.command-not-found.enable = false;

```

### With database

```
j@jrpi ~> sudo nix-channel --add https://nixos.org/channels/nixos-25.05 nixos
j@jrpi ~> sudo nix-channel --update
# bash
[j@jrpi:~]$ asdf
The program 'asdf' is not in your PATH. You can make it available in an
ephemeral shell by typing:
  nix-shell -p asdf-vm

# zsh
j@jrpi:~/ > asdf
The program 'asdf' is not in your PATH. You can make it available in an
ephemeral shell by typing:
  nix-shell -p asdf-vm
# fish
j@jrpi ~> asdf
The program 'asdf' is not in your PATH. You can make it available in an
ephemeral shell by typing:
  nix-shell -p asdf-vm
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
