### PR TITLE
chromium,chromedriver: 137.0.7151.103 -> 137.0.7151.119

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "137.0.7151.103",
+    "version": "137.0.7151.119",
     "chromedriver": {
-      "version": "137.0.7151.104",
-      "hash_darwin": "sha256-K7kixWvPmTX35LB6whyHetvtaGxCBYoyr30LozPjQxI=",
-      "hash_darwin_aarch64": "sha256-57cLYzeZi1jKTBQcsSP0JD2RJDIl9RVQSGdY6cz3J68="
+      "version": "137.0.7151.120",
+      "hash_darwin": "sha256-3NECoMlK57ZlCUPra20rJrZcx9FnMWvTXlcdksn8FUc=",
+      "hash_darwin_aarch64": "sha256-P1trGStKjTD/h+avjAXE5N6nqvAra9RDsSvrR/pTRUA="
     },
     "deps": {
       "depot_tools": {
@@ -20,8 +20,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "3dcc738117a3439068c9773ccd31f9858923fc4a",
-        "hash": "sha256-MIEjHLpfKIBiTFh+bO+NUf6iDpizTP9yfXQqbHfiDwo=",
+        "rev": "e0ac9d12dff5f2d33c935958b06bf1ded7f1c08c",
+        "hash": "sha256-+3C2n/7bbIOpXGvBrFnSMNlgLVRMoPtOF14CDROVClI=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -241,8 +241,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "e423961606946be24c8c1ec0d1ec91511efbabc5",
-        "hash": "sha256-MhooXuF6aw+ixPzvVCBl+6T+79cTReCYx86qqXAZ6bg="
+        "rev": "afc8e923a37090445d6d97ca23fea49d9eb7b9cf",
+        "hash": "sha256-io0J6tt0RXumjjSklZyJpALV5IikPbROd40xcrX4iBs="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -791,8 +791,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "41f53aba7095888c959932bd8f2ee8b4e16af223",
-        "hash": "sha256-ICrdvHA6fe2CUphRgPdlofazr0L+NFypWDNOI5e5QIM="
+        "rev": "075234cf3d7622d9d588a6f748fc4501aa23080c",
+        "hash": "sha256-wrLxRuJ3rq1yC0PIUGPsuDB/YNee1x3J/i6ZSLk70HM="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/06/stable-channel-update-for-desktop_17.html

This update includes 3 security fixes.

CVEs:
CVE-2025-6191 CVE-2025-6192

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.
