### PR TITLE
vectorcode.chromadb: enable check phase

### DIFF
--- a/pkgs/by-name/ve/vectorcode/package.nix
+++ b/pkgs/by-name/ve/vectorcode/package.nix
@@ -148,6 +148,12 @@ python.pkgs.buildPythonApplication rec {
     "test_supported_rerankers_initialization"
   ];
 
+  passthru = {
+    # Expose these overridden inputs for debugging
+    inherit python;
+    inherit (python.pkgs) chromadb;
+  };
+
   meta = {
     description = "Code repository indexing tool to supercharge your LLM experience";
     homepage = "https://github.com/Davidyz/VectorCode";

--- a/pkgs/by-name/ve/vectorcode/package.nix
+++ b/pkgs/by-name/ve/vectorcode/package.nix
@@ -107,6 +107,10 @@ python.pkgs.buildPythonApplication rec {
     ];
   };
 
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
   postInstall = ''
     $out/bin/vectorcode --print-completion=bash >vectorcode.bash
     $out/bin/vectorcode --print-completion=zsh >vectorcode.zsh
@@ -127,7 +131,6 @@ python.pkgs.buildPythonApplication rec {
 
   nativeCheckInputs =
     [
-      installShellFiles
       versionCheckHook
     ]
     ++ (with python.pkgs; [

--- a/pkgs/by-name/ve/vectorcode/package.nix
+++ b/pkgs/by-name/ve/vectorcode/package.nix
@@ -127,6 +127,12 @@ python.pkgs.buildPythonApplication rec {
       };
   '';
 
+  # Test collection breaks on aarch64-linux, because the transitive onnxruntime
+  # tries to read /sys/devices/system/cpu, which does not exist in the sandbox.
+  #
+  # We inherit the issue from chromadb, so inherit its `doCheck` attribute.
+  inherit (python.pkgs.chromadb) doCheck;
+
   pythonImportsCheck = [ "vectorcode" ];
 
   nativeCheckInputs =

--- a/pkgs/by-name/ve/vectorcode/package.nix
+++ b/pkgs/by-name/ve/vectorcode/package.nix
@@ -45,7 +45,47 @@ let
         dependencies = old.dependencies ++ [
           self.chroma-hnswlib
         ];
-        doCheck = false;
+
+        # The base package disables additional tests, so explicitly override
+        disabledTests = [
+          # Tests are flaky / timing sensitive
+          "test_fastapi_server_token_authn_allows_when_it_should_allow"
+          "test_fastapi_server_token_authn_rejects_when_it_should_reject"
+
+          # Issue with event loop
+          "test_http_client_bw_compatibility"
+
+          # httpx ReadError
+          "test_not_existing_collection_delete"
+        ];
+
+        disabledTestPaths = [
+          # Tests require network access
+          "chromadb/test/auth/test_simple_rbac_authz.py"
+          "chromadb/test/db/test_system.py"
+          "chromadb/test/ef/test_default_ef.py"
+          "chromadb/test/property/"
+          "chromadb/test/property/test_cross_version_persist.py"
+          "chromadb/test/stress/"
+          "chromadb/test/test_api.py"
+
+          # httpx failures
+          "chromadb/test/api/test_delete_database.py"
+
+          # Cannot be loaded by pytest without path hacks (fixed in 1.0.0)
+          "chromadb/test/test_logservice.py"
+          "chromadb/test/proto/test_utils.py"
+          "chromadb/test/segment/distributed/test_protobuf_translation.py"
+
+          # Hypothesis FailedHealthCheck due to nested @given tests
+          "chromadb/test/cache/test_cache.py"
+
+          # Tests fail when running in parallel.
+          # E.g. when building the building python 3.12 and 3.13 versions simultaneously.
+          # ValueError: An instance of Chroma already exists for ephemeral with different settings
+          "chromadb/test/test_chroma.py"
+          "chromadb/test/test_client.py"
+        ];
       });
     };
   };

--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -171,10 +171,10 @@ buildPythonPackage rec {
 
   # Disable on aarch64-linux due to broken onnxruntime
   # https://github.com/microsoft/onnxruntime/issues/10038
-  pythonImportsCheck = lib.optionals (stdenv.hostPlatform.system != "aarch64-linux") [ "chromadb" ];
+  pythonImportsCheck = lib.optionals doCheck [ "chromadb" ];
 
   # Test collection breaks on aarch64-linux
-  doCheck = stdenv.hostPlatform.system != "aarch64-linux";
+  doCheck = with stdenv.buildPlatform; !(isAarch && isLinux);
 
   env = {
     ZSTD_SYS_USE_PKG_CONFIG = true;


### PR DESCRIPTION
Follow up to https://github.com/NixOS/nixpkgs/pull/417720#discussion_r2153550800

I've marked @sarahec as the author of 3cf4c4b9dd483dfbc72360bd69281dcd4e5a3dfb, as it is lifted directly from their work in #412528. Note most of the changes in #421528 aren't needed because here we're overriding the v1.0 base package, and most things stay the same.

Additionally, ~~the `broken` flag has been restored to chromadb on aarch64-linux.~~ This was dropped in https://github.com/NixOS/nixpkgs/pull/412528, but the brokenness was just being _hidden_ by disabling the import check on aarch64-linux. The package is _still_ broken due to an onnxruntime issue (https://github.com/microsoft/onnxruntime/issues/10038). EDIT: this issue only occurs in the build sandbox, so I haven't marked it as broken.

cc @fabaff @sarahec @dotlambda @GaetanLepage

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Added `vectorcode.chromadb` and `vectorcode.python` passthrus to expose overridden inputs and aid debugging
- Removed `doCheck = false`
- Added disabled test list from #412528
- ~~Restored chromadb's `broken` flag on aarch64-linux~~
- ~~Removed condition from chromadb's `pythonImportsCheck`~~

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
