### PR TITLE
ci/eval: specify temp Nix store for Nix commands

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -55,6 +55,7 @@ let
       }
       ''
         export NIX_STATE_DIR=$(mktemp -d)
+        export NIX_STORE_DIR=$(mktemp -d)
         mkdir $out
         export GC_INITIAL_HEAP_SIZE=4g
         command time -f "Attribute eval done [%MKB max resident, %Es elapsed] %C" \
@@ -144,6 +145,7 @@ let
       }
       ''
         export NIX_STATE_DIR=$(mktemp -d)
+        export NIX_STORE_DIR=$(mktemp -d)
         nix-store --init
 
         echo "System: $evalSystem"


### PR DESCRIPTION
When I ran this on macOS:

```
nix build -f ci eval.singleSystem --argstr evalSystem aarch64-darwin --arg chunkSize 10000 --arg quickTest true -L --no-link
```

I get an error:

```
attrpaths-superset.json> error: creating directory '/nix/store/.links': Operation not permitted
```

It seems Nix commands executed to generate `attrpaths-superset.json` and run `nixpkgs-eval-*` try to unconditionally create `.links` directory in Nix store.

This change points them to an empty Nix Store in a temporary directory.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
