### PR TITLE
libvncserver: 0.9.14 -> 0.9.15

### DIFF
--- a/pkgs/by-name/li/libvncserver/package.nix
+++ b/pkgs/by-name/li/libvncserver/package.nix
@@ -12,6 +12,7 @@
   systemd,
 
   enableShared ? !stdenv.hostPlatform.isStatic,
+  buildExamples ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -42,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "WITH_SYSTEMD" withSystemd)
     (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
+    (lib.cmakeBool "WITH_EXAMPLES" buildExamples)
   ];
 
   buildInputs =

--- a/pkgs/by-name/li/libvncserver/package.nix
+++ b/pkgs/by-name/li/libvncserver/package.nix
@@ -10,6 +10,8 @@
   libpng,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   systemd,
+
+  enableShared ? !stdenv.hostPlatform.isStatic,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +39,10 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
   ];
 
-  cmakeFlags = [ (lib.cmakeBool "WITH_SYSTEMD" withSystemd) ];
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_SYSTEMD" withSystemd)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" enableShared)
+  ];
 
   buildInputs =
     [

--- a/pkgs/by-name/li/libvncserver/package.nix
+++ b/pkgs/by-name/li/libvncserver/package.nix
@@ -12,9 +12,9 @@
   systemd,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libvncserver";
-  version = "0.9.14";
+  version = "0.9.15";
 
   outputs = [
     "out"
@@ -24,8 +24,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "LibVNC";
     repo = "libvncserver";
-    rev = "LibVNCServer-${version}";
-    sha256 = "sha256-kqVZeCTp+Z6BtB6nzkwmtkJ4wtmjlSQBg05lD02cVvQ=";
+    tag = "LibVNCServer-${finalAttrs.version}";
+    hash = "sha256-a3acEjJM+ZA9jaB6qZ/czjIfx/L3j71VjJ6mtlqYcSw=";
   };
 
   patches = [
@@ -37,9 +37,7 @@ stdenv.mkDerivation rec {
     cmake
   ];
 
-  cmakeFlags = [
-    "-DWITH_SYSTEMD=${if withSystemd then "ON" else "OFF"}"
-  ];
+  cmakeFlags = [ (lib.cmakeBool "WITH_SYSTEMD" withSystemd) ];
 
   buildInputs =
     [
@@ -63,4 +61,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ raskin ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/li/libvncserver/pkgconfig.patch
+++ b/pkgs/by-name/li/libvncserver/pkgconfig.patch
@@ -1,7 +1,7 @@
-diff --git a/libvncclient.pc.cmakein b/libvncclient.pc.cmakein
+diff --git a/src/libvncclient/libvncclient.pc.cmakein b/src/libvncclient/libvncclient.pc.cmakein
 index ceeda39d..2516e643 100644
---- a/libvncclient.pc.cmakein
-+++ b/libvncclient.pc.cmakein
+--- a/src/libvncclient/libvncclient.pc.cmakein
++++ b/src/libvncclient/libvncclient.pc.cmakein
 @@ -1,7 +1,7 @@
  prefix=@CMAKE_INSTALL_PREFIX@
  exec_prefix=@CMAKE_INSTALL_PREFIX@
@@ -12,10 +12,10 @@ index ceeda39d..2516e643 100644
  
  Name: LibVNCClient
  Description: A library for easy implementation of a VNC client.
-diff --git a/libvncserver.pc.cmakein b/libvncserver.pc.cmakein
+diff --git a/src/libvncserver/libvncserver.pc.cmakein b/src/libvncserver/libvncserver.pc.cmakein
 index 33ec6685..57244742 100644
---- a/libvncserver.pc.cmakein
-+++ b/libvncserver.pc.cmakein
+--- a/src/libvncserver/libvncserver.pc.cmakein
++++ b/src/libvncserver/libvncserver.pc.cmakein
 @@ -1,7 +1,7 @@
  prefix=@CMAKE_INSTALL_PREFIX@
  exec_prefix=@CMAKE_INSTALL_PREFIX@


### PR DESCRIPTION
Changelog: https://github.com/LibVNC/libvncserver/releases/tag/LibVNCServer-0.9.15
Important changes include `Fixed building with OpenSSL >= 3.0.0.`

Also enables toggling between static and shared builds, and disables building examples by default.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
