### PR TITLE
pyroscope: init at 1.13.4

### DIFF
--- a/pkgs/by-name/py/pyroscope/package.nix
+++ b/pkgs/by-name/py/pyroscope/package.nix
@@ -1,0 +1,45 @@
+{
+  buildGoModule,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  ...
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pyroscope";
+  version = "1.13.4";
+
+  src = fetchFromGitHub {
+    owner = "grafana";
+    repo = "pyroscope";
+    rev = "v1.13.4";
+    hash = "sha256-nyb91BO4zzJl3AG/ojBO+q7WiicZYmOtztW6FTlQHMM=";
+  };
+
+  vendorHash = "sha256-GZMoXsoE3pL0T3tkWY7i1f9sGy5uVDqeurCvBteqV9A=";
+  proxyVendor = true;
+
+  subPackages = [
+    "cmd/pyroscope"
+    "cmd/profilecli"
+  ];
+
+  ldflags = [
+    "-X=github.com/grafana/pyroscope/pkg/util/build.Branch=${finalAttrs.src.rev}"
+    "-X=github.com/grafana/pyroscope/pkg/util/build.Version=${finalAttrs.version}"
+    "-X=github.com/grafana/pyroscope/pkg/util/build.Revision=${finalAttrs.src.rev}"
+    "-X=github.com/grafana/pyroscope/pkg/util/build.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Continuous Profiling Platform. Debug performance issues down to a single line of code";
+    homepage = "https://github.com/grafana/pyroscope";
+    changelog = "https://github.com/grafana/pyroscope/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.teams.mercury ];
+    mainProgram = "pyroscope";
+  };
+})

--- a/pkgs/by-name/py/pyroscope/package.nix
+++ b/pkgs/by-name/py/pyroscope/package.nix
@@ -1,7 +1,10 @@
 {
+  stdenv,
   buildGoModule,
   lib,
   fetchFromGitHub,
+  versionCheckHook,
+  installShellFiles,
   nix-update-script,
   ...
 }:
@@ -32,10 +35,25 @@ buildGoModule (finalAttrs: {
     "-X=github.com/grafana/pyroscope/pkg/util/build.BuildDate=1970-01-01T00:00:00Z"
   ];
 
+  # We're overriding the version in 'ldFlags', so we should check that the
+  # derivation 'version' string is found in 'pyroscope --version'.
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "--version";
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd pyroscope \
+      --bash <($out/bin/pyroscope completion bash) \
+      --fish <($out/bin/pyroscope completion fish) \
+      --zsh <($out/bin/pyroscope completion zsh)
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Continuous Profiling Platform. Debug performance issues down to a single line of code";
+    description = "Continuous profiling platform; debug performance issues down to a single line of code";
     homepage = "https://github.com/grafana/pyroscope";
     changelog = "https://github.com/grafana/pyroscope/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;


### PR DESCRIPTION
init `pyroscope`; taking another stab at https://github.com/NixOS/nixpkgs/pull/309859 (among others).

of note, this PR does **not** cover the following work:
- frontend - [upstream builds in Docker](https://github.com/grafana/pyroscope/blob/main/cmd/pyroscope/frontend.Dockerfile), maybe this wouldn't be so bad to package up I just didn't attempt it
- module - didn't attempt, would follow up afterwards if this gets used
- NixOS tests - would follow after module init

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
