### PR TITLE
workflows/labels: fix approval label with maintainers

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -113,7 +113,7 @@ jobs:
                 // And the labels that should be there
                 const after = JSON.parse(await readFile('comparison/changed-paths.json', 'utf-8')).labels
                 if (approvals.size > 0) after.push(`12.approvals: ${approvals.size > 2 ? '3+' : approvals.size}`)
-                if (Array.from(maintainers).some(approvals.has)) after.push('12.approved-by: package-maintainer')
+                if (Array.from(maintainers).some(m => approvals.has(m))) after.push('12.approved-by: package-maintainer')
 
                 // Remove the ones not needed anymore
                 await Promise.all(


### PR DESCRIPTION
This currently fails with:

```
Method Set.prototype.has called on incompatible receiver undefined
```

Seems like my syntax test previously only hit the case without maintainers, in which case it doesn't throw :/.

The reason why this fails is explained here: https://stackoverflow.com/a/51849963

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
