### PR TITLE
fctix5 packages and module update

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -130,6 +130,8 @@
 
 - `renovate` was updated to v41. See the upstream release notes for [v40](https://github.com/renovatebot/renovate/releases/tag/40.0.0) and [v41](https://github.com/renovatebot/renovate/releases/tag/41.0.0) for breaking changes.
 
+- `i18n.inputMethod.fcitx5.plasma6Support` has been removed because qt6 is the only one used for fcitx5-configtool now.
+
 - The `boot.readOnlyNixStore` has been removed. Control over bind mount options on `/nix/store` is now offered by the `boot.nixStoreMountOpts` option.
 
 - The Postfix module has been updated and likely requires configuration changes:

--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -7,11 +7,7 @@
 let
   imcfg = config.i18n.inputMethod;
   cfg = imcfg.fcitx5;
-  fcitx5Package =
-    if cfg.plasma6Support then
-      pkgs.qt6Packages.fcitx5-with-addons.override { inherit (cfg) addons; }
-    else
-      pkgs.libsForQt5.fcitx5-with-addons.override { inherit (cfg) addons; };
+  fcitx5Package = pkgs.qt6Packages.fcitx5-with-addons.override { inherit (cfg) addons; };
   settingsFormat = pkgs.formats.ini { };
 in
 {
@@ -31,15 +27,6 @@ in
         description = ''
           Use the Wayland input method frontend.
           See [Using Fcitx 5 on Wayland](https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland).
-        '';
-      };
-      plasma6Support = lib.mkOption {
-        type = lib.types.bool;
-        default = config.services.desktopManager.plasma6.enable;
-        defaultText = lib.literalExpression "config.services.desktopManager.plasma6.enable";
-        description = ''
-          Use qt6 versions of fcitx5 packages.
-          Required for configuring fcitx5 in KDE System Settings.
         '';
       };
       quickPhrase = lib.mkOption {
@@ -108,6 +95,9 @@ in
   imports = [
     (lib.mkRemovedOptionModule [ "i18n" "inputMethod" "fcitx5" "enableRimeData" ] ''
       RIME data is now included in `fcitx5-rime` by default, and can be customized using `fcitx5-rime.override { rimeDataPkgs = ...; }`
+    '')
+    (lib.mkRemovedOptionModule [ "i18n" "inputMethod" "fcitx5" "plasma6Support" ] ''
+      qt6 is the only one used for fcitx5-configtool now.
     '')
   ];
 

--- a/pkgs/by-name/li/libime/package.nix
+++ b/pkgs/by-name/li/libime/package.nix
@@ -22,21 +22,21 @@ let
     url = "https://download.fcitx-im.org/data/lm_sc.arpa-${arpaVer}.tar.zst";
     hash = "sha256-7oPs8g1S6LzNukz2zVcYPVPCV3E6Xrd+46Y9UPw3lt0=";
   };
-  dictVer = "20241001";
+  dictVer = "20250327";
   dict = fetchurl {
     url = "https://download.fcitx-im.org/data/dict-${dictVer}.tar.zst";
-    hash = "sha256-0zE7iKaGIKI7yNX5VkzxtniEjcevVBxPXwIZjlo2hr8=";
+    hash = "sha256-fKa+R1TA1MJ7p3AsDc5lFlm9LKH6pcvyhI2BoAU8jBM=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "libime";
-  version = "1.1.10";
+  version = "1.1.11";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "libime";
     tag = version;
-    hash = "sha256-liVJEBUYcVYjjJCMW68xXbEHKQpAgTLCPm2yIdWG3IQ=";
+    hash = "sha256-C9l7VBSUdSpnt+8ghdmLljZXHFswTyi/ItqeeYTjF4Y=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/wp/wpsoffice-cn/package.nix
+++ b/pkgs/by-name/wp/wpsoffice-cn/package.nix
@@ -102,7 +102,6 @@ stdenv.mkDerivation rec {
     libmysqlclient
     llvmPackages.openmp
     dbus
-    libsForQt5.fcitx5-qt
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -12,7 +12,6 @@
   pango,
   expat,
   fribidi,
-  fmt,
   wayland,
   systemd,
   wayland-protocols,
@@ -46,13 +45,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5";
-  version = "5.1.12";
+  version = "5.1.13";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-Jk7YY6nrY1Yn9KeNlRJbMF/fCMIlUVg/Elt7SymlK84=";
+    hash = "sha256-nqJrdlHR9wyRAAxolzgTjbxFzKvceLy+bscEyvNsXhs=";
   };
 
   prePatch = ''
@@ -69,7 +68,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     expat
-    fmt
     isocodes
     cairo
     enchant

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -45,13 +45,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5";
-  version = "5.1.13";
+  version = "5.1.14";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-nqJrdlHR9wyRAAxolzgTjbxFzKvceLy+bscEyvNsXhs=";
+    hash = "sha256-wLJZyoWjf02+m8Kw+IcfbZY2NnjMGtCWur2+w141eS4=";
   };
 
   prePatch = ''

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-anthy.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-anthy.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-anthy";
-  version = "5.1.6";
+  version = "5.1.7";
 
   src = fetchurl {
     url = "https://download.fcitx-im.org/fcitx5/fcitx5-anthy/${pname}-${version}.tar.zst";
-    hash = "sha256-XIgzYHiSE/PHNGUt68IZXKahPwYOZ3O0bq/KO1MrnCI=";
+    hash = "sha256-lY5GFbeIee7u1NsLbkYt6BvST9lidvZLpaylL0wE2+0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chewing.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chewing.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-chewing";
-  version = "5.1.7";
+  version = "5.1.8";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-QL1rRMsaDP98as0zlmoDPoVnbqbKQFoUFSCX+j31JcM=";
+    hash = "sha256-On8lbZL7hyY399a/q6iCNkDvRljv3zirzEO1wIG+MNE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix
@@ -20,10 +20,10 @@
 }:
 
 let
-  pyStrokeVer = "20121124";
+  pyStrokeVer = "20250329";
   pyStroke = fetchurl {
     url = "http://download.fcitx-im.org/data/py_stroke-${pyStrokeVer}.tar.gz";
-    hash = "sha256-jrEoqb+kOVLmfPL87h/RNMb0z9MXvC9sOKYV9etk4kg=";
+    hash = "sha256-wafKciXTYUq4M1P8gnUDAGqYBEd2IBj1N2BCXXtTA6Y=";
   };
   pyTableVer = "20121124";
   pyTable = fetchurl {
@@ -34,13 +34,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-chinese-addons";
-  version = "5.1.8";
+  version = "5.1.9";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-QO136EbUFxT7yA1Fs4DvV0CKpdCMw/s5s9sW3vRzGD8=";
+    hash = "sha256-xHLd7X9IdYTsVyqbghVzdC2i9AVipFHKRxP2Zqq7zGw=";
   };
 
   nativeBuildInputs = [
@@ -64,12 +64,9 @@ stdenv.mkDerivation rec {
     opencc
     qtwebengine
     fmt
+    qtbase
   ]
   ++ lib.optional luaSupport fcitx5-lua;
-
-  cmakeFlags = [
-    (lib.cmakeBool "USE_QT6" (lib.versions.major qtbase.version == "6"))
-  ];
 
   dontWrapQtApps = true;
 

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
@@ -30,19 +30,18 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-configtool";
-  version = "5.1.9";
+  version = "5.1.10";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-x4DhPxiwPR16xQpBFnJ1DiU435BHOOs6pFj+zJQXFUI=";
+    hash = "sha256-Py2UDBQRqvT7kwZeQIXKrIjGAbOjjxEyEfO5tdtizW4=";
   };
 
   cmakeFlags = [
     (lib.cmakeBool "KDE_INSTALL_USE_QT_SYS_PATHS" true)
     (lib.cmakeBool "ENABLE_KCM" kcmSupport)
-    (lib.cmakeBool "USE_QT6" (lib.versions.major qtbase.version == "6"))
   ];
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-hangul.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-hangul.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-hangul";
-  version = "5.1.6";
+  version = "5.1.7";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-WTTMW86KsrncfDHttri2eSA0bp/Vm4QVyl9tWkJn00E=";
+    hash = "sha256-66VW/hzKMVwXd7ktPQHrVbsWazKedS+/giTLIh5fkwo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-lua.nix
@@ -10,13 +10,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "fcitx5-lua";
-  version = "5.0.14";
+  version = "5.0.15";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-7FBUOsaKr9cuEaqd4dqnAGL5sd3RF+qV6GEkOUQ1/k4=";
+    hash = "sha256-BhsckLi6FSrRw+QZ8pTEgjV4BaTKSKAJtmcRCFoOUwU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-m17n.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-m17n.nix
@@ -9,19 +9,18 @@
   m17n_lib,
   m17n_db,
   gettext,
-  fmt,
   nixosTests,
 }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-m17n";
