### PR TITLE
league-mono: init at 2.300

### DIFF
--- a/pkgs/by-name/le/league-mono/package.nix
+++ b/pkgs/by-name/le/league-mono/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchzip,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "league-mono";
+  version = "2.300";
+
+  src = fetchzip {
+    url = "https://github.com/theleagueof/league-mono/releases/download/${finalAttrs.version}/LeagueMono-${finalAttrs.version}.tar.xz";
+    hash = "sha256-b945/ej5jVzq5enyiCmgdtqB7CcfxBGR7NJFWlydK0c=";
+  };
+
+  outputs = [
+    "out"
+    "web"
+    "variable"
+    "variableweb"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m444 -t $out/share/fonts/truetype $src/static/TTF/*.ttf
+    install -D -m444 -t $out/share/fonts/opentype $src/static/OTF/*.otf
+    install -D -m444 -t $web/share/fonts/webfont $src/static/WOFF2/*.woff2
+    install -D -m444 -t $variable/share/fonts/truetype $src/variable/TTF/*.ttf
+    install -D -m444 -t $variableweb/share/fonts/webfont $src/variable/WOFF2/*.woff2
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "monospace/variable font fun";
+    longDescription = ''
+      Five weights of monospace fun. League Mono is a mashup of sorts, inspired
+      by some beautiful forms found in both Fira Mono, Libertinus Mono, and
+      Courier(?!). League Mono was created in glyphs using masters for the
+      UltraLight, Regular, and Bold weights, and interpolated instances for the
+      Light and SemiBold weights. This, unfortunately, is not supported by UFO
+      files, which is why there is a Glyphs source and source files for each
+      weight.
+    '';
+    homepage = "https://www.theleagueofmoveabletype.com/league-mono";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+})

--- a/pkgs/by-name/le/league-of-moveable-type/package.nix
+++ b/pkgs/by-name/le/league-of-moveable-type/package.nix
@@ -9,6 +9,7 @@
   junction-font,
   knewave,
   league-gothic,
+  league-mono,
   league-script-number-one,
   league-spartan,
   linden-hill,


### PR DESCRIPTION
Skipping `*.woff` files since I don’t see the point when they provide `*.woff2`.

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
