### PR TITLE
fixVersioneerSourcesHook: init

### DIFF
--- a/pkgs/by-name/fi/fixVersioneerSourcesHook/package.nix
+++ b/pkgs/by-name/fi/fixVersioneerSourcesHook/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  makeSetupHook,
+  fetchFromGitHub,
+  fetchzip,
+  fixVersioneerSourcesHook,
+  runCommand,
+}:
+makeSetupHook {
+  name = "fixVersioneerSourcesHook";
+
+  passthru.tests.test =
+    let
+      # An example of a project that uses versioneer
+      src = fetchFromGitHub {
+        owner = "jcrist";
+        repo = "msgspec";
+        tag = "0.19.0";
+        hash = "sha256-CajdPNAkssriY/sie5gR+4k31b3Wd7WzqcsFmrlSoPY=";
+      };
+      # Make a clean tarball out of the source to be fetched by fetchzip later
+      srcClean = runCommand "source-clean.tar.gz" { } ''
+        tar -cf $out -C ${src} .
+      '';
+      # Patch tarball adding a common error produced in GitHub source archives
+      srcDirty = runCommand "source-dirty.tar.gz" { } ''
+        unpackFile ${src}
+        chmod -R u+w source
+        cd source
+        sed -i 's/git_refnames = " (\(.*\))"/git_refnames = " (HEAD -> main, \1)"/' msgspec/_version.py
+        tar -cf $out .
+      '';
+      # Make the result of fetchzip not fixed output to run it with and without hook
+      doFetch =
+        name: src: withHook:
+        (fetchzip {
+          inherit name;
+          url = "file://${src}";
+          stripRoot = false;
+          nativeBuildInputs = lib.optionals withHook [ fixVersioneerSourcesHook ];
+        }).overrideAttrs
+          {
+            outputHashAlgo = null;
+            outputHash = null;
+          };
+    in
+    # Now verify that all these produce the result equal to the clean one
+    runCommand "test-fixVersioneerSourcesHook"
+      {
+        clean = doFetch "clean" srcClean false;
+        cleanWithHook = doFetch "cleanWithHook" srcClean true;
+        dirtyWithHook = doFetch "dirtyWithHook" srcDirty true;
+      }
+      ''
+        diff -ru $clean $cleanWithHook
+        diff -ru $clean $dirtyWithHook
+        touch $out
+      '';
+} ./setup-hook.sh

--- a/pkgs/by-name/fi/fixVersioneerSourcesHook/setup-hook.sh
+++ b/pkgs/by-name/fi/fixVersioneerSourcesHook/setup-hook.sh
@@ -1,0 +1,18 @@
+appendToVar postFetchHooks fixVersioneerSource
+
+fixVersioneerSource() {
+  local versionfile
+  # try pyproject.toml
+  versionfile="$([ -f "$out/pyproject.toml" ] && awk 'match($0, /^versionfile_source ?= ?['"'"'"](.*)['"'"'"]/, m) { print m[1] }' "$out/pyproject.toml" || true)"
+  if [ -z "$versionfile" ]; then
+    echo "'versionfile_source' not found in 'pyproject.toml', trying 'setup.cfg'"
+    # try setup.cfg
+    versionfile="$([ -f "$out/pyproject.toml" ] && awk 'match($0, /^versionfile_source ?= ?(.*)/, m) { print m[1] }' "$out/setup.cfg" || true)"
+    if [ -z "$versionfile" ]; then
+      echo "'versionfile_source' not found in 'setup.cfg'"
+      return
+    fi
+  fi
+  echo "found versionfile_source = $versionfile"
+  sed -i 's/git_refnames = " (.*\(tag:[^,)]*\).*)"/git_refnames = " (\1)"/' "$out/$versionfile"
+}

--- a/pkgs/development/python-modules/ancp-bids/default.nix
+++ b/pkgs/development/python-modules/ancp-bids/default.nix
@@ -7,6 +7,7 @@
   setuptools,
   numpy,
   pandas,
