### PR TITLE
python312Packages.fireworks-ai: 0.15.13 -> 0.17.16

### DIFF
--- a/pkgs/development/python-modules/asyncstdlib-fw/default.nix
+++ b/pkgs/development/python-modules/asyncstdlib-fw/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  pdm-backend,
+}:
+
+buildPythonPackage rec {
+  pname = "asyncstdlib-fw";
+  version = "3.13.2";
+  pyproject = true;
+
+  # Not available from any repo
+  src = fetchPypi {
+    pname = "asyncstdlib_fw";
+    inherit version;
+    hash = "sha256-Ua0JTCBMWTbDBA84wy/W1UmzkcmA8h8foJW2X7aAah8=";
+  };
+
+  build-system = [
+    pdm-backend
+  ];
+
+  doCheck = false; # no tests supplied
+
+  pythonImportsCheck = [
+    "asyncstdlib"
+  ];
+
+  meta = {
+    description = "Fork of asyncstdlib that work with fireworks-ai";
+    homepage = "https://pypi.org/project/asyncstdlib-fw/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/betterproto-fw/default.nix
+++ b/pkgs/development/python-modules/betterproto-fw/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  grpclib,
+  python-dateutil,
+  typing-extensions,
+
+  # optional dependencies
+  jinja2,
+  ruff,
+  betterproto-rust-codec,
+}:
+
+buildPythonPackage rec {
+  pname = "betterproto-fw";
+  version = "2.0.3";
+  pyproject = true;
+
+  # Not available on Github
+  src = fetchPypi {
+    pname = "betterproto_fw";
+    inherit version;
+    hash = "sha256-ut5GchUiTygHhC2hj+gSWKCoVnZrrV8KIKFHTFzba5M=";
+  };
+
+  build-system = [
+    pdm-backend
+  ];
+
+  dependencies = [
+    grpclib
+    python-dateutil
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    compiler = [
+      jinja2
+      ruff
+    ];
+    rust-codec = [
+      betterproto-rust-codec
+    ];
+  };
+
+  doCheck = false; # no tests supplied
+
+  pythonImportsCheck = [
+    "betterproto"
+  ];
+
+  meta = {
+    description = "Fork of betterproto used in fireworks-ai";
+    homepage = "https://pypi.org/project/betterproto-fw/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/betterproto-rust-codec/default.nix
+++ b/pkgs/development/python-modules/betterproto-rust-codec/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build
+  cargo,
+  rustc,
+  rustPlatform,
+}:
+
+buildPythonPackage rec {
+  pname = "betterproto-rust-codec";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "124C41p";
+    repo = "betterproto-rust-codec";
+    tag = "v${version}";
+    hash = "sha256-Q8oCk/VVe4Dcw6Z5PBFJBKRlsHgi6Jn+FWDqLH8BgYc=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-zYXE55o1/Tt6XJahV6WcGANPM/9xk6uYwQLazkIJj7A=";
+  };
+
+  build-system = [
+    rustPlatform.maturinBuildHook
+  ];
+
+  nativeBuildInputs = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+  ];
+
+  pythonImportsCheck = [
+    "betterproto_rust_codec"
+  ];
+
+  meta = {
+    description = "Converter between betterproto messages and the Protobuf wire format";
+    homepage = "https://github.com/124C41p/betterproto-rust-codec/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/fireworks-ai/default.nix
+++ b/pkgs/development/python-modules/fireworks-ai/default.nix
@@ -4,15 +4,26 @@
   fetchPypi,
 
   # build-system
-  setuptools,
-  versioneer,
+  pdm-backend,
+
+  # local dependencies
+  black,
+  mypy,
 
   # dependencies
-  httpx,
-  httpx-ws,
+  grpcio,
+  grpclib,
   httpx-sse,
-  pydantic,
+  httpx-ws,
+  httpx,
+  mmh3,
+  openai,
   pillow,
+  protobuf,
+  pydantic,
+  python-dateutil,
+  rich,
+  typing-extensions,
 
   # optional dependencies
   fastapi,
@@ -25,29 +36,98 @@
   tqdm,
 }:
 
+let
+  asyncstdlib-fw = buildPythonPackage rec {
+    pname = "asyncstdlib_fw";
+    version = "3.13.2";
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-Ua0JTCBMWTbDBA84wy/W1UmzkcmA8h8foJW2X7aAah8=";
+    };
+
+    build-system = [
+      pdm-backend
+    ];
+
+    dependencies = [
+      black
+      mypy
+    ];
+
+    pythonImportsCheck = [
+      "asyncstdlib"
+    ];
+  };
+
+  betterproto-fw = buildPythonPackage rec {
+    pname = "betterproto_fw";
+    version = "2.0.3";
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit version pname;
+      hash = "sha256-ut5GchUiTygHhC2hj+gSWKCoVnZrrV8KIKFHTFzba5M=";
+    };
+
+    build-system = [
+      pdm-backend
+    ];
+
+    dependencies = [
+      grpclib
+      python-dateutil
+      typing-extensions
+    ];
+
+    pythonImportsCheck = [
+      "betterproto"
+    ];
+
+  };
+in
 buildPythonPackage rec {
   pname = "fireworks-ai";
-  version = "0.15.13";
+  version = "0.17.16";
   pyproject = true;
 
   # no source available
   src = fetchPypi {
     pname = "fireworks_ai";
     inherit version;
-    hash = "sha256-ZZSF4R1HOYpNmKnL2OPWoUwdSJJ2j2e3+hzW0QH55io=";
+    hash = "sha256-WblcAaYjnzwPS4n5rixNHbHLNGTE3bTPXvQ9lYZ1f9A=";
   };
 
   build-system = [
-    setuptools
-    versioneer
+    pdm-backend
+  ];
+
+  pythonRelaxDeps = [
+    "protobuf"
   ];
 
   dependencies = [
+    asyncstdlib-fw
+    betterproto-fw
+    grpcio
+    grpclib
     httpx
-    httpx-ws
+    httpx
     httpx-sse
-    pydantic
+    httpx-sse
+    httpx-ws
+    httpx-ws
+    mmh3
+    openai
     pillow
+    pillow
+    protobuf
+    pydantic
+    pydantic
+    python-dateutil
+    rich
+    typing-extensions
   ];
 
   optional-dependencies = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1046,6 +1046,8 @@ self: super: with self; {
 
   asyncstdlib = callPackage ../development/python-modules/asyncstdlib { };
 
+  asyncstdlib-fw = callPackage ../development/python-modules/asyncstdlib-fw { };
+
   asynctest = callPackage ../development/python-modules/asynctest { };
 
   asyncua = callPackage ../development/python-modules/asyncua { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1806,6 +1806,8 @@ self: super: with self; {
 
   betterproto = callPackage ../development/python-modules/betterproto { };
 
+  betterproto-fw = callPackage ../development/python-modules/betterproto-fw { };
+
   betterproto-rust-codec = callPackage ../development/python-modules/betterproto-rust-codec { };
 
   bezier = callPackage ../development/python-modules/bezier { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1806,6 +1806,8 @@ self: super: with self; {
 
   betterproto = callPackage ../development/python-modules/betterproto { };
 
+  betterproto-rust-codec = callPackage ../development/python-modules/betterproto-rust-codec { };
+
   bezier = callPackage ../development/python-modules/bezier { };
 
   beziers = callPackage ../development/python-modules/beziers { };


### PR DESCRIPTION
Note: The vendor does not publish release notes and only distributes on PyPi

1. (Large) version bump
2. Added python 3 packages `asyncstdio-fw`, `betterproto-fw`, and `betterproto-rust-codec` to support new dependencies.
3. Update dependencies per https://pypistats.org/packages/fireworks-ai

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
