### PR TITLE
python3Packages.msgspec: fix src hash

### DIFF
--- a/pkgs/development/python-modules/msgspec/default.nix
+++ b/pkgs/development/python-modules/msgspec/default.nix
@@ -17,7 +17,11 @@ buildPythonPackage rec {
     owner = "jcrist";
     repo = "msgspec";
     tag = version;
-    hash = "sha256-g2yhw9fMucBHlGx9kAMQL87znXlQT9KbxQ/QcmUetqI=";
+    # Note that this hash changes after some time after release because they
+    # use `$Format:%d$` in msgspec/_version.py, and GitHub produces different
+    # tarballs depending on whether tagged commit is the last commit, see
+    # https://github.com/NixOS/nixpkgs/issues/84312
+    hash = "sha256-CajdPNAkssriY/sie5gR+4k31b3Wd7WzqcsFmrlSoPY=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
The source hash changes because they use `$Format:%d$` in their code, and GitHub can substitute this with different things in different times, see https://github.com/NixOS/nixpkgs/issues/84312.

In this case, the diff looks like this:

```
diff -ur /nix/store/v2yfg05q83i154bdi2s96g21zi079rgi-source/msgspec/_version.py /nix/store/94zddrfms1ikx61i0plxnqdd3gavfdzr-source/msgspec/_version.py
--- /nix/store/v2yfg05q83i154bdi2s96g21zi079rgi-source/msgspec/_version.py      1970-01-01 00:00:01.000000000 +0000
+++ /nix/store/94zddrfms1ikx61i0plxnqdd3gavfdzr-source/msgspec/_version.py      1970-01-01 00:00:01.000000000 +0000
@@ -24,7 +24,7 @@
     # setup.py/versioneer.py will grep for the variable names, so they must
     # each be defined on a line of their own. _version.py will just call
     # get_keywords().
-    git_refnames = " (HEAD -> main, tag: 0.19.0)"
+    git_refnames = " (tag: 0.19.0)"
     git_full = "dd965dce22e5278d4935bea923441ecde31b5325"
     git_date = "2024-12-27 11:06:58 -0600"
     keywords = {"refnames": git_refnames, "full": git_full, "date": git_date}
```

Fix the hash and add a comment explaining the situation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
