### PR TITLE
[WIP] pcb-rnd: init at 3.1.7

### DIFF
--- a/pkgs/by-name/li/librnd/package.nix
+++ b/pkgs/by-name/li/librnd/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  gtk4,
+  libGLU,
+  libepoxy,
+  motif,
+  gd,
+  # similar as debian
+  # https://salsa.debian.org/electronics-team/ringdove-eda/librnd/-/blob/debian/debian/rules
+  librndBuildIn ? [
+    "script" # optionally requires 'fungw', not packaged
+    "diag_rnd"
+    "lib_gensexpr"
+    "hid_batch"
+    "lib_portynet"
+    "lib_exp_text"
+    "import_pixmap_pnm"
+    "lib_hid_common"
+    "lib_hid_gl"
+  ],
+  librndPlugin ? [
+    "lib_wget"
+    "lib_gtk4_common"
+    "import_pixmap_gd"
+    "hid_lesstif"
+    "hid_gtk4_gl"
+    "irc"
+    "lib_exp_pixmap"
+  ],
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "librnd";
+  version = "4.3.2";
+
+  # Error: unknown argument bindir
+  # outputs = [ "out" "dev" "doc" ];
+
+  src = fetchurl {
+    url = "http://repo.hu/projects/librnd/releases/librnd-${finalAttrs.version}.tar.gz";
+    hash = "sha256-MSuQDeRtSgKboQ4viIxNKfvY+IhWqKQFucMArAOKgYU=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    gtk4
+    libGLU
+    libepoxy
+    motif
+    gd
+  ];
+
+  configureFlags =
+    (lib.map (x: "--buildin-${x}") librndBuildIn) ++ (lib.map (x: "--plugin-${x}") librndPlugin);
+
+  enableParallelBuilding = true;
+
+  passthru = {
+    inherit librndBuildIn librndPlugin;
+  };
+
+  meta = {
+    description = "Flexible, modular two-dimensional CAD engine";
+    homepage = "http://www.repo.hu/projects/librnd";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ ];
+    teams = [ lib.teams.ngi ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/pc/pcb-rnd/package.nix
+++ b/pkgs/by-name/pc/pcb-rnd/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  wrapGAppsHook4,
+  librnd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pcb-rnd";
+  version = "3.1.7";
+
+  # Alternative: https://salsa.debian.org/electronics-team/ringdove-eda/pcb-rnd
+  src = fetchurl {
+    url = "http://repo.hu/projects/pcb-rnd/releases/pcb-rnd-${finalAttrs.version}.tar.gz";
+    hash = "sha256-IUV2FbJwjIEBNIH0f16VKWqRoMAiYe7OeXpSHG3+KT0=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    librnd
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    ln -s $out/share/doc/pcb-rnd/resources/logo.svg $out/share/icons/hicolor/scalable/apps/pcb-rnd.svg
+    install -Dm644 doc/resources/pcb-rnd.desktop -t $out/share/applications
+  '';
+
+  env = {
+    LIBRND_PREFIX = librnd.outPath;
+  };
+
+  meta = {
+    description = "Flexible, modular Printed Circuit Board editor";
+    homepage = "https://repo.hu/projects/pcb-rnd";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ ];
+    teams = [ lib.teams.ngi ];
+    mainProgram = "pcb-rnd";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Still trying to figure out plugins of `pcb-rnd`. `librnd` should be ready.

Fork of [pcb](https://search.nixos.org/packages?channel=unstable&show=pcb&from=0&size=50&sort=relevance&type=packages&query=pcb)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
