### PR TITLE
wechat: init darwin at 4.0.5.24

### DIFF
--- a/pkgs/by-name/we/wechat/darwin.nix
+++ b/pkgs/by-name/we/wechat/darwin.nix
@@ -1,0 +1,30 @@
+{
+  pname,
+  version,
+  src,
+  meta,
+  stdenvNoCC,
+  _7zz,
+}:
+
+stdenvNoCC.mkDerivation {
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
+
+  # dmg is APFS formatted
+  nativeBuildInputs = [ _7zz ];
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -a WeChat.app $out/Applications
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/by-name/we/wechat/linux.nix
+++ b/pkgs/by-name/we/wechat/linux.nix
@@ -1,0 +1,30 @@
+{
+  pname,
+  version,
+  src,
+  meta,
+  appimageTools,
+}:
+
+let
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+    postExtract = ''
+      patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/wechat/wechat
+    '';
+  };
+in
+appimageTools.wrapAppImage {
+  inherit pname version meta;
+
+  src = appimageContents;
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+    cp ${appimageContents}/wechat.desktop $out/share/applications/
+    mkdir -p $out/share/pixmaps
+    cp ${appimageContents}/wechat.png $out/share/pixmaps/
+
+    substituteInPlace $out/share/applications/wechat.desktop --replace-fail AppRun wechat
+  '';
+}

--- a/pkgs/by-name/we/wechat/package.nix
+++ b/pkgs/by-name/we/wechat/package.nix
@@ -1,45 +1,14 @@
 {
-  lib,
-  appimageTools,
+  callPackage,
   fetchurl,
+  lib,
   stdenvNoCC,
 }:
 
 let
   inherit (stdenvNoCC.hostPlatform) system;
+
   pname = "wechat";
-  version = "4.0.1.11";
-  sources = {
-    aarch64-linux = fetchurl {
-      url = "https://web.archive.org/web/20250512112413if_/https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_arm64.AppImage";
-      hash = "sha256-Rg+FWNgOPC02ILUskQqQmlz1qNb9AMdvLcRWv7NQhGk=";
-    };
-    x86_64-linux = fetchurl {
-      url = "https://web.archive.org/web/20250512110825if_/https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_x86_64.AppImage";
-      hash = "sha256-gBWcNQ1o1AZfNsmu1Vi1Kilqv3YbR+wqOod4XYAeVKo=";
-    };
-  };
-  src = appimageTools.extract {
-    inherit pname version;
-    src = sources.${system};
-    postExtract = ''
-      patchelf --replace-needed libtiff.so.5 libtiff.so $out/opt/wechat/wechat
-    '';
-  };
-in
-
-appimageTools.wrapAppImage {
-  inherit pname version src;
-
-  extraInstallCommands = ''
-    mkdir -p $out/share/applications
-    cp ${src}/wechat.desktop $out/share/applications/
-    mkdir -p $out/share/pixmaps
-    cp ${src}/wechat.png $out/share/pixmaps/
-
-    substituteInPlace $out/share/applications/wechat.desktop --replace-fail AppRun wechat
-  '';
-
   meta = {
     description = "Messaging and calling app";
     homepage = "https://www.wechat.com/en/";
@@ -49,8 +18,43 @@ appimageTools.wrapAppImage {
     maintainers = with lib.maintainers; [ prince213 ];
     mainProgram = "wechat";
     platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
       "aarch64-linux"
       "x86_64-linux"
     ];
   };
+
+  sources =
+    let
+      any-darwin = {
+        version = "4.0.5.24";
+        src = fetchurl {
+          url = "https://web.archive.org/web/20250608064358if_/https://dldir1v6.qq.com/weixin/Universal/Mac/WeChatMac.dmg";
+          hash = "sha256-ieixBgYhZ5jU3TWCV7BXKFBidJ1bbabXBHTkrpNcGDI=";
+        };
+      };
+    in
+    {
+      aarch64-darwin = any-darwin;
+      x86_64-darwin = any-darwin;
+      aarch64-linux = {
+        version = "4.0.1.11";
+        src = fetchurl {
+          url = "https://web.archive.org/web/20250512112413if_/https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_arm64.AppImage";
+          hash = "sha256-Rg+FWNgOPC02ILUskQqQmlz1qNb9AMdvLcRWv7NQhGk=";
+        };
+      };
+      x86_64-linux = {
+        version = "4.0.1.11";
+        src = fetchurl {
+          url = "https://web.archive.org/web/20250512110825if_/https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_x86_64.AppImage";
+          hash = "sha256-gBWcNQ1o1AZfNsmu1Vi1Kilqv3YbR+wqOod4XYAeVKo=";
+        };
+      };
+    };
+in
+callPackage (if stdenvNoCC.hostPlatform.isDarwin then ./darwin.nix else ./linux.nix) {
+  inherit pname meta;
+  inherit (sources.${system} or (throw "Unsupported system: ${system}")) version src;
 }


### PR DESCRIPTION
Follow up of https://github.com/NixOS/nixpkgs/pull/416642.

Resolves https://github.com/NixOS/nixpkgs/issues/354234.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
