### PR TITLE
zerotier: add zerotier-systemd-manager AND corresponding service option

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27100,6 +27100,12 @@
     githubId = 3992240;
     name = "Elijah Rum";
   };
+  x-zvf = {
+    email = "peter@bohner.me";
+    github = "x-zvf";
+    githubId = 37499690;
+    name = "Peter Bohner";
+  };
   x0ba = {
     name = "x0ba";
     email = "dax@omg.lol";

--- a/pkgs/by-name/ze/zerotier-systemd-manager/package.nix
+++ b/pkgs/by-name/ze/zerotier-systemd-manager/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "zerotier-systemd-manager";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "zerotier";
+    repo = "zerotier-systemd-manager";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-vq6AqrA9ryzLcLEsPD2KbBZhF5YjF48ErIWb8e3b9JI=";
+  };
+
+  vendorHash = "sha256-40e/FFzHbWo0+bZoHQWzM7D60VUEr+ipxc5Tl0X9E2A=";
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Get ZeroTier playing nice with systemd-networkd and resolvectl";
+    homepage = "https://github.com/zerotier/zerotier-systemd-manager";
+    license = lib.licenses.bsd3;
+    mainProgram = "zerotier-systemd-manager";
+    maintainers = with lib.maintainers; [
+      x-zvf
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This pr packages [zerotier-systemd-manager](https://github.com/zerotier/zerotier-systemd-manager/) and provides the option `services.zerotierone.generateSystemdNetworkdConfig` to automatically invoke it after service start.
The corresponding `services.zerotierone.systemdManagerPackage` is also added, to be able to specify the package of the tool.

Usage of this tool is necessary (if avoiding manual configuration) to have working DNS resolution for zerotier DNS records
when using systemd-networkd.

## Things done


- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
