### PR TITLE
vassal: add desktop entry

### DIFF
--- a/pkgs/by-name/va/vassal/package.nix
+++ b/pkgs/by-name/va/vassal/package.nix
@@ -6,6 +6,7 @@
   jre,
   makeWrapper,
   wrapGAppsHook3,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -47,6 +48,13 @@ stdenv.mkDerivation rec {
     "man"
     "info"
   ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/vassal";
+  versionCheckProgramArg = "--version";
 
   meta = with lib; {
     description = "Free, open-source boardgame engine";

--- a/pkgs/by-name/va/vassal/package.nix
+++ b/pkgs/by-name/va/vassal/package.nix
@@ -6,6 +6,8 @@
   jre,
   makeWrapper,
   wrapGAppsHook3,
+  makeDesktopItem,
+  copyDesktopItems,
   versionCheckHook,
 }:
 
@@ -25,6 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     makeWrapper
     wrapGAppsHook3
+    copyDesktopItems
   ];
 
   installPhase = ''
@@ -40,8 +43,22 @@ stdenv.mkDerivation rec {
       --add-flags "-Duser.dir=$out -cp $out/share/vassal/Vengine.jar \
       VASSAL.launch.ModuleManager"
 
+    install -Dm444 -t "$out/share/icons/hicolor/scalable/apps/" VASSAL.svg
+
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "VASSAL";
+      exec = "vassal";
+      icon = "VASSAL";
+      desktopName = "VASSAL";
+      comment = "The open-source boardgame engine";
+      categories = [ "Game" ];
+      startupWMClass = "VASSAL-launch-ModuleManager";
+    })
+  ];
 
   # Don't move doc to share/, VASSAL expects it to be in the root
   forceShare = [

--- a/pkgs/by-name/va/vassal/package.nix
+++ b/pkgs/by-name/va/vassal/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.lgpl21Only;
     maintainers = with maintainers; [ tvestelind ];
-    platforms = platforms.unix;
+    platforms = with lib.platforms; unix ++ windows;
     mainProgram = "vassal";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Screenshots on my GNOME

* Overview: ![Screenshot From 2025-06-19 22-00-45](https://github.com/user-attachments/assets/570df4fb-a22c-4829-bc3e-d2cf47cd59a1)

* GNOME Dash: ![Screenshot From 2025-06-19 22-01-22](https://github.com/user-attachments/assets/042bcffb-51c8-4198-8445-cdec0794c135)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
