### PR TITLE
mastodon: refactor passthru on source

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1062,7 +1062,7 @@ rec {
         // (optionalAttrs (extraPassthru != { } || src ? passthru) {
           passthru = extraPassthru // src.passthru or { };
         })
-        # Forward any additional arguments to the derviation
+        # Forward any additional arguments to the derivation
         // (removeAttrs args [
           "src"
           "name"

--- a/pkgs/servers/mastodon/source.nix
+++ b/pkgs/servers/mastodon/source.nix
@@ -7,17 +7,18 @@
 let
   version = "4.3.8";
 in
-(applyPatches {
+applyPatches {
   src = fetchFromGitHub {
     owner = "mastodon";
     repo = "mastodon";
     rev = "v${version}";
     hash = "sha256-08AApylDOz8oExZ0cRaZTgNAuP+1wiLkx0SDhkO2fMM=";
+
+    passthru = {
+      inherit version;
+      yarnHash = "sha256-IC4d/skIHEzJPuKlq4rMAqV+ydqquA6toq4WWCfuDxo=";
+      yarnMissingHashes = null;
+    };
   };
   patches = patches ++ [ ];
-})
-// {
-  inherit version;
-  yarnHash = "sha256-IC4d/skIHEzJPuKlq4rMAqV+ydqquA6toq4WWCfuDxo=";
-  yarnMissingHashes = null;
 }


### PR DESCRIPTION
Any attribute concatenation onto the result of mkDerivation will break *some* overrideability.

This case is rather obscure. You'd have to do something like this to get an eval failure:

```
(mastodon.override { srcOverride = mastodon.src.overrideAttrs { }; })
```

This is not what I'am actually doing: I am calling `overrideAttrs` on every `callPackage` call for an experiment - and this break with it.

## Things done

Should cause no rebuilds.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
