### PR TITLE
sage: refactor passthru on sage-env

### DIFF
--- a/pkgs/by-name/sa/sage/sage-env.nix
+++ b/pkgs/by-name/sa/sage/sage-env.nix
@@ -102,6 +102,12 @@ in
 writeTextFile rec {
   name = "sage-env";
   destination = "/${name}";
+
+  passthru = {
+    lib = sagelib;
+    docbuild = sage-docbuild;
+  };
+
   text =
     ''
       export PKG_CONFIG_PATH='${
@@ -204,9 +210,4 @@ writeTextFile rec {
             ]
           }''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH"
       '';
-}
-// {
-  # equivalent of `passthru`, which `writeTextFile` doesn't support
-  lib = sagelib;
-  docbuild = sage-docbuild;
 }


### PR DESCRIPTION
`writeTextFile` supports `passthru` today, so let's use it.

The previous solution could cause eval errors in some obscure override scenarios - so obscure, that I can't provide a simple reproducer. But, I did hit it during some experimentation.

## Things done

Should not cause any rebuilds.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
