### PR TITLE
nero-umu: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3407,6 +3407,12 @@
     github = "blenderfreaky";
     githubId = 14351657;
   };
+  blghnks = {
+    email = "bilgehankuch@gmail.com";
+    name = "Bilgehan Kuş";
+    github = "blghnks";
+    githubId = 175811412;
+  };
   blinry = {
     name = "blinry";
     email = "mail@blinry.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7651,6 +7651,12 @@
     github = "ErinvanderVeen";
     githubId = 10973664;
   };
+  ern775 = {
+    email = "eren.demir2479090@gmail.com";
+    github = "ern775";
+    githubId = 188162351;
+    name = "Eren Demir";
+  };
   erooke = {
     email = "ethan@roo.ke";
     name = "Ethan Rooke";

--- a/pkgs/by-name/ne/nero-umu/nerofs.patch
+++ b/pkgs/by-name/ne/nero-umu/nerofs.patch
@@ -1,0 +1,57 @@
+--- a/src/nerofs.cpp
++++ b/src/nerofs.cpp
+@@ -173,31 +173,19 @@
+ 
+ QString NeroFS::GetIcoextract()
+ {
+-    // TODO: this is for flexibility in sandboxed environments(?)
+-    // idk what the "good" path should be for Flatpak, so...
+-    if(QDir("/usr/bin").exists("icoextract")) {
+-        return "/usr/bin/icoextract";
+-    } else return "";
++    return QStandardPaths::findExecutable("icoextract");
+ }
+ 
+ 
+ QString NeroFS::GetIcoutils()
+ {
+-    // TODO: this is for flexibility in sandboxed environments(?)
+-    // idk what the "good" path should be for Flatpak, so...
+-    if(QDir("/usr/bin").exists("icotool")) {
+-        return "/usr/bin/icotool";
+-    } else return "";
++    return QStandardPaths::findExecutable("icotool");
+ }
+ 
+ 
+ QString NeroFS::GetUmU()
+ {
+-    // TODO: this is for flexibility in sandboxed environments(?)
+-    // idk what the "good" path should be for Flatpak, so...
+-    if(QDir("/usr/bin").exists("umu-run")) {
+-        return "/usr/bin/umu-run";
+-    } else return "";
++    return QStandardPaths::findExecutable("umu-run");
+ }
+ 
+ QString NeroFS::GetWinetricks(const QString &runner)
+@@ -207,17 +195,13 @@
+             return protonsPath.path() + '/' + runner + "/protonfixes/winetricks";
+         else {
+             // fall back to system winetricks
+-            if(QDir("/usr/bin").exists("winetricks"))
+-                return "/usr/bin/winetricks";
+-            else return "";
++            return QStandardPaths::findExecutable("winetricks");
+         }
+     } else if(QDir(protonsPath.path() + '/' + currentRunner + "/protonfixes").exists("winetricks"))
+         return protonsPath.path() + '/' + currentRunner + "/protonfixes/winetricks";
+     else {
+         // fall back to system winetricks
+-        if(QDir("/usr/bin").exists("winetricks"))
+-            return "/usr/bin/winetricks";
+-        else return "";
++        return QStandardPaths::findExecutable("winetricks");
+     }
+ }
+ 

--- a/pkgs/by-name/ne/nero-umu/neroprefix.patch
+++ b/pkgs/by-name/ne/nero-umu/neroprefix.patch
@@ -1,0 +1,11 @@
+--- a/src/neroprefixsettings.cpp
++++ b/src/neroprefixsettings.cpp
+@@ -598,7 +598,7 @@
+         tmpDir.mkdir("nero-manager");
+     QProcess process;
+     process.setWorkingDirectory(tmpDir.path()+"/nero-manager");
+-    process.start("/usr/bin/curl", { "-o", "bridge.zip", "-L", "https://github.com/EnderIce2/rpc-bridge/releases/latest/download/bridge.zip" });
++    process.start(QStandardPaths::findExecutable("curl"), { "-o", "bridge.zip", "-L", "https://github.com/EnderIce2/rpc-bridge/releases/latest/download/bridge.zip" });
+     printf("Downloading Discord RPC Bridge...\n");
+ 
+     NeroPrefixSettingsWindow::blockSignals(true);

--- a/pkgs/by-name/ne/nero-umu/package.nix
+++ b/pkgs/by-name/ne/nero-umu/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  qt6,
+  qt6Packages,
+  icu,
+  icoextract,
+  icoutils,
+  umu-launcher,
+  winetricks,
+  curl,
+  mangohud,
+  gamescope,
+  gamemode,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nero-umu";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "SeongGino";
+    repo = "Nero-umu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sX/Z/b5stauut8qg6IV/DdsCIkdx1N3+y1jwoXHr1LY=";
+  };
+
+  #Replace quazip git submodule with pre-packaged quazip
+  postUnpack = ''
+    rmdir source/lib/quazip/
+    ln -s ${qt6Packages.quazip.src} source/lib/quazip
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qttools
+    qt6.qt5compat
+    qt6Packages.quazip
+    icu
+  ];
+
+  runtimeDeps = [
+    icoextract
+    icoutils
+    winetricks
+    curl
+    umu-launcher
+    mangohud
+    gamescope
+    gamemode
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "NERO_QT_VERSION" "Qt6")
+  ];
+
+  #Fixes to be able to find binaries for nix
+  patches = [
+    ./nerofs.patch
+    ./neroprefix.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 "nero-umu" "$out/bin/nero-umu"
+    for size in 32 48 64 128; do
+      install -Dm644 "$src/img/ico/ico_"$size".png" "$out/share/icons/hicolor/"$size"x"$size"/apps/xyz.TOS.Nero.png"
+    done
+    install -Dm644 "$src/xyz.TOS.Nero.desktop" "$out/share/applications/xyz.TOS.Nero.desktop"
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeDeps}
+    )
+  '';
+
+  meta = {
+    homepage = "https://github.com/SeongGino/Nero-umu";
+    description = "Fast and efficient Proton prefix runner and manager using umu as backend";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "nero-umu";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      ern775
+      blghnks
+      keenanweaver
+    ];
+  };
+})


### PR DESCRIPTION
<!--
Added nero-umu
https://github.com/SeongGino/Nero-umu
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
