### PR TITLE
speki: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24500,6 +24500,11 @@
     githubId = 156964;
     name = "Thomas Boerger";
   };
+  tbs1996 = {
+    github = "tbs1996";
+    githubId = 56874491;
+    name = "Tor Berge Sæbjørnsen";
+  };
   tbwanderer = {
     github = "tbwanderer";
     githubId = 125365236;

--- a/pkgs/by-name/sp/speki/package.nix
+++ b/pkgs/by-name/sp/speki/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  libiconv,
+  glib,
+  gtk3,
+  libsoup_3,
+  webkitgtk_4_1,
+  xdotool,
+  wrapGAppsHook3,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "speki";
+  version = "0.1.0-unstable-2025-06-17";
+
+  src = fetchFromGitHub {
+    owner = "tbs1996";
+    repo = "spekispace";
+    rev = "cc11bce95f63eda31f4e5fdf9df9736a36fe17b5";
+    hash = "sha256-bv3WOw1FyfBTombSqyAVEWnP092s8OQzkKr5TwnyplE=";
+  };
+
+  cargoHash = "sha256-ZHjompyL8xx9r5DWqIsyRa0Zq33f4Xngz8kNF0mdIzY=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    openssl
+    libiconv
+    glib
+    gtk3
+    libsoup_3
+    webkitgtk_4_1
+    xdotool
+  ];
+
+  meta = {
+    description = "Ontological flashcard app";
+    homepage = "https://github.com/tbs1996/spekispace";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ tbs1996 ];
+    mainProgram = "speki";
+  };
+})


### PR DESCRIPTION

Adds the flashcard app 'speki' to nixpkgs and myself (tbs1996) as a maintainer.

It currently does not have any users but i'm very serious about the project, been developing it for almost a year, and I'm ready to publish it. 

repo: https://github.com/TBS1996/spekispace

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
