### PR TITLE
libxslt: Fix three security issues

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -51,6 +51,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-J3KUyzMRmrcbK8gfL0Rem8lDW4k60VuyzSsOhZoO6Eo=";
   };
 
+  patches = [
+    # Unmerged ABI-breaking patch required to fix the following security issues:
+    # - https://gitlab.gnome.org/GNOME/libxslt/-/issues/139
+    # - https://gitlab.gnome.org/GNOME/libxslt/-/issues/140
+    # See also https://gitlab.gnome.org/GNOME/libxml2/-/issues/906
+    # Source: https://github.com/chromium/chromium/blob/4fb4ae8ce3daa399c3d8ca67f2dfb9deffcc7007/third_party/libxml/chromium/xml-attr-extra.patch
+    ./xml-attr-extra.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libxml2/xml-attr-extra.patch
+++ b/pkgs/development/libraries/libxml2/xml-attr-extra.patch
@@ -1,0 +1,20 @@
+diff --git a/include/libxml/tree.h b/include/libxml/tree.h
+index e5a8fb709471f..7819d5819b427 100644
+--- a/include/libxml/tree.h
++++ b/include/libxml/tree.h
+@@ -454,6 +454,7 @@ struct _xmlAttr {
+     xmlAttributeType atype;     /* the attribute type if validating */
+     void            *psvi;	/* for type/PSVI information */
+     struct _xmlID   *id;        /* the ID struct */
++    unsigned int     extra;     /* extra data for XPath/XSLT */
+ };
+ 
+ /**
+@@ -592,6 +593,7 @@ struct _xmlDoc {
+ 				   document */
+     int             properties;	/* set of xmlDocProperties for this document
+ 				   set at the end of parsing */
++    unsigned int    extra;      /* extra data for XPath/XSLT */
+ };
+ 
+ 

