### PR TITLE
gramps: 6.0.1 -> 6.0.2

### DIFF
--- a/pkgs/by-name/gr/gramps/disable-gtk-warning-dialog.patch
+++ b/pkgs/by-name/gr/gramps/disable-gtk-warning-dialog.patch
@@ -1,14 +1,13 @@
 diff --git a/gramps/gui/grampsgui.py b/gramps/gui/grampsgui.py
-index 0c0d4c3..522f65a 100644
+index 26ef1a2..217e2a6 100644
 --- a/gramps/gui/grampsgui.py
 +++ b/gramps/gui/grampsgui.py
-@@ -573,9 +573,6 @@ class Gramps:
-         dbstate = DbState()
-         self._vm = ViewManager(app, dbstate, config.get("interface.view-categories"))
+@@ -575,7 +575,7 @@ class Gramps:
  
--        if lin() and glocale.lang != "C" and not gettext.find(GTK_GETTEXT_DOMAIN):
--            _display_gtk_gettext_message(parent=self._vm.window)
--
-         _display_translator_message(parent=self._vm.window)
- 
-         self._vm.init_interface()
+         if (
+             lin()
+-            and "SNAP" not in os.environ
++            and False
+             and glocale.lang != "C"
+             and not gettext.find(GTK_GETTEXT_DOMAIN)
+         ):

--- a/pkgs/by-name/gr/gramps/package.nix
+++ b/pkgs/by-name/gr/gramps/package.nix
@@ -23,7 +23,7 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  version = "6.0.1";
+  version = "6.0.2";
   pname = "gramps";
   pyproject = true;
 
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication rec {
     owner = "gramps-project";
     repo = "gramps";
     tag = "v${version}";
-    hash = "sha256-EKiC7zFIAXwKXun8jixanVmBI5XyQlxBcN5rxbqdq9k=";
+    hash = "sha256-ivOa45NNw6h+QxPvN+2fOoQOU6t+HYslR4t9vA+xTic=";
   };
 
   patches = [


### PR DESCRIPTION
https://github.com/gramps-project/gramps/releases/tag/v6.0.2
https://github.com/gramps-project/gramps/compare/v6.0.1...v6.0.2

Looks like they added a specific check for snaps to disable the dialogue so I had to update the patch.
https://github.com/gramps-project/gramps/commit/1c5d02391f2890fd13af375ebc71f9b91e5050f6


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
