### PR TITLE
goose-cli: 1.0.24 -> 1.0.27

### DIFF
--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -7,6 +7,7 @@
   dbus,
   xorg,
   pkg-config,
+  protobuf,
   writableTmpDirAsHomeHook,
   nix-update-script,
   llvmPackages,
@@ -26,19 +27,22 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "goose-cli";
-  version = "1.0.24";
+  version = "1.0.27";
 
   src = fetchFromGitHub {
     owner = "block";
     repo = "goose";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pkqZZwA25IszAnaW0G5adUI2NIEqqQnTQRqlqHWgJRg=";
+    hash = "sha256-+HNAOw/BJVNHiDHeEBKoAAs66IXCdYhm1VzVFIzk4m8=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-Wct5XnBueG58+A4zZpcKy0vA2Kjwmtk505JZKNPFTDQ=";
+  cargoHash = "sha256-v+UQFbFpkwX+7oNFvKf2v2u3OSkPdgOWntXLW6XJibE=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+  ];
 
   buildInputs = [ dbus ] ++ lib.optionals stdenv.hostPlatform.isLinux [ xorg.libxcb ];
 
@@ -70,6 +74,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "--skip=logging::tests::test_log_file_name::with_session_name_without_error_capture"
       "--skip=logging::tests::test_log_file_name::without_session_name"
       "--skip=developer::tests::test_text_editor_str_replace"
+      # need API keys
+      "--skip=providers::factory::tests::test_create_lead_worker_provider"
+      "--skip=providers::factory::tests::test_create_regular_provider_without_lead_config"
+      "--skip=providers::factory::tests::test_lead_model_env_vars_with_defaults"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       "--skip=providers::gcpauth::tests::test_load_from_metadata_server"


### PR DESCRIPTION
Update version of `goose-cli` from 1.0.24 to 1.0.27.
Here is summary of the changes:
- Update version string from 1.0.24 to 1.0.27
- Update hashes
- Add protobuf to nativeBuildInputs (required by lance-encoding dependency, which is introduced on https://github.com/block/goose/commit/bf1c0d51e477c4ac586be58f57b208203e0dc0d7)
- Skip tests that require API keys (introduced on https://github.com/block/goose/commit/2f8f8e5767bb1fdc53dfaa4a492c9184f02c3721)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
