### PR TITLE
caesura: init at 0.25.2

### DIFF
--- a/pkgs/by-name/ca/caesura/package.nix
+++ b/pkgs/by-name/ca/caesura/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchzip,
+  rustPlatform,
+  eyed3,
+  flac,
+  imagemagick,
+  intermodal,
+  lame,
+  makeBinaryWrapper,
+  sox,
+  writableTmpDirAsHomeHook,
+}:
+let
+  runtimeDeps = [
+    eyed3
+    flac
+    intermodal
+    imagemagick
+    lame
+    sox
+  ];
+
+  testSampleContent = fetchzip {
+    url = "https://archive.org/download/tennyson-discography_/Tennyson%20-%20With%20You%20-%20Lay-by.zip";
+    hash = "sha256-/MgnOgn+OSPPg9wkJ32hq+1MXDdW+Qo9MqLtZMLQYBY=";
+    stripRoot = false;
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "caesura";
+  version = "0.25.2";
+
+  src = fetchFromGitHub {
+    owner = "RogueOneEcho";
+    repo = "caesura";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rpaOFmD/0/c5F6TIS7vGn7G3+rLOoBZKMW/HuzroUxM=";
+  };
+
+  cargoHash = "sha256-agdhYEhhw3gMdZmYiQZVeLARkMsYQ/AWLTrpiaH0mtA=";
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
+  '';
+
+  checkFlags = [
+    # Those test need internet access for its `Source` (i.e: tracker)
+    "--skip=commands::spectrogram::tests::spectrogram_command_tests::spectrogram_command"
+    "--skip=commands::transcode::tests::transcode_command_tests::transcode_command"
+    "--skip=utils::source::tests::source_provider_tests::source_provider"
+  ];
+
+  preCheck = ''
+    # From samples/download-sample
+    mkdir samples/content/
+    ln -s ${finalAttrs.passthru.testSampleContent} "samples/content/Tennyson - With You (2014) [Digital] "'{'"16-44.1 Bandcamp"'}'" (FLAC)"
+    # Adapted from .github/workflows/on-push.yml
+    tee config.yml <<EOF
+    announce_url: https://flacsfor.me/YOUR_ANNOUNCE_KEY/announce
+    api_key: YOUR_API_KEY
+    content:
+    - samples/content
+    source: $(mktemp -d)
+    verbosity: trace
+    EOF
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/caesura \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.passthru.runtimeDeps}
+  '';
+
+  passthru = {
+    inherit runtimeDeps testSampleContent;
+  };
+
+  meta = {
+    description = "versatile command line tool for automated verifying and transcoding of all your torrents";
+    homepage = "https://github.com/RogueOneEcho/caesura";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ ambroisie ];
+    mainProgram = "caesura";
+  };
+})


### PR DESCRIPTION
## Things done

Requires #417013.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
