### PR TITLE
phpExtensions.gnupg: 1.5.1 -> 1.5.3

### DIFF
--- a/pkgs/development/php-packages/gnupg/default.nix
+++ b/pkgs/development/php-packages/gnupg/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "1.5.1";
+  version = "1.5.3";
 in
 buildPecl {
   inherit version;
@@ -20,7 +20,7 @@ buildPecl {
     repo = "php-gnupg";
     rev = "gnupg-${version}";
     fetchSubmodules = true;
-    hash = "sha256-kEc0883sYgmAf1mkH0zRjHzUASnZgQvdYE6VzT5X2RI=";
+    hash = "sha256-F9Rq+mmUhvXfIuoifqRM/ZIMYszCF93cvv13Vt/A5Mo=";
   };
 
   buildInputs = [ gpgme ];
@@ -28,19 +28,19 @@ buildPecl {
 
   postPhpize = ''
     substituteInPlace configure \
-      --replace '/usr/bin/file' '${file}/bin/file' \
-      --replace 'SEARCH_PATH="/usr/local /usr /opt"' 'SEARCH_PATH="${gpgme.dev}"'
+      --replace-fail '/usr/bin/file' '${file}/bin/file' \
+      --replace-fail 'SEARCH_PATH="/usr/local /usr /opt /opt/homebrew"' 'SEARCH_PATH="${gpgme.dev}"'
   '';
 
   postConfigure = ''
     substituteInPlace Makefile \
-      --replace 'run-tests.php' 'run-tests.php -q --offline'
+      --replace-fail 'run-tests.php' 'run-tests.php -q --offline'
     substituteInPlace tests/gnupg_res_init_file_name.phpt \
-      --replace '/usr/bin/gpg' '${gnupg}/bin/gpg' \
-      --replace 'string(12)' 'string(${toString (lib.stringLength "${gnupg}/bin/gpg")})'
+      --replace-fail '/usr/bin/gpg' '${gnupg}/bin/gpg' \
+      --replace-fail 'string(12)' 'string(${toString (lib.stringLength "${gnupg}/bin/gpg")})'
     substituteInPlace tests/gnupg_oo_init_file_name.phpt \
-      --replace '/usr/bin/gpg' '${gnupg}/bin/gpg' \
-      --replace 'string(12)' 'string(${toString (lib.stringLength "${gnupg}/bin/gpg")})'
+      --replace-fail '/usr/bin/gpg' '${gnupg}/bin/gpg' \
+      --replace-fail 'string(12)' 'string(${toString (lib.stringLength "${gnupg}/bin/gpg")})'
   '';
 
   doCheck = true;


### PR DESCRIPTION
Update package, https://pecl.php.net/package-changelog.php?package=gnupg&release=1.5.3

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.
