### PR TITLE
jaxodraw: init at 2.1-0-unstable-2025-01-18

### DIFF
--- a/pkgs/by-name/ja/jaxodraw/package.nix
+++ b/pkgs/by-name/ja/jaxodraw/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  maven,
+  fetchsvn,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  jdk,
+  jre,
+}:
+
+let
+  version = "2.1-0-unstable-2025-01-18";
+  description = "Java program for drawing Feynman diagrams";
+in
+maven.buildMavenPackage {
+  pname = "jaxodraw";
+  inherit version;
+
+  # pom.xml in the 2.1-0 source refers to non-existent ../pom/pom.xml and fails to build.
+  # src = fetchurl {
+  #   url = "mirror://sourceforge/jaxodraw/jaxodraw-${version}-src.tar.gz";
+  #   hash = "sha256-EE0amcFKm/zUO4PzPhkPYZYykZw+ARJFu0/hlUOhu5s=";
+  # };
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/jaxodraw/code/trunk/jaxodraw";
+    rev = "3346";
+    hash = "sha256-jZ2Jvrysb5TeoAw5gubhtn39gMxdAGh/vTsaSIEZ7zs=";
+  };
+
+  mvnJdk = jdk;
+  mvnParameters = "-PskipTests"; # Tests fail
+  mvnHash = "sha256-QfMyiz0zWFi3kUwH8pcgu7FiXleP/KO111avs1WWWG0=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "jaxodraw";
+      desktopName = "JaxoDraw";
+      exec = "jaxodraw";
+      icon = "jaxodraw";
+      categories = [
+        "Science"
+        "Education"
+        "Physics"
+      ];
+      comment = description;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 target/jaxodraw-*-with-deps.jar $out/lib/jaxodraw/jaxodraw.jar
+    makeWrapper ${lib.getExe jre} $out/bin/jaxodraw \
+      --add-flags "-jar $out/lib/jaxodraw/jaxodraw.jar"
+
+    install -Dm644 src/site/resources/images/top.png $out/share/icons/hicolor/128x128/apps/jaxodraw.png
+
+    runHook postInstall
+  '';
+
+  meta = {
+    inherit description;
+    homepage = "https://jaxodraw.sourceforge.io";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    mainProgram = "jaxodraw";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This version seems to have a bug of not exiting after the user closes the GUI, but <kbd>Ctrl</kbd>+<kbd>C</kbd> works.

The unstable version does not seem to need `axodraw4j.sty` anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
