### PR TITLE
perlPackages.CryptX: 0.080 -> 0.087

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -7905,10 +7905,10 @@ with self;
 
   CryptX = buildPerlPackage {
     pname = "CryptX";
-    version = "0.080";
+    version = "0.087";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIK/CryptX-0.080.tar.gz";
-      hash = "sha256-tFe3khlKbJwT8G/goLXqFYllwygvOFypPh8AorM+fok=";
+      url = "mirror://cpan/authors/id/M/MI/MIK/CryptX-0.087.tar.gz";
+      hash = "sha256-gHDsKVFg1I83bY/xssvwvxUtqfIDOTk4LwDxP3SM030=";
     };
     meta = {
       description = "Cryptographic toolkit";


### PR DESCRIPTION
Fixes CVE-2025-40914.

Changes:
https://metacpan.org/release/MIK/CryptX-0.087/source/Changes


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 417960`
Commit: `48f276fab4e3bf3e8ea100cc0ed143cf4a99283b`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 37 packages built:</summary>
  <ul>
    <li>almanah</li>
    <li>dkimproxy</li>
    <li>evolution</li>
    <li>evolution-ews</li>
    <li>evolutionWithPlugins</li>
    <li>kpcli</li>
    <li>perl538Packages.CryptJWT</li>
    <li>perl538Packages.CryptJWT.devdoc</li>
    <li>perl538Packages.CryptPKCS10</li>
    <li>perl538Packages.CryptPKCS10.devdoc</li>
    <li>perl538Packages.CryptX</li>
    <li>perl538Packages.CryptX.devdoc</li>
    <li>perl538Packages.DataULID</li>
    <li>perl538Packages.DataULID.devdoc</li>
    <li>perl538Packages.FileKDBX</li>
    <li>perl538Packages.FileKDBX.devdoc</li>
    <li>perl538Packages.MailDKIM</li>
    <li>perl538Packages.MailDKIM.devdoc</li>
    <li>perl538Packages.NetSSHPerl</li>
    <li>perl538Packages.NetSSHPerl.devdoc</li>
    <li>perl540Packages.CryptJWT</li>
    <li>perl540Packages.CryptJWT.devdoc</li>
    <li>perl540Packages.CryptPKCS10</li>
    <li>perl540Packages.CryptPKCS10.devdoc</li>
    <li>perl540Packages.CryptX</li>
    <li>perl540Packages.CryptX.devdoc</li>
    <li>perl540Packages.DataULID</li>
    <li>perl540Packages.DataULID.devdoc</li>
    <li>perl540Packages.FileKDBX</li>
    <li>perl540Packages.FileKDBX.devdoc</li>
    <li>perl540Packages.MailDKIM</li>
    <li>perl540Packages.MailDKIM.devdoc</li>
    <li>perl540Packages.NetSSHPerl</li>
    <li>perl540Packages.NetSSHPerl.devdoc</li>
    <li>spamassassin</li>
    <li>spamassassin.devdoc</li>
    <li>sympa</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
