### PR TITLE
root: remove unneeded workaround for 3D graphics usage

### DIFF
--- a/pkgs/by-name/ro/root/package.nix
+++ b/pkgs/by-name/ro/root/package.nix
@@ -237,12 +237,6 @@ stdenv.mkDerivation rec {
     }"
   '';
 
-  # workaround for
-  # https://github.com/root-project/root/issues/14778
-  env.NIX_LDFLAGS = lib.optionalString (
-    !stdenv.hostPlatform.isDarwin
-  ) "--version-script,${writeText "version.map" "ROOT { global: *; };"}";
-
   # To use the debug information on the fly (without installation)
   # add the outPath of root.debug into NIX_DEBUG_INFO_DIRS (in PATH-like format)
   # and make sure that gdb from Nixpkgs can be found in PATH.


### PR DESCRIPTION
See also the discussion upstream:
https://github.com/root-project/root/issues/14778

@veprbl. Very likely the situation changed a lot when we moved to `builtin_clang=OFF`, and now the workaround doesn't appear to be necessary anymore.

I validated that the 3D graphics is working by successfully running this 3D graphics tutorial:
https://root.cern/doc/master/glViewerExercise_8C.html