### PR TITLE
jetbrains-toolbox: 2.6.2.41321 -> 2.6.3.43718

### DIFF
--- a/pkgs/by-name/je/jetbrains-toolbox/package.nix
+++ b/pkgs/by-name/je/jetbrains-toolbox/package.nix
@@ -19,10 +19,7 @@ let
     homepage = "https://jetbrains.com/";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with lib.maintainers; [
-      AnatolyPopov
-      ners
-    ];
+    maintainers = with lib.maintainers; [ ners ];
     platforms = [
       "aarch64-linux"
       "aarch64-darwin"

--- a/pkgs/by-name/je/jetbrains-toolbox/package.nix
+++ b/pkgs/by-name/je/jetbrains-toolbox/package.nix
@@ -1,18 +1,16 @@
 {
   lib,
-  stdenv,
-  appimageTools,
+  stdenvNoCC,
+  buildFHSEnv,
   fetchzip,
   fetchurl,
-  makeWrapper,
-  icu,
-  libappindicator-gtk3,
+  appimageTools,
   undmg,
 }:
 
 let
   pname = "jetbrains-toolbox";
-  version = "2.6.2.41321";
+  version = "2.6.3.43718";
 
   updateScript = ./update.sh;
 
@@ -20,7 +18,11 @@ let
     description = "Jetbrains Toolbox";
     homepage = "https://jetbrains.com/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ AnatolyPopov ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      AnatolyPopov
+      ners
+    ];
     platforms = [
       "aarch64-linux"
       "aarch64-darwin"
@@ -31,70 +33,77 @@ let
   };
 
   selectSystem =
-    attrs:
-    attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    let
+      inherit (stdenvNoCC.hostPlatform) system;
+    in
+    attrs: attrs.${system} or (throw "Unsupported system: ${system}");
 
