### PR TITLE
[Backport release-25.05] libpromhttp: drop

### DIFF
--- a/pkgs/development/libraries/prometheus-client-c/default.nix
+++ b/pkgs/development/libraries/prometheus-client-c/default.nix
@@ -68,13 +68,4 @@ rec {
     subdir = "prom";
     description = "Prometheus Client in C";
   };
-  libpromhttp = build {
-    pname = "libpromhttp";
-    subdir = "promhttp";
-    buildInputs = [
-      libmicrohttpd
-      libprom
-    ];
-    description = "Prometheus HTTP Endpoint in C";
-  };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1007,6 +1007,7 @@ mapAliases {
   liboop = throw "liboop has been removed as it is unmaintained upstream."; # Added 2024-08-14
   libosmo-sccp = libosmo-sigtran; # Added 2024-12-20
   libpqxx_6 = throw "libpqxx_6 has been removed, please use libpqxx"; # Added 2024-10-02
+  libpromhttp = throw "'libpromhttp' has been removed as it is broken and unmaintained upstream."; # Added 2025-06-16
   libpulseaudio-vanilla = libpulseaudio; # Added 2022-04-20
   libqt5pas = libsForQt5.libqtpas; # Added 2024-12-25
   libquotient = libsForQt5.libquotient; # Added 2023-11-11

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8919,7 +8919,6 @@ with pkgs;
       stdenv = gccStdenv; # Required for darwin
     })
     libprom
-    libpromhttp
     ;
 
   libpulsar = callPackage ../development/libraries/libpulsar {


### PR DESCRIPTION
Backport of #417072 to `release-25.05`. Fixes Hydra build.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.