### PR TITLE
python3Packages.diagrams: fix add missing pngs

### DIFF
--- a/pkgs/development/python-modules/diagrams/0001-Add-build-system-section.patch
+++ b/pkgs/development/python-modules/diagrams/0001-Add-build-system-section.patch
@@ -1,0 +1,21 @@
+From 59b84698b142f5a0998ee9e395df717a1b77e9b2 Mon Sep 17 00:00:00 2001
+From: Fabian Affolter <mail@fabian-affolter.ch>
+Date: Wed, 1 Jan 2025 21:57:06 +0100
+Subject: [PATCH] Add build-system section
+
+---
+ pyproject.toml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index bcb1e65e3..00dc374fe 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -28,3 +28,7 @@ black = "^24.4"
+ 
+ [tool.black]
+ line-length=120
++
++[build-system]
++requires = ["poetry_core>=1.0.0"]
++build-backend = "poetry.core.masonry.api"

--- a/pkgs/development/python-modules/diagrams/0002-Fix-packaging-Ensure-resources-are-included.patch
+++ b/pkgs/development/python-modules/diagrams/0002-Fix-packaging-Ensure-resources-are-included.patch
@@ -1,0 +1,28 @@
+From 4ecaacf3fa93720a13cc06732d427415ae66d48f Mon Sep 17 00:00:00 2001
+From: Nick Bathum <nickbathum@gmail.com>
+Date: Fri, 14 Mar 2025 20:36:49 -0400
+Subject: [PATCH] Fix packaging: Ensure resources are included in both sdist
+ and wheel
+
+Poetry's `include` directive defaults to only including files in the sdist.
+See https://github.com/python-poetry/poetry-core/pull/773
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 0262552..c7deb2d 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -7,7 +7,7 @@ authors = ["mingrammer <mingrammer@gmail.com>"]
+ readme = "README.md"
+ homepage = "https://diagrams.mingrammer.com"
+ repository = "https://github.com/mingrammer/diagrams"
+-include = ["resources/**/*"]
++include = [{ path = "resources/**/*", format = ["sdist", "wheel"] }]
+ 
+ [tool.poetry.scripts]
+ diagrams="diagrams.cli:main"
+-- 
+2.47.2
+

--- a/pkgs/development/python-modules/diagrams/default.nix
+++ b/pkgs/development/python-modules/diagrams/default.nix
@@ -29,11 +29,9 @@ buildPythonPackage rec {
 
   patches = [
     # Add build-system, https://github.com/mingrammer/diagrams/pull/1089
-    (fetchpatch {
-      name = "add-build-system.patch";
-      url = "https://github.com/mingrammer/diagrams/commit/59b84698b142f5a0998ee9e395df717a1b77e9b2.patch";
-      hash = "sha256-/zV5X4qgHJs+KO9gHyu6LqQ3hB8Zx+BzOFo7K1vQK78=";
-    })
+    ./0001-Add-build-system-section.patch
+    # Fix poetry include, https://github.com/mingrammer/diagrams/pull/1128
+    ./0002-Fix-packaging-Ensure-resources-are-included.patch
     ./remove-black-requirement.patch
   ];
 


### PR DESCRIPTION
Pull in the `resource` folder when poetry builds the wheel.

This change uses the patch from https://github.com/mingrammer/diagrams/pull/1128

Fixes #406527


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
