### PR TITLE
workflows/{labels,reviewers}: fix concurrency groups for nested workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,3 +18,25 @@ Some architectural notes about key decisions and concepts in our workflows:
 - **head commit**: The HEAD commit in the pull request's branch. Same as `github.event.pull_request.head.sha`.
 - **merge commit**: The temporary "test merge commit" that GitHub Actions creates and updates for the pull request. Same as `refs/pull/${{ github.event.pull_request.number }}/merge`.
 - **target commit**: The base branch's parent of the "test merge commit" to compare against.
+
+## Concurrency Groups
+
+We use [GitHub's Concurrency Groups](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) to cancel older jobs on pushes to Pull Requests.
+When two workflows are in the same group, a newer workflow cancels an older workflow.
+Thus, it is important how to construct the group keys:
+
+- Because we want to run jobs for different events at same time, we add `github.event_name` to the key. This is the case for the `pull_request` which runs on changes to the workflow files to test the new files and the same workflow from the base branch run via `pull_request_event`.
+
+- We don't want workflows of different Pull Requests to cancel each other, so we include `github.event.pull_request.number`. The [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-using-a-fallback-value) show using `github.head_ref` for this purpose, but this doesn't work well with forks: Different users could have the same head branch name in their forks and run CI for their PRs at the same time.
+
+- Sometimes, there is no `pull_request.number`. That's the case for `push` or `workflow_run` events. To ensure non-PR runs are never cancelled, we add a fallback of `github.run_id`. This is a unique value for each workflow run.
+
+- Of course, we run multiple workflows at the same time, so we add `github.workflow` to the key. Otherwise workflows would cancel each other.
+
+- There is a special case for reusable workflows called via `workflow_call` - they will have `github.workflow` set to their parent workflow's name. Thus, they would cancel each other. That's why we additionally hardcode the name of the workflow as well.
+
+This results in a key with the following semantics:
+
+```
+<running-workflow>-<triggering-workflow>-<triggered-event>-<pull-request/fallback>
+```

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ on:
     types: [closed, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ on:
     types: [closed, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: backport-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: build-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: check-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -30,7 +30,7 @@ on:
     types: [opened, ready_for_review, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: codeowners-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -30,7 +30,7 @@ on:
     types: [opened, ready_for_review, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/dismissed-review.yml
+++ b/.github/workflows/dismissed-review.yml
@@ -7,7 +7,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/dismissed-review.yml
+++ b/.github/workflows/dismissed-review.yml
@@ -7,7 +7,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: dismissed-review-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/edited.yml
+++ b/.github/workflows/edited.yml
@@ -17,7 +17,7 @@ on:
     types: [edited]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/edited.yml
+++ b/.github/workflows/edited.yml
@@ -17,7 +17,7 @@ on:
     types: [edited]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: edited-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/eval-aliases.yml
+++ b/.github/workflows/eval-aliases.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: eval-aliases-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/eval-aliases.yml
+++ b/.github/workflows/eval-aliases.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -17,7 +17,7 @@ on:
       - python-updates
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: eval-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}
@@ -256,8 +256,6 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    with:
-      caller: ${{ github.workflow }}
 
   reviewers:
     name: Reviewers
@@ -268,5 +266,3 @@ jobs:
     if: needs.prepare.outputs.targetSha
     uses: ./.github/workflows/reviewers.yml
     secrets: inherit
-    with:
-      caller: ${{ github.workflow }}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -17,7 +17,7 @@ on:
       - python-updates
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,11 +7,6 @@ name: "Label PR"
 
 on:
   workflow_call:
-    inputs:
-      caller:
-        description: Name of the calling workflow.
-        required: true
-        type: string
   workflow_run:
     workflows:
       - Review dismissed
@@ -19,7 +14,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ inputs.caller }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: labels-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -19,7 +19,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ inputs.caller }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ inputs.caller }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: lint-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -17,7 +17,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ inputs.caller }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.run_id }}
+  group: ${{ inputs.caller }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -10,14 +10,9 @@ on:
   pull_request_target:
     types: [ready_for_review]
   workflow_call:
-    inputs:
-      caller:
-        description: Name of the calling workflow.
-        required: true
-        type: string
 
 concurrency:
-  group: ${{ inputs.caller }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: reviewers-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
This [didn't work as intended](https://github.com/NixOS/nixpkgs/pull/413785#issuecomment-2970315246). When a workflow is run with `workflow_call`, it will have `github.workflow` set to the *parent* workflow. So the `caller` input that we passed, resulted in this concurrency key:

```
Eval-Eval-...
```

But that's bad, because the labels and reviewers workflows will cancel each other!

What we actually want is this:
- Label and Reviewers workflow should have different groups.
- Reviewers called via Eval and called directly via undraft should have *different* groups.

We can't use the default condition we use everywhere else, because `github.workflow` is the same for Label and Reviewers. Thus, we hardcode the workflow's name as well. This essentially means we have this as a key:

```
<name-of-running-workflow>-<name-of-triggering-workflow>-<name-of-event>-<name-of-head-branch>
```

This should do what we want.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
