### PR TITLE
libkrun-efi: init at 1.15.1, krunkit: init at 1.0.0 (Supersedes #416870)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20581,6 +20581,12 @@
     githubId = 39039420;
     name = "Quinn Dougherty";
   };
+  quinneden = {
+    email = "quinn@qeden.dev";
+    github = "quinneden";
+    githubId = 125415641;
+    name = "Quinn Edenfield";
+  };
   QuiNzX = {
     name = "QuiNz-";
     github = "QuiNzX";

--- a/pkgs/by-name/kr/krunkit/package.nix
+++ b/pkgs/by-name/kr/krunkit/package.nix
@@ -1,0 +1,58 @@
+{
+  cargo,
+  darwin,
+  pkg-config,
+  rustc,
+  stdenv,
+  fetchFromGitHub,
+  libepoxy,
+  libkrun-efi,
+  rustPlatform,
+  lib,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "krunkit";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "krunkit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dsEZZiLgHyd6xeXZCdDd4zsxzwQeIhAK+lewY2ZfvpY=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-i0cC3aOEqcvOcwTPbM6AazMzd8Q+QLwuhnvPGv3ntsc=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    darwin.sigtool
+    pkg-config
+    rustc
+    rustPlatform.bindgenHook
+    rustPlatform.cargoSetupHook
+  ];
+
+  buildInputs = [
+    libepoxy
+    libkrun-efi
+  ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  # This is necessary in order for the binary to keep its entitlements
+  dontStrip = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Launch configurable virtual machines with libkrun";
+    homepage = "https://github.com/containers/krunkit";
+    license = lib.licenses.asl20;
+    platforms = [ "aarch64-darwin" ];
+    maintainers = with lib.maintainers; [ quinneden ];
+  };
+})

--- a/pkgs/by-name/li/libkrun-efi/package.nix
+++ b/pkgs/by-name/li/libkrun-efi/package.nix
@@ -1,0 +1,117 @@
+{
+  cargo,
+  fetchFromGitHub,
+  fetchurl,
+  fixDarwinDylibNames,
+  lib,
+  libepoxy,
+  libkrun-efi,
+  moltenvk,
+  pkg-config,
+  rustc,
+  rustPlatform,
+  rutabaga_gfx,
+  nix-update-script,
+  stdenv,
+  buildPackages,
+  meson,
+  ninja,
+  vulkan-headers,
+  withGpu ? true,
+}:
+let
+  virglrenderer = stdenv.mkDerivation (finalAttrs: {
+    pname = "virglrenderer";
+    version = "0.10.4d-krunkit";
+
+    src = fetchurl {
+      url = "https://gitlab.freedesktop.org/slp/virglrenderer/-/archive/${finalAttrs.version}/virglrenderer-${finalAttrs.version}.tar.bz2";
+      hash = "sha256-M/buj97QUeY6CYeW0VICD5F6FBPi9ATPGHpNA48xL3o=";
+    };
+
+    separateDebugInfo = true;
+
+    buildInputs = [
+      libepoxy
+      moltenvk
+      vulkan-headers
+    ];
+
+    nativeBuildInputs = [
+      meson
+      ninja
+      pkg-config
+      (buildPackages.python3.withPackages (ps: [ ps.pyyaml ]))
+    ];
+
+    mesonFlags = [
+      (lib.mesonBool "render-server" false)
+      (lib.mesonBool "venus" true)
+      (lib.mesonEnable "drm" false)
+    ];
+
+    meta = {
+      description = "Virtual 3D GPU library that allows a qemu guest to use the host GPU for accelerated 3D rendering";
+      mainProgram = "virgl_test_server";
+      homepage = "https://gitlab.freedesktop.org/slp/virglrenderer";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+      maintainers = [ lib.maintainers.quinneden ];
+    };
+  });
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libkrun-efi";
+  version = "1.15.1";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "libkrun";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VhlFyYJ/TH12I3dUq0JTus60rQEJq5H4Pm1puCnJV5A=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-dK3V7HCCvTqmQhB5Op2zmBPa9FO3h9gednU9tpQk+1U=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    fixDarwinDylibNames
+    pkg-config
+    rustc
+    rustPlatform.bindgenHook
+    rustPlatform.cargoSetupHook
+  ];
+
+  buildInputs = [
+    libepoxy
+    rutabaga_gfx
+    virglrenderer
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "EFI=1"
+  ]
+  ++ lib.optional withGpu "GPU=1";
+
+  passthru = {
+    tests.withoutGpu = libkrun-efi.override { withGpu = false; };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "EFI variant of Libkrun, a dynamic library providing Virtualization-based process isolation capabilities";
+    homepage = "https://github.com/containers/libkrun";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ quinneden ];
+    platforms = [ "aarch64-darwin" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Added `quinneden` to `maintainers/maintainers-list.nix`
- Added `libkrun-efi`, the EFI variant of `libkrun` for `aarch64-darwin`.
- Added `krunkit`, a CLI tool for running linux VMs on `aarch64-darwin` using `libkrun-efi`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
