### PR TITLE
treewide: remove astsmtl as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2328,12 +2328,6 @@
     githubId = 119769817;
     name = "goatastronaut0212";
   };
-  astsmtl = {
-    email = "astsmtl@yandex.ru";
-    github = "astsmtl";
-    githubId = 2093941;
-    name = "Alexander Tsamutali";
-  };
   asymmetric = {
     email = "lorenzo@mailbox.org";
     github = "asymmetric";

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -133,7 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/brummer10/guitarix";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
-      astsmtl
       lord-valen
     ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/goldendict/default.nix
+++ b/pkgs/applications/misc/goldendict/default.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation rec {
     platforms = with platforms; linux ++ darwin;
     mainProgram = "goldendict";
     maintainers = with maintainers; [
-      astsmtl
       sikmir
     ];
     license = licenses.gpl3Plus;

--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -228,7 +228,6 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2Plus
       mit
     ];
-    maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/al/alienarena/package.nix
+++ b/pkgs/by-name/al/alienarena/package.nix
@@ -60,7 +60,6 @@ stdenv.mkDerivation rec {
     homepage = "https://alienarena.org";
     # Engine is under GPLv2, everything else is under
     license = lib.licenses.unfreeRedistributable;
-    maintainers = with lib.maintainers; [ astsmtl ];
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
   };

--- a/pkgs/by-name/ap/apg/package.nix
+++ b/pkgs/by-name/ap/apg/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation {
     '';
     homepage = "https://github.com/wilx/apg";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ astsmtl ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ca/caps/package.nix
+++ b/pkgs/by-name/ca/caps/package.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.quitte.de/dsp/caps.html";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.astsmtl ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/li/libcue/package.nix
+++ b/pkgs/by-name/li/libcue/package.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/lipnitsk/libcue";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/li/libmikmod/package.nix
+++ b/pkgs/by-name/li/libmikmod/package.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
     homepage = "https://mikmod.shlomifish.org/";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [
-      astsmtl
       lovek323
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/m1/m17n_db/package.nix
+++ b/pkgs/by-name/m1/m17n_db/package.nix
@@ -36,6 +36,5 @@ stdenv.mkDerivation rec {
     }";
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ astsmtl ];
   };
 }

--- a/pkgs/by-name/ma/mars/package.nix
+++ b/pkgs/by-name/ma/mars/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation {
     homepage = "https://mars-game.sourceforge.net/";
     description = "Game about fighting with ships in a 2D space setting";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.astsmtl ];
     platforms = lib.platforms.linux;
     mainProgram = "mars";
   };

--- a/pkgs/by-name/qu/quesoglc/package.nix
+++ b/pkgs/by-name/qu/quesoglc/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://quesoglc.sourceforge.net/";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ astsmtl ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ry/rymcast/package.nix
+++ b/pkgs/by-name/ry/rymcast/package.nix
@@ -48,6 +48,5 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ astsmtl ];
   };
 }

--- a/pkgs/by-name/sa/sakura/package.nix
+++ b/pkgs/by-name/sa/sakura/package.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
-      astsmtl
       codyopel
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/sf/sfml_2/package.nix
+++ b/pkgs/by-name/sf/sfml_2/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
       It is written in C++, and has bindings for various languages such as C, .Net, Ruby, Python.
     '';
     license = lib.licenses.zlib;
-    maintainers = [ lib.maintainers.astsmtl ];
     platforms = lib.platforms.unix;
     badPlatforms = [
       # error: implicit instantiation of undefined template 'std::char_traits<unsigned int>'

--- a/pkgs/by-name/te/teeworlds/package.nix
+++ b/pkgs/by-name/te/teeworlds/package.nix
@@ -142,7 +142,6 @@ stdenv.mkDerivation rec {
       # zlib src/engine/external/zlib/
     ];
     maintainers = with lib.maintainers; [
-      astsmtl
       Luflosi
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/te/terminus_font/package.nix
+++ b/pkgs/by-name/te/terminus_font/package.nix
@@ -56,6 +56,5 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://terminus-font.sourceforge.net/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ astsmtl ];
   };
 }

--- a/pkgs/by-name/tr/transmission_3/package.nix
+++ b/pkgs/by-name/tr/transmission_3/package.nix
@@ -170,7 +170,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "http://www.transmissionbt.com/";
     license = lib.licenses.gpl2Plus; # parts are under MIT
-    maintainers = with lib.maintainers; [ astsmtl ];
     platforms = lib.platforms.unix;
   };
 

--- a/pkgs/by-name/ur/urbanterror/package.nix
+++ b/pkgs/by-name/ur/urbanterror/package.nix
@@ -116,7 +116,6 @@ stdenv.mkDerivation {
     '';
     mainProgram = "urbanterror";
     maintainers = with lib.maintainers; [
-      astsmtl
       drupol
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -164,7 +164,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [
-      astsmtl
       antono
     ];
     teams = [ teams.gnome ];

--- a/pkgs/by-name/wa/warzone2100/package.nix
+++ b/pkgs/by-name/wa/warzone2100/package.nix
@@ -141,7 +141,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://wz2100.net";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [
-      astsmtl
       fgaz
     ];
     platforms = platforms.all;

--- a/pkgs/games/oilrush/default.nix
+++ b/pkgs/games/oilrush/default.nix
@@ -130,7 +130,6 @@ stdenv.mkDerivation {
     '';
     homepage = "http://oilrush-game.com/";
     license = lib.licenses.unfree;
-    #maintainers = with lib.maintainers; [ astsmtl ];
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];

--- a/pkgs/games/warsow/default.nix
+++ b/pkgs/games/warsow/default.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.warsow.net";
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [
-      astsmtl
       abbradar
     ];
     platforms = warsow-engine.meta.platforms;

--- a/pkgs/games/warsow/engine.nix
+++ b/pkgs/games/warsow/engine.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation {
     homepage = "http://www.warsow.net";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [
-      astsmtl
       abbradar
     ];
     platforms = platforms.linux;

--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -64,7 +64,6 @@ let
     homepage = "https://www.xonotic.org/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      astsmtl
       zalakain
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [
-      astsmtl
       qusic
     ];
     platforms = platforms.linux;

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -277,7 +277,6 @@ let
         homepage = "https://www.musicpd.org/";
         license = licenses.gpl2Only;
         maintainers = with maintainers; [
-          astsmtl
           tobim
         ];
         platforms = platforms.unix;

--- a/pkgs/tools/inputmethods/m17n-lib/default.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/default.nix
@@ -32,6 +32,5 @@ stdenv.mkDerivation rec {
     description = "Multilingual text processing library (runtime)";
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ astsmtl ];
   };
 }

--- a/pkgs/tools/misc/qjoypad/default.nix
+++ b/pkgs/tools/misc/qjoypad/default.nix
@@ -53,7 +53,6 @@ mkDerivation rec {
     '';
     homepage = "https://github.com/panzi/qjoypad/";
     license = lib.licenses.gpl2Only;
-    maintainers = with maintainers; [ astsmtl ];
     platforms = with platforms; linux;
     mainProgram = "qjoypad";
   };


### PR DESCRIPTION
@astsmtl has been inactive for a few years. Removal of them as a maintainer (assuming they do not become active in the next week) would help ensure that we don't wait unnecessarily for them, and could help others adopt their packages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
