### PR TITLE
nixos/postfix: modernize, cleanup

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -118,8 +118,8 @@
 
 - The Postfix module has been updated and likely requires configuration changes:
   - The `services.postfix.sslCert` and `sslKey` options were removed and you now need to configure
-    - [services.postfix.config.smtpd_tls_chain_files](#opt-services.postfix.config.smtpd_tls_chain_files) for server certificates,
-    - [services.postfix.config.smtp_tls_chain_files](#opt-services.postfix.config) for client certificates.
+    - [services.postfix.settings.main.smtpd_tls_chain_files](#opt-services.postfix.settings.main.smtpd_tls_chain_files) for server certificates,
+    - [services.postfix.settings.main.smtp_tls_chain_files](#opt-services.postfix.settings.main) for client certificates.
 
 - `vmalert` now supports multiple instances with the option `services.vmalert.instances."".enable`
 

--- a/nixos/modules/services/mail/mailman.md
+++ b/nixos/modules/services/mail/mailman.md
@@ -14,12 +14,14 @@ For a basic configuration with Postfix as the MTA, the following settings are su
 {
   services.postfix = {
     enable = true;
-    relayDomains = [ "hash:/var/lib/mailman/data/postfix_domains" ];
-    sslCert = config.security.acme.certs."lists.example.org".directory + "/full.pem";
-    sslKey = config.security.acme.certs."lists.example.org".directory + "/key.pem";
     config = {
       transport_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
       local_recipient_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
+      relay_domains = [ "hash:/var/lib/mailman/data/postfix_domains" ];
+      smtpd_tls_chain_files = [
+        config.security.acme.certs."lists.example.org".directory + "/full.pem"
+        config.security.acme.certs."lists.example.org".directory + "/key.pem"
+      ];
     };
   };
   services.mailman = {

--- a/nixos/modules/services/mail/mailman.md
+++ b/nixos/modules/services/mail/mailman.md
@@ -14,7 +14,7 @@ For a basic configuration with Postfix as the MTA, the following settings are su
 {
   services.postfix = {
     enable = true;
-    config = {
+    settings.main = {
       transport_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
       local_recipient_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
       relay_domains = [ "hash:/var/lib/mailman/data/postfix_domains" ];

--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -554,9 +554,9 @@ in
     ];
 
     services.postfix = lib.mkIf cfg.enablePostfix {
-      recipientDelimiter = "+"; # bake recipient addresses in mail envelopes via VERP
       config = {
         owner_request_special = "no"; # Mailman handles -owner addresses on its own
+        recipient_delimiter = "+"; # bake recipient addresses in mail envelopes via VERP
       };
     };
 

--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -554,7 +554,7 @@ in
     ];
 
     services.postfix = lib.mkIf cfg.enablePostfix {
-      config = {
+      settings.main = {
         owner_request_special = "no"; # Mailman handles -owner addresses on its own
         recipient_delimiter = "+"; # bake recipient addresses in mail envelopes via VERP
       };

--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -120,7 +120,10 @@ in
 
     services.postfix = {
       enable = true;
-      recipientDelimiter = "+";
+      config = {
+        recipient_delimiter = "+";
+        propagate_unmatched_extensions = "virtual";
+      };
       masterConfig.mlmmj = {
         type = "unix";
         private = true;
@@ -139,8 +142,6 @@ in
       };
 
       extraAliases = concatMapLines (alias cfg.listDomain) cfg.mailLists;
-
-      extraConfig = "propagate_unmatched_extensions = virtual";
 
       virtual = concatMapLines (virtual cfg.listDomain) cfg.mailLists;
       transport = concatMapLines (transport cfg.listDomain) cfg.mailLists;

--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -120,11 +120,11 @@ in
 
     services.postfix = {
       enable = true;
-      config = {
+      settings.main = {
         recipient_delimiter = "+";
         propagate_unmatched_extensions = "virtual";
       };
-      masterConfig.mlmmj = {
+      settings.master.mlmmj = {
         type = "unix";
         private = true;
         privileged = true;

--- a/nixos/modules/services/mail/pfix-srsd.nix
+++ b/nixos/modules/services/mail/pfix-srsd.nix
@@ -51,7 +51,7 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf (cfg.enable && cfg.configurePostfix && config.services.postfix.enable) {
-      services.postfix.config = {
+      services.postfix.settings.main = {
         sender_canonical_maps = [ "tcp:127.0.0.1:10001" ];
         sender_canonical_classes = [ "envelope_sender" ];
         recipient_canonical_maps = [ "tcp:127.0.0.1:10002" ];

--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -135,7 +135,7 @@ in
   config = mkMerge [
     (mkIf (cfg.enable && config.services.postfix.enable && cfg.configurePostfix) {
       # https://github.com/Zuplu/postfix-tlspol#postfix-configuration
-      services.postfix.config = {
+      services.postfix.settings.main = {
         smtp_dns_support_level = "dnssec";
         smtp_tls_security_level = "dane";
         smtp_tls_policy_maps =

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -54,9 +54,7 @@ let
     in
     lib.concatStringsSep "\n" (
       lib.mapAttrsToList mkEntry (lib.filterAttrsRecursive (_: value: value != null) cfg.config)
-    )
-    + "\n"
-    + cfg.extraConfig;
+    );
 
   masterCfOptions =
     {
@@ -733,14 +731,6 @@ in
         };
       };
 
-      extraConfig = lib.mkOption {
-        type = lib.types.lines;
-        default = "";
-        description = ''
-          Extra lines to be added verbatim to the main.cf configuration file.
-        '';
-      };
-
       canonical = lib.mkOption {
         type = lib.types.lines;
         default = "";
@@ -1221,7 +1211,7 @@ in
 
   imports = [
     (lib.mkRemovedOptionModule [ "services" "postfix" "sslCACert" ]
-      "services.postfix.sslCACert was replaced by services.postfix.tlsTrustedAuthorities. In case you intend that your server should validate requested client certificates use services.postfix.extraConfig."
+      "services.postfix.sslCACert was replaced by services.postfix.tlsTrustedAuthorities. In case you intend that your server should validate requested client certificates use services.postfix.config.smtp_tls_CAfile."
     )
     (lib.mkRemovedOptionModule [ "services" "postfix" "sslCert" ]
       "services.postfix.sslCert was removed. Use services.postfix.config.smtpd_tls_chain_files for the server certificate, or services.postfix.config.smtp_tls_chain_files for the client certificate."
@@ -1237,6 +1227,9 @@ in
     )
     (lib.mkRemovedOptionModule [ "services" "postfix" "relayPort" ]
       "services.postfix.relayHost was removed in favor of services.postfix.config.relayhost, which now takes a list of host/port."
+    )
+    (lib.mkRemovedOptionModule [ "services" "postfix" "extraConfig" ]
+      "services.postfix.extraConfig was replaced by the structured freeform service.postfix.config option."
     )
     (lib.mkRenamedOptionModule
       [ "services" "postfix" "networks" ]

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -521,6 +521,17 @@ in
               ])
             );
           options = {
+            message_size_limit = mkOption {
+              type = with types; nullOr int;
+              default = 10240000; # 10 MiB
+              example = 52428800; # 50 MiB
+              description = ''
+                Maximum size of an email message in bytes.
+
+                <https://www.postfix.org/postconf.5.html#message_size_limit>
+              '';
+            };
+
             mydestination = mkOption {
               type =
                 with types;

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -6,6 +6,7 @@
 }:
 let
   inherit (lib)
+    literalExpression
     mkOption
     types
     ;
@@ -468,95 +469,6 @@ in
         '';
       };
 
-      networks = lib.mkOption {
-        type = lib.types.nullOr (lib.types.listOf lib.types.str);
-        default = null;
-        example = [ "192.168.0.1/24" ];
-        description = ''
-          Net masks for trusted - allowed to relay mail to third parties -
-          hosts. Leave empty to use mynetworks_style configuration or use
-          default (localhost-only).
-        '';
-      };
-
-      networksStyle = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = ''
-          Name of standard way of trusted network specification to use,
-          leave blank if you specify it explicitly or if you want to use
-          default (localhost-only).
-        '';
-      };
-
-      hostname = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = ''
-          Hostname to use. Leave blank to use just the hostname of machine.
-          It should be FQDN.
-        '';
-      };
-
-      domain = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = ''
-          Domain to use. Leave blank to use hostname minus first component.
-        '';
-      };
-
-      origin = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = ''
-          Origin to use in outgoing e-mail. Leave blank to use hostname.
-        '';
-      };
-
-      destination = lib.mkOption {
-        type = lib.types.nullOr (lib.types.listOf lib.types.str);
-        default = null;
-        example = [ "localhost" ];
-        description = ''
-          Full (!) list of domains we deliver locally. Leave blank for
-          acceptable Postfix default.
-        '';
-      };
-
-      relayDomains = lib.mkOption {
-        type = lib.types.nullOr (lib.types.listOf lib.types.str);
-        default = null;
-        example = [ "localdomain" ];
-        description = ''
-          List of domains we agree to relay to. Default is empty.
-        '';
-      };
-
-      relayHost = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = ''
-          Mail relay for outbound mail.
-        '';
-      };
-
-      relayPort = lib.mkOption {
-        type = lib.types.int;
-        default = 25;
-        description = ''
-          SMTP port for relay mail relay.
-        '';
-      };
-
-      lookupMX = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether relay specified is just domain whose MX must be used.
-        '';
-      };
-
       postmasterAlias = lib.mkOption {
         type = lib.types.str;
         default = "root";
@@ -609,6 +521,154 @@ in
               ])
             );
           options = {
+            mydestination = mkOption {
+              type =
+                with types;
+                nullOr (oneOf [
+                  str
+                  (listOf str)
+                ]);
+              default = [
+                "$myhostname"
+                "localhost.$mydomain"
+                "localhost"
+              ];
+              description = ''
+                List of domain names intended for local delivery using /etc/passwd and /etc/aliases.
+
+                ::: {.warning}
+                Do not include [virtual](https://www.postfix.org/VIRTUAL_README.html) domains in this list.
+                :::
+
+                <https://www.postfix.org/postconf.5.html#mydestination>
+              '';
+            };
+
+            myhostname = mkOption {
+              type = with types; nullOr types.str;
+              default = null;
+              example = "mail.example.com";
+              description = ''
+                The internet hostname of this mail system.
+
+                Leave unset to default to the system hostname with the {option}`mydomain` suffix.
+
+                <https://www.postfix.org/postconf.5.html#myhostname>
+              '';
+            };
+
+            mynetworks = mkOption {
+              type = with types; nullOr (listOf str);
+              default = null;
+              example = [
+                "127.0.0.0/8"
+                "::1"
+              ];
+              description = ''
+                List of trusted remote SMTP clients, that are allowed to relay mail.
+
+                Leave unset to let Postfix populate this list based on the {option}`mynetworks_style` setting.
+
+                <https://www.postfix.org/postconf.5.html#mynetworks>
+              '';
+            };
+
+            mynetworks_style = mkOption {
+              type =
+                with types;
+                nullOr (enum [
+                  "host"
+                  "subnet"
+                  "class"
+                ]);
+              default = "host";
+              description = ''
+                The method used for generating the default value for {option}`mynetworks`, if that option is unset.
+
+                <https://www.postfix.org/postconf.5.html#mynetworks_style>
+              '';
+            };
+
+            recipient_delimiter = lib.mkOption {
+              type = with types; nullOr str;
+              default = "";
+              example = "+";
+              description = ''
+                Set of characters used as the delimiters for address extensions.
+
+                This allows creating different forwarding rules per extension.
+
+                <https://www.postfix.org/postconf.5.html#recipient_delimiter>
+              '';
+            };
+
+            relayhost = mkOption {
+              type = with types; nullOr (listOf str);
+              default = [ ];
+              example = [ "[relay.example.com]:587" ];
+              description = ''
+                List of hosts to use for relaying outbound mail.
+
+                ::: {.note}
+                Putting the hostname in angled brackets, e.g. `[relay.example.com]`, turns off MX and SRV lookups for the hostname.
+                :::
+
+                <https://www.postfix.org/postconf.5.html#relayhost>
+              '';
+            };
+
+            relay_domains = mkOption {
+              type = with types; nullOr (listOf str);
+              default = [ ];
+              example = [ "lists.example.com" ];
+              description = ''
+                List of domains delivered via the relay transport.
+
+                <https://www.postfix.org/postconf.5.html#relay_domains>
+              '';
+            };
+
+            smtp_tls_CAfile = mkOption {
+              type = types.path;
+              default = config.security.pki.caBundle;
+              defaultText = literalExpression ''
+                config.security.pki.caBundle
+              '';
+              example = literalExpression ''
+                ''${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+              '';
+              description = ''
+                File containing CA certificates of root CAs trusted to sign either remote SMTP server certificates or intermediate CA certificates.
+
+                Defaults to the system CA bundle that is managed through the `security.pki` options.
+
+                <https://www.postfix.org/postconf.5.html#smtp_tls_CAfile>
+              '';
+            };
+
+            smtp_tls_security_level = mkOption {
+              type = types.enum [
+                "none"
+                "may"
+                "encrypt"
+                "dane"
+                "dane-only"
+                "fingerprint"
+                "verify"
+                "secure"
+              ];
+              default = "may";
+              description = ''
+                The client TLS security level.
+
+                ::: {.tip}
+                Use `dane` with a local DNSSEC validating DNS resolver enabled.
+                :::
+
+                <https://www.postfix.org/postconf.5.html#smtp_tls_security_level>
+              '';
+            };
+
             smtpd_tls_chain_files = mkOption {
               type = with types; listOf path;
               default = [ ];
@@ -651,6 +711,10 @@ in
           The main.cf configuration file as key value set.
 
           Null values will not be rendered.
+
+          ::: {.tip}
+          Check `postconf -d` for the default values of all settings.
+          :::
         '';
         example = {
           mail_owner = "postfix";
@@ -663,25 +727,6 @@ in
         default = "";
         description = ''
           Extra lines to be added verbatim to the main.cf configuration file.
-        '';
-      };
-
-      tlsTrustedAuthorities = lib.mkOption {
-        type = lib.types.str;
-        default = config.security.pki.caBundle;
-        defaultText = lib.literalExpression "config.security.pki.caBundle";
-        example = lib.literalExpression ''"''${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"'';
-        description = ''
-          File containing trusted certification authorities (CA) to verify certificates of mailservers contacted for mail delivery. This sets [smtp_tls_CAfile](https://www.postfix.org/postconf.5.html#smtp_tls_CAfile). Defaults to system trusted certificates (see `security.pki.*` options).
-        '';
-      };
-
-      recipientDelimiter = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        example = "+";
-        description = ''
-          Delimiter for address extension: so mail to user+test can be handled by ~user/.forward+test
         '';
       };
 
@@ -990,24 +1035,6 @@ in
             mail_spool_directory = "/var/spool/mail/";
             setgid_group = cfg.setgidGroup;
           })
-          // lib.optionalAttrs (cfg.relayHost != "") {
-            relayhost =
-              if cfg.lookupMX then
-                "${cfg.relayHost}:${toString cfg.relayPort}"
-              else
-                "[${cfg.relayHost}]:${toString cfg.relayPort}";
-          }
-          // lib.optionalAttrs (!config.networking.enableIPv6) { inet_protocols = lib.mkDefault "ipv4"; }
-          // lib.optionalAttrs (cfg.networks != null) { mynetworks = cfg.networks; }
-          // lib.optionalAttrs (cfg.networksStyle != "") { mynetworks_style = cfg.networksStyle; }
-          // lib.optionalAttrs (cfg.hostname != "") { myhostname = cfg.hostname; }
-          // lib.optionalAttrs (cfg.domain != "") { mydomain = cfg.domain; }
-          // lib.optionalAttrs (cfg.origin != "") { myorigin = cfg.origin; }
-          // lib.optionalAttrs (cfg.destination != null) { mydestination = cfg.destination; }
-          // lib.optionalAttrs (cfg.relayDomains != null) { relay_domains = cfg.relayDomains; }
-          // lib.optionalAttrs (cfg.recipientDelimiter != "") {
-            recipient_delimiter = cfg.recipientDelimiter;
-          }
           // lib.optionalAttrs haveAliases { alias_maps = [ "${cfg.aliasMapType}:/etc/postfix/aliases" ]; }
           // lib.optionalAttrs haveTransport { transport_maps = [ "hash:/etc/postfix/transport" ]; }
           // lib.optionalAttrs haveVirtual {
@@ -1022,10 +1049,6 @@ in
           // lib.optionalAttrs (cfg.dnsBlacklists != [ ]) { smtpd_client_restrictions = clientRestrictions; }
           // lib.optionalAttrs cfg.enableHeaderChecks {
             header_checks = [ "regexp:/etc/postfix/header_checks" ];
-          }
-          // lib.optionalAttrs (cfg.tlsTrustedAuthorities != "") {
-            smtp_tls_CAfile = cfg.tlsTrustedAuthorities;
-            smtp_tls_security_level = lib.mkDefault "may";
           };
 
         services.postfix.masterConfig = {
@@ -1194,6 +1217,51 @@ in
     )
     (lib.mkRemovedOptionModule [ "services" "postfix" "sslKey" ]
       "services.postfix.sslKey was removed. Use services.postfix.config.smtpd_tls_chain_files for server private key, or services.postfix.config.smtp_tls_chain_files for the client private key."
+    )
+    (lib.mkRemovedOptionModule [ "services" "postfix" "lookupMX" ]
+      "services.postfix.lookupMX was removed. Use services.postfix.config.relayhost and put the hostname in angled brackets, if you need to turn off MX and SRV lookups."
+    )
+    (lib.mkRemovedOptionModule [ "services" "postfix" "relayHost" ]
+      "services.postfix.relayHost was removed in favor of services.postfix.config.relayhost, which now takes a list of host/port."
+    )
+    (lib.mkRemovedOptionModule [ "services" "postfix" "relayPort" ]
+      "services.postfix.relayHost was removed in favor of services.postfix.config.relayhost, which now takes a list of host/port."
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "postfix" "networks" ]
+      [ "services" "postfix" "config" "mynetworks" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "postfix" "networkStyle" ]
+      [ "services" "postfix" "config" "mynetworks_style" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "postfix" "hostname" ]
+      [ "services" "postfix" "config" "myhostname" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "postfix" "domain" ]
+      [ "services" "postfix" "config" "mydomain" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "postfix" "origin" ]
+      [ "services" "postfix" "config" "myorigin" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "postfix" "destination" ]
+      [ "services" "postfix" "config" "mydestination" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "postfix" "relayDomains" ]
+      [ "services" "postfix" "config" "relay_domains" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "postfix" "recipientDelimiter" ]
+      [ "services" "postfix" "config" "recipient_delimiter" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "postfix" "tlsTrustedAuthoriies" ]
+      [ "services" "postfix" "config" "smtp_tls_CAfile" ]
     )
 
     (lib.mkChangedOptionModule

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -356,23 +356,47 @@ in
       enableSmtp = lib.mkOption {
         type = lib.types.bool;
         default = true;
-        description = "Whether to enable smtp in master.cf.";
+        description = ''
+          Whether to enable the `smtp` service configured in the master.cf.
+
+          This service listens for plain text SMTP connections on port 25
+          and supports explicit TLS via StartTLS.
+
+          It is the primary port used by SMTP servers to exchange mail.
+        '';
       };
 
       enableSubmission = lib.mkOption {
         type = lib.types.bool;
         default = false;
-        description = "Whether to enable smtp submission.";
+        description = "
+          Whether to enable the `submission` service configured in master.cf.
+
+          This service listens for plain text SMTP connections on port 587
+          and supports explicit TLS via StartTLS.
+
+          It is a way for clients to login and submit mails after an inband
+          connection upgrade using StartTLS.
+
+          ::: {.warning}
+          [RFC 8314](https://www.rfc-editor.org/rfc/rfc8314) discourages the use
+          of explicit TLS for mail submissionn.
+          :::
+        ";
       };
 
       enableSubmissions = lib.mkOption {
         type = lib.types.bool;
         default = false;
         description = ''
-          Whether to enable smtp submission via smtps.
+          Whether to enable the `submissions` service configured in master.cf.
 
-          According to RFC 8314 this should be preferred
-          over STARTTLS for submission of messages by end user clients.
+          This service listen for implicit TLS connections on port 465.
+
+          ::: {.info}
+          Per [RFC 8314](https://www.rfc-editor.org/rfc/rfc8314) implicit TLS
+          is recommended for mail submission.
+          :::
         '';
       };
 

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -340,6 +340,11 @@ in
 
 {
 
+  meta.maintainers = with lib.maintainers; [
+    dotlambda
+    hexa
+  ];
+
   ###### interface
 
   options = {

--- a/nixos/modules/services/mail/postsrsd.nix
+++ b/nixos/modules/services/mail/postsrsd.nix
@@ -235,7 +235,7 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf (cfg.enable && cfg.configurePostfix && config.services.postfix.enable) {
-      services.postfix.config = {
+      services.postfix.settings.main = {
         # https://github.com/roehling/postsrsd#configuration
         sender_canonical_maps = "socketmap:${cfg.settings.socketmap}:forward";
         sender_canonical_classes = "envelope_sender";

--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -426,7 +426,7 @@ in
     };
     services.postfix = mkIf (cfg.postfix.enable && cfg.mda.enable) {
       # Not sure limiting to 1 is necessary, but better safe than sorry.
-      config.public-inbox_destination_recipient_limit = "1";
+      settings.main.public-inbox_destination_recipient_limit = "1";
 
       # Register the addresses as existing
       virtual = concatStringsSep "\n" (
@@ -443,7 +443,7 @@ in
       );
 
       # The public-inbox transport
-      masterConfig.public-inbox = {
+      settings.master.public-inbox = {
         type = "unix";
         privileged = true; # Required for user=
         command = "pipe";

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -451,7 +451,7 @@ in
         '';
       };
     };
-    services.postfix.config = mkIf cfg.postfix.enable cfg.postfix.config;
+    services.postfix.settings.main = mkIf cfg.postfix.enable cfg.postfix.config;
 
     systemd.services.postfix = mkIf cfg.postfix.enable {
       serviceConfig.SupplementaryGroups = [ postfixCfg.group ];

--- a/nixos/modules/services/mail/schleuder.nix
+++ b/nixos/modules/services/mail/schleuder.nix
@@ -115,9 +115,7 @@ in
           flags=DRhu user=schleuder argv=/${pkgs.schleuder}/bin/schleuder work ''${recipient}
       '';
       transport = lib.mkIf (cfg.lists != [ ]) (postfixMap (lib.genAttrs cfg.lists (_: "schleuder:")));
-      extraConfig = ''
-        schleuder_destination_recipient_limit = 1
-      '';
+      config.schleuder_destination_recipient_limit = 1;
       # review: does this make sense?
       localRecipients = lib.mkIf (cfg.lists != [ ]) cfg.lists;
     };

--- a/nixos/modules/services/mail/schleuder.nix
+++ b/nixos/modules/services/mail/schleuder.nix
@@ -115,7 +115,7 @@ in
           flags=DRhu user=schleuder argv=/${pkgs.schleuder}/bin/schleuder work ''${recipient}
       '';
       transport = lib.mkIf (cfg.lists != [ ]) (postfixMap (lib.genAttrs cfg.lists (_: "schleuder:")));
-      config.schleuder_destination_recipient_limit = 1;
+      settings.main.schleuder_destination_recipient_limit = 1;
       # review: does this make sense?
       localRecipients = lib.mkIf (cfg.lists != [ ]) cfg.lists;
     };

--- a/nixos/modules/services/mail/sympa.nix
+++ b/nixos/modules/services/mail/sympa.nix
@@ -585,44 +585,46 @@ in
 
     services.postfix = lib.mkIf (cfg.mta.type == "postfix") {
       enable = true;
-      config = {
-        recipient_delimiter = "+";
-        virtual_alias_maps = [ "hash:${dataDir}/virtual.sympa" ];
-        virtual_mailbox_maps = [
-          "hash:${dataDir}/transport.sympa"
-          "hash:${dataDir}/sympa_transport"
-          "hash:${dataDir}/virtual.sympa"
-        ];
-        virtual_mailbox_domains = [ "hash:${dataDir}/transport.sympa" ];
-        transport_maps = [
-          "hash:${dataDir}/transport.sympa"
-          "hash:${dataDir}/sympa_transport"
-        ];
-      };
-      masterConfig = {
-        "sympa" = {
-          type = "unix";
-          privileged = true;
-          chroot = false;
-          command = "pipe";
-          args = [
-            "flags=hqRu"
-            "user=${user}"
-            "argv=${pkg}/libexec/queue"
-            "\${nexthop}"
+      settings = {
+        main = {
+          recipient_delimiter = "+";
+          virtual_alias_maps = [ "hash:${dataDir}/virtual.sympa" ];
+          virtual_mailbox_maps = [
+            "hash:${dataDir}/transport.sympa"
+            "hash:${dataDir}/sympa_transport"
+            "hash:${dataDir}/virtual.sympa"
+          ];
+          virtual_mailbox_domains = [ "hash:${dataDir}/transport.sympa" ];
+          transport_maps = [
+            "hash:${dataDir}/transport.sympa"
+            "hash:${dataDir}/sympa_transport"
           ];
         };
-        "sympabounce" = {
-          type = "unix";
-          privileged = true;
-          chroot = false;
-          command = "pipe";
-          args = [
-            "flags=hqRu"
-            "user=${user}"
-            "argv=${pkg}/libexec/bouncequeue"
-            "\${nexthop}"
-          ];
+        master = {
+          "sympa" = {
+            type = "unix";
+            privileged = true;
+            chroot = false;
+            command = "pipe";
+            args = [
+              "flags=hqRu"
+              "user=${user}"
+              "argv=${pkg}/libexec/queue"
+              "\${nexthop}"
+            ];
+          };
+          "sympabounce" = {
+            type = "unix";
+            privileged = true;
+            chroot = false;
+            command = "pipe";
+            args = [
+              "flags=hqRu"
+              "user=${user}"
+              "argv=${pkg}/libexec/bouncequeue"
+              "\${nexthop}"
+            ];
+          };
         };
       };
     };

--- a/nixos/modules/services/mail/sympa.nix
+++ b/nixos/modules/services/mail/sympa.nix
@@ -585,8 +585,8 @@ in
 
     services.postfix = lib.mkIf (cfg.mta.type == "postfix") {
       enable = true;
-      recipientDelimiter = "+";
       config = {
+        recipient_delimiter = "+";
         virtual_alias_maps = [ "hash:${dataDir}/virtual.sympa" ];
         virtual_mailbox_maps = [
           "hash:${dataDir}/transport.sympa"

--- a/nixos/modules/services/mail/zeyple.nix
+++ b/nixos/modules/services/mail/zeyple.nix
@@ -128,6 +128,6 @@ in
         -o smtpd_authorized_xforward_hosts=127.0.0.0/8,[::1]/128
     '';
 
-    services.postfix.extraConfig = "content_filter = zeyple";
+    services.postfix.config.content_filter = "zeyple";
   };
 }

--- a/nixos/modules/services/mail/zeyple.nix
+++ b/nixos/modules/services/mail/zeyple.nix
@@ -128,6 +128,6 @@ in
         -o smtpd_authorized_xforward_hosts=127.0.0.0/8,[::1]/128
     '';
 
-    services.postfix.config.content_filter = "zeyple";
+    services.postfix.settings.main.content_filter = "zeyple";
   };
 }

--- a/nixos/modules/services/monitoring/parsedmarc.nix
+++ b/nixos/modules/services/monitoring/parsedmarc.nix
@@ -427,9 +427,9 @@ in
 
     services.postfix = lib.mkIf cfg.provision.localMail.enable {
       enable = true;
-      origin = cfg.provision.localMail.hostname;
       config = {
         myhostname = cfg.provision.localMail.hostname;
+        myorigin = cfg.provision.localMail.hostname;
         mydestination = cfg.provision.localMail.hostname;
       };
     };

--- a/nixos/modules/services/monitoring/parsedmarc.nix
+++ b/nixos/modules/services/monitoring/parsedmarc.nix
@@ -427,7 +427,7 @@ in
 
     services.postfix = lib.mkIf cfg.provision.localMail.enable {
       enable = true;
-      config = {
+      settings.main = {
         myhostname = cfg.provision.localMail.hostname;
         myorigin = cfg.provision.localMail.hostname;
         mydestination = cfg.provision.localMail.hostname;

--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -1076,19 +1076,23 @@ in
 
     services.postfix = lib.mkIf cfg.mail.incoming.enable {
       enable = true;
-      sslCert = lib.optionalString (cfg.sslCertificate != null) cfg.sslCertificate;
-      sslKey = lib.optionalString (cfg.sslCertificateKey != null) cfg.sslCertificateKey;
 
-      origin = cfg.hostname;
-      relayDomains = [ cfg.hostname ];
       config = {
         smtpd_recipient_restrictions = "check_policy_service unix:private/discourse-policy";
         append_dot_mydomain = lib.mkDefault false;
         compatibility_level = "2";
         smtputf8_enable = false;
         smtpd_banner = lib.mkDefault "ESMTP server";
+        smtpd_tls_chain_files =
+          lib.optionals (cfg.sslCertificate != null && cfg.sslCertificateKey != null)
+            [
+              cfg.sslCertificateKey
+              cfg.sslCertificate
+            ];
         myhostname = lib.mkDefault cfg.hostname;
         mydestination = lib.mkDefault "localhost";
+        myorigin = cfg.hostname;
+        relay_domains = [ cfg.hostname ];
       };
       transport = ''
         ${cfg.hostname} discourse-mail-receiver:

--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -1077,7 +1077,7 @@ in
     services.postfix = lib.mkIf cfg.mail.incoming.enable {
       enable = true;
 
-      config = {
+      settings.main = {
         smtpd_recipient_restrictions = "check_policy_service unix:private/discourse-policy";
         append_dot_mydomain = lib.mkDefault false;
         compatibility_level = "2";
@@ -1097,7 +1097,7 @@ in
       transport = ''
         ${cfg.hostname} discourse-mail-receiver:
       '';
-      masterConfig = {
+      settings.master = {
         "discourse-mail-receiver" = {
           type = "unix";
           privileged = true;

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -1100,7 +1100,7 @@ in
 
         services.postfix = lib.mkIf (cfg.smtp.createLocally && cfg.smtp.host == "127.0.0.1") {
           enable = true;
-          hostname = lib.mkDefault "${cfg.localDomain}";
+          config.myhostname = lib.mkDefault "${cfg.localDomain}";
         };
 
         services.redis.servers.mastodon = lib.mkIf redisActuallyCreateLocally (

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -1100,7 +1100,7 @@ in
 
         services.postfix = lib.mkIf (cfg.smtp.createLocally && cfg.smtp.host == "127.0.0.1") {
           enable = true;
-          config.myhostname = lib.mkDefault "${cfg.localDomain}";
+          settings.main.myhostname = lib.mkDefault "${cfg.localDomain}";
         };
 
         services.redis.servers.mastodon = lib.mkIf redisActuallyCreateLocally (

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -959,7 +959,7 @@ in
 
     services.postfix = lib.mkIf cfg.smtp.createLocally {
       enable = true;
-      hostname = lib.mkDefault "${cfg.localDomain}";
+      config.myhostname = lib.mkDefault "${cfg.localDomain}";
     };
 
     users.users = lib.mkMerge [

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -959,7 +959,7 @@ in
 
     services.postfix = lib.mkIf cfg.smtp.createLocally {
       enable = true;
-      config.myhostname = lib.mkDefault "${cfg.localDomain}";
+      settings.main.myhostname = lib.mkDefault "${cfg.localDomain}";
     };
 
     users.users = lib.mkMerge [

--- a/nixos/tests/alps.nix
+++ b/nixos/tests/alps.nix
@@ -27,11 +27,14 @@ in
         enable = true;
         enableSubmission = true;
         enableSubmissions = true;
-        tlsTrustedAuthorities = "${certs.ca.cert}";
-        config.smtpd_tls_chain_files = [
-          "${certs.${domain}.key}"
-          "${certs.${domain}.cert}"
-        ];
+
+        config = {
+          smtp_tls_CAfile = "${certs.ca.cert}";
+          smtpd_tls_chain_files = [
+            "${certs.${domain}.key}"
+            "${certs.${domain}.cert}"
+          ];
+        };
       };
       services.dovecot2 = {
         enable = true;

--- a/nixos/tests/alps.nix
+++ b/nixos/tests/alps.nix
@@ -28,7 +28,7 @@ in
         enableSubmission = true;
         enableSubmissions = true;
 
-        config = {
+        settings.main = {
           smtp_tls_CAfile = "${certs.ca.cert}";
           smtpd_tls_chain_files = [
             "${certs.${domain}.key}"

--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -107,13 +107,13 @@ in
 
       services.postfix = {
         enable = true;
-        origin = clientDomain;
-        relayDomains = [ clientDomain ];
         config = {
           compatibility_level = "2";
-          smtpd_banner = "ESMTP server";
+          mydestination = [ clientDomain ];
           myhostname = clientDomain;
-          mydestination = clientDomain;
+          origin = clientDomain;
+          relay_domains = [ clientDomain ];
+          smtpd_banner = "ESMTP server";
         };
       };
 

--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -107,7 +107,7 @@ in
 
       services.postfix = {
         enable = true;
-        config = {
+        settings.main = {
           compatibility_level = "2";
           mydestination = [ clientDomain ];
           myhostname = clientDomain;

--- a/nixos/tests/mailman.nix
+++ b/nixos/tests/mailman.nix
@@ -13,11 +13,11 @@
       services.mailman.webHosts = [ "example.com" ];
 
       services.postfix.enable = true;
-      services.postfix.destination = [
+      services.postfix.config.mydestination = [
         "example.com"
         "example.net"
       ];
-      services.postfix.relayDomains = [ "hash:/var/lib/mailman/data/postfix_domains" ];
+      services.postfix.config.relay_domains = [ "hash:/var/lib/mailman/data/postfix_domains" ];
       services.postfix.config.local_recipient_maps = [
         "hash:/var/lib/mailman/data/postfix_lmtp"
         "proxy:unix:passwd.byname"

--- a/nixos/tests/mailman.nix
+++ b/nixos/tests/mailman.nix
@@ -13,16 +13,18 @@
       services.mailman.webHosts = [ "example.com" ];
 
       services.postfix.enable = true;
-      services.postfix.config.mydestination = [
-        "example.com"
-        "example.net"
-      ];
-      services.postfix.config.relay_domains = [ "hash:/var/lib/mailman/data/postfix_domains" ];
-      services.postfix.config.local_recipient_maps = [
-        "hash:/var/lib/mailman/data/postfix_lmtp"
-        "proxy:unix:passwd.byname"
-      ];
-      services.postfix.config.transport_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
+      services.postfix.settings.main = {
+        mydestination = [
+          "example.com"
+          "example.net"
+        ];
+        relay_domains = [ "hash:/var/lib/mailman/data/postfix_domains" ];
+        local_recipient_maps = [
+          "hash:/var/lib/mailman/data/postfix_lmtp"
+          "proxy:unix:passwd.byname"
+        ];
+        transport_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
+      };
 
       users.users.user = {
         isNormalUser = true;

--- a/nixos/tests/matrix/synapse.nix
+++ b/nixos/tests/matrix/synapse.nix
@@ -182,16 +182,15 @@ in
 
         services.postfix = {
           enable = true;
-          hostname = "${mailerDomain}";
-          # open relay for subnet
-          networksStyle = "subnet";
           enableSubmission = true;
-          tlsTrustedAuthorities = "${mailerCerts.ca.cert}";
 
           # blackhole transport
           transport = "example.com discard:silently";
 
           config = {
+            myhostname = "${mailerDomain}";
+            # open relay for subnet
+            mynetworks_style = "subnet";
             debug_peer_level = "10";
             smtpd_relay_restrictions = [
               "permit_mynetworks"

--- a/nixos/tests/matrix/synapse.nix
+++ b/nixos/tests/matrix/synapse.nix
@@ -187,7 +187,7 @@ in
           # blackhole transport
           transport = "example.com discard:silently";
 
-          config = {
+          settings.main = {
             myhostname = "${mailerDomain}";
             # open relay for subnet
             mynetworks_style = "subnet";

--- a/nixos/tests/parsedmarc/default.nix
+++ b/nixos/tests/parsedmarc/default.nix
@@ -184,7 +184,7 @@ in
             services.postfix = {
               enable = true;
               origin = mailDomain;
-              config = {
+              settings.main = {
                 myhostname = mailDomain;
                 mydestination = mailDomain;
               };

--- a/nixos/tests/postfix.nix
+++ b/nixos/tests/postfix.nix
@@ -13,11 +13,13 @@ import ./make-test-python.nix {
         enable = true;
         enableSubmission = true;
         enableSubmissions = true;
-        tlsTrustedAuthorities = "${certs.ca.cert}";
-        config.smtpd_tls_chain_files = [
-          certs.${domain}.key
-          certs.${domain}.cert
-        ];
+        config = {
+          smtp_tls_CAfile = "${certs.ca.cert}";
+          smtpd_tls_chain_files = [
+            certs.${domain}.key
+            certs.${domain}.cert
+          ];
+        };
         submissionsOptions = {
           smtpd_sasl_auth_enable = "yes";
           smtpd_client_restrictions = "permit";

--- a/nixos/tests/postfix.nix
+++ b/nixos/tests/postfix.nix
@@ -13,7 +13,7 @@ import ./make-test-python.nix {
         enable = true;
         enableSubmission = true;
         enableSubmissions = true;
-        config = {
+        settings.main = {
           smtp_tls_CAfile = "${certs.ca.cert}";
           smtpd_tls_chain_files = [
             certs.${domain}.key

--- a/nixos/tests/public-inbox.nix
+++ b/nixos/tests/public-inbox.nix
@@ -166,7 +166,7 @@ in
         setSendmail = true;
         #sslCert = "${tls-cert}/cert.pem";
         #sslKey = "${tls-cert}/key.pem";
-        recipientDelimiter = "+";
+        config.recipient_delimiter = "+";
       };
 
       environment.systemPackages = [

--- a/nixos/tests/public-inbox.nix
+++ b/nixos/tests/public-inbox.nix
@@ -166,7 +166,7 @@ in
         setSendmail = true;
         #sslCert = "${tls-cert}/cert.pem";
         #sslKey = "${tls-cert}/key.pem";
-        config.recipient_delimiter = "+";
+        settings.main.recipient_delimiter = "+";
       };
 
       environment.systemPackages = [

--- a/nixos/tests/rspamd.nix
+++ b/nixos/tests/rspamd.nix
@@ -293,7 +293,7 @@ in
       };
       services.postfix = {
         enable = true;
-        destination = [ "example.com" ];
+        config.mydestination = [ "example.com" ];
       };
       services.rspamd = {
         enable = true;

--- a/nixos/tests/rspamd.nix
+++ b/nixos/tests/rspamd.nix
@@ -293,7 +293,7 @@ in
       };
       services.postfix = {
         enable = true;
-        config.mydestination = [ "example.com" ];
+        settings.main.mydestination = [ "example.com" ];
       };
       services.rspamd = {
         enable = true;

--- a/nixos/tests/schleuder.nix
+++ b/nixos/tests/schleuder.nix
@@ -11,7 +11,7 @@ in
       services.postfix = {
         enable = true;
         enableSubmission = true;
-        config = {
+        settings.main = {
           mydomain = domain;
           destination = domain;
           smtp_tls_CAfile = "${certs.ca.cert}";

--- a/nixos/tests/schleuder.nix
+++ b/nixos/tests/schleuder.nix
@@ -11,13 +11,15 @@ in
       services.postfix = {
         enable = true;
         enableSubmission = true;
-        tlsTrustedAuthorities = "${certs.ca.cert}";
-        config.smtpd_tls_chain_files = [
-          "${certs.${domain}.key}"
-          "${certs.${domain}.cert}"
-        ];
-        inherit domain;
-        destination = [ domain ];
+        config = {
+          mydomain = domain;
+          destination = domain;
+          smtp_tls_CAfile = "${certs.ca.cert}";
+          smtpd_tls_chain_files = [
+            "${certs.${domain}.key}"
+            "${certs.${domain}.cert}"
+          ];
+        };
         localRecipients = [
           "root"
           "alice"

--- a/pkgs/by-name/po/postfix/update.sh
+++ b/pkgs/by-name/po/postfix/update.sh
@@ -5,6 +5,6 @@ set -eu -o pipefail
 
 # Expect the text in format of '<a href="official/postfix-3.7.4.tar.gz">Source code</a> |'
 # Stable release goes first.
-new_version="$(curl -s http://cdn.postfix.johnriley.me/mirrors/postfix-release/index.html |
+new_version="$(curl -s https://postfix-mirror.horus-it.com/postfix-release/index.html |
     pcregrep -o1 '"official/postfix-([0-9.]+)[.]tar[.]gz">' | head -n1)"
 update-source-version postfix "$new_version"


### PR DESCRIPTION
Work to bring the Postfix module more in line with the values of RFC 42. In particular
- Migrate top-level options into freeform config option.
- Fold main and master config into `settings.{main,master}`.
  - TODO: Other config files to follow in another PR
- Improve option documentation and type checks.
- Prune options, for which upstream provides reasonable defaults
- Fix the mirror URL in the update script
- Treewide migration of postfix consumers to the `settings.{main,master}` options

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
