### PR TITLE
{collectd,libcollectdclient}: fix build

### DIFF
--- a/pkgs/by-name/li/libcollectdclient/package.nix
+++ b/pkgs/by-name/li/libcollectdclient/package.nix
@@ -1,24 +1,26 @@
 { lib, collectd }:
 
-collectd.overrideAttrs (oldAttrs: {
+collectd.overrideAttrs (prevAttrs: {
   pname = "libcollectdclient";
+
   buildInputs = [ ];
 
-  configureFlags = (oldAttrs.configureFlags or [ ]) ++ [
+  configureFlags = (prevAttrs.configureFlags or [ ]) ++ [
+    "--with-perl-bindings=no"
     "--disable-daemon"
     "--disable-all-plugins"
   ];
 
   postInstall = "rm -rf $out/{bin,etc,sbin,share}";
 
-  meta = with lib; {
+  meta = {
     description = "C Library for collectd, a daemon which collects system performance statistics periodically";
-    homepage = "http://collectd.org";
-    license = licenses.gpl2;
-    platforms = platforms.linux; # TODO: collectd may be linux but the C client may be more portable?
-    maintainers = [
-      maintainers.sheenobu
-      maintainers.bjornfor
+    homepage = "https://collectd.org";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      sheenobu
+      bjornfor
     ];
   };
 })

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -1,33 +1,40 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   fetchpatch,
   callPackage,
   autoreconfHook,
   pkg-config,
   libtool,
+  bison,
+  flex,
+  perl,
   nixosTests,
   ...
 }@args:
 let
   plugins = callPackage ./plugins.nix args;
 in
-stdenv.mkDerivation rec {
-  version = "5.12.0";
+stdenv.mkDerivation (finalAttrs: {
   pname = "collectd";
+  version = "5.12.0";
 
-  src = fetchurl {
-    url = "https://collectd.org/files/${pname}-${version}.tar.bz2";
-    sha256 = "1mh97afgq6qgmpvpr84zngh58m0sl1b4wimqgvvk376188q09bjv";
+  src = fetchFromGitHub {
+    owner = "collectd";
+    repo = "collectd";
+    tag = "collectd-${finalAttrs.version}";
+    hash = "sha256-UTlCY1GPRpbdQFLFUDjNr1PgEdGv4WNtjr8TYbxHK5A=";
   };
 
+  # All of these are going to be included in the next release
   patches = [
     # fix -t never printing syntax errors
     # should be included in next release
     (fetchpatch {
+      name = "fix-broken-dash-t-option.patch";
       url = "https://github.com/collectd/collectd/commit/3f575419e7ccb37a3b10ecc82adb2e83ff2826e1.patch";
-      sha256 = "0jwjdlfl0dp7mlbwygp6h0rsbaqfbgfm5z07lr5l26z6hhng2h2y";
+      hash = "sha256-XkDxLITmG0FLpgf8Ut1bDqulM4DmPs8Xrec2QB1tkks=";
     })
     (fetchpatch {
       name = "no_include_longintrepr.patch";
@@ -39,7 +46,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    bison
+    flex
+    perl # for pod2man
   ];
+
   buildInputs = [
     libtool
   ] ++ plugins.buildInputs;
@@ -52,9 +63,12 @@ stdenv.mkDerivation rec {
     ++ plugins.configureFlags
     ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "--with-fp-layout=nothing" ];
 
+  # Used in `src/virt.c`
+  env.NIX_CFLAGS_COMPILE = "-DATTRIBUTE_UNUSED=__attribute__((unused))";
+
   # do not create directories in /var during installPhase
   postConfigure = ''
-    substituteInPlace Makefile --replace '$(mkinstalldirs) $(DESTDIR)$(localstatedir)/' '#'
+    substituteInPlace Makefile --replace-fail '$(mkinstalldirs) $(DESTDIR)$(localstatedir)/' '#'
   '';
 
   postInstall = ''
@@ -69,11 +83,11 @@ stdenv.mkDerivation rec {
     inherit (nixosTests) collectd;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Daemon which collects system performance statistics periodically";
     homepage = "https://collectd.org";
-    license = licenses.gpl2Plus;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ bjornfor ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ bjornfor ];
   };
-}
+})


### PR DESCRIPTION
https://hydra.nixos.org/build/300269816

Three issues fixed:

1. Intermittent connection failures to https://collectd.org made the `src` derivation flaky, so switched to the upstream github repository.
2. No Bison or Flex listed as a dependency, so parser and scanner were not generated.
3. `src/virt.c` includes `ATTRIBUTE_UNUSED` but it's not defined anywhere.

Also switched to `finalAttrs` style and SRI hash format throughout, and reduced the scope of `with lib`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.