### PR TITLE
treewide: use pytest-cov-stub

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -68,7 +68,7 @@ let
       nativeCheckInputs = with pypkgs; [
         pytestCheckHook
         pytest-twisted
-        pytest-cov
+        pytest-cov-stub
         mock
         mccabe
         pylint

--- a/pkgs/by-name/be/bepasty/package.nix
+++ b/pkgs/by-name/be/bepasty/package.nix
@@ -57,7 +57,7 @@ bepastyPython.pkgs.buildPythonPackage rec {
     build
     flake8
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     selenium
     tox
     twine

--- a/pkgs/by-name/bu/buku/package.nix
+++ b/pkgs/by-name/bu/buku/package.nix
@@ -40,14 +40,14 @@ buildPythonApplication rec {
 
   nativeCheckInputs = [
     hypothesis
-    pytest
+    pytestCheckHook
     pytest-recording
     pyyaml
     mypy-extensions
     click
     pylint
     flake8
-    pytest-cov
+    pytest-cov-stub
     pyyaml
   ];
 

--- a/pkgs/by-name/ca/canaille/package.nix
+++ b/pkgs/by-name/ca/canaille/package.nix
@@ -58,7 +58,7 @@ python.pkgs.buildPythonApplication rec {
       coverage
       flask-webtest
       pyquery
-      pytest-cov
+      pytest-cov-stub
       pytest-httpserver
       pytest-lazy-fixtures
       pytest-smtpd

--- a/pkgs/by-name/cl/cloudsmith-cli/package.nix
+++ b/pkgs/by-name/cl/cloudsmith-cli/package.nix
@@ -51,7 +51,7 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = with python3.pkgs; [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   checkInputs = with python3.pkgs; [

--- a/pkgs/by-name/fa/fastcov/package.nix
+++ b/pkgs/by-name/fa/fastcov/package.nix
@@ -32,7 +32,7 @@ python3Packages.buildPythonPackage rec {
   dontUseCmakeConfigure = true; # cmake is used for testing
 
   nativeCheckInputs = with python3Packages; [
-    pytest
+    pytestCheckHook
     pytest-cov-stub
   ];
 

--- a/pkgs/by-name/gi/git-pw/package.nix
+++ b/pkgs/by-name/gi/git-pw/package.nix
@@ -36,7 +36,7 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs = with python3.pkgs; [
     pytest-cov-stub
-    pytest
+    pytestCheckHook
     git
   ];
 

--- a/pkgs/by-name/gi/gitfs/package.nix
+++ b/pkgs/by-name/gi/gitfs/package.nix
@@ -27,8 +27,8 @@ python3Packages.buildPythonApplication rec {
   '';
 
   nativeCheckInputs = with python3Packages; [
-    pytest
-    pytest-cov
+    pytestCheckHook
+    pytest-cov-stub
     mock
   ];
   propagatedBuildInputs = with python3Packages; [
@@ -38,8 +38,7 @@ python3Packages.buildPythonApplication rec {
     six
   ];
 
-  checkPhase = "py.test";
-  doCheck = false;
+  pythonImportsCheck = [ "gitfs" ];
 
   meta = {
     description = "FUSE filesystem that fully integrates with git";
@@ -53,5 +52,8 @@ python3Packages.buildPythonApplication rec {
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.robbinch ];
     mainProgram = "gitfs";
+    # requires <=python39, otherwise you get this at runtime:
+    # AttributeError: module 'collections' has no attribute 'MutableMapping'
+    broken = true;
   };
 }

--- a/pkgs/by-name/me/memray/package.nix
+++ b/pkgs/by-name/me/memray/package.nix
@@ -44,7 +44,7 @@ python3Packages.buildPythonApplication rec {
     with python3Packages;
     [
       ipython
-      pytest-cov # fix Unknown pytest.mark.no_cover
+      pytest-cov-stub # fix Unknown pytest.mark.no_cover
       pytest-textual-snapshot
       pytestCheckHook
     ]

--- a/pkgs/by-name/pa/patroni/package.nix
+++ b/pkgs/by-name/pa/patroni/package.nix
@@ -44,7 +44,7 @@ python3Packages.buildPythonApplication rec {
     flake8
     mock
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     requests
     versionCheckHook
     writableTmpDirAsHomeHook

--- a/pkgs/by-name/re/rexi/package.nix
+++ b/pkgs/by-name/re/rexi/package.nix
@@ -27,9 +27,9 @@ python3Packages.buildPythonApplication rec {
   ];
 
   nativeCheckInputs = with python3Packages; [
-    pytest
+    pytestCheckHook
     pytest-asyncio
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/by-name/so/solaar/package.nix
+++ b/pkgs/by-name/so/solaar/package.nix
@@ -56,7 +56,7 @@ python3Packages.buildPythonApplication rec {
   nativeCheckInputs = with python3Packages; [
     pytestCheckHook
     pytest-mock
-    pytest-cov
+    pytest-cov-stub
   ];
 
   # the -cli symlink is just to maintain compabilility with older versions where

--- a/pkgs/by-name/un/unblob/package.nix
+++ b/pkgs/by-name/un/unblob/package.nix
@@ -116,7 +116,7 @@ python3.pkgs.buildPythonApplication rec {
     with python3.pkgs;
     [
       pytestCheckHook
-      pytest-cov
+      pytest-cov # cannot use stub
       versionCheckHook
     ]
     ++ runtimeDeps;

--- a/pkgs/by-name/vi/vim-vint/package.nix
+++ b/pkgs/by-name/vi/vim-vint/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
 }:
 
 with python3Packages;
@@ -10,17 +10,19 @@ buildPythonApplication rec {
   pname = "vim-vint";
   version = "0.3.21";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "15qdh8fby9xgfjxidcfv1xmrqqrxxapky7zmyn46qx1abhp9piax";
+  src = fetchFromGitHub {
+    owner = "Vimjas";
+    repo = "vint";
+    tag = "v${version}";
+    hash = "sha256-A0yXDkB/b9kEEXSoLeqVdmdm4p2PYL2QHqbF4FgAn30=";
   };
 
   # For python 3.5 > version > 2.7 , a nested dependency (pythonPackages.hypothesis) fails.
   disabled = !pythonAtLeast "3.5";
 
   nativeCheckInputs = [
-    pytest
-    pytest-cov
+    pytestCheckHook
+    pytest-cov-stub
   ];
   propagatedBuildInputs = [
     ansicolor
@@ -29,10 +31,13 @@ buildPythonApplication rec {
     setuptools
   ];
 
-  # Unpin test dependency versions. This is fixed in master but not yet released.
   preCheck = ''
-    sed -i 's/==.*//g' test-requirements.txt
-    sed -i 's/mock == 1.0.1/mock/g' setup.py
+    substituteInPlace \
+      test/acceptance/test_cli.py \
+      test/acceptance/test_cli_vital.py \
+      --replace-fail \
+        "cmd = ['bin/vint'" \
+        "cmd = ['$out/bin/vint'"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/vu/vulnix/package.nix
+++ b/pkgs/by-name/vu/vulnix/package.nix
@@ -28,8 +28,8 @@ python3Packages.buildPythonApplication rec {
 
   nativeCheckInputs = with python3Packages; [
     freezegun
-    pytest
-    pytest-cov
+    pytestCheckHook
+    pytest-cov-stub
   ];
 
   propagatedBuildInputs =
@@ -48,7 +48,7 @@ python3Packages.buildPythonApplication rec {
 
   postBuild = "make -C doc";
 
-  checkPhase = "py.test src/vulnix";
+  pytestFlagsArray = [ "src/vulnix" ];
 
   postInstall = ''
     install -D -t $doc/share/doc/vulnix README.rst CHANGES.rst

--- a/pkgs/by-name/zu/zulip-term/package.nix
+++ b/pkgs/by-name/zu/zulip-term/package.nix
@@ -67,7 +67,7 @@ buildPythonApplication rec {
     ]
     ++ (with python3.pkgs; [
       pytestCheckHook
-      pytest-cov
+      pytest-cov-stub
       pytest-mock
     ]);
 

--- a/pkgs/development/python-modules/colcon-mixin/default.nix
+++ b/pkgs/development/python-modules/colcon-mixin/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   colcon,
-  pytest-cov,
+  pytest-cov-stub,
   pytestCheckHook,
   setuptools,
   scspell,
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytest-cov
+    pytest-cov-stub
     pytestCheckHook
     scspell
     writableTmpDirAsHomeHook

--- a/pkgs/development/python-modules/colcon-ros-domain-id-coordinator/default.nix
+++ b/pkgs/development/python-modules/colcon-ros-domain-id-coordinator/default.nix
@@ -4,7 +4,7 @@
   colcon,
   fetchFromGitHub,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-repeat,
   pytest-rerunfailures,
   scspell,
@@ -30,7 +30,7 @@ buildPythonPackage {
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     pytest-repeat
     pytest-rerunfailures
     scspell

--- a/pkgs/development/python-modules/deltalake/default.nix
+++ b/pkgs/development/python-modules/deltalake/default.nix
@@ -11,7 +11,7 @@
   pkg-config,
   pytestCheckHook,
   pytest-benchmark,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-mock,
   pandas,
   azure-storage-blob,
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pandas
     pytest-benchmark
-    pytest-cov
+    pytest-cov-stub
     pytest-mock
     azure-storage-blob
   ];

--- a/pkgs/development/python-modules/dramatiq-abort/default.nix
+++ b/pkgs/development/python-modules/dramatiq-abort/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   gevent,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   dramatiq,
   redis,
   setuptools,
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     redis
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
   ];
 
   pythonImportsCheck = [ "dramatiq_abort" ];

--- a/pkgs/development/python-modules/haystack-ai/default.nix
+++ b/pkgs/development/python-modules/haystack-ai/default.nix
@@ -42,7 +42,7 @@
   pylint,
   pytest,
   pytest-asyncio,
-  pytest-cov-stub,
+  pytest-cov,
   # , pytest-custom-exit-code
   python-multipart,
   reno,
@@ -167,7 +167,7 @@ buildPythonPackage rec {
       pylint
       pytest
       pytest-asyncio
-      pytest-cov-stub
+      pytest-cov
       # pytest-custom-exit-code
       python-multipart
       reno

--- a/pkgs/development/python-modules/iocapture/default.nix
+++ b/pkgs/development/python-modules/iocapture/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   flexmock,
-  pytest,
+  pytestCheckHook,
   pytest-cov-stub,
   six,
 }:
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     flexmock
-    pytest
+    pytestCheckHook
     pytest-cov-stub
     six
   ];

--- a/pkgs/development/python-modules/langchain-perplexity/default.nix
+++ b/pkgs/development/python-modules/langchain-perplexity/default.nix
@@ -13,7 +13,7 @@
   # tests
   langchain-tests,
   pytest-asyncio,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-mock,
   pytestCheckHook,
 
@@ -51,7 +51,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     langchain-tests
     pytest-asyncio
-    pytest-cov
+    pytest-cov-stub
     pytest-mock
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/nonbloat-db/default.nix
+++ b/pkgs/development/python-modules/nonbloat-db/default.nix
@@ -14,7 +14,7 @@
   # tests
   pytestCheckHook,
   pytest-asyncio,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-mock,
   pytest-randomly,
   faker,
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-asyncio
-    pytest-cov
+    pytest-cov-stub
     pytest-mock
     pytest-randomly
     faker

--- a/pkgs/development/python-modules/pdfplumber/default.nix
+++ b/pkgs/development/python-modules/pdfplumber/default.nix
@@ -11,7 +11,7 @@
   pdfminer-six,
   pillow,
   pypdfium2,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-parallel,
   pytestCheckHook,
   types-pillow,
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     nbexec
     pandas
     pandas-stubs
-    pytest-cov
+    pytest-cov-stub
     pytest-parallel
     pytestCheckHook
     types-pillow

--- a/pkgs/development/python-modules/plaster/default.nix
+++ b/pkgs/development/python-modules/plaster/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   buildPythonPackage,
   fetchPypi,
   pytest,
@@ -23,4 +24,11 @@ buildPythonPackage rec {
     pytest
     pytest-cov-stub
   ];
+
+  meta = {
+    description = "Loader interface around multiple config file formats";
+    homepage = "https://pypi.org/project/plaster/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
 }

--- a/pkgs/development/python-modules/plaster/default.nix
+++ b/pkgs/development/python-modules/plaster/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pytest,
+  pytestCheckHook,
   pytest-cov-stub,
 }:
 
@@ -16,12 +16,8 @@ buildPythonPackage rec {
     hash = "sha256-+L78VL+MEUfBCrQCl+yEwmdvotTqXW9STZQ2qAB075g=";
   };
 
-  checkPhase = ''
-    py.test
-  '';
-
   nativeCheckInputs = [
-    pytest
+    pytestCheckHook
     pytest-cov-stub
   ];
 

--- a/pkgs/development/python-modules/polars/default.nix
+++ b/pkgs/development/python-modules/polars/default.nix
@@ -9,7 +9,7 @@
   pkgs, # zstd hidden by python3Packages.zstd
   pytestCheckHook,
   pytest-codspeed ? null, # Not in Nixpkgs
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   pytest-benchmark,
   rustc,
@@ -229,7 +229,7 @@ buildPythonPackage rec {
     nativeCheckInputs = [
       pytestCheckHook
       pytest-codspeed
-      pytest-cov
+      pytest-cov-stub
       pytest-xdist
       pytest-benchmark
     ];

--- a/pkgs/development/python-modules/property-manager/default.nix
+++ b/pkgs/development/python-modules/property-manager/default.nix
@@ -5,7 +5,7 @@
   humanfriendly,
   verboselogs,
   coloredlogs,
-  pytest,
+  pytestCheckHook,
   pytest-cov-stub,
 }:
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     verboselogs
   ];
   nativeCheckInputs = [
-    pytest
+    pytestCheckHook
     pytest-cov-stub
   ];
 

--- a/pkgs/development/python-modules/pygerber/default.nix
+++ b/pkgs/development/python-modules/pygerber/default.nix
@@ -26,7 +26,6 @@
   dulwich,
   tzlocal,
   pytest-xdist,
-  pytest-cov,
   pytest-lsp,
   pytest-asyncio,
   pytest-mock,
@@ -77,7 +76,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest-asyncio
-    pytest-cov
     pytest-xdist
     pytest-lsp
     pytest-mock
@@ -93,6 +91,8 @@ buildPythonPackage rec {
     "test/gerberx3/test_assets.py"
     "test/gerberx3/test_language_server/tests.py"
   ];
+
+  pytestFlagsArray = [ "--override-ini required_plugins=''" ];
 
   pythonImportsCheck = [ "pygerber" ];
 

--- a/pkgs/development/python-modules/pyscaffold/default.nix
+++ b/pkgs/development/python-modules/pyscaffold/default.nix
@@ -23,7 +23,7 @@
   certifi,
   flake8,
   pytest,
-  pytest-cov-stub,
+  pytest-cov,
   pytest-randomly,
   pytest-xdist,
   sphinx,
@@ -80,7 +80,7 @@ buildPythonPackage rec {
       flake8
       pre-commit
       pytest
-      pytest-cov-stub
+      pytest-cov
       pytest-randomly
       pytest-xdist
       setuptools

--- a/pkgs/development/python-modules/pyscaffoldext-cookiecutter/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-cookiecutter/default.nix
@@ -11,7 +11,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov-stub,
+  pytest-cov,
   pytest-xdist,
   tox,
   virtualenv,
@@ -44,7 +44,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov-stub
+      pytest-cov
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-custom-extension/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-custom-extension/default.nix
@@ -11,7 +11,7 @@
   pyscaffold,
   pre-commit,
   pytest,
-  pytest-cov-stub,
+  pytest-cov,
   pytest-xdist,
   tox,
   virtualenv,
@@ -45,7 +45,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov-stub
+      pytest-cov
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-django/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-django/default.nix
@@ -10,7 +10,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov-stub,
+  pytest-cov,
   pytest-xdist,
   tox,
   virtualenv,
@@ -42,7 +42,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov-stub
+      pytest-cov
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-dsproject/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-dsproject/default.nix
@@ -11,7 +11,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov-stub,
+  pytest-cov,
   pytest-xdist,
   tox,
   virtualenv,
@@ -44,7 +44,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov-stub
+      pytest-cov
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-markdown/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-markdown/default.nix
@@ -11,7 +11,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov-stub,
+  pytest-cov,
   pytest-xdist,
   tox,
   twine,
@@ -46,7 +46,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov-stub
+      pytest-cov
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/pyscaffoldext-travis/default.nix
+++ b/pkgs/development/python-modules/pyscaffoldext-travis/default.nix
@@ -10,7 +10,7 @@
   configupdater,
   pre-commit,
   pytest,
-  pytest-cov-stub,
+  pytest-cov,
   pytest-xdist,
   tox,
   virtualenv,
@@ -42,7 +42,7 @@ buildPythonPackage rec {
       configupdater
       pre-commit
       pytest
-      pytest-cov-stub
+      pytest-cov
       pytest-xdist
       setuptools-scm
       tox

--- a/pkgs/development/python-modules/reikna/default.nix
+++ b/pkgs/development/python-modules/reikna/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   sphinx,
   pytest-cov-stub,
-  pytest,
+  pytestCheckHook,
   mako,
   numpy,
   funcsigs,
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     sphinx
     pytest-cov-stub
-    pytest
+    pytestCheckHook
   ];
 
   propagatedBuildInputs =
@@ -38,10 +38,6 @@ buildPythonPackage rec {
     ]
     ++ lib.optional withCuda pycuda
     ++ lib.optional withOpenCL pyopencl;
-
-  checkPhase = ''
-    py.test
-  '';
 
   # Requires device
   doCheck = false;

--- a/pkgs/development/python-modules/sanic-ext/default.nix
+++ b/pkgs/development/python-modules/sanic-ext/default.nix
@@ -18,7 +18,7 @@
   msgspec,
   pydantic,
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-asyncio,
   tox,
   jinja2,
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     msgspec
     pydantic
     pytest
-    pytest-cov
+    pytest-cov-stub
     pytest-asyncio
     tox
     jinja2

--- a/pkgs/development/python-modules/sklearn-compat/default.nix
+++ b/pkgs/development/python-modules/sklearn-compat/default.nix
@@ -6,7 +6,7 @@
   scikit-learn,
   pandas,
   pytestCheckHook,
-  pytest-cov,
+  pytest-cov-stub,
   pytest-xdist,
   pytz,
 }:
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pandas
     pytestCheckHook
-    pytest-cov
+    pytest-cov-stub
     pytest-xdist
     pytz
   ];

--- a/pkgs/servers/isso/default.nix
+++ b/pkgs/servers/isso/default.nix
@@ -66,13 +66,9 @@ buildPythonApplication rec {
   '';
 
   nativeCheckInputs = [
-    pytest
-    pytest-cov
+    pytestCheckHook
+    pytest-cov-stub
   ];
-
-  checkPhase = ''
-    pytest
-  '';
 
   passthru.tests = { inherit (nixosTests) isso; };
 

--- a/pkgs/tools/audio/beets/common.nix
+++ b/pkgs/tools/audio/beets/common.nix
@@ -145,7 +145,7 @@ python3Packages.buildPythonApplication {
     with python3Packages;
     [
       pytestCheckHook
-      pytest-cov
+      pytest-cov-stub
       mock
       rarfile
       responses


### PR DESCRIPTION
Not scripted

---

- **treewide: don't propagate pytest-cov-stubs in optional-dependencies**
- **python3Packages.plaster: add meta**
- **gitfs: mark broken**
- **vim-vint: run tests**

---

- **beetsPackages.beets-minimal: use pytest-cov-stub**
- **bepasty: use pytest-cov-stub**
- **buku: use pytest-cov-stub**
- **canaille: use pytest-cov-stub**
- **cloudsmith-cli: use pytest-cov-stub**
- **deluge-2_x: use pytest-cov-stub**
- **isso: use pytest-cov-stub**
- **logitech-udev-rules: use pytest-cov-stub**
- **memray: use pytest-cov-stub**
- **patroni: use pytest-cov-stub**
- **python3Packages.colcon-mixin: use pytest-cov-stub**
- **python3Packages.colcon-ros-domain-id-coordinator: use pytest-cov-stub**
- **python3Packages.deltalake: use pytest-cov-stub**
- **python3Packages.dramatiq-abort: use pytest-cov-stub**
- **python3Packages.langchain-perplexity: use pytest-cov-stub**
- **python3Packages.nonbloat-db: use pytest-cov-stub**
- **python3Packages.pdfplumber: use pytest-cov-stub**
- **python3Packages.polars: use pytest-cov-stub**
- **python3Packages.sklearn-compat: use pytest-cov-stub**
- **rexi: use pytest-cov-stub**
- **vulnix: use pytest-cov-stub**
- **zulip-term: use pytest-cov-stub**
- **python3Packages.sanic-ext: use pytest-cov-stub**

---

- **unblob: add note about how pytest-cov-stub cannot be used**
- **python3Packages.pygerber: remove pytest-cov**

---

- **fastcov: use pytestCheckHook**
- **git-pw: use pytestCheckHook**
- **python3Packages.iocapture: use pytestCheckHook**
- **python3Packages.plaster: use pytestCheckHook**
- **python3Packages.property-manager: use pytestCheckHook**
- **python3Packages.reikna: use pytestCheckHook**

---

I built the following packages:

<details>

beets
beetsPackages.beets
beetsPackages.beets-minimal
beetsPackages.beets-stable
beetsPackages.beets-unstable
beets-unstable
bepasty
buku
bump-my-version
canaille
cloudsmith-cli
deluge
deluge-2_x
deluged
deluge-gtk
fastcov
galario
git-pw
isso
logitech-udev-rules
memray
patroni
python312Packages.bump-my-version
python312Packages.colcon-mixin
python312Packages.colcon-ros-domain-id-coordinator
python312Packages.deltalake
python312Packages.dramatiq-abort
python312Packages.iocapture
python312Packages.langchain-perplexity
python312Packages.nonbloat-db
python312Packages.plaster
python312Packages.polars
python312Packages.property-manager
python312Packages.pygerber
python312Packages.reikna
python312Packages.sklearn-compat
python313Packages.bump-my-version
python313Packages.colcon-mixin
python313Packages.colcon-ros-domain-id-coordinator
python313Packages.deltalake
python313Packages.dramatiq-abort
python313Packages.iocapture
python313Packages.langchain-perplexity
python313Packages.nonbloat-db
python313Packages.plaster
python313Packages.polars
python313Packages.property-manager
python313Packages.pygerber
python313Packages.reikna
python313Packages.sklearn-compat
rexi
solaar
unblob
vulnix
zulip-term

</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
