### PR TITLE
workflows/labels: fix syntax error

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -173,7 +173,7 @@ jobs:
                   before.filter(name => !after.includes(name))
                   .map(name => github.rest.issues.removeLabel({
                     ...context.repo,
-                    issue_number: pull_request.number
+                    issue_number: pull_request.number,
                     name
                   }))
                 )
@@ -183,7 +183,7 @@ jobs:
                 if (added.length > 0) {
                   await github.rest.issues.addLabels({
                     ...context.repo,
-                    issue_number: pull_request.number
+                    issue_number: pull_request.number,
                     labels: added
                   })
                 }


### PR DESCRIPTION
Introduced in #416808, 4d537009c6d2bf00f7177571909f61debff796c4.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
