### PR TITLE
dtee: init at 1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18086,6 +18086,12 @@
     githubId = 148037;
     name = "Joachim Breitner";
   };
+  nomis = {
+    email = "nixpkgs@octiron.net";
+    github = "nomis";
+    githubId = 70171;
+    name = "Simon Arlott";
+  };
   nomisiv = {
     email = "simon@nomisiv.com";
     github = "NomisIV";

--- a/pkgs/by-name/dt/dtee/package.nix
+++ b/pkgs/by-name/dt/dtee/package.nix
@@ -1,0 +1,91 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  pkgs,
+  stdenv,
+  # nativeBuildInputs
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  sphinx,
+  # buildInputs
+  boost,
+  # nativeCheckInputs
+  bash,
+  coreutils,
+  diffutils,
+  findutils,
+  glibcLocales,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dtee";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "nomis";
+    repo = "dtee";
+    tag = finalAttrs.version;
+    hash = "sha256-trREhITO3cY4j75mpudWhOA3GXI0Q8GkUxNq2s6154w=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  # Make "#!/usr/bin/env bash" work in tests
+  postPatch = "patchShebangs tests";
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pkg-config
+    python3
+    sphinx # For the man page
+  ];
+
+  buildInputs = [ boost ];
+
+  nativeCheckInputs = [
+    bash
+    coreutils
+    diffutils
+    findutils
+    glibcLocales # For tests that check translations work
+  ];
+
+  # Use the correct copyright year on the man page (workaround for https://github.com/sphinx-doc/sphinx/issues/13231)
+  preBuild = ''
+    SOURCE_DATE_EPOCH=$(python3 $NIX_BUILD_TOP/$sourceRoot/release_date.py -e ${finalAttrs.version}) || exit 1
+    export SOURCE_DATE_EPOCH
+  '';
+
+  mesonFlags = [ "--unity on" ];
+  doCheck = true;
+
+  meta = {
+    description = "Run a program with standard output and standard error copied to files";
+    longDescription = ''
+      Run a program with standard output and standard error copied to files
+      while maintaining the original standard output and standard error in
+      the original order. When invoked as "cronty", allows programs to be run
+      from cron, suppressing all output unless the process outputs an error
+      message or has a non-zero exit status whereupon the original output
+      will be written as normal and the exit code will be appended to standard
+      error.
+    '';
+
+    homepage = "https://dtee.readthedocs.io/";
+    downloadPage = "https://github.com/nomis/dtee/releases/tag/${finalAttrs.version}";
+    changelog = "https://dtee.readthedocs.io/en/${finalAttrs.version}/changelog.html";
+
+    license = lib.licenses.gpl3Plus;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = with lib.maintainers; [ nomis ];
+    mainProgram = "dtee";
+    # Only Linux has reliable local datagram sockets
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Packages [dtee](https://dtee.readthedocs.io/) which allows capturing stdout and stderr separately while maintaining the original output order. Intended for use with cron to suppress all output unless there's an error.

This package only works on Linux because no other platform has reliable local datagram sockets.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
