### PR TITLE
undmg-hdiutil: init

### DIFF
--- a/pkgs/by-name/ai/airbuddy/package.nix
+++ b/pkgs/by-name/ai/airbuddy/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  _7zz,
+  undmg-hdiutil,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -20,16 +20,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontBuild = true;
   dontFixup = true;
 
-  # AirBuddy.dmg is APFS formatted, unpack with 7zz
-  nativeBuildInputs = [ _7zz ];
-
-  sourceRoot = "AirBuddy.app";
+  # dmg is APFS formatted
+  nativeBuildInputs = [ undmg-hdiutil ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/Applications/AirBuddy.app
-    cp -R . $out/Applications/AirBuddy.app
+    mkdir -p $out/Applications
+    cp -a AirBuddy.app $out/Applications
 
     runHook postInstall
   '';

--- a/pkgs/by-name/al/aldente/package.nix
+++ b/pkgs/by-name/al/aldente/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  _7zz,
+  undmg-hdiutil,
   nix-update-script,
 }:
 
@@ -18,16 +18,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontBuild = true;
   dontFixup = true;
 
-  # AlDente.dmg is APFS formatted, unpack with 7zz
-  nativeBuildInputs = [ _7zz ];
-
-  sourceRoot = "AlDente.app";
+  # dmg is APFS formatted
+  nativeBuildInputs = [ undmg-hdiutil ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/Applications/AlDente.app
-    cp -R . $out/Applications/AlDente.app
+    mkdir -p $out/Applications
+    cp -a AlDente.app $out/Applications
 
     runHook postInstall
   '';

--- a/pkgs/by-name/lm/lmstudio/darwin.nix
+++ b/pkgs/by-name/lm/lmstudio/darwin.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   fetchurl,
-  undmg,
+  undmg-hdiutil,
   meta,
   pname,
   version,
@@ -16,9 +16,8 @@ stdenv.mkDerivation {
     inherit url hash;
   };
 
-  nativeBuildInputs = [ undmg ];
-
-  sourceRoot = ".";
+  # dmg is APFS formatted
+  nativeBuildInputs = [ undmg-hdiutil ];
 
   installPhase = ''
     runHook preInstall
@@ -29,25 +28,6 @@ stdenv.mkDerivation {
 
   # LM Studio ships Scripts inside the App Bundle, which may be messed up by standard fixups
   dontFixup = true;
-
-  # undmg doesn't support APFS and 7zz does break the xattr. Took that approach from https://github.com/NixOS/nixpkgs/blob/a3c6ed7ad2649c1a55ffd94f7747e3176053b833/pkgs/by-name/in/insomnia/package.nix#L52
-  unpackCmd = ''
-    echo "Creating temp directory"
-    mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
-    function finish {
-      echo "Ejecting temp directory"
-      /usr/bin/hdiutil detach $mnt -force
-      rm -rf $mnt
-    }
-    # Detach volume when receiving SIG "0"
-    trap finish EXIT
-    # Mount DMG file
-    echo "Mounting DMG file into \"$mnt\""
-    /usr/bin/hdiutil attach -nobrowse -mountpoint $mnt $curSrc
-    # Copy content to local dir for later use
-    echo 'Copying extracted content into "sourceRoot"'
-    cp -a $mnt/LM\ Studio.app $PWD/
-  '';
 
   inherit passthru;
 }

--- a/pkgs/by-name/no/nosql-workbench/package.nix
+++ b/pkgs/by-name/no/nosql-workbench/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   jdk21,
   stdenv,
-  _7zz,
+  undmg-hdiutil,
 }:
 let
   pname = "nosql-workbench";
@@ -50,12 +50,8 @@ if stdenv.hostPlatform.isDarwin then
       meta
       ;
 
-    sourceRoot = ".";
-
-    # DMG file is using APFS which is unsupported by "undmg".
-    # Instead, use "7zz" to extract the contents.
-    # "undmg" issue: https://github.com/matthewbauer/undmg/issues/4
-    nativeBuildInputs = [ _7zz ];
+    # dmg is APFS formatted
+    nativeBuildInputs = [ undmg-hdiutil ];
 
     buildInputs = [ jdk21 ];
 

--- a/pkgs/by-name/un/undmg-hdiutil/package.nix
+++ b/pkgs/by-name/un/undmg-hdiutil/package.nix
@@ -1,0 +1,7 @@
+{
+  makeSetupHook,
+}:
+
+makeSetupHook {
+  name = "undmg-hdiutil";
+} ./setup-hook.sh

--- a/pkgs/by-name/un/undmg-hdiutil/setup-hook.sh
+++ b/pkgs/by-name/un/undmg-hdiutil/setup-hook.sh
@@ -1,0 +1,10 @@
+unpackCmdHooks+=(_tryUnpackDmg)
+_tryUnpackDmg() {
+  if ! [[ "$curSrc" =~ \.dmg$ ]]; then return 1; fi
+  mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
+  /usr/bin/hdiutil attach -nobrowse -mountpoint $mnt "$curSrc"
+  mkdir source
+  cp -a $mnt/* source
+  /usr/bin/hdiutil detach $mnt -force
+  rm -rf $mnt
+}

--- a/pkgs/by-name/un/unnaturalscrollwheels/package.nix
+++ b/pkgs/by-name/un/unnaturalscrollwheels/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  _7zz,
+  undmg-hdiutil,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "unnaturalscrollwheels";
@@ -12,10 +12,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     url = "https://github.com/ther0n/UnnaturalScrollWheels/releases/download/${finalAttrs.version}/UnnaturalScrollWheels-${finalAttrs.version}.dmg";
     sha256 = "1c6vlf0kc7diz0hb1fmrqaj7kzzfvr65zcchz6xv5cxf0md4n70r";
   };
-  sourceRoot = ".";
 
-  # APFS format is unsupported by undmg
-  nativeBuildInputs = [ _7zz ];
+  # dmg is APFS formatted
+  nativeBuildInputs = [ undmg-hdiutil ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
undmg doesn't support extracting .dmg files using APFS, so we need hdiutil to extract.

Upstream issue: https://github.com/matthewbauer/undmg/issues/4

Implementation is adapted from
https://github.com/NixOS/nixpkgs/blob/5d776754c55133731aaf51a4d925538af08c4e2a/pkgs/by-name/in/insomnia/package.nix#L52-L68

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
