### PR TITLE
various: remove useless callPackage

### DIFF
--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -227,12 +227,9 @@ let
       ) vimPlugins.nvim-treesitter.grammarPlugins;
       isNvimGrammar = x: builtins.elem x nvimGrammars;
 
-      toNvimTreesitterGrammar = callPackage (
-        { }:
-        makeSetupHook {
-          name = "to-nvim-treesitter-grammar";
-        } ./to-nvim-treesitter-grammar.sh
-      ) { };
+      toNvimTreesitterGrammar = makeSetupHook {
+        name = "to-nvim-treesitter-grammar";
+      } ./to-nvim-treesitter-grammar.sh;
     in
 
     (toVimPlugin (

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -1,16 +1,12 @@
 {
-  buildPackages,
-  callPackage,
-  cargo,
   cargo-nextest,
   clang,
   diffutils,
   lib,
   makeSetupHook,
-  maturin,
   rust,
-  rustc,
   stdenv,
+  pkgsHostTarget,
   pkgsTargetTarget,
 
   # This confusingly-named parameter indicates the *subdirectory of
@@ -21,138 +17,118 @@
   pkgsCross,
 }:
 {
-  cargoBuildHook = callPackage (
-    { }:
-    makeSetupHook {
-      name = "cargo-build-hook.sh";
-      substitutions = {
-        inherit (stdenv.targetPlatform.rust) rustcTarget;
-        inherit (rust.envVars) setEnv;
+  cargoBuildHook = makeSetupHook {
+    name = "cargo-build-hook.sh";
+    substitutions = {
+      inherit (stdenv.targetPlatform.rust) rustcTarget;
+      inherit (rust.envVars) setEnv;
 
+    };
+    passthru.tests =
+      {
+        test = tests.rust-hooks.cargoBuildHook;
+      }
+      // lib.optionalAttrs (stdenv.isLinux) {
+        testCross = pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
       };
-      passthru.tests =
-        {
-          test = tests.rust-hooks.cargoBuildHook;
-        }
-        // lib.optionalAttrs (stdenv.isLinux) {
-          testCross = pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
-        };
-    } ./cargo-build-hook.sh
-  ) { };
+  } ./cargo-build-hook.sh;
 
-  cargoCheckHook = callPackage (
-    { }:
-    makeSetupHook {
-      name = "cargo-check-hook.sh";
-      substitutions = {
-        inherit (stdenv.targetPlatform.rust) rustcTarget;
-        inherit (rust.envVars) setEnv;
+  cargoCheckHook = makeSetupHook {
+    name = "cargo-check-hook.sh";
+    substitutions = {
+      inherit (stdenv.targetPlatform.rust) rustcTarget;
+      inherit (rust.envVars) setEnv;
+    };
+    passthru.tests =
+      {
+        test = tests.rust-hooks.cargoCheckHook;
+      }
+      // lib.optionalAttrs (stdenv.isLinux) {
+        testCross = pkgsCross.riscv64.tests.rust-hooks.cargoCheckHook;
       };
-      passthru.tests =
-        {
-          test = tests.rust-hooks.cargoCheckHook;
-        }
-        // lib.optionalAttrs (stdenv.isLinux) {
-          testCross = pkgsCross.riscv64.tests.rust-hooks.cargoCheckHook;
-        };
-    } ./cargo-check-hook.sh
-  ) { };
+  } ./cargo-check-hook.sh;
 
-  cargoInstallHook = callPackage (
-    { }:
-    makeSetupHook {
-      name = "cargo-install-hook.sh";
-      substitutions = {
-        targetSubdirectory = target;
+  cargoInstallHook = makeSetupHook {
+    name = "cargo-install-hook.sh";
+    substitutions = {
+      targetSubdirectory = target;
+    };
+    passthru.tests =
+      {
+        test = tests.rust-hooks.cargoInstallHook;
+      }
+      // lib.optionalAttrs (stdenv.isLinux) {
+        testCross = pkgsCross.riscv64.tests.rust-hooks.cargoInstallHook;
       };
-      passthru.tests =
-        {
-          test = tests.rust-hooks.cargoInstallHook;
-        }
-        // lib.optionalAttrs (stdenv.isLinux) {
-          testCross = pkgsCross.riscv64.tests.rust-hooks.cargoInstallHook;
-        };
-    } ./cargo-install-hook.sh
-  ) { };
+  } ./cargo-install-hook.sh;
 
