### PR TITLE
minikube: 1.34.0 -> 1.36.0

### DIFF
--- a/pkgs/applications/networking/cluster/docker-machine/hyperkit.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/hyperkit.nix
@@ -12,6 +12,7 @@ buildGoModule rec {
     buildInputs
     vendorHash
     doCheck
+    postPatch
     ;
 
   pname = "docker-machine-hyperkit";

--- a/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
@@ -16,9 +16,11 @@ buildGoModule rec {
 
   pname = "docker-machine-kvm2";
 
-  postPatch = ''
-    sed -i '/GOARCH=$*/d' Makefile
-  '';
+  postPatch =
+    minikube.postPatch
+    + ''
+      sed -i '/GOARCH=$*/d' Makefile
+    '';
 
   buildPhase = ''
     make docker-machine-driver-kvm2 COMMIT=${src.rev}

--- a/pkgs/by-name/mi/minikube/package.nix
+++ b/pkgs/by-name/mi/minikube/package.nix
@@ -15,9 +15,9 @@
 
 buildGoModule rec {
   pname = "minikube";
-  version = "1.34.0";
+  version = "1.36.0";
 
-  vendorHash = "sha256-gw5Ol7Gp26KyIaiMvwik8FJpABpMT86vpFnZnAJ6hhs=";
+  vendorHash = "sha256-ro4QwvTf1O6/iffxEKi6pAenX8E3fPu4omqbLcigsTk=";
 
   doCheck = false;
 
@@ -25,10 +25,14 @@ buildGoModule rec {
     owner = "kubernetes";
     repo = "minikube";
     rev = "v${version}";
-    sha256 = "sha256-Z7x3MOQUF3a19X4SSiIUfSJ3xl3482eKH700m/9pqcU=";
+    sha256 = "sha256-We5EyEWvrQ/k27920kE1XMijQWSYvLle7N3KUOsTfbc=";
   };
   postPatch =
-    (lib.optionalString (withQemu && stdenv.hostPlatform.isDarwin) ''
+    ''
+      substituteInPlace Makefile \
+        --replace-fail "export GOTOOLCHAIN := go\$(GO_VERSION)" "export GOTOOLCHAIN := local"
+    ''
+    + (lib.optionalString (withQemu && stdenv.hostPlatform.isDarwin) ''
       substituteInPlace \
         pkg/minikube/registry/drvs/qemu2/qemu2.go \
         --replace "/usr/local/opt/qemu/share/qemu" "${qemu}/share/qemu" \


### PR DESCRIPTION
* minikube 1.34.0 -> 1.36.0
  * [1.35.0 release notes](https://github.com/kubernetes/minikube/releases/tag/v1.35.0)
  * [1.36.0 release notes](https://github.com/kubernetes/minikube/releases/tag/v1.36.0)
  * [git changelog from 1.34.0 to 1.36.0](https://github.com/kubernetes/minikube/compare/v1.34.0...v1.36.0)
* update minikube to use `local` as GOTOOLCHAIN instead of the one currently explicitly specified in the Makefile
* update docker-machine-kvm2 & docker-machine-hyperkit (built from the same sources) with same GOTOOLCHAIN changes
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (note: have tested compilation on x86_64 linux; I do not have access to a darwin system to test compilation of docker-machine-hyperkit, but at least this change should be necessary for that to compile with the newer minikube sources)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`) (tested minikube bin; brought up a cluster with the docker driver, verified basic cluster functionality)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `e0c95f0013a0d5a85a7b168c85f573f232a42ba1`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>docker-machine-kvm2</li>
    <li>minikube</li>
  </ul>
</details>
