### PR TITLE
generic-builder: optimize - reduce execve calls when sourcing

### DIFF
--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -404,6 +404,50 @@ in
     stdenv' = bootStdenv;
   };
 
+  ensure-no-execve-in-setup-sh =
+    derivation {
+      name = "ensure-no-execve-in-setup-sh";
+      system = stdenv.system;
+      builder = "${stdenv.bootstrapTools}/bin/bash";
+      PATH = "${pkgs.strace}/bin:${stdenv.bootstrapTools}/bin";
+      initialPath = [
+        stdenv.bootstrapTools
+        pkgs.strace
+      ];
+      args = [
+        "-c"
+        ''
+          countCall() {
+            echo "$stats" | tr -s ' ' | grep "$1" | cut -d ' ' -f5
+          }
+
+          # prevent setup.sh from running `nproc` when cores=0
+          # (this would mess up the syscall stats)
+          export NIX_BUILD_CORES=1
+
+          echo "Analyzing setup.sh with strace"
+          stats=$(strace -fc bash -c ". ${../../stdenv/generic/setup.sh}" 2>&1)
+          echo "$stats" | head -n15
+
+          # fail if execve calls is > 1
+          stats=$(strace -fc bash -c ". ${../../stdenv/generic/setup.sh}" 2>&1)
+          execveCalls=$(countCall execve)
+          if [ "$execveCalls" -gt 1 ]; then
+            echo "execve calls: $execveCalls; expected: 1"
+            echo "ERROR: setup.sh should not launch additional processes when being sourced"
+            exit 1
+          else
+            echo "setup.sh doesn't launch extra processes when sourcing, as expected"
+          fi
+
+          touch $out
+        ''
+      ];
+    }
+    // {
+      meta = { };
+    };
+
   structuredAttrsByDefault = lib.recurseIntoAttrs {
 
     hooks = lib.recurseIntoAttrs (
@@ -570,6 +614,5 @@ in
           diff $out/json $goldenJson
         '';
       };
-
   };
 }


### PR DESCRIPTION
This improves the implementation of `dumpVars` by removing a call to `install`.

This improves performance when sourcing setup.sh by more than 10%
It should also improve the performance when transitioning between build phases significantly as no process executions are issued anymore,

A test is added, which ensures that no extra execve calls are issued while sourcing setup.sh.
This test can also be used to benchmark the sourcing of different implementations of setup.sh.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