-  version = "5.1.3";
+  version = "5.1.4";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-kHMCMsJ8+rI0AtS9zEE5knGvKALhgfmgS8lC/CTmYs0=";
+    hash = "sha256-TJMJGjO9V6EOzxt6Z7rwOfIQWK38XolDhUKbjbNUGhA=";
   };
 
   nativeBuildInputs = [
@@ -35,7 +34,6 @@ stdenv.mkDerivation rec {
     fcitx5
     m17n_db
     m17n_lib
-    fmt
   ];
 
   passthru.tests = {

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-qt.nix
@@ -16,13 +16,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fcitx5-qt${majorVersion}";
-  version = "5.1.9";
+  version = "5.1.10";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-qt";
     rev = version;
-    hash = "sha256-cOCLPsWRcwukGCKAYHrZSRUYlmfYxdyspX5Y0rqbD2w=";
+    hash = "sha256-JhmaAAJ1fevCPItVnneUCAalnDDaCjjkAl9QRhSkBk4=";
   };
 
   postPatch = ''

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-rime.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-rime.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-rime";
-  version = "5.1.10";
+  version = "5.1.11";
 
   src = fetchurl {
     url = "https://download.fcitx-im.org/fcitx5/${pname}/${pname}-${version}.tar.zst";
-    hash = "sha256-ACW79fLgrS+Qv8YJjGr4WldTJsnnGhC0WWf8ia9khYk=";
+    hash = "sha256-cc/B99tdVVWnvdl7dYYQlIvk8F2xXUOr6sF36yxQZfY=";
   };
 
   cmakeFlags = [

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-skk.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-skk.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-skk";
-  version = "5.1.6";
+  version = "5.1.7";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = pname;
     rev = version;
-    hash = "sha256-1gfR0wXBXM6Gttwldg2vm8DUUW4OciqKMQkpFQHqLoE=";
+    hash = "sha256-WMkcZSocanhWMn9kiWyB07jEW4x84G07kAYvn5heenc=";
   };
 
   nativeBuildInputs = [
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_QT" enableQt)
-    (lib.cmakeBool "USE_QT6" (lib.versions.major qtbase.version == "6"))
     "-DSKK_DEFAULT_PATH=${skkDictionaries.l}/share/skk/SKK-JISYO.L"
   ];
 

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-unikey.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-unikey.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx5-unikey";
-  version = "5.1.6";
+  version = "5.1.7";
 
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "fcitx5-unikey";
     rev = version;
-    hash = "sha256-hx3GXoloO3eQP9yhLY8v1ahwvOTCe5XcBey+ZbReRjE=";
+    hash = "sha256-ve+vu/bK3GYgjn9KxuOsFZFi9eymi1TFlzUHu4fJAkk=";
   };
 
   nativeBuildInputs = [
@@ -31,10 +31,6 @@ stdenv.mkDerivation rec {
     qtbase
     fcitx5
     fcitx5-qt
-  ];
-
-  cmakeFlags = [
-    (lib.cmakeBool "USE_QT6" (lib.versions.major qtbase.version == "6"))
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/tools/inputmethods/fcitx5/update.py
+++ b/pkgs/tools/inputmethods/fcitx5/update.py
@@ -35,7 +35,7 @@ def main():
     for repo in REPOS:
         rev = get_latest_tag(repo)
         if repo == "fcitx5-qt":
-            subprocess.run(["nix-update", "--commit", "--version", rev, "libsForQt5.{}".format(repo)])
+            subprocess.run(["nix-update", "--commit", "--version", rev, "qt6Packages.{}".format(repo)])
         else:
             subprocess.run(["nix-update", "--commit", "--version", rev, repo])
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -737,11 +737,11 @@ mapAliases {
   futuresql = libsForQt5.futuresql; # added 2023-11-11
   fx_cast_bridge = fx-cast-bridge; # added 2023-07-26
 
-  fcitx5-chinese-addons = libsForQt5.fcitx5-chinese-addons; # Added 2024-03-01
-  fcitx5-configtool = libsForQt5.fcitx5-configtool; # Added 2024-03-01
-  fcitx5-skk-qt = libsForQt5.fcitx5-skk-qt; # Added 2024-03-01
-  fcitx5-unikey = libsForQt5.fcitx5-unikey; # Added 2024-03-01
-  fcitx5-with-addons = libsForQt5.fcitx5-with-addons; # Added 2024-03-01
+  fcitx5-chinese-addons = qt6Packages.fcitx5-chinese-addons; # Added 2024-03-01
+  fcitx5-configtool = qt6Packages.fcitx5-configtool; # Added 2024-03-01
+  fcitx5-skk-qt = qt6Packages.fcitx5-skk-qt; # Added 2024-03-01
+  fcitx5-unikey = qt6Packages.fcitx5-unikey; # Added 2024-03-01
+  fcitx5-with-addons = qt6Packages.fcitx5-with-addons; # Added 2024-03-01
 
   ### G ###
 

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -132,16 +132,6 @@ makeScopeWithSplicing' {
 
         fcitx5-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-qt.nix { };
 
-        fcitx5-chinese-addons = callPackage ../tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix { };
-
-        fcitx5-configtool = callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };
-
-        fcitx5-skk-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-skk.nix { enableQt = true; };
-
-        fcitx5-unikey = callPackage ../tools/inputmethods/fcitx5/fcitx5-unikey.nix { };
-
-        fcitx5-with-addons = callPackage ../tools/inputmethods/fcitx5/with-addons.nix { };
-
         futuresql = callPackage ../development/libraries/futuresql { };
 
         qgpgme = callPackage ../development/libraries/gpgme { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[changelog](https://groups.google.com/g/fcitx/c/ng7y3skpFmc)

## Highlight
fcitx5-configtool is only based on qt6 now, so I remove qt5 support in nixos module. fcitx5-qt can work with qt5 as before. 
Ones who want to use qt5 version's fcitx5, should wrap it manually with addons by overriding it without fcitx5-configtool. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
