### PR TITLE
caddy: added support for plugin alias handling

### DIFF
--- a/pkgs/by-name/ca/caddy/plugins.nix
+++ b/pkgs/by-name/ca/caddy/plugins.nix
@@ -29,6 +29,7 @@ in
 {
   plugins,
   hash ? fakeHash,
+  doInstallCheck ? true,
 }:
 
 let
@@ -83,40 +84,74 @@ caddy.overrideAttrs (
 
     # xcaddy built output always uses pseudo-version number
     # we enforce user provided plugins are present and have matching tags here
-    doInstallCheck = true;
+    inherit doInstallCheck;
     installCheckPhase = ''
       runHook preInstallCheck
 
       ${toShellVar "notfound" pluginsSorted}
 
-      while read kind module version; do
-        [[ "$kind" = "dep" ]] || continue
-        module="''${module}@''${version}"
+      local build_info_output
+      build_info_output=$($out/bin/caddy build-info)
+
+      print_common_advice() {
+        echo "  - if you are using \`go.mod\` alias or other advanced usage(s), set \`doInstallCheck = false\` or write your own \`installCheckPhase\` in \`caddy.withPlugins\` call"
+        echo "  - if you are sure this error is caused by packaging, or caused by caddy/xcaddy, raise an issue with nixpkgs or upstream"
+      }
+
+      while read -r kind module version rest; do
+        if [[ "$kind" != "dep" && "$kind" != "=>" ]]; then
+          continue
+        fi
+
+        if [[ -z "$module" || -z "$version" ]]; then
+          continue
+        fi
+
+        local module_from_build="''${module}@''${version}"
+
         for i in "''${!notfound[@]}"; do
-          if [[ ''${notfound[i]} = ''${module} ]]; then
+          local user_plugin="''${notfound[i]}"
+          local expected_in_build="$user_plugin"
+
+          if [[ "$user_plugin" == *"="* ]]; then
+            expected_in_build="''${user_plugin#*=}"
+          fi
+
+          if [[ "$expected_in_build" == "$module_from_build" ]]; then
             unset 'notfound[i]'
+            break
           fi
         done
-      done < <($out/bin/caddy build-info)
+      done < <(echo "$build_info_output")
 
       if (( ''${#notfound[@]} )); then
         for plugin in "''${notfound[@]}"; do
-          base=''${plugin%@*}
-          specified=''${plugin#*@}
-          found=0
+          if [[ "$plugin" == *"="* ]]; then
+            echo "Plugin with alias \"$plugin\" not found in build:"
+            echo "  The check looks for the replacement module \"''${plugin#*=}\" in the build output."
+            echo "  This replacement module was not found:"
+            print_common_advice
+          else
+            local base=''${plugin%@*}
+            local specified=''${plugin#*@}
+            local found=0
 
-          while read kind module expected; do
-            [[ "$kind" = "dep" && "$module" = "$base" ]] || continue
-            echo "Plugin \"$base\" have incorrect tag:"
-            echo "  specified: \"$base@$specified\""
-            echo "  got: \"$base@$expected\""
-            found=1
-          done < <($out/bin/caddy build-info)
+            while read -r kind module expected rest; do
+              if [[ ("$kind" = "dep" || "$kind" = "=>") && "$module" = "$base" ]]; then
+                echo "Plugin \"$base\" have incorrect tag:"
+                echo "  specified: \"$base@$specified\""
+                echo "  got: \"$base@$expected\""
+                found=1
+                break
+              fi
+            done < <(echo "$build_info_output")
 
-          if (( found == 0 )); then
-            echo "Plugin \"$base\" not found in build:"
-            echo "  specified: \"$base@$specified\""
-            echo "  plugin does not exist in the xcaddy build output, open an issue in nixpkgs or upstream"
+            if (( found == 0 )); then
+              echo "Plugin \"$base\" not found in build:"
+              echo "  specified: \"$base@$specified\""
+              echo "  plugin does not exist in the xcaddy build output:"
+              print_common_advice
+            fi
           fi
         done
 


### PR DESCRIPTION
This PR allows using aliased plugins in caddy. (Which is usefull, when testing PRs for caddy plugins)
Before this PR the `caddy.withPlugins` build failed, because it could not find the aliased plugin during the install phase.

Please verify the fix, as I used the help of AI to fix it. I checked the changes and it looks fine to me and I also added the change to the 25.05 branch, which I currently run, and build my system with it and that build succeeded as well.
But please double check the changes.

I used this to test it:
```
        pkgs.caddy.withPlugins {
          # Get version for untagged repo, see: https://github.com/NixOS/nixpkgs/pull/358586#issuecomment-2564016652
          plugins = [
            "github.com/caddy-dns/netcup=github.com/oltdaniel/caddy-dns-netcup@v0.0.0-20250609190907-1de4cf24d747"
            "github.com/mholt/caddy-l4@v0.0.0-20250124234235-87e3e5e2c7f9"
          ];
          hash = "sha256-MbqBfyhOXDYc7PGexNV3mbTENUqZGMP4WjbtnOqrAyY=";
        }

```

replaces: https://github.com/NixOS/nixpkgs/pull/415790

## Things done

It now checks the build-info output for aliased packages. Those appear in the build-info not in a single line, but in a second line, starting with "=>".
Please verify the changes.


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
