### PR TITLE
teams/ci: init

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -15,9 +15,9 @@
 
 # CI
 /.github/*_TEMPLATE*                    @SigmaSquadron
-/.github/actions                        @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
-/.github/workflows                      @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
-/ci                                     @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
+/.github/actions                        @NixOS/nixpkgs-ci
+/.github/workflows                      @NixOS/nixpkgs-ci
+/ci                                     @NixOS/nixpkgs-ci
 /ci/OWNERS                              @infinisil @philiptaron
 
 # Development support

--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -15,9 +15,9 @@
 
 # CI
 /.github/*_TEMPLATE*                    @SigmaSquadron
-/.github/actions                        @NixOS/Security @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
-/.github/workflows                      @NixOS/Security @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
-/ci                                     @NixOS/Security @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
+/.github/actions                        @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
+/.github/workflows                      @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
+/ci                                     @Mic92 @zowoq @infinisil @azuwis @wolfgangwalther @philiptaron
 /ci/OWNERS                              @infinisil @philiptaron
 
 # Development support

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -186,6 +186,19 @@ with lib.maintainers;
     shortName = "Categorization";
   };
 
+  ci = {
+    members = [
+      MattSturgeon
+      mic92
+      philiptaron
+      wolfgangwalther
+      zowoq
+    ];
+    githubTeams = [ "nixpkgs-ci" ];
+    scope = "Maintain Nixpkgs' in-tree Continuous Integration, including GitHub Actions.";
+    shortName = "CI";
+  };
+
   cinnamon = {
     members = [
       bobby285271


### PR DESCRIPTION
@philiptaron [suggested](https://github.com/NixOS/nixpkgs/pull/412688#pullrequestreview-2884218440) to create a team for CI. Let's do that.

This will become especially handy once we enable "required status checks". To avoid locking us out, we probably need the CI team to be able to *bypass* the required status checks. Otherwise some changes to CI might not be possible: Sometimes new workflows fail temporarily, until they are merged. Or worse, if we make a mistake and merge something that only starts failing on master, we might not be able to fix it without bypassing those checks. Adding bypass actors for branch protection rules can only happen for teams, so we need one anyway.

The change proposed here, encodes the status-quo and takes the current codeowners to form that team. Still, we should discuss membership.

We have a few factors to consider:
- Membership in the team will likely allow bypassing the "required status checks" branch protection rule. Should not make a difference for non-committers, but could be something that some committers don't even *want* to be able to do.
- We currently have 9 codeowners (including the security team) listed for CI related things. That's very close to the self-imposed limit of 10, after which the codeowners workflow will currently not request reviews anymore. We need to be careful not to accidentally disable pings entirely :)

Of course, the number of codeowners shouldn't be a hard limit - we can always adjust CI. Short-term we could raise the limit, but longer term, I hope to be able to implement "requesting reviews *from teams*" instead of extracting the members for each team and pinging them separately. This way, we could ping the security and CI teams with two pings only.

I think the current codeowners can be roughly split into three categories:
- I assume that members of @NixOS/Security are happy with their current observer role.
- @Mic92 @philiptaron @wolfgangwalther, who have been actively contributing/reviewing lately.
- @azuwis @infinisil @zowoq who have been mostly observing lately.

(very much by feel, not by facts, please correct me if wrong)

The obvious question to the last tree: Do you want to be part of that team or rather have fewer notifications?

Also, there are two more candidates:
- @MattSturgeon, who will [probably be a committer soon](https://github.com/NixOS/nixpkgs-committers/issues/50#issuecomment-2889313760) and is already providing great reviews for CI stuff.
- @winterqt, who had already [declared intent to become a codeowner](https://github.com/NixOS/nixpkgs/pull/406825/commits/45d186d14807ecb94b283be7a626b123bcfe03de) earlier.

## Things done

- [x] Team needs to be created in the org and members added. https://github.com/NixOS/org/issues/128
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
