### PR TITLE
treewide: remove bluescreen303 as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3432,12 +3432,6 @@
     githubId = 75451918;
     name = "Charlie Root";
   };
-  bluescreen303 = {
-    email = "mathijs@bluescreen303.nl";
-    github = "bluescreen303";
-    githubId = 16330;
-    name = "Mathijs Kwik";
-  };
   blusk = {
     email = "bluskript@gmail.com";
     github = "bluskript";

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -12,7 +12,6 @@ in
 {
   name = "mongodb";
   meta.maintainers = with pkgs.lib.maintainers; [
-    bluescreen303
     offline
     phile314
     niklaskorz

--- a/pkgs/by-name/an/andyetitmoves/package.nix
+++ b/pkgs/by-name/an/andyetitmoves/package.nix
@@ -95,6 +95,5 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.andyetitmoves.net/";
     license = licenses.unfree;
-    maintainers = with maintainers; [ bluescreen303 ];
   };
 }

--- a/pkgs/by-name/du/duperemove/package.nix
+++ b/pkgs/by-name/du/duperemove/package.nix
@@ -57,7 +57,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/markfasheh/duperemove";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [
-      bluescreen303
       thoughtpolice
     ];
     platforms = platforms.linux;

--- a/pkgs/by-name/gp/gpac/package.nix
+++ b/pkgs/by-name/gp/gpac/package.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gpac.wp.imt.fr";
     license = licenses.lgpl21;
     maintainers = with maintainers; [
-      bluescreen303
       mgdelacroix
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/li/liblockfile/package.nix
+++ b/pkgs/by-name/li/liblockfile/package.nix
@@ -27,8 +27,6 @@ stdenv.mkDerivation rec {
     mainProgram = "dotlockfile";
     homepage = "http://packages.debian.org/unstable/libs/liblockfile1";
     license = lib.licenses.gpl2Plus;
-
-    maintainers = [ lib.maintainers.bluescreen303 ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/lo/lockfileProgs/package.nix
+++ b/pkgs/by-name/lo/lockfileProgs/package.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation rec {
     description = "Programs for locking and unlocking files and mailboxes";
     homepage = "http://packages.debian.org/sid/lockfile-progs";
     license = lib.licenses.gpl2Only;
-
-    maintainers = [ lib.maintainers.bluescreen303 ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/lo/logcheck/package.nix
+++ b/pkgs/by-name/lo/logcheck/package.nix
@@ -49,6 +49,5 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://salsa.debian.org/debian/logcheck";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.bluescreen303 ];
   };
 }

--- a/pkgs/by-name/sa/safecopy/package.nix
+++ b/pkgs/by-name/sa/safecopy/package.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
 
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.bluescreen303 ];
     mainProgram = "safecopy";
   };
 }

--- a/pkgs/by-name/sp/spice-protocol/package.nix
+++ b/pkgs/by-name/sp/spice-protocol/package.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
     description = "Protocol headers for the SPICE protocol";
     homepage = "https://www.spice-space.org/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ bluescreen303 ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/by-name/sp/spice/package.nix
+++ b/pkgs/by-name/sp/spice/package.nix
@@ -108,7 +108,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21;
 
     maintainers = with maintainers; [
-      bluescreen303
       atemu
     ];
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/by-name/vo/vobcopy/package.nix
+++ b/pkgs/by-name/vo/vobcopy/package.nix
@@ -28,8 +28,6 @@ stdenv.mkDerivation rec {
     description = "Copies DVD .vob files to harddisk, decrypting them on the way";
     homepage = "http://vobcopy.org/projects/c/c.shtml";
     license = lib.licenses.gpl2Plus;
-
-    maintainers = [ lib.maintainers.bluescreen303 ];
     platforms = lib.platforms.all;
     mainProgram = "vobcopy";
   };

--- a/pkgs/os-specific/linux/i7z/default.nix
+++ b/pkgs/os-specific/linux/i7z/default.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation rec {
     mainProgram = "i7z";
     homepage = "https://github.com/DimitryAndric/i7z";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ bluescreen303 ];
     # broken on ARM
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -188,7 +188,6 @@ stdenv.mkDerivation rec {
     inherit license;
 
     maintainers = with maintainers; [
-      bluescreen303
       offline
     ];
     platforms = subtractLists systems.doubles.i686 systems.doubles.unix;

--- a/pkgs/servers/nosql/rethinkdb/default.nix
+++ b/pkgs/servers/nosql/rethinkdb/default.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       thoughtpolice
-      bluescreen303
     ];
   };
 }

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -104,7 +104,6 @@ buildPythonPackage rec {
     '';
     license = licenses.publicDomain;
     maintainers = with maintainers; [
-      bluescreen303
       fpletz
     ];
     platforms = with platforms; linux ++ darwin;


### PR DESCRIPTION
@bluescreen303 has been totally inactive on GitHub since January, and inactive on nixpkgs since December 2022. Removal of them as a maintainer (assuming they do not become active in the next week) would help ensure that we don't wait unnecessarily for them, and could help others adopt their packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
