### PR TITLE
feat(buildGoModule): add goModules (dependency FOD) to passthru

### DIFF
--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -66,14 +66,7 @@ lib.extendMkDerivation {
 
       ...
     }@args:
-    {
-      inherit
-        modRoot
-        vendorHash
-        deleteVendor
-        proxyVendor
-        goSum
-        ;
+    let
       goModules =
         if (finalAttrs.vendorHash == null) then
           ""
@@ -203,6 +196,16 @@ lib.extendMkDerivation {
             # in case an overlay clears passthru by accident, don't fail evaluation
           }).overrideAttrs
             (finalAttrs.passthru.overrideModAttrs or overrideModAttrs);
+    in
+    {
+      inherit
+        modRoot
+        vendorHash
+        deleteVendor
+        proxyVendor
+        goSum
+        goModules
+        ;
 
       nativeBuildInputs = [ go ] ++ nativeBuildInputs;
 
@@ -389,7 +392,7 @@ lib.extendMkDerivation {
       disallowedReferences = lib.optional (!allowGoReference) go;
 
       passthru = {
-        inherit go;
+        inherit go goModules;
         # Canonicallize `overrideModAttrs` as an attribute overlay.
         # `passthru.overrideModAttrs` will be overridden
         # when users want to override `goModules`.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I've exposed the `goModules` derivation (generated from the module's `go.mod`/`go.sum`) in `passthru`. I ran into an issue trying to generate derivations for each of the `go` modules in https://github.com/hashicorp/terraform-provider-scaffolding-framework/tree/ffe107b9af03f804b72f817502ca45f6b0490fe3 (recent commit on `main`). This repo contains nested `go` modules. So, when performing the `go generate` step in the derivation for `./tools` (cf. [here](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/ffe107b9af03f804b72f817502ca45f6b0490fe3/tools/tools.go#L13-L22)) I found that things were failing because the `vendor` directory in the root didn't match the `go.mod`/`go.sum` associated with the parent module - at least, that's what it looked like. I still need to work to make a reproduction that's not located on my work machine.

I found that by adding a step, where I do something like
```
cp -r ${repoRootDerivation.goModules} ../vendor # ../vendor points to the repo root
```
with the changes from this PR, resolves the `go` compiler's complaints about `modules/vendor.txt` not aligning with `go.mod`/`go.sum`.

I'm posting here right now to gather feedback. But, I plan to share a derivation which uses and benefits from these changes to provide some more concrete technical context. Maybe by looking at the problem this is trying to solve, we can develop a better solution.

I like this solution because it doesn't really change `buildGoModule` (hashes don't change and I didn't need to add a bunch of backward compatibility layers like if I wanted to make `modRoots = [ ./root1 ./sub/root2 ]` and related. This is also a nice change because it allows projects which _don't_ have nested `go` modules to easily inspect the dependencies of a `buildGoModule` derivation by doing something like `nix build ".#${BUILD_GO_MODULE_DRV}.goModules" && tree -L"$BIG_NUMBER" ./result/*`


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
