### PR TITLE
workflows/labels: count approving reviewers, not reviews

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -96,7 +96,7 @@ jobs:
                     name == '12.approved-by: package-maintainer'
                   )
 
-                const approvals =
+                const approvals = new Set(
                   (await github.paginate(github.rest.pulls.listReviews, {
                     owner: context.repo.owner,
                     repo: context.repo.repo,
@@ -104,15 +104,16 @@ jobs:
                   }))
                   .filter(review => review.state == 'APPROVED')
                   .map(review => review.user.id)
-
-                const maintainers = Object.keys(
-                  JSON.parse(await readFile('comparison/maintainers.json', 'utf-8'))
                 )
+
+                const maintainers = new Set(Object.keys(
+                  JSON.parse(await readFile('comparison/maintainers.json', 'utf-8'))
+                ))
 
                 // And the labels that should be there
                 const after = JSON.parse(await readFile('comparison/changed-paths.json', 'utf-8')).labels
-                if (approvals.length > 0) after.push(`12.approvals: ${approvals.length > 2 ? '3+' : approvals.length}`)
-                if (maintainers.some(id => approvals.includes(id))) after.push('12.approved-by: package-maintainer')
+                if (approvals.size > 0) after.push(`12.approvals: ${approvals.size > 2 ? '3+' : approvals.size}`)
+                if (Array.from(maintainers).some(approvals.has)) after.push('12.approved-by: package-maintainer')
 
                 // Remove the ones not needed anymore
                 await Promise.all(


### PR DESCRIPTION
A single reviewer approving a Pull Request multiple times should only count once.

Example: #416076 - two approvals by make-42 resulted in an `approvals: 2` label.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
