### PR TITLE
llama-swap: init at v137 & llama-swap: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19937,6 +19937,12 @@
     name = "Kevin Mullins";
     keys = [ { fingerprint = "2CD2 B030 BD22 32EF DF5A  008A 3618 20A4 5DB4 1E9A"; } ];
   };
+  podium868909 = {
+    email = "89096245@proton.me";
+    github = "podium868909";
+    githubId = 150333826;
+    name = "podium868909";
+  };
   podocarp = {
     email = "xdjiaxd@gmail.com";
     github = "podocarp";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1196,6 +1196,7 @@
   ./services/networking/legit.nix
   ./services/networking/libreswan.nix
   ./services/networking/livekit.nix
+  ./services/networking/llama-swap.nix
   ./services/networking/lldpd.nix
   ./services/networking/logmein-hamachi.nix
   ./services/networking/lokinet.nix

--- a/nixos/modules/services/networking/llama-swap.nix
+++ b/nixos/modules/services/networking/llama-swap.nix
@@ -1,0 +1,71 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.llama-swap;
+  settingsFormat = pkgs.formats.yaml { };
+  configFile = settingsFormat.generate "config.yml" cfg.settings;
+in
+{
+  options.services.llama-swap = {
+    enable = lib.mkEnableOption "enable the llama-swap service";
+
+    package = lib.mkPackageOption pkgs "llama-swap" { };
+
+    port = lib.mkOption {
+      default = 8080;
+      example = 11343;
+      type = lib.types.port;
+      description = ''
+        Port that llama-swap listens on.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to open the firewall for llama-swap.
+        This adds `services.llama-swap.port` to `networking.firewall.allowedTCPPorts`.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = settingsFormat.type; };
+      description = ''
+        llama-swap configuration. Refer to https://github.com/mostlygeek/llama-swap for details on supported values.
+      '';
+      example = ''
+          {
+          healthCheckTimeout = 60;
+          models = {
+            "deepcoder-14b" = {
+              proxy = "http://127.0.0.1:8009";
+              cmd = "$\{
+            (pkgs.llama-cpp.override { rocmSupport = true; })
+            }/bin/llama-server -m /var/lib/llama-cpp/models/agentica-org_DeepCoder-14B-Preview-Q6_K_L.gguf -md /var/lib/llama-cpp/models/agentica-org_DeepCoder-1.5B-Preview-Q6_K_L.gguf --port 8009 --ctx-size 16384 --flash-attn --n-gpu-layers 49 --n-gpu-layers-draft 29 --cache-type-k q8_0 --cache-type-v q8_0 --temp 0.6 --top-p 0.95 --log-colors --prio-batch 2 --prio 2 --no-webui";
+            };
+          };
+        };
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.llama-swap = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      description = "llama-swap is a light weight, transparent proxy server that provides automatic model swapping to llama.cpp's server.";
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} --listen :${toString cfg.port} --config ${configFile}";
+        Restart = "on-failure";
+        RestartSec = 3;
+        Type = "exec";
+        DynamicUser = true;
+      };
+    };
+    networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.port ]; };
+  };
+}

--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+let
+  version = "137";
+
+  src = fetchFromGitHub {
+    owner = "mostlygeek";
+    repo = "llama-swap";
+    rev = "v${version}";
+    hash = "sha256-DyAbZMTy4gvmF8HnUJ5B4ypIqhL9MDS7zBzeQfapFD8=";
+  };
+
+  ui = buildNpmPackage (finalAttrs: {
+    pname = "llama-swap-ui";
+    inherit version src;
+
+    postPatch = ''
+      substituteInPlace vite.config.ts \
+        --replace-fail '../proxy/ui_dist' '${placeholder "out"}/ui_dist'
+    '';
+
+    sourceRoot = "source/ui";
+
+    npmDepsHash = "sha256-smdqD1X9tVr0XMhQYpLBZ57/3iP8tYVoVJ2wR/gAC3w=";
+
+    postInstall = ''
+      rm -rf $out/lib
+    '';
+
+    meta = {
+      description = "llama-swap - UI";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ peterhoeg ];
+      platforms = lib.platforms.unix;
+    };
+  });
+
+in
+buildGoModule rec {
+  pname = "llama-swap";
+  inherit version src;
+
+  vendorHash = "sha256-nSdvqYVBBVIdoa991bLVwfHPGAO4OHzW8lEQPQ6cuMs=";
+
+  preBuild = ''
+    cp -r ${ui}/ui_dist proxy/
+  '';
+
+  subPackages =
+    [
+      "."
+      "proxy"
+    ]
+    ++ lib.optionals doCheck [
+      "misc/process-cmd-test"
+      "misc/simple-responder"
+    ];
+
+  nativeBuildInputs = [ versionCheckHook ];
+
+  ldflags = [
+    "-X main.version=${version}"
+    "-X main.date=unknown"
+    "-X main.commit=v${version}"
+  ];
+
+  postInstall = ''
+    install -Dm444 -t $out/share/doc/${pname} *.md *.yaml
+    cp -r examples $out/share/doc/${pname}/
+  '';
+
+  # need to adjust proxy/helpers_test.go for it to find the binaries
+  doCheck = false;
+  # if we run the tests in installCheckPhase instead, adjust this
+  postCheck = ''
+    rm -f $out/bin/{process-cmd-test,simple-responder}
+  '';
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "-version";
+
+  meta = {
+    description = "Model swapping for llama.cpp (or any local OpenAPI compatible server)";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ peterhoeg ];
+    platforms = lib.platforms.unix;
+    mainProgram = "llama-swap";
+  };
+}


### PR DESCRIPTION
adds llama-swap package at v125 & added module
https://github.com/mostlygeek/llama-swap

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
