### PR TITLE
kbd: split man & scripts outputs

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -19,11 +19,9 @@
 - `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by sil](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.
 - `space-orbit` package has been removed due to lack of upstream maintenance. Debian upstream stopped tracking it in 2011.
 - `command-not-found` package is now disabled by default; it works only for nix-channels based systems, and requires setup for it to work.
-
 - Derivations setting both `separateDebugInfo` and one of `allowedReferences`, `allowedRequistes`, `disallowedReferences` or `disallowedRequisites` must now set `__structuredAttrs` to `true`. The effect of reference whitelisting or blacklisting will be disabled on the `debug` output created by `separateDebugInfo`.
-
 - `victoriametrics` no longer contains VictoriaLogs components. These have been separated into the new package `victorialogs`.
-
+- `kbd` package's `outputs` now include a `man` and `scripts` outputs. The `unicode_start` and `unicode_stop` Bash scripts are now part of the `scripts` output, allowing most usages of the `kbd` package to not pull in `bash`.
 - `gnome-keyring` no longer ships with an SSH agent anymore because it has been deprecated upstream. You should use `gcr_4` instead, which provides the same features. More information on why this was done can be found on [the relevant GCR upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67).
 
 - `lima` package now only includes the guest agent for the host's architecture by default. If your guest VM's architecture differs from your Lima host's, you'll need to enable the `lima-additional-guestagents` package by setting `withAdditionalGuestAgents = true` when overriding lima with this input.

--- a/pkgs/by-name/kb/kbd/package.nix
+++ b/pkgs/by-name/kb/kbd/package.nix
@@ -8,6 +8,7 @@
   flex,
   check,
   pam,
+  bash,
   coreutils,
   gzip,
   bzip2,
@@ -85,6 +86,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     check
     pam
+    bash
   ];
   NIX_LDFLAGS = lib.optional stdenv.hostPlatform.isStatic "-laudit";
   nativeBuildInputs = [
@@ -92,6 +94,7 @@ stdenv.mkDerivation rec {
     pkg-config
     flex
   ];
+  strictDeps = true;
 
   passthru.tests = {
     inherit (nixosTests) keymap kbd-setfont-decompress kbd-update-search-paths-patch;

--- a/pkgs/by-name/kb/kbd/package.nix
+++ b/pkgs/by-name/kb/kbd/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     for i in $out/bin/unicode_{start,stop}; do
       substituteInPlace "$i" \
-        --replace /usr/bin/tty ${coreutils}/bin/tty
+        --replace-fail /usr/bin/tty ${coreutils}/bin/tty
     done
   '';
 

--- a/pkgs/by-name/kb/kbd/package.nix
+++ b/pkgs/by-name/kb/kbd/package.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     "out"
     "vlock"
     "dev"
+    "scripts"
+    "man"
   ];
 
   configureFlags =
@@ -77,9 +79,10 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    for i in $out/bin/unicode_{start,stop}; do
-      substituteInPlace "$i" \
+    for s in unicode_{start,stop}; do
+      substituteInPlace ''${!outputBin}/bin/$s \
         --replace-fail /usr/bin/tty ${coreutils}/bin/tty
+      moveToOutput "bin/$s" "$scripts"
     done
   '';
 


### PR DESCRIPTION
## Description of changes

A follow up to:

- https://github.com/NixOS/nixpkgs/pull/391836

So cc @blitz, @drupol, @nikstur & @toastal.

## Things done

- [x] Tested that the following likewise commands print the expected (only `.scripts` depends on bash): `nix why-depends --precise --all -f. kbd.out bashInteractive.out`
- [x] Tested `bicon` builds with this change applied on branch `master` (`bicon` depends directly on `kbd`, and building it doesn't require building many subsequent dependencies).
- Built `kbd` on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
