### PR TITLE
workflows/labels: handle null reviewer

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -201,7 +201,7 @@ jobs:
                       pull_number: pull_request.number
                     }))
                     .filter(review => review.state == 'APPROVED')
-                    .map(review => review.user.id)
+                    .map(review => review.user?.id)
                   )
 
                   const maintainers = new Set(Object.keys(


### PR DESCRIPTION
Review user can be null when the account has been deleted since posting the review.

In #357086, the `labels.yml` workflow [threw a NPE](https://github.com/NixOS/nixpkgs/actions/runs/15714120733/job/44280732234?pr=357086#step:4:214). Inspecting the API for that PR, https://api.github.com/repos/NixOS/nixpkgs/pulls/357086/reviews shows that @ghost appears as a `null` user in the review object:

```json
{
    "id": 2567488583,
    "node_id": "PRR_kwDOAEVQ_M6ZCMRH",
    "user": null,
    "body": "",
    "state": "APPROVED",
    "html_url": "https://github.com/NixOS/nixpkgs/pull/357086#pullrequestreview-2567488583",
    "pull_request_url": "https://api.github.com/repos/NixOS/nixpkgs/pulls/357086",
    "author_association": "NONE",
    "_links": {
        "html": {
            "href": "https://github.com/NixOS/nixpkgs/pull/357086#pullrequestreview-2567488583"
        },
        "pull_request": {
            "href": "https://api.github.com/repos/NixOS/nixpkgs/pulls/357086"
        }
    },
    "submitted_at": "2025-01-22T15:07:21Z",
    "commit_id": "9e9011a38a52a92a4b9ac18f23dfccc57e42aa7c"
}
```

I wasn't sure if we still want to _count_ such reviews. We can either include a null element in the `approvals` set, _or_ we can filter out null users.

```js
.filter(review => review.state == 'APPROVED')
.filter(review => review.user)
.map(review => review.user.id)
```

or

```js
.filter(review => review.state == 'APPROVED')
.map(review => review.user?.id)
```

I went with the latter for now as it's simpler, and _someone_ did approve the PR at some point, even if they've since deleted their account or been banned...

Fixes #417627

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Inspected the reported failure
- [ ] Tested the fix
      _(I'm not sure setting up the failure scenario in a fork is worth the effort, in this case)_
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
