### PR TITLE
dput-ng: Add missing dependency python3Packages.distro-info, install required configuration files

### DIFF
--- a/pkgs/by-name/di/distro-info-data/package.nix
+++ b/pkgs/by-name/di/distro-info-data/package.nix
@@ -1,0 +1,29 @@
+{
+  fetchFromGitLab,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "distro-info-data";
+  version = "0.67";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = "distro-info-data";
+    tag = "debian/${finalAttrs.version}";
+    hash = "sha256-xm/ajsPKtnmuyEkVxM1AxV7Tl0njkqjOmhE5rKRQ36Q=";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "Information about Debian and Ubuntu releases";
+    homepage = "https://salsa.debian.org/debian/distro-info-data";
+    changelog = "https://salsa.debian.org/debian/distro-info-data/-/blob/${finalAttrs.src.tag}/debian/changelog";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ andersk ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/dp/dput-ng/package.nix
+++ b/pkgs/by-name/dp/dput-ng/package.nix
@@ -31,6 +31,7 @@ python3.pkgs.buildPythonApplication {
     coverage
     xdg
     python-debian
+    distro-info
   ];
 
   postInstall = ''

--- a/pkgs/by-name/dp/dput-ng/package.nix
+++ b/pkgs/by-name/dp/dput-ng/package.nix
@@ -20,6 +20,10 @@ python3.pkgs.buildPythonApplication {
     hash = "sha256-zrH4h4C4y3oTiOXsidFv/rIJNzCdV2lqzNEg0SOkX4w=";
   };
 
+  postPatch = ''
+    substituteInPlace dput/core.py --replace-fail /usr/share/dput-ng "$out/share/dput-ng"
+  '';
+
   build-system = with python3.pkgs; [
     setuptools
   ];
@@ -36,6 +40,8 @@ python3.pkgs.buildPythonApplication {
 
   postInstall = ''
     cp -r bin $out/
+    mkdir -p "$out/share/dput-ng"
+    cp -r skel/* "$out/share/dput-ng/"
   '';
 
   pythonImportsCheck = [ "dput" ];

--- a/pkgs/development/python-modules/distro-info/default.nix
+++ b/pkgs/development/python-modules/distro-info/default.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  distro-info-data,
+  fetchurl,
+  lib,
+  setuptools,
+  unittestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "distro-info";
+  version = "1.14";
+  pyproject = true;
+
+  # Not using fetchFromGitLab because it incorrectly sets
+  # SOURCE_DATE_EPOCH=315619200 (1980-01-02) and breaks tests.
+  src = fetchurl {
+    url = "https://salsa.debian.org/debian/distro-info/-/archive/debian/${version}/distro-info-debian-${version}.tar.gz";
+    hash = "sha256-nRLTlDPnll1jvwfg9FSxs9TmImvQkn9DVqSRSOKTAGI=";
+  };
+
+  postPatch = ''
+    substituteInPlace python/distro_info.py \
+      --replace-fail /usr/share/distro-info ${distro-info-data}/share/distro-info
+  '';
+
+  build-system = [ setuptools ];
+  pypaBuildFlags = "python";
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+  preCheck = ''
+    cd python
+    rm distro_info_test/test_flake8.py distro_info_test/test_pylint.py
+  '';
+
+  meta = {
+    description = "Information about Debian and Ubuntu releases";
+    homepage = "https://salsa.debian.org/debian/distro-info";
+    changelog = "https://salsa.debian.org/debian/distro-info/-/blob/debian/${version}/debian/changelog";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ andersk ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3645,6 +3645,8 @@ self: super: with self; {
 
   distro = callPackage ../development/python-modules/distro { };
 
+  distro-info = callPackage ../development/python-modules/distro-info { };
+
   distutils =
     if pythonOlder "3.12" then null else callPackage ../development/python-modules/distutils { };
 


### PR DESCRIPTION
I needed these fixes to get dput-ng to run successfully.

```console
$ dput ppa:andersk/ppa hello_2.10-5~ppa1_source.changes
Uploading hello using ftp to ppa (host: ppa.launchpad.net; directory: ~andersk/ppa)
running supported-distribution: check whether the target distribution is currently supported (using distro-info)
{'allowed': ['release'], 'known': ['release', 'proposed', 'updates', 'backports', 'security']}
running required-fields: check whether a field is present and non-empty in the changes file
running checksum: verify checksums before uploading
running suite-mismatch: check the target distribution for common errors
running check-debs: makes sure the upload contains a binary package
running gpg: check GnuPG signatures before the upload
Uploading hello_2.10-5~ppa1.dsc
Uploading hello_2.10.orig.tar.gz
Uploading hello_2.10.orig.tar.gz.asc
Uploading hello_2.10-5~ppa1.debian.tar.xz
Uploading hello_2.10-5~ppa1_source.buildinfo
Uploading hello_2.10-5~ppa1_source.changes
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
