### PR TITLE
Revert "nixos-rebuild-ng: silence reexec messages" 

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -13,7 +13,9 @@ from .models import Action, BuildAttr, Flake, ImageVariants, NRError, Profile
 from .process import Remote, cleanup_ssh
 from .utils import Args, LogFormatter, tabulate
 
-logger: Final = logging.getLogger()
+NIXOS_REBUILD_ATTR: Final = "config.system.build.nixos-rebuild"
+
+logger: Final = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
@@ -276,33 +278,33 @@ def reexec(
     flake_build_flags: Args,
 ) -> None:
     drv = None
-    attr = "config.system.build.nixos-rebuild"
     try:
         # Parsing the args here but ignore ask_sudo_password since it is not
         # needed and we would end up asking sudo password twice
         if flake := Flake.from_arg(args.flake, Remote.from_arg(args.target_host, None)):
             drv = nix.build_flake(
-                attr,
+                NIXOS_REBUILD_ATTR,
                 flake,
                 flake_build_flags | {"no_link": True},
             )
         else:
             build_attr = BuildAttr.from_arg(args.attr, args.file)
             drv = nix.build(
-                attr,
+                NIXOS_REBUILD_ATTR,
                 build_attr,
                 build_flags | {"no_out_link": True},
             )
     except CalledProcessError:
         logger.warning(
-            "could not build a newer version of nixos-rebuild, using current version"
+            "could not build a newer version of nixos-rebuild, using current version",
+            exc_info=logger.isEnabledFor(logging.DEBUG),
         )
 
     if drv:
         new = drv / f"bin/{EXECUTABLE}"
         current = Path(argv[0])
         if new != current:
-            logging.debug(
+            logger.debug(
                 "detected newer version of script, re-exec'ing, current=%s, new=%s",
                 current,
                 new,
@@ -319,9 +321,9 @@ def reexec(
                 # - Exec format error (e.g.: another OS/CPU arch)
                 logger.warning(
                     "could not re-exec in a newer version of nixos-rebuild, "
-                    + "using current version"
+                    + "using current version",
+                    exc_info=logger.isEnabledFor(logging.DEBUG),
                 )
-                logger.debug("re-exec exception", exc_info=True)
                 # We already run clean-up, let's re-exec in the current version
                 # to avoid issues
                 os.execve(current, argv, os.environ | {"_NIXOS_REBUILD_REEXEC": "1"})

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -51,7 +51,6 @@ def build(
     attr: str,
     build_attr: BuildAttr,
     build_flags: Args | None = None,
-    quiet: bool = False,
 ) -> Path:
     """Build NixOS attribute using classic Nix.
 
@@ -64,7 +63,7 @@ def build(
         build_attr.to_attr(attr),
         *dict_to_flags(build_flags),
     ]
-    r = run_wrapper(run_args, stdout=PIPE, stderr=PIPE if quiet else None)
+    r = run_wrapper(run_args, stdout=PIPE)
     return Path(r.stdout.strip())
 
 
@@ -72,7 +71,6 @@ def build_flake(
     attr: str,
     flake: Flake,
     flake_build_flags: Args | None = None,
-    quiet: bool = False,
 ) -> Path:
     """Build NixOS attribute using Flakes.
 
@@ -86,7 +84,7 @@ def build_flake(
         flake.to_attr(attr),
         *dict_to_flags(flake_build_flags),
     ]
-    r = run_wrapper(run_args, stdout=PIPE, stderr=PIPE if quiet else None)
+    r = run_wrapper(run_args, stdout=PIPE)
     return Path(r.stdout.strip())
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -140,10 +140,9 @@ def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -
     mock_build.assert_has_calls(
         [
             call(
-                nr.NIXOS_REBUILD_ATTR,
+                "config.system.build.nixos-rebuild",
                 nr.models.BuildAttr(ANY, ANY),
                 {"build": True, "no_out_link": True},
-                quiet=True,
             )
         ]
     )
@@ -188,7 +187,6 @@ def test_reexec_flake(
         "config.system.build.nixos-rebuild",
         nr.models.Flake(ANY, ANY),
         {"flake": True, "no_link": True},
-        quiet=True,
     )
     # do not exec if there is no new version
     mock_execve.assert_not_called()
@@ -268,7 +266,6 @@ def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
                 ],
                 check=True,
                 stdout=PIPE,
-                stderr=None,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(
@@ -343,7 +340,6 @@ def test_execute_nix_build_vm(mock_run: Mock, tmp_path: Path) -> None:
                 ],
                 check=True,
                 stdout=PIPE,
-                stderr=None,
                 **DEFAULT_RUN_KWARGS,
             )
         ]
@@ -408,7 +404,6 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
                 ],
                 check=True,
                 stdout=PIPE,
-                stderr=None,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(
@@ -476,7 +471,6 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
                 ],
                 check=True,
                 stdout=PIPE,
-                stderr=None,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(
@@ -767,7 +761,6 @@ def test_execute_nix_switch_flake_target_host(
                 ],
                 check=True,
                 stdout=PIPE,
-                stderr=None,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(
@@ -1035,7 +1028,6 @@ def test_execute_build(mock_run: Mock, tmp_path: Path) -> None:
                 ],
                 check=True,
                 stdout=PIPE,
-                stderr=None,
                 **DEFAULT_RUN_KWARGS,
             )
         ]
@@ -1075,7 +1067,6 @@ def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
                 ],
                 check=True,
                 stdout=PIPE,
-                stderr=None,
                 **DEFAULT_RUN_KWARGS,
             ),
             call(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -140,7 +140,7 @@ def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -
     mock_build.assert_has_calls(
         [
             call(
-                "config.system.build.nixos-rebuild",
+                nr.NIXOS_REBUILD_ATTR,
                 nr.models.BuildAttr(ANY, ANY),
                 {"build": True, "no_out_link": True},
             )
@@ -184,7 +184,7 @@ def test_reexec_flake(
 
     nr.reexec(argv, args, {"build": True}, {"flake": True})
     mock_build.assert_called_once_with(
-        "config.system.build.nixos-rebuild",
+        nr.NIXOS_REBUILD_ATTR,
         nr.models.Flake(ANY, ANY),
         {"flake": True, "no_link": True},
     )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -36,18 +36,14 @@ def test_build(mock_run: Mock) -> None:
             "foo",
         ],
         stdout=PIPE,
-        stderr=None,
     )
 
     assert n.build(
-        "config.system.build.attr",
-        m.BuildAttr(Path("file"), "preAttr"),
-        quiet=True,
+        "config.system.build.attr", m.BuildAttr(Path("file"), "preAttr")
     ) == Path("/path/to/file")
     mock_run.assert_called_with(
         ["nix-build", Path("file"), "--attr", "preAttr.config.system.build.attr"],
         stdout=PIPE,
-        stderr=PIPE,
     )
 
 
@@ -78,26 +74,6 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
             "foo",
         ],
         stdout=PIPE,
-        stderr=None,
-    )
-
-    assert n.build_flake(
-        "config.system.build.toplevel",
-        flake,
-        None,
-        quiet=True,
-    ) == Path("/path/to/file")
-    mock_run.assert_called_with(
-        [
-            "nix",
-            "--extra-experimental-features",
-            "nix-command flakes",
-            "build",
-            "--print-out-paths",
-            '.#nixosConfigurations."hostname".config.system.build.toplevel',
-        ],
-        stdout=PIPE,
-        stderr=PIPE,
     )
 
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #417303.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
