### PR TITLE
pkgs/README: rename `gtkspell` to `gspell`

### DIFF
--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -97,7 +97,7 @@ Now that this is out of the way. To add a package to Nixpkgs:
 
    - GNU Multiple Precision arithmetic library (GMP): [`pkgs/development/libraries/gmp`](development/libraries/gmp). Also done by the generic builder, but has a dependency on `m4`.
 
-   - Pan, a GTK-based newsreader: [`pkgs/by-name/pa/pan/package.nix`](./by-name/pa/pan/package.nix). Has an optional dependency on `gtkspell`, which is only built if `spellCheck` is `true`.
+   - Pan, a GTK-based newsreader: [`pkgs/by-name/pa/pan/package.nix`](./by-name/pa/pan/package.nix). Has an optional dependency on `gspell`, which is only built if `spellCheck` is `true`.
 
    - Apache HTTPD: [`pkgs/servers/http/apache-httpd/2.4.nix`](servers/http/apache-httpd/2.4.nix). A bunch of optional features, variable substitutions in the configure flags, a post-install hook, and miscellaneous hackery.
 


### PR DESCRIPTION
Minor documentation change. `gtkspell` was renamed into `gspell`:

https://github.com/NixOS/nixpkgs/blob/cbfb263ce1c171b034095fced9b85de27c967c48/pkgs/by-name/pa/pan/package.nix#L8