### PR TITLE
pan-python + pan-os-python: init at 0.25.0 + 1.12.3

### DIFF
--- a/pkgs/development/python-modules/pan-os-python/default.nix
+++ b/pkgs/development/python-modules/pan-os-python/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  packaging,
+  pan-python,
+  poetry-core,
+}:
+
+buildPythonPackage rec {
+  pname = "pan-os-python";
+  version = "1.12.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "pan_os_python";
+    inherit version;
+    hash = "sha256-b3jHu//GX031UbApDzYjCUXpI5MOdHwk9mXVymsFttk=";
+  };
+
+  postPatch = ''
+    # Modernize project definition
+    substituteInPlace pyproject.toml \
+      --replace-fail 'poetry.masonry.api' 'poetry.core.masonry.api' \
+      --replace-fail 'poetry>=0.12' 'poetry-core' \
+      --replace-fail 'pan-python = "^0.17.0"' 'pan-python = "^0.25.0"'
+    substituteInPlace panos/__init__.py \
+      --replace-fail "from distutils.version import LooseVersion" "from packaging.version import Version as LooseVersion"
+  '';
+
+  dependencies = [
+    packaging
+    pan-python
+  ];
+
+  build-system = [ poetry-core ];
+
+  pythonImportsCheck = [ "panos" ];
+
+  meta = {
+    description = "Palo Alto Networks PAN-OS SDK for Python";
+    homepage = "https://github.com/PaloAltoNetworks/pan-os-python";
+    changelog = "https://github.com/PaloAltoNetworks/pan-os-python/releases/tag/v${version}";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+}

--- a/pkgs/development/python-modules/pan-python/default.nix
+++ b/pkgs/development/python-modules/pan-python/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchurl,
+}:
+
+buildPythonPackage rec {
+  pname = "pan-python";
+  version = "0.25.0";
+  format = "wheel";
+
+  # fetchPypi doesn't appear to work, possibly because the uploaded archives on PyPI
+  # are named (notice '_' vs. '-'):
+  #  - pan-python-0.25.0.tar.gz
+  #  - pan_python-0.25.0-py3-none-any.whl
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/68/b0/0af75e586869bc5eee67e75472771e820189cbedbdde619353191a2828b7/pan_python-0.25.0-py3-none-any.whl";
+    hash = "sha256-IWqXsFORXzo8n+J39ZaqAK1vD1uIxy3idtt1+Sq5x+0=";
+  };
+
+  pythonImportsCheck = [ "pan" ];
+
+  meta = {
+    description = "Python package for Palo Alto Networks Next-Generation Firewalls, WildFire and AutoFocus";
+    homepage = "https://github.com/kevinsteves/pan-python";
+    changelog = "https://github.com/kevinsteves/pan-python/releases/tag/v${version}";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11260,6 +11260,8 @@ self: super: with self; {
 
   pamqp = callPackage ../development/python-modules/pamqp { };
 
+  pan-os-python = callPackage ../development/python-modules/pan-os-python { };
+
   pan-python = callPackage ../development/python-modules/pan-python { };
 
   panacotta = callPackage ../development/python-modules/panacotta { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11260,6 +11260,8 @@ self: super: with self; {
 
   pamqp = callPackage ../development/python-modules/pamqp { };
 
+  pan-python = callPackage ../development/python-modules/pan-python { };
+
   panacotta = callPackage ../development/python-modules/panacotta { };
 
   panasonic-viera = callPackage ../development/python-modules/panasonic-viera { };


### PR DESCRIPTION
Adds two new Python packages, `pan-python` and `pan-os-python`, the latter depends on the former.

Commits: 
- `python3Packages.pan-python`: init at 0.25.0
- `python3Packages.pan-os-python`: init at 1.12.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
