### PR TITLE
barebox: undrop & update code

### DIFF
--- a/pkgs/misc/barebox/default.nix
+++ b/pkgs/misc/barebox/default.nix
@@ -1,0 +1,105 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  bison,
+  dtc,
+  flex,
+  libusb1,
+  lzop,
+  openssl,
+  pkg-config,
+  buildPackages,
+}:
+
+let
+  buildBarebox =
+    {
+      filesToInstall,
+      installDir ? "$out",
+      defconfig,
+      extraMeta ? { },
+      ...
+    }@args:
+    stdenv.mkDerivation rec {
+      pname = "barebox-${defconfig}";
+
+      version = "2020.12.0";
+
+      src = fetchurl {
+        url = "https://www.barebox.org/download/barebox-${version}.tar.bz2";
+        sha256 = "06vsd95ihaa2nywpqy6k0c7xwk2pzws4yvbp328yd2pfiigachrv";
+      };
+
+      postPatch = ''
+        patchShebangs scripts
+      '';
+
+      nativeBuildInputs = [
+        bison
+        dtc
+        flex
+        openssl
+        libusb1
+        lzop
+        pkg-config
+      ];
+      depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+      hardeningDisable = [ "all" ];
+
+      makeFlags = [
+        "DTC=dtc"
+        "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+      ];
+
+      configurePhase = ''
+        runHook preConfigure
+
+        make ${defconfig}
+
+        runHook postConfigure
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p ${installDir}
+        cp ${lib.concatStringsSep " " filesToInstall} ${installDir}
+
+        runHook postInstall
+      '';
+
+      enableParallelBuilding = true;
+
+      dontStrip = true;
+
+      meta =
+        with lib;
+        {
+          homepage = "https://www.barebox.org";
+          description = "Swiss Army Knive for bare metal";
+          license = licenses.gpl2Only;
+          maintainers = with maintainers; [ emantor ];
+        }
+        // extraMeta;
+    }
+    // removeAttrs args [ "extraMeta" ];
+
+in
+{
+  inherit buildBarebox;
+
+  bareboxTools = buildBarebox {
+    defconfig = "hosttools_defconfig";
+    installDir = "$out/bin";
+    extraMeta.platforms = lib.platforms.linux;
+    filesToInstall = [
+      "scripts/bareboximd"
+      "scripts/imx/imx-usb-loader"
+      "scripts/omap4_usbboot"
+      "scripts/omap3-usb-loader"
+      "scripts/kwboot"
+    ];
+  };
+}

--- a/pkgs/misc/barebox/default.nix
+++ b/pkgs/misc/barebox/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  buildBarebox =
+  buildBarebox = lib.makeOverridable (
     {
       filesToInstall,
       installDir ? "$out",
@@ -84,8 +84,8 @@ let
         }
         // extraMeta;
     }
-    // removeAttrs args [ "extraMeta" ];
-
+    // removeAttrs args [ "extraMeta" ]
+  );
 in
 {
   inherit buildBarebox;

--- a/pkgs/misc/barebox/default.nix
+++ b/pkgs/misc/barebox/default.nix
@@ -24,11 +24,11 @@ let
     stdenv.mkDerivation rec {
       pname = "barebox-${defconfig}";
 
-      version = "2020.12.0";
+      version = "2026.06.1";
 
       src = fetchurl {
         url = "https://www.barebox.org/download/barebox-${version}.tar.bz2";
-        sha256 = "06vsd95ihaa2nywpqy6k0c7xwk2pzws4yvbp328yd2pfiigachrv";
+        sha256 = "sha256-h1KzdSgZ7EqvhIodBt8FJCpklUUl+xW2zwezw91+vX8=";
       };
 
       postPatch = ''
@@ -100,6 +100,7 @@ in
       "scripts/omap4_usbboot"
       "scripts/omap3-usb-loader"
       "scripts/kwboot"
+      "scripts/rk-usb-loader"
     ];
   };
 }

