### PR TITLE
nixos/scion: upgrade to 0.12 and fix module accordingly

### DIFF
--- a/nixos/modules/services/networking/scion/scion-control.nix
+++ b/nixos/modules/services/networking/scion/scion-control.nix
@@ -16,7 +16,6 @@ let
     general = {
       id = "cs";
       config_dir = "/etc/scion";
-      reconnect_to_dispatcher = true;
     };
     beacon_db = {
       connection = "${connectionDir}/scion-control/control.beacon.db";

--- a/nixos/modules/services/networking/scion/scion-daemon.nix
+++ b/nixos/modules/services/networking/scion/scion-daemon.nix
@@ -16,7 +16,6 @@ let
     general = {
       id = "sd";
       config_dir = "/etc/scion";
-      reconnect_to_dispatcher = true;
     };
     path_db = {
       connection = "${connectionDir}/scion-daemon/sd.path.db";

--- a/nixos/modules/services/networking/scion/scion-dispatcher.nix
+++ b/nixos/modules/services/networking/scion/scion-dispatcher.nix
@@ -14,8 +14,7 @@ let
   defaultConfig = {
     dispatcher = {
       id = "dispatcher";
-      socket_file_mode = "0770";
-      application_socket = "/dev/shm/dispatcher/default.sock";
+      local_udp_forwarding = true;
     };
     log.console = {
       level = "info";

--- a/nixos/tests/scion/freestanding-deployment/topology1.json
+++ b/nixos/tests/scion/freestanding-deployment/topology1.json
@@ -1,4 +1,5 @@
 {
+  "dispatched_ports": "31000-32767",
   "attributes": [
     "core"
   ],

--- a/nixos/tests/scion/freestanding-deployment/topology2.json
+++ b/nixos/tests/scion/freestanding-deployment/topology2.json
@@ -1,4 +1,5 @@
 {
+  "dispatched_ports": "31000-32767",
   "attributes": [
     "core"
   ],

--- a/nixos/tests/scion/freestanding-deployment/topology3.json
+++ b/nixos/tests/scion/freestanding-deployment/topology3.json
@@ -1,4 +1,5 @@
 {
+  "dispatched_ports": "31000-32767",
   "attributes": [
     "core"
   ],

--- a/nixos/tests/scion/freestanding-deployment/topology4.json
+++ b/nixos/tests/scion/freestanding-deployment/topology4.json
@@ -1,4 +1,5 @@
 {
+  "dispatched_ports": "31000-32767",
   "attributes": [],
   "isd_as": "42-ffaa:1:4",
   "mtu": 1472,

--- a/nixos/tests/scion/freestanding-deployment/topology5.json
+++ b/nixos/tests/scion/freestanding-deployment/topology5.json
@@ -1,4 +1,5 @@
 {
+  "dispatched_ports": "31000-32767",
   "attributes": [],
   "isd_as": "42-ffaa:1:5",
   "mtu": 1472,

--- a/pkgs/by-name/sc/scion/package.nix
+++ b/pkgs/by-name/sc/scion/package.nix
@@ -5,7 +5,7 @@
   nixosTests,
 }:
 let
-  version = "0.11.0";
+  version = "0.12.0";
 in
 
 buildGoModule {
@@ -17,10 +17,10 @@ buildGoModule {
     owner = "scionproto";
     repo = "scion";
     rev = "v${version}";
-    hash = "sha256-JemqSr1XBwW1hLuWQrApY/hqLj/VpW3xSJedVIoFSiY=";
+    hash = "sha256-J51GIQQhS623wFUU5dI/TwT2rkDH69518lpdCLZ/iM0=";
   };
 
-  vendorHash = "sha256-akFbHgo8xI2/4aQsyutjhXPM5d0A3se3kG/6Ebw1Qcs=";
+  vendorHash = "sha256-Ew/hQM8uhaM89sCcPKUBbiGukDq3h5x+KID3w/8BDHg=";
 
   excludedPackages = [
     "acceptance"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

These are the necessary changes to use SCION 0.12, and I believe the dispatcher can now be disabled optionally, but we'll leave it on for now in order to maintain backwards compatibility with applications that require the dispatcher, they should begin working when applications upgrade their snet/pan library, as they will begin using UDP instead of the dispatcher socket.

#scion-hackathon-2025

Closes https://github.com/NixOS/nixpkgs/pull/348572

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
