### PR TITLE
nixos-rebuild-ng: fix switch inside a path symlinked to nix store

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -4,7 +4,7 @@ import subprocess
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Self, TypedDict, override
+from typing import Any, ClassVar, Self, TypedDict, override
 
 from .process import Remote, run_wrapper
 
@@ -61,6 +61,20 @@ class BuildAttr:
         return cls(Path(file or "default.nix"), attr)
 
 
+def _get_hostname(target_host: Remote | None) -> str | None:
+    if target_host:
+        try:
+            return run_wrapper(
+                ["uname", "-n"],
+                stdout=subprocess.PIPE,
+                remote=target_host,
+            ).stdout.strip()
+        except (AttributeError, subprocess.CalledProcessError):
+            return None
+    else:
+        return platform.node()
+
+
 @dataclass(frozen=True)
 class Flake:
     path: Path | str
@@ -75,15 +89,13 @@ class Flake:
         return f"{self.path}#{self.attr}"
 
     @classmethod
-    def parse(
-        cls,
-        flake_str: str,
-        hostname_fn: Callable[[], str | None] = lambda: None,
-    ) -> Self:
+    def parse(cls, flake_str: str, target_host: Remote | None = None) -> Self:
         m = cls._re.match(flake_str)
         assert m is not None, f"got no matches for {flake_str}"
         attr = m.group("attr")
-        nixos_attr = f'nixosConfigurations."{attr or hostname_fn() or "default"}"'
+        nixos_attr = (
+            f'nixosConfigurations."{attr or _get_hostname(target_host) or "default"}"'
+        )
         path_str = m.group("path")
         if ":" in path_str:
             return cls(path_str, nixos_attr)
@@ -107,24 +119,11 @@ class Flake:
 
     @classmethod
     def from_arg(cls, flake_arg: Any, target_host: Remote | None) -> Self | None:
-        def get_hostname() -> str | None:
-            if target_host:
-                try:
-                    return run_wrapper(
-                        ["uname", "-n"],
-                        stdout=subprocess.PIPE,
-                        remote=target_host,
-                    ).stdout.strip()
-                except (AttributeError, subprocess.CalledProcessError):
-                    return None
-            else:
-                return platform.node()
-
         match flake_arg:
             case str(s):
-                return cls.parse(s, get_hostname)
+                return cls.parse(s, target_host)
             case True:
-                return cls.parse(".", get_hostname)
+                return cls.parse(".", target_host)
             case False:
                 return None
             case _:
@@ -133,7 +132,7 @@ class Flake:
                 if default_path.exists():
                     # It can be a symlink to the actual flake.
                     default_path = default_path.resolve()
-                    return cls.parse(str(default_path.parent), get_hostname)
+                    return cls.parse(str(default_path.parent), target_host)
                 else:
                     return None
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -2,11 +2,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from pytest import MonkeyPatch
-
 import nixos_rebuild.models as m
-
-from .helpers import get_qualified_name
 
 
 def test_build_attr_from_arg() -> None:
@@ -30,7 +26,7 @@ def test_build_attr_to_attr() -> None:
     )
 
 
