### PR TITLE
[Backport release-25.05] python313Packages.streaming-form-data: fix build

### DIFF
--- a/pkgs/development/python-modules/streaming-form-data/default.nix
+++ b/pkgs/development/python-modules/streaming-form-data/default.nix
@@ -26,6 +26,12 @@ buildPythonPackage rec {
   # So, just drop the dependency to not have to deal with it.
   patches = [ ./drop-smart-open.patch ];
 
+  # The repo has a vendored copy of the cython output, which doesn't build on 3.13,
+  # so regenerate it with our cython, which does.
+  preBuild = ''
+    cython streaming_form_data/_parser.pyx
+  '';
+
   nativeBuildInputs = [ cython ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
Backport of 18590d1e372a8e4414120da1a0c497e1ed353454 to `release-25.05`. Fixes Hydra build.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.