### PR TITLE
vulkan-docs: init at 1.4.319

### DIFF
--- a/pkgs/by-name/vu/vulkan-docs/add-man3-target.patch
+++ b/pkgs/by-name/vu/vulkan-docs/add-man3-target.patch
@@ -1,0 +1,105 @@
+diff --git a/Makefile b/Makefile
+index 0d493cf7..dfe45ba6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -60,6 +60,7 @@ IMAGEOPTS = inline
+ #  manhtml - HTML5 single-page reference guide - NOT SUPPORTED
+ #  manpdf - PDF reference guide - NOT SUPPORTED
+ #  manhtmlpages - HTML5 separate per-feature refpages
++#  man3pages - man3 separate per-feature refpages
+ #  allchecks - checks for style guide compliance, XML consistency,
+ #   internal link validity, and other easy to catch errors.
+ 
+@@ -69,7 +70,7 @@ alldocs: allspecs allman proposals
+ 
+ allspecs: html pdf styleguide registry
+ 
+-allman: manhtmlpages
++allman: manhtmlpages man3pages
+ 
+ # Invokes all the automated checks, but CHECK_XREFS can be set to empty
+ # on the command line to avoid building an HTML spec target.
+@@ -618,13 +619,24 @@ manhtmlpages: $(REFPATH)/apispec.adoc $(GENDEPENDS)
+ 	$(QUIET) echo "manhtmlpages: building HTML refpages with these options:"
+ 	$(QUIET) echo $(ASCIIDOC) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) \
+ 	    $(ADOCREFOPTS) -d manpage -o REFPAGE.html REFPAGE.adoc
+-	$(MAKE) $(SUBMAKEOPTIONS) -e buildmanpages
++	$(MAKE) $(SUBMAKEOPTIONS) -e buildmanhtmlpages
++
++man3pages: $(REFPATH)/apispec.adoc $(GENDEPENDS)
++	$(QUIET) echo "man3pages: building man3 refpages with these options:"
++	$(QUIET) echo $(ASCIIDOC) -b manpage $(ADOCOPTS) $(ADOCHTMLOPTS) \
++	    $(ADOCREFOPTS) -d manpage -o REFPAGE.html REFPAGE.adoc
++	$(MAKE) $(SUBMAKEOPTIONS) -e buildman3pages
+ 
+ # Build the individual refpages, then the symbolic links from aliases
+ MANHTMLDIR  = $(OUTDIR)/man/html
+ MANHTML     = $(MANSOURCES:$(REFPATH)/%.adoc=$(MANHTMLDIR)/%.html)
+-buildmanpages: $(MANHTML)
+-	$(MAKE) $(SUBMAKEOPTIONS) -e manaliases
++buildmanhtmlpages: $(MANHTML)
++	$(MAKE) $(SUBMAKEOPTIONS) -e manhtmlaliases
++
++MAN3DIR 	= $(OUTDIR)/man/man3
++MAN3    	= $(MANSOURCES:$(REFPATH)/%.adoc=$(MAN3DIR)/%.3)
++buildman3pages: $(MAN3)
++	$(MAKE) $(SUBMAKEOPTIONS) -e man3aliases
+ 
+ # Asciidoctor options to build refpages
+ #
+@@ -652,6 +664,16 @@ $(MANHTMLDIR)/%.html: $(REFPATH)/%.adoc $(GENDEPENDS) $(KATEXINSTDIR)
+ 	    $(TRANSLATEMATH) $@ ; \
+ 	fi
+ 
++$(MAN3DIR)/%.3: KATEXDIR = ../../katex
++$(MAN3DIR)/%.3: $(REFPATH)/%.adoc $(GENDEPENDS) $(KATEXINSTDIR)
++	$(VERYQUIET)echo "Building $@ from $< using default options"
++	$(VERYQUIET)$(MKDIR) $(MAN3DIR)
++	$(VERYQUIET)$(ASCIIDOC) -b manpage $(ADOCOPTS) $(ADOCREFOPTS) \
++		-d manpage -o $@ $<
++	$(VERYQUIET)if egrep -q '\\[([]' $@ ; then \
++		$(TRANSLATEMATH) $@ ; \
++	fi
++
+ # The 'manhtml' and 'manpdf' targets are NO LONGER SUPPORTED by Khronos.
+ # They generate HTML5 and PDF single-file versions of the refpages.
+ # The generated refpage sources are included by $(REFPATH)/apispec.adoc,
+@@ -681,9 +703,13 @@ $(OUTDIR)/apispec.html: $(SPECVERSION) $(REFPATH)/apispec.adoc $(SVGFILES) $(GEN
+ # Create links for refpage aliases
+ 
+ MAKEMANALIASES = $(SCRIPTS)/makemanaliases.py
+-manaliases: $(PYAPIMAP)
++
++manhtmlaliases: $(PYAPIMAP)
+ 	$(PYTHON) $(MAKEMANALIASES) -genpath $(GENERATED) -refdir $(MANHTMLDIR)
+ 
++man3aliases: $(PYAPIMAP)
++	$(PYTHON) $(MAKEMANALIASES) -genpath $(GENERATED) -refdir $(MAN3DIR) -man3
++
+ # Antora-related targets
+ 
+ # Targets generated from the XML and registry processing scripts
+diff --git a/scripts/makemanaliases.py b/scripts/makemanaliases.py
+index 4d9102e6..e0c3b279 100755
+--- a/scripts/makemanaliases.py
++++ b/scripts/makemanaliases.py
+@@ -20,6 +20,8 @@ if __name__ == '__main__':
+                         required=True,
+                         help='Path to directory containing reference pages to symlink')
+ 
++    parser.add_argument('-man3', action='store_true', default=False, help='Set to true when dealing with man3 pages')
++
+     args = parser.parse_args()
+ 
+     # Look for apimap.py in the specified directory
+@@ -45,6 +47,10 @@ if __name__ == '__main__':
+ 
+         alias = f"{key}.html"
+         src = f"{api.alias[key]}.html"
++        if args.man3:
++            alias = f"{key}.3"
++            src = f"{api.alias[key]}.3"
++        
+ 
+         if not os.access(src, os.R_OK):
+             # This should not happen, but is possible if the api module is

