### PR TITLE
garage_2: init at 2.0.0, move tests to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -535,7 +535,10 @@ in
   mimir = runTest ./mimir.nix;
   galene = discoverTests (import ./galene.nix);
   gancio = runTest ./gancio.nix;
-  garage = handleTest ./garage { };
+  garage_1 = import ./garage {
+    inherit runTest;
+    package = pkgs.garage_1_x;
+  };
   gatus = runTest ./gatus.nix;
   getaddrinfo = runTest ./getaddrinfo.nix;
   gemstash = handleTest ./gemstash.nix { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -537,7 +537,11 @@ in
   gancio = runTest ./gancio.nix;
   garage_1 = import ./garage {
     inherit runTest;
-    package = pkgs.garage_1_x;
+    package = pkgs.garage_1;
+  };
+  garage_2 = import ./garage {
+    inherit runTest;
+    package = pkgs.garage_2;
   };
   gatus = runTest ./gatus.nix;
   getaddrinfo = runTest ./getaddrinfo.nix;

--- a/nixos/tests/garage/basic.nix
+++ b/nixos/tests/garage/basic.nix
@@ -1,87 +1,31 @@
-{ mkNode, ... }:
+{
+  lib,
+  mkNode,
+  package,
+  testScriptSetup,
+  ...
+}:
 {
   name = "garage-basic";
 
   nodes = {
-    single_node = mkNode { replicationMode = "none"; };
+    single_node = mkNode {
+      extraSettings =
+        if (lib.versionAtLeast package.version "2") then
+          {
+            replication_factor = 1;
+            consistency_mode = "consistent";
+          }
+        else
+          {
+            replication_mode = "none";
+          };
+    };
   };
 
   testScript = # python
     ''
-      from typing import List
-      from dataclasses import dataclass
-      import re
-
-      start_all()
-
-      cur_version_regex = re.compile('Current cluster layout version: (?P<ver>\d*)')
-      key_creation_regex = re.compile('Key name: (?P<key_name>.*)\nKey ID: (?P<key_id>.*)\nSecret key: (?P<secret_key>.*)')
-
-      @dataclass
-      class S3Key:
-         key_name: str
-         key_id: str
-         secret_key: str
-
-      @dataclass
-      class GarageNode:
-         node_id: str
-         host: str
-
-      def get_node_fqn(machine: Machine) -> GarageNode:
-        node_id, host = machine.succeed("garage node id").split('@')
-        return GarageNode(node_id=node_id, host=host)
-
-      def get_node_id(machine: Machine) -> str:
-        return get_node_fqn(machine).node_id
-
-      def get_layout_version(machine: Machine) -> int:
-        version_data = machine.succeed("garage layout show")
-        m = cur_version_regex.search(version_data)
-        if m and m.group('ver') is not None:
-          return int(m.group('ver')) + 1
-        else:
-          raise ValueError('Cannot find current layout version')
-
-      def apply_garage_layout(machine: Machine, layouts: List[str]):
-         for layout in layouts:
-            machine.succeed(f"garage layout assign {layout}")
-         version = get_layout_version(machine)
-         machine.succeed(f"garage layout apply --version {version}")
-
-      def create_api_key(machine: Machine, key_name: str) -> S3Key:
-         output = machine.succeed(f"garage key create {key_name}")
-         m = key_creation_regex.match(output)
-         if not m or not m.group('key_id') or not m.group('secret_key'):
-            raise ValueError('Cannot parse API key data')
-         return S3Key(key_name=key_name, key_id=m.group('key_id'), secret_key=m.group('secret_key'))
-
-      def get_api_key(machine: Machine, key_pattern: str) -> S3Key:
-         output = machine.succeed(f"garage key info {key_pattern}")
-         m = key_creation_regex.match(output)
-         if not m or not m.group('key_name') or not m.group('key_id') or not m.group('secret_key'):
-             raise ValueError('Cannot parse API key data')
-         return S3Key(key_name=m.group('key_name'), key_id=m.group('key_id'), secret_key=m.group('secret_key'))
-
-      def test_bucket_writes(node):
-        node.succeed("garage bucket create test-bucket")
-        s3_key = create_api_key(node, "test-api-key")
-        node.succeed("garage bucket allow --read --write test-bucket --key test-api-key")
-        other_s3_key = get_api_key(node, 'test-api-key')
-        assert other_s3_key.secret_key == other_s3_key.secret_key
-        node.succeed(
-          f"mc alias set test-garage http://[::1]:3900 {s3_key.key_id} {s3_key.secret_key} --api S3v4"
-        )
-        node.succeed("echo test | mc pipe test-garage/test-bucket/test.txt")
-        assert node.succeed("mc cat test-garage/test-bucket/test.txt").strip() == "test"
-
-      def test_bucket_over_http(node, bucket='test-bucket', url=None):
-        if url is None:
-           url = f"{bucket}.web.garage"
-
-        node.succeed(f'garage bucket website --allow {bucket}')
-        node.succeed(f'echo hello world | mc pipe test-garage/{bucket}/index.html')
-        assert (node.succeed(f"curl -H 'Host: {url}' http://localhost:3902")).strip() == 'hello world'
+      ${testScriptSetup}
 
       with subtest("Garage works as a single-node S3 storage"):
         single_node.wait_for_unit("garage.service")

--- a/nixos/tests/garage/basic.nix
+++ b/nixos/tests/garage/basic.nix
@@ -1,17 +1,13 @@
-args@{ mkNode, ver, ... }:
-(import ../make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "garage-basic";
-    meta = {
-      maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
-    };
+{ mkNode, ... }:
+{
+  name = "garage-basic";
 
-    nodes = {
-      single_node = mkNode { replicationMode = "none"; };
-    };
+  nodes = {
+    single_node = mkNode { replicationMode = "none"; };
+  };
 
-    testScript = ''
+  testScript = # python
+    ''
       from typing import List
       from dataclasses import dataclass
       import re
@@ -54,9 +50,7 @@ args@{ mkNode, ver, ... }:
          machine.succeed(f"garage layout apply --version {version}")
 
       def create_api_key(machine: Machine, key_name: str) -> S3Key:
-         output = machine.succeed(f"garage key ${
-           if ver == "0_8" then "new --name" else "create"
-         } {key_name}")
+         output = machine.succeed(f"garage key create {key_name}")
          m = key_creation_regex.match(output)
          if not m or not m.group('key_id') or not m.group('secret_key'):
             raise ValueError('Cannot parse API key data')
@@ -94,13 +88,9 @@ args@{ mkNode, ver, ... }:
         single_node.wait_for_open_port(3900)
         # Now Garage is initialized.
         single_node_id = get_node_id(single_node)
-        apply_garage_layout(single_node, [f'-z qemutest -c ${
-          if ver == "0_8" then "1" else "1G"
-        } "{single_node_id}"'])
+        apply_garage_layout(single_node, [f'-z qemutest -c 1G "{single_node_id}"'])
         # Now Garage is operational.
         test_bucket_writes(single_node)
         test_bucket_over_http(single_node)
     '';
-  }
-))
-  args
+}

--- a/nixos/tests/garage/common.nix
+++ b/nixos/tests/garage/common.nix
@@ -1,0 +1,85 @@
+{ ... }:
+{
+  _module.args.testScriptSetup = # python
+    ''
+      from typing import List
+      from dataclasses import dataclass
+      import re
+
+      start_all()
+
+      cur_version_regex = re.compile(r'Current cluster layout version: (?P<ver>\d*)')
+
+      @dataclass
+      class S3Key:
+         key_name: str
+         key_id: str
+         secret_key: str
+
+      @dataclass
+      class GarageNode:
+         node_id: str
+         host: str
+
+      def get_node_fqn(machine: Machine) -> GarageNode:
+        node_id, host = machine.succeed("garage node id").split('@')
+        return GarageNode(node_id=node_id, host=host)
+
+      def get_node_id(machine: Machine) -> str:
+        return get_node_fqn(machine).node_id
+
+      def get_layout_version(machine: Machine) -> int:
+        version_data = machine.succeed("garage layout show")
+        m = cur_version_regex.search(version_data)
+        if m and m.group('ver') is not None:
+          return int(m.group('ver')) + 1
+        else:
+          raise ValueError('Cannot find current layout version')
+
+      def apply_garage_layout(machine: Machine, layouts: List[str]):
+         for layout in layouts:
+            machine.succeed(f"garage layout assign {layout}")
+         version = get_layout_version(machine)
+         machine.succeed(f"garage layout apply --version {version}")
+
+      def create_api_key(machine: Machine, key_name: str) -> S3Key:
+         output = machine.succeed(f"garage key create {key_name}")
+         return parse_api_key_data(output)
+
+      def get_api_key(machine: Machine, key_pattern: str) -> S3Key:
+         output = machine.succeed(f"garage key info {key_pattern}")
+         return parse_api_key_data(output)
+
+      def parse_api_key_data(text) -> S3Key:
+        key_creation_regex = re.compile(r'Key name: \s*(?P<key_name>.*)|' r'Key ID: \s*(?P<key_id>.*)|' r'Secret key: \s*(?P<secret_key>.*)', re.IGNORECASE)
+        fields = {}
+        for match in key_creation_regex.finditer(text):
+          for key, value in match.groupdict().items():
+            if value:
+              fields[key] = value.strip()
+        try:
+          return S3Key(**fields)
+        except TypeError as e:
+          raise ValueError(f"Cannot parse API key data. Missing required field(s): {e}")
+
+      def test_bucket_writes(node):
+        node.succeed("garage bucket create test-bucket")
+        s3_key = create_api_key(node, "test-api-key")
+        node.succeed("garage bucket allow --read --write test-bucket --key test-api-key")
+        other_s3_key = get_api_key(node, 'test-api-key')
+        assert other_s3_key.secret_key == other_s3_key.secret_key
+        node.succeed(
+          f"mc alias set test-garage http://[::1]:3900 {s3_key.key_id} {s3_key.secret_key} --api S3v4"
+        )
+        node.succeed("echo test | mc pipe test-garage/test-bucket/test.txt")
+        assert node.succeed("mc cat test-garage/test-bucket/test.txt").strip() == "test"
+
+      def test_bucket_over_http(node, bucket='test-bucket', url=None):
+        if url is None:
+           url = f"{bucket}.web.garage"
+
+        node.succeed(f'garage bucket website --allow {bucket}')
+        node.succeed(f'echo hello world | mc pipe test-garage/{bucket}/index.html')
+        assert (node.succeed(f"curl -H 'Host: {url}' http://localhost:3902")).strip() == 'hello world'
+    '';
+}

--- a/nixos/tests/garage/default.nix
+++ b/nixos/tests/garage/default.nix
@@ -5,8 +5,8 @@
 let
   mkNode =
     {
-      replicationMode,
       publicV6Address ? "::1",
+      extraSettings ? { },
     }:
     { pkgs, ... }:
     {
@@ -26,8 +26,6 @@ let
         enable = true;
         inherit package;
         settings = {
-          replication_mode = replicationMode;
-
           rpc_bind_addr = "[::]:3901";
           rpc_public_addr = "[${publicV6Address}]:3901";
           rpc_secret = "5c1915fa04d0b6739675c61bf5907eb0fe3d9c69850c83820f51b4d25d13868c";
@@ -43,7 +41,7 @@ let
             root_domain = ".web.garage";
             index = "index.html";
           };
-        };
+        } // extraSettings;
       };
       environment.systemPackages = [ pkgs.minio-client ];
 
