### PR TITLE
phpExtensions.ioncube-loader: 13.0.2 -> 14.4.1

### DIFF
--- a/pkgs/development/php-packages/ioncube-loader/default.nix
+++ b/pkgs/development/php-packages/ioncube-loader/default.nix
@@ -1,51 +1,45 @@
 {
   stdenv,
   lib,
-  fetchzip,
+  fetchurl,
   php,
 }:
 
 let
-  phpVersion = lib.versions.majorMinor php.version;
+  source =
+    {
+      "aarch64-darwin" = {
+        url = "https://web.archive.org/web/20250614103627/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_arm64.tar.gz";
+        sha256 = "sha256-Dji4PIX5GqU6mOC7ZrSEu3dAZtsiVVuvKQ9Z5aGiuQ4=";
+      };
+      "aarch64-linux" = {
+        url = "https://web.archive.org/web/20250614103715/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_aarch64.tar.gz";
+        sha256 = "sha256-zushkH7g3L62bDdjgTZamWcxOp35xQisOjSG6e2EEHg=";
+      };
+      "x86_64-linux" = {
+        url = "https://web.archive.org/web/20250614103238/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz";
+        sha256 = "sha256-W8AXulfQx2nkT9nznCCx2lrayKA3R+n2TyhU1ScNjMg=";
+      };
+    }
+    .${stdenv.hostPlatform.system};
 
-  variant = {
-    "aarch64-darwin" = {
-      url = "https://web.archive.org/web/20240209234707/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_arm64.tar.gz";
-      sha256 = "sha256-J6+bOXX9uRdrGouMAxt7nROjjfH4P2txb1hmPoHUmdM=";
-      prefix = "dar";
-    };
-    "aarch64-linux" = {
-      url = "https://web.archive.org/web/20240209234617/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_aarch64.tar.gz";
-      sha256 = "sha256-oOO4zr0CssxVGIUIfmAujILqOfQf8dJPADkr03a8HAs=";
-      prefix = "lin";
-    };
-    "x86_64-linux" = {
-      url = "https://web.archive.org/web/20240209052345if_/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz";
-      sha256 = "sha256-rsXKgxKHldBKDjJTsOdJP4SxfxLmMPDY+GizBpuDeyw=";
-      prefix = "lin";
-    };
-    "x86_64-darwin" = {
-      url = "https://web.archive.org/web/20240209234406/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_mac_x86-64.tar.gz";
-      sha256 = "sha256-bz2hQOaFbXePa8MhAZHESpZMRjjBH51IgvbR2EfBYMg=";
-      prefix = "mac";
-    };
-  };
+  phpVersion = lib.versions.majorMinor php.version;
+  systemPrefix = lib.substring 0 3 stdenv.hostPlatform.parsed.kernel.name; # lin, dar, fre
+
+  filename = "ioncube_loader_${systemPrefix}_${phpVersion}${lib.optionalString php.ztsSupport "_ts"}.so";
 in
 stdenv.mkDerivation {
-  version = "13.0.2";
   pname = "ioncube-loader";
+  version = "14.4.1";
+
   extensionName = "ioncube-loader";
 
-  src = fetchzip {
-    url = variant.${stdenv.hostPlatform.system}.url;
-    sha256 = variant.${stdenv.hostPlatform.system}.sha256;
-  };
+  src = fetchurl source;
 
   installPhase = ''
-    mkdir -p $out/lib/php/extensions
-    cp $src/ioncube_loader_${
-      variant.${stdenv.hostPlatform.system}.prefix
-    }_${phpVersion}.so $out/lib/php/extensions/ioncube-loader.so
+    runHook preInstall
+    install -Dm755 '${filename}' $out/lib/php/extensions/ioncube-loader.so
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -58,7 +52,6 @@ stdenv.mkDerivation {
     platforms = [
       "x86_64-linux"
       "aarch64-linux"
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- x86_64-darwin is no longer supported by upstream
- added support for Zend Thread Safety

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
