### PR TITLE
python3Packages.onnxruntime: mark as broken on aarch64-linux

### DIFF
--- a/pkgs/by-name/on/onnxruntime/fix-cpuinfo-logging.patch
+++ b/pkgs/by-name/on/onnxruntime/fix-cpuinfo-logging.patch
@@ -1,0 +1,27 @@
+diff --git a/onnxruntime/core/common/cpuid_info.cc b/onnxruntime/core/common/cpuid_info.cc
+index 91961bf22c..2f742ad971 100644
+--- a/onnxruntime/core/common/cpuid_info.cc
++++ b/onnxruntime/core/common/cpuid_info.cc
+@@ -3,6 +3,7 @@
+ #include "core/common/cpuid_info.h"
+ #include "core/common/logging/logging.h"
+ #include "core/common/logging/severity.h"
++#include <iostream>
+ 
+ #ifdef __linux__
+ 
+@@ -364,8 +365,12 @@ CPUIDInfo::CPUIDInfo() {
+ #if defined(CPUINFO_SUPPORTED)
+   pytorch_cpuinfo_init_ = cpuinfo_initialize();
+   if (!pytorch_cpuinfo_init_) {
+-    LOGS_DEFAULT(WARNING) << "Failed to initialize PyTorch cpuinfo library. May cause CPU EP performance degradation "
+-                             "due to undetected CPU features.";
++    constexpr const char* message = "Failed to init pytorch cpuinfo library, may cause CPU EP performance degradation due to undetected CPU features.";
++    if (logging::LoggingManager::HasDefaultLogger()) {
++      LOGS_DEFAULT(WARNING) << message;
++    } else {
++      std::cerr << message << std::endl;
++    }
+   }
+ #endif  // defined(CPUINFO_SUPPORTED)
+ #if defined(__linux__)

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -108,6 +108,9 @@ effectiveStdenv.mkDerivation rec {
     # We apply the referenced 1064.patch ourselves to our nix dependency.
     #  FIND_PACKAGE_ARGS for CUDA was added in https://github.com/microsoft/onnxruntime/commit/87744e5 so it might be possible to delete this patch after upgrading to 1.17.0
     ./nvcc-gsl.patch
+
+    # https://github.com/microsoft/onnxruntime/pull/15661
+    ./fix-cpuinfo-logging.patch
   ];
 
   nativeBuildInputs =

--- a/pkgs/development/python-modules/onnxruntime/default.nix
+++ b/pkgs/development/python-modules/onnxruntime/default.nix
@@ -84,7 +84,7 @@ buildPythonPackage {
       # Many downstream packages (vectorcode for e.g.) crash when importing `onnxruntime`:
       # in onnxruntime/capi/_pybind_state.py
       # Fatal Python error: Aborted
-      "aarch64-linux"
+      # "aarch64-linux"
     ];
   };
 }

--- a/pkgs/development/python-modules/onnxruntime/default.nix
+++ b/pkgs/development/python-modules/onnxruntime/default.nix
@@ -79,5 +79,12 @@ buildPythonPackage {
     # sympy
   ];
 
-  meta = onnxruntime.meta;
+  meta = onnxruntime.meta // {
+    badPlatforms = (onnxruntime.meta.badPlatforms or [ ]) ++ [
+      # Many downstream packages (vectorcode for e.g.) crash when importing `onnxruntime`:
+      # in onnxruntime/capi/_pybind_state.py
+      # Fatal Python error: Aborted
+      "aarch64-linux"
+    ];
+  };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Several downstream packages crash when using `python3Packages.onnxruntime` on `aarch64-linux`.
I propose to disable it on this platform.

cc @ck3d @puffnfresh @cbourjau

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
