### PR TITLE
firefox: backport patch for mozbz 1955112

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/139-wayland-drag-animation.patch
+++ b/pkgs/applications/networking/browsers/firefox/139-wayland-drag-animation.patch
@@ -1,0 +1,53 @@
+# HG changeset patch
+# User Dão Gottwald <dao@mozilla.com>
+# Date 1742828426 0
+# Node ID aa8a29bd1fb9668c81475b534b4ceb220dd4fe55
+# Parent  653a7b21210b5b61a36af11b99ccd51e6c85a905
+Bug 1955112 - Finish tab moving animation when a drag session wasn't ended properly. r=dwalker,tabbrowser-reviewers
+
+Differential Revision: https://phabricator.services.mozilla.com/D242631
+
+diff --git a/browser/components/tabbrowser/content/tabs.js b/browser/components/tabbrowser/content/tabs.js
+--- a/browser/components/tabbrowser/content/tabs.js
++++ b/browser/components/tabbrowser/content/tabs.js
+@@ -1012,18 +1012,39 @@
+         newMargin *= -1;
+       }
+       ind.style.transform = this.verticalMode
+         ? "translateY(" + Math.round(newMargin) + "px)"
+         : "translateX(" + Math.round(newMargin) + "px)";
+     }
+ 
+     #setMovingTabMode(movingTab) {
++      if (movingTab == this.#isMovingTab()) {
++        return;
++      }
++
+       this.toggleAttribute("movingtab", movingTab);
+       gNavToolbox.toggleAttribute("movingtab", movingTab);
++
++      if (movingTab) {
++        // This is a bit of an escape hatch in case a tab drag & drop session
++        // wasn't ended properly, leaving behind the movingtab attribute, which
++        // may break the UI (bug 1954163). We don't get mousemove events while
++        // dragging tabs, so at that point it should be safe to assume that we
++        // should not be in drag and drop mode, and clean things up if needed.
++        requestAnimationFrame(() => {
++          this.addEventListener(
++            "mousemove",
++            () => {
++              this.finishAnimateTabMove();
++            },
++            { once: true }
++          );
++        });
++      }
+     }
+ 
+     #isMovingTab() {
+       return this.hasAttribute("movingtab");
+     }
+ 
+     #expandGroupOnDrop(draggedTab) {
+       if (
+

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -310,6 +310,11 @@ buildStdenv.mkDerivation {
       ./no-buildconfig-ffx121.patch
     ]
     ++ lib.optionals (lib.versionAtLeast version "136") [ ./no-buildconfig-ffx136.patch ]
+    ++ lib.optionals (lib.versionAtLeast version "139" && lib.versionOlder version "141") [
+      # https://bugzilla.mozilla.org/show_bug.cgi?id=1955112
+      # https://hg-edge.mozilla.org/mozilla-central/rev/aa8a29bd1fb9
+      ./139-wayland-drag-animation.patch
+    ]
     ++ lib.optionals (lib.versionAtLeast version "139") [ ./139-relax-apple-sdk.patch ]
     ++ lib.optionals (lib.versionOlder version "139") [
       # Fix for missing vector header on macOS


### PR DESCRIPTION
Works around a wayland bug that makes the UI appear frozen, when a tab drag visual wasn't ended properly.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
