### PR TITLE
python3Packages.mizani: 0.13.5 -> 0.14.1

### DIFF
--- a/pkgs/development/python-modules/mizani/default.nix
+++ b/pkgs/development/python-modules/mizani/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "mizani";
-  version = "0.13.5";
+  version = "0.14.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "has2k1";
     repo = "mizani";
     tag = "v${version}";
-    hash = "sha256-W88B8WCwIqjMhjoDJaksHBhvg/Sr0RRDwo9stniyzkM=";
+    hash = "sha256-g7eGajqFLgFWxNKefuYVWF439zVohU8W1j3w91nblEY=";
   };
 
   build-system = [ setuptools-scm ];

--- a/pkgs/development/python-modules/plotnine/default.nix
+++ b/pkgs/development/python-modules/plotnine/default.nix
@@ -19,6 +19,7 @@
   pytestCheckHook,
   pytest-cov-stub,
   scikit-misc,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -33,7 +34,25 @@ buildPythonPackage rec {
     hash = "sha256-nTMu0zx13XepqQyrJrAvBCjjHdY02tlXlFk2kITHZfI=";
   };
 
+  # Fixes: TypeError: hue_pal.__init__() got an unexpected keyword argument 'color_space'
+  #
+  # In the mizani 0.14.0 release, hue_pal was changed to use HCL color space from HSL (or HSLuv) space.
+  # The previous functionality is still available with hls_pal.
+  postPatch = ''
+    substituteInPlace plotnine/scales/scale_color.py \
+      --replace-fail \
+        "from mizani.palettes import hue_pal" \
+        "from mizani.palettes import hls_pal" \
+      --replace-fail \
+        "hue_pal(" \
+        "hls_pal("
+  '';
+
   build-system = [ setuptools-scm ];
+
+  pythonRelaxDeps = [
+    "mizani"
+  ];
 
   dependencies = [
     matplotlib
@@ -49,11 +68,8 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-cov-stub
     scikit-misc
+    writableTmpDirAsHomeHook
   ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   pythonImportsCheck = [ "plotnine" ];
 


### PR DESCRIPTION
## Things done

Diff: https://github.com/has2k1/mizani/compare/refs/tags/v0.13.5...refs/tags/v0.14.1
Changelogs:
- https://github.com/has2k1/mizani/releases/tag/v0.14.0
- https://github.com/has2k1/mizani/releases/tag/v0.14.1

cc @samuela

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
