### PR TITLE
libvirt: 11.0.0 -> 11.4.0

### DIFF
--- a/pkgs/by-name/li/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+++ b/pkgs/by-name/li/libvirt/0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
@@ -402,10 +402,10 @@ index 3b859ea7b4..ccddb3e805 100644
    ]
  endif
 diff --git a/src/security/apparmor/meson.build b/src/security/apparmor/meson.build
-index b9257c816d..98701755d8 100644
+index 09d9fac02c..ee0c74ceec 100644
 --- a/src/security/apparmor/meson.build
 +++ b/src/security/apparmor/meson.build
-@@ -57,7 +57,7 @@ foreach name : apparmor_gen_profiles
+@@ -20,16 +20,16 @@ foreach name : apparmor_gen_profiles
      output: name,
      configuration: apparmor_gen_profiles_conf,
      install: true,
@@ -413,39 +413,25 @@ index b9257c816d..98701755d8 100644
 +    install_dir: install_prefix + apparmor_dir,
    )
  endforeach
- 
-@@ -68,13 +68,13 @@ foreach name : apparmor_gen_abstractions
-     command: apparmor_gen_cmd,
-     capture: true,
-     install: true,
--    install_dir: apparmor_dir / 'abstractions',
-+    install_dir: install_prefix + apparmor_dir / 'abstractions',
-   )
- endforeach
- 
+
+ install_data(
+   [ 'libvirt-qemu', 'libvirt-lxc' ],
+-  install_dir: apparmor_dir / 'abstractions',
++  install_dir: install_prefix + apparmor_dir / 'abstractions',
+ )
+
  install_data(
    [ 'TEMPLATE.qemu', 'TEMPLATE.lxc' ],
 -  install_dir: apparmor_dir / 'libvirt',
 +  install_dir: install_prefix + apparmor_dir / 'libvirt',
  )
- 
- if not conf.has('WITH_APPARMOR_3')
-@@ -83,7 +83,7 @@ if not conf.has('WITH_APPARMOR_3')
-   # files in order to limit the amount of filesystem clutter.
-   install_data(
-     'usr.lib.libvirt.virt-aa-helper.local',
--    install_dir: apparmor_dir / 'local',
-+    install_dir: install_prefix + apparmor_dir / 'local',
-     rename: 'usr.lib.libvirt.virt-aa-helper',
-   )
- endif
 diff --git a/src/storage/meson.build b/src/storage/meson.build
 index 404d6a6941..fb4e67a0a8 100644
 --- a/src/storage/meson.build
 +++ b/src/storage/meson.build
 @@ -126,9 +126,9 @@ if conf.has('WITH_STORAGE')
    }
- 
+
    virt_install_dirs += [
 -    confdir / 'storage',
 -    confdir / 'storage' / 'autostart',
@@ -455,20 +441,27 @@ index 404d6a6941..fb4e67a0a8 100644
 +    install_prefix + runstatedir / 'libvirt' / 'storage',
    ]
  endif
- 
+
 diff --git a/tools/meson.build b/tools/meson.build
-index 1bb84be0be..e04a4e986d 100644
+index a099148d3c..d0d6510f17 100644
 --- a/tools/meson.build
 +++ b/tools/meson.build
-@@ -121,7 +121,7 @@ if conf.has('WITH_LOGIN_SHELL')
+@@ -123,12 +123,12 @@ if conf.has('WITH_LOGIN_SHELL')
      install_rpath: libvirt_rpath,
    )
- 
+
 -  install_data('virt-login-shell.conf', install_dir: sysconfdir / 'libvirt')
 +  install_data('virt-login-shell.conf', install_dir: install_prefix + sysconfdir / 'libvirt')
+
+   # Install the sysuser config for the setgid binary
+   install_data(
+     'libvirt-login-shell.sysusers.conf',
+-    install_dir: sysusersdir,
++    install_dir: install_prefix + sysusersdir,
+     rename: [ 'libvirt-login-shell.conf' ],
+   )
  endif
- 
- if host_machine.system() == 'windows'
+
 diff --git a/tools/ssh-proxy/meson.build b/tools/ssh-proxy/meson.build
 index e9f312fa25..95d5d8fe0b 100644
 --- a/tools/ssh-proxy/meson.build

--- a/pkgs/by-name/li/libvirt/package.nix
+++ b/pkgs/by-name/li/libvirt/package.nix
@@ -115,14 +115,14 @@ assert enableZfs -> isLinux;
 stdenv.mkDerivation rec {
   pname = "libvirt";
   # if you update, also bump <nixpkgs/pkgs/development/python-modules/libvirt/default.nix> and SysVirt in <nixpkgs/pkgs/top-level/perl-packages.nix>
-  version = "11.0.0";
+  version = "11.4.0";
 
   src = fetchFromGitLab {
     owner = "libvirt";
     repo = "libvirt";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-QxyOc/RbWZnjA4XIDNK7xZqBcP2ciHsOlszaa5pl6XA=";
+    hash = "sha256-0bOX95Ly8d1/XZan/EyxI6JaACJvOu9QsTkFNQTreqI=";
   };
 
   patches =

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "libvirt";
-  version = "11.0.0";
+  version = "11.4.0";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "libvirt";
     repo = "libvirt-python";
     tag = "v${version}";
-    hash = "sha256-c6viZTQFpLB+k/f45m/AZe+ggDxQbGjQgD51yCuyepc=";
+    hash = "sha256-jI14/lBuqSqI8mnTa7dqa+B+6tU2erW6wlT8E0eTgtY=";
   };
 
   postPatch = ''

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32337,12 +32337,12 @@ with self;
 
   SysVirt = buildPerlModule rec {
     pname = "Sys-Virt";
-    version = "11.0.0";
+    version = "11.2.0";
     src = fetchFromGitLab {
       owner = "libvirt";
       repo = "libvirt-perl";
       tag = "v${version}";
-      hash = "sha256-k1fpVLWbFgZOUvCPLN6EpYgSfpwig5mHiWMRo8iRvZc=";
+      hash = "sha256-e/Zb9ox/ehfybpxiCAsEl97T1vjBNpRYJK/kmehPHsY=";
     };
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [


### PR DESCRIPTION
Updating libvirt from `11.0.0` (2025-01-15) to `11.4.0` (2025-06-02).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
