### PR TITLE
foxglove-cli: init at 1.0.23

### DIFF
--- a/pkgs/by-name/fo/foxglove-cli/package.nix
+++ b/pkgs/by-name/fo/foxglove-cli/package.nix
@@ -1,0 +1,85 @@
+{
+  stdenv,
+  lib,
+  buildGoModule,
+  buildPackages,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "foxglove-cli";
+  version = "1.0.23";
+
+  src = fetchFromGitHub {
+    owner = "foxglove";
+    repo = "foxglove-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jJD8sRTiJ4UGouc3KFgdgpjL7AQuU4wdxIaLqd/bih4=";
+  };
+
+  vendorHash = "sha256-8WHfXLcpYI2TlXOgjwcuJW61ftTHQEDP0Wc5XZ8ZsCQ=";
+
+  env.CGO_ENABLED = 0;
+  tags = [ "netgo" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  modRoot = "foxglove";
+
+  checkFlags =
+    let
+      skippedTests = [
+        "TestDoExport"
+        "TestExport"
+        "TestExportCommand"
+        "TestImport"
+        "TestImportCommand"
+        "TestLogin"
+        "TestLoginCommand"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      installShellCompletion --cmd foxglove \
+        --bash <(${emulator} $out/bin/foxglove completion bash) \
+        --fish <(${emulator} $out/bin/foxglove completion fish) \
+        --zsh <(${emulator} $out/bin/foxglove completion zsh)
+    ''
+  );
+
+  passthru.updateScript = nix-update-script { };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    changelog = "https://github.com/foxglove/foxglove-cli/releases/tag/v${finalAttrs.version}";
+    description = "Interact with the Foxglove platform";
+    downloadPage = "https://github.com/foxglove/foxglove-cli";
+    homepage = "https://docs.foxglove.dev/docs/cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sascha8a ];
+    mainProgram = "foxglove";
+  };
+})


### PR DESCRIPTION
Packages the Foxglove CLI - see [https://github.com/foxglove/foxglove-cli](https://github.com/foxglove/foxglove-cli)

This is my first time packaging a go binary, so please take this with a grain of salt.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
