### PR TITLE
snapcraft: 8.9.2 -> 8.9.4

### DIFF
--- a/pkgs/by-name/ch/charmcraft/package.nix
+++ b/pkgs/by-name/ch/charmcraft/package.nix
@@ -7,6 +7,7 @@
   cacert,
   versionCheckHook,
   writableTmpDirAsHomeHook,
+  stdenv,
 }:
 let
   version = "4.10.0";
@@ -26,6 +27,17 @@ let
           substituteInPlace pyproject.toml --replace-fail "setuptools==75.8.0" "setuptools"
           substituteInPlace craft_application/git/_git_repo.py --replace-fail "/snap/core22/current/etc/ssl/certs" "${cacert}/etc/ssl/certs"
         '';
+
+        disabledTestPaths = [
+          # These tests assert outputs of commands that assume Ubuntu-related output.
+          "tests/unit/services/test_lifecycle.py"
+        ];
+
+        disabledTests =
+          old.disabledTests
+          ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+            "test_process_grammar_full"
+          ];
       });
     };
   };

--- a/pkgs/by-name/ch/charmcraft/package.nix
+++ b/pkgs/by-name/ch/charmcraft/package.nix
@@ -32,7 +32,7 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "charmcraft";
-  version = "3.5.0";
+  version = "3.5.1";
 
   pyproject = true;
 
@@ -40,7 +40,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "canonical";
     repo = "charmcraft";
     tag = version;
-    hash = "sha256-NIOfjd4r9mDP0x1IpIVJlU+Aza0a17bc3jDxtInrf4A=";
+    hash = "sha256-4zlUHttny6nIRhx/5aDz2sh1Va0+nN+7cezBGtt5Img=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -14,7 +14,7 @@
 
 python312Packages.buildPythonApplication rec {
   pname = "snapcraft";
-  version = "8.9.2";
+  version = "8.9.4";
 
   pyproject = true;
 
@@ -22,7 +22,7 @@ python312Packages.buildPythonApplication rec {
     owner = "canonical";
     repo = "snapcraft";
     tag = version;
-    hash = "sha256-4Dv2q/aKWnQkQ6ANYev/5fT1fFKh1MytYJtHK0iAzhk=";
+    hash = "sha256-iiz+sVncztaCNndU+4YMhxECw7R6ks+25apRnd0WgyM=";
   };
 
   patches = [
@@ -111,6 +111,7 @@ python312Packages.buildPythonApplication rec {
     "docutils"
     "jsonschema"
     "pygit2"
+    "requests"
     "urllib3"
     "validators"
   ];

--- a/pkgs/development/python-modules/craft-application/default.nix
+++ b/pkgs/development/python-modules/craft-application/default.nix
@@ -127,12 +127,21 @@ buildPythonPackage rec {
       "test_process_grammar_build_for"
       "test_process_grammar_platform"
       "test_process_grammar_default"
+      "test_create_craft_manifest"
+      "test_create_project_manifest"
+      "test_from_packed_artifact"
+      "test_teardown_session_create_manifest"
     ];
 
-  disabledTestPaths = [
-    # These tests assert outputs of commands that assume Ubuntu-related output.
-    "tests/unit/services/test_lifecycle.py"
-  ];
+  disabledTestPaths =
+    [
+      # These tests assert outputs of commands that assume Ubuntu-related output.
+      "tests/unit/services/test_lifecycle.py"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+      # Hard-coded assumptions around use of "amd64" arch strings.
+      "tests/unit/services/test_project.py"
+    ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/python-modules/craft-parts/default.nix
+++ b/pkgs/development/python-modules/craft-parts/default.nix
@@ -109,6 +109,8 @@ buildPythonPackage rec {
       # These tests have hardcoded "amd64" strings which fail on aarch64
       "tests/unit/executor/test_environment.py"
       "tests/unit/features/overlay/test_executor_environment.py"
+      # Hard-coded assumptions about arguments relating to 'x86_64'
+      "tests/unit/plugins/test_dotnet_v2_plugin.py"
     ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
## Things done

Bumps snapcraft and charmcraft to the latest versions:

https://github.com/canonical/snapcraft/releases/tag/8.9.4
https://github.com/canonical/charmcraft/releases/tag/3.5.1
 
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
