### PR TITLE
freecad: remove qt5 and explicit wayland builds

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -13,14 +13,12 @@
   hdf5,
   libGLU,
   libredwg,
-  libsForQt5,
   libspnav,
   libXmu,
   medfile,
   mpi,
   ninja,
   ode,
-  opencascade-occt_7_6,
   opencascade-occt,
   pkg-config,
   python3Packages,
@@ -34,8 +32,6 @@
   yaml-cpp,
   zlib,
   withWayland ? false,
-  qtVersion ? 5,
-  qt5,
   qt6,
   nix-update-script,
 }:
@@ -51,13 +47,10 @@ let
     py-slvs
     pybind11
     pycollada
-    pyside2
-    pyside2-tools
     pyside6
     python
     pyyaml
     scipy
-    shiboken2
     shiboken6
     ;
   freecad-utils = callPackage ./freecad-utils.nix { };
@@ -75,21 +68,16 @@ freecad-utils.makeCustomizable (
       fetchSubmodules = true;
     };
 
-    nativeBuildInputs =
-      [
-        cmake
-        ninja
-        pkg-config
-        gfortran
-        swig
-        doxygen
-        wrapGAppsHook3
-      ]
-      ++ lib.optionals (qtVersion == 5) [
-        pyside2-tools
-        qt5.wrapQtAppsHook
-      ]
-      ++ lib.optionals (qtVersion == 6) [ qt6.wrapQtAppsHook ];
+    nativeBuildInputs = [
+      cmake
+      ninja
+      pkg-config
+      gfortran
+      swig
+      doxygen
+      wrapGAppsHook3
+      qt6.wrapQtAppsHook
+    ];
 
     buildInputs =
       [
@@ -119,20 +107,6 @@ freecad-utils.makeCustomizable (
         xercesc
         yaml-cpp
         zlib
-      ]
-      ++ lib.optionals (qtVersion == 5) [
-        libsForQt5.soqt
-        opencascade-occt_7_6
-        pyside2
-        pyside2-tools
-        shiboken2
-        qt5.qtbase
-        qt5.qttools
-        qt5.qtwayland
-        qt5.qtwebengine
-        qt5.qtxmlpatterns
-      ]
-      ++ lib.optionals (qtVersion == 6) [
         opencascade-occt
         pyside6
         shiboken6
@@ -145,9 +119,7 @@ freecad-utils.makeCustomizable (
       ++ lib.optionals ifcSupport [
         ifcopenshell
       ]
-      ++ lib.optionals spaceNavSupport (
-        [ libspnav ] ++ lib.optionals (qtVersion == 5) [ libsForQt5.qtx11extras ]
-      );
+      ++ lib.optionals spaceNavSupport [ libspnav ];
 
     patches = [
       ./0001-NIXOS-don-t-ignore-PYTHONPATH.patch
@@ -158,40 +130,25 @@ freecad-utils.makeCustomizable (
       })
     ];
 
-    cmakeFlags =
-      [
-        "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
-        "-DBUILD_FLAT_MESH:BOOL=ON"
-        "-DBUILD_DRAWING=ON"
-        "-DBUILD_FLAT_MESH:BOOL=ON"
-        "-DINSTALL_TO_SITEPACKAGES=OFF"
-        "-DFREECAD_USE_PYBIND11=ON"
-      ]
-      ++ lib.optionals (qtVersion == 5) [
-        "-DBUILD_QT5=ON"
-        "-DSHIBOKEN_INCLUDE_DIR=${shiboken2}/include"
-        "-DSHIBOKEN_LIBRARY=Shiboken2::libshiboken"
-        (
-          "-DPYSIDE_INCLUDE_DIR=${pyside2}/include"
-          + ";${pyside2}/include/PySide2/QtCore"
-          + ";${pyside2}/include/PySide2/QtWidgets"
-          + ";${pyside2}/include/PySide2/QtGui"
-        )
-        "-DPYSIDE_LIBRARY=PySide2::pyside2"
-      ]
-      ++ lib.optionals (qtVersion == 6) [
-        "-DBUILD_QT5=OFF"
-        "-DBUILD_QT6=ON"
-        "-DSHIBOKEN_INCLUDE_DIR=${shiboken6}/include"
-        "-DSHIBOKEN_LIBRARY=Shiboken6::libshiboken"
-        (
-          "-DPYSIDE_INCLUDE_DIR=${pyside6}/include"
-          + ";${pyside6}/include/PySide6/QtCore"
-          + ";${pyside6}/include/PySide6/QtWidgets"
-          + ";${pyside6}/include/PySide6/QtGui"
-        )
-        "-DPYSIDE_LIBRARY=PySide6::pyside6"
-      ];
+    cmakeFlags = [
+      "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
+      "-DBUILD_FLAT_MESH:BOOL=ON"
+      "-DBUILD_DRAWING=ON"
+      "-DBUILD_FLAT_MESH:BOOL=ON"
+      "-DINSTALL_TO_SITEPACKAGES=OFF"
+      "-DFREECAD_USE_PYBIND11=ON"
+      "-DBUILD_QT5=OFF"
+      "-DBUILD_QT6=ON"
+      "-DSHIBOKEN_INCLUDE_DIR=${shiboken6}/include"
+      "-DSHIBOKEN_LIBRARY=Shiboken6::libshiboken"
+      (
+        "-DPYSIDE_INCLUDE_DIR=${pyside6}/include"
+        + ";${pyside6}/include/PySide6/QtCore"
+        + ";${pyside6}/include/PySide6/QtWidgets"
+        + ";${pyside6}/include/PySide6/QtGui"
+      )
+      "-DPYSIDE_LIBRARY=PySide6::pyside6"
+    ];
 
     # This should work on both x86_64, and i686 linux
     preBuild = ''

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -31,7 +31,6 @@
   xercesc,
   yaml-cpp,
   zlib,
-  withWayland ? false,
   qt6,
   nix-update-script,
 }:
@@ -162,7 +161,7 @@ freecad-utils.makeCustomizable (
     qtWrapperArgs = [
       "--set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1"
       "--prefix PATH : ${libredwg}/bin"
-    ] ++ lib.optionals (!withWayland) [ "--set QT_QPA_PLATFORM xcb" ];
+    ];
 
     postFixup = ''
       mv $out/share/doc $out

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -696,6 +696,7 @@ mapAliases {
   fractal-next = fractal; # added 2023-11-25
   framework-system-tools = framework-tool; # added 2023-12-09
   francis = kdePackages.francis; # added 2024-07-13
+  freecad-qt6 = freecad; # added 2025-06-14
   freerdp3 = freerdp; # added 2025-03-25
   freerdpUnstable = freerdp; # added 2025-03-25
   frostwire = throw "frostwire was removed, as it was broken due to reproducibility issues, use `frostwire-bin` package instead."; # added 2024-05-17

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -697,6 +697,7 @@ mapAliases {
   framework-system-tools = framework-tool; # added 2023-12-09
   francis = kdePackages.francis; # added 2024-07-13
   freecad-qt6 = freecad; # added 2025-06-14
+  freecad-wayland = freecad; # added 2025-06-14
   freerdp3 = freerdp; # added 2025-03-25
   freerdpUnstable = freerdp; # added 2025-03-25
   frostwire = throw "frostwire was removed, as it was broken due to reproducibility issues, use `frostwire-bin` package instead."; # added 2024-05-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14954,8 +14954,6 @@ with pkgs;
 
   flightgear = libsForQt5.callPackage ../games/flightgear { };
 
-  freecad-wayland = freecad.override { withWayland = true; };
-
   freeciv = callPackage ../games/freeciv {
     sdl2Client = false;
     gtkClient = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14955,10 +14955,6 @@ with pkgs;
   flightgear = libsForQt5.callPackage ../games/flightgear { };
 
   freecad-wayland = freecad.override { withWayland = true; };
-  freecad-qt6 = freecad.override {
-    withWayland = true;
-    qtVersion = 6;
-  };
 
   freeciv = callPackage ../games/freeciv {
     sdl2Client = false;


### PR DESCRIPTION
Qt5 support is was officially reduced by qt [1].

FreeCAD supports both Qt5 and Qt6. While their github
build still uses Qt5, the official flatpak uses Qt6 [2].

Additionally, keeping Qt5 support requires pinning
python to 3.12 or older, as shiboken2 would break.
Currently, this breakage is imminent: #412204 unpinned
python, with the next staging-next merge updating py to 3.13.

Qt will figure out which platform plugin to use. Many of our packages already explicitly unset `QT_QPA_PLATFORM`, it makes little sense to force it here.

[1] https://www.qt.io/blog/extended-security-maintenance-for-qt-5.15-begins-may-2025
[2] https://github.com/flathub/org.freecad.FreeCAD/blob/ad843adc0a29a2c78bdd60624376aab61445ed63/org.freecad.FreeCAD.yaml#L62

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
