### PR TITLE
gnucap: fix overriding with overrideAttrs

### DIFF
--- a/pkgs/by-name/gn/gnucap/package.nix
+++ b/pkgs/by-name/gn/gnucap/package.nix
@@ -1,8 +1,6 @@
 {
   callPackage,
   fetchFromSavannah,
-  gnucap,
-  gnucap-full,
   installShellFiles,
   lib,
   readline,
@@ -12,30 +10,13 @@
   writeScript,
 }:
 
-let
-  version = "20240220";
-  meta = with lib; {
-    description = "Gnu Circuit Analysis Package";
-    longDescription = ''
-      Gnucap is a modern general purpose circuit simulator with several advantages over Spice derivatives.
-      It performs nonlinear dc and transient analyses, fourier analysis, and ac analysis.
-    '';
-    homepage = "http://www.gnucap.org/";
-    changelog = "https://git.savannah.gnu.org/gitweb/?p=gnucap.git;a=blob;f=NEWS";
-    license = licenses.gpl3Only;
-    platforms = platforms.all;
-    broken = stdenv.hostPlatform.isDarwin; # Relies on LD_LIBRARY_PATH
-    maintainers = [ maintainers.raboof ];
-    mainProgram = "gnucap";
-  };
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnucap";
-  inherit version;
+  version = "20240220";
 
   src = fetchFromSavannah {
     repo = "gnucap";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-aZMiNKwI6eQZAxlF/+GoJhKczohgGwZ0/Wgpv3+AhYY=";
   };
 
@@ -53,42 +34,59 @@ stdenv.mkDerivation {
     installManPage man/*
   '';
 
-  passthru.tests = {
-    verilog = runCommand "gnucap-verilog-test" { } ''
-      echo "attach mgsim" | ${gnucap-full}/bin/gnucap -a msgsim > $out
-      cat $out | grep "verilog: already installed"
-    '';
+  passthru = {
+    tests = {
+      verilog = runCommand "gnucap-verilog-test" { } ''
+        echo "attach mgsim" | ${
+          finalAttrs.finalPackage.withPlugins (p: [ p.verilog ])
+        }/bin/gnucap -a msgsim > $out
+        cat $out | grep "verilog: already installed"
+      '';
+    };
+
+    plugins = callPackage ./plugins.nix { };
+    withPlugins =
+      p:
+      let
+        gnucap = finalAttrs.finalPackage;
+        selectedPlugins = p gnucap.plugins;
+        wrapper = writeScript "gnucap" ''
+          export GNUCAP_PLUGPATH=${gnucap}/lib/gnucap
+          for plugin in ${builtins.concatStringsSep " " selectedPlugins}; do
+            export GNUCAP_PLUGPATH=$plugin/lib/gnucap:$GNUCAP_PLUGPATH
+          done
+          ${lib.getExe gnucap}
+        '';
+      in
+      stdenv.mkDerivation {
+        pname = "${finalAttrs.pname}-with-plugins";
+        inherit (finalAttrs) version;
+
+        propagatedBuildInputs = selectedPlugins;
+
+        dontUnpack = true;
+
+        installPhase = ''
+          mkdir -p $out/bin
+          cp ${wrapper} $out/bin/gnucap
+        '';
+
+        inherit (finalAttrs) meta;
+      };
   };
 
-  inherit meta;
-}
-// {
-  plugins = callPackage ./plugins.nix { };
-  withPlugins =
-    p:
-    let
-      selectedPlugins = p gnucap.plugins;
-      wrapper = writeScript "gnucap" ''
-        export GNUCAP_PLUGPATH=${gnucap}/lib/gnucap
-        for plugin in ${builtins.concatStringsSep " " selectedPlugins}; do
-          export GNUCAP_PLUGPATH=$plugin/lib/gnucap:$GNUCAP_PLUGPATH
-        done
-        ${lib.getExe gnucap}
-      '';
-    in
-    stdenv.mkDerivation {
-      pname = "gnucap-with-plugins";
-      inherit version;
-
-      propagatedBuildInputs = selectedPlugins;
-
-      dontUnpack = true;
-
-      installPhase = ''
-        mkdir -p $out/bin
-        cp ${wrapper} $out/bin/gnucap
-      '';
-
-      inherit meta;
-    };
-}
+  meta = with lib; {
+    description = "Gnu Circuit Analysis Package";
+    longDescription = ''
+      Gnucap is a modern general purpose circuit simulator with several advantages over Spice derivatives.
+      It performs nonlinear dc and transient analyses, fourier analysis, and ac analysis.
+    '';
+    homepage = "http://www.gnucap.org/";
+    changelog = "https://git.savannah.gnu.org/gitweb/?p=gnucap.git;a=blob;f=NEWS";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    broken = stdenv.hostPlatform.isDarwin; # Relies on LD_LIBRARY_PATH
+    maintainers = [ maintainers.raboof ];
+    mainProgram = "gnucap";
+  };
+})

--- a/pkgs/by-name/gn/gnucap/package.nix
+++ b/pkgs/by-name/gn/gnucap/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     installShellFiles
   ];
+
   buildInputs = [
     readline
     termcap
@@ -75,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
       };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Gnu Circuit Analysis Package";
     longDescription = ''
       Gnucap is a modern general purpose circuit simulator with several advantages over Spice derivatives.
@@ -83,10 +84,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "http://www.gnucap.org/";
     changelog = "https://git.savannah.gnu.org/gitweb/?p=gnucap.git;a=blob;f=NEWS";
-    license = licenses.gpl3Only;
-    platforms = platforms.all;
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin; # Relies on LD_LIBRARY_PATH
-    maintainers = [ maintainers.raboof ];
+    maintainers = [ lib.maintainers.raboof ];
     mainProgram = "gnucap";
   };
 })


### PR DESCRIPTION
Any attribute concatenation onto the result of mkDerivation will break overrideability.

Before this PR, the following would fail to evaluate:

```
(gnucap.overrideAttrs { pname = "my-gnucap"; }).withPlugins (p: [ p.verilog ])'
```

The error is:

```
error: attribute 'withPlugins' missing
```

With this PR, it works as expected.

(greetings from the rabbit-hole I find myself in while looking into `meta.position` and maintainer-pings-without-eval, @philiptaron)

## Things done

Should not cause any rebuilds.

Test with:

```
nix-build -E 'with import ./. {}; (gnucap.overrideAttrs { pname = "my-gnucap"; }).withPlugins (p: [ p.verilog ])'
nix-build -A gnucap.tests
```

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
