### PR TITLE
xfce.xfburn: 0.7.2 -> 0.8.0

### DIFF
--- a/pkgs/desktops/xfce/applications/xfburn/default.nix
+++ b/pkgs/desktops/xfce/applications/xfburn/default.nix
@@ -1,7 +1,14 @@
 {
-  mkXfceDerivation,
+  stdenv,
   lib,
+  fetchFromGitLab,
   docbook_xsl,
+  glib,
+  libxslt,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
   exo,
   gst_all_1,
   gtk3,
@@ -9,24 +16,37 @@
   libgudev,
   libisofs,
   libxfce4ui,
-  libxslt,
+  libxfce4util,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfburn";
-  version = "0.7.2";
-  odd-unstable = false;
+  version = "0.8.0";
 
-  sha256 = "sha256-eJ+MxNdJiDTLW4GhrwgQIyFuOSTWsF34Oet9HJAtIqI=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "xfburn";
+    tag = "xfburn-${finalAttrs.version}";
+    hash = "sha256-10MjUxy1Ul6CVLdEWFnjppgsI4fAUWqkT2azJBzp0/Q=";
+  };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
-    libxslt
     docbook_xsl
+    glib # glib-genmarshal
+    libxslt # xsltproc
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
   ];
 
   buildInputs = [
     exo
+    glib
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     gtk3
@@ -34,11 +54,17 @@ mkXfceDerivation {
     libgudev
     libisofs
     libxfce4ui
+    libxfce4util
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "xfburn-"; };
+
+  meta = {
     description = "Disc burner and project creator for Xfce";
+    homepage = "https://gitlab.xfce.org/apps/xfburn";
+    license = lib.licenses.gpl2Plus;
     mainProgram = "xfburn";
-    teams = [ teams.xfce ];
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
https://gitlab.xfce.org/apps/xfburn/-/compare/xfburn-0.7.2...xfburn-0.8.0

Yet another port to meson update, previous: https://github.com/NixOS/nixpkgs/pull/412702.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