--- a/pkgs/by-name/vu/vulkan-docs/all-extensions.py
+++ b/pkgs/by-name/vu/vulkan-docs/all-extensions.py
@@ -1,0 +1,4 @@
+import sys
+sys.path.insert(0, 'scripts')
+from extdependency import ApiDependencies
+print(" ".join(sorted(ApiDependencies().allExtensions())), end='')

--- a/pkgs/by-name/vu/vulkan-docs/no-internal-katex.patch
+++ b/pkgs/by-name/vu/vulkan-docs/no-internal-katex.patch
@@ -1,0 +1,72 @@
+diff --git a/Makefile b/Makefile
+index c4fc6fb1..f5f1c044 100644
+--- a/Makefile
++++ b/Makefile
+@@ -320,14 +320,6 @@ COMMONDOCS     = $(SPECFILES) $(GENDEPENDS)
+ # Script to translate math on build time
+ TRANSLATEMATH = $(NODEJS) $(SCRIPTS)/translate_math.js $(KATEXSRCDIR)/katex.min.js
+ 
+-# Install katex in KATEXINSTDIR ($(OUTDIR)/katex) to be shared by all
+-# HTML targets.
+-# We currently only need the css and fonts, but copy all of KATEXSRCDIR anyway.
+-$(KATEXINSTDIR): $(KATEXSRCDIR)
+-	$(QUIET)$(MKDIR) $(KATEXINSTDIR)
+-	$(QUIET)$(RMRF)  $(KATEXINSTDIR)
+-	$(QUIET)$(CP) -rf $(KATEXSRCDIR) $(KATEXINSTDIR)
+-
+ # Spec targets
+ # There is some complexity to try and avoid short virtual targets like 'html'
+ # causing specs to *always* be regenerated.
+@@ -363,14 +355,14 @@ getchunker:
+ html: $(HTMLDIR)/vkspec.html $(SPECSRC) $(COMMONDOCS)
+ 
+ $(HTMLDIR)/vkspec.html: KATEXDIR = ../katex
+-$(HTMLDIR)/vkspec.html: $(SPECSRC) $(COMMONDOCS) $(KATEXINSTDIR)
++$(HTMLDIR)/vkspec.html: $(SPECSRC) $(COMMONDOCS)
+ 	$(QUIET)$(ASCIIDOC) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) -o $@ $(SPECSRC)
+ 	$(QUIET)$(TRANSLATEMATH) $@
+ 
+ diff_html: $(HTMLDIR)/diff.html $(SPECSRC) $(COMMONDOCS)
+ 
+ $(HTMLDIR)/diff.html: KATEXDIR = ../katex
+-$(HTMLDIR)/diff.html: $(SPECSRC) $(COMMONDOCS) $(KATEXINSTDIR)
++$(HTMLDIR)/diff.html: $(SPECSRC) $(COMMONDOCS)
+ 	$(QUIET)$(ASCIIDOC) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) \
+ 	    -a diff_extensions="$(DIFFEXTENSIONS)" \
+ 	    -r $(CONFIGS)/extension-highlighter.rb --trace \
+@@ -419,7 +411,7 @@ STYLEFILES = $(wildcard $(SPECDIR)/style/[A-Za-z]*.adoc)
+ styleguide: $(OUTDIR)/styleguide.html
+ 
+ $(OUTDIR)/styleguide.html: KATEXDIR = katex
+-$(OUTDIR)/styleguide.html: $(STYLESRC) $(STYLEFILES) $(GENDEPENDS) $(KATEXINSTDIR)
++$(OUTDIR)/styleguide.html: $(STYLESRC) $(STYLEFILES) $(GENDEPENDS)
+ 	$(QUIET)$(MKDIR) $(OUTDIR)
+ 	$(QUIET)$(ASCIIDOC) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) -o $@ $(STYLESRC)
+ 	$(QUIET)$(TRANSLATEMATH) $@
+@@ -639,7 +631,7 @@ ADOCREFOPTS = -a cross-file-links -a refprefix='refpage.' -a isrefpage \
+ # Running translate_math.js on every refpage is slow and most of them
+ # do not contain math, so do a quick search for latexmath delimiters.
+ $(MANHTMLDIR)/%.html: KATEXDIR = ../../katex
+-$(MANHTMLDIR)/%.html: $(REFPATH)/%.adoc $(GENDEPENDS) $(KATEXINSTDIR)
++$(MANHTMLDIR)/%.html: $(REFPATH)/%.adoc $(GENDEPENDS)
+ 	$(VERYQUIET)echo "Building $@ from $< using default options"
+ 	$(VERYQUIET)$(MKDIR) $(MANHTMLDIR)
+ 	$(VERYQUIET)$(ASCIIDOC) -b html5 $(ADOCOPTS) $(ADOCHTMLOPTS) $(ADOCREFOPTS) \
+@@ -649,7 +641,7 @@ $(MANHTMLDIR)/%.html: $(REFPATH)/%.adoc $(GENDEPENDS) $(KATEXINSTDIR)
+ 	fi
+ 
+ $(MAN3DIR)/%.3: KATEXDIR = ../../katex
+-$(MAN3DIR)/%.3: $(REFPATH)/%.adoc $(GENDEPENDS) $(KATEXINSTDIR)
++$(MAN3DIR)/%.3: $(REFPATH)/%.adoc $(GENDEPENDS)
+ 	$(VERYQUIET)echo "Building $@ from $< using default options"
+ 	$(VERYQUIET)$(MKDIR) $(MAN3DIR)
+ 	$(VERYQUIET)$(ASCIIDOC) -b manpage $(ADOCOPTS) $(ADOCREFOPTS) \
+@@ -678,7 +670,7 @@ manhtml: $(OUTDIR)/apispec.html
+ 
+ $(OUTDIR)/apispec.html: KATEXDIR = katex
+ $(OUTDIR)/apispec.html: ADOCMISCOPTS =
+-$(OUTDIR)/apispec.html: $(SPECVERSION) $(REFPATH)/apispec.adoc $(SVGFILES) $(GENDEPENDS) $(KATEXINSTDIR)
++$(OUTDIR)/apispec.html: $(SPECVERSION) $(REFPATH)/apispec.adoc $(SVGFILES) $(GENDEPENDS)
+ 	$(QUIET)$(MKDIR) $(OUTDIR)
+ 	$(QUIET)$(ASCIIDOC) -b html5 -a html_spec_relative='html/vkspec.html' \
+ 	    $(ADOCOPTS) $(ADOCHTMLOPTS) -o $@ $(REFPATH)/apispec.adoc

