### PR TITLE
smoked-salmon: init at 0.9.6

### DIFF
--- a/pkgs/by-name/sm/smoked-salmon/package.nix
+++ b/pkgs/by-name/sm/smoked-salmon/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  cambia,
+  ffmpeg-headless,
+  flac,
+  lame,
+  mp3val,
+  oxipng,
+  python3Packages,
+  sox,
+}:
+let
+  runtimeDeps = [
+    cambia
+    oxipng
+    ffmpeg-headless
+    flac
+    lame
+    mp3val
+    sox
+  ];
+in
+python3Packages.buildPythonApplication rec {
+  pname = "smoked-salmon";
+  version = "0.9.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "smokin-salmon";
+    repo = "smoked-salmon";
+    tag = version;
+    hash = "sha256-GxH2hqA/11yqLC8fH3GVvfohAmTxy/ibqxa0Xcupxn0=";
+  };
+
+  # Upstream tends to use very narrow version constraints
+  pythonRelaxDeps = true;
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    aiohttp
+    aiohttp-jinja2
+    beautifulsoup4
+    bitstring
+    click
+    filetype
+    httpx
+    jinja2
+    msgspec
+    musicbrainzngs
+    mutagen
+    platformdirs
+    pyperclip
+    qbittorrent-api
+    ratelimit
+    requests
+    rich
+    send2trash
+    setuptools
+    torf
+    tqdm
+    unidecode
+    wheel
+  ];
+
+  makeWrapperArgs = [
+    "--suffix"
+    "PATH"
+    ":"
+    (lib.makeBinPath runtimeDeps)
+  ];
+
+  passthru = {
+    inherit runtimeDeps;
+  };
+
+  meta = {
+    description = "Uploading script for Gazelle-based music trackers";
+    homepage = "https://github.com/smokin-salmon/smoked-salmon";
+    license = with lib.licenses; [ asl20 ];
+    mainProgram = "salmon";
+    maintainers = with lib.maintainers; [ ambroisie ];
+  };
+}


### PR DESCRIPTION
## Things done

Builds on top of #416776.

- Built on platform(s)
  - [X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