--- a/pkgs/development/libraries/libxslt/77-Use-a-dedicated-node-type-to-maintain-the-list-of-cached-rv-ts.patch
+++ b/pkgs/development/libraries/libxslt/77-Use-a-dedicated-node-type-to-maintain-the-list-of-cached-rv-ts.patch
@@ -1,0 +1,704 @@
+From afbaf5fcf0a92973ffaeb38fe4ab3e8a818f4c5a Mon Sep 17 00:00:00 2001
+From: Daniel Cheng <zetafunction@gmail.com>
+Date: Thu, 5 Jun 2025 09:43:53 -0700
+Subject: [PATCH] Use a dedicated node type to maintain the list of cached RVTs
+
+While evaluating a stylesheet, result value trees (result tree fragments
+in the XSLT spec) are represented as xmlDocs and cached on the transform
+context in a linked list, using xmlDoc's prev and next pointers to
+maintain the list.
+
+However, XPath evaluations can inadvertently traverse these links, which
+are an implementation detail and do not reflect the actual document
+structure. Using a dedicated node type avoids these unintended
+traversals.
+---
+ libxslt/transform.c     |  87 ++++++++--------
+ libxslt/variables.c     | 219 +++++++++++++++++++++++++---------------
+ libxslt/xsltInternals.h |  23 +++--
+ 3 files changed, 199 insertions(+), 130 deletions(-)
+
+diff --git a/libxslt/transform.c b/libxslt/transform.c
+index 54ef821b..2d06ae77 100644
+--- a/libxslt/transform.c
++++ b/libxslt/transform.c
+@@ -518,19 +518,20 @@ xsltTransformCacheFree(xsltTransformCachePtr cache)
+     /*
+     * Free tree fragments.
+     */
+-    if (cache->RVT) {
+-	xmlDocPtr tmp, cur = cache->RVT;
++    if (cache->rvtList) {
++	xsltRVTListPtr tmp, cur = cache->rvtList;
+ 	while (cur) {
+ 	    tmp = cur;
+-	    cur = (xmlDocPtr) cur->next;
+-	    if (tmp->_private != NULL) {
++	    cur = cur->next;
++	    if (tmp->RVT->_private != NULL) {
+ 		/*
+-		* Tree the document info.
++		* Free the document info.
+ 		*/
+-		xsltFreeDocumentKeys((xsltDocumentPtr) tmp->_private);
+-		xmlFree(tmp->_private);
++		xsltFreeDocumentKeys((xsltDocumentPtr) tmp->RVT->_private);
++		xmlFree(tmp->RVT->_private);
+ 	    }
+-	    xmlFreeDoc(tmp);
++            xmlFreeDoc(tmp->RVT);
++            xmlFree(tmp);
+ 	}
+     }
+     /*
+@@ -2263,38 +2264,36 @@ xsltLocalVariablePush(xsltTransformContextPtr ctxt,
+  * are preserved; all other fragments are freed/cached.
+  */
+ static void
+-xsltReleaseLocalRVTs(xsltTransformContextPtr ctxt, xmlDocPtr base)
++xsltReleaseLocalRVTs(xsltTransformContextPtr ctxt, xsltRVTListPtr base)
+ {
+-    xmlDocPtr cur = ctxt->localRVT, tmp;
++    xsltRVTListPtr cur = ctxt->localRVTList, tmp;
+ 
+     if (cur == base)
+         return;
+-    if (cur->prev != NULL)
+-        xsltTransformError(ctxt, NULL, NULL, "localRVT not head of list\n");
+ 
+-    /* Reset localRVT early because some RVTs might be registered again. */
+-    ctxt->localRVT = base;
+-    if (base != NULL)
+-        base->prev = NULL;
++    /* Reset localRVTList early because some RVTs might be registered again. */
++    ctxt->localRVTList = base;
+ 
+     do {
+         tmp = cur;
+-        cur = (xmlDocPtr) cur->next;
+-        if (tmp->compression == XSLT_RVT_LOCAL) {
+-            xsltReleaseRVT(ctxt, tmp);
+-        } else if (tmp->compression == XSLT_RVT_GLOBAL) {
+-            xsltRegisterPersistRVT(ctxt, tmp);
+-        } else if (tmp->compression == XSLT_RVT_FUNC_RESULT) {
++        cur = cur->next;
++        if (tmp->RVT->compression == XSLT_RVT_LOCAL) {
++            xsltReleaseRVTList(ctxt, tmp);
++        } else if (tmp->RVT->compression == XSLT_RVT_GLOBAL) {
++            xsltRegisterPersistRVT(ctxt, tmp->RVT);
++            xmlFree(tmp);
++        } else if (tmp->RVT->compression == XSLT_RVT_FUNC_RESULT) {
+             /*
+              * This will either register the RVT again or move it to the
+              * context variable.
+              */
+-            xsltRegisterLocalRVT(ctxt, tmp);
+-            tmp->compression = XSLT_RVT_FUNC_RESULT;
++            xsltRegisterLocalRVT(ctxt, tmp->RVT);
++            tmp->RVT->compression = XSLT_RVT_FUNC_RESULT;
++            xmlFree(tmp);
+         } else {
+             xmlGenericError(xmlGenericErrorContext,
+-                    "xsltReleaseLocalRVTs: Unexpected RVT flag %p\n",
+-                    tmp->psvi);
++                    "xsltReleaseLocalRVTs: Unexpected RVT flag %d\n",
++                    tmp->RVT->compression);
+         }
+     } while (cur != base);
+ }
+@@ -2322,7 +2321,7 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
+     xmlNodePtr oldInsert, oldInst, oldCurInst, oldContextNode;
+     xmlNodePtr cur, insert, copy = NULL;
+     int level = 0, oldVarsNr;
+-    xmlDocPtr oldLocalFragmentTop;
++    xsltRVTListPtr oldLocalFragmentTop;
+ 
+ #ifdef XSLT_REFACTORED
+     xsltStylePreCompPtr info;
+@@ -2368,7 +2367,7 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
+     }
+     ctxt->depth++;
+ 
+-    oldLocalFragmentTop = ctxt->localRVT;
++    oldLocalFragmentTop = ctxt->localRVTList;
+     oldInsert = insert = ctxt->insert;
+     oldInst = oldCurInst = ctxt->inst;
+     oldContextNode = ctxt->node;
+@@ -2602,7 +2601,7 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
+ 		    /*
+ 		    * Cleanup temporary tree fragments.
+ 		    */
+-		    if (oldLocalFragmentTop != ctxt->localRVT)
++		    if (oldLocalFragmentTop != ctxt->localRVTList)
+ 			xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+ 
+ 		    ctxt->insert = oldInsert;
+@@ -2697,7 +2696,7 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
+ 		    /*
+ 		    * Cleanup temporary tree fragments.
+ 		    */
+-		    if (oldLocalFragmentTop != ctxt->localRVT)
++		    if (oldLocalFragmentTop != ctxt->localRVTList)
+ 			xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+ 
+ 		    ctxt->insert = oldInsert;
+@@ -2763,7 +2762,7 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
+ 		/*
+ 		* Cleanup temporary tree fragments.
+ 		*/
+-		if (oldLocalFragmentTop != ctxt->localRVT)
++		if (oldLocalFragmentTop != ctxt->localRVTList)
+ 		    xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+ 
+                 ctxt->insert = oldInsert;
+@@ -2893,7 +2892,7 @@ xsltApplySequenceConstructor(xsltTransformContextPtr ctxt,
+ 		/*
+ 		* Cleanup temporary tree fragments.
+ 		*/
+-		if (oldLocalFragmentTop != ctxt->localRVT)
++		if (oldLocalFragmentTop != ctxt->localRVTList)
+ 		    xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+ 
+                 ctxt->insert = oldInsert;
+@@ -3072,7 +3071,7 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
+     int oldVarsBase = 0;
+     xmlNodePtr cur;
+     xsltStackElemPtr tmpParam = NULL;
+-    xmlDocPtr oldUserFragmentTop;
++    xsltRVTListPtr oldUserFragmentTop;
+ #ifdef WITH_PROFILER
+     long start = 0;
+ #endif
+@@ -3120,8 +3119,8 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
+         return;
+ 	}
+ 
+-    oldUserFragmentTop = ctxt->tmpRVT;
+-    ctxt->tmpRVT = NULL;
++    oldUserFragmentTop = ctxt->tmpRVTList;
++    ctxt->tmpRVTList = NULL;
+ 
+     /*
+     * Initiate a distinct scope of local params/variables.
+@@ -3232,16 +3231,16 @@ xsltApplyXSLTTemplate(xsltTransformContextPtr ctxt,
+     * user code should now use xsltRegisterLocalRVT() instead
+     * of the obsolete xsltRegisterTmpRVT().
+     */
+-    if (ctxt->tmpRVT) {
+-	xmlDocPtr curdoc = ctxt->tmpRVT, tmp;
++    if (ctxt->tmpRVTList) {
++	xsltRVTListPtr curRVTList = ctxt->tmpRVTList, tmp;
+ 
+-	while (curdoc != NULL) {
+-	    tmp = curdoc;
+-	    curdoc = (xmlDocPtr) curdoc->next;
+-	    xsltReleaseRVT(ctxt, tmp);
++	while (curRVTList != NULL) {
++	    tmp = curRVTList;
++	    curRVTList = curRVTList->next;
++	    xsltReleaseRVTList(ctxt, tmp);
+ 	}
+     }
+-    ctxt->tmpRVT = oldUserFragmentTop;
++    ctxt->tmpRVTList = oldUserFragmentTop;
+ 
+     /*
+     * Pop the xsl:template declaration from the stack.
+@@ -5319,7 +5318,7 @@ xsltIf(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
+ 
+ #ifdef XSLT_FAST_IF
+     {
+-	xmlDocPtr oldLocalFragmentTop = ctxt->localRVT;
++	xsltRVTListPtr oldLocalFragmentTop = ctxt->localRVTList;
+ 
+ 	res = xsltPreCompEvalToBoolean(ctxt, contextNode, comp);
+ 
+@@ -5327,7 +5326,7 @@ xsltIf(xsltTransformContextPtr ctxt, xmlNodePtr contextNode,
+ 	* Cleanup fragments created during evaluation of the
+ 	* "select" expression.
+ 	*/
+-	if (oldLocalFragmentTop != ctxt->localRVT)
++	if (oldLocalFragmentTop != ctxt->localRVTList)
+ 	    xsltReleaseLocalRVTs(ctxt, oldLocalFragmentTop);
+     }
+ 
+diff --git a/libxslt/variables.c b/libxslt/variables.c
+index eb98aab2..6696d9a1 100644
+--- a/libxslt/variables.c
++++ b/libxslt/variables.c
+@@ -47,6 +47,21 @@ static const xmlChar *xsltComputingGlobalVarMarker =
+ #define XSLT_VAR_IN_SELECT (1<<1)
+ #define XSLT_TCTXT_VARIABLE(c) ((xsltStackElemPtr) (c)->contextVariable)
+ 
++static xsltRVTListPtr
++xsltRVTListCreate(void)
++{
++    xsltRVTListPtr ret;
++
++    ret = (xsltRVTListPtr) xmlMalloc(sizeof(xsltRVTList));
++    if (ret == NULL) {
++	xsltTransformError(NULL, NULL, NULL,
++	    "xsltRVTListCreate: malloc failed\n");
++	return(NULL);
++    }
++    memset(ret, 0, sizeof(xsltRVTList));
++    return(ret);
++}
++
+ /************************************************************************
+  *									*
+  *  Result Value Tree (Result Tree Fragment) interfaces			*
+@@ -64,6 +79,7 @@ static const xmlChar *xsltComputingGlobalVarMarker =
+ xmlDocPtr
+ xsltCreateRVT(xsltTransformContextPtr ctxt)
+ {
++    xsltRVTListPtr rvtList;
+     xmlDocPtr container;
+ 
+     /*
+@@ -76,12 +92,11 @@ xsltCreateRVT(xsltTransformContextPtr ctxt)
+     /*
+     * Reuse a RTF from the cache if available.
+     */
+-    if (ctxt->cache->RVT) {
+-	container = ctxt->cache->RVT;
+-	ctxt->cache->RVT = (xmlDocPtr) container->next;
+-	/* clear the internal pointers */
+-	container->next = NULL;
+-	container->prev = NULL;
++    if (ctxt->cache->rvtList) {
++        rvtList = ctxt->cache->rvtList;
++	container = ctxt->cache->rvtList->RVT;
++	ctxt->cache->rvtList = rvtList->next;
++        xmlFree(rvtList);
+ 	if (ctxt->cache->nbRVT > 0)
+ 	    ctxt->cache->nbRVT--;
+ #ifdef XSLT_DEBUG_PROFILE_CACHE
+@@ -119,11 +134,16 @@ xsltCreateRVT(xsltTransformContextPtr ctxt)
+ int
+ xsltRegisterTmpRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
+ {
++    xsltRVTListPtr list;
++
+     if ((ctxt == NULL) || (RVT == NULL))
+ 	return(-1);
+ 
+-    RVT->prev = NULL;
++    list = xsltRVTListCreate();
++    if (list == NULL) return(-1);
++
+     RVT->compression = XSLT_RVT_LOCAL;
++    list->RVT = RVT;
+ 
+     /*
+     * We'll restrict the lifetime of user-created fragments
+@@ -131,15 +151,13 @@ xsltRegisterTmpRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
+     * var/param itself.
+     */
+     if (ctxt->contextVariable != NULL) {
+-	RVT->next = (xmlNodePtr) XSLT_TCTXT_VARIABLE(ctxt)->fragment;
+-	XSLT_TCTXT_VARIABLE(ctxt)->fragment = RVT;
++	list->next = XSLT_TCTXT_VARIABLE(ctxt)->fragment;
++	XSLT_TCTXT_VARIABLE(ctxt)->fragment = list;
+ 	return(0);
+     }
+ 
+-    RVT->next = (xmlNodePtr) ctxt->tmpRVT;
+-    if (ctxt->tmpRVT != NULL)
+-	ctxt->tmpRVT->prev = (xmlNodePtr) RVT;
+-    ctxt->tmpRVT = RVT;
++    list->next = ctxt->tmpRVTList;
++    ctxt->tmpRVTList = list;
+     return(0);
+ }
+ 
+@@ -159,11 +177,16 @@ int
+ xsltRegisterLocalRVT(xsltTransformContextPtr ctxt,
+ 		     xmlDocPtr RVT)
+ {
++    xsltRVTListPtr list;
++
+     if ((ctxt == NULL) || (RVT == NULL))
+ 	return(-1);
+ 
+-    RVT->prev = NULL;
++    list = xsltRVTListCreate();
++    if (list == NULL) return(-1);
++
+     RVT->compression = XSLT_RVT_LOCAL;
++    list->RVT = RVT;
+ 
+     /*
+     * When evaluating "select" expressions of xsl:variable
+@@ -174,8 +197,8 @@ xsltRegisterLocalRVT(xsltTransformContextPtr ctxt,
+     if ((ctxt->contextVariable != NULL) &&
+ 	(XSLT_TCTXT_VARIABLE(ctxt)->flags & XSLT_VAR_IN_SELECT))
+     {
+-	RVT->next = (xmlNodePtr) XSLT_TCTXT_VARIABLE(ctxt)->fragment;
+-	XSLT_TCTXT_VARIABLE(ctxt)->fragment = RVT;
++	list->next = XSLT_TCTXT_VARIABLE(ctxt)->fragment;
++	XSLT_TCTXT_VARIABLE(ctxt)->fragment = list;
+ 	return(0);
+     }
+     /*
+@@ -183,10 +206,8 @@ xsltRegisterLocalRVT(xsltTransformContextPtr ctxt,
+     * If not reference by a returning instruction (like EXSLT's function),
+     * then this fragment will be freed, when the instruction exits.
+     */
+-    RVT->next = (xmlNodePtr) ctxt->localRVT;
+-    if (ctxt->localRVT != NULL)
+-	ctxt->localRVT->prev = (xmlNodePtr) RVT;
+-    ctxt->localRVT = RVT;
++    list->next = ctxt->localRVTList;
++    ctxt->localRVTList = list;
+     return(0);
+ }
+ 
+@@ -344,8 +365,9 @@ xsltFlagRVTs(xsltTransformContextPtr ctxt, xmlXPathObjectPtr obj, int val) {
+  * @ctxt:  an XSLT transformation context
+  * @RVT:  a result value tree (Result Tree Fragment)
+  *
+- * Either frees the RVT (which is an xmlDoc) or stores
+- * it in the context's cache for later reuse.
++ * Either frees the RVT (which is an xmlDoc) or stores it in the context's
++ * cache for later reuse. Preserved for ABI/API compatibility; internal use
++ * has all migrated to xsltReleaseRVTList().
+  */
+ void
+ xsltReleaseRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
+@@ -353,36 +375,64 @@ xsltReleaseRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
+     if (RVT == NULL)
+ 	return;
+ 
++    xsltRVTListPtr list = xsltRVTListCreate();
++    if (list == NULL) {
++        if (RVT->_private != NULL) {
++            xsltFreeDocumentKeys((xsltDocumentPtr) RVT->_private);
++            xmlFree(RVT->_private);
++        }
++        xmlFreeDoc(RVT);
++        return;
++    }
++
++    xsltReleaseRVTList(ctxt, list);
++}
++
++/**
++ * xsltReleaseRVTList:
++ * @ctxt:  an XSLT transformation context
++ * @list:  a list node containing a result value tree (Result Tree Fragment)
++ *
++ * Either frees the list node or stores it in the context's cache for later
++ * reuse. Optimization to avoid adding a fallible allocation path when the
++ * caller already has a RVT list node.
++ */
++void
++xsltReleaseRVTList(xsltTransformContextPtr ctxt, xsltRVTListPtr list)
++{
++    if (list == NULL)
++	return;
++
+     if (ctxt && (ctxt->cache->nbRVT < 40)) {
+ 	/*
+ 	* Store the Result Tree Fragment.
+ 	* Free the document info.
+ 	*/
+-	if (RVT->_private != NULL) {
+-	    xsltFreeDocumentKeys((xsltDocumentPtr) RVT->_private);
+-	    xmlFree(RVT->_private);
+-	    RVT->_private = NULL;
++	if (list->RVT->_private != NULL) {
++	    xsltFreeDocumentKeys((xsltDocumentPtr) list->RVT->_private);
++	    xmlFree(list->RVT->_private);
++	    list->RVT->_private = NULL;
+ 	}
+ 	/*
+ 	* Clear the document tree.
+ 	*/
+-	if (RVT->children != NULL) {
+-	    xmlFreeNodeList(RVT->children);
+-	    RVT->children = NULL;
+-	    RVT->last = NULL;
++	if (list->RVT->children != NULL) {
++	    xmlFreeNodeList(list->RVT->children);
++	    list->RVT->children = NULL;
++	    list->RVT->last = NULL;
+ 	}
+-	if (RVT->ids != NULL) {
+-	    xmlFreeIDTable((xmlIDTablePtr) RVT->ids);
+-	    RVT->ids = NULL;
++	if (list->RVT->ids != NULL) {
++	    xmlFreeIDTable((xmlIDTablePtr) list->RVT->ids);
++	    list->RVT->ids = NULL;
+ 	}
+ 
+ 	/*
+ 	* Reset the ownership information.
+ 	*/
+-	RVT->compression = 0;
++	list->RVT->compression = 0;
+ 
+-	RVT->next = (xmlNodePtr) ctxt->cache->RVT;
+-	ctxt->cache->RVT = RVT;
++	list->next = ctxt->cache->rvtList;
++	ctxt->cache->rvtList = list;
+ 
+ 	ctxt->cache->nbRVT++;
+ 
+@@ -394,11 +444,12 @@ xsltReleaseRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
+     /*
+     * Free it.
+     */
+-    if (RVT->_private != NULL) {
+-	xsltFreeDocumentKeys((xsltDocumentPtr) RVT->_private);
+-	xmlFree(RVT->_private);
++    if (list->RVT->_private != NULL) {
++	xsltFreeDocumentKeys((xsltDocumentPtr) list->RVT->_private);
++	xmlFree(list->RVT->_private);
+     }
+-    xmlFreeDoc(RVT);
++    xmlFreeDoc(list->RVT);
++    xmlFree(list);
+ }
+ 
+ /**
+@@ -416,14 +467,17 @@ xsltReleaseRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
+ int
+ xsltRegisterPersistRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
+ {
++    xsltRVTListPtr list;
++
+     if ((ctxt == NULL) || (RVT == NULL)) return(-1);
+ 
++    list = xsltRVTListCreate();
++    if (list == NULL) return(-1);
++
+     RVT->compression = XSLT_RVT_GLOBAL;
+-    RVT->prev = NULL;
+-    RVT->next = (xmlNodePtr) ctxt->persistRVT;
+-    if (ctxt->persistRVT != NULL)
+-	ctxt->persistRVT->prev = (xmlNodePtr) RVT;
+-    ctxt->persistRVT = RVT;
++    list->RVT = RVT;
++    list->next = ctxt->persistRVTList;
++    ctxt->persistRVTList = list;
+     return(0);
+ }
+ 
+@@ -438,52 +492,55 @@ xsltRegisterPersistRVT(xsltTransformContextPtr ctxt, xmlDocPtr RVT)
+ void
+ xsltFreeRVTs(xsltTransformContextPtr ctxt)
+ {
+-    xmlDocPtr cur, next;
++    xsltRVTListPtr cur, next;
+ 
+     if (ctxt == NULL)
+ 	return;
+     /*
+     * Local fragments.
+     */
+-    cur = ctxt->localRVT;
++    cur = ctxt->localRVTList;
+     while (cur != NULL) {
+-        next = (xmlDocPtr) cur->next;
+-	if (cur->_private != NULL) {
+-	    xsltFreeDocumentKeys(cur->_private);
+-	    xmlFree(cur->_private);
++        next = cur->next;
++	if (cur->RVT->_private != NULL) {
++	    xsltFreeDocumentKeys(cur->RVT->_private);
++	    xmlFree(cur->RVT->_private);
+ 	}
+-	xmlFreeDoc(cur);
++	xmlFreeDoc(cur->RVT);
++        xmlFree(cur);
+ 	cur = next;
+     }
+-    ctxt->localRVT = NULL;
++    ctxt->localRVTList = NULL;
+     /*
+     * User-created per-template fragments.
+     */
+-    cur = ctxt->tmpRVT;
++    cur = ctxt->tmpRVTList;
+     while (cur != NULL) {
+-        next = (xmlDocPtr) cur->next;
+-	if (cur->_private != NULL) {
+-	    xsltFreeDocumentKeys(cur->_private);
+-	    xmlFree(cur->_private);
++        next = cur->next;
++	if (cur->RVT->_private != NULL) {
++	    xsltFreeDocumentKeys(cur->RVT->_private);
++	    xmlFree(cur->RVT->_private);
+ 	}
+-	xmlFreeDoc(cur);
++	xmlFreeDoc(cur->RVT);
++        xmlFree(cur);
+ 	cur = next;
+     }
+-    ctxt->tmpRVT = NULL;
++    ctxt->tmpRVTList = NULL;
+     /*
+     * Global fragments.
+     */
+-    cur = ctxt->persistRVT;
++    cur = ctxt->persistRVTList;
+     while (cur != NULL) {
+-        next = (xmlDocPtr) cur->next;
+-	if (cur->_private != NULL) {
+-	    xsltFreeDocumentKeys(cur->_private);
+-	    xmlFree(cur->_private);
++        next = cur->next;
++	if (cur->RVT->_private != NULL) {
++	    xsltFreeDocumentKeys(cur->RVT->_private);
++	    xmlFree(cur->RVT->_private);
+ 	}
+-	xmlFreeDoc(cur);
++	xmlFreeDoc(cur->RVT);
++        xmlFree(cur);
+ 	cur = next;
+     }
+-    ctxt->persistRVT = NULL;
++    ctxt->persistRVTList = NULL;
+ }
+ 
+ /************************************************************************
+@@ -571,21 +628,22 @@ xsltFreeStackElem(xsltStackElemPtr elem) {
+     * Release the list of temporary Result Tree Fragments.
+     */
+     if (elem->context) {
+-	xmlDocPtr cur;
++	xsltRVTListPtr cur;
+ 
+ 	while (elem->fragment != NULL) {
+ 	    cur = elem->fragment;
+-	    elem->fragment = (xmlDocPtr) cur->next;
+-
+-            if (cur->compression == XSLT_RVT_LOCAL) {
+-		xsltReleaseRVT(elem->context, cur);
+-            } else if (cur->compression == XSLT_RVT_FUNC_RESULT) {
+-                xsltRegisterLocalRVT(elem->context, cur);
+-                cur->compression = XSLT_RVT_FUNC_RESULT;
++	    elem->fragment = cur->next;
++
++            if (cur->RVT->compression == XSLT_RVT_LOCAL) {
++		xsltReleaseRVTList(elem->context, cur);
++            } else if (cur->RVT->compression == XSLT_RVT_FUNC_RESULT) {
++                xsltRegisterLocalRVT(elem->context, cur->RVT);
++                cur->RVT->compression = XSLT_RVT_FUNC_RESULT;
++                xmlFree(cur);
+             } else {
+                 xmlGenericError(xmlGenericErrorContext,
+                         "xsltFreeStackElem: Unexpected RVT flag %d\n",
+-                        cur->compression);
++                        cur->RVT->compression);
+             }
+ 	}
+     }
+@@ -944,6 +1002,7 @@ xsltEvalVariable(xsltTransformContextPtr ctxt, xsltStackElemPtr variable,
+ 	} else {
+ 	    if (variable->tree) {
+ 		xmlDocPtr container;
++                xsltRVTListPtr rvtList;
+ 		xmlNodePtr oldInsert;
+ 		xmlDocPtr  oldOutput;
+                 const xmlChar *oldLastText;
+@@ -968,7 +1027,11 @@ xsltEvalVariable(xsltTransformContextPtr ctxt, xsltStackElemPtr variable,
+ 		* when the variable is freed, it will also free
+ 		* the Result Tree Fragment.
+ 		*/
+-		variable->fragment = container;
++                rvtList = xsltRVTListCreate();
++                if (rvtList == NULL)
++                    goto error;
++                rvtList->RVT = container;
++		variable->fragment = rvtList;
+                 container->compression = XSLT_RVT_LOCAL;
+ 
+ 		oldOutput = ctxt->output;
+@@ -2361,5 +2424,3 @@ local_variable_found:
+ 
+     return(valueObj);
+ }
+-
+-
+diff --git a/libxslt/xsltInternals.h b/libxslt/xsltInternals.h
+index 6faa07db..ec84e1df 100644
+--- a/libxslt/xsltInternals.h
++++ b/libxslt/xsltInternals.h
+@@ -1410,6 +1410,8 @@ struct _xsltStylePreComp {
+ 
+ #endif /* XSLT_REFACTORED */
+ 
++typedef struct _xsltRVTList xsltRVTList;
++typedef xsltRVTList *xsltRVTListPtr;
+ 
+ /*
+  * The in-memory structure corresponding to an XSLT Variable
+@@ -1427,7 +1429,7 @@ struct _xsltStackElem {
+     xmlNodePtr tree;		/* the sequence constructor if no eval
+ 				    string or the location */
+     xmlXPathObjectPtr value;	/* The value if computed */
+-    xmlDocPtr fragment;		/* The Result Tree Fragments (needed for XSLT 1.0)
++    xsltRVTListPtr fragment;	/* The Result Tree Fragments (needed for XSLT 1.0)
+ 				   which are bound to the variable's lifetime. */
+     int level;                  /* the depth in the tree;
+                                    -1 if persistent (e.g. a given xsl:with-param) */
+@@ -1639,10 +1641,15 @@ struct _xsltStylesheet {
+     unsigned long opCount;
+ };
+ 
++struct _xsltRVTList {
++  xmlDocPtr RVT;
++  xsltRVTListPtr next;
++};
++
+ typedef struct _xsltTransformCache xsltTransformCache;
+ typedef xsltTransformCache *xsltTransformCachePtr;
+ struct _xsltTransformCache {
+-    xmlDocPtr RVT;
++    xsltRVTListPtr rvtList;
+     int nbRVT;
+     xsltStackElemPtr stackItems;
+     int nbStackItems;
+@@ -1749,8 +1756,8 @@ struct _xsltTransformContext {
+      * handling of temporary Result Value Tree
+      * (XSLT 1.0 term: "Result Tree Fragment")
+      */
+-    xmlDocPtr       tmpRVT;		/* list of RVT without persistance */
+-    xmlDocPtr       persistRVT;		/* list of persistant RVTs */
++    xsltRVTListPtr  tmpRVTList;	        /* list of RVT without persistance */
++    xsltRVTListPtr  persistRVTList;     /* list of persistant RVTs */
+     int             ctxtflags;          /* context processing flags */
+ 
+     /*
+@@ -1783,7 +1790,7 @@ struct _xsltTransformContext {
+     xmlDocPtr initialContextDoc;
+     xsltTransformCachePtr cache;
+     void *contextVariable; /* the current variable item */
+-    xmlDocPtr localRVT; /* list of local tree fragments; will be freed when
++    xsltRVTListPtr localRVTList; /* list of local tree fragments; will be freed when
+ 			   the instruction which created the fragment
+                            exits */
+     xmlDocPtr localRVTBase; /* Obsolete */
+@@ -1932,8 +1939,11 @@ XSLTPUBFUN int XSLTCALL
+ XSLTPUBFUN void XSLTCALL
+ 			xsltFreeRVTs		(xsltTransformContextPtr ctxt);
+ XSLTPUBFUN void XSLTCALL
+-			xsltReleaseRVT		(xsltTransformContextPtr ctxt,
++			xsltReleaseRVT          (xsltTransformContextPtr ctxt,
+ 						 xmlDocPtr RVT);
++XSLTPUBFUN void XSLTCALL
++			xsltReleaseRVTList	(xsltTransformContextPtr ctxt,
++						 xsltRVTListPtr list);
+ /*
+  * Extra functions for Attribute Value Templates
+  */
+@@ -1992,4 +2002,3 @@ XSLTPUBFUN int XSLTCALL
+ #endif
+ 
+ #endif /* __XML_XSLT_H__ */
+-
+-- 
+GitLab
+

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -33,6 +33,23 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Wj1rODylr8I1sXERjpD1/2qifp/qMwMGUjGm1APwGDo=";
   };
 
+  patches = [
+    # Fix use-after-free with key data stored cross-RVT
+    # https://gitlab.gnome.org/GNOME/libxslt/-/issues/144
+    # Source: https://gitlab.gnome.org/GNOME/libxslt/-/merge_requests/77
+    ./77-Use-a-dedicated-node-type-to-maintain-the-list-of-cached-rv-ts.patch
+
+    # Fix type confusion in xmlNode.psvi between stylesheet and source nodes
+    # https://gitlab.gnome.org/GNOME/libxslt/-/issues/139
+    # Fix heap-use-after-free in xmlFreeID caused by `atype` corruption
+    # https://gitlab.gnome.org/GNOME/libxslt/-/issues/140
+    #
+    # Depends on unmerged libxml2 patch that breaks ABI.
+    #
+    # Source: https://github.com/chromium/chromium/blob/4fb4ae8ce3daa399c3d8ca67f2dfb9deffcc7007/third_party/libxslt/chromium/new-unified-atype-extra.patch
+    ./new-unified-atype-extra.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libxslt/new-unified-atype-extra.patch
+++ b/pkgs/development/libraries/libxslt/new-unified-atype-extra.patch
@@ -1,0 +1,206 @@
+diff --git a/libxslt/functions.c b/libxslt/functions.c
+index 72a58dc4d6592..309af458c22f7 100644
+--- a/libxslt/functions.c
++++ b/libxslt/functions.c
+@@ -760,7 +760,7 @@ xsltGenerateIdFunction(xmlXPathParserContextPtr ctxt, int nargs){
+     }
+ 
+     if (xsltGetSourceNodeFlags(cur) & XSLT_SOURCE_NODE_HAS_ID) {
+-        id = (unsigned long) (size_t) *psviPtr;
++        id = (unsigned long) xsltGetSourceNodeValue(cur);
+     } else {
+         if (cur->type == XML_TEXT_NODE && cur->line == USHRT_MAX) {
+             /* Text nodes store big line numbers in psvi. */
+@@ -772,7 +772,7 @@ xsltGenerateIdFunction(xmlXPathParserContextPtr ctxt, int nargs){
+             goto out;
+         }
+ 
+-        if (tctxt->currentId == ULONG_MAX) {
++        if (tctxt->currentId == XSLT_SOURCE_NODE_VALUE_MAX) {
+             xsltTransformError(tctxt, NULL, NULL,
+                     "generate-id(): id overflow\n");
+             ctxt->error = XPATH_MEMORY_ERROR;
+@@ -780,7 +780,7 @@ xsltGenerateIdFunction(xmlXPathParserContextPtr ctxt, int nargs){
+         }
+ 
+         id = ++tctxt->currentId;
+-        *psviPtr = (void *) (size_t) id;
++        xsltSetSourceNodeValue(cur, id);
+         xsltSetSourceNodeFlags(tctxt, cur, XSLT_SOURCE_NODE_HAS_ID);
+     }
+ 
+diff --git a/libxslt/transform.c b/libxslt/transform.c
+index 54ef821b5016f..1ac2471d6441b 100644
+--- a/libxslt/transform.c
++++ b/libxslt/transform.c
+@@ -5772,7 +5772,8 @@ xsltCleanupSourceDoc(xmlDocPtr doc) {
+             xmlAttrPtr prop = cur->properties;
+ 
+             while (prop) {
+-                prop->atype &= ~(XSLT_SOURCE_NODE_MASK << 27);
++                prop->extra &=
++                    ~(XSLT_SOURCE_NODE_MASK << XSLT_SOURCE_NODE_SHIFT_32);
+                 prop->psvi = NULL;
+                 prop = prop->next;
+             }
+diff --git a/libxslt/xsltutils.c b/libxslt/xsltutils.c
+index a20da96182289..b431fafbbb441 100644
+--- a/libxslt/xsltutils.c
++++ b/libxslt/xsltutils.c
+@@ -1920,26 +1920,26 @@ xsltSaveResultToString(xmlChar **doc_txt_ptr, int * doc_txt_len,
+ int
+ xsltGetSourceNodeFlags(xmlNodePtr node) {
+     /*
+-     * Squeeze the bit flags into the upper bits of
++     * Squeeze the bit flags into the upper 4 bits of
+      *
+-     * - 'int properties' member in struct _xmlDoc
+-     * - 'xmlAttributeType atype' member in struct _xmlAttr
++     * - 'unsigned int extra' member in struct _xmlDoc
++     * - 'unsigned int extra' member in struct _xmlAttr
+      * - 'unsigned short extra' member in struct _xmlNode
+      */
+     switch (node->type) {
+         case XML_DOCUMENT_NODE:
+         case XML_HTML_DOCUMENT_NODE:
+-            return ((xmlDocPtr) node)->properties >> 27;
++            return ((xmlDocPtr) node)->extra >> XSLT_SOURCE_NODE_SHIFT_32;
+ 
+         case XML_ATTRIBUTE_NODE:
+-            return ((xmlAttrPtr) node)->atype >> 27;
++            return ((xmlAttrPtr) node)->extra >> XSLT_SOURCE_NODE_SHIFT_32;
+ 
+         case XML_ELEMENT_NODE:
+         case XML_TEXT_NODE:
+         case XML_CDATA_SECTION_NODE:
+         case XML_PI_NODE:
+         case XML_COMMENT_NODE:
+-            return node->extra >> 12;
++            return node->extra >> XSLT_SOURCE_NODE_SHIFT_32;
+ 
+         default:
+             return 0;
+@@ -1964,11 +1964,13 @@ xsltSetSourceNodeFlags(xsltTransformContextPtr ctxt, xmlNodePtr node,
+     switch (node->type) {
+         case XML_DOCUMENT_NODE:
+         case XML_HTML_DOCUMENT_NODE:
+-            ((xmlDocPtr) node)->properties |= flags << 27;
++            ((xmlDocPtr) node)->extra |=
++                ((unsigned) flags << XSLT_SOURCE_NODE_SHIFT_32);
+             return 0;
+ 
+         case XML_ATTRIBUTE_NODE:
+-            ((xmlAttrPtr) node)->atype |= flags << 27;
++            ((xmlAttrPtr) node)->extra |=
++                ((unsigned) flags << XSLT_SOURCE_NODE_SHIFT_32);
+             return 0;
+ 
+         case XML_ELEMENT_NODE:
+@@ -1976,7 +1978,7 @@ xsltSetSourceNodeFlags(xsltTransformContextPtr ctxt, xmlNodePtr node,
+         case XML_CDATA_SECTION_NODE:
+         case XML_PI_NODE:
+         case XML_COMMENT_NODE:
+-            node->extra |= flags << 12;
++            node->extra |= ((unsigned) flags << XSLT_SOURCE_NODE_SHIFT_16);
+             return 0;
+ 
+         default:
+@@ -1998,11 +2000,13 @@ xsltClearSourceNodeFlags(xmlNodePtr node, int flags) {
+     switch (node->type) {
+         case XML_DOCUMENT_NODE:
+         case XML_HTML_DOCUMENT_NODE:
+-            ((xmlDocPtr) node)->properties &= ~(flags << 27);
++            ((xmlDocPtr) node)->extra &=
++                ~((unsigned) flags << XSLT_SOURCE_NODE_SHIFT_32);
+             return 0;
+ 
+         case XML_ATTRIBUTE_NODE:
+-            ((xmlAttrPtr) node)->atype &= ~(flags << 27);
++            ((xmlAttrPtr) node)->extra &=
++                ~((unsigned) flags << XSLT_SOURCE_NODE_SHIFT_32);
+             return 0;
+ 
+         case XML_ELEMENT_NODE:
+@@ -2010,7 +2014,55 @@ xsltClearSourceNodeFlags(xmlNodePtr node, int flags) {
+         case XML_CDATA_SECTION_NODE:
+         case XML_PI_NODE:
+         case XML_COMMENT_NODE:
+-            node->extra &= ~(flags << 12);
++            node->extra &= ~((unsigned) flags << XSLT_SOURCE_NODE_SHIFT_16);
++            return 0;
++
++        default:
++            return -1;
++    }
++}
++
++/**
++ * xsltGetSourceNodeValue:
++ * @node:  Node from source document
++ *
++ * Returns the associated 28 bit unsigned value for a source node,
++ * or 0 if node does not have an associated value.
++ */
++int
++xsltGetSourceNodeValue(xmlNodePtr node) {
++    switch (node->type) {
++        case XML_DOCUMENT_NODE:
++        case XML_HTML_DOCUMENT_NODE:
++            return (((xmlDocPtr) node)->extra & XSLT_SOURCE_NODE_VALUE_MASK);
++
++        case XML_ATTRIBUTE_NODE:
++            return (((xmlAttrPtr) node)->extra & XSLT_SOURCE_NODE_VALUE_MASK);
++
++        default:
++            return 0;
++    }
++}
++
++/**
++ * xsltSetSourceNodeValue:
++ * @node:  Node from source document
++ * @value:  28 bit unsigned value to associate with the node.
++ *
++ * Returns 0 on success, -1 on error.
++ */
++int
++xsltSetSourceNodeValue(xmlNodePtr node, int value) {
++    switch (node->type) {
++        case XML_DOCUMENT_NODE:
++        case XML_HTML_DOCUMENT_NODE:
++            ((xmlDocPtr) node)->extra &= ~XSLT_SOURCE_NODE_VALUE_MASK;
++            ((xmlDocPtr) node)->extra |= (value & XSLT_SOURCE_NODE_VALUE_MASK);
++            return 0;
++
++        case XML_ATTRIBUTE_NODE:
++            ((xmlAttrPtr) node)->extra &= ~XSLT_SOURCE_NODE_VALUE_MASK;
++            ((xmlAttrPtr) node)->extra |= (value & XSLT_SOURCE_NODE_VALUE_MASK);
+             return 0;
+ 
+         default:
+diff --git a/libxslt/xsltutils.h b/libxslt/xsltutils.h
+index 2514774b3f11a..1e753eebadd98 100644
+--- a/libxslt/xsltutils.h
++++ b/libxslt/xsltutils.h
+@@ -261,6 +261,10 @@ XSLTPUBFUN xmlXPathCompExprPtr XSLTCALL
+ #define XSLT_SOURCE_NODE_MASK       15u
+ #define XSLT_SOURCE_NODE_HAS_KEY    1u
+ #define XSLT_SOURCE_NODE_HAS_ID     2u
++#define XSLT_SOURCE_NODE_SHIFT_16   12u
++#define XSLT_SOURCE_NODE_SHIFT_32   28u
++#define XSLT_SOURCE_NODE_VALUE_MASK ((1 << XSLT_SOURCE_NODE_SHIFT_32) - 1)
++#define XSLT_SOURCE_NODE_VALUE_MAX  XSLT_SOURCE_NODE_VALUE_MASK
+ int
+ xsltGetSourceNodeFlags(xmlNodePtr node);
+ int
+@@ -268,6 +272,10 @@ xsltSetSourceNodeFlags(xsltTransformContextPtr ctxt, xmlNodePtr node,
+                        int flags);
+ int
+ xsltClearSourceNodeFlags(xmlNodePtr node, int flags);
++int
++xsltSetSourceNodeValue(xmlNodePtr node, int value);
++int
++xsltGetSourceNodeValue(xmlNodePtr node);
+ void **
+ xsltGetPSVIPtr(xmlNodePtr cur);
+ /** DOC_ENABLE */


### PR DESCRIPTION
Note, libxslt is no longer maintained upstream. The patches were provided by Chromium developers.

Unfortunately, the patch for https://gitlab.gnome.org/GNOME/libxslt/-/issues/139 and https://gitlab.gnome.org/GNOME/libxslt/-/issues/140 depends on unmerged libxml2 patch that breaks ABI.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
