### PR TITLE
foxglove-studio: init at 2.37.0

### DIFF
--- a/pkgs/by-name/fo/foxglove-studio/package.nix
+++ b/pkgs/by-name/fo/foxglove-studio/package.nix
@@ -1,0 +1,94 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeDesktopItem,
+  makeWrapper,
+  copyDesktopItems,
+  alsa-lib,
+  at-spi2-core,
+  gtk3,
+  libGL,
+  libappindicator,
+  libdrm,
+  libgbm,
+  libnotify,
+  libxcb,
+  nss,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "foxglove-studio";
+  version = "2.37.0";
+
+  src = fetchurl {
+    url = "https://get.foxglove.dev/desktop/v${finalAttrs.version}/foxglove-studio-${finalAttrs.version}-linux-amd64.deb";
+    hash = "sha256-XY+RclsP8uQS5aKe1FopdItAjbQ9uWQ8uVD9pb9n42U=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    dpkg
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-core
+    gtk3
+    libGL
+    libappindicator
+    libdrm
+    libgbm
+    libnotify
+    libxcb
+    nss
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,opt,share}
+
+    cp -r opt/Foxglove $out/opt/
+    cp -r usr/share/icons $out/share/
+    cp -r usr/share/mime $out/share/
+
+    ln -s "$out/opt/Foxglove/foxglove-studio" $out/bin/foxglove-studio
+
+    runHook postInstall
+  '';
+
+  preFixup = ''patchelf --add-needed libGL.so.1 --add-needed libEGL.so.1 $out/opt/Foxglove/foxglove-studio'';
+
+  passthru.updateScript = ./update.sh;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "foxglove-studio";
+      desktopName = "Foxglove Studio";
+      comment = "Integrated robotics visualization and debugging";
+      exec = "foxglove-studio %U";
+      icon = "foxglove-studio";
+      categories = [ "Development" ];
+      mimeTypes = [
+        "application/octet-stream"
+        "application/zip"
+        "x-scheme-handler/foxglove"
+      ];
+    })
+  ];
+
+  meta = {
+    changelog = "https://docs.foxglove.dev/changelog/foxglove/v${finalAttrs.version}";
+    description = "Visualization and observability platform for robotics";
+    downloadPage = "https://foxglove.dev/download";
+    homepage = "https://foxglove.dev/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ sascha8a ];
+    platforms = [ "x86_64-linux" ];
+    hydraPlatforms = [ ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/fo/foxglove-studio/update.sh
+++ b/pkgs/by-name/fo/foxglove-studio/update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+
+set -eu -o pipefail
+
+changelog_url="https://docs.foxglove.dev/changelog/tags/foxglove"
+
+# Extract the latest version from the changelog page
+version=$(
+  curl -s "$changelog_url" \
+  | grep 'Downloads: ' \
+  | grep '<a href="https://get.foxglove.dev/desktop/v' \
+  | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' \
+  | head -1
+)
+
+update-source-version foxglove-studio "$version"


### PR DESCRIPTION
Package for [Foxglove Studio](https://foxglove.dev/), a robotics visualization tool. 

The package is straight forward, with some minor fixes to find `libGL` at runtime using a wrapper and a desktop entry, to open `foxglove://` urls.

Note: This is based upon the great work in [https://github.com/NixOS/nixpkgs/pull/366007](https://github.com/NixOS/nixpkgs/pull/366007) by @lennart-rth and [https://github.com/NixOS/nixpkgs/pull/383690](https://github.com/NixOS/nixpkgs/pull/383690) by @jerry8137.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
