### PR TITLE
nixos-rebuild: restore local sudo functionality

### DIFF
--- a/nixos/tests/nixos-rebuild-target-host.nix
+++ b/nixos/tests/nixos-rebuild-target-host.nix
@@ -57,7 +57,7 @@
           users.users.alice.extraGroups = [ "wheel" ];
           users.users.bob.extraGroups = [ "wheel" ];
 
-          # Disable sudo for root to ensure sudo isn't called without `--use-remote-sudo`
+          # Disable sudo for root to ensure sudo isn't called without `--sudo`
           security.sudo.extraRules = lib.mkForce [
             {
               groups = [ "wheel" ];
@@ -170,20 +170,20 @@
       # Ensure sudo is disabled for root
       target.fail("sudo true")
 
-      # This test also ensures that sudo is not called without --use-remote-sudo
+      # This test also ensures that sudo is not called without --sudo
       with subtest("Deploy to root@target"):
         deployer.succeed("nixos-rebuild switch -I nixos-config=/root/configuration-1.nix --target-host root@target &>/dev/console")
         target_hostname = deployer.succeed("ssh alice@target cat /etc/hostname").rstrip()
         assert target_hostname == "config-1-deployed", f"{target_hostname=}"
 
       with subtest("Deploy to alice@target with passwordless sudo"):
-        deployer.succeed("nixos-rebuild switch -I nixos-config=/root/configuration-2.nix --target-host alice@target --use-remote-sudo &>/dev/console")
+        deployer.succeed("nixos-rebuild switch -I nixos-config=/root/configuration-2.nix --target-host alice@target --sudo &>/dev/console")
         target_hostname = deployer.succeed("ssh alice@target cat /etc/hostname").rstrip()
         assert target_hostname == "config-2-deployed", f"{target_hostname=}"
 
       with subtest("Deploy to bob@target with password based sudo"):
         # TODO: investigate why --ask-sudo-password from nixos-rebuild-ng is not working here
-        deployer.succeed(r'${lib.optionalString withNg "NIX_SSHOPTS=-t "}passh -c 3 -C -p ${nodes.target.users.users.bob.password} -P "\[sudo\] password" nixos-rebuild switch -I nixos-config=/root/configuration-3.nix --target-host bob@target --use-remote-sudo &>/dev/console')
+        deployer.succeed(r'${lib.optionalString withNg "NIX_SSHOPTS=-t "}passh -c 3 -C -p ${nodes.target.users.users.bob.password} -P "\[sudo\] password" nixos-rebuild switch -I nixos-config=/root/configuration-3.nix --target-host bob@target --sudo &>/dev/console')
         target_hostname = deployer.succeed("ssh alice@target cat /etc/hostname").rstrip()
         assert target_hostname == "config-3-deployed", f"{target_hostname=}"
 

--- a/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
+++ b/pkgs/os-specific/linux/nixos-rebuild/_nixos-rebuild
@@ -35,7 +35,7 @@ _nixos-rebuild() {
     --profile-name -p # name
     --rollback
     --specialisation -c # name
-    --use-remote-sudo
+    --use-sudo
     --no-ssh-tty
     --build-host # host
     --target-host # host

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -38,7 +38,7 @@
 .br
 .Op Fl -build-host Va host
 .Op Fl -target-host Va host
-.Op Fl -use-remote-sudo
+.Op Fl -sudo
 .Op Fl -no-ssh-tty
 .br
 .Op Fl -verbose | v
@@ -404,7 +404,7 @@ or
 is also set. This is useful when the target-host connection to cache.nixos.org
 is faster than the connection between hosts.
 .
-.It Fl -use-remote-sudo
+.It Fl -sudo
 When set, nixos-rebuild prefixes activation commands that run on the
 .Fl -target-host
 system with

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -33,6 +33,7 @@ imageVariant=
 buildHost=
 targetHost=
 remoteSudo=
+localSudo=
 noSSHTTY=
 verboseScript=
 noFlake=
@@ -173,6 +174,9 @@ while [ "$#" -gt 0 ]; do
       --use-remote-sudo)
         remoteSudo=1
         ;;
+      --use-local-sudo)
+        localSudo=1
+        ;;
       --no-ssh-tty)
         noSSHTTY=1
         ;;
@@ -256,7 +260,7 @@ targetHostSudoCmd() {
         t="-t"
     fi
 
-    if [ -n "$remoteSudo" ]; then
+    if [[ -n "$remoteSudo" || -n "$localSudo" ]]; then
         useSudo=1 SSHOPTS="$SSHOPTS $t" targetHostCmd "$@"
     else
         # While a tty might not be necessary, we apply it to be consistent with

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -32,8 +32,7 @@ specialisation=
 imageVariant=
 buildHost=
 targetHost=
-remoteSudo=
-localSudo=
+useSudo=
 noSSHTTY=
 verboseScript=
 noFlake=
@@ -171,11 +170,8 @@ while [ "$#" -gt 0 ]; do
         targetHost="$1"
         shift 1
         ;;
-      --use-remote-sudo)
-        remoteSudo=1
-        ;;
-      --use-local-sudo)
-        localSudo=1
+      --sudo | --use-remote-sudo)
+        useSudo=1
         ;;
       --no-ssh-tty)
         noSSHTTY=1
@@ -241,7 +237,7 @@ buildHostCmd() {
 
 targetHostCmd() {
     local c
-    if [[ "${useSudo:-x}" = 1 ]]; then
+    if [[ "${withSudo:-x}" = 1 ]]; then
         c=("sudo")
     else
         c=()
@@ -260,8 +256,8 @@ targetHostSudoCmd() {
         t="-t"
     fi
 
-    if [[ -n "$remoteSudo" || -n "$localSudo" ]]; then
-        useSudo=1 SSHOPTS="$SSHOPTS $t" targetHostCmd "$@"
+    if [[ -n "$useSudo" ]]; then
+        withSudo=1 SSHOPTS="$SSHOPTS $t" targetHostCmd "$@"
     else
         # While a tty might not be necessary, we apply it to be consistent with
         # sudo usage, and an experience that is more consistent with local deployment.


### PR DESCRIPTION
This functionality used to exist and was then removed in #331741. The issue was that $SUDO_USER is already used by `sudo` as an environment variable.

This change makes it possible to checkout a flake repository, as a user, enter the devshell, and with the additions below and apply changes with `nixos-rebuild switch`.

`sudo nixos-rebuild switch` also works but is not optimal. It loses the environment variables of the user and leaves a root-owned ./result symlink.

```nix
{ pkgs }:
let
  nixos-rebuild = pkgs.writeShellApplication {
    name = "nixos-rebuild";
    runtimeInputs = [ pkgs.nixos-rebuild ];
    text = ''
      set -euo pipefail
      exec nixos-rebuild --flake "$PRJ_ROOT" --use-local-sudo "$@"
    '';
  };
in
pkgs.mkShellNoCC {
  packages = [
    nixos-rebuild
  ];

  shellHook = ''
    export PRJ_ROOT=$PWD
  '';
}
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
