### PR TITLE
nixos-rebuild-ng: run `nix build` commands in temporary directory

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -86,7 +86,18 @@ def build_flake(
         flake.to_attr(attr),
         *dict_to_flags(flake_build_flags),
     ]
-    r = run_wrapper(run_args, stdout=PIPE, stderr=PIPE if quiet else None)
+    r = run_wrapper(
+        run_args,
+        stdout=PIPE,
+        stderr=PIPE if quiet else None,
+        # Running build inside tmpdir thanks to this nasty bug from `nix`
+        # that happens when `nix build` is run from a symlink pointing to the
+        # nix store (e.g., /run/opengl-driver/lib)
+        # See:
+        # - https://github.com/NixOS/nix/issues/13367
+        # - https://github.com/NixOS/nixpkgs/issues/144811
+        cwd=tmpdir.TMPDIR_PATH,
+    )
     return Path(r.stdout.strip())
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Final, Self, TypedDict, Unpack
 
 from . import tmpdir
@@ -67,6 +68,7 @@ class Remote:
 # Not exhaustive, but we can always extend it later.
 class RunKwargs(TypedDict, total=False):
     capture_output: bool
+    cwd: str | Path | None
     stderr: int | None
     stdout: int | None
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -11,6 +11,7 @@ import pytest
 from pytest import MonkeyPatch
 
 import nixos_rebuild as nr
+from nixos_rebuild import tmpdir
 
 from .helpers import get_qualified_name
 
@@ -409,6 +410,7 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
                 check=True,
                 stdout=PIPE,
                 stderr=None,
+                cwd=tmpdir.TMPDIR_PATH,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(
@@ -477,6 +479,7 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
                 check=True,
                 stdout=PIPE,
                 stderr=None,
+                cwd=tmpdir.TMPDIR_PATH,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(
@@ -768,6 +771,7 @@ def test_execute_nix_switch_flake_target_host(
                 check=True,
                 stdout=PIPE,
                 stderr=None,
+                cwd=tmpdir.TMPDIR_PATH,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(
@@ -1076,6 +1080,7 @@ def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
                 check=True,
                 stdout=PIPE,
                 stderr=None,
+                cwd=tmpdir.TMPDIR_PATH,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -79,6 +79,7 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
         ],
         stdout=PIPE,
         stderr=None,
+        cwd=ANY,
     )
 
     assert n.build_flake(
@@ -98,6 +99,7 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
         ],
         stdout=PIPE,
         stderr=PIPE,
+        cwd=ANY,
     )
 
 


### PR DESCRIPTION
This is to avoid a nasty bug in `nix`, that together with another issue in `systemd-boot-builder.py` causes a broken generation to be created that causes further new activations to also be broken.

Fix issue #144811.

Alternative for https://github.com/NixOS/nixpkgs/pull/417191.

Before:

```
/run/opengl-driver/lib
❯ sudo nixos-rebuild switch
[sudo] password for thiagoko:
warning: could not re-exec in a newer version of nixos-rebuild, using current version
warning:nixos_rebuild:could not re-exec in a newer version of nixos-rebuild, using current version
building the system configuration...
Failed to find executable /nix/store/ijz8g3gibqyr2zqfkrhshb5f50a46dv5-mesa-25.1.3/bin/switch-to-configuration: No such file or directory
Command '['systemd-run', '-E', 'LOCALE_ARCHIVE', '-E', 'NIXOS_INSTALL_BOOTLOADER', '--collect', '--no-ask-password', '--pipe', '--quiet', '--service-type=exec', '--unit=nixos-rebuild-switch-to-configuration', PosixPath('/nix/store/ijz8g3gibqyr2zqfkrhshb5f50a46dv5-mesa-25.1.3/bin/switch-to-configuration'), 'switch']' returned non-zero exit status 1.
```

After:
```
/run/opengl-driver/lib
❯ sudo ~/Projects/nixpkgs/result/bin/nixos-rebuild-ng switch
[sudo] password for thiagoko:
building the system configuration...
activating the configuration...
showing changes compared to /run/current-system...
<<< /run/current-system
>>> /nix/store/fbgjjkgwpg6cgzyv8sq7rxvnnvgha91h-nixos-system-sankyuu-nixos-25.11.20250613.ee930f9
No version or selection state changes.
Closure size: 3679 -> 3679 (0 paths added, 0 paths removed, delta +0, disk usage +0B).
setting up /etc...
reloading user units for thiagoko...
restarting sysinit-reactivation.target
the following new units were started: libvirtd.service, NetworkManager-dispatcher.service
Done. The new configuration is /nix/store/fbgjjkgwpg6cgzyv8sq7rxvnnvgha91h-nixos-system-sankyuu-nixos-25.11.20250613.ee930f9
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
