### PR TITLE
dbus-broker: 36 -> 37

### DIFF
--- a/pkgs/by-name/db/dbus-broker/package.nix
+++ b/pkgs/by-name/db/dbus-broker/package.nix
@@ -13,7 +13,10 @@
 
 let
   meta = {
-    maintainers = with lib.maintainers; [ peterhoeg ];
+    maintainers = with lib.maintainers; [
+      peterhoeg
+      rvdp
+    ];
     platforms = lib.platforms.linux;
   };
 

--- a/pkgs/by-name/db/dbus-broker/package.nix
+++ b/pkgs/by-name/db/dbus-broker/package.nix
@@ -54,8 +54,8 @@ let
   # part of the dbus-broker project, just in separate repositories.
   c-dvar = dep {
     pname = "c-dvar";
-    version = "1.1.0";
-    hash = "sha256-p/C+BktclVseCtZJ1Q/YK03vP2ClnYRLB1Vmj2OQJD4=";
+    version = "1.2.0";
+    hash = "sha256-OlV6yR1tNWFN+rxPPGmbfbh7WyB6FwORyZR1V553iYE=";
     buildInputs = [
       c-stdaux
       c-utf8
@@ -91,8 +91,8 @@ let
   };
   c-stdaux = dep {
     pname = "c-stdaux";
-    version = "1.5.0";
-    hash = "sha256-MsnuEyVCmOIr/q6I1qyPsNXp48jxIEcXoYLHbOAZtW0=";
+    version = "1.6.0";
+    hash = "sha256-/15lop+WUkTW9v9h7BBdwRSpJgcBXaJNtMM7LXgcQE4=";
   };
   c-utf8 = dep {
     pname = "c-utf8";
@@ -105,13 +105,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dbus-broker";
-  version = "36";
+  version = "37";
 
   src = fetchFromGitHub {
     owner = "bus1";
     repo = "dbus-broker";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-5dAMKjybqrHG57vArbtWEPR/svSj2ION75JrjvnnpVM=";
+    hash = "sha256-a9ydcJKZP8MLzu9lv40p9sTyo8IsU++9HOFeGU3+Tok=";
   };
 
   patches = [

--- a/pkgs/by-name/db/dbus-broker/paths.patch
+++ b/pkgs/by-name/db/dbus-broker/paths.patch
@@ -1,11 +1,11 @@
 diff --git a/src/launch/launcher.c b/src/launch/launcher.c
-index 5bf5cf5..06ce7f4 100644
+index 7b1fb19..6bc2c46 100644
 --- a/src/launch/launcher.c
 +++ b/src/launch/launcher.c
-@@ -924,9 +924,7 @@ static int launcher_load_standard_session_services(Launcher *launcher, NSSCache
- 
- static int launcher_load_standard_system_services(Launcher *launcher, NSSCache *nss_cache) {
+@@ -945,9 +945,7 @@ static int launcher_load_standard_system_services(Launcher *launcher, NSSCache *
          static const char *default_data_dirs[] = {
+                 "/etc",
+                 "/run",
 -                "/usr/local/share",
 -                "/usr/share",
 -                "/lib",
@@ -13,7 +13,7 @@ index 5bf5cf5..06ce7f4 100644
                  NULL,
          };
          const char *suffix = "dbus-1/system-services";
-@@ -1012,9 +1010,9 @@ static int launcher_parse_config(Launcher *launcher, ConfigRoot **rootp, NSSCach
+@@ -1033,9 +1031,9 @@ static int launcher_parse_config(Launcher *launcher, ConfigRoot **rootp, NSSCach
          if (launcher->configfile)
                  configfile = launcher->configfile;
          else if (launcher->user_scope)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
https://github.com/bus1/dbus-broker/releases/tag/v37

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
