### PR TITLE
asus-wmi-screenpad-ctl: init at 1.0.0

### DIFF
--- a/pkgs/by-name/as/asus-wmi-screenpad-ctl/package.nix
+++ b/pkgs/by-name/as/asus-wmi-screenpad-ctl/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+let
+  version = "1.0.0";
+in
+rustPlatform.buildRustPackage {
+  pname = "asus-wmi-screenpad-ctl";
+  inherit version;
+
+  src = fetchFromGitHub {
+    repo = "asus-wmi-screenpad-ctl";
+    owner = "aldenparker";
+    tag = "v${version}";
+    hash = "sha256-TV61Kh8A7PFJPRONqeCK1xEK2AHfiV/eoZOCL0SZ+5M=";
+  };
+
+  cargoHash = "sha256-ZluFoV9TclY6NOB5sHBN+1ht3zovmb4H+q7qT/Ywwmc=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Brightness control program for the asus-wmi-screenpad kernel module";
+    mainProgram = "asus-wmi-screenpad-ctl";
+    homepage = "https://github.com/aldenparker/asus-wmi-screenpad-ctl";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aldenparker ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Adds [asus-wmi-screenpad-ctl](https://github.com/aldenparker/asus-wmi-screenpad-ctl) at v1.0.0. The program is a small rust program that controls the brightness of the Asus Screenpad display through simple commands.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
