### PR TITLE
prusa-slicer: allow wayland

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/allow_wayland.patch
+++ b/pkgs/applications/misc/prusa-slicer/allow_wayland.patch
@@ -1,0 +1,54 @@
+commit c9282b73f3d09daff23a2603addd94605596ebe7
+Author: Robert Schiele <rschiele@gmail.com>
+Date:   Thu May 8 19:16:46 2025 +0200
+
+    remove forcing GDK_BACKEND to x11
+    
+    It seems the problems on Wayland from the past are removed meanwhile.
+
+diff --git a/src/CLI/GuiParams.cpp b/src/CLI/GuiParams.cpp
+index f44b91651f..41b42ff368 100644
+--- a/src/CLI/GuiParams.cpp
++++ b/src/CLI/GuiParams.cpp
+@@ -107,9 +107,8 @@ int start_gui_with_params(GUI::GUI_InitParams& params)
+ #if !defined(_WIN32) && !defined(__APPLE__)
+     // likely some linux / unix system
+     const char* display = boost::nowide::getenv("DISPLAY");
+-    // const char *wayland_display = boost::nowide::getenv("WAYLAND_DISPLAY");
+-    //if (! ((display && *display) || (wayland_display && *wayland_display))) {
+-    if (!(display && *display)) {
++    const char *wayland_display = boost::nowide::getenv("WAYLAND_DISPLAY");
++    if (! ((display && *display) || (wayland_display && *wayland_display))) {
+         // DISPLAY not set.
+         boost::nowide::cerr << "DISPLAY not set, GUI mode not available." << std::endl << std::endl;
+         print_help(false);
+@@ -141,4 +140,4 @@ int start_as_gcode_viewer(GUI::GUI_InitParams& gui_params)
+ }
+ #else // SLIC3R_GUI
+     // If there is no GUI, we shall ignore the parameters. Remove them from the list.
+-#endif // SLIC3R_GUI
+\ No newline at end of file
++#endif // SLIC3R_GUI
+diff --git a/src/CLI/Setup.cpp b/src/CLI/Setup.cpp
+index 82e03d466d..95acdf3477 100644
+--- a/src/CLI/Setup.cpp
++++ b/src/CLI/Setup.cpp
+@@ -212,11 +212,6 @@ static bool setup_common()
+     save_main_thread_id();
+ 
+ #ifdef __WXGTK__
+-    // On Linux, wxGTK has no support for Wayland, and the app crashes on
+-    // startup if gtk3 is used. This env var has to be set explicitly to
+-    // instruct the window manager to fall back to X server mode.
+-    ::setenv("GDK_BACKEND", "x11", /* replace */ true);
+-
+     // https://github.com/prusa3d/PrusaSlicer/issues/12969
+     ::setenv("WEBKIT_DISABLE_COMPOSITING_MODE", "1", /* replace */ false);
+     ::setenv("WEBKIT_DISABLE_DMABUF_RENDERER", "1", /* replace */ false);
+@@ -338,4 +333,4 @@ bool setup(Data& cli, int argc, char** argv)
+     return true;
+ }
+ 
+-}
+\ No newline at end of file
++}

--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -69,6 +69,13 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "version_${finalAttrs.version}";
   };
 
+  # only applies to prusa slicer because super-slicer overrides *all* patches
+  patches = [
+    # https://github.com/NixOS/nixpkgs/issues/415703
+    # https://gitlab.archlinux.org/archlinux/packaging/packages/prusa-slicer/-/merge_requests/5
+    ./allow_wayland.patch
+  ];
+
   # (not applicable to super-slicer fork)
   postPatch = lib.optionalString (finalAttrs.pname == "prusa-slicer") (
     # Patch required for GCC 14, but breaks on clang


### PR DESCRIPTION
fixes some issues when running prusa-slicer through xwayland on proprietary nvidia gpu drivers: #415703

`prusa-slicer` now runs wayland native:
![image](https://github.com/user-attachments/assets/34bcc34c-1f3d-4650-8a83-955a07d364c0)

cc @Xaver106 if you can test this PR, would be good. I never reproduced your issues, so this is by all means a "blind" fix. Which means confirmation by an affected user would help.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
