### PR TITLE
python3Packages.{kokoro, misaki}: init at 0-unstable-2025-06-16

### DIFF
--- a/pkgs/development/python-modules/kokoro/default.nix
+++ b/pkgs/development/python-modules/kokoro/default.nix
@@ -1,0 +1,59 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchPypi,
+  hatchling,
+  huggingface-hub,
+  lib,
+  loguru,
+  misaki,
+  numpy,
+  pytestCheckHook,
+  torch,
+  transformers,
+}:
+
+buildPythonPackage {
+  pname = "kokoro";
+  version = "0-unstable-2025-06-16";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hexgrad";
+    repo = "kokoro";
+    rev = "2668b2e279d0f94977995230e523b0183763f30e";
+    hash = "sha256-slXbn0W1632Hak6Z0ofF0gyavxRLoxS4fyPQLHSapjA=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    huggingface-hub
+    loguru
+    misaki
+    numpy
+    torch
+    transformers
+  ] ++ misaki.optional-dependencies.en; # kokoro depends on misaki[en]
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    # See https://github.com/hexgrad/kokoro/issues/225
+    "test_different_window_sizes"
+    "test_stft_reconstruction"
+  ];
+
+  pythonImportsCheck = [
+    "kokoro"
+  ];
+
+  meta = {
+    description = "Open-weight TTS model with 82 million parameters";
+    homepage = "https://github.com/hexgrad/kokoro";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/misaki/default.nix
+++ b/pkgs/development/python-modules/misaki/default.nix
@@ -1,0 +1,118 @@
+{
+  addict,
+  buildPythonPackage,
+  espeak-ng,
+  fetchFromGitHub,
+  fetchpatch2,
+  fugashi,
+  hatchling,
+  jaconv,
+  jamo,
+  jieba,
+  lib,
+  nltk,
+  num2words,
+  ordered-set,
+  phonemizer,
+  pip,
+  pypinyin,
+  pythonOlder,
+  regex,
+  replaceVars,
+  spacy-curated-transformers,
+  spacy,
+  pytestCheckHook,
+  stdenv,
+  torch,
+  transformers,
+  unidic,
+}:
+
+buildPythonPackage {
+  pname = "misaki";
+  version = "0-unstable-2025-06-16";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hexgrad";
+    repo = "misaki";
+    rev = "49ddead831fc1a46beab3f9cb6064d93fd3f6347";
+    hash = "sha256-XkmCG0Vkw/iyLNmwhaW5gp6sg8ieHFeK6fBJ3Jb+J8Q=";
+  };
+
+  patches = [
+    (fetchpatch2 {
+      name = "pr82-remove-pip-dependency.patch";
+      url = "https://github.com/hexgrad/misaki/commit/7d2fdff9fe046dd52b638bbb1b243fb789f4cb31.patch?full_index=1";
+      hash = "sha256-N796YWrGe51FYVdxbQ8omJxeGdvOAiKEUKhhm10TQO8=";
+    })
+    (replaceVars ./set-espeak-paths.patch {
+      espeak-library-path = "${lib.getLib espeak-ng}/lib/libespeak-ng${stdenv.hostPlatform.extensions.sharedLibrary}";
+      espeak-data-path = "${lib.getLib espeak-ng}/share/espeak-ng-data";
+    })
+  ];
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    addict
+    regex
+  ];
+
+  # See https://github.com/hexgrad/misaki/blob/main/pyproject.toml#L26
+  passthru.optional-dependencies = {
+    en = [
+      num2words
+      spacy
+      spacy-curated-transformers
+      phonemizer
+      # phonemizer-fork -- we already patch phonemizer in nixpkgs, no need for the "-fork" version
+      # espeakng-loader -- ./set-espeak-paths.patch obviates the need for this
+      torch
+      transformers
+    ];
+    ja = [
+      fugashi
+      jaconv
+      # mojimoji -- not packaged as of 2025-06-16
+      unidic
+      # pyopenjtalk -- not packaged as of 2025-06-16
+    ];
+    ko = [
+      jamo
+      nltk
+    ];
+    zh = [
+      jieba
+      ordered-set
+      pypinyin
+      # cn2an -- not packaged as of 2025-06-16
+      # pypinyin-dict -- not packaged as of 2025-06-16
+    ];
+    vi = [
+      num2words
+      spacy
+      spacy-curated-transformers
+      # underthesea -- not packaged as of 2025-06-16
+    ];
+    # he = [ mishkal-hebrew ]; -- not packaged as of 2025-06-16
+  };
+
+  # Package does not have tests as of 2025-06-16, but phonemizer is required for
+  # pythonImportsCheck.
+  nativeCheckInputs = [ phonemizer ];
+
+  pythonImportsCheck = [
+    "misaki"
+    "misaki.espeak"
+  ];
+
+  meta = {
+    description = "G2P engine for TTS";
+    homepage = "https://github.com/hexgrad/misaki";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/misaki/set-espeak-paths.patch
+++ b/pkgs/development/python-modules/misaki/set-espeak-paths.patch
@@ -1,0 +1,20 @@
+diff --git a/misaki/espeak.py b/misaki/espeak.py
+index e5d880c..42c2596 100644
+--- a/misaki/espeak.py
++++ b/misaki/espeak.py
+@@ -1,13 +1,12 @@
+ from phonemizer.backend.espeak.wrapper import EspeakWrapper
+ from typing import Tuple
+-import espeakng_loader
+ import phonemizer
+ import re
+ 
+ # Set espeak-ng library path and espeak-ng-data
+-EspeakWrapper.set_library(espeakng_loader.get_library_path())
++EspeakWrapper.set_library("@espeak-library-path@")
+ # Change data_path as needed when editing espeak-ng phonemes
+-EspeakWrapper.set_data_path(espeakng_loader.get_data_path())
++EspeakWrapper.set_data_path("@espeak-data-path@")
+ 
+ # EspeakFallback is used as a last resort for English
+ class EspeakFallback:

--- a/pkgs/development/python-modules/phonemizer/default.nix
+++ b/pkgs/development/python-modules/phonemizer/default.nix
@@ -4,6 +4,7 @@
   replaceVars,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch2,
   joblib,
   segments,
   attrs,
@@ -30,6 +31,13 @@ buildPythonPackage rec {
     (replaceVars ./backend-paths.patch {
       libespeak = "${lib.getLib espeak-ng}/lib/libespeak-ng${stdenv.hostPlatform.extensions.sharedLibrary}";
       # FIXME package festival
+    })
+    # This patch is needed for python3Packages.misaki. See https://github.com/thewh1teagle/espeakng-loader?tab=readme-ov-file#usage-with-phonemizer
+    # and https://github.com/bootphon/phonemizer/pull/191.
+    (fetchpatch2 {
+      name = "pr191-add-option-to-use-custom-espeak-data-path.patch";
+      url = "https://github.com/bootphon/phonemizer/commit/cc1db4bfaf688fdfb8275fd83d218f06411455e6.patch?full_index=1";
+      hash = "sha256-PMeX7A9BBVLS3Sk/Lum85GpJzKXM5tULTWSURq3MD8E=";
     })
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7630,6 +7630,8 @@ self: super: with self; {
 
   knx-frontend = callPackage ../development/python-modules/knx-frontend { };
 
+  kokoro = callPackage ../development/python-modules/kokoro { };
+
   kombu = callPackage ../development/python-modules/kombu { };
 
   konnected = callPackage ../development/python-modules/konnected { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9080,6 +9080,8 @@ self: super: with self; {
 
   misaka = callPackage ../development/python-modules/misaka { };
 
+  misaki = callPackage ../development/python-modules/misaki { };
+
   misoc = callPackage ../development/python-modules/misoc { };
 
   miss-hit = callPackage ../development/python-modules/miss-hit { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
