### PR TITLE
python3Packages.python-wayland-extra: init at 0.7.0, python3Packages.streamcontroller-streamdeck: init at 0.1.5, Streamcontroller: 1.5.0-beta.8 -> 1.5.0-beta.12

### DIFF
--- a/pkgs/by-name/st/streamcontroller/package.nix
+++ b/pkgs/by-name/st/streamcontroller/package.nix
@@ -18,19 +18,19 @@
 }:
 let
   # We have to hardcode revision because upstream often create multiple releases for the same version number.
-  # This is the commit hash that maps to 1.5.0-beta.8 released on 2025-03-12
-  rev = "de11d84afac7873044568606a8468c78d57aceda";
+  # This is the commit hash that maps to 1.5.0-beta.12 released on 2025-10-11
+  rev = "73b7632ff2977d05763acd56e53bdc7a37d30c0c";
 in
 stdenv.mkDerivation {
   pname = "streamcontroller";
 
-  version = "1.5.0-beta.8";
+  version = "1.5.0-beta.12";
 
   src = fetchFromGitHub {
     repo = "StreamController";
     owner = "StreamController";
     inherit rev;
-    hash = "sha256-pE92/oX9iZYCIhwDkPkjPq/cDUQLUGs+Ou5rjFEIBpo=";
+    hash = "sha256-6H0FPkvjKSfso1+E0JwseOnubDXwYys0RVBbyaGCXw0=";
   };
 
   # The installation method documented upstream
@@ -167,6 +167,7 @@ stdenv.mkDerivation {
     pyro5
     pyspellchecker
     python-dateutil
+    python-wayland-extra
     pyudev
     pyusb
     pyyaml
@@ -182,7 +183,7 @@ stdenv.mkDerivation {
     smmap
     speedtest-cli
     streamcontroller-plugin-tools
-    streamdeck
+    streamcontroller-streamdeck
     textual
     tinycss2
     tqdm

--- a/pkgs/development/python-modules/python-wayland-extra/default.nix
+++ b/pkgs/development/python-modules/python-wayland-extra/default.nix
@@ -1,0 +1,48 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  hatchling,
+  black,
+  lxml,
+  pytest,
+  requests,
+  ruff,
+}:
+
+buildPythonPackage rec {
+  pname = "python-wayland-extra";
+  version = "0.7.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "python_wayland_extra";
+    hash = "sha256-HSBOCWP3o/BHmg3LO+LU+GpYkEYSqdljjYcEPdOnxZk=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "black", "lxml", "requests", "pytest", "ruff"' ""
+  '';
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    lxml
+    requests
+  ];
+
+  # requires working wayland display
+  doCheck = false;
+
+  pythonImportsCheck = [ "wayland" ];
+
+  meta = {
+    description = "Implementation of the Wayland protocol with no external dependencies";
+    homepage = "https://github.com/dennisrijsdijk/python-wayland-extra";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sifmelcara ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/streamcontroller-streamdeck/default.nix
+++ b/pkgs/development/python-modules/streamcontroller-streamdeck/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  replaceVars,
+  pkgs,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "streamcontroller-streamdeck";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "streamcontroller_streamdeck";
+    hash = "sha256-JSDCg9PLDqxM1KdoCEnYzJip71re6rdS/mLn6fsGn9E=";
+  };
+
+  patches = [
+    # substitute libusb path
+    (replaceVars ./hardcode-libusb.patch {
+      libusb = "${pkgs.hidapi}/lib/libhidapi-libusb${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "StreamDeck" ];
+  doCheck = false;
+
+  meta = with lib; {
+    # This is a fork of abcminiuser/python-elgato-streamdeck targeted at StreamController.
+    description = "Python library to control the Elgato Stream Deck";
+    homepage = "https://github.com/StreamController/streamcontroller-python-elgato-streamdeck";
+    license = licenses.mit;
+    maintainers = with maintainers; [
+      majiir
+      sifmelcara
+    ];
+  };
+}

--- a/pkgs/development/python-modules/streamcontroller-streamdeck/hardcode-libusb.patch
+++ b/pkgs/development/python-modules/streamcontroller-streamdeck/hardcode-libusb.patch
@@ -1,0 +1,13 @@
+diff --git a/src/StreamDeck/Transport/LibUSBHIDAPI.py b/src/StreamDeck/Transport/LibUSBHIDAPI.py
+index edf53a1..2d38af3 100644
+--- a/src/StreamDeck/Transport/LibUSBHIDAPI.py
++++ b/src/StreamDeck/Transport/LibUSBHIDAPI.py
+@@ -155,7 +155,7 @@ class LibUSBHIDAPI(Transport):
+ 
+             search_library_names = {
+                 "Windows": ["hidapi.dll", "libhidapi-0.dll", "./hidapi.dll"],
+-                "Linux": ["libhidapi-libusb.so", "libhidapi-libusb.so.0"],
++                "Linux": ["@libusb@"],
+                 "Darwin": ["libhidapi.dylib"],
+                 "FreeBSD": ["libhidapi.so"],
+             }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18212,6 +18212,10 @@ self: super: with self; {
     callPackage ../development/python-modules/streamcontroller-plugin-tools
       { };
 
+  streamcontroller-streamdeck =
+    callPackage ../development/python-modules/streamcontroller-streamdeck
+      { };
+
   streamdeck = callPackage ../development/python-modules/streamdeck { };
 
   streaming-form-data = callPackage ../development/python-modules/streaming-form-data { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15593,6 +15593,8 @@ self: super: with self; {
 
   python-watcherclient = callPackage ../development/python-modules/python-watcherclient { };
 
+  python-wayland-extra = callPackage ../development/python-modules/python-wayland-extra { };
+
   python-whois = callPackage ../development/python-modules/python-whois { };
 
   python-wink = callPackage ../development/python-modules/python-wink { };


### PR DESCRIPTION
Fixes #416461

 @ciferkey 

## Things done

Add 2 new python packages, which are new dependencies required by the new version of streamcontroller. `streamcontroller_streamdeck` is a fork of existing `streamdeck` package made by author of streamcontroller, required by the new version of streamcontroller.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
