### PR TITLE
php.extensions.systemd: init at 0.1.2-unstable-2018-06-11

### DIFF
--- a/pkgs/development/php-packages/systemd/default.nix
+++ b/pkgs/development/php-packages/systemd/default.nix
@@ -1,0 +1,54 @@
+{
+  buildPecl,
+  fetchFromGitHub,
+  fetchpatch,
+  lib,
+  php,
+  runCommand,
+  systemd,
+}:
+
+buildPecl {
+  pname = "systemd";
+  version = "0.1.2-unstable-2018-06-11";
+
+  src = fetchFromGitHub {
+    owner = "systemd";
+    repo = "php-systemd";
+    rev = "22cf92a6b54ef4c5c13c301fc97d7a7b1615ee62";
+    hash = "sha256-UhpE9QXChqKLBqutpQ2Y6neo/ULlJGNojf9DCYJfQMU=";
+  };
+
+  patches = [
+    # Add missing arginfo to suppress the warning
+    # https://github.com/systemd/php-systemd/issues/9
+    (fetchpatch {
+      url = "https://github.com/systemd/php-systemd/commit/0f25ec9aab7747e85445a48213020ea6adda3658.diff";
+      hash = "sha256-SNRYDRxaeP9LlHxfZOak0OSqZ3AJA+I9Ln0k+yO0DvE=";
+    })
+    # Define SD_JOURNAL_SUPPRESS_LOCATION so that the php source code location is used, instead of the C one
+    # https://github.com/systemd/php-systemd/issues/2
+    (fetchpatch {
+      url = "https://github.com/systemd/php-systemd/commit/23575461b8cc55fa9c4132a58393b6438c2aff5c.diff";
+      hash = "sha256-KBGWdNE7spXpqbeS4c2D5IU3Dz8zGxx4r22FDOA0KzM=";
+    })
+  ];
+
+  buildInputs = [ systemd.dev ];
+
+  configureFlags = [ "--with-systemd=${systemd.dev}" ];
+
+  # php will exit with a non-zero exit code, if the extension is not loaded
+  passthru.tests.smokeTest = runCommand "php-systemd-smoke-test" { } ''
+    echo "<?php sd_journal_send('MESSAGE=Hello world.'); ?>" |
+      ${lib.getExe (php.withExtensions ({ all, ... }: [ all.systemd ]))}
+    echo ok > $out
+  '';
+
+  meta = {
+    description = "PHP extension allowing native interaction with systemd and its journal";
+    homepage = "https://github.com/systemd/php-systemd";
+    license = lib.licenses.mit;
+    teams = [ lib.teams.php ];
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -389,6 +389,8 @@ lib.makeScope pkgs.newScope (
 
         swoole = callPackage ../development/php-packages/swoole { };
 
+        systemd = callPackage ../development/php-packages/systemd { };
+
         tideways = callPackage ../development/php-packages/tideways { };
 
         uuid = callPackage ../development/php-packages/uuid { };


### PR DESCRIPTION
Add [php-systemd] to `php.extensions`.

Fixes: #262142

[php-systemd]: https://github.com/systemd/php-systemd

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
