### PR TITLE
[25.05] ardour: 8.11 -> 8.12, use finalAttrs pattern

### DIFF
--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -64,14 +64,14 @@
 }:
 stdenv.mkDerivation rec {
   pname = "ardour";
-  version = "8.11";
+  version = "8.12";
 
   # We can't use `fetchFromGitea` here, as attempting to fetch release archives from git.ardour.org
   # result in an empty archive. See https://tracker.ardour.org/view.php?id=7328 for more info.
   src = fetchgit {
     url = "git://git.ardour.org/ardour/ardour.git";
     rev = version;
-    hash = "sha256-z+rIWFVua1IG4GZ8kH3quKaBbN+I7Yr62vukJZk6KAg=";
+    hash = "sha256-4IgBQ53cwPA35YwNQyo+qBqsMGv+TLn6w1zaDX97erE=";
   };
 
   bundledContent = fetchzip {

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -230,6 +230,7 @@ in {
     maintainers = with lib.maintainers; [
       magnetophon
       mitchmindtree
+      ryand56
     ];
   };
 })

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -62,175 +62,179 @@
   optimize ? true, # disable to print Lua DSP script output to stdout
   videoSupport ? true,
 }:
-stdenv.mkDerivation (finalAttrs: let
-  majorVersion = lib.versions.major finalAttrs.version;
-in {
-  pname = "ardour";
-  version = "8.12";
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    majorVersion = lib.versions.major finalAttrs.version;
+  in
+  {
+    pname = "ardour";
+    version = "8.12";
 
-  # We can't use `fetchFromGitea` here, as attempting to fetch release archives from git.ardour.org
-  # result in an empty archive. See https://tracker.ardour.org/view.php?id=7328 for more info.
-  src = fetchgit {
-    url = "git://git.ardour.org/ardour/ardour.git";
-    rev = finalAttrs.version;
-    hash = "sha256-4IgBQ53cwPA35YwNQyo+qBqsMGv+TLn6w1zaDX97erE=";
-  };
+    # We can't use `fetchFromGitea` here, as attempting to fetch release archives from git.ardour.org
+    # result in an empty archive. See https://tracker.ardour.org/view.php?id=7328 for more info.
+    src = fetchgit {
+      url = "git://git.ardour.org/ardour/ardour.git";
+      rev = finalAttrs.version;
+      hash = "sha256-4IgBQ53cwPA35YwNQyo+qBqsMGv+TLn6w1zaDX97erE=";
+    };
 
-  bundledContent = fetchzip {
-    url = "https://web.archive.org/web/20221026200824/http://stuff.ardour.org/loops/ArdourBundledMedia.zip";
-    hash = "sha256-IbPQWFeyMuvCoghFl1ZwZNNcSvLNsH84rGArXnw+t7A=";
-    # archive does not contain a single folder at the root
-    stripRoot = false;
-  };
+    bundledContent = fetchzip {
+      url = "https://web.archive.org/web/20221026200824/http://stuff.ardour.org/loops/ArdourBundledMedia.zip";
+      hash = "sha256-IbPQWFeyMuvCoghFl1ZwZNNcSvLNsH84rGArXnw+t7A=";
+      # archive does not contain a single folder at the root
+      stripRoot = false;
+    };
 
-  patches = [
-    # AS=as in the environment causes build failure https://tracker.ardour.org/view.php?id=8096
-    ./as-flags.patch
-    ./default-plugin-search-paths.patch
-  ];
+    patches = [
+      # AS=as in the environment causes build failure https://tracker.ardour.org/view.php?id=8096
+      ./as-flags.patch
+      ./default-plugin-search-paths.patch
+    ];
 
-  # Ardour's wscript requires git revision and date to be available.
-  # Since they are not, let's generate the file manually.
-  postPatch = ''
-    printf '#include "libs/ardour/ardour/revision.h"\nnamespace ARDOUR { const char* revision = "${finalAttrs.version}"; const char* date = ""; }\n' > libs/ardour/revision.cc
-    sed 's|/usr/include/libintl.h|${glibc.dev}/include/libintl.h|' -i wscript
-    patchShebangs ./tools/
-    substituteInPlace libs/ardour/video_tools_paths.cc \
-      --replace-fail 'ffmpeg_exe = X_("");' 'ffmpeg_exe = X_("${ffmpeg}/bin/ffmpeg");' \
-      --replace-fail 'ffprobe_exe = X_("");' 'ffprobe_exe = X_("${ffmpeg}/bin/ffprobe");'
-  '';
+    # Ardour's wscript requires git revision and date to be available.
+    # Since they are not, let's generate the file manually.
+    postPatch = ''
+      printf '#include "libs/ardour/ardour/revision.h"\nnamespace ARDOUR { const char* revision = "${finalAttrs.version}"; const char* date = ""; }\n' > libs/ardour/revision.cc
+      sed 's|/usr/include/libintl.h|${glibc.dev}/include/libintl.h|' -i wscript
+      patchShebangs ./tools/
+      substituteInPlace libs/ardour/video_tools_paths.cc \
+        --replace-fail 'ffmpeg_exe = X_("");' 'ffmpeg_exe = X_("${ffmpeg}/bin/ffmpeg");' \
+        --replace-fail 'ffprobe_exe = X_("");' 'ffprobe_exe = X_("${ffmpeg}/bin/ffprobe");'
+    '';
 
-  nativeBuildInputs = [
-    doxygen
-    graphviz # for dot
-    itstool
-    makeWrapper
-    perl
-    pkg-config
-    python3
-    wafHook
-  ];
-
-  buildInputs =
-    [
-      alsa-lib
-      aubio
-      boost
-      cairomm
-      cppunit
-      curl
-      dbus
-      ffmpeg
-      fftw
-      fftwSinglePrec
-      flac
-      fluidsynth
-      glibmm
-      gtkmm2
-      hidapi
+    nativeBuildInputs = [
+      doxygen
+      graphviz # for dot
       itstool
-      kissfft
-      libarchive
-      libjack2
-      liblo
-      libltc
-      libogg
-      libpulseaudio
-      librdf_rasqal
-      libsamplerate
-      libsigcxx
-      libsndfile
-      libusb1
-      libuv
-      libwebsockets
-      libxml2
-      libxslt
-      lilv
-      lrdf
-      lv2
-      pango
+      makeWrapper
       perl
+      pkg-config
       python3
-      qm-dsp
-      readline
-      rubberband
-      serd
-      sord
-      soundtouch
-      sratom
-      suil
-      taglib
-      vamp-plugin-sdk
-    ]
-    ++ lib.optionals videoSupport [
-      harvid
-      xjadeo
+      wafHook
     ];
 
-  wafConfigureFlags = [
-    "--cxx17"
-    "--docs"
-    "--freedesktop"
-    "--no-phone-home"
-    "--ptformat"
-    "--run-tests"
-    "--test"
-    # since we don't have https://github.com/agfline/LibAAF yet,
-    # we need to use some of ardours internal libs, see:
-    # https://discourse.ardour.org/t/ardour-8-2-released/109615/6
-    # and
-    # https://discourse.ardour.org/t/ardour-8-2-released/109615/8
-    # "--use-external-libs"
-  ] ++ lib.optional optimize "--optimize";
+    buildInputs =
+      [
+        alsa-lib
+        aubio
+        boost
+        cairomm
+        cppunit
+        curl
+        dbus
+        ffmpeg
+        fftw
+        fftwSinglePrec
+        flac
+        fluidsynth
+        glibmm
+        gtkmm2
+        hidapi
+        itstool
+        kissfft
+        libarchive
+        libjack2
+        liblo
+        libltc
+        libogg
+        libpulseaudio
+        librdf_rasqal
+        libsamplerate
+        libsigcxx
+        libsndfile
+        libusb1
+        libuv
+        libwebsockets
+        libxml2
+        libxslt
+        lilv
+        lrdf
+        lv2
+        pango
+        perl
+        python3
+        qm-dsp
+        readline
+        rubberband
+        serd
+        sord
+        soundtouch
+        sratom
+        suil
+        taglib
+        vamp-plugin-sdk
+      ]
+      ++ lib.optionals videoSupport [
+        harvid
+        xjadeo
+      ];
 
-  postInstall =
-    ''
-      # wscript does not install these for some reason
-      install -vDm 644 "build/gtk2_ardour/ardour.xml" \
-        -t "$out/share/mime/packages"
-      install -vDm 644 "build/gtk2_ardour/ardour${majorVersion}.desktop" \
-        -t "$out/share/applications"
-      for size in 16 22 32 48 256 512; do
-        install -vDm 644 "gtk2_ardour/resources/Ardour-icon_''${size}px.png" \
-          "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour${majorVersion}.png"
-      done
-      install -vDm 644 "ardour.1"* -t "$out/share/man/man1"
+    wafConfigureFlags = [
+      "--cxx17"
+      "--docs"
+      "--freedesktop"
+      "--no-phone-home"
+      "--ptformat"
+      "--run-tests"
+      "--test"
+      # since we don't have https://github.com/agfline/LibAAF yet,
+      # we need to use some of ardours internal libs, see:
+      # https://discourse.ardour.org/t/ardour-8-2-released/109615/6
+      # and
+      # https://discourse.ardour.org/t/ardour-8-2-released/109615/8
+      # "--use-external-libs"
+    ] ++ lib.optional optimize "--optimize";
 
-      # install additional bundled beats, chords and progressions
-      cp -rp "${finalAttrs.bundledContent}"/* "$out/share/ardour${majorVersion}/media"
-    ''
-    + lib.optionalString videoSupport ''
-      # `harvid` and `xjadeo` must be accessible in `PATH` for video to work.
-      wrapProgram "$out/bin/ardour${majorVersion}" \
-        --prefix PATH : "${
-          lib.makeBinPath [
-            harvid
-            xjadeo
-          ]
-        }"
-    '';
+    postInstall =
+      ''
+        # wscript does not install these for some reason
+        install -vDm 644 "build/gtk2_ardour/ardour.xml" \
+          -t "$out/share/mime/packages"
+        install -vDm 644 "build/gtk2_ardour/ardour${majorVersion}.desktop" \
+          -t "$out/share/applications"
+        for size in 16 22 32 48 256 512; do
+          install -vDm 644 "gtk2_ardour/resources/Ardour-icon_''${size}px.png" \
+            "$out/share/icons/hicolor/''${size}x''${size}/apps/ardour${majorVersion}.png"
+        done
+        install -vDm 644 "ardour.1"* -t "$out/share/man/man1"
 
-  LINKFLAGS = "-lpthread";
+        # install additional bundled beats, chords and progressions
+        cp -rp "${finalAttrs.bundledContent}"/* "$out/share/ardour${majorVersion}/media"
+      ''
+      + lib.optionalString videoSupport ''
+        # `harvid` and `xjadeo` must be accessible in `PATH` for video to work.
+        wrapProgram "$out/bin/ardour${majorVersion}" \
+          --prefix PATH : "${
+            lib.makeBinPath [
+              harvid
+              xjadeo
+            ]
+          }"
+      '';
 
-  meta = {
-    description = "Multi-track hard disk recording software";
-    longDescription = ''
-      Ardour is a digital audio workstation (DAW), You can use it to
-      record, edit and mix multi-track audio and midi. Produce your
-      own CDs. Mix video soundtracks. Experiment with new ideas about
-      music and sound.
+    LINKFLAGS = "-lpthread";
 
-      Please consider supporting the ardour project financially:
-      https://community.ardour.org/donate
-    '';
-    homepage = "https://ardour.org/";
-    license = lib.licenses.gpl2Plus;
-    mainProgram = "ardour8";
-    platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [
-      magnetophon
-      mitchmindtree
-      ryand56
-    ];
-  };
-})
+    meta = {
+      description = "Multi-track hard disk recording software";
+      longDescription = ''
+        Ardour is a digital audio workstation (DAW), You can use it to
+        record, edit and mix multi-track audio and midi. Produce your
+        own CDs. Mix video soundtracks. Experiment with new ideas about
+        music and sound.
+
+        Please consider supporting the ardour project financially:
+        https://community.ardour.org/donate
+      '';
+      homepage = "https://ardour.org/";
+      license = lib.licenses.gpl2Plus;
+      mainProgram = "ardour8";
+      platforms = lib.platforms.linux;
+      maintainers = with lib.maintainers; [
+        magnetophon
+        mitchmindtree
+        ryand56
+      ];
+    };
+  }
+)


### PR DESCRIPTION
Backports #416831

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
