### PR TITLE
nodejs_20: fix fetchpatch2 usage

### DIFF
--- a/pkgs/development/web/nodejs/gyp-patches.nix
+++ b/pkgs/development/web/nodejs/gyp-patches.nix
@@ -1,21 +1,23 @@
 { fetchpatch2 }:
 let
   name = "gyp-darwin-sandbox.patch";
-  url = "https://github.com/nodejs/gyp-next/commit/706d04aba5bd18f311dc56f84720e99f64c73466.patch";
+  url = "https://github.com/nodejs/gyp-next/commit/706d04aba5bd18f311dc56f84720e99f64c73466.patch?full_index=1";
 in
 [
   # Fixes builds with Nix sandbox on Darwin for gyp.
   # See https://github.com/NixOS/nixpkgs/issues/261820
   # and https://github.com/nodejs/gyp-next/pull/216
   (fetchpatch2 {
-    inherit name url;
-    hash = "sha256-l8FzgLq9CbVJCkXfnTyDQ+vXKCz65wpaffE74oSU+kY=";
+    inherit url;
+    name = "tools-${name}";
+    hash = "sha256-iV9qvj0meZkgRzFNur2v1jtLZahbqvSJ237NoM8pPZc=";
     stripLen = 1;
     extraPrefix = "tools/gyp/";
   })
   (fetchpatch2 {
-    inherit name url;
-    hash = "sha256-UVUn4onXfJgFoAdApLAbliiBgM9rxDdIo53WjFryoBI=";
+    inherit url;
+    name = "deps-${name}";
+    hash = "sha256-1iyeeAprmWpmLafvOOXW45iZ4jWFSloWJxQ0reAKBOo=";
     stripLen = 1;
     extraPrefix = "deps/npm/node_modules/node-gyp/gyp/";
   })


### PR DESCRIPTION
#257446

For convenience the two patches are also no longer identically named.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.