-  cargoNextestHook = callPackage (
-    { }:
-    makeSetupHook {
-      name = "cargo-nextest-hook.sh";
-      propagatedBuildInputs = [ cargo-nextest ];
-      substitutions = {
-        inherit (stdenv.targetPlatform.rust) rustcTarget;
+  cargoNextestHook = makeSetupHook {
+    name = "cargo-nextest-hook.sh";
+    propagatedBuildInputs = [ cargo-nextest ];
+    substitutions = {
+      inherit (stdenv.targetPlatform.rust) rustcTarget;
+    };
+    passthru.tests =
+      {
+        test = tests.rust-hooks.cargoNextestHook;
+      }
+      // lib.optionalAttrs (stdenv.isLinux) {
+        testCross = pkgsCross.riscv64.tests.rust-hooks.cargoNextestHook;
       };
-      passthru.tests =
-        {
-          test = tests.rust-hooks.cargoNextestHook;
-        }
-        // lib.optionalAttrs (stdenv.isLinux) {
-          testCross = pkgsCross.riscv64.tests.rust-hooks.cargoNextestHook;
-        };
-    } ./cargo-nextest-hook.sh
-  ) { };
+  } ./cargo-nextest-hook.sh;
 
-  cargoSetupHook = callPackage (
-    { }:
-    makeSetupHook {
-      name = "cargo-setup-hook.sh";
-      propagatedBuildInputs = [ ];
-      substitutions = {
-        defaultConfig = ../fetchcargo-default-config.toml;
+  cargoSetupHook = makeSetupHook {
+    name = "cargo-setup-hook.sh";
+    propagatedBuildInputs = [ ];
+    substitutions = {
+      defaultConfig = ../fetchcargo-default-config.toml;
 
-        # Specify the stdenv's `diff` by abspath to ensure that the user's build
-        # inputs do not cause us to find the wrong `diff`.
-        diff = "${lib.getBin diffutils}/bin/diff";
+      # Specify the stdenv's `diff` by abspath to ensure that the user's build
+      # inputs do not cause us to find the wrong `diff`.
+      diff = "${lib.getBin diffutils}/bin/diff";
 
-        cargoConfig =
-          lib.optionalString (stdenv.hostPlatform.config != stdenv.targetPlatform.config) ''
-            [target."${stdenv.targetPlatform.rust.rustcTarget}"]
-            "linker" = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc"
-            "rustflags" = [ "-C", "target-feature=${
-              if pkgsTargetTarget.stdenv.targetPlatform.isStatic then "+" else "-"
-            }crt-static" ]
-          ''
-          + ''
-            [target."${stdenv.hostPlatform.rust.rustcTarget}"]
-            "linker" = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
-          '';
+      cargoConfig =
+        lib.optionalString (stdenv.hostPlatform.config != stdenv.targetPlatform.config) ''
+          [target."${stdenv.targetPlatform.rust.rustcTarget}"]
+          "linker" = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc"
+          "rustflags" = [ "-C", "target-feature=${
+            if pkgsTargetTarget.stdenv.targetPlatform.isStatic then "+" else "-"
+          }crt-static" ]
+        ''
+        + ''
+          [target."${stdenv.hostPlatform.rust.rustcTarget}"]
+          "linker" = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
+        '';
+    };
+
+    passthru.tests =
+      {
+        test = tests.rust-hooks.cargoSetupHook;
+      }
+      // lib.optionalAttrs (stdenv.isLinux) {
+        testCross = pkgsCross.riscv64.tests.rust-hooks.cargoSetupHook;
       };
-      passthru.tests =
-        {
-          test = tests.rust-hooks.cargoSetupHook;
-        }
-        // lib.optionalAttrs (stdenv.isLinux) {
-          testCross = pkgsCross.riscv64.tests.rust-hooks.cargoSetupHook;
-        };
-    } ./cargo-setup-hook.sh
-  ) { };
+  } ./cargo-setup-hook.sh;
 
-  maturinBuildHook = callPackage (
-    { pkgsHostTarget }:
-    makeSetupHook {
-      name = "maturin-build-hook.sh";
-      propagatedBuildInputs = [
-        pkgsHostTarget.maturin
-        pkgsHostTarget.cargo
-        pkgsHostTarget.rustc
-      ];
-      substitutions = {
-        inherit (stdenv.targetPlatform.rust) rustcTarget;
-        inherit (rust.envVars) setEnv;
+  maturinBuildHook = makeSetupHook {
+    name = "maturin-build-hook.sh";
+    propagatedBuildInputs = [
+      pkgsHostTarget.maturin
+      pkgsHostTarget.cargo
+      pkgsHostTarget.rustc
+    ];
+    substitutions = {
+      inherit (stdenv.targetPlatform.rust) rustcTarget;
+      inherit (rust.envVars) setEnv;
 
-      };
-    } ./maturin-build-hook.sh
-  ) { };
+    };
+  } ./maturin-build-hook.sh;
 
