### PR TITLE
vtk: 9.2.6 -> 9.5.0

### DIFF
--- a/pkgs/by-name/ex/exhibit/package.nix
+++ b/pkgs/by-name/ex/exhibit/package.nix
@@ -36,7 +36,7 @@ python3Packages.buildPythonApplication rec {
 
   dependencies = with python3Packages; [
     pygobject3
-    f3d_egl
+    f3d
   ];
 
   dontWrapGApps = true;

--- a/pkgs/by-name/f3/f3d/package.nix
+++ b/pkgs/by-name/f3/f3d/package.nix
@@ -9,10 +9,7 @@
   libXt,
   openusd,
   tbb,
-  # There is a f3d overridden with EGL enabled vtk in top-level/all-packages.nix
-  # compiling with EGL enabled vtk will result in f3d running in headless mode
-  # See https://github.com/NixOS/nixpkgs/pull/324022. This may change later.
-  vtk_9,
+  vtk,
   autoPatchelfHook,
   python3Packages,
   opencascade-occt,
@@ -50,7 +47,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    vtk_9
+    vtk
     opencascade-occt
     assimp
     fontconfig

--- a/pkgs/development/libraries/vtk/9.x.nix
+++ b/pkgs/development/libraries/vtk/9.x.nix
@@ -1,5 +1,0 @@
-import ./generic.nix {
-  majorVersion = "9.2";
-  minorVersion = "6";
-  sourceSha256 = "sha256-BvyNScTlb0mMQPyzilY+2NTsMTWNAQHomI8LtNU53RI=";
-}

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -1,0 +1,30 @@
+{
+  callPackage,
+  fetchpatch2,
+}:
+let
+  mkVtk = initArgs: callPackage (import ./generic.nix initArgs) { };
+in
+{
+  vtk_9_5 = mkVtk {
+    version = "9.5.0";
+    sourceSha256 = "sha256-BK6GJGuVV8a2GvvFNKbfCZJE+8jzk3+C5rwFcJU6+H0=";
+    patches = [
+      # https://gitlab.kitware.com/vtk/vtk/-/issues/19699
+      (fetchpatch2 {
+        url = "https://gitlab.kitware.com/vtk/vtk/-/commit/6b4f7b853675c63e4831c366ca8f78e320c1bfb5.diff";
+        hash = "sha256-hWJc5RxW6iK+W/rTxp2GUWKcm/2+oxbP5nVZ0EUSKHE=";
+      })
+      # https://gitlab.kitware.com/vtk/vtk/-/issues/19705
+      (fetchpatch2 {
+        url = "https://gitlab.kitware.com/vtk/vtk/-/commit/ce10dfe82ffa19c8108885625a6f8b3f980bed3b.diff";
+        hash = "sha256-kyPM0whL4WeaV27sNM1fbbs5kwMYn+9E561HtvnwHRc=";
+      })
+      # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12262
+      (fetchpatch2 {
+        url = "https://gitlab.kitware.com/vtk/vtk/-/commit/c0e0f793e6adf740f5b1c91ac330afdbc2a03b72.diff";
+        hash = "sha256-BinSv8sPqpAEcgkn8trnCPv2snR9MGcA8rkVflAhc5w=";
+      })
+    ];
+  };
+}

--- a/pkgs/development/libraries/vtk/vtk.egg-info
+++ b/pkgs/development/libraries/vtk/vtk.egg-info
@@ -1,5 +1,0 @@
-Metadata-Version: 2.1
-Name: vtk
-Version: @VTK_VER@
-Summary: VTK is an open-source toolkit for 3D computer graphics, image processing, and visualization
-Platform: UNKNOWN

--- a/pkgs/development/python-modules/pyvista/default.nix
+++ b/pkgs/development/python-modules/pyvista/default.nix
@@ -25,6 +25,9 @@ buildPythonPackage rec {
     hash = "sha256-9N1dF/zwjzoxX4xYIr5084M9pAk3YK3T48OUnCoC0NU=";
   };
 
+  # remove this line once pyvista 0.46 is released
+  pythonRelaxDeps = [ "vtk" ];
+
   build-system = [ setuptools ];
 
   dependencies = [
@@ -43,7 +46,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "pyvista" ];
 
   meta = with lib; {
-    broken = pythonAtLeast "3.13"; # segfault
     description = "Easier Pythonic interface to VTK";
     homepage = "https://pyvista.org";
     changelog = "https://github.com/pyvista/pyvista/releases/tag/${src.tag}";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -666,6 +666,7 @@ mapAliases {
 
   ### F ###
 
+  f3d_egl = lib.warnOnInstantiate "'f3d' now build with egl support by default, so `f3d_egl` is deprecated, consider using 'f3d' instead." f3d; # added 2025-07-18
   factor-lang-scope = throw "'factor-lang-scope' has been renamed to 'factorPackages'"; # added 2024-11-28
   fahcontrol = throw "fahcontrol has been removed because the download is no longer available"; # added 2024-09-24
   fahviewer = throw "fahviewer has been removed because the download is no longer available"; # added 2024-09-24
@@ -2121,6 +2122,9 @@ mapAliases {
   vocal = throw "'vocal' has been archived upstream. Consider using 'gnome-podcasts' or 'kasts' instead."; # Added 2025-04-12
   void = throw "'void' has been removed due to lack of upstream maintenance"; # Added 2025-01-25
   volnoti = throw "'volnoti' has been removed due to lack of maintenance upstream."; # Added 2024-12-04
+  vtk_9 = lib.warnOnInstantiate "'vtk_9' has been renamed to 'vtk_9_5'" vtk_9_5; # Added 2025-07-18
+  vtk_9_egl = lib.warnOnInstantiate "'vtk_9_5' now build with egl support by default, so `vtk_9_egl` is deprecated, consider using 'vtk_9_5' instead." vtk_9_5; # Added 2025-07-18
+  vtk_9_withQt5 = throw "'vtk_9_withQt5' has been removed, Consider using 'vtkWithQt5' instead." vtkWithQt5; # Added 2025-07-18
   vuze = throw "'vuze' was removed because it is unmaintained upstream and insecure (CVE-2018-13417). BiglyBT is a maintained fork."; # Added 2024-11-22
   vwm = throw "'vwm' was removed as it is broken and not maintained upstream"; # Added 2025-05-17
   inherit (libsForQt5.mauiPackages) vvave; # added 2022-05-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2112,8 +2112,6 @@ with pkgs;
     waylandSupport = !stdenv.hostPlatform.isDarwin;
   };
 
-  f3d_egl = f3d.override { vtk_9 = vtk_9_egl; };
-
   fast-cli = nodePackages.fast-cli;
 
   ### TOOLS/TYPESETTING/TEX
@@ -9635,17 +9633,19 @@ with pkgs;
     wine = wineWowPackages.staging;
   };
 
-  vtk_9 = libsForQt5.callPackage ../development/libraries/vtk/9.x.nix {
-    stdenv = if stdenv.cc.isClang then llvmPackages_17.stdenv else stdenv;
+  inherit (callPackage ../development/libraries/vtk { }) vtk_9_5;
+
+  vtk = vtk_9_5;
+
+  vtk-full = vtk.override {
+    qtVersion = "6";
+    mpiSupport = true;
+    pythonSupport = true;
   };
 
-  vtk_9_withQt5 = vtk_9.override { enableQt = true; };
+  vtkWithQt5 = vtk.override { qtVersion = "5"; };
 
-  vtk = vtk_9;
-
-  vtk_9_egl = vtk_9.override { enableEgl = true; };
-
-  vtkWithQt5 = vtk_9_withQt5;
+  vtkWithQt6 = vtk.override { qtVersion = "6"; };
 
   vulkan-caps-viewer = libsForQt5.callPackage ../tools/graphics/vulkan-caps-viewer { };
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -240,6 +240,7 @@ mapAliases ({
   ev3dev2 = python-ev3dev2; # added 2023-06-19
   evernote = throw "evernote is intended for use with Python 2.X";
   eyeD3 = eyed3; # added 2024-01-03
+  f3d_egl = lib.warnOnInstantiate "'f3d' now build with egl support by default, so `f3d_egl` is deprecated, consider using 'f3d' instead." f3d; # added 2025-07-18
   Fabric = fabric; # addedd 2023-02-19
   face_recognition = face-recognition; # added 2022-10-15
   face_recognition_models = face-recognition-models; # added 2022-10-15

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4870,13 +4870,6 @@ self: super: with self; {
     }
   );
 
-  f3d_egl = toPythonModule (
-    pkgs.f3d_egl.override {
-      withPythonBinding = true;
-      python3Packages = self;
-    }
-  );
-
   f5-icontrol-rest = callPackage ../development/python-modules/f5-icontrol-rest { };
 
   f5-sdk = callPackage ../development/python-modules/f5-sdk { };
@@ -19389,12 +19382,7 @@ self: super: with self; {
 
   vtjp = callPackage ../development/python-modules/vtjp { };
 
-  vtk = toPythonModule (
-    pkgs.vtk_9.override {
-      inherit python;
-      enablePython = true;
-    }
-  );
+  vtk = toPythonModule (pkgs.vtk-full.override { python3Packages = self; });
 
   vttlib = callPackage ../development/python-modules/vttlib { };
 


### PR DESCRIPTION
VTK introduces deprecated APIs in every minor release. These deprecated APIs are typically removed after two subsequent minor versions, which often leads to compatibility issues for downstream packages. Since VTK currently publishes a new minor version approximately every six months, I plan to start creating separate package variants for each minor release starting from VTK 9.5. I intend to maintain at least three concurrent minor versions of VTK.

changes:
1. ~~add headlessDisplayHook doing check for vtk~~. I will maintain the graphical test presonly.
2. drop alias 'vtk_9', add alias 'vtk_9_5'.
3. drop 'f3d_egl/vtk_9_egl'. As vtk_9_5 has been built with egl support by default and will not cause a headless display in f3d.

optional dependent pr:
1. https://github.com/NixOS/nixpkgs/pull/415234
2. https://github.com/NixOS/nixpkgs/pull/423726
3. https://github.com/NixOS/nixpkgs/pull/422597

dependent pr:

4. https://github.com/NixOS/nixpkgs/pull/416458
5. https://github.com/NixOS/nixpkgs/pull/414827
6. https://github.com/NixOS/nixpkgs/pull/417665
7. https://github.com/NixOS/nixpkgs/pull/421276
8. https://github.com/NixOS/nixpkgs/pull/422203
9. https://github.com/pyvista/pyvista/pull/7690

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
