### PR TITLE
newcomputermodern: add updateScript; 6.0.0 -> 7.0.2; add `meta.changelog`

### DIFF
--- a/pkgs/by-name/ne/newcomputermodern/package.nix
+++ b/pkgs/by-name/ne/newcomputermodern/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchgit,
   fontforge,
+  gitUpdater,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -35,6 +36,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     install -m444 -Dt $out/share/fonts/opentype/public sfd/*.otf
     runHook postInstall
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Computer Modern fonts including matching non-latin alphabets";

--- a/pkgs/by-name/ne/newcomputermodern/package.nix
+++ b/pkgs/by-name/ne/newcomputermodern/package.nix
@@ -8,12 +8,12 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "newcomputermodern";
-  version = "6.0.0";
+  version = "7.0.2";
 
   src = fetchgit {
     url = "https://git.gnu.org.ua/newcm.git";
     rev = finalAttrs.version;
-    hash = "sha256-AMzEytBn9PbyYFNJ2CMPg8ejsL3eFhY+eZHXShaLG9E=";
+    hash = "sha256-J2k3gbQgmb+hsIYQi+kCccejrNccHryuC140rNwNPTQ=";
   };
 
   nativeBuildInputs = [ fontforge ];

--- a/pkgs/by-name/ne/newcomputermodern/package.nix
+++ b/pkgs/by-name/ne/newcomputermodern/package.nix
@@ -42,6 +42,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "Computer Modern fonts including matching non-latin alphabets";
     homepage = "https://ctan.org/pkg/newcomputermodern";
+    changelog = "https://mirrors.rit.edu/CTAN/fonts/newcomputermodern/README";
     # "The GUST Font License (GFL), which is a free license, legally
     # equivalent to the LaTeX Project Public License (LPPL), version 1.3c or
     # later." - GUST website


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package update, `updateScript` additon, and changelog URL addition.

(If the updateScript or meta.changelog is undesired, let me know.)

<details open>
<summary><b>Upstream Changelog</b></summary>

- Version 7.0.2
  - Fontspec files reworked to fully support slshape and scshape in
    all text faces.
  - Additional fontspec files for Mono-Regular+Book to cover the missing
    Oblique Mono fonts.
  - Some more kerning for upright partialdiff and some capital letters.
- Version 7.0.1
  - Math kerning introduced for Latin Italic Math Capitals and Capital
    Calligraphics with period and comma.
  - Several metrics bug fixes.
- Version 7.0.0
  - Added NewCMSansMath-Regular
  - Sans letters used for math variables are a new design (and not the
    original with a slant) so they really look as variables!
  - NewCM mathbb/symbb symbols in Sans have been reworked to match the
    Sans design in both style and wight.
  - Same goes for mathcal/symcal letters.
  - Math Kerning has been introduced in ALL math fonts to compensate for
    bad spacing especially of the index of mathcal/symcal letters.
  - Added ss06 and ss07 to be selected for auto middle beta and theta in Greek.
  - The kerning of Greek Oblique block has been greatly improved;
    "theorem" statements now look much better.
  - testmath-newcm.tex/pdf has been added to the documentation from the
    AMS bundle to showcase the new SansMath font.
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
