### PR TITLE
pytestCheckHook: invoke the pytest command directly

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1332,6 +1332,10 @@ Adding `pytest` is not required, since it is included with `pytestCheckHook`.
 
 :   To append additional command-line arguments to `pytest`.
 
+`dontDisableSourceMoudleTestPaths`
+
+:   To opt out the default behaviour of adding source modules right under the current working directory to `disabledTestPaths`.
+
 By default, `pytest` automatically discovers which tests to run.
 If tests are explicitly enabled, only those tests will run.
 A test, that is both enabled and disabled, will not run.

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -37,6 +37,9 @@
 - `pytestCheckHook` now invokes the `pytest` command directly instead of using `python3 -m pytest`, preventing the current working directory of the `pytestCheckPhase` (usually the build directory) from becoming the first directory to search for modules.
   The installed site packages directory now becomes the first directory to search for modules, and Python packages that need to test against the built and installed package no longer need to `cd` to another directory before testing.
 
+  In addition, `pytestCheckHook` now adds the source module into `disabledTestPaths` if they are right under the current working directory, preventing import mismatch when using the installed modules for testing.
+  Python packages no longer need to delete the source modules before running `pytest`.
+
 - `versionCheckHook`: Packages that previously relied solely on `pname` to locate the program used to version check, but have a differing `meta.mainProgram` entry, might now fail.
 
 

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -34,6 +34,9 @@
 
 - `meta.mainProgram`: Changing this `meta` entry can lead to a package rebuild due to being used to determine the `NIX_MAIN_PROGRAM` environment variable.
 
+- `pytestCheckHook` now invokes the `pytest` command directly instead of using `python3 -m pytest`, preventing the current working directory of the `pytestCheckPhase` (usually the build directory) from becoming the first directory to search for modules.
+  The installed site packages directory now becomes the first directory to search for modules, and Python packages that need to test against the built and installed package no longer need to `cd` to another directory before testing.
+
 - `versionCheckHook`: Packages that previously relied solely on `pname` to locate the program used to version check, but have a differing `meta.mainProgram` entry, might now fail.
 
 

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -157,7 +157,7 @@ in
       name = "pytest-check-hook";
       propagatedBuildInputs = [ pytest ];
       substitutions = {
-        inherit pythonCheckInterpreter;
+        inherit pythonCheckInterpreter pythonSitePackages;
       };
       passthru = {
         tests = {

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -25,7 +25,7 @@ function pytestCheckPhase() {
     runHook preCheck
 
     # Compose arguments
-    local -a flagsArray=(-m pytest)
+    local -a flagsArray=()
 
     local -a _pathsArray
     local path
@@ -88,7 +88,7 @@ EOF
 
     concatTo flagsArray pytestFlags
     echoCmd 'pytest flags' "${flagsArray[@]}"
-    @pythonCheckInterpreter@ "${flagsArray[@]}"
+    @pythonCheckInterpreter@ -m pytest "${flagsArray[@]}"
 
     runHook postCheck
     echo "Finished executing pytestCheckPhase"

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -88,7 +88,7 @@ EOF
 
     concatTo flagsArray pytestFlags
     echoCmd 'pytest flags' "${flagsArray[@]}"
-    @pythonCheckInterpreter@ -m pytest "${flagsArray[@]}"
+    pytest "${flagsArray[@]}"
 
     runHook postCheck
     echo "Finished executing pytestCheckPhase"


### PR DESCRIPTION
This PR make `pytestCheckHook` invoke the pytest executable as `pytest` instead of `python -m pytest` to prevent additional Python module search paths (such as CWD) from prefixing to `sys.paths`.[1] In addition, `pytestCheckHook` now adds the source module into `disabledTestPaths` if they are right under the CWD, preventing import mismatch when using the installed modules for testing. 

The installed site packages directory now becomes the first directory to search for modules, and Python packages that need to test against the built and installed package no longer need to `cd` to another directory or delete the source modules before testing.

Closes #255262

Cc:
@doronbehar who proposed the fix
@FRidh who introduced the original pattern

[1]: https://docs.python.org/3/library/sys.html#sys.path

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
