### PR TITLE
albyhub: 1.17.1 -> 1.17.2

### DIFF
--- a/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
+++ b/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
@@ -7,12 +7,12 @@
 
 buildGoModule rec {
   pname = "ldk-node-go";
-  version = "0-unstable-2025-05-21";
+  version = "0-unstable-2025-05-25";
 
   src = fetchFromGitHub {
     owner = "getAlby";
     repo = "ldk-node-go";
-    rev = "ca26307fa2d8ee4d30da9affd0b202897f9919f6";
+    rev = "13acf1fb7bb52c76dc5a47084dc35e00108e5f28";
     hash = "sha256-UdsfN6UL9lKPQSCfF8oA89U0M3pqj/TcFcs01E7WoXs=";
   };
 

--- a/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
+++ b/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
@@ -5,7 +5,7 @@
   ldkNode,
 }:
 
-buildGoModule rec {
+buildGoModule {
   pname = "ldk-node-go";
   version = "0-unstable-2025-05-25";
 

--- a/pkgs/by-name/al/albyhub/ldk-node/default.nix
+++ b/pkgs/by-name/al/albyhub/ldk-node/default.nix
@@ -6,7 +6,7 @@
   llvmPackages,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ldk-node";
   version = "0-unstable-2025-05-21";
 
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Embeds the LDK node implementation compiled as shared library objects";
     homepage = "https://github.com/getAlby/ldk-node";
-    changelog = "https://github.com/getAlby/ldk-node/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/getAlby/ldk-node/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit
@@ -45,4 +45,4 @@ rustPlatform.buildRustPackage rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ bleetube ];
   };
-}
+})

--- a/pkgs/by-name/al/albyhub/package.nix
+++ b/pkgs/by-name/al/albyhub/package.nix
@@ -23,16 +23,16 @@ in
 
 buildGoModule rec {
   pname = "albyhub";
-  version = "1.17.1";
+  version = "1.17.2";
 
   src = fetchFromGitHub {
     owner = "getAlby";
     repo = "hub";
     tag = "v${version}";
-    hash = "sha256-ZDTCA3nMJEA8I7PeSgwQAe+wU8Wk0GaH3ItQLzPhOBQ=";
+    hash = "sha256-7+5VWLO4J+ArHyTxapqVQL5GPofV4/QXCu5g+Ix9HoI=";
   };
 
-  vendorHash = "sha256-4e75SqQiRUEEjtDZKDZsGSRavZFh5ulJdMz0Ne7gME0=";
+  vendorHash = "sha256-uk0SzrzgT9BpFGMv5qUwXonXLvVgfjjudy+rlj3j5Yo=";
   proxyVendor = true; # needed for secp256k1-zkp CGO bindings
 
   nativeBuildInputs = [

--- a/pkgs/by-name/al/albyhub/package.nix
+++ b/pkgs/by-name/al/albyhub/package.nix
@@ -21,14 +21,14 @@ let
 
 in
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "albyhub";
   version = "1.17.2";
 
   src = fetchFromGitHub {
     owner = "getAlby";
     repo = "hub";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7+5VWLO4J+ArHyTxapqVQL5GPofV4/QXCu5g+Ix9HoI=";
   };
 
@@ -48,7 +48,7 @@ buildGoModule rec {
   ];
 
   frontendYarnOfflineCache = fetchYarnDeps {
-    yarnLock = src + "/frontend/yarn.lock";
+    yarnLock = finalAttrs.src + "/frontend/yarn.lock";
     hash = "sha256-SStTJGqeqPvXBKjFMPjKEts+jg6A9Vaqi+rZkr/ytdc=";
   };
 
@@ -56,7 +56,7 @@ buildGoModule rec {
     export HOME=$TMPDIR
     pushd frontend
       fixup-yarn-lock yarn.lock
-      yarn config set yarn-offline-mirror "${frontendYarnOfflineCache}"
+      yarn config set yarn-offline-mirror "${finalAttrs.frontendYarnOfflineCache}"
       yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
       patchShebangs node_modules
       yarn --offline build:http
@@ -68,7 +68,7 @@ buildGoModule rec {
   ];
 
   ldflags = [
-    "-X github.com/getAlby/hub/version.Tag=v${version}"
+    "-X github.com/getAlby/hub/version.Tag=v${finalAttrs.version}"
     "-s"
     "-w"
   ];
@@ -95,4 +95,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ bleetube ];
     mainProgram = "albyhub";
   };
-}
+})


### PR DESCRIPTION
> In this release, we add auto-swaps to ensure you can always receive payments, an onchain transaction list to the node page, and we've redesigned the friends and family into a new page for sub-wallets. Plus, many other minor improvements, bug fixes, and dependency updates, including the latest LDK update which includes important fixes to a few rare issues.

See the full [release notes for details](https://github.com/getAlby/hub/releases).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