--- a/pkgs/by-name/vu/vulkan-docs/package.nix
+++ b/pkgs/by-name/vu/vulkan-docs/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  asciidoctor-with-extensions,
+  hexapdf,
+  nodejs_24,
+  python3,
+  python3Packages,
+  nodePackages,
+  katex ? nodePackages.katex,
+  he ? nodePackages.he,
+  allExtensions ? true,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "vulkan-docs";
+  version = "1.4.319";
+
+  src = fetchFromGitHub {
+    owner = "KhronosGroup";
+    repo = "Vulkan-Docs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-euJSkdJtith+eeiYM3zYEmJx/4yaVqcBLU0NKjj83l0=";
+  };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    asciidoctor-with-extensions
+    nodejs_24
+    python3
+    python3Packages.pyparsing
+    he
+    hexapdf
+  ];
+
+  patches = [
+    ./add-man3-target.patch
+    ./no-internal-katex.patch
+    ./remove-escape-string-regexp.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-quiet "KATEXDIR =" "KATEXDIR = ${katex}/lib/node_modules/katex/dist #"
+
+    substituteInPlace config/katex_replace/extension.rb \
+      --replace-warn "../katex/" "${katex}/lib/node_modules/katex/dist/"
+  '';
+
+  preBuild = toString (
+    lib.optional allExtensions ''
+      makeFlagsArray+=(EXTENSIONS="$(python3 ${./all-extensions.py})")
+    ''
+  );
+
+  makeFlags = [ "alldocs" ];
+
+  postBuild = ''
+    # replace html-style formatting and use known sections
+    substituteInPlace gen/out/man/man3/* \
+      --replace-quiet "<code>" "\fB" \
+      --replace-quiet "</code>" "\fP" \
+      --replace-quiet "<strong>" "\fI" \
+      --replace-quiet "<strong class=\"purple\">" "\fI" \
+      --replace-quiet "</strong>" "\fP" \
+      --replace-quiet "C SPECIFICATION" "SYNOPSIS"
+
+    # replace .URL with bold typesetting
+    find gen/out/man/man3 -type f -exec \
+      sed -i 's/\.URL "\(.*\)\.html" ".*" ".*"/\\fB\1\\fP/g' '{}' \;
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/man
+    mv gen/out/man/man3 $out/share/man/man3
+    mv gen/out $out/share/doc
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Vulkan API Specification and related tools";
+    homepage = "https://github.com/KhronosGroup/Vulkan-Docs";
+    license = with lib.licenses; [
+      # taken from https://github.com/KhronosGroup/Vulkan-Docs/blob/v1.4.318/LICENSE.adoc
+      asl20
+      cc-by-40
+      mit
+      mplus
+    ];
+    maintainers = [ lib.maintainers.evythedemon ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/vu/vulkan-docs/remove-escape-string-regexp.patch
+++ b/pkgs/by-name/vu/vulkan-docs/remove-escape-string-regexp.patch
@@ -1,0 +1,21 @@
+diff --git a/scripts/translate_math.js b/scripts/translate_math.js
+index 758bfc31..40d90f65 100644
+--- a/scripts/translate_math.js
++++ b/scripts/translate_math.js
+@@ -7,7 +7,6 @@
+ 
+ const katex = require(process.argv[2]);
+ const fs = require("fs");
+-const escapeRegex = require("escape-string-regexp");
+ const he = require('he');
+ 
+ const filepath = process.argv[3];
+@@ -22,7 +21,7 @@ const delimiters = [
+                    ]
+ 
+ for( var delim of delimiters ) {
+-    const regex = new RegExp( escapeRegex(delim.left) + "([\\S\\s]*?)" + escapeRegex(delim.right), "g");
++    const regex = new RegExp( RegExp.escape(delim.left) + "([\\S\\s]*?)" + RegExp.escape(delim.right), "g");
+     html = html.replace( regex,
+         function(match, g1) {
+             return katex.renderToString( he.decode(g1, {'strict': true}), {displayMode: delim.display, output: 'html', strict: true} );


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds vulkan docs and manpages.

With this one can do
```
man 3 VkInstanceCreateInfo
```

![image](https://github.com/user-attachments/assets/50768225-10e1-4826-b353-47b449679214)



This also includes html references and some other files, generated by the Vulkan-Docs repo.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
