### PR TITLE
kapitano: init at 1.1.2

### DIFF
--- a/pkgs/by-name/ka/kapitano/package.nix
+++ b/pkgs/by-name/ka/kapitano/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  fetchFromGitea,
+  meson,
+  ninja,
+  pkg-config,
+  glib,
+  gtk4,
+  libadwaita,
+  python3Packages,
+  clamav,
+  appstream-glib,
+  desktop-file-utils,
+  libxml2,
+  gobject-introspection,
+  wrapGAppsHook4,
+  librsvg,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "kapitano";
+  version = "1.1.2";
+  pyproject = false;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "zynequ";
+    repo = "Kapitano";
+    tag = version;
+    hash = "sha256-914M0VRyuzDiITUT5sjt9vNaqshn4skz/FWWMxgPTdc=";
+    fetchLFS = true;
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    desktop-file-utils
+    libxml2
+    pkg-config
+    appstream-glib
+    wrapGAppsHook4
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+    librsvg
+  ];
+
+  dependencies = with python3Packages; [ pygobject3 ];
+
+  postPatch = ''
+    substituteInPlace src/config/paths_config.py \
+      --replace-fail 'USER_DATA_DIR = GLib.get_user_data_dir()' 'USER_DATA_DIR = os.path.join(GLib.get_user_data_dir(), "kapitano"); os.makedirs(USER_DATA_DIR, exist_ok=True)'
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      ''${gappsWrapperArgs[@]}
+      --prefix PATH : "${lib.makeBinPath [ clamav ]}"
+    )
+  '';
+
+  meta = {
+    description = "Modern ClamAV front-end that uses gtk4/libadwaita";
+    homepage = "https://codeberg.org/zynequ/Kapitano";
+    mainProgram = "kapitano";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ lonerOrz ];
+  };
+}


### PR DESCRIPTION
### PR 描述：

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
-->

**Add `[kapitano](https://codeberg.org/zynequ/Kapitano)`: a modern GTK4/libadwaita frontend for ClamAV**

This PR adds a new package: [`kapitano`](https://codeberg.org/zynequ/Kapitano), a modern and simple ClamAV GUI frontend using GTK4 and libadwaita. It's a lightweight application for scanning files and directories using ClamAV, designed with a GNOME/Adwaita UI.

Fixes #416861

---

### Things done

* Built on platform(s)

  * [x] x86\_64-linux
* [x] Tested basic functionality of the application (`./result/bin/kapitano` launches GUI and works with ClamAV)
* [x] Confirmed runtime Python deps (`gi`, `cairo`) available via `propagatedBuildInputs`
* [x] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

---

This is a small, standalone GTK4 application and a good candidate for inclusion in `nixpkgs`. Maintainer has been added to `meta.maintainers`.

---