-def test_flake_parse(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
+def test_flake_parse() -> None:
     assert m.Flake.parse("/path/to/flake#attr") == m.Flake(
         Path("/path/to/flake"), 'nixosConfigurations."attr"'
     )
@@ -40,34 +36,11 @@ def test_flake_parse(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
     assert m.Flake.parse("/path/to/flake", lambda: "hostname") == m.Flake(
         Path("/path/to/flake"), 'nixosConfigurations."hostname"'
     )
-    # change directory to tmpdir
-    with monkeypatch.context() as patch_context:
-        patch_context.chdir(tmpdir)
-        assert m.Flake.parse(".#attr") == m.Flake(
-            Path("."), 'nixosConfigurations."attr"'
-        )
-        assert m.Flake.parse("#attr") == m.Flake(
-            Path("."), 'nixosConfigurations."attr"'
-        )
-        assert m.Flake.parse(".") == m.Flake(Path("."), 'nixosConfigurations."default"')
     assert m.Flake.parse("path:/to/flake#attr") == m.Flake(
         "path:/to/flake", 'nixosConfigurations."attr"'
     )
     assert m.Flake.parse("github:user/repo/branch") == m.Flake(
         "github:user/repo/branch", 'nixosConfigurations."default"'
-    )
-    git_root = tmpdir / "git_root"
-    git_root.mkdir()
-    (git_root / ".git").mkdir()
-    assert m.Flake.parse(str(git_root)) == m.Flake(
-        f"git+file://{git_root}", 'nixosConfigurations."default"'
-    )
-
-    work_tree = tmpdir / "work_tree"
-    work_tree.mkdir()
-    (work_tree / ".git").write_text("gitdir: /path/to/git", "utf-8")
-    assert m.Flake.parse(str(work_tree)) == m.Flake(
-        "git+file:///path/to/git", 'nixosConfigurations."default"'
     )
 
 
@@ -81,9 +54,7 @@ def test_flake_to_attr() -> None:
 
 
 @patch("platform.node", autospec=True)
-def test_flake_from_arg(
-    mock_node: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
-) -> None:
+def test_flake_from_arg(mock_node: Mock) -> None:
     mock_node.return_value = "hostname"
 
     # Flake string
@@ -95,11 +66,9 @@ def test_flake_from_arg(
     assert m.Flake.from_arg(False, None) is None
 
     # True
-    with monkeypatch.context() as patch_context:
-        patch_context.chdir(tmpdir)
-        assert m.Flake.from_arg(True, None) == m.Flake(
-            Path("."), 'nixosConfigurations."hostname"'
-        )
+    assert m.Flake.from_arg(True, None) == m.Flake(
+        Path("."), 'nixosConfigurations."hostname"'
+    )
 
     # None when we do not have /etc/nixos/flake.nix
     with patch(
@@ -108,28 +77,6 @@ def test_flake_from_arg(
         return_value=False,
     ):
         assert m.Flake.from_arg(None, None) is None
-
-    # None when we have a file in /etc/nixos/flake.nix
-    with (
-        patch(
-            "pathlib.Path.exists",
-            autospec=True,
-            return_value=True,
-        ),
-        patch(
-            "pathlib.Path.is_symlink",
-            autospec=True,
-            return_value=False,
-        ),
-        patch(
-            get_qualified_name(m.discover_git),
-            autospec=True,
-            return_value="/etc/nixos",
-        ),
-    ):
-        assert m.Flake.from_arg(None, None) == m.Flake(
-            "git+file:///etc/nixos", 'nixosConfigurations."hostname"'
-        )
 
     with (
         patch(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -56,8 +56,7 @@ def test_build(mock_run: Mock) -> None:
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
-    monkeypatch.chdir(tmpdir)
+def test_build_flake(mock_run: Mock) -> None:
     flake = m.Flake.parse(".#hostname")
 
     assert n.build_flake(
@@ -193,10 +192,7 @@ def test_build_remote(
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build_remote_flake(
-    mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path
-) -> None:
-    monkeypatch.chdir(tmpdir)
+def test_build_remote_flake(mock_run: Mock, monkeypatch: MonkeyPatch) -> None:
     flake = m.Flake.parse(".#hostname")
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
@@ -318,7 +314,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     # Flake
-    flake = m.Flake.parse(f"{tmpdir}#attr")
+    flake = m.Flake.parse("#attr")
     n.edit(flake, {"commit_lock_file": True})
     mock_run.assert_called_with(
         [
@@ -328,7 +324,7 @@ def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
             "edit",
             "--commit-lock-file",
             "--",
-            f'{tmpdir}#nixosConfigurations."attr"',
+            '.#nixosConfigurations."attr"',
         ],
         check=False,
     )


### PR DESCRIPTION
PR #375493 was introduced to fix an issue of different behavior between `nixos-rebuild repl` and `nixos-rebuild switch` by forcing usage of `git+file://` protocol when evaluating the Flake. This sadly reintroduced an older issue from the original `nixos-rebuild` that is caused by a pretty nasty bug in `nix`:
- https://github.com/NixOS/nixpkgs/issues/144811

Let's do the same fix we did for `nixos-rebuild` and just stopping normalizing the Flake (https://github.com/NixOS/nixpkgs/pull/153515). This will bring back the original issues this code is supposed to fix, but I argue that a difference between `nixos-rebuild repl` and `nixos-rebuild switch` is better than having a broken system.

Fix: #144811.

**Before**

```
/run/opengl-driver/lib
❯ sudo nixos-rebuild switch
[sudo] password for thiagoko:
warning: could not re-exec in a newer version of nixos-rebuild, using current version
warning:nixos_rebuild:could not re-exec in a newer version of nixos-rebuild, using current version
building the system configuration...
Failed to find executable /nix/store/ijz8g3gibqyr2zqfkrhshb5f50a46dv5-mesa-25.1.3/bin/switch-to-configuration: No such file or directory
Command '['systemd-run', '-E', 'LOCALE_ARCHIVE', '-E', 'NIXOS_INSTALL_BOOTLOADER', '--collect', '--no-ask-password', '--pipe', '--quiet', '--service-type=exec', '--unit=nixos-rebuild-switch-to-configuration', PosixPath('/nix/store/ijz8g3gibqyr2zqfkrhshb5f50a46dv5-mesa-25.1.3/bin/switch-to-configuration'), 'switch']' returned non-zero exit status 1.
```

**After**
```
# need to remove the broken generations first
~/Projects/nixpkgs master*
❯ sudo nix-env -p /nix/var/nix/profiles/system --delete-generations old #
removing profile version 288
removing profile version 289
/run/opengl-driver/lib
❯ sudo ~/Projects/nixpkgs/result/bin/nixos-rebuild-ng switch
building the system configuration...
activating the configuration...
showing changes compared to /run/current-system...
<<< /run/current-system
>>> /nix/store/fbgjjkgwpg6cgzyv8sq7rxvnnvgha91h-nixos-system-sankyuu-nixos-25.11.20250613.ee930f9
No version or selection state changes.
Closure size: 3679 -> 3679 (0 paths added, 0 paths removed, delta +0, disk usage +0B).
setting up /etc...
reloading user units for thiagoko...
restarting sysinit-reactivation.target
the following new units were started: libvirtd.service, NetworkManager-dispatcher.service
Done. The new configuration is /nix/store/fbgjjkgwpg6cgzyv8sq7rxvnnvgha91h-nixos-system-sankyuu-nixos-25.11.20250613.ee930f9
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
