### PR TITLE
scala: refactor bare to passthru

### DIFF
--- a/pkgs/development/compilers/scala/default.nix
+++ b/pkgs/development/compilers/scala/default.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation {
   '';
 
   inherit (bare) meta;
-}
-// {
-  inherit bare;
+
+  passthru = { inherit bare; };
 }


### PR DESCRIPTION
The `.bare` attribute is probably only supposed to be used inside nixpkgs, i.e. for `scala-next`. Still, this link breaks in some obscure override scenarios, so let's improve that with a passthru.

Also: Any attribute concatenation onto the result of mkDerivation will break some overrideability.

## Things done

Should cause no rebuilds.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
