### PR TITLE
nixos/sshd: add generateHostKeys setting

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -22,4 +22,4 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- `services.openssh` now supports generating host SSH keys by setting `services.openssh.generateHostKeys = true` while leaving `services.openssh.enable` disabled.  This is particularly useful for systems that have no need of an SSH daemon but want SSH host keys for other purposes such as using agenix or sops-nix.

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -381,6 +381,19 @@ in
         '';
       };
 
+      generateHostKeys = lib.mkOption {
+        type = lib.types.bool;
+        default = config.services.openssh.enable;
+        defaultText = lib.literalExpression "services.openssh.enable";
+        description = ''
+          Whether to generate SSH host keys.
+
+          This can be enabled explicitly if you want to generate host keys but
+          don't want to enable the SSH daemon.
+        '';
+        example = true;
+      };
+
       banner = lib.mkOption {
         type = lib.types.nullOr lib.types.lines;
         default = null;
@@ -669,115 +682,232 @@ in
 
   ###### implementation
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
 
-    users.users.sshd = {
-      isSystemUser = true;
-      group = "sshd";
-      description = "SSH privilege separation user";
-    };
-    users.groups.sshd = { };
-
-    services.openssh.moduliFile = lib.mkDefault "${cfg.package}/etc/ssh/moduli";
-    services.openssh.sftpServerExecutable = lib.mkDefault "${cfg.package}/libexec/sftp-server";
-
-    environment.etc =
-      authKeysFiles
-      // authPrincipalsFiles
-      // {
-        "ssh/moduli".source = cfg.moduliFile;
-        "ssh/sshd_config".source = sshconf;
+      users.users.sshd = {
+        isSystemUser = true;
+        group = "sshd";
+        description = "SSH privilege separation user";
       };
+      users.groups.sshd = { };
 
-    systemd.tmpfiles.settings."ssh-root-provision" = {
-      "/root"."d-" = {
-        user = "root";
-        group = ":root";
-        mode = ":700";
-      };
-      "/root/.ssh"."d-" = {
-        user = "root";
-        group = ":root";
-        mode = ":700";
-      };
-      "/root/.ssh/authorized_keys"."f^" = {
-        user = "root";
-        group = ":root";
-        mode = ":600";
-        argument = "ssh.authorized_keys.root";
-      };
-    };
+      services.openssh.moduliFile = lib.mkDefault "${cfg.package}/etc/ssh/moduli";
+      services.openssh.sftpServerExecutable = lib.mkDefault "${cfg.package}/libexec/sftp-server";
 
-    systemd = {
-      sockets.sshd = lib.mkIf cfg.startWhenNeeded {
-        description = "SSH Socket";
-        wantedBy = [ "sockets.target" ];
-        socketConfig.ListenStream =
-          if cfg.listenAddresses != [ ] then
-            lib.concatMap (
-              { addr, port }:
-              if port != null then [ "${addr}:${toString port}" ] else map (p: "${addr}:${toString p}") cfg.ports
-            ) cfg.listenAddresses
-          else
-            cfg.ports;
-        socketConfig.Accept = true;
-        # Prevent brute-force attacks from shutting down socket
-        socketConfig.TriggerLimitIntervalSec = 0;
-      };
+      environment.etc =
+        authKeysFiles
+        // authPrincipalsFiles
+        // {
+          "ssh/moduli".source = cfg.moduliFile;
+          "ssh/sshd_config".source = sshconf;
+        };
 
-      services."sshd@" = {
-        description = "SSH per-connection Daemon";
-        after = [
-          "network.target"
-          "sshd-keygen.service"
-        ];
-        wants = [ "sshd-keygen.service" ];
-        stopIfChanged = false;
-        path = [ cfg.package ];
-        environment.LD_LIBRARY_PATH = nssModulesPath;
-
-        serviceConfig = {
-          ExecStart = lib.concatStringsSep " " [
-            "-${lib.getExe' cfg.package "sshd"}"
-            "-i"
-            "-D"
-            "-f /etc/ssh/sshd_config"
-          ];
-          KillMode = "process";
-          StandardInput = "socket";
-          StandardError = "journal";
+      systemd.tmpfiles.settings."ssh-root-provision" = {
+        "/root"."d-" = {
+          user = "root";
+          group = ":root";
+          mode = ":700";
+        };
+        "/root/.ssh"."d-" = {
+          user = "root";
+          group = ":root";
+          mode = ":700";
+        };
+        "/root/.ssh/authorized_keys"."f^" = {
+          user = "root";
+          group = ":root";
+          mode = ":600";
+          argument = "ssh.authorized_keys.root";
         };
       };
 
-      services.sshd = lib.mkIf (!cfg.startWhenNeeded) {
-        description = "SSH Daemon";
-        wantedBy = [ "multi-user.target" ];
-        after = [
-          "network.target"
-          "sshd-keygen.service"
-        ];
-        wants = [ "sshd-keygen.service" ];
-        stopIfChanged = false;
-        path = [ cfg.package ];
-        environment.LD_LIBRARY_PATH = nssModulesPath;
+      systemd = {
+        sockets.sshd = lib.mkIf cfg.startWhenNeeded {
+          description = "SSH Socket";
+          wantedBy = [ "sockets.target" ];
+          socketConfig.ListenStream =
+            if cfg.listenAddresses != [ ] then
+              lib.concatMap (
+                { addr, port }:
+                if port != null then [ "${addr}:${toString port}" ] else map (p: "${addr}:${toString p}") cfg.ports
+              ) cfg.listenAddresses
+            else
+              cfg.ports;
+          socketConfig.Accept = true;
+          # Prevent brute-force attacks from shutting down socket
+          socketConfig.TriggerLimitIntervalSec = 0;
+        };
 
-        restartTriggers = [ config.environment.etc."ssh/sshd_config".source ];
-
-        serviceConfig = {
-          Type = "notify-reload";
-          Restart = "always";
-          ExecStart = lib.concatStringsSep " " [
-            (lib.getExe' cfg.package "sshd")
-            "-D"
-            "-f"
-            "/etc/ssh/sshd_config"
+        services."sshd@" = {
+          description = "SSH per-connection Daemon";
+          after = [
+            "network.target"
+            "sshd-keygen.service"
           ];
-          KillMode = "process";
+          wants = lib.mkIf cfg.generateHostKeys [ "sshd-keygen.service" ];
+          stopIfChanged = false;
+          path = [ cfg.package ];
+          environment.LD_LIBRARY_PATH = nssModulesPath;
+
+          serviceConfig = {
+            ExecStart = lib.concatStringsSep " " [
+              "-${lib.getExe' cfg.package "sshd"}"
+              "-i"
+              "-D"
+              "-f /etc/ssh/sshd_config"
+            ];
+            KillMode = "process";
+            StandardInput = "socket";
+            StandardError = "journal";
+          };
+        };
+
+        services.sshd = lib.mkIf (!cfg.startWhenNeeded) {
+          description = "SSH Daemon";
+          wantedBy = [ "multi-user.target" ];
+          after = [
+            "network.target"
+            "sshd-keygen.service"
+          ];
+          wants = lib.mkIf cfg.generateHostKeys [ "sshd-keygen.service" ];
+          stopIfChanged = false;
+          path = [ cfg.package ];
+          environment.LD_LIBRARY_PATH = nssModulesPath;
+
+          restartTriggers = [ config.environment.etc."ssh/sshd_config".source ];
+
+          serviceConfig = {
+            Type = "notify-reload";
+            Restart = "always";
+            ExecStart = lib.concatStringsSep " " [
+              (lib.getExe' cfg.package "sshd")
+              "-D"
+              "-f"
+              "/etc/ssh/sshd_config"
+            ];
+            KillMode = "process";
+          };
         };
       };
 
-      services.sshd-keygen = {
+      networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall cfg.ports;
+
+      security.pam.services.sshd = lib.mkIf cfg.settings.UsePAM {
+        startSession = true;
+        showMotd = true;
+        unixAuth = if cfg.settings.PasswordAuthentication == true then true else false;
+      };
+
+      # These values are merged with the ones defined externally, see:
+      # https://github.com/NixOS/nixpkgs/pull/10155
+      # https://github.com/NixOS/nixpkgs/pull/41745
+      services.openssh.authorizedKeysFiles =
+        lib.optional cfg.authorizedKeysInHomedir "%h/.ssh/authorized_keys"
+        ++ [ "/etc/ssh/authorized_keys.d/%u" ];
+
+      services.openssh.settings.AuthorizedPrincipalsFile = lib.mkIf (
+        authPrincipalsFiles != { }
+      ) "/etc/ssh/authorized_principals.d/%u";
+
+      services.openssh.extraConfig = lib.mkOrder 0 (
+        lib.concatStringsSep "\n" (
+          [
+            "Banner ${if cfg.banner == null then "none" else pkgs.writeText "ssh_banner" cfg.banner}"
+            "AddressFamily ${if config.networking.enableIPv6 then "any" else "inet"}"
+          ]
+          ++ lib.map (port: ''Port ${toString port}'') cfg.ports
+          ++ lib.map (
+            { port, addr, ... }:
+            ''ListenAddress ${addr}${lib.optionalString (port != null) (":" + toString port)}''
+          ) cfg.listenAddresses
+          ++ lib.optional cfgc.setXAuthLocation "XAuthLocation ${lib.getExe pkgs.xorg.xauth}"
+          ++ lib.optional cfg.allowSFTP ''Subsystem sftp ${cfg.sftpServerExecutable} ${lib.concatStringsSep " " cfg.sftpFlags}''
+          ++ [
+            "AuthorizedKeysFile ${toString cfg.authorizedKeysFiles}"
+          ]
+          ++ lib.optional (cfg.authorizedKeysCommand != "none") ''
+            AuthorizedKeysCommand ${cfg.authorizedKeysCommand}
+            AuthorizedKeysCommandUser ${cfg.authorizedKeysCommandUser}
+          ''
+          ++ lib.map (k: "HostKey ${k.path}") cfg.hostKeys
+        )
+      );
+
+      system.checks = [
+        (pkgs.runCommand "check-sshd-config"
+          {
+            nativeBuildInputs = [ validationPackage ];
+          }
+          ''
+            ${lib.concatMapStringsSep "\n" (
+              lport: "sshd -G -T -C lport=${toString lport} -f ${sshconf} > /dev/null"
+            ) cfg.ports}
+            ${lib.concatMapStringsSep "\n" (
+              la:
+              lib.concatMapStringsSep "\n" (
+                port:
+                "sshd -G -T -C ${lib.escapeShellArg "laddr=${la.addr},lport=${toString port}"} -f ${sshconf} > /dev/null"
+              ) (if la.port != null then [ la.port ] else cfg.ports)
+            ) cfg.listenAddresses}
+            touch $out
+          ''
+        )
+      ];
+
+      assertions = [
+        {
+          assertion = if cfg.settings.X11Forwarding then cfgc.setXAuthLocation else true;
+          message = "cannot enable X11 forwarding without setting xauth location";
+        }
+        {
+          assertion =
+            (builtins.match "(.*\n)?(\t )*[Kk][Ee][Rr][Bb][Ee][Rr][Oo][Ss][Aa][Uu][Tt][Hh][Ee][Nn][Tt][Ii][Cc][Aa][Tt][Ii][Oo][Nn][ |\t|=|\"]+yes.*" "${configFile}\n${cfg.extraConfig}")
+            != null
+            -> cfgc.package.withKerberos;
+          message = "cannot enable Kerberos authentication without using a package with Kerberos support";
+        }
+        {
+          assertion =
+            (builtins.match "(.*\n)?(\t )*[Gg][Ss][Ss][Aa][Pp][Ii][Aa][Uu][Tt][Hh][Ee][Nn][Tt][Ii][Cc][Aa][Tt][Ii][Oo][Nn][ |\t|=|\"]+yes.*" "${configFile}\n${cfg.extraConfig}")
+            != null
+            -> cfgc.package.withKerberos;
+          message = "cannot enable GSSAPI authentication without using a package with Kerberos support";
+        }
+        (
+          let
+            duplicates =
+              # Filter out the groups with more than 1 element
+              lib.filter (l: lib.length l > 1) (
+                # Grab the groups, we don't care about the group identifiers
+                lib.attrValues (
+                  # Group the settings that are the same in lower case
+                  lib.groupBy lib.strings.toLower (lib.attrNames cfg.settings)
+                )
+              );
+            formattedDuplicates = lib.concatMapStringsSep ", " (
+              dupl: "(${lib.concatStringsSep ", " dupl})"
+            ) duplicates;
+          in
+          {
+            assertion = lib.length duplicates == 0;
+            message = ''Duplicate sshd config key; does your capitalization match the option's? Duplicate keys: ${formattedDuplicates}'';
+          }
+        )
+      ]
+      ++ lib.forEach cfg.listenAddresses (
+        { addr, ... }:
+        {
+          assertion = addr != null;
+          message = "addr must be specified in each listenAddresses entry";
+        }
+      );
+    })
+
+    (lib.mkIf cfg.generateHostKeys {
+      systemd.services.sshd-keygen = {
         description = "SSH Host Keys Generation";
+        wantedBy = [ "multi-user.target" ];
         unitConfig = {
           ConditionFileNotEmpty = map (k: "|!${k.path}") cfg.hostKeys;
         };
@@ -802,119 +932,7 @@ in
           fi
         '');
       };
-    };
-
-    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall cfg.ports;
-
-    security.pam.services.sshd = lib.mkIf cfg.settings.UsePAM {
-      startSession = true;
-      showMotd = true;
-      unixAuth = if cfg.settings.PasswordAuthentication == true then true else false;
-    };
-
-    # These values are merged with the ones defined externally, see:
-    # https://github.com/NixOS/nixpkgs/pull/10155
-    # https://github.com/NixOS/nixpkgs/pull/41745
-    services.openssh.authorizedKeysFiles =
-      lib.optional cfg.authorizedKeysInHomedir "%h/.ssh/authorized_keys"
-      ++ [ "/etc/ssh/authorized_keys.d/%u" ];
-
-    services.openssh.settings.AuthorizedPrincipalsFile = lib.mkIf (
-      authPrincipalsFiles != { }
-    ) "/etc/ssh/authorized_principals.d/%u";
-
-    services.openssh.extraConfig = lib.mkOrder 0 (
-      lib.concatStringsSep "\n" (
-        [
-          "Banner ${if cfg.banner == null then "none" else pkgs.writeText "ssh_banner" cfg.banner}"
-          "AddressFamily ${if config.networking.enableIPv6 then "any" else "inet"}"
-        ]
-        ++ lib.map (port: ''Port ${toString port}'') cfg.ports
-        ++ lib.map (
-          { port, addr, ... }:
-          ''ListenAddress ${addr}${lib.optionalString (port != null) (":" + toString port)}''
-        ) cfg.listenAddresses
-        ++ lib.optional cfgc.setXAuthLocation "XAuthLocation ${lib.getExe pkgs.xorg.xauth}"
-        ++ lib.optional cfg.allowSFTP ''Subsystem sftp ${cfg.sftpServerExecutable} ${lib.concatStringsSep " " cfg.sftpFlags}''
-        ++ [
-          "AuthorizedKeysFile ${toString cfg.authorizedKeysFiles}"
-        ]
-        ++ lib.optional (cfg.authorizedKeysCommand != "none") ''
-          AuthorizedKeysCommand ${cfg.authorizedKeysCommand}
-          AuthorizedKeysCommandUser ${cfg.authorizedKeysCommandUser}
-        ''
-        ++ lib.map (k: "HostKey ${k.path}") cfg.hostKeys
-      )
-    );
-
-    system.checks = [
-      (pkgs.runCommand "check-sshd-config"
-        {
-          nativeBuildInputs = [ validationPackage ];
-        }
-        ''
-          ${lib.concatMapStringsSep "\n" (
-            lport: "sshd -G -T -C lport=${toString lport} -f ${sshconf} > /dev/null"
-          ) cfg.ports}
-          ${lib.concatMapStringsSep "\n" (
-            la:
-            lib.concatMapStringsSep "\n" (
-              port:
-              "sshd -G -T -C ${lib.escapeShellArg "laddr=${la.addr},lport=${toString port}"} -f ${sshconf} > /dev/null"
-            ) (if la.port != null then [ la.port ] else cfg.ports)
-          ) cfg.listenAddresses}
-          touch $out
-        ''
-      )
-    ];
-
-    assertions = [
-      {
-        assertion = if cfg.settings.X11Forwarding then cfgc.setXAuthLocation else true;
-        message = "cannot enable X11 forwarding without setting xauth location";
-      }
-      {
-        assertion =
-          (builtins.match "(.*\n)?(\t )*[Kk][Ee][Rr][Bb][Ee][Rr][Oo][Ss][Aa][Uu][Tt][Hh][Ee][Nn][Tt][Ii][Cc][Aa][Tt][Ii][Oo][Nn][ |\t|=|\"]+yes.*" "${configFile}\n${cfg.extraConfig}")
-          != null
-          -> cfgc.package.withKerberos;
-        message = "cannot enable Kerberos authentication without using a package with Kerberos support";
-      }
-      {
-        assertion =
-          (builtins.match "(.*\n)?(\t )*[Gg][Ss][Ss][Aa][Pp][Ii][Aa][Uu][Tt][Hh][Ee][Nn][Tt][Ii][Cc][Aa][Tt][Ii][Oo][Nn][ |\t|=|\"]+yes.*" "${configFile}\n${cfg.extraConfig}")
-          != null
-          -> cfgc.package.withKerberos;
-        message = "cannot enable GSSAPI authentication without using a package with Kerberos support";
-      }
-      (
-        let
-          duplicates =
-            # Filter out the groups with more than 1 element
-            lib.filter (l: lib.length l > 1) (
-              # Grab the groups, we don't care about the group identifiers
-              lib.attrValues (
-                # Group the settings that are the same in lower case
-                lib.groupBy lib.strings.toLower (lib.attrNames cfg.settings)
-              )
-            );
-          formattedDuplicates = lib.concatMapStringsSep ", " (
-            dupl: "(${lib.concatStringsSep ", " dupl})"
-          ) duplicates;
-        in
-        {
-          assertion = lib.length duplicates == 0;
-          message = ''Duplicate sshd config key; does your capitalization match the option's? Duplicate keys: ${formattedDuplicates}'';
-        }
-      )
-    ]
-    ++ lib.forEach cfg.listenAddresses (
-      { addr, ... }:
-      {
-        assertion = addr != null;
-        message = "addr must be specified in each listenAddresses entry";
-      }
-    );
-  };
+    })
+  ];
 
 }


### PR DESCRIPTION
If a user doesn't want to enable the SSH daemon, but does want to have SSH host keys configured for some other reason (e.g. they're used for host identification in some other way), provide a `generateHostKeys` setting that will generate the keys without otherwise setting up sshd.

No release notes, as I don't think the change is significant enough to warrant them. I will tag for back-application as it's a minor change with no back-compatibility issues.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - ~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~ _no new module_
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
