### PR TITLE
pdf-over: init at 4.4.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27859,6 +27859,12 @@
     githubId = 1901799;
     name = "Nathan van Doorn";
   };
+  tanja = {
+    email = "nix@blahaj.jetzt";
+    github = "Tanja-4732";
+    githubId = 18219148;
+    name = "Tanja";
+  };
   tanya1866 = {
     email = "tanyaarora@tutamail.com";
     matrix = "@tanya1866:matrix.org";

--- a/pkgs/by-name/pd/pdf-over/package.nix
+++ b/pkgs/by-name/pd/pdf-over/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  fetchFromGitHub,
+  jre,
+  makeWrapper,
+  maven,
+  stripJavaArchivesHook,
+
+  glib,
+  gtk3,
+  gsettings-desktop-schemas,
+  libfido2,
+  wrapGAppsHook3,
+}:
+
+maven.buildMavenPackage (finalAttrs: {
+  pname = "pdf-over";
+  version = "4.4.8";
+
+  src = fetchFromGitHub {
+    owner = "a-sit";
+    repo = "PDF-Over";
+    tag = "pdf-over-${finalAttrs.version}";
+    hash = "sha256-CAWNHOFddoKGasT/+AZS/TiehbW586ObAhwlfqbpLq8=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  buildInputs = [
+    glib
+    gtk3
+    gsettings-desktop-schemas
+    libfido2
+  ];
+
+  postPatch = ''
+    substituteInPlace pom.xml \
+      --replace-fail '2.0.34' '2.0.37'
+  '';
+
+  mvnHash = "sha256-VvHkqQmaT3M3cGWqnXpAfYj9E69DKMCBUjYps2bxFE0=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    stripJavaArchivesHook
+    wrapGAppsHook3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    cp -r 'pdf-over-gui/target/staging/''${pdfover-build.output-filename}/lib' $out/share/java
+    cp -r 'pdf-over-gui/target/staging/''${pdfover-build.output-filename}/icons' $out/share/icons
+
+    runHook postInstall
+  '';
+
+  dontWrapGAppsHook = true;
+
+  doCheck = true;
+
+  postFixup = ''
+    classpath=$(find $out/share/java -name "*.jar" -printf ':%h/%f');
+
+    makeWrapper ${lib.getExe jre} $out/bin/pdf-over \
+          --add-flags "-classpath $out/share/java/pdf-over-gui-${finalAttrs.version}.jar:''${classpath#:}" \
+          --add-flags "at.asit.pdfover.gui.Main" \
+          ''${gappsWrapperArgs[@]} \
+          --prefix LD_LIBRARY_PATH ":" ${
+            lib.makeLibraryPath [
+              gtk3
+              glib
+              gsettings-desktop-schemas
+              libfido2
+            ]
+          }
+  '';
+
+  meta = {
+    description = "eIDAS-compliant PDF-signing tool for the Austrian eGovernment platform";
+    longDescription = ''
+      A simple, yet configurable eIDAS-compliant PDF-signing tool for the Austrian eGovernment platform
+      supporting both FIDO2 L2 certified security tokens and smartphone-based
+      signing for creating legally valid qualified signatures on PDFs
+    '';
+    homepage = "https://technology.a-sit.at/en/pdf-over/";
+    license = lib.licenses.eupl12;
+    mainProgram = "pdf-over";
+    maintainers = with lib.maintainers; [ tanja ];
+  };
+})


### PR DESCRIPTION
## Hiiiiiii this is my first PR/MR here :tada: :cat2: 

Pls be patient :point_right::point_left: 

And yea, obviously, this is a WIP;  
I'll fill in the stuff here as I go :3
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Description

Package PDF-Over, a tool used in Austria for qualified, digital signatures.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
