### PR TITLE
python3Packages.aiohttp: fix tests on aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -34,6 +34,7 @@
   blockbuster,
   freezegun,
   gunicorn,
+  isa-l,
   isal,
   proxy-py,
   pytest-codspeed,
@@ -58,6 +59,10 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-ciZGOOfVXYoLzYNIkota3MXMRMxlztf+mFFo0y9r+Lk=";
   };
+
+  patches = lib.optionals (!lib.meta.availableOn stdenv.hostPlatform isa-l) [
+    ./remove-isal.patch
+  ];
 
   postPatch = ''
     rm -r vendor
@@ -105,7 +110,8 @@ buildPythonPackage rec {
     blockbuster
     freezegun
     gunicorn
-    isal
+    # broken on aarch64-darwin
+    (if lib.meta.availableOn stdenv.hostPlatform isa-l then isal else null)
     proxy-py
     pytest-codspeed
     pytest-cov-stub

--- a/pkgs/development/python-modules/aiohttp/remove-isal.patch
+++ b/pkgs/development/python-modules/aiohttp/remove-isal.patch
@@ -1,0 +1,21 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 62fb04f2e..bb5b279dd 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -12,7 +12,6 @@ from typing import Any, AsyncIterator, Callable, Generator, Iterator
+ from unittest import mock
+ from uuid import uuid4
+ 
+-import isal.isal_zlib
+ import pytest
+ import zlib_ng.zlib_ng
+ from blockbuster import blockbuster_ctx
+@@ -333,7 +332,7 @@ def unused_port_socket() -> Generator[socket.socket, None, None]:
+         s.close()
+ 
+ 
+-@pytest.fixture(params=[zlib, zlib_ng.zlib_ng, isal.isal_zlib])
++@pytest.fixture(params=[zlib, zlib_ng.zlib_ng])
+ def parametrize_zlib_backend(
+     request: pytest.FixtureRequest,
+ ) -> Generator[None, None, None]:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