@@ -54,19 +52,21 @@ in
 {
   basic = runTest {
     imports = [
+      ./common.nix
       ./basic.nix
     ];
     _module.args = {
-      inherit mkNode;
+      inherit mkNode package;
     };
   };
 
   with-3node-replication = runTest {
     imports = [
+      ./common.nix
       ./with-3node-replication.nix
     ];
     _module.args = {
-      inherit mkNode;
+      inherit mkNode package;
     };
   };
 }

--- a/nixos/tests/garage/with-3node-replication.nix
+++ b/nixos/tests/garage/with-3node-replication.nix
@@ -1,32 +1,28 @@
-args@{ mkNode, ver, ... }:
-(import ../make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "garage-3node-replication";
-    meta = {
-      maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
-    };
+{ mkNode, ... }:
+{
+  name = "garage-3node-replication";
 
-    nodes = {
-      node1 = mkNode {
-        replicationMode = "3";
-        publicV6Address = "fc00:1::1";
-      };
-      node2 = mkNode {
-        replicationMode = "3";
-        publicV6Address = "fc00:1::2";
-      };
-      node3 = mkNode {
-        replicationMode = "3";
-        publicV6Address = "fc00:1::3";
-      };
-      node4 = mkNode {
-        replicationMode = "3";
-        publicV6Address = "fc00:1::4";
-      };
+  nodes = {
+    node1 = mkNode {
+      replicationMode = "3";
+      publicV6Address = "fc00:1::1";
     };
+    node2 = mkNode {
+      replicationMode = "3";
+      publicV6Address = "fc00:1::2";
+    };
+    node3 = mkNode {
+      replicationMode = "3";
+      publicV6Address = "fc00:1::3";
+    };
+    node4 = mkNode {
+      replicationMode = "3";
+      publicV6Address = "fc00:1::4";
+    };
+  };
 
-    testScript = ''
+  testScript = # python
+    ''
       from typing import List
       from dataclasses import dataclass
       import re
@@ -68,9 +64,7 @@ args@{ mkNode, ver, ... }:
          machine.succeed(f"garage layout apply --version {version}")
 
       def create_api_key(machine: Machine, key_name: str) -> S3Key:
-         output = machine.succeed(f"garage key ${
-           if ver == "0_8" then "new --name" else "create"
-         } {key_name}")
+         output = machine.succeed(f"garage key create {key_name}")
          m = key_creation_regex.match(output)
          if not m or not m.group('key_id') or not m.group('secret_key'):
             raise ValueError('Cannot parse API key data')
@@ -125,7 +119,7 @@ args@{ mkNode, ver, ... }:
         zones = ["nixcon", "nixcon", "paris_meetup", "fosdem"]
         apply_garage_layout(node1,
         [
-          f'{ndata.node_id} -z {zones[index]} -c ${if ver == "0_8" then "1" else "1G"}'
+          f'{ndata.node_id} -z {zones[index]} -c 1G'
           for index, ndata in enumerate(node_ids.values())
         ])
         # Now Garage is operational.
@@ -133,6 +127,4 @@ args@{ mkNode, ver, ... }:
         for node in nodes:
            test_bucket_over_http(get_machine(node))
     '';
-  }
-))
-  args
+}