--- a/pkgs/misc/barebox/default.nix
+++ b/pkgs/misc/barebox/default.nix
@@ -21,13 +21,13 @@ let
       extraMeta ? { },
       ...
     }@args:
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation (finalAttrs: {
       pname = "barebox-${defconfig}";
 
       version = "2026.06.1";
 
       src = fetchurl {
-        url = "https://www.barebox.org/download/barebox-${version}.tar.bz2";
+        url = "https://www.barebox.org/download/barebox-${finalAttrs.version}.tar.bz2";
         sha256 = "sha256-h1KzdSgZ7EqvhIodBt8FJCpklUUl+xW2zwezw91+vX8=";
       };
 
@@ -83,7 +83,7 @@ let
           maintainers = with maintainers; [ emantor ];
         }
         // extraMeta;
-    }
+    })
     // removeAttrs args [ "extraMeta" ]
   );
 in

--- a/pkgs/misc/barebox/default.nix
+++ b/pkgs/misc/barebox/default.nix
@@ -10,6 +10,7 @@
   openssl,
   pkg-config,
   buildPackages,
+  lz4,
 }:
 
 let
@@ -44,6 +45,7 @@ let
         bison
         dtc
         flex
+        lz4
         lzop
         openssl
         pkg-config

--- a/pkgs/misc/barebox/default.nix
+++ b/pkgs/misc/barebox/default.nix
@@ -31,6 +31,7 @@ let
     }@args:
     stdenv.mkDerivation (finalAttrs: {
       pname = "barebox-${defconfig}";
+      strictDeps = true;
 
       version = if version == null then defaultVersion else version;
       src = if src == null then defaultSrc else src;
@@ -43,11 +44,17 @@ let
         bison
         dtc
         flex
-        openssl
-        libusb1
         lzop
+        openssl
         pkg-config
       ];
+
+      buildInputs = [
+        libusb1
+        lzop
+        openssl
+      ];
+
       depsBuildBuild = [ buildPackages.stdenv.cc ];
 
       hardeningDisable = [ "all" ];
@@ -75,6 +82,8 @@ let
       '';
 
       enableParallelBuilding = true;
+
+      __structuredAttrs = true;
 
       dontStrip = true;
 

--- a/pkgs/misc/barebox/default.nix
+++ b/pkgs/misc/barebox/default.nix
@@ -13,8 +13,16 @@
 }:
 
 let
+  defaultVersion = "2026.06.1";
+  defaultSrc = fetchurl {
+    url = "https://www.barebox.org/download/barebox-${defaultVersion}.tar.bz2";
+    sha256 = "sha256-h1KzdSgZ7EqvhIodBt8FJCpklUUl+xW2zwezw91+vX8=";
+  };
+
   buildBarebox = lib.makeOverridable (
     {
+      version ? null,
+      src ? null,
       filesToInstall,
       installDir ? "$out",
       defconfig,
@@ -24,12 +32,8 @@ let
     stdenv.mkDerivation (finalAttrs: {
       pname = "barebox-${defconfig}";
 
-      version = "2026.06.1";
-
-      src = fetchurl {
-        url = "https://www.barebox.org/download/barebox-${finalAttrs.version}.tar.bz2";
-        sha256 = "sha256-h1KzdSgZ7EqvhIodBt8FJCpklUUl+xW2zwezw91+vX8=";
-      };
+      version = if version == null then defaultVersion else version;
+      src = if src == null then defaultSrc else src;
 
       postPatch = ''
         patchShebangs scripts

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8243,6 +8243,12 @@ with pkgs;
     ubootWandboard
     ;
 
+  # Upstream Barebox:
+  inherit (callPackage ../misc/barebox { })
+    buildBarebox
+    bareboxTools
+    ;
+
   usbrelay = callPackage ../os-specific/linux/usbrelay { };
   usbrelayd = callPackage ../os-specific/linux/usbrelay/daemon.nix { };
 


### PR DESCRIPTION
## Things done
- Undrop barebox
- run nixpkgs-fmt
- update to 2025.04.0
- adjust towards U-Boot derivation
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