+  fixVersioneerSourcesHook,
 }:
 
 buildPythonPackage rec {
@@ -21,7 +22,8 @@ buildPythonPackage rec {
     owner = "ANCPLabOldenburg";
     repo = "ancp-bids";
     tag = version;
-    hash = "sha256-n8QfQ2PGdAO6kTfkbFpj3f2gYa3vwuYg+vPpZlGNpb0=";
+    hash = "sha256-dfk7AILVWXCvA12l6RrrUIR93A8nT0kn/tZT/cN63ZU=";
+    nativeBuildInputs = [ fixVersioneerSourcesHook ];
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/bayespy/default.nix
+++ b/pkgs/development/python-modules/bayespy/default.nix
@@ -8,6 +8,7 @@
   h5py,
   truncnorm,
   pytestCheckHook,
+  fixVersioneerSourcesHook,
 }:
 
 buildPythonPackage rec {
@@ -19,7 +20,8 @@ buildPythonPackage rec {
     owner = "bayespy";
     repo = "bayespy";
     tag = version;
-    hash = "sha256-X7CwJBrKHlU1jqMkt/7XEzaiwul1Yzkb/V64lXG4Aqo=";
+    hash = "sha256-kx87XY4GCL1PQIeZyovEbrPyCC/EVA6Hdvt+3P/D6VI=";
+    nativeBuildInputs = [ fixVersioneerSourcesHook ];
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/birch/default.nix
+++ b/pkgs/development/python-modules/birch/default.nix
@@ -8,6 +8,7 @@
   pytestCheckHook,
   pytest-cov-stub,
   pyyaml,
+  fixVersioneerSourcesHook,
 }:
 
 buildPythonPackage rec {
@@ -18,8 +19,9 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "shaypal5";
     repo = "birch";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-KdQZzQJvJ+logpcLQfaqqEEZJ/9VmNTQX/a4v0oBC98=";
+    nativeBuildInputs = [ fixVersioneerSourcesHook ];
   };
 
   patches = [

--- a/pkgs/development/python-modules/coredis/default.nix
+++ b/pkgs/development/python-modules/coredis/default.nix
@@ -14,6 +14,7 @@
   redis,
   typing-extensions,
   wrapt,
+  fixVersioneerSourcesHook,
 }:
 
 buildPythonPackage rec {
@@ -26,6 +27,7 @@ buildPythonPackage rec {
     repo = "coredis";
     tag = version;
     hash = "sha256-5Ho9X2VCOwKo079M2ReJ93jqEpG2ZV6vKM5/qrgzjxM=";
+    nativeBuildInputs = [ fixVersioneerSourcesHook ];
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/dask-jobqueue/default.nix
+++ b/pkgs/development/python-modules/dask-jobqueue/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fixVersioneerSourcesHook,
 
   # build-system
   setuptools,
@@ -27,6 +28,7 @@ buildPythonPackage rec {
     repo = "dask-jobqueue";
     tag = version;
     hash = "sha256-YujfhjOJzl4xsjjsyrQkEu/CBR04RwJ79c1iSTcMIgw=";
+    nativeBuildInputs = [ fixVersioneerSourcesHook ];
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Add a hook that would fix a common issue with projects using Versioneer on GitHub: when GitHub runs analog of `git archive` to generate an archive from a tag, it subsitutes `$Format:%d$` with `(HEAD -> main, tag: the_tag)` when the tag points to the latest commit, but when more commits are added, it becomes `(tag: the_tag)`, which changes source hash.

Packages that are either automatically or manually updated early, get source with this `HEAD -> main` part and so their sources are not reproducible more often.

Adding this hook to projects that use Versioneer will remove this `HEAD -> main` part of the description string and make the source reproducible. Here's how it would look, for example:

```nix
src = fetchFromGitHub {
  owner = "ANCPLabOldenburg";
  repo = "ancp-bids";
  tag = version;
  hash = "sha256-vmw8SAikvbaHnPOthBQxTbyvDwnnZwCOV97aUogIgxw=";
  nativeBuildInputs = [ fixVersioneerSourcesHook ];
};
```

I ran into this issue when preparing https://github.com/NixOS/nixpkgs/pull/416464, the general case of this issue is described in https://github.com/NixOS/nixpkgs/issues/84312.

To see which Python packages are using Versioneer, I ran following script:

<details>

<summary>find-versioneer.sh</summary>

```bash
#!/usr/bin/env bash
e='
with import ./. {
  system = "x86_64-linux";
  overlays = [ ];
  config = { };
};
python3Packages
|> lib.mapAttrsToList (
  name: p:
  if
    lib.isAttrs p
    && lib.isAttrs p.src or null
    && lib.hasPrefix "https://github.com" p.src.url or ""
    && p.src ? owner
    && p.src ? repo
  then
    {
      inherit name;
      inherit (p.src) url owner repo;
    }
  else
    null
)
|> lib.filter (p: p != null |> builtins.tryEval |> (r: r.success && r.value))
|> lib.concatMapStringsSep "\n" (p: "${p.name} ${p.owner} ${p.repo}")
'

eval() {
  nix eval --extra-experimental-features pipe-operators --raw --impure --expr "$e"
}

while read name owner repo; do
  echo -n "$name"
  if gh api --cache 48h "/repos/${owner}/${repo}/contents/versioneer.py" > /dev/null 2>&1; then
    echo
  fi
  echo -ne "\r${name//?/ }\r"
done < <(eval)
```

</details>

And it produced the following list of packages that most likely have unstable source hashes after each release:

<details>

<summary>Packages</summary>

```
ancp-bids
bayespy
birch
cons
coredis
crochet
dask-jobqueue
dask-yarn
datalad
datalad-gooey
datashape
debugpy
ed25519
eliot
etelemetry
etuples
fipy
flask-limiter
gcsfs
geometric
geopandas
great-expectations
hieroglyph
intake-parquet
junos-eznc
jupyter-repo2docker
kotsu
libusb1
limits
llvmlite
logical-unification
magic-wormhole
matchpy
minikanren
monai
monai-deploy
msgspec
nbconflux
ncclient
ndindex
numba
numbaWithCuda
parallel-ssh
pims
propka
pydata-google-auth
pylatex
pyprecice
pyrevolve
pytest-mpi
python-jsonrpc-server
rembg
s3fs
salmon-mail
shapely
spake2
ssh-python
ssh2-python
strenum
trackpy
```

</details>

Trying to rebuild all of them, I got following packages with broken hashes:

<details>

<summary>Packages with broken sources</summary>

```
cons
datalad
debugpy
etuples
fipy
intake-parquet
logical-unification
monai
monai-deploy
msgspec
pims
propka
pydata-google-auth
pylatex
rembg
salmon-mail
trackpy
```

</details>

I've added the hook to some packages and fixed hashes if they were broken to show some examples. I picked a small number of packages with no dependants to avoid mass rebuild.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