-  linux = appimageTools.wrapAppImage rec {
-    inherit pname version meta;
+  selectKernel =
+    let
+      inherit (stdenvNoCC.hostPlatform.parsed) kernel;
+    in
+    attrs: attrs.${kernel.name} or (throw "Unsupported kernel: ${kernel.name}");
 
-    source =
-      let
-        arch = selectSystem {
-          x86_64-linux = "";
-          aarch64-linux = "-arm64";
-        };
-      in
-      fetchzip {
-        url = "https://download.jetbrains.com/toolbox/jetbrains-toolbox-${version}${arch}.tar.gz";
-        hash = selectSystem {
-          x86_64-linux = "sha256-nIvlO313GZhIpgyCUhp2FUzllD3tk0oRrxFzxtHSIQA=";
-          aarch64-linux = "sha256-iggrnpjqLEqiteXnmA+eynTB7cs9YeOnNW4DWGP6mk0=";
-        };
+  selectCpu =
+    let
+      inherit (stdenvNoCC.hostPlatform.parsed) cpu;
+    in
+    attrs: attrs.${cpu.name} or (throw "Unsupported CPU: ${cpu.name}");
+
+  sourceForVersion =
+    version:
+    let
+      archSuffix = selectCpu {
+        x86_64 = "";
+        aarch64 = "-arm64";
       };
-
-    src = appimageTools.extractType2 {
-      inherit pname version;
-      src = source + "/jetbrains-toolbox";
+      hash = selectSystem {
+        x86_64-linux = "sha256-qsj2Jsf4P03LeekaAcUQLVloKpY1pjnT0ffdo0LSD3M=";
+        aarch64-linux = "sha256-QkavbPl1EnucbHWwqUcResuOFybMZLGlhZzv+YGqzeY=";
+        x86_64-darwin = "sha256-3CzUKAp+Y/sCnGgI7UkMun4XnNEUSIg9dWFile1MLk4=";
+        aarch64-darwin = "sha256-A4smWImeHwgQa9oaRpt/WPRxG+DWCdQ7ZrjNNKwV06I=";
+      };
+    in
+    selectKernel {
+      linux = fetchzip {
+        url = "https://download-cdn.jetbrains.com/toolbox/jetbrains-toolbox-${version}${archSuffix}.tar.gz";
+        inherit hash;
+      };
+      darwin = fetchurl {
+        url = "https://download-cdn.jetbrains.com/toolbox/jetbrains-toolbox-${version}${archSuffix}.dmg";
+        inherit hash;
+      };
+    };
+in
+selectKernel {
+  linux =
+    let
+      src = sourceForVersion version;
+    in
+    buildFHSEnv {
+      inherit pname version meta;
+      passthru = {
+        inherit src updateScript;
+      };
+      multiPkgs =
+        pkgs:
+        with pkgs;
+        [
+          icu
+          libappindicator-gtk3
+        ]
+        ++ appimageTools.defaultFhsEnvArgs.multiPkgs pkgs;
+      runScript = "${src}/bin/jetbrains-toolbox --update-failed";
     };
 
-    nativeBuildInputs = [ makeWrapper ];
+  darwin = stdenvNoCC.mkDerivation (finalAttrs: {
+    inherit
+      pname
+      version
+      meta
+      ;
 
-    extraInstallCommands = ''
-      install -Dm644 ${src}/jetbrains-toolbox.desktop $out/share/applications/jetbrains-toolbox.desktop
-      install -Dm644 ${src}/.DirIcon $out/share/icons/hicolor/scalable/apps/jetbrains-toolbox.svg
-      wrapProgram $out/bin/jetbrains-toolbox \
-        --prefix LD_LIBRARY_PATH : ${
-          lib.makeLibraryPath [
-            icu
-            libappindicator-gtk3
-          ]
-        } \
-        --append-flags "--update-failed"
-    '';
-
-    passthru = {
-      src = source;
-      inherit updateScript;
-    };
-  };
-
-  darwin = stdenv.mkDerivation (finalAttrs: {
-    inherit pname version meta;
-
-    src =
-      let
-        arch = selectSystem {
-          x86_64-darwin = "";
-          aarch64-darwin = "-arm64";
-        };
-      in
-      fetchurl {
-        url = "https://download.jetbrains.com/toolbox/jetbrains-toolbox-${finalAttrs.version}${arch}.dmg";
-        hash = selectSystem {
-          x86_64-darwin = "sha256-518Ew3yhj6wrTfPklNTC6La0EOb/XmrFcNmoeNbod8k=";
-          aarch64-darwin = "sha256-Enyn4iJn8qLUdrvin44bGLv0dzl5VOL6KPi4AODhtPE=";
-        };
-      };
+    src = sourceForVersion finalAttrs.version;
 
     nativeBuildInputs = [ undmg ];
 
@@ -114,5 +123,4 @@ let
       inherit updateScript;
     };
   });
-in
-if stdenv.hostPlatform.isDarwin then darwin else linux
+}

--- a/pkgs/by-name/je/jetbrains-toolbox/update.sh
+++ b/pkgs/by-name/je/jetbrains-toolbox/update.sh
@@ -4,7 +4,7 @@
 set -eou pipefail
 
 latestVersion=$(curl -Ls 'https://data.services.jetbrains.com/products?code=TBA&release.type=release' | jq -r '.[0].releases | flatten | .[0].build')
-currentVersion=$(nix-instantiate --eval -E "with import ./. {}; jetbrains-toolbox.version or (lib.getVersion jetbrains-toolbox)" | tr -d '"')
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; jetbrains-toolbox.version" | tr -d '"')
 
 echo "latest  version: $latestVersion"
 echo "current version: $currentVersion"
@@ -14,28 +14,20 @@ if [[ "$latestVersion" == "$currentVersion" ]]; then
     exit 0
 fi
 
-linux_systems=(
-    "x86_64-linux:"
-    "aarch64-linux:-arm64"
-)
+update-source-version jetbrains-toolbox $latestVersion
 
-for entry in "${linux_systems[@]}"; do
-    arch="${entry%%:*}"
-    suffix="${entry#*:}"
-    prefetch=$(nix-prefetch-url --unpack "https://download.jetbrains.com/toolbox/jetbrains-toolbox-$latestVersion$suffix.tar.gz")
+systems=$(nix-instantiate --eval --json -E 'with import ./. {}; jetbrains-toolbox.meta.platforms' | jq -r '.[]')
+
+for system in $systems; do
+    arch="${system%%:*}"
+    suffix="${system#*:}"
+    url=$(nix-instantiate --eval --json -E "with import ./. { system = \"$system\"; }; jetbrains-toolbox.src.url" | jq -r)
+    if [[ $url == *.tar.gz ]]; then
+      unpack="--unpack"
+    else
+      unpack=""
+    fi
+    prefetch=$(nix-prefetch-url $unpack "$url")
     hash=$(nix hash convert --hash-algo sha256 --to sri $prefetch)
-    update-source-version jetbrains-toolbox $latestVersion $hash --system=$arch --ignore-same-version
-done
-
-darwin_systems=(
-    "x86_64-darwin:"
-    "aarch64-darwin:-arm64"
-)
-
-for entry in "${darwin_systems[@]}"; do
-    arch="${entry%%:*}"
-    suffix="${entry#*:}"
-    prefetch=$(nix-prefetch-url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-$latestVersion$suffix.dmg")
-    hash=$(nix hash convert --hash-algo sha256 --to sri $prefetch)
-    update-source-version jetbrains-toolbox $latestVersion $hash --system=$arch --ignore-same-version
+    update-source-version jetbrains-toolbox $latestVersion $hash --system=$system --ignore-same-version
 done


### PR DESCRIPTION
JetBrains have switched from an AppImage distribution to a simple tarball one.

This PR simply copies the FHS setup from wrapAppImage and gets rid of the existing LD_LIBRARY_PATH hack.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