-  bindgenHook = callPackage (
-    { }:
-    makeSetupHook {
-      name = "rust-bindgen-hook";
-      substitutions = {
-        libclang = (lib.getLib clang.cc);
-        inherit clang;
-      };
-    } ./rust-bindgen-hook.sh
-  ) { };
+  bindgenHook = makeSetupHook {
+    name = "rust-bindgen-hook";
+    substitutions = {
+      libclang = (lib.getLib clang.cc);
+      inherit clang;
+    };
+  } ./rust-bindgen-hook.sh;
 }

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -56,9 +56,6 @@
         (callPackages ../../../build-support/rust/hooks {
           inherit
             stdenv
-            cargo
-            rustc
-            callPackage
             ;
         })
         cargoBuildHook

--- a/pkgs/development/interpreters/lua-5/hooks/default.nix
+++ b/pkgs/development/interpreters/lua-5/hooks/default.nix
@@ -1,9 +1,7 @@
 # Hooks for building lua packages.
 {
   lua,
-  lib,
   makeSetupHook,
-  runCommand,
 }:
 
 let
@@ -21,11 +19,8 @@ in
 
   # luarocks installs data in a non-overridable location. Until a proper luarocks patch,
   # we move the files around ourselves
-  luarocksMoveDataFolder = callPackage (
-    { }:
-    makeSetupHook {
-      name = "luarocks-move-rock";
-      propagatedBuildInputs = [ ];
-    } ./luarocks-move-data.sh
-  ) { };
+  luarocksMoveDataFolder = makeSetupHook {
+    name = "luarocks-move-rock";
+    propagatedBuildInputs = [ ];
+  } ./luarocks-move-data.sh;
 }

--- a/pkgs/development/interpreters/octave/hooks/default.nix
+++ b/pkgs/development/interpreters/octave/hooks/default.nix
@@ -1,16 +1,10 @@
 # Hooks for building Octave packages.
 {
-  octave,
-  lib,
-  callPackage,
   makeSetupHook,
 }:
 
-rec {
-  writeRequiredOctavePackagesHook = callPackage (
-    { }:
-    makeSetupHook {
-      name = "write-required-octave-packages-hook";
-    } ./write-required-octave-packages-hook.sh
-  ) { };
+{
+  writeRequiredOctavePackagesHook = makeSetupHook {
+    name = "write-required-octave-packages-hook";
+  } ./write-required-octave-packages-hook.sh;
 }

--- a/pkgs/servers/nextcloud/packages/default.nix
+++ b/pkgs/servers/nextcloud/packages/default.nix
@@ -25,8 +25,7 @@ let
     {
       # Create a derivation from the official Nextcloud apps.
       # This takes the data generated from the go tool.
-      mkNextcloudDerivation = self.callPackage (
-        { }:
+      mkNextcloudDerivation =
         { pname, data }:
         pkgs.fetchNextcloudApp {
           appName = pname;
@@ -39,8 +38,7 @@ let
             description
             homepage
             ;
-        }
-      ) { };
+        };
 
     }
     // lib.mapAttrs (

--- a/pkgs/tools/misc/bat-extras/default.nix
+++ b/pkgs/tools/misc/bat-extras/default.nix
@@ -1,4 +1,3 @@
-{ }:
 self: {
   buildBatExtrasPkg = self.callPackage ./buildBatExtrasPkg.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1909,7 +1909,7 @@ with pkgs;
 
   babelfish = callPackage ../shells/fish/babelfish.nix { };
 
-  bat-extras = recurseIntoAttrs (lib.makeScope newScope (callPackage ../tools/misc/bat-extras { }));
+  bat-extras = recurseIntoAttrs (lib.makeScope newScope (import ../tools/misc/bat-extras));
 
   beauty-line-icon-theme = callPackage ../data/icons/beauty-line-icon-theme {
     inherit (plasma5Packages) breeze-icons;


### PR DESCRIPTION
The pattern of `callPackage ({ }: ...) { };` is quite pointless - or I'm missing its purpose.

The only remotely useful case is where you have an expression calling `callPackage` on multiple functions, some of which might need arguments and some don't. This happens for example in `pkgs/development/cuda-modules/generic-builders/manifest.nix` or `pkgs/development/compilers/flutter/artifacts/prepare-artifacts.nix`.

For this reason, I couldn't add an error thrown to `callPackge` directly.

Maybe we can instead add a linting rule to `nixpkgs-vet`, where patterns that `callPackage` on a specific file or an inlined function, must have arguments? This would still allow importing variable-defined files/functions without arguments in edge-cases.

*Background: I'm trying to find the position of a package via `callPackage`, which could be much more precise than the current approach in `meta.position`. But this only works for functions with arguments. I could special case the position-code, but I figured that this more likely than not something that people run into accidentally and not on purpose.*

## Things done

Should not cause rebuilds.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
