### PR TITLE
[Backport release-25.05] gleam: 1.10.0 -> 1.11.1

### DIFF
--- a/pkgs/by-name/gl/gleam/package.nix
+++ b/pkgs/by-name/gl/gleam/package.nix
@@ -53,7 +53,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://gleam.run/";
     changelog = "https://github.com/gleam-lang/gleam/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.philtaken ];
+    maintainers = with lib.maintainers; [
+      philtaken
+      llakala
+    ];
     teams = [ lib.teams.beam ];
   };
 })

--- a/pkgs/by-name/gl/gleam/package.nix
+++ b/pkgs/by-name/gl/gleam/package.nix
@@ -15,16 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gleam";
-  version = "1.10.0";
+  version = "1.11.1";
 
   src = fetchFromGitHub {
     owner = "gleam-lang";
     repo = "gleam";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0qK9dWkKnoXbIIBMN3p5noPEke/bgC8Bjtmf6lwtyr4=";
+    hash = "sha256-ZNDN9MRA9D+5xdVp3Lxt76bLzHRK7304O6WVPrlUq2U=";
   };
 
-  cargoHash = "sha256-EoRu8p6cUe1li54nVUkf+3qywIsDXh4ptIVLluJ3eFs=";
+  cargoHash = "sha256-TJqylGjXdkunE5mHkpFnvv3SENBFwtQehV0q2k3hNMY=";
 
   nativeBuildInputs = [
     git


### PR DESCRIPTION
Manual backport, since bot failed with merge conflict. Did a separate backport for the maintainer change - let me know if I should squash it instead. I also chose to skip the intermediary backport from 1.10.0 -> 1.11.0.