### PR TITLE
python3Packages.duckdb-engine: 0.15.0 -> 0.17.0

### DIFF
--- a/pkgs/development/python-modules/duckdb-engine/default.nix
+++ b/pkgs/development/python-modules/duckdb-engine/default.nix
@@ -11,12 +11,12 @@
   sqlalchemy,
 
   # testing
+  fsspec,
   hypothesis,
   pandas,
   pyarrow,
   pytest-remotedata,
   pytestCheckHook,
-  python,
   pythonAtLeast,
   pythonOlder,
   snapshottest,
@@ -25,14 +25,14 @@
 
 buildPythonPackage rec {
   pname = "duckdb-engine";
-  version = "0.15.0";
+  version = "0.17.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     repo = "duckdb_engine";
     owner = "Mause";
     tag = "v${version}";
-    hash = "sha256-mxv6xYO31MDzHvIf7Zk+kFtm6fX3x3AaJNn7RhvJ2fY=";
+    hash = "sha256-AhYCiIhi7jMWKIdDwZZ8MgfDg3F02/jooGLOp6E+E5g=";
   };
 
   build-system = [ poetry-core ];
@@ -50,6 +50,7 @@ buildPythonPackage rec {
 
   checkInputs =
     [
+      fsspec
       hypothesis
       pandas
       pyarrow

--- a/pkgs/development/python-modules/duckdb-engine/default.nix
+++ b/pkgs/development/python-modules/duckdb-engine/default.nix
@@ -2,18 +2,24 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pytestCheckHook,
-  pythonAtLeast,
-  pythonOlder,
-  python,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
   duckdb,
+  sqlalchemy,
+
+  # testing
   hypothesis,
   pandas,
   pyarrow,
-  poetry-core,
   pytest-remotedata,
+  pytestCheckHook,
+  python,
+  pythonAtLeast,
+  pythonOlder,
   snapshottest,
-  sqlalchemy,
   typing-extensions,
 }:
 
@@ -22,8 +28,6 @@ buildPythonPackage rec {
   version = "0.15.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
-
   src = fetchFromGitHub {
     repo = "duckdb_engine";
     owner = "Mause";
@@ -31,9 +35,9 @@ buildPythonPackage rec {
     hash = "sha256-mxv6xYO31MDzHvIf7Zk+kFtm6fX3x3AaJNn7RhvJ2fY=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     duckdb
     sqlalchemy
   ];
@@ -48,9 +52,9 @@ buildPythonPackage rec {
     [
       hypothesis
       pandas
+      pyarrow
       pytest-remotedata
       typing-extensions
-      pyarrow
     ]
     ++ lib.optionals (pythonOlder "3.12") [
       # requires wasmer which is broken for python 3.12
@@ -68,27 +72,19 @@ buildPythonPackage rec {
     "duckdb_engine/tests/test_datatypes.py"
   ];
 
-  disabledTests =
-    [
-      # incompatible with duckdb 1.1.1
-      "test_with_cache"
-      # these aren't set for some reason
-      "test_user_agent"
-      "test_user_agent_with_custom_user_agent"
-    ]
-    ++ lib.optionals (python.pythonVersion == "3.11") [
-      # incompatible with duckdb 1.1.1
-      "test_all_types_reflection"
-      "test_nested_types"
-    ];
+  disabledTests = [
+    # user agent not available in nixpkgs
+    "test_user_agent"
+    "test_user_agent_with_custom_user_agent"
+  ];
 
   pythonImportsCheck = [ "duckdb_engine" ];
 
-  meta = with lib; {
+  meta = {
     description = "SQLAlchemy driver for duckdb";
     homepage = "https://github.com/Mause/duckdb_engine";
     changelog = "https://github.com/Mause/duckdb_engine/blob/${src.tag}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ cpcloud ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cpcloud ];
   };
 }


### PR DESCRIPTION
1. Package cleanup: modernize build, remove `with lib;`, remove `pythonOlder`, recheck tests and update `disabledTests` for current `duckdb`.
2. Version bump

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
