### PR TITLE
workflows/labels: fix pull_request event trigger

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -212,6 +212,11 @@ jobs:
                   if (approvals.size > 0) after.push(`12.approvals: ${approvals.size > 2 ? '3+' : approvals.size}`)
                   if (Array.from(maintainers).some(m => approvals.has(m))) after.push('12.approved-by: package-maintainer')
 
+                  if (context.eventName == 'pull_request') {
+                    core.info('Skipping labeling on a pull_request event (no privileges).')
+                    return
+                  }
+
                   // Remove the ones not needed anymore
                   await Promise.all(
                     before.filter(name => !after.includes(name))
@@ -247,12 +252,12 @@ jobs:
         name: Labels from touched files
         if: |
           github.event_name == 'pull_request_target' &&
-          github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
+          (github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
             github.head_ref == 'haskell-updates' ||
             github.head_ref == 'python-updates' ||
             github.head_ref == 'staging-next' ||
             startsWith(github.head_ref, 'staging-next-')
-          )
+          ))
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml # default
@@ -262,12 +267,12 @@ jobs:
         name: Labels from touched files (no sync)
         if: |
           github.event_name == 'pull_request_target' &&
-          github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
+          (github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
             github.head_ref == 'haskell-updates' ||
             github.head_ref == 'python-updates' ||
             github.head_ref == 'staging-next' ||
             startsWith(github.head_ref, 'staging-next-')
-          )
+          ))
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler-no-sync.yml
@@ -280,12 +285,12 @@ jobs:
         # the backport labels.
         if: |
           github.event_name == 'pull_request_target' &&
-          github.event.pull_request.head.repo.owner.login == 'NixOS' && (
+          (github.event.pull_request.head.repo.owner.login == 'NixOS' && (
             github.head_ref == 'haskell-updates' ||
             github.head_ref == 'python-updates' ||
             github.head_ref == 'staging-next' ||
             startsWith(github.head_ref, 'staging-next-')
-          )
+          ))
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler-development-branches.yml


### PR DESCRIPTION
When the job is run with the pull_request trigger for validation of changes to the workflow itself, we need to run everything that can be run without privileges - but not more.

We tried to do so for the three actions/labeler steps, but failed to set up the condition correctly. We also need to exit early for our JavaScript based labeler, just before making the mutation requests.

The failure mode can be seen in #417957, where `PR / Labels (pull_request)` should not fail right now.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
