### PR TITLE
rmenu: 1.2.2 -> 1.3.0, add update script

### DIFF
--- a/pkgs/by-name/rm/rmenu/package.nix
+++ b/pkgs/by-name/rm/rmenu/package.nix
@@ -9,6 +9,7 @@
   rustPlatform,
   webkitgtk_4_1,
   wrapGAppsHook3,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "rmenu";
@@ -61,7 +62,7 @@ rustPlatform.buildRustPackage rec {
     # fix config and theme
     mkdir -p $out/share/rmenu
     cp -vf $src/rmenu/public/config.yaml $out/share/rmenu/config.yaml
-    substituteInPlace $out/share/rmenu/config.yaml --replace "~/.config/rmenu" "$out"
+    substituteInPlace $out/share/rmenu/config.yaml --replace-fail "~/.config/rmenu" "$out"
     ln -sf  $out/themes/dark.css $out/share/rmenu/style.css
   '';
 
@@ -74,6 +75,8 @@ rustPlatform.buildRustPackage rec {
       --suffix PATH : "$out/bin"
     )
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/imgurbot12/rmenu/releases/tag/v${version}";

--- a/pkgs/by-name/rm/rmenu/package.nix
+++ b/pkgs/by-name/rm/rmenu/package.nix
@@ -1,4 +1,5 @@
 {
+  cmake,
   fetchFromGitHub,
   glib,
   gtk3,
@@ -7,23 +8,26 @@
   networkmanager,
   pkg-config,
   rustPlatform,
+  versionCheckHook,
   webkitgtk_4_1,
   wrapGAppsHook3,
+  xdotool,
   nix-update-script,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "rmenu";
-  version = "1.2.2";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
-    rev = "v${version}";
+    tag = "v${version}";
     owner = "imgurbot12";
     repo = "rmenu";
-    hash = "sha256-khauloUGVuekR+Lran1DLnsxwY8sIf5PsEKY7sNy1K4=";
+    hash = "sha256-cmuB7JfHQuDFo8YaenTDwpe+TxKFaoJM5YwrT7eAfPM=";
   };
 
   nativeBuildInputs = [
     pkg-config
+    cmake
     wrapGAppsHook3
   ];
 
@@ -33,19 +37,19 @@ rustPlatform.buildRustPackage rec {
     libsoup_3
     networkmanager
     webkitgtk_4_1
+    xdotool
   ];
 
   strictDeps = true;
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-9sKcvVN14gfR30FvF8/esdJoIbSgHUl/aHRBWA8DRWg=";
+  cargoHash = "sha256-FIlFy3/Hih40My5fTykYjvaQEmnB3ZC5vX3lfKdW9Gk=";
 
   postInstall = ''
     # copy themes and plugins
-    mkdir $out/themes
-    mkdir $out/plugins
-    cp -vfr $src/themes/* $out/themes/.
-    cp -vfr $src/other-plugins/* $out/plugins/.
+    mkdir -p $out/themes $out/plugins/css
+    cp -vfr $src/themes/* $out/themes
+    cp -vfr $src/plugins/misc/* $out/plugins
     mv $out/bin/* $out/plugins # everything is a plugin by default
 
     # rmenu and rmenu-build are actual binaries
@@ -53,15 +57,15 @@ rustPlatform.buildRustPackage rec {
     mv $out/plugins/rmenu-build $out/bin/rmenu-build
 
     # fix plugin names
-    # desktop  network  pactl-audio.sh  powermenu.sh  run  window
-    mv $out/plugins/run $out/plugins/rmenu-run
-    mv $out/plugins/desktop $out/plugins/rmenu-desktop
-    mv $out/plugins/network $out/plugins/rmenu-network
-    mv $out/plugins/window $out/plugins/rmenu-window
+    # desktop  network  pactl-audio.sh  powermenu.sh  run  window  emoji  search
+    for plugin in desktop emoji files network run search window ; do
+      mv $out/plugins/$plugin $out/plugins/rmenu-$plugin
+    done
 
     # fix config and theme
     mkdir -p $out/share/rmenu
     cp -vf $src/rmenu/public/config.yaml $out/share/rmenu/config.yaml
+    cp -vf $src/plugins/emoji/css/* $out/plugins/css
     substituteInPlace $out/share/rmenu/config.yaml --replace-fail "~/.config/rmenu" "$out"
     ln -sf  $out/themes/dark.css $out/share/rmenu/style.css
   '';
@@ -75,6 +79,9 @@ rustPlatform.buildRustPackage rec {
       --suffix PATH : "$out/bin"
     )
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Changelog: https://github.com/imgurbot12/rmenu/releases/tag/v1.3.0

I checked all the new plugins:
- file picker (like fzf but gui)
- emoji picker
- bang search

As well as the old plugins.
To make these update work, some tweaks to the build were necessary to satisfy new external dependencies and accommodate some restructuring upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