--- a/nixos/tests/garage/with-3node-replication.nix
+++ b/nixos/tests/garage/with-3node-replication.nix
@@ -1,101 +1,47 @@
-{ mkNode, ... }:
+{
+  lib,
+  mkNode,
+  package,
+  testScriptSetup,
+  ...
+}:
+let
+  extraSettings =
+    if (lib.versionAtLeast package.version "2") then
+      {
+        replication_factor = 3;
+        consistency_mode = "consistent";
+      }
+    else
+      {
+        replication_mode = "3";
+      };
+in
 {
   name = "garage-3node-replication";
 
   nodes = {
     node1 = mkNode {
-      replicationMode = "3";
+      inherit extraSettings;
       publicV6Address = "fc00:1::1";
     };
     node2 = mkNode {
-      replicationMode = "3";
+      inherit extraSettings;
       publicV6Address = "fc00:1::2";
     };
     node3 = mkNode {
-      replicationMode = "3";
+      inherit extraSettings;
       publicV6Address = "fc00:1::3";
     };
     node4 = mkNode {
-      replicationMode = "3";
+      inherit extraSettings;
       publicV6Address = "fc00:1::4";
     };
   };
 
   testScript = # python
     ''
-      from typing import List
-      from dataclasses import dataclass
-      import re
-      start_all()
-
-      cur_version_regex = re.compile('Current cluster layout version: (?P<ver>\d*)')
-      key_creation_regex = re.compile('Key name: (?P<key_name>.*)\nKey ID: (?P<key_id>.*)\nSecret key: (?P<secret_key>.*)')
-
-      @dataclass
-      class S3Key:
-         key_name: str
-         key_id: str
-         secret_key: str
-
-      @dataclass
-      class GarageNode:
-         node_id: str
-         host: str
-
-      def get_node_fqn(machine: Machine) -> GarageNode:
-        node_id, host = machine.succeed("garage node id").split('@')
-        return GarageNode(node_id=node_id, host=host)
-
-      def get_node_id(machine: Machine) -> str:
-        return get_node_fqn(machine).node_id
-
-      def get_layout_version(machine: Machine) -> int:
-        version_data = machine.succeed("garage layout show")
-        m = cur_version_regex.search(version_data)
-        if m and m.group('ver') is not None:
-          return int(m.group('ver')) + 1
-        else:
-          raise ValueError('Cannot find current layout version')
-
-      def apply_garage_layout(machine: Machine, layouts: List[str]):
-         for layout in layouts:
-            machine.succeed(f"garage layout assign {layout}")
-         version = get_layout_version(machine)
-         machine.succeed(f"garage layout apply --version {version}")
-
-      def create_api_key(machine: Machine, key_name: str) -> S3Key:
-         output = machine.succeed(f"garage key create {key_name}")
-         m = key_creation_regex.match(output)
-         if not m or not m.group('key_id') or not m.group('secret_key'):
-            raise ValueError('Cannot parse API key data')
-         return S3Key(key_name=key_name, key_id=m.group('key_id'), secret_key=m.group('secret_key'))
-
-      def get_api_key(machine: Machine, key_pattern: str) -> S3Key:
-         output = machine.succeed(f"garage key info {key_pattern}")
-         m = key_creation_regex.match(output)
-         if not m or not m.group('key_name') or not m.group('key_id') or not m.group('secret_key'):
-             raise ValueError('Cannot parse API key data')
-         return S3Key(key_name=m.group('key_name'), key_id=m.group('key_id'), secret_key=m.group('secret_key'))
-
-      def test_bucket_writes(node):
-        node.succeed("garage bucket create test-bucket")
-        s3_key = create_api_key(node, "test-api-key")
-        node.succeed("garage bucket allow --read --write test-bucket --key test-api-key")
-        other_s3_key = get_api_key(node, 'test-api-key')
-        assert other_s3_key.secret_key == other_s3_key.secret_key
-        node.succeed(
-          f"mc alias set test-garage http://[::1]:3900 {s3_key.key_id} {s3_key.secret_key} --api S3v4"
-        )
-        node.succeed("echo test | mc pipe test-garage/test-bucket/test.txt")
-        assert node.succeed("mc cat test-garage/test-bucket/test.txt").strip() == "test"
-
-      def test_bucket_over_http(node, bucket='test-bucket', url=None):
-        if url is None:
-           url = f"{bucket}.web.garage"
-
-        node.succeed(f'garage bucket website --allow {bucket}')
-        node.succeed(f'echo hello world | mc pipe test-garage/{bucket}/index.html')
-        assert (node.succeed(f"curl -H 'Host: {url}' http://localhost:3902")).strip() == 'hello world'
+      ${testScriptSetup}
 
       with subtest("Garage works as a multi-node S3 storage"):
         nodes = ('node1', 'node2', 'node3', 'node4')

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -92,7 +92,7 @@ let
         "k2v::poll::test_poll_item"
       ];
 
