### PR TITLE
immich: 1.134.0 -> 1.135.0

### DIFF
--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -39,61 +39,23 @@ let
   sources = lib.importJSON sourcesJSON;
   inherit (sources) version;
 
-  esbuild_0_23 = buildPackages.esbuild.override {
+  esbuild' = buildPackages.esbuild.override {
     buildGoModule =
       args:
       buildPackages.buildGoModule (
         args
         // rec {
-          version = "0.23.0";
+          version = "0.25.5";
           src = fetchFromGitHub {
             owner = "evanw";
             repo = "esbuild";
             tag = "v${version}";
-            hash = "sha256-AH4Y5ELPicAdJZY5CBf2byOxTzOyQFRh4XoqRUQiAQw=";
+            hash = "sha256-jemGZkWmN1x2+ZzJ5cLp3MoXO0oDKjtZTmZS9Be/TDw=";
           };
           vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
         }
       );
   };
-
-  esbuild_0_25 = buildPackages.esbuild.override {
-    buildGoModule =
-      args:
-      buildPackages.buildGoModule (
-        args
-        // rec {
-          version = "0.25.2";
-          src = fetchFromGitHub {
-            owner = "evanw";
-            repo = "esbuild";
-            tag = "v${version}";
-            hash = "sha256-aDxheDMeQYqCT9XO3In6RbmzmXVchn+bjgf3nL3VE4I=";
-          };
-          vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
-        }
-      );
-  };
-
-  # Immich server does not actually need esbuild, but react-email and vite do.
-  # As esbuild doesn't support passing multiple binaries, we use a custom
-  # "shim", that picks the right version depending on the working directory.
-  # The correct version can be looked up in package-lock.json
-  # TODO: There are numerous other env vars this *could* be based on.
-  esbuildShim = buildPackages.writeShellScriptBin "esbuild" ''
-    echo "nixpkgs: esbuild shim for '$PWD'" >&2
-    case "$PWD" in
-      "/build/server/node_modules/esbuild")
-        exec ${lib.getExe esbuild_0_23} "$@"
-      ;;
-      "/build/server/node_modules/vite/node_modules/esbuild")
-        exec ${lib.getExe esbuild_0_25} "$@"
-        exit 0
-      ;;
-    esac
-    echo "nixpkgs: Couldn't resolve esbuild version for '$PWD'" >&2
-    exit 1
-  '';
 
   buildLock = {
     sources =
@@ -263,7 +225,7 @@ buildNpmPackage' {
   makeCacheWritable = true;
 
   env.SHARP_FORCE_GLOBAL_LIBVIPS = 1;
-  env.ESBUILD_BINARY_PATH = lib.getExe esbuildShim;
+  env.ESBUILD_BINARY_PATH = lib.getExe esbuild';
 
   preBuild = ''
     # If exiftool-vendored.pl isn't found, exiftool is searched for on the PATH

--- a/pkgs/by-name/im/immich/sources.json
+++ b/pkgs/by-name/im/immich/sources.json
@@ -1,26 +1,26 @@
 {
-  "version": "1.134.0",
-  "hash": "sha256-TTHgEQyKx54pFWvCD1FT8KZSO9/EZxULZS97VGTfFcE=",
+  "version": "1.135.0",
+  "hash": "sha256-wxdKFuya2GP6lETiG73CYVox/BS+QpgXUjh8ZlVzhrg=",
   "components": {
     "cli": {
-      "npmDepsHash": "sha256-FOtzQF+3yWJI1lzZq79pbPehDFHAsNk5bx71vm1xWBQ=",
-      "version": "2.2.68"
+      "npmDepsHash": "sha256-oAtLuOtkzGD9grfamDQEdmfN2VIPuFYmdn51VNP11M8=",
+      "version": "2.2.69"
     },
     "server": {
-      "npmDepsHash": "sha256-VzduZY7yMgjoCtTzW5rCooFubJeZuSnkYe9mwmI/n6Q=",
-      "version": "1.134.0"
+      "npmDepsHash": "sha256-8G3UKfKp+Wzt7yjM/90omtAZMJ+iOSRQ8lxXiEEDwpM=",
+      "version": "1.135.0"
     },
     "web": {
-      "npmDepsHash": "sha256-/T8GZ+kqx/G+9Yn76v2vj+KteoS046d0Cxk58YN+3es=",
-      "version": "1.134.0"
+      "npmDepsHash": "sha256-Ej3qCjXXT9oGDQrccoTFpcl1xHMovaLUJi/vRK1nRa4=",
+      "version": "1.135.0"
     },
     "open-api/typescript-sdk": {
-      "npmDepsHash": "sha256-gTS+zrhL4mqT0UOLfzrKFdumtwZPmlQntj+DbCaQ2s8=",
-      "version": "1.134.0"
+      "npmDepsHash": "sha256-FCTKMkfl9eBLUmEFg/CYKp8eii+bzh3jujk8A7gtAes=",
+      "version": "1.135.0"
     },
     "geonames": {
-      "timestamp": "20250527235755",
-      "hash": "sha256-vAoQS07EEPkDhrnJGz3iX+sBaPDUHB5uF0a/pr5+zD4="
+      "timestamp": "20250618213339",
+      "hash": "sha256-iO77kJ/rMBu2S7sfu5GAZKRh4OGeR8fT/6Y8mBpgePQ="
     }
   }
 }


### PR DESCRIPTION
Diff: https://github.com/immich-app/immich/compare/v1.134.0...v1.135.0

Changelog: https://github.com/immich-app/immich/releases/tag/v1.135.0

PSA:
> We received a few reports from users who were concerned about the privacy implications of Google Cast on the web. Immich needs to fetch a third-party script from Google to check if casting is supported in the browser and to communicate with the cast library in Chrome. This causes a network request to Google each time Immich is loaded.
>
> We have made Google Cast opt-in now to remove this requirement. If you use Google Cast on the web, you may enable Google Cast for your user by going to `Account Settings > Features > Settings > Cast` or by using [this link](https://my.immich.app/user-settings?isOpen=feature+cast).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
