### PR TITLE
karakeep: changing cache dir location away from nix store

### DIFF
--- a/nixos/modules/services/web-apps/karakeep.nix
+++ b/nixos/modules/services/web-apps/karakeep.nix
@@ -169,11 +169,15 @@ in
         "karakeep-workers.service"
       ];
       partOf = [ "karakeep.service" ];
-      environment = karakeepEnv;
+      environment = {
+        NEXT_CACHE_DIR = "%C/karakeep";
+      }
+      // karakeepEnv;
       serviceConfig = {
         ExecStart = "${cfg.package}/lib/karakeep/start-web";
         User = "karakeep";
         Group = "karakeep";
+        CacheDirectory = "karakeep";
         StateDirectory = "karakeep";
         EnvironmentFile = environmentFiles;
         PrivateTmp = "yes";

--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -80,6 +80,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
+  preInstall = ''
+    # provide a environment variable to override the cache directory
+    # https://github.com/vercel/next.js/discussions/58864
+    patch -p1 -i ${./patches/cache-from-env-not-nix-store.patch}
+  '';
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/ka/karakeep/patches/cache-from-env-not-nix-store.patch
+++ b/pkgs/by-name/ka/karakeep/patches/cache-from-env-not-nix-store.patch
@@ -1,0 +1,14 @@
+diff --git a/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js b/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js
+index cba8876..c3d7c43 100644
+--- a/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js
++++ b/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js
+@@ -409,7 +409,8 @@ class ImageOptimizerCache {
+         ]);
+     }
+     constructor({ distDir, nextConfig }){
+-        this.cacheDir = (0, _path.join)(distDir, "cache", "images");
++        const cacheDir = process.env["NEXT_CACHE_DIR"] || (0, _path.join)(distDir, "cache");
++        this.cacheDir = (0, _path.join)(cacheDir, "images");
+         this.nextConfig = nextConfig;
+     }
+     async get(cacheKey) {


### PR DESCRIPTION
Next.js image optimizer is trying to create directories in the nix store whenever a link is added, and in my personal instance that meant that I got no details except the URL visible in the app.

This PR ~(which is based on PR #412414)~ solves this by changing a function call in the built package, making the cache dir configurable using an environment variable.

This is coupled with setting that variable to `$CACHE_DIR` in the nixos module so the systemd unit takes care of it.

I haven't been able to test this in noninteractive nixosTest since I need to create an account in the browser before I can use the CLI.

Here's what it looked like before:
```
$ journalctl -xeu karakeep-web
maj 30 12:24:17 sulaco start-web[8283]:  ⨯ Failed to write image to cache 5rfdRTXxSUJzUihFGQs5wXX6pm9rcWtWebn42P0Mm8s= Error: ENOENT: no such file or directory, mkdir '/nix/store/ccwqm7sbbk4ik1cc06kza6vz4ff92cyj-karakeep-0.24.1/lib/karakeep/apps/web/.next/standalone/apps/web/.next/cache'
maj 30 12:24:17 sulaco start-web[8283]:     at async Object.mkdir (node:internal/fs/promises:857:10)
maj 30 12:24:17 sulaco start-web[8283]:     at async writeToCacheDir (/nix/store/ccwqm7sbbk4ik1cc06kza6vz4ff92cyj-karakeep-0.24.1/lib/karakeep/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js:178:5)
maj 30 12:24:17 sulaco start-web[8283]:     at async ImageOptimizerCache.set (/nix/store/ccwqm7sbbk4ik1cc06kza6vz4ff92cyj-karakeep-0.24.1/lib/karakeep/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js:451:13)
maj 30 12:24:17 sulaco start-web[8283]:     at async /nix/store/ccwqm7sbbk4ik1cc06kza6vz4ff92cyj-karakeep-0.24.1/lib/karakeep/apps/web/.next/standalone/node_modules/next/dist/server/response-cache/index.js:121:25
maj 30 12:24:17 sulaco start-web[8283]:     at async /nix/store/ccwqm7sbbk4ik1cc06kza6vz4ff92cyj-karakeep-0.24.1/lib/karakeep/apps/web/.next/standalone/node_modules/next/dist/lib/batcher.js:45:32 {
maj 30 12:24:17 sulaco start-web[8283]:   errno: -2,
maj 30 12:24:17 sulaco start-web[8283]:   code: 'ENOENT',
maj 30 12:24:17 sulaco start-web[8283]:   syscall: 'mkdir',
maj 30 12:24:17 sulaco start-web[8283]:   path: '/nix/store/ccwqm7sbbk4ik1cc06kza6vz4ff92cyj-karakeep-0.24.1/lib/karakeep/apps/web/.next/standalone/apps/web/.next/cache'
maj 30 12:24:17 sulaco start-web[8283]: }
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
