### PR TITLE
[25.05] nixpkgs-review: 3.2.0 -> 3.4.0

### DIFF
--- a/pkgs/by-name/ni/nixpkgs-review/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-review/package.nix
@@ -18,14 +18,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "nixpkgs-review";
-  version = "3.3.0";
+  version = "3.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "nixpkgs-review";
     tag = version;
-    hash = "sha256-Ey07yahJQv5ppf8TiwIt1Cn4xo4QMZ5v+CsJRDelWNY=";
+    hash = "sha256-qVGaIq05vJA5HmCauASvMiUUg+58v4GOp6NMY9fIGLo=";
   };
 
   build-system = [

--- a/pkgs/by-name/ni/nixpkgs-review/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-review/package.nix
@@ -18,14 +18,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "nixpkgs-review";
-  version = "3.2.0";
+  version = "3.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "nixpkgs-review";
     tag = version;
-    hash = "sha256-XJRZpAiIbwN5itqxHTcAqd6VnuUOO8TwShZiupJc8dc=";
+    hash = "sha256-Ey07yahJQv5ppf8TiwIt1Cn4xo4QMZ5v+CsJRDelWNY=";
   };
 
   build-system = [


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/416457 which includes a previou update to apply cleanly.

We'll need to spread this for it to be able to download eval results after https://github.com/NixOS/nixpkgs/pull/415006.