### PR TITLE
treewide: remove maintainers with deleted GitHub accounts

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -211,12 +211,6 @@
     github = "365tuwe";
     githubId = 10263091;
   };
-  _3699n = {
-    email = "nicholas@nvk.pm";
-    github = "3699n";
-    githubId = 7414843;
-    name = "Nicholas von Klitzing";
-  };
   _3JlOy-PYCCKUi = {
     name = "3JlOy-PYCCKUi";
     email = "3jl0y_pycckui@riseup.net";
@@ -240,14 +234,6 @@
     github = "414owen";
     githubId = 1714287;
     name = "Owen Shepherd";
-  };
-  _4825764518 = {
-    email = "4825764518@purelymail.com";
-    matrix = "@kenzie:matrix.kenzi.dev";
-    github = "4825764518";
-    githubId = 100122841;
-    name = "Kenzie";
-    keys = [ { fingerprint = "D292 365E 3C46 A5AA 75EE  B30B 78DB 7EDE 3540 794B"; } ];
   };
   _4ever2 = {
     email = "eske@cs.au.dk";
@@ -5286,13 +5272,6 @@
     name = "Carl Richard Theodor Schneider";
     keys = [ { fingerprint = "2017 E152 BB81 5C16 955C  E612 45BC C1E2 709B 1788"; } ];
   };
-  cryo = {
-    email = "cryo@disroot.org";
-    github = "cry0ice";
-    githubId = 176274027;
-    name = "Cryo";
-    keys = [ { fingerprint = "2CF7 F8E8 2258 5751 2591  F97F 4B12 E34A 25A9 AB35"; } ];
-  };
   Cryolitia = {
     name = "Cryolitia PukNgae";
     email = "Cryolitia@gmail.com";
@@ -5385,12 +5364,6 @@
     githubId = 160894;
 
     keys = [ { fingerprint = "BBED 1B08 8CED 7F95 8917 FBE8 5004 F0FA D051 576D"; } ];
-  };
-  cyewashish = {
-    name = "Cyewashish";
-    email = "wawashish@cyekaivy.dev";
-    github = "cyewashish";
-    githubId = 180875322;
   };
   cynerd = {
     name = "Karel Kočí";
@@ -10778,14 +10751,6 @@
     name = "Silvan Mosberger";
     keys = [ { fingerprint = "6C2B 55D4 4E04 8266 6B7D  DA1A 422E 9EDA E015 7170"; } ];
   };
-  infinitivewitch = {
-    name = "Infinitive Witch";
-    email = "infinitivewitch@disroot.org";
-    matrix = "@infinitivewitch:fedora.im";
-    github = "infinitivewitch";
-    githubId = 128256833;
-    keys = [ { fingerprint = "CF3D F4AD C7BD 1FDB A88B  E4B3 CA2D 43DA 939D 94FB"; } ];
-  };
   ingenieroariel = {
     email = "ariel@nunez.co";
     github = "ingenieroariel";
@@ -13045,12 +13010,6 @@
     githubId = 59027018;
     name = "Andrey Khorokhorin";
   };
-  kho-dialga = {
-    email = "ivandashenyou@gmail.com";
-    github = "Kho-Dialga";
-    githubId = 55767703;
-    name = "Iván Brito";
-  };
   khumba = {
     email = "bog@khumba.net";
     github = "khumba";
@@ -14195,12 +14154,6 @@
     name = "Liassica";
     keys = [ { fingerprint = "83BE 3033 6164 B971 FA82  7036 0D34 0E59 4980 7BDD"; } ];
   };
-  liberatys = {
-    email = "liberatys@hey.com";
-    name = "Nick Anthony Flueckiger";
-    github = "liberatys";
-    githubId = 35100156;
-  };
   liberodark = {
     email = "liberodark@gmail.com";
     github = "liberodark";
@@ -14889,12 +14842,6 @@
     github = "Luz";
     githubId = 208297;
     name = "Luz";
-  };
-  lw = {
-    email = "lw@fmap.me";
-    github = "lolwat97";
-    githubId = 2057309;
-    name = "Sergey Sofeychuk";
   };
   lx = {
     email = "alex@adnab.me";
@@ -16543,12 +16490,6 @@
     githubId = 24192522;
     name = "MithicSpirit";
   };
-  mjanczyk = {
-    email = "m@dragonvr.pl";
-    github = "mjanczyk";
-    githubId = 1001112;
-    name = "Marcin Janczyk";
-  };
   mjm = {
     email = "matt@mattmoriarity.com";
     github = "mjm";
@@ -17512,12 +17453,6 @@
     github = "ndl";
     githubId = 137805;
     name = "Alexander Tsvyashchenko";
-  };
-  ne9z = {
-    email = "yuchen@apvc.uk";
-    github = "ne9z";
-    githubId = 77314501;
-    name = "Maurice Zhou";
   };
   nealfennimore = {
     email = "hi@neal.codes";
@@ -19407,12 +19342,6 @@
     email = "pete.perickson@gmail.com";
     github = "petee";
     githubId = 89916;
-  };
-  petercommand = {
-    email = "petercommand@gmail.com";
-    github = "ptrcmd";
-    githubId = 1260660;
-    name = "petercommand";
   };
   peterhoeg = {
     email = "peter@hoeg.com";
@@ -23483,14 +23412,6 @@
     github = "SnO2WMaN";
     githubId = 15155608;
   };
-  snowflake = {
-    email = "snowflake@pissmail.com";
-    name = "Snowflake";
-    github = "snf1k";
-    githubId = 149651684;
-    matrix = "@snowflake:mozilla.org";
-    keys = [ { fingerprint = "8223 7B6F 2FF4 8F16 B652  6CA3 934F 9E5F 9701 2C0B"; } ];
-  };
   snpschaaf = {
     email = "philipe.schaaf@secunet.com";
     name = "Philippe Schaaf";
@@ -26217,12 +26138,6 @@
     email = "nix.victor@0x23.dk";
     github = "vdot0x23";
     githubId = 40716069;
-  };
-  vector1dev = {
-    name = "vector1dev";
-    matrix = "@vector1dev:vector1.dev";
-    github = "vector1dev";
-    githubId = 127302590;
   };
   vedantmgoyal9 = {
     name = "Vedant Mohan Goyal";

--- a/nixos/tests/etesync-dav.nix
+++ b/nixos/tests/etesync-dav.nix
@@ -3,7 +3,7 @@
 
   name = "etesync-dav";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ _3699n ];
+    maintainers = [ ];
   };
 
   nodes.machine =

--- a/pkgs/by-name/ch/chsrc/package.nix
+++ b/pkgs/by-name/ch/chsrc/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
       gpl3Plus
       mit
     ];
-    maintainers = with lib.maintainers; [ cryo ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
     mainProgram = "chsrc";
   };

--- a/pkgs/by-name/dn/dns-over-https/package.nix
+++ b/pkgs/by-name/dn/dns-over-https/package.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
     changelog = "https://github.com/m13253/dns-over-https/releases/tag/v${version}";
     description = "High performance DNS over HTTPS client & server";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ cryo ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/em/emojify/package.nix
+++ b/pkgs/by-name/em/emojify/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     description = "Emoji on the command line";
     homepage = "https://github.com/mrowa44/emojify";
     license = licenses.mit;
-    maintainers = with maintainers; [ snowflake ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
     mainProgram = "emojify";
   };

--- a/pkgs/by-name/gi/gifgen/package.nix
+++ b/pkgs/by-name/gi/gifgen/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     description = "Simple high quality GIF encoding";
     homepage = "https://github.com/lukechilds/gifgen";
     license = licenses.mit;
-    maintainers = with maintainers; [ snowflake ];
+    maintainers = with maintainers; [ ];
     mainProgram = "gifgen";
     platforms = platforms.all;
   };

--- a/pkgs/by-name/gu/guile-aspell/package.nix
+++ b/pkgs/by-name/gu/guile-aspell/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Guile bindings for the aspell library";
     homepage = "https://github.com/spk121/guile-aspell";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ snowflake ];
+    maintainers = with maintainers; [ ];
     platforms = guile.meta.platforms;
   };
 })

--- a/pkgs/by-name/im/imgur-screenshot/package.nix
+++ b/pkgs/by-name/im/imgur-screenshot/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/jomo/imgur-screenshot/";
     platforms = platforms.linux;
     license = licenses.mit;
-    maintainers = with maintainers; [ lw ];
+    maintainers = with maintainers; [ ];
     mainProgram = "imgur-screenshot";
   };
 }

--- a/pkgs/by-name/ke/keepass-keepassrpc/package.nix
+++ b/pkgs/by-name/ke/keepass-keepassrpc/package.nix
@@ -22,7 +22,6 @@ let
       platforms = [ "x86_64-linux" ];
       license = licenses.gpl2;
       maintainers = with maintainers; [
-        mjanczyk
         svsdep
         mgregoire
       ];

--- a/pkgs/by-name/le/lenpaste/package.nix
+++ b/pkgs/by-name/le/lenpaste/package.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
     description = "Web service that allows you to share notes anonymously, an alternative to pastebin.com";
     homepage = "https://git.lcomrade.su/root/lenpaste";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ vector1dev ];
+    maintainers = with maintainers; [ ];
     mainProgram = "lenpaste";
   };
 }

--- a/pkgs/by-name/pr/proton-caller/package.nix
+++ b/pkgs/by-name/pr/proton-caller/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/caverym/proton-caller/releases/tag/${version}";
     homepage = "https://github.com/caverym/proton-caller";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kho-dialga ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "proton-call";
   };
 }

--- a/pkgs/by-name/py/pyrosimple/package.nix
+++ b/pkgs/by-name/py/pyrosimple/package.nix
@@ -68,9 +68,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://kannibalox.github.io/pyrosimple/";
     changelog = "https://github.com/kannibalox/pyrosimple/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      ne9z
-      vamega
-    ];
+    maintainers = with lib.maintainers; [ vamega ];
   };
 }

--- a/pkgs/by-name/qa/qalculate-qt/package.nix
+++ b/pkgs/by-name/qa/qalculate-qt/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Ultimate desktop calculator";
     homepage = "http://qalculate.github.io";
-    maintainers = with maintainers; [ _4825764518 ];
+    maintainers = with maintainers; [ ];
     license = licenses.gpl2Plus;
     mainProgram = "qalculate-qt";
     platforms = platforms.unix;

--- a/pkgs/by-name/se/sem/package.nix
+++ b/pkgs/by-name/se/sem/package.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
     homepage = "https://github.com/semaphoreci/cli";
     changelog = "https://github.com/semaphoreci/cli/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ liberatys ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/se/session-desktop/package.nix
+++ b/pkgs/by-name/se/session-desktop/package.nix
@@ -60,7 +60,6 @@ stdenvNoCC.mkDerivation {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [
       alexnortung
-      cyewashish
     ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/xm/xmousepasteblock/package.nix
+++ b/pkgs/by-name/xm/xmousepasteblock/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Middle mouse button primary X selection/clipboard paste disabler";
     homepage = "https://github.com/milaq/XMousePasteBlock";
     license = lib.licenses.gpl2Only;
-    maintainers = [ maintainers.petercommand ];
+    maintainers = [ ];
     mainProgram = "xmousepasteblock";
   };
 }

--- a/pkgs/development/python-modules/etebase/default.nix
+++ b/pkgs/development/python-modules/etebase/default.nix
@@ -76,6 +76,6 @@ buildPythonPackage rec {
     homepage = "https://www.etebase.com/";
     description = "Python client library for Etebase";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ _3699n ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/servers/news/leafnode/1.nix
+++ b/pkgs/servers/news/leafnode/1.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Implementation of a store & forward NNTP proxy, stable release";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.ne9z ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/servers/news/leafnode/default.nix
+++ b/pkgs/servers/news/leafnode/default.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Implementation of a store & forward NNTP proxy, under development";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.ne9z ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
Each of these maintainers came up in maintainers/scripts/check-maintainer-usernames as "WARN: error fetching $ATTRNAME".

For each removed maintainer, I have manually confirmed that both their GitHub ID and GitHub username result in a 404 when using the API calls https://api.github.com/user/$ID and https://api.github.com/users/$USERNAME respectively.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
