### PR TITLE
tmuxPlugins: allow simple overrideAttrs without function

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -16,7 +16,7 @@ let
       rtp = "${derivation}/${path}/${rtpFilePath}";
     }
     // {
-      overrideAttrs = f: mkTmuxPlugin (attrs // f attrs);
+      overrideAttrs = f: mkTmuxPlugin (attrs // (if lib.isFunction f then f attrs else f));
     };
 
   mkTmuxPlugin =


### PR DESCRIPTION
Regular `overrideAttrs` also supports passing a plain attribute set.

Before this PR:

```
nix-repl> tmuxPlugins.battery.overrideAttrs { pname = "my-battery"; }
error: attempt to call something which is not a function but a set: {
pname = "my-battery"; }
```

After, it works.

## Things done

Should cause no rebuilds.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
