### PR TITLE
pyrefly: 0.17.1 -> 0.20.2; refactor

### DIFF
--- a/pkgs/by-name/py/pyrefly/package.nix
+++ b/pkgs/by-name/py/pyrefly/package.nix
@@ -1,36 +1,26 @@
 {
   lib,
-  python3,
-  fetchPypi,
+  rustPlatform,
+  fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
-  rustPlatform,
-  maturin,
 }:
-python3.pkgs.buildPythonApplication rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pyrefly";
-  version = "0.17.1";
-  pyproject = true;
+  version = "0.20.2";
 
-  # fetch from PyPI instead of GitHub, since source repo does not have Cargo.lock
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-w4ivRtmApXiXQT95GI4vvYBop7yxdbbkpW+YTyFtgXM=";
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "pyrefly";
+    tag = finalAttrs.version;
+    hash = "sha256-E3CPs3/c5/0VKeRFI6dNRj0xUoU9YBV1rZ1qFt4E2+U=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    hash = "sha256-Op5ueVkzZTiJ1zeBGVi8oeLcfSzXMYfk5zEg4OGyA5g=";
-  };
+  buildAndTestSubdir = "pyrefly";
+  cargoHash = "sha256-EkGw7y5NtJ6Yd3DzL4z+81I0v5WyIwZ28klHXMqHjJc=";
 
-  build-system = [ maturin ];
-
-  nativeBuildInputs = with rustPlatform; [
-    cargoSetupHook
-    maturinBuildHook
-  ];
-
-  nativeCheckInputs = [ versionCheckHook ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   # requires unstable rust features
   env.RUSTC_BOOTSTRAP = 1;
@@ -48,4 +38,4 @@ python3.pkgs.buildPythonApplication rec {
       QuiNzX
     ];
   };
-}
+})


### PR DESCRIPTION
In this PR I've refactored the pyrefly derivation to make use of ``rustPlatform.buildRustPackage``
instead of ``buildPythonApplication``. 
This change is finally possible because the meta devs included a Cargo.lock file in their github repo. 
Link of the issue in pyrefly repo; [pyrefly](https://github.com/facebook/pyrefly/issues/432) 
Thanks to @dtomvan for creating the issue.

Automatic package updates by [nix-update](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#automatic-package-updates)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