-      passthru.tests = nixosTests.garage;
+      passthru.tests = nixosTests."garage_${lib.versions.major version}";
 
       meta = {
         description = "S3-compatible object store for small self-hosted geo-distributed deployments";

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -137,11 +137,20 @@ rec {
     cargoHash = "sha256-vcvD0Fn/etnAuXrM3+rj16cqpEmW2nzRmrjXsftKTFE=";
   };
 
+  garage_2_0_0 = generic {
+    version = "2.0.0";
+    hash = "sha256-dn7FoouF+5qmW6fcC20bKQSc6D2G9yrWdBK3uN3bF58=";
+    cargoHash = "sha256-6VM/EesrUIaQOeDGqzb0kOqMz4hW7zBJUnaRQ9C3cqc=";
+  };
+
   garage_0_8 = garage_0_8_7;
 
   garage_0_9 = garage_0_9_4;
 
   garage_1_x = garage_1_2_0;
+  garage_1 = garage_1_x;
+
+  garage_2 = garage_2_0_0;
 
   garage = garage_1_x;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3038,8 +3038,13 @@ with pkgs;
     garage_0_9
     garage_0_8_7
     garage_0_9_4
+
     garage_1_2_0
     garage_1_x
+    garage_1
+
+    garage_2_0_0
+    garage_2
     ;
 
   gaugePlugins = recurseIntoAttrs (callPackage ../by-name/ga/gauge/plugins { });


### PR DESCRIPTION
I renamed this to `garage_2` even though it diverges from the previous standard, but it seems cleaner to me.

https://garagehq.deuxfleurs.fr/blog/2025-06-garage-v2/ 
https://git.deuxfleurs.fr/Deuxfleurs/garage/releases/tag/v2.0.0

We may want to consider cleaning up the 0.x versions in a future PR.

Marking for backport as it's a new version that won't affect 1.x users on stable